### PR TITLE
ci: move builder image to open-gsd ghcr

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     container:
-      image: ghcr.io/gsd-redux/gsd-ci-builder:latest
+      image: ghcr.io/open-gsd/gsd-ci-builder:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/next-publish.yml
+++ b/.github/workflows/next-publish.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: next
     container:
-      image: ghcr.io/gsd-redux/gsd-ci-builder:latest
+      image: ghcr.io/open-gsd/gsd-ci-builder:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,6 @@
 name: Pipeline
 
-# Rebuilds the CI builder Docker image when Dockerfile changes on main.
+# Rebuilds the CI builder Docker image when its build inputs change on main.
 # Dev and prod publishing live in separate workflows (dev-publish.yml,
 # prod-release.yml) — both manual "Run workflow" triggers.
 
@@ -31,12 +31,12 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2
 
-      - name: Check for Dockerfile changes
+      - name: Check for builder image changes
         id: check
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          CHANGED=$(git diff --name-only "${HEAD_SHA}~1" "${HEAD_SHA}" -- Dockerfile || echo "")
+          CHANGED=$(git diff --name-only "${HEAD_SHA}~1" "${HEAD_SHA}" -- Dockerfile package.json .github/workflows/pipeline.yml || echo "")
           echo "changed=$([[ -n "$CHANGED" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
@@ -51,6 +51,6 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: |
           docker build --target builder \
-            -t ghcr.io/gsd-redux/gsd-ci-builder:latest \
+            -t ghcr.io/open-gsd/gsd-ci-builder:latest \
             .
-          docker push ghcr.io/gsd-redux/gsd-ci-builder:latest
+          docker push ghcr.io/open-gsd/gsd-ci-builder:latest

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ The active public baseline starts at `1.0.0`.
 
 Historical tags and archived refs may exist for traceability, but active release notes should be written from this baseline forward.
 
+## Community
+
+Join the [GSD Discord community](https://discord.com/invite/nKXTsAcmbT).
+
 ## License
 
 MIT

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -153,16 +153,16 @@ For `@dev` or `@next` rollbacks, the next successful merge will overwrite the ta
 | Secret: `ANTHROPIC_API_KEY` | Prod environment only |
 | Secret: `OPENAI_API_KEY` | Prod environment only |
 | Variable: `RUN_LIVE_TESTS` | `false` (set to `true` to enable live LLM tests) |
-| GHCR | Enabled for the `gsd-redux` org |
+| GHCR | Enabled for the `open-gsd` org |
 
 ### Docker Images
 
 | Image | Base | Purpose | Tags |
 |-------|------|---------|------|
-| `ghcr.io/gsd-redux/gsd-ci-builder` | `node:24-bookworm` | CI build environment with Rust toolchain | `:latest`, `:<date>` |
+| `ghcr.io/open-gsd/gsd-ci-builder` | `node:24-bookworm` | CI build environment with Rust toolchain | `:latest`, `:<date>` |
 | `ghcr.io/open-gsd/gsd-pi` | `node:24-slim` | User-facing runtime | `:latest`, `:next`, `:v<version>` |
 
-The CI builder image is rebuilt automatically when the `Dockerfile` changes. It eliminates ~3-5 min of toolchain setup per CI run.
+The CI builder image is rebuilt automatically when its build inputs change. It eliminates ~3-5 min of toolchain setup per CI run.
 
 ## LLM Fixture Tests
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "release:bump": "node scripts/bump-version.mjs",
     "release:update-changelog": "node scripts/update-changelog.mjs",
     "docker:build-runtime": "docker build --target runtime -t ghcr.io/open-gsd/gsd-pi .",
-    "docker:build-builder": "docker build --target builder -t ghcr.io/gsd-redux/gsd-ci-builder .",
+    "docker:build-builder": "docker build --target builder -t ghcr.io/open-gsd/gsd-ci-builder .",
     "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && node scripts/prepublish-check.mjs && npm run build && npm run typecheck:extensions && npm run validate-pack",
     "test:live-regression": "node --experimental-strip-types tests/live-regression/run.ts",
     "test:e2e": "node --experimental-strip-types --test --test-concurrency=1 \"tests/e2e/*.e2e.test.ts\"",

--- a/src/tests/ci-builder-image-config.test.ts
+++ b/src/tests/ci-builder-image-config.test.ts
@@ -1,0 +1,50 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for CI builder image workflow configuration.
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { parse } from "yaml";
+
+const BUILDER_IMAGE = "ghcr.io/open-gsd/gsd-ci-builder";
+
+test("publish workflows use the builder image produced by pipeline", () => {
+  const devPublish = readWorkflow("dev-publish.yml");
+  const nextPublish = readWorkflow("next-publish.yml");
+  const pipeline = readWorkflow("pipeline.yml");
+
+  assert.equal(devPublish.jobs["dev-publish"].container.image, `${BUILDER_IMAGE}:latest`);
+  assert.equal(nextPublish.jobs["next-publish"].container.image, `${BUILDER_IMAGE}:latest`);
+
+  const buildStep = pipeline.jobs["update-builder"].steps.find((step: { name?: string }) => (
+    step.name === "Build and push CI builder image"
+  ));
+  assert.ok(buildStep, "pipeline should include a CI builder publish step");
+  assert.match(buildStep.run, new RegExp(`docker build --target builder[\\s\\S]*-t ${escapeRegExp(BUILDER_IMAGE)}:latest`));
+  assert.match(buildStep.run, new RegExp(`docker push ${escapeRegExp(BUILDER_IMAGE)}:latest`));
+});
+
+test("package builder script targets the same image namespace", () => {
+  const packageJson = JSON.parse(readFileSync(join(repoRoot(), "package.json"), "utf8"));
+
+  assert.equal(packageJson.scripts["docker:build-builder"], `docker build --target builder -t ${BUILDER_IMAGE} .`);
+});
+
+function readWorkflow(fileName: string): any {
+  return parse(readFileSync(join(repoRoot(), ".github", "workflows", fileName), "utf8"));
+}
+
+function repoRoot(): string {
+  let current = dirname(fileURLToPath(import.meta.url));
+  while (current !== dirname(current)) {
+    if (existsSync(join(current, ".github", "workflows"))) return current;
+    current = dirname(current);
+  }
+  throw new Error("Could not locate repository root");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Linked issue

Closes #1

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Moves CI publish workflows and the builder image pipeline to `ghcr.io/open-gsd/gsd-ci-builder`.
**Why:** Dev Publish failed before checkout because Actions could not pull the old `ghcr.io/gsd-redux/gsd-ci-builder:latest` image.
**How:** Updates live workflow/package refs, broadens the builder rebuild trigger to its build inputs, and adds a structured config regression test.

## What

- Updates Dev Publish and Next Publish job containers to use `ghcr.io/open-gsd/gsd-ci-builder:latest`.
- Updates the pipeline builder publish target and local `docker:build-builder` script to the same namespace.
- Documents the current GHCR namespace in the CI/CD guide.
- Adds a config regression test that parses the workflows and package metadata to keep the publish workflows aligned with the pipeline-produced builder image.
- Restores the canonical Discord community link required by the existing README invite regression test.

## Why

Dev Publish run 26298131056 failed during `Initialize containers` with `manifest unknown` while pulling `ghcr.io/gsd-redux/gsd-ci-builder:latest`. The repo now lives under `open-gsd`, so the publish workflows need to consume a builder image in the current GHCR namespace.

## How

The pipeline now rebuilds the builder image when `Dockerfile`, `package.json`, or `.github/workflows/pipeline.yml` changes. That lets this PR publish the new `open-gsd` builder image after merge, then Dev Publish and Next Publish can pull the image from the same namespace.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual/local checks:

- `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/tests/ci-builder-image-config.test.js dist-test/src/resources/extensions/gsd/tests/discord-invite-links.test.js` — 5 passed, 0 failed, 0 skipped.
- `npm run verify:pr` — build, extension typecheck, and compiled unit tests passed: 9772 passed, 0 failed, 9 skipped.
- `git diff --check` — passed.
- `node scripts/ci_monitor.cjs check-actions` on changed workflows — completed with existing action patch-version warnings only.

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->
