### PR TITLE
ci: use hosted runner for native publish

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -103,7 +103,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
     # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     name: Publish platform packages
 
     steps:


### PR DESCRIPTION
## Linked issue

Closes #5

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Runs the native publish job on `ubuntu-latest`.
**Why:** The v1.0.0 publish retry built all native artifacts, then sat queued on the Blacksmith publish runner.
**How:** Keeps trusted publishing on a GitHub-hosted runner by changing only the publish job's `runs-on` value.

## What

Updates the `Publish platform packages` job in `.github/workflows/build-native.yml` only.

## Why

The trusted-publishing release run completed all five native build jobs, including linux ARM64, then queued on `blacksmith-4vcpu-ubuntu-2404` for the publish job. `ubuntu-latest` supports OIDC trusted publishing and is available for this workflow.

Cancelled retry: https://github.com/open-gsd/gsd-pi/actions/runs/26301608263

## How

Changes the publish job runner from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-latest`.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-native.yml"); puts "yaml ok"'`
- `git diff --check`
- `actionlint -ignore 'SC1001' -ignore 'SC1012' .github/workflows/build-native.yml`

## AI disclosure

- [ ] This PR includes AI-assisted code
