### PR TITLE
ci: claim opengsd npm package identity

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Publish platform packages
         run: |
           for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
-            echo "Publishing @gsd-build/engine-${platform}..."
+            echo "Publishing @opengsd/engine-${platform}..."
             cd "native/npm/${platform}"
             if OUTPUT=$(npm publish --access public ${{ steps.version-check.outputs.tag_flag }} 2>&1); then
               echo "$OUTPUT"
@@ -177,7 +177,7 @@ jobs:
           for attempt in $(seq 1 5); do
             FAILED=0
             for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
-              PKG="@gsd-build/engine-${platform}"
+              PKG="@opengsd/engine-${platform}"
               PUBLISHED=$(npm view "${PKG}@${VERSION}" version 2>/dev/null || echo "")
               if [ "${PUBLISHED}" != "${VERSION}" ]; then
                 FAILED=1
@@ -191,7 +191,7 @@ jobs:
             if [ "$attempt" = "5" ]; then
               echo "::error::One or more platform packages not found after 5 attempts. Aborting."
               for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
-                PKG="@gsd-build/engine-${platform}"
+                PKG="@opengsd/engine-${platform}"
                 PUBLISHED=$(npm view "${PKG}@${VERSION}" version 2>/dev/null || echo "")
                 if [ "${PUBLISHED}" = "${VERSION}" ]; then
                   echo "  ✓ ${PKG}@${VERSION}"
@@ -208,7 +208,7 @@ jobs:
           done
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --omit=optional
 
       - name: Build
         run: npm run build
@@ -241,16 +241,16 @@ jobs:
           npm init -y > /dev/null 2>&1
 
           # Wait for npm registry with exponential backoff (5s, 10s, 20s, 30s, 30s, 30s, 30s — max ~155s vs fixed 5min)
-          echo "Waiting for gsd-pi@${VERSION} to appear on npm..."
+          echo "Waiting for @opengsd/gsd-pi@${VERSION} to appear on npm..."
           DELAY=5
           for attempt in $(seq 1 8); do
-            PUBLISHED=$(npm view "gsd-pi@${VERSION}" version 2>/dev/null || echo "")
+            PUBLISHED=$(npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null || echo "")
             if [ "${PUBLISHED}" = "${VERSION}" ]; then
               echo "  ✓ Version ${VERSION} visible on npm (attempt ${attempt})"
               break
             fi
             if [ "$attempt" = "8" ]; then
-              echo "::warning::gsd-pi@${VERSION} not visible on npm after 8 attempts — skipping smoke test"
+              echo "::warning::@opengsd/gsd-pi@${VERSION} not visible on npm after 8 attempts — skipping smoke test"
               exit 0
             fi
             echo "  Attempt ${attempt}: not yet visible, retrying in ${DELAY}s..."
@@ -260,12 +260,12 @@ jobs:
           done
 
           # Install and verify with backoff (5s, 10s, 20s)
-          echo "Installing gsd-pi@${VERSION}..."
+          echo "Installing @opengsd/gsd-pi@${VERSION}..."
           DELAY=5
           for attempt in 1 2 3; do
-            if npm install "gsd-pi@${VERSION}" 2>&1 | tee /tmp/install-output.txt; then
+            if npm install "@opengsd/gsd-pi@${VERSION}" 2>&1 | tee /tmp/install-output.txt; then
               echo "  ✓ Install succeeded"
-              RAW=$(node node_modules/gsd-pi/dist/loader.js --version 2>&1 || echo "FAILED")
+              RAW=$(node node_modules/@opengsd/gsd-pi/dist/loader.js --version 2>&1 || echo "FAILED")
               ACTUAL=$(echo "$RAW" | sed 's/\x1b\[[0-9;]*m//g' | grep -oE "^${VERSION}$" | head -1)
               if [ "$ACTUAL" = "$VERSION" ]; then
                 echo "  ✓ gsd --version = ${VERSION}"
@@ -282,7 +282,7 @@ jobs:
             sleep "$DELAY"
             DELAY=$((DELAY * 2))
           done
-          echo "::error::Smoke test failed — gsd-pi@${VERSION} not installable"
+          echo "::error::Smoke test failed — @opengsd/gsd-pi@${VERSION} not installable"
           exit 1
 
       - name: Verify dist-tag after publish
@@ -292,7 +292,7 @@ jobs:
           echo "Verifying npm dist-tag 'latest' points to ${VERSION}..."
           DELAY=5
           for attempt in $(seq 1 6); do
-            LATEST=$(npm view gsd-pi dist-tags.latest 2>/dev/null || echo "")
+            LATEST=$(npm view @opengsd/gsd-pi dist-tags.latest 2>/dev/null || echo "")
             if [ "${LATEST}" = "${VERSION}" ]; then
               echo "  ✓ npm dist-tags.latest = ${VERSION}"
               exit 0
@@ -302,5 +302,5 @@ jobs:
             DELAY=$((DELAY * 2))
             if [ "$DELAY" -gt 30 ]; then DELAY=30; fi
           done
-          echo "::error::dist-tags.latest is '${LATEST}' but expected '${VERSION}' — run: npm dist-tag add gsd-pi@${VERSION} latest"
+          echo "::error::dist-tags.latest is '${LATEST}' but expected '${VERSION}' — run: npm dist-tag add @opengsd/gsd-pi@${VERSION} latest"
           exit 1

--- a/.github/workflows/cleanup-dev-versions.yml
+++ b/.github/workflows/cleanup-dev-versions.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PACKAGE="gsd-pi"
+          PACKAGE="@opengsd/gsd-pi"
           MAX_AGE_DAYS=30
           CUTOFF=$(date -u -d "-${MAX_AGE_DAYS} days" +%s 2>/dev/null || date -u -v-${MAX_AGE_DAYS}d +%s)
 
@@ -48,7 +48,7 @@ jobs:
             " 2>/dev/null || echo "0")
 
             if [ "${PUBLISH_TIME}" -gt 0 ] && [ "${PUBLISH_TIME}" -lt "${CUTOFF}" ]; then
-              echo "Unpublishing ${PACKAGE}@${VERSION} (published $(date -u -d @${PUBLISH_TIME} +%Y-%m-%d 2>/dev/null || date -u -r ${PUBLISH_TIME} +%Y-%m-%d))"
+              echo "Unpublishing ${PACKAGE}@${VERSION} (published $(date -u -d "@${PUBLISH_TIME}" +%Y-%m-%d 2>/dev/null || date -u -r "${PUBLISH_TIME}" +%Y-%m-%d))"
               npm unpublish "${PACKAGE}@${VERSION}" || echo "  Warning: failed to unpublish ${VERSION}"
               REMOVED=$((REMOVED + 1))
             fi

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -1,4 +1,4 @@
-# gsd-pi + CI: manual @dev channel publish with approval gate
+# @opengsd/gsd-pi + CI: manual @dev channel publish with approval gate
 name: Dev Publish
 
 # Manual pre-release. Click "Run workflow" in the Actions tab to stamp a
@@ -98,20 +98,20 @@ jobs:
       - name: Publish @dev
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
-          if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
+          if npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null; then
             echo "::error::Version ${VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
-            echo "::error::Move the tag manually if intended: npm dist-tag add gsd-pi@${VERSION} dev"
+            echo "::error::Move the tag manually if intended: npm dist-tag add @opengsd/gsd-pi@${VERSION} dev"
             exit 1
           else
             npm publish --tag dev
           fi
-          echo "Verifying gsd-pi@${VERSION} is reachable on npm..."
+          echo "Verifying @opengsd/gsd-pi@${VERSION} is reachable on npm..."
           for i in 1 2 3 4 5; do
-            npm view "gsd-pi@${VERSION}" version 2>/dev/null && echo "Confirmed: gsd-pi@${VERSION} is live." && exit 0
+            npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null && echo "Confirmed: @opengsd/gsd-pi@${VERSION} is live." && exit 0
             echo "Attempt $i: not yet visible — waiting 10s..."
             sleep 10
           done
-          echo "::error::Publish step succeeded but gsd-pi@${VERSION} is not reachable on npm after 50s. Check NPM_TOKEN permissions and registry config."
+          echo "::error::Publish step succeeded but @opengsd/gsd-pi@${VERSION} is not reachable on npm after 50s. Check NPM_TOKEN permissions and registry config."
           exit 1
 
   dev-verify:
@@ -129,17 +129,17 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'npm'
 
-      - name: Install published gsd-pi@dev globally (with registry propagation retry)
+      - name: Install published @opengsd/gsd-pi@dev globally (with registry propagation retry)
         env:
           DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
         run: |
           for i in 1 2 3 4 5 6; do
-            npm install -g "gsd-pi@${DEV_VERSION}" && exit 0
+            npm install -g "@opengsd/gsd-pi@${DEV_VERSION}" && exit 0
             echo "Attempt $i failed — waiting 10s for npm registry propagation..."
             sleep 10
           done
-          echo "::error::Failed to install gsd-pi@${DEV_VERSION} after 6 attempts."
-          echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
+          echo "::error::Failed to install @opengsd/gsd-pi@${DEV_VERSION} after 6 attempts."
+          echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate @opengsd/gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
           exit 1
 
       - name: Run smoke tests (against installed binary)
@@ -162,6 +162,6 @@ jobs:
         env:
           DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
         run: |
-          echo "::error::Post-publish verification failed for gsd-pi@${DEV_VERSION}."
-          echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
+          echo "::error::Post-publish verification failed for @opengsd/gsd-pi@${DEV_VERSION}."
+          echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate @opengsd/gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
           exit 1

--- a/.github/workflows/next-publish.yml
+++ b/.github/workflows/next-publish.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Publish @next
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
-          if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
+          if npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null; then
             echo "::error::Version ${VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
-            echo "::error::Move the tag manually if intended: npm dist-tag add gsd-pi@${VERSION} next"
+            echo "::error::Move the tag manually if intended: npm dist-tag add @opengsd/gsd-pi@${VERSION} next"
             exit 1
           else
             npm publish --tag next
@@ -120,16 +120,16 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'npm'
 
-      - name: Install published gsd-pi@next globally (with registry propagation retry)
+      - name: Install published @opengsd/gsd-pi@next globally (with registry propagation retry)
         env:
           NEXT_VERSION: ${{ needs.next-publish.outputs.next-version }}
         run: |
           for i in 1 2 3 4 5 6; do
-            npm install -g "gsd-pi@${NEXT_VERSION}" && exit 0
+            npm install -g "@opengsd/gsd-pi@${NEXT_VERSION}" && exit 0
             echo "Attempt $i failed — waiting 10s for npm registry propagation..."
             sleep 10
           done
-          echo "::error::Failed to install gsd-pi@${NEXT_VERSION} after 6 attempts. The @next tag may point at a broken artifact — deprecate it with: npm deprecate gsd-pi@${NEXT_VERSION} 'broken build'"
+          echo "::error::Failed to install @opengsd/gsd-pi@${NEXT_VERSION} after 6 attempts. The @next tag may point at a broken artifact — deprecate it with: npm deprecate @opengsd/gsd-pi@${NEXT_VERSION} 'broken build'"
           exit 1
 
       - name: Run smoke tests (against installed binary)
@@ -152,6 +152,6 @@ jobs:
         env:
           NEXT_VERSION: ${{ needs.next-publish.outputs.next-version }}
         run: |
-          echo "::error::Post-publish verification failed for gsd-pi@${NEXT_VERSION}. The @next tag still points at this version on npm."
-          echo "::error::Recommended actions: (1) investigate the failing step above, (2) deprecate the broken version with 'npm deprecate gsd-pi@${NEXT_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Next Publish."
+          echo "::error::Post-publish verification failed for @opengsd/gsd-pi@${NEXT_VERSION}. The @next tag still points at this version on npm."
+          echo "::error::Recommended actions: (1) investigate the failing step above, (2) deprecate the broken version with 'npm deprecate @opengsd/gsd-pi@${NEXT_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Next Publish."
           exit 1

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -115,7 +115,7 @@ jobs:
           else
             if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
               echo "::error::Version ${RELEASE_VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
-              echo "::error::Promote manually if intended: npm dist-tag add gsd-pi@${RELEASE_VERSION} latest"
+              echo "::error::Promote manually if intended: npm dist-tag add @opengsd/gsd-pi@${RELEASE_VERSION} latest"
               exit 1
             else
               echo "$OUTPUT"
@@ -149,7 +149,7 @@ jobs:
           NOTES=$(cat /tmp/release-notes.md)
           curl -s -X POST "$DISCORD_WEBHOOK" \
             -H "Content-Type: application/json" \
-            -d "$(jq -n --arg c "**GSD v${RELEASE_VERSION} Released**\n\n${NOTES}\n\n\`npm i gsd-pi@${RELEASE_VERSION}\`" '{content:$c}')"
+            -d "$(jq -n --arg c "**GSD v${RELEASE_VERSION} Released**\n\n${NOTES}\n\n\`npm i @opengsd/gsd-pi@${RELEASE_VERSION}\`" '{content:$c}')"
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -28,7 +28,7 @@ jobs:
             const reportedVersion = match[1].trim().replace(/^v/, '');
             core.info('Reported version: ' + reportedVersion);
 
-            const npmResponse = await fetch('https://registry.npmjs.org/gsd-pi/latest');
+            const npmResponse = await fetch('https://registry.npmjs.org/@opengsd%2fgsd-pi/latest');
             if (!npmResponse.ok) {
               core.setFailed('npm registry request failed: ' + npmResponse.status);
               return;
@@ -81,7 +81,7 @@ jobs:
               'Before we investigate further, please upgrade and check whether the issue still occurs:',
               '',
               '```bash',
-              'npm install -g gsd-pi@latest',
+              'npm install -g @opengsd/gsd-pi@latest',
               'gsd --version   # should print ' + latestVersion,
               '```',
               '',

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gsd-build/engine-darwin-arm64",
+  "name": "@opengsd/engine-darwin-arm64",
   "version": "1.0.0",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gsd-build/engine-darwin-x64",
+  "name": "@opengsd/engine-darwin-x64",
   "version": "1.0.0",
   "description": "GSD native engine binary for macOS Intel",
   "os": [

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gsd-build/engine-linux-arm64-gnu",
+  "name": "@opengsd/engine-linux-arm64-gnu",
   "version": "1.0.0",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gsd-build/engine-linux-x64-gnu",
+  "name": "@opengsd/engine-linux-x64-gnu",
   "version": "1.0.0",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gsd-build/engine-win32-x64-msvc",
+  "name": "@opengsd/engine-win32-x64-msvc",
   "version": "1.0.0",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gsd-pi",
+  "name": "@opengsd/gsd-pi",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gsd-pi",
+      "name": "@opengsd/gsd-pi",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -67,11 +67,11 @@
       },
       "optionalDependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.83",
-        "@gsd-build/engine-darwin-arm64": ">=1.0.0",
-        "@gsd-build/engine-darwin-x64": ">=1.0.0",
-        "@gsd-build/engine-linux-arm64-gnu": ">=1.0.0",
-        "@gsd-build/engine-linux-x64-gnu": ">=1.0.0",
-        "@gsd-build/engine-win32-x64-msvc": ">=1.0.0",
+        "@opengsd/engine-darwin-arm64": ">=1.0.0",
+        "@opengsd/engine-darwin-x64": ">=1.0.0",
+        "@opengsd/engine-linux-arm64-gnu": ">=1.0.0",
+        "@opengsd/engine-linux-x64-gnu": ">=1.0.0",
+        "@opengsd/engine-win32-x64-msvc": ">=1.0.0",
         "fsevents": "~2.3.3",
         "koffi": "^2.9.0"
       }
@@ -1606,71 +1606,6 @@
     "node_modules/@gsd-build/daemon": {
       "resolved": "packages/daemon",
       "link": true
-    },
-    "node_modules/@gsd-build/engine-darwin-arm64": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-darwin-arm64/-/engine-darwin-arm64-2.78.1.tgz",
-      "integrity": "sha512-AGiFQQkspnEhBRefNecBLktWTYVRn2TmVSaYw4f1iql5BSmNJx+mcjttxLTAcNA9bcZjebJyDq0VOYK15enahQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@gsd-build/engine-darwin-x64": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-darwin-x64/-/engine-darwin-x64-2.78.1.tgz",
-      "integrity": "sha512-lnWeKMJ3narqQ24NlGfdi9DDszCNcHsl25wg31vpwSfDzPTsWShY8iehv6eiIolX5k4qNdd6QlLb7AgOf+/4Rw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@gsd-build/engine-linux-arm64-gnu": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-linux-arm64-gnu/-/engine-linux-arm64-gnu-2.78.1.tgz",
-      "integrity": "sha512-ASRWW5lGkbXAy827Q2erORyHKRfQb+VD+ngGWa+BG9eGyUx2JTEl+YvmZJayv9T2xQzJZU/wk5o2JPgrpm1yLg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@gsd-build/engine-linux-x64-gnu": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-linux-x64-gnu/-/engine-linux-x64-gnu-2.78.1.tgz",
-      "integrity": "sha512-ZKhoAXXzVdJieA8dkoWkVpPAzQ4TC9ePGS3HgneG06x5aq7eKH2jeYz2QYaU2vREp0e5mAXaKSoQjgv3bgl98g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@gsd-build/engine-win32-x64-msvc": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-win32-x64-msvc/-/engine-win32-x64-msvc-2.78.1.tgz",
-      "integrity": "sha512-fqj/QOGG2EoIwatdMSlT98t8ej4I76ru1JEanwS+HFumfIW7ONItlDiRji1xTg92o4Q0g9W3URc87uD3rzTskA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@gsd-build/mcp-server": {
       "resolved": "packages/mcp-server",
@@ -6468,6 +6403,61 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "node_modules/@opengsd/engine-darwin-arm64": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ]
+    },
+    "node_modules/@opengsd/engine-darwin-x64": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ]
+    },
+    "node_modules/@opengsd/engine-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ]
+    },
+    "node_modules/@opengsd/engine-linux-x64-gnu": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ]
+    },
+    "node_modules/@opengsd/engine-win32-x64-msvc": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gsd-pi",
+  "name": "@opengsd/gsd-pi",
   "version": "1.0.0",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
@@ -157,11 +157,11 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.83",
-    "@gsd-build/engine-darwin-arm64": ">=1.0.0",
-    "@gsd-build/engine-darwin-x64": ">=1.0.0",
-    "@gsd-build/engine-linux-arm64-gnu": ">=1.0.0",
-    "@gsd-build/engine-linux-x64-gnu": ">=1.0.0",
-    "@gsd-build/engine-win32-x64-msvc": ">=1.0.0",
+    "@opengsd/engine-darwin-arm64": ">=1.0.0",
+    "@opengsd/engine-darwin-x64": ">=1.0.0",
+    "@opengsd/engine-linux-arm64-gnu": ">=1.0.0",
+    "@opengsd/engine-linux-x64-gnu": ">=1.0.0",
+    "@opengsd/engine-win32-x64-msvc": ">=1.0.0",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0"
   },

--- a/packages/native/src/__tests__/truncate.test.mjs
+++ b/packages/native/src/__tests__/truncate.test.mjs
@@ -114,7 +114,7 @@ describe("truncateHead", () => {
 
 // ── truncateOutput ───────────────────────────────────────────────────────
 
-// `truncateOutput` may be missing from published `@gsd-build/engine-*`
+// `truncateOutput` may be missing from published `@opengsd/engine-*`
 // binaries (see #4854 — coverage fix surfaced that some symbols weren't
 // in the shipped binary). Skip this suite when the function isn't
 // present rather than failing with a TypeError on every test.

--- a/packages/native/src/native.ts
+++ b/packages/native/src/native.ts
@@ -3,7 +3,7 @@
  *
  * Locates and loads the compiled Rust N-API addon (`.node` file).
  * Resolution order:
- *   1. @gsd-build/engine-{platform} npm optional dependency (production install)
+ *   1. @opengsd/engine-{platform} npm optional dependency (production install)
  *   2. native/addon/gsd_engine.{platform}.node (local release build)
  *   3. native/addon/gsd_engine.dev.node (local debug build)
  */
@@ -37,10 +37,10 @@ function loadNative(): Record<string, unknown> {
   const packageSuffix = platformPackageMap[platformTag];
   if (packageSuffix) {
     try {
-      _loadedSuccessfully = true; return _require(`@gsd-build/engine-${packageSuffix}`) as Record<string, unknown>;
+      _loadedSuccessfully = true; return _require(`@opengsd/engine-${packageSuffix}`) as Record<string, unknown>;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      errors.push(`@gsd-build/engine-${packageSuffix}: ${message}`);
+      errors.push(`@opengsd/engine-${packageSuffix}: ${message}`);
     }
   }
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -3,13 +3,13 @@
 /**
  * GSD Interactive Installer
  *
- * Entry point for `npx gsd-pi` or `npx gsd-pi@latest`.
+ * Entry point for `npx @opengsd/gsd-pi` or `npx @opengsd/gsd-pi@latest`.
  * When invoked directly (not as a postinstall hook), runs the visual
  * installer with full terminal access — banner, spinners, progress.
  *
  * If GSD is already installed and the user runs `gsd`, this script
  * is NOT invoked — the normal loader.js handles that via the "gsd" bin.
- * This script only fires for `npx gsd-pi` (the package name bin).
+ * This script only fires for `npx @opengsd/gsd-pi` (the package name bin).
  */
 
 import { execSync, spawnSync, exec as execCb } from 'child_process'
@@ -24,8 +24,8 @@ import { createInterface } from 'readline'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-// packageRoot is always relative to this script — it's the gsd-pi package directory.
-// This is correct whether running as postinstall (inside node_modules/gsd-pi) or
+// packageRoot is always relative to this script — it's the @opengsd/gsd-pi package directory.
+// This is correct whether running as postinstall (inside node_modules/@opengsd/gsd-pi) or
 // via npx (inside a transient cache), since __dirname resolves to the script's location.
 const IS_POSTINSTALL = !!process.env.npm_lifecycle_event
 const packageRoot = resolve(__dirname, '..')
@@ -61,8 +61,8 @@ if (HAS_HELP) {
   ${c.bold}GSD Installer${c.reset} ${c.dim}v${gsdVersion}${c.reset}
 
   ${c.yellow}Usage:${c.reset}
-    npx gsd-pi@latest          Install GSD globally (recommended)
-    npx gsd-pi@latest --local  Install GSD to current project
+    npx @opengsd/gsd-pi@latest          Install GSD globally (recommended)
+    npx @opengsd/gsd-pi@latest --local  Install GSD to current project
 
   ${c.yellow}Options:${c.reset}
     ${c.cyan}--local${c.reset}     Install to current directory instead of globally
@@ -166,11 +166,11 @@ const managedBinaryPath = join(managedBinDir, platform() === 'win32' ? 'rtk.exe'
 // ── Step: npm install -g ───────────────────────────────────────────────────
 
 async function installGlobally() {
-  startSpinner('Installing gsd-pi globally...             ')
+  startSpinner('Installing @opengsd/gsd-pi globally...             ')
   try {
     const result = await new Promise((res) => {
       execCb(
-        `npm install -g gsd-pi@${gsdVersion}`,
+        `npm install -g @opengsd/gsd-pi@${gsdVersion}`,
         { timeout: 300_000 },
         (error, stdout, stderr) => {
           res({ ok: !error, stdout: stdout || '', stderr: stderr || '', error })
@@ -185,11 +185,11 @@ async function installGlobally() {
         .filter(l => !l.includes('npm warn') && !l.includes('npm WARN') && l.trim())
         .slice(-3)
         .join('; ')
-      printFail('Global install failed', meaningful || 'run npm install -g gsd-pi manually')
+      printFail('Global install failed', meaningful || 'run npm install -g @opengsd/gsd-pi manually')
       return false
     }
 
-    printStep('Installed globally', 'npm install -g gsd-pi')
+    printStep('Installed globally', 'npm install -g @opengsd/gsd-pi')
     return true
   } catch (err) {
     stopSpinner()
@@ -199,11 +199,11 @@ async function installGlobally() {
 }
 
 async function installLocally() {
-  startSpinner('Installing gsd-pi locally...              ')
+  startSpinner('Installing @opengsd/gsd-pi locally...              ')
   try {
     const result = await new Promise((res) => {
       execCb(
-        `npm install gsd-pi@${gsdVersion}`,
+        `npm install @opengsd/gsd-pi@${gsdVersion}`,
         { cwd: process.cwd(), timeout: 300_000 },
         (error, stdout, stderr) => {
           res({ ok: !error, stdout: stdout || '', stderr: stderr || '', error })
@@ -218,11 +218,11 @@ async function installLocally() {
         .filter(l => !l.includes('npm warn') && !l.includes('npm WARN') && l.trim())
         .slice(-3)
         .join('; ')
-      printFail('Local install failed', meaningful || 'run npm install gsd-pi manually')
+      printFail('Local install failed', meaningful || 'run npm install @opengsd/gsd-pi manually')
       return false
     }
 
-    printStep('Installed locally', 'npm install gsd-pi')
+    printStep('Installed locally', 'npm install @opengsd/gsd-pi')
     return true
   } catch (err) {
     stopSpinner()

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -152,7 +152,7 @@ try {
   // Checks every package with `gsd.linkable: true` — not just a hand-picked subset —
   // so any future addition is automatically covered.
   console.log('==> Verifying workspace package resolution (every linkable package)...');
-  const installedRoot = join(installDir, 'node_modules', 'gsd-pi');
+  const installedRoot = join(installDir, 'node_modules', '@opengsd', 'gsd-pi');
   let resolutionFailed = false;
   for (const pkg of getLinkablePackages()) {
     const pkgPath = join(installedRoot, 'node_modules', pkg.scope, pkg.name);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ function exitIfManagedResourcesAreNewer(currentAgentDir: string): void {
   process.stderr.write(
     `[gsd] ${chalk.yellow('Version mismatch detected')}\n` +
     `[gsd] Synced resources are from ${chalk.bold(`v${managedVersion}`)}, but this \`gsd\` binary is ${chalk.dim(`v${currentVersion}`)}.\n` +
-    `[gsd] Run ${chalk.bold('npm install -g gsd-pi@latest')} or ${chalk.bold('gsd update')}, then try again.\n`,
+    `[gsd] Run ${chalk.bold('npm install -g @opengsd/gsd-pi@latest')} or ${chalk.bold('gsd update')}, then try again.\n`,
   )
   process.exit(1)
 }

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -19,7 +19,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     '',
     'Update GSD to the latest version.',
     '',
-    'Equivalent to: npm install -g gsd-pi@latest',
+    'Equivalent to: npm install -g @opengsd/gsd-pi@latest',
   ].join('\n'),
 
   sessions: [

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -110,7 +110,7 @@ if (!existsSync(appRoot)) {
 // GSD_CODING_AGENT_DIR — tells pi's getAgentDir() to return ~/.gsd/agent/ instead of ~/.gsd/agent/
 process.env.GSD_CODING_AGENT_DIR = agentDir
 
-// GSD_PKG_ROOT — absolute path to gsd-pi package root. Used by deployed extensions
+// GSD_PKG_ROOT — absolute path to @opengsd/gsd-pi package root. Used by deployed extensions
 // (e.g. auto.ts resume path) to import modules like resource-loader.js that live
 // in the package tree, not in the deployed ~/.gsd/agent/ tree.
 process.env.GSD_PKG_ROOT = gsdRoot
@@ -234,11 +234,11 @@ if (missingPackages.length > 0) {
   process.stderr.write(
     `\nError: GSD installation is broken — missing packages: ${missing}\n\n` +
     `This is usually caused by one of:\n` +
-    `  • An outdated version installed from npm (run: npm install -g gsd-pi@latest)\n` +
+    `  • An outdated version installed from npm (run: npm install -g @opengsd/gsd-pi@latest)\n` +
     `  • The packages/ directory was excluded from the installed tarball\n` +
     `  • A filesystem error prevented linking or copying the workspace packages\n\n` +
     `Fix it by reinstalling:\n\n` +
-    `  npm install -g gsd-pi@latest\n\n` +
+    `  npm install -g @opengsd/gsd-pi@latest\n\n` +
     `If the issue persists, please open an issue at:\n` +
     `  https://github.com/open-gsd/gsd-pi/issues\n`
   )

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -36,7 +36,7 @@ import {
   scopeGsdWorkflowToolsForDispatch,
 } from "./bootstrap/register-hooks.js";
 
-const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/gsd-pi/latest";
+const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/@opengsd%2fgsd-pi/latest";
 const UPDATE_FETCH_TIMEOUT_MS = 5000;
 
 // Detects a bun-installed gsd via `process.argv[1]`. Mirrors isBunInstall in
@@ -474,7 +474,7 @@ function compareSemverLocal(a: string, b: string): number {
 export async function handleUpdate(ctx: ExtensionCommandContext): Promise<void> {
   const { execSync } = await import("node:child_process");
 
-  const NPM_PACKAGE = "gsd-pi";
+  const NPM_PACKAGE = "@opengsd/gsd-pi";
   const current = process.env.GSD_VERSION || "0.0.0";
 
   ctx.ui.notify(`Current version: v${current}\nChecking npm registry...`, "info");

--- a/src/resources/extensions/gsd/file-lock.ts
+++ b/src/resources/extensions/gsd/file-lock.ts
@@ -15,7 +15,7 @@ function _require(name: string): any {
   } catch {
     try {
       const gsdPiRequire = createRequire(
-        join(process.cwd(), "node_modules", "gsd-pi", "index.js"),
+        join(process.cwd(), "node_modules", "@opengsd", "gsd-pi", "index.js"),
       );
       return gsdPiRequire(name);
     } catch {

--- a/src/tests/build-script-contract.test.ts
+++ b/src/tests/build-script-contract.test.ts
@@ -12,7 +12,7 @@ function findRepoRoot(start: string): string {
 	for (let i = 0; i < 10; i++) {
 		try {
 			const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
-			if (pkg.name === "gsd-pi" && pkg.workspaces) return dir;
+			if (pkg.name === "@opengsd/gsd-pi" && pkg.workspaces) return dir;
 		} catch {
 			// Keep walking.
 		}

--- a/src/tests/integration/pack-install.test.ts
+++ b/src/tests/integration/pack-install.test.ts
@@ -72,7 +72,7 @@ function runNpmQuiet(args: string[], sandbox: NpmSandbox): void {
 
 function packTarball(sandbox: NpmSandbox): string {
   const pkg = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8"));
-  const safeName = pkg.name.replace(/^@[^/]+\//, "").replace(/\//g, "-");
+  const safeName = pkg.name.replace(/^@/, "").replace(/\//g, "-");
   const tarball = `${safeName}-${pkg.version}.tgz`;
   const packDestination = join(sandbox.rootDir, "pack-output");
 
@@ -166,7 +166,7 @@ test("tarball installs and gsd binary resolves", async (t) => {
   assert.ok(existsSync(installedBin), `gsd binary exists in node_modules/.bin/ (${binName})`);
 
   // Verify loader.js is executable (has shebang)
-  const installedLoader = join(sandbox.installPrefix, "node_modules", "gsd-pi", "dist", "loader.js");
+  const installedLoader = join(sandbox.installPrefix, "node_modules", "@opengsd", "gsd-pi", "dist", "loader.js");
   const loaderContent = readFileSync(installedLoader, "utf-8");
   if (process.platform !== "win32") {
     assert.ok(loaderContent.startsWith("#!/usr/bin/env node"), "loader.js has node shebang");
@@ -176,6 +176,7 @@ test("tarball installs and gsd binary resolves", async (t) => {
   const installedGsdExt = join(
     sandbox.installPrefix,
     "node_modules",
+    "@opengsd",
     "gsd-pi",
     "src",
     "resources",
@@ -283,6 +284,6 @@ test("gsd exits early with a clear message when synced resources are newer than 
 
   assert.equal(result.code, 1, "startup exits with code 1 on version skew");
   assert.match(result.stderr, /Version mismatch detected/, "prints a friendly skew header");
-  assert.match(result.stderr, /npm install -g gsd-pi@latest|gsd update/, "prints upgrade guidance");
+  assert.match(result.stderr, /npm install -g @opengsd\/gsd-pi@latest|gsd update/, "prints upgrade guidance");
   assert.doesNotMatch(result.stderr, /\[gsd\] Extension load error/, "fails before extension loading");
 });

--- a/src/tests/integration/web-boot-node24.test.ts
+++ b/src/tests/integration/web-boot-node24.test.ts
@@ -60,7 +60,7 @@ test(
   "resolveTypeStrippingFlag returns --experimental-transform-types for paths under node_modules/ on Node >= 22.7",
   { skip: !isNode22_7OrNewer },
   () => {
-    const flag = resolveTypeStrippingFlag("/usr/lib/node_modules/gsd-pi")
+    const flag = resolveTypeStrippingFlag("/usr/lib/node_modules/@opengsd/gsd-pi")
     assert.equal(flag, "--experimental-transform-types")
   },
 )
@@ -69,7 +69,7 @@ test(
   "resolveTypeStrippingFlag returns --experimental-strip-types for paths under node_modules/ on Node < 22.7",
   { skip: isNode22_7OrNewer },
   () => {
-    const flag = resolveTypeStrippingFlag("/usr/lib/node_modules/gsd-pi")
+    const flag = resolveTypeStrippingFlag("/usr/lib/node_modules/@opengsd/gsd-pi")
     // On older Node, falls back to strip-types since transform-types isn't available
     assert.equal(flag, "--experimental-strip-types")
   },

--- a/src/tests/integration/web-subprocess-module-resolution.test.ts
+++ b/src/tests/integration/web-subprocess-module-resolution.test.ts
@@ -18,7 +18,7 @@ test("isUnderNodeModules returns false for paths outside node_modules", () => {
 
 test("isUnderNodeModules returns true for Unix paths under node_modules/", () => {
   assert.equal(
-    isUnderNodeModules("/usr/lib/node_modules/gsd-pi"),
+    isUnderNodeModules("/usr/lib/node_modules/@opengsd/gsd-pi"),
     true,
   )
 })
@@ -56,7 +56,7 @@ test("resolveSubprocessModule returns source .ts path when NOT under node_module
 })
 
 test("resolveSubprocessModule returns compiled .js path when under node_modules and dist file exists", () => {
-  const packageRoot = "/usr/lib/node_modules/gsd-pi"
+  const packageRoot = "/usr/lib/node_modules/@opengsd/gsd-pi"
   const distPath = join(packageRoot, "dist", "resources/extensions/gsd/workspace-index.js")
   const result = resolveSubprocessModule(
     packageRoot,
@@ -71,7 +71,7 @@ test("resolveSubprocessModule returns compiled .js path when under node_modules 
 })
 
 test("resolveSubprocessModule falls back to source .ts when under node_modules but dist file missing", () => {
-  const packageRoot = "/usr/lib/node_modules/gsd-pi"
+  const packageRoot = "/usr/lib/node_modules/@opengsd/gsd-pi"
   const result = resolveSubprocessModule(
     packageRoot,
     "resources/extensions/gsd/workspace-index.ts",
@@ -100,7 +100,7 @@ test("resolveSubprocessModule handles Windows paths under node_modules", () => {
 })
 
 test("resolveSubprocessModule strips .ts extension when building dist .js path", () => {
-  const packageRoot = "/usr/lib/node_modules/gsd-pi"
+  const packageRoot = "/usr/lib/node_modules/@opengsd/gsd-pi"
   let checkedPath = ""
   resolveSubprocessModule(
     packageRoot,
@@ -122,9 +122,9 @@ test("resolveSubprocessModule strips .ts extension when building dist .js path",
 test("buildSubprocessPrefixArgs omits TS loaders when compiled JS was selected", () => {
   assert.deepEqual(
     buildSubprocessPrefixArgs(
-      "/usr/lib/node_modules/gsd-pi",
+      "/usr/lib/node_modules/@opengsd/gsd-pi",
       {
-        modulePath: "/usr/lib/node_modules/gsd-pi/dist/resources/extensions/gsd/workspace-index.js",
+        modulePath: "/usr/lib/node_modules/@opengsd/gsd-pi/dist/resources/extensions/gsd/workspace-index.js",
         useCompiledJs: true,
       },
       "file:///loader.mjs",

--- a/src/tests/npm-package-identity.test.ts
+++ b/src/tests/npm-package-identity.test.ts
@@ -1,0 +1,54 @@
+// Project/App: GSD-2
+// File Purpose: Regression coverage for the public npm package identity.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+function findRepoRoot(start: string): string {
+	let dir = start;
+	for (let i = 0; i < 10; i++) {
+		try {
+			const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+			if (pkg.name === "@opengsd/gsd-pi" && pkg.workspaces) return dir;
+		} catch {
+			// Keep walking.
+		}
+		const parent = resolve(dir, "..");
+		if (parent === dir) break;
+		dir = parent;
+	}
+	throw new Error(`Could not locate repo root from ${start}`);
+}
+
+const projectRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
+
+function readPackageJson(path: string): { name?: string; optionalDependencies?: Record<string, string> } {
+	return JSON.parse(readFileSync(join(projectRoot, path), "utf8"));
+}
+
+test("published npm package names use the @opengsd scope", () => {
+	const rootPackage = readPackageJson("package.json");
+	assert.equal(rootPackage.name, "@opengsd/gsd-pi");
+
+	const platforms = [
+		"darwin-arm64",
+		"darwin-x64",
+		"linux-arm64-gnu",
+		"linux-x64-gnu",
+		"win32-x64-msvc",
+	];
+
+	for (const platform of platforms) {
+		const nativePackage = readPackageJson(`native/npm/${platform}/package.json`);
+		const expectedName = `@opengsd/engine-${platform}`;
+		assert.equal(nativePackage.name, expectedName);
+		assert.equal(
+			rootPackage.optionalDependencies?.[expectedName],
+			">=1.0.0",
+			`root package must install the ${expectedName} native optional dependency`,
+		);
+	}
+});

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -52,7 +52,7 @@ test("resolveInstallCommand returns bun command when running under Bun (#4145)",
   const orig = (process.versions as Record<string, string | undefined>).bun;
   try {
     (process.versions as Record<string, string | undefined>).bun = "1.0.0";
-    assert.equal(resolveInstallCommand("gsd-pi@latest"), "bun add -g gsd-pi@latest");
+    assert.equal(resolveInstallCommand("@opengsd/gsd-pi@latest"), "bun add -g @opengsd/gsd-pi@latest");
   } finally {
     if (orig === undefined) {
       delete (process.versions as Record<string, string | undefined>).bun;
@@ -67,7 +67,7 @@ test("resolveInstallCommand returns npm command when not running under Bun (#414
   const orig = (process.versions as Record<string, string | undefined>).bun;
   try {
     delete (process.versions as Record<string, string | undefined>).bun;
-    assert.equal(resolveInstallCommand("gsd-pi@latest"), "npm install -g gsd-pi@latest");
+    assert.equal(resolveInstallCommand("@opengsd/gsd-pi@latest"), "npm install -g @opengsd/gsd-pi@latest");
   } finally {
     if (orig !== undefined) {
       (process.versions as Record<string, string | undefined>).bun = orig;
@@ -104,7 +104,7 @@ test("/gsd update handler fetches latest version through the registry endpoint (
     }
   }
 
-  assert.deepEqual(fetchUrls, ["https://registry.npmjs.org/gsd-pi/latest"]);
+  assert.deepEqual(fetchUrls, ["https://registry.npmjs.org/@opengsd%2fgsd-pi/latest"]);
   assert.ok(notifications.some((notification) => notification.message.includes("Already up to date")));
 });
 
@@ -130,7 +130,7 @@ test("isBunInstall detects bun install via argv[1] even when process.versions.bu
 
     // Non-bun path must NOT match
     delete process.env.BUN_INSTALL;
-    process.argv[1] = "/usr/local/lib/node_modules/gsd-pi/dist/loader.js";
+    process.argv[1] = "/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js";
     assert.equal(isBunInstall(), false, "npm global install path should not match");
 
     // Prefix false-positive guard: /.bun/bin-other should not match /.bun/bin
@@ -158,7 +158,7 @@ test("isBunInstall returns true when running under Bun runtime (#4145)", async (
   try {
     (process.versions as Record<string, string | undefined>).bun = "1.0.0";
     // Even with a non-bun argv[1], runtime detection wins
-    process.argv[1] = "/usr/local/lib/node_modules/gsd-pi/dist/loader.js";
+    process.argv[1] = "/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js";
     assert.equal(isBunInstall(), true);
   } finally {
     if (orig === undefined) {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -6,10 +6,10 @@ import { appRoot } from './app-paths.js'
 import { execSync } from 'node:child_process'
 
 const CACHE_FILE = join(appRoot, '.update-check')
-const NPM_PACKAGE_NAME = 'gsd-pi'
+const NPM_PACKAGE_NAME = '@opengsd/gsd-pi'
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24 hours
 const FETCH_TIMEOUT_MS = 5000
-const DEFAULT_REGISTRY_URL = `https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`
+const DEFAULT_REGISTRY_URL = `https://registry.npmjs.org/@opengsd%2fgsd-pi/latest`
 
 interface UpdateCheckCache {
   lastCheck: number
@@ -102,7 +102,7 @@ export function resolveInstallCommand(pkg: string): string {
 }
 
 function printUpdateBanner(current: string, latest: string): void {
-  const installCmd = resolveInstallCommand('gsd-pi')
+  const installCmd = resolveInstallCommand('@opengsd/gsd-pi')
   process.stderr.write(
     `  ${chalk.yellow('Update available:')} ${chalk.dim(`v${current}`)} → ${chalk.bold(`v${latest}`)}\n` +
     `  ${chalk.dim('Run')} ${installCmd} ${chalk.dim('or')} /gsd update ${chalk.dim('to upgrade')}\n\n`,

--- a/src/update-cmd.ts
+++ b/src/update-cmd.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process'
 import { compareSemver, fetchLatestVersionFromRegistry, resolveInstallCommand } from './update-check.js'
 
-const NPM_PACKAGE = 'gsd-pi'
+const NPM_PACKAGE = '@opengsd/gsd-pi'
 
 export async function runUpdate(): Promise<void> {
   const current = process.env.GSD_VERSION || '0.0.0'

--- a/src/web/ts-subprocess-flags.ts
+++ b/src/web/ts-subprocess-flags.ts
@@ -6,7 +6,7 @@ import { join } from "node:path"
  *
  * Node v24 enforces ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING for files
  * resolved under `node_modules/`. When GSD is installed globally via npm,
- * all source files live under `node_modules/gsd-pi/src/...`, so
+ * all source files live under `node_modules/@opengsd/gsd-pi/src/...`, so
  * `--experimental-strip-types` fails deterministically.
  *
  * `--experimental-transform-types` applies a full TypeScript transform that

--- a/src/web/update-service.ts
+++ b/src/web/update-service.ts
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process"
 import { compareSemver } from "../update-check.ts"
 
-const NPM_PACKAGE_NAME = "gsd-pi"
-const REGISTRY_URL = `https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`
+const NPM_PACKAGE_NAME = "@opengsd/gsd-pi"
+const REGISTRY_URL = `https://registry.npmjs.org/@opengsd%2fgsd-pi/latest`
 const FETCH_TIMEOUT_MS = 5000
 const NPM_COMMAND = process.platform === "win32" ? "npm.cmd" : "npm"
 
@@ -59,7 +59,7 @@ export function getUpdateStatus(): UpdateState {
 }
 
 /**
- * Triggers an async global npm install of gsd-pi@latest.
+ * Triggers an async global npm install of @opengsd/gsd-pi@latest.
  * Returns `true` if the update was started, `false` if one is already running.
  * The child process runs in the background; poll `getUpdateStatus()` for progress.
  */
@@ -70,7 +70,7 @@ export function triggerUpdate(targetVersion?: string): boolean {
 
   updateState = { status: "running", targetVersion }
 
-  const child = spawn(NPM_COMMAND, ["install", "-g", "gsd-pi@latest"], {
+  const child = spawn(NPM_COMMAND, ["install", "-g", "@opengsd/gsd-pi@latest"], {
     stdio: ["ignore", "ignore", "pipe"],
     // Detach so the child process is not killed if the parent exits
     detached: false,

--- a/tests/live-regression/run.ts
+++ b/tests/live-regression/run.ts
@@ -13,7 +13,7 @@
  * These tests DO NOT require LLM API keys — they test the state machine
  * and infrastructure, not the LLM execution.
  *
- * Run from CI pipeline after `npm install -g gsd-pi@<version>`:
+ * Run from CI pipeline after `npm install -g @opengsd/gsd-pi@<version>`:
  *   node --experimental-strip-types tests/live-regression/run.ts
  *
  * Or locally:


### PR DESCRIPTION
## TL;DR

**What:** Switches the public npm release identity to @opengsd/gsd-pi and @opengsd/engine-*.
**Why:** v1.0.0 needs to claim the new @opengsd npm packages instead of publishing to the old gsd-pi/@gsd-build package history.
**How:** Updates package manifests, native package resolution, release/update/install workflows, and package-install tests to use the @opengsd scope.

## What

- Renames the root npm package to @opengsd/gsd-pi.
- Renames native platform npm packages to @opengsd/engine-* and updates root optionalDependencies.
- Updates release, dev, next, cleanup, version-check, install, update, and smoke-test paths to use @opengsd/gsd-pi.
- Keeps GitHub repo URLs, Docker image names, and internal workspace package names unchanged.
- Adds regression coverage that the public npm package identity and native optional dependencies stay aligned.

## Why

The intended v1.0.0 release is for the new @opengsd npm scope. Publishing to the historical gsd-pi/@gsd-build names reuses old npm history and blocks the clean v1.0 claim.

Closes #10

## How

The release workflow publishes native packages first as @opengsd/engine-* and then publishes the main package as @opengsd/gsd-pi. The publish job installs dependencies with optional deps omitted before the first native package claim, while the published package still declares the platform optional dependencies for consumers.

Validation performed:

- npm view @opengsd/gsd-pi returns E404/missing before claim.
- npm ci --omit=optional
- npm run build
- npm run validate-pack
- npm run typecheck:extensions
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/integration/pack-install.test.ts src/tests/npm-package-identity.test.ts src/tests/update-cmd-diagnostics.test.ts
- npx --yes actionlint -ignore 'SC1001' -ignore 'SC1012' .github/workflows/build-native.yml .github/workflows/version-check.yml .github/workflows/prod-release.yml .github/workflows/dev-publish.yml .github/workflows/next-publish.yml .github/workflows/cleanup-dev-versions.yml
- git diff --check

### Change type checklist

- [ ] feat — New feature or capability
- [ ] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [x] test — Adding or updating tests
- [ ] docs — Documentation only
- [x] chore — Build, CI, or tooling changes

### Breaking changes

The public npm install target changes from gsd-pi to @opengsd/gsd-pi for this release line.