### PR TITLE
ci: allow npm token bootstrap publish

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -14,6 +14,14 @@ on:
         options:
           - "false"
           - "true"
+      publish_auth:
+        description: "npm publish auth mode"
+        required: false
+        default: "trusted"
+        type: choice
+        options:
+          - "trusted"
+          - "token"
 
 permissions:
   contents: read
@@ -115,10 +123,18 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
 
-      - name: Verify trusted publishing toolchain
+      - name: Verify npm publish toolchain
         run: |
-          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
-          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('npm trusted publishing requires Node >= 22.14.0'); }"
+          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('npm trusted publishing requires npm >= 11.5.1'); }"
+
+      - name: Select npm publish auth
+        run: |
+          if [ "${{ github.event.inputs.publish_auth || 'trusted' }}" = "token" ]; then
+            echo "Using NPM_TOKEN for npm publish bootstrap."
+          else
+            echo "Using npm trusted publishing for npm publish."
+          fi
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -151,6 +167,8 @@ jobs:
           fi
 
       - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
         run: |
           for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
             echo "Publishing @opengsd/engine-${platform}..."
@@ -220,6 +238,8 @@ jobs:
         run: npm run validate-pack
 
       - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
         run: |
           # --ignore-scripts: skip prepublishOnly since we built explicitly above
           if OUTPUT=$(npm publish --ignore-scripts ${{ steps.version-check.outputs.tag_flag }} 2>&1); then


### PR DESCRIPTION
## TL;DR

**What:** Adds a manual token-auth option to the native publish workflow.
**Why:** npm packages must exist before trusted publishing can be configured from package settings.
**How:** Keeps trusted publishing as the default and uses secrets.NPM_TOKEN only when a manual run sets publish_auth=token.

## What

- Adds a workflow_dispatch publish_auth input with trusted/token choices.
- Keeps trusted publishing as the default auth mode.
- Exposes NODE_AUTH_TOKEN from secrets.NPM_TOKEN only to npm publish steps when publish_auth=token.

## Why

The first @opengsd package publish needs a one-time token bootstrap because npm trusted publisher settings are only available after package creation.

Closes #12

## How

Manual release bootstrap can run:

```bash
gh workflow run build-native.yml --repo open-gsd/gsd-pi --ref main -f publish=true -f publish_auth=token
```

Future runs can omit publish_auth or set publish_auth=trusted.

Validation performed:

- npx --yes actionlint -ignore 'SC1001' -ignore 'SC1012' .github/workflows/build-native.yml
- git diff --check

### Change type checklist

- [ ] feat — New feature or capability
- [ ] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [ ] test — Adding or updating tests
- [ ] docs — Documentation only
- [x] chore — Build, CI, or tooling changes

### Breaking changes

None. Trusted publishing remains the default workflow mode.