### PR TITLE
ci: cross-compile linux arm64 native release

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -34,7 +34,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
-          - os: blacksmith-4vcpu-ubuntu-2404-arm
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64-gnu
             cross: true


### PR DESCRIPTION
## Linked issue

Closes #5

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Keeps the linux ARM64 native release job on the standard Ubuntu runner while cross-compiling to ARM64.
**Why:** The previous fix corrected the Rust target, but the Blacksmith ARM runner label remained queued and blocked the v1.0.0 publish run.
**How:** Uses `ubuntu-latest` for the runner and `aarch64-unknown-linux-gnu` for the Rust target, preserving the existing cross-toolchain install.

## What

Updates the `linux-arm64-gnu` matrix row in `.github/workflows/build-native.yml` only.

## Why

The trusted-publishing retry reached four successful build legs, but `Build linux-arm64-gnu` stayed queued on the Blacksmith ARM runner. This keeps the release path on available hosted Linux capacity and uses the workflow's existing cross-compilation setup.

Cancelled retry: https://github.com/open-gsd/gsd-pi/actions/runs/26301410803

## How

The matrix now uses:

- `os: ubuntu-latest`
- `target: aarch64-unknown-linux-gnu`
- existing `cross: true`

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [x] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-native.yml"); puts "yaml ok"'`
- `git diff --check`
- `actionlint -ignore 'SC1001' -ignore 'SC1012' .github/workflows/build-native.yml`

## AI disclosure

- [ ] This PR includes AI-assisted code
