### PR TITLE
ci: publish stable native releases with latest tag

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -146,8 +146,8 @@ jobs:
             echo "Prerelease detected: ${VERSION} → publishing with --tag next"
           else
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-            echo "tag_flag=" >> "$GITHUB_OUTPUT"
-            echo "Stable release: ${VERSION} → publishing with --tag latest (default)"
+            echo "tag_flag=--tag latest" >> "$GITHUB_OUTPUT"
+            echo "Stable release: ${VERSION} → publishing with --tag latest"
           fi
 
       - name: Publish platform packages


### PR DESCRIPTION
## Linked issue

Closes #5

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Publishes stable native releases with an explicit `--tag latest`.
**Why:** npm rejects implicit `latest` for `1.0.0` because `3.0.0` already exists on the package.
**How:** Sets the stable publish `tag_flag` to `--tag latest` instead of leaving it blank.

## What

Updates `.github/workflows/build-native.yml` stable release tag detection only.

## Why

The trusted-publishing run reached npm and failed with:

`Cannot implicitly apply the "latest" tag because previously published version 3.0.0 is higher than the new version 1.0.0. You must specify a tag using --tag.`

Failed run: https://github.com/open-gsd/gsd-pi/actions/runs/26301880478

## How

For non-prerelease versions, the workflow now emits `tag_flag=--tag latest`, so both platform packages and the main package publish stable releases explicitly.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-native.yml"); puts "yaml ok"'`
- `git diff --check`
- `actionlint -ignore 'SC1001' -ignore 'SC1012' .github/workflows/build-native.yml`

## AI disclosure

- [ ] This PR includes AI-assisted code
