### PR TITLE
ci: fix linux arm64 native release target

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -34,8 +34,8 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
-          - os: ubuntu-latest
-            target: blacksmith-4vcpu-ubuntu-2404-arm
+          - os: blacksmith-4vcpu-ubuntu-2404-arm
+            target: aarch64-unknown-linux-gnu
             platform: linux-arm64-gnu
             cross: true
           - os: windows-latest


### PR DESCRIPTION
## Linked issue

Closes #5

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Corrects the linux ARM64 native release matrix to separate the runner label from the Rust target triple.
**Why:** The v1.0.0 trusted-publishing run failed before publish because `rustup target add` received the Blacksmith runner label.
**How:** Runs the linux-arm64 job on the Blacksmith ARM runner and passes `aarch64-unknown-linux-gnu` to rustup/cargo.

## What

Updates `.github/workflows/build-native.yml` for the `linux-arm64-gnu` matrix entry only.

## Why

The manual trusted-publishing release run failed in `Build linux-arm64-gnu` at `Add Rust compilation target`:

https://github.com/open-gsd/gsd-pi/actions/runs/26301186746

That blocked publishing `gsd-pi@1.0.0` and the matching native engine package set.

## How

The matrix now uses:

- `os: blacksmith-4vcpu-ubuntu-2404-arm` for the runner
- `target: aarch64-unknown-linux-gnu` for Rust commands

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [x] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-native.yml"); puts "yaml ok"'`
- `git diff --check`
- `actionlint .github/workflows/build-native.yml` was run; it reports pre-existing shellcheck warnings in the publish script and does not know the Blacksmith ARM runner label. Blacksmith documents `blacksmith-4vcpu-ubuntu-2404-arm` as a valid runner label.

## AI disclosure

- [ ] This PR includes AI-assisted code
