### PR TITLE
fix(update): support opengsd upgrade path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,52 @@ Older release history has been archived outside the active changelog so new work
 
 ## Install
 
+GSD installs and updates from the scoped npm package `@opengsd/gsd-pi`.
+
 ```bash
-npm install -g gsd-pi
+npm install -g @opengsd/gsd-pi@latest
+```
+
+The source repository is [`open-gsd/gsd-pi`](https://github.com/open-gsd/gsd-pi), but user installs should use npm rather than cloning the repo.
+
+## Upgrade From Older GSD-2 Installs
+
+If your existing `gsd` command came from the old package location, clear stale local update/resource state and install the scoped package directly:
+
+macOS / Linux:
+
+```bash
+rm -f ~/.gsd/.update-check ~/.gsd/agent/managed-resources.json
+npm install -g @opengsd/gsd-pi@latest
+```
+
+Windows PowerShell:
+
+```powershell
+Remove-Item "$env:USERPROFILE\.gsd\.update-check" -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:USERPROFILE\.gsd\agent\managed-resources.json" -Force -ErrorAction SilentlyContinue
+npm install -g @opengsd/gsd-pi@latest
+```
+
+Windows Command Prompt:
+
+```bat
+del "%USERPROFILE%\.gsd\.update-check" 2>nul
+del "%USERPROFILE%\.gsd\agent\managed-resources.json" 2>nul
+npm install -g @opengsd/gsd-pi@latest
+```
+
+Or run the installer from the new package on any OS:
+
+```bash
+npx @opengsd/gsd-pi@latest
+```
+
+After that, future upgrades can use either command:
+
+```bash
+gsd upgrade
+gsd update
 ```
 
 ## Quick Start

--- a/src/cli-policy.ts
+++ b/src/cli-policy.ts
@@ -6,7 +6,7 @@
  *
  * When the synced resource manifest claims a newer gsd version than the
  * running binary, exitIfManagedResourcesAreNewer() blocks every command
- * with a "Version mismatch detected" diagnostic. The `update` subcommand
+ * with a "Version mismatch detected" diagnostic. The `update`/`upgrade` subcommands
  * MUST bypass that gate so the user can recover by upgrading the binary —
  * otherwise they're stuck in a broken state with no escape hatch.
  *
@@ -14,5 +14,5 @@
  * predicate before calling exitIfManagedResourcesAreNewer().
  */
 export function shouldBypassManagedResourceMismatchGate(firstMessage: string | undefined): boolean {
-  return firstMessage === 'update'
+  return firstMessage === 'update' || firstMessage === 'upgrade'
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ function exitIfManagedResourcesAreNewer(currentAgentDir: string): void {
   process.stderr.write(
     `[gsd] ${chalk.yellow('Version mismatch detected')}\n` +
     `[gsd] Synced resources are from ${chalk.bold(`v${managedVersion}`)}, but this \`gsd\` binary is ${chalk.dim(`v${currentVersion}`)}.\n` +
-    `[gsd] Run ${chalk.bold('npm install -g @opengsd/gsd-pi@latest')} or ${chalk.bold('gsd update')}, then try again.\n`,
+    `[gsd] Run ${chalk.bold('npm install -g @opengsd/gsd-pi@latest')} or ${chalk.bold('gsd upgrade')}, then try again.\n`,
   )
   process.exit(1)
 }
@@ -227,10 +227,10 @@ function ensureRtkBootstrap(): Promise<void> {
   return rtkBootstrapPromise
 }
 
-// `gsd update` — update to the latest version via npm.
+// `gsd update` / `gsd upgrade` — update to the latest version via npm.
 // MUST run before exitIfManagedResourcesAreNewer(): when the bundled resource
 // manifest is from a newer version than the running binary, every other
-// command is blocked — only `update` should bypass the gate so the user can
+// command is blocked — only self-upgrade commands should bypass the gate so the user can
 // actually upgrade out of the broken state. See shouldBypassManagedResourceMismatchGate.
 if (shouldBypassManagedResourceMismatchGate(cliFlags.messages[0])) {
   const { runUpdate } = await import('./update-cmd.js')
@@ -335,6 +335,7 @@ const subcommandsExemptFromEarlyTtyCheck = new Set([
   'remove',
   'sessions',
   'update',
+  'upgrade',
   'web',
   'worktree',
   'wt',

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -22,6 +22,14 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     'Equivalent to: npm install -g @opengsd/gsd-pi@latest',
   ].join('\n'),
 
+  upgrade: [
+    'Usage: gsd upgrade',
+    '',
+    'Upgrade GSD to the latest @opengsd package.',
+    '',
+    'Equivalent to: npm install -g @opengsd/gsd-pi@latest',
+  ].join('\n'),
+
   sessions: [
     'Usage: gsd sessions',
     '',
@@ -194,6 +202,7 @@ export function printHelp(version: string): void {
   process.stdout.write('  remove <source>          Remove an installed package source\n')
   process.stdout.write('  list                     List installed package sources\n')
   process.stdout.write('  update                   Update GSD to the latest version\n')
+  process.stdout.write('  upgrade                  Alias for update\n')
   process.stdout.write('  sessions                 List and resume a past session\n')
   process.stdout.write('  worktree <cmd>           Manage worktrees (list, merge, clean, remove)\n')
   process.stdout.write('  auto [args]              Run auto-mode without TUI (pipeable)\n')

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -33,6 +33,7 @@ const resourceFingerprintFileName = '.managed-resources-content-hash'
 
 interface ManagedResourceManifest {
   gsdVersion: string
+  packageName?: string
   syncedAt?: number
   /** Content fingerprint of bundled resources — detects same-version content changes. */
   contentHash?: string
@@ -79,6 +80,15 @@ function getBundledGsdVersion(): string {
   }
 }
 
+function getBundledPackageName(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8'))
+    return typeof pkg?.name === 'string' ? pkg.name : '@opengsd/gsd-pi'
+  } catch {
+    return '@opengsd/gsd-pi'
+  }
+}
+
 function writeManagedResourceManifest(agentDir: string): void {
   // Record root-level files and subdirectory extension names currently in the
   // bundled extensions source so that future upgrades can detect and prune any
@@ -108,6 +118,7 @@ function writeManagedResourceManifest(agentDir: string): void {
 
   const manifest: ManagedResourceManifest = {
     gsdVersion: getBundledGsdVersion(),
+    packageName: getBundledPackageName(),
     syncedAt: Date.now(),
     contentHash: getCurrentResourceFingerprint(),
     installedExtensionRootFiles,
@@ -119,10 +130,15 @@ function writeManagedResourceManifest(agentDir: string): void {
 export function readManagedResourceVersion(agentDir: string): string | null {
   try {
     const manifest = JSON.parse(readFileSync(getManagedResourceManifestPath(agentDir), 'utf-8')) as ManagedResourceManifest
+    if (!isCurrentPackageManifest(manifest)) return null
     return typeof manifest?.gsdVersion === 'string' ? manifest.gsdVersion : null
   } catch {
     return null
   }
+}
+
+function isCurrentPackageManifest(manifest: ManagedResourceManifest | null): boolean {
+  return manifest?.packageName === getBundledPackageName()
 }
 
 function readManagedResourceManifest(agentDir: string): ManagedResourceManifest | null {
@@ -196,7 +212,11 @@ function collectFileEntries(dir: string, root: string, out: string[]): void {
 
 
 export function getNewerManagedResourceVersion(agentDir: string, currentVersion: string): string | null {
-  const managedVersion = readManagedResourceVersion(agentDir)
+  const manifest = readManagedResourceManifest(agentDir)
+  if (!isCurrentPackageManifest(manifest)) {
+    return null
+  }
+  const managedVersion = typeof manifest?.gsdVersion === 'string' ? manifest.gsdVersion : null
   if (!managedVersion) {
     return null
   }
@@ -591,7 +611,7 @@ export function initResources(agentDir: string, skillsDir: string = join(homedir
   // Skip the full copy when both version AND content fingerprint match.
   // Version-only checks miss same-version content changes (npm link dev workflow,
   // hotfixes within a release). The content hash catches those at ~1ms cost.
-  if (manifest && manifest.gsdVersion === currentVersion) {
+  if (manifest && isCurrentPackageManifest(manifest) && manifest.gsdVersion === currentVersion) {
     // Version matches — check content fingerprint for same-version staleness.
     const currentHash = getCurrentResourceFingerprint()
     const hasStaleExtensionFiles = hasStaleCompiledExtensionSiblings(extensionsDir, bundledExtensionsDir)

--- a/src/resources/extensions/gsd/commands-bootstrap.ts
+++ b/src/resources/extensions/gsd/commands-bootstrap.ts
@@ -45,6 +45,7 @@ const TOP_LEVEL_SUBCOMMANDS = [
   { cmd: "park", desc: "Park a milestone" },
   { cmd: "unpark", desc: "Reactivate a parked milestone" },
   { cmd: "update", desc: "Update GSD to the latest version" },
+  { cmd: "upgrade", desc: "Alias for update; installs the latest @opengsd package" },
   { cmd: "start", desc: "Start a workflow template" },
   { cmd: "templates", desc: "List available workflow templates" },
   { cmd: "extensions", desc: "Manage extensions" },

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -72,6 +72,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "park", desc: "Park a milestone — skip without deleting" },
   { cmd: "unpark", desc: "Reactivate a parked milestone" },
   { cmd: "update", desc: "Update GSD to the latest version" },
+  { cmd: "upgrade", desc: "Alias for update; installs the latest @opengsd package" },
   { cmd: "start", desc: "Start a workflow template (bugfix, spike, feature, etc.)" },
   { cmd: "templates", desc: "List available workflow templates" },
   { cmd: "extensions", desc: "Manage extensions (list, enable, disable, info)" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -147,6 +147,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",
     "  /gsd inspect        Show SQLite DB diagnostics (schema, row counts, recent entries)",
     "  /gsd update         Update GSD to the latest version via npm",
+    "  /gsd upgrade        Alias for /gsd update",
     "  /gsd language       Set or clear the global response language  [off|clear|<language>]",
   ];
   const full = ["full", "--full", "all"].includes(args.trim().toLowerCase());

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -278,7 +278,7 @@ Examples:
     await handleInspect(ctx);
     return true;
   }
-  if (trimmed === "update") {
+  if (trimmed === "update" || trimmed === "upgrade") {
     await handleUpdate(ctx);
     return true;
   }

--- a/src/resources/extensions/gsd/tests/update-command.test.ts
+++ b/src/resources/extensions/gsd/tests/update-command.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { registerGSDCommand } from "../commands.ts";
+import { handleOpsCommand } from "../commands/handlers/ops.ts";
 
 function createMockPi() {
   const commands = new Map<string, any>();
@@ -44,12 +45,33 @@ test("/gsd update appears in subcommand completions", () => {
   assert.equal(updateEntry.label, "update");
 });
 
+test("/gsd upgrade appears in subcommand completions", () => {
+  const pi = createMockPi();
+  registerGSDCommand(pi as any);
+
+  const gsd = pi.commands.get("gsd");
+  assert.ok(gsd, "registerGSDCommand should register /gsd");
+
+  const completions = gsd.getArgumentCompletions("upgrade");
+  const upgradeEntry = completions.find((c: any) => c.value === "upgrade");
+  assert.ok(upgradeEntry, "upgrade should appear in completions");
+  assert.equal(upgradeEntry.label, "upgrade");
+});
+
 test("/gsd update appears in help description", () => {
   const pi = createMockPi();
   registerGSDCommand(pi as any);
 
   const gsd = pi.commands.get("gsd");
   assert.ok(gsd?.description?.includes("update"), "description should mention update");
+});
+
+test("/gsd upgrade appears in help description", () => {
+  const pi = createMockPi();
+  registerGSDCommand(pi as any);
+
+  const gsd = pi.commands.get("gsd");
+  assert.ok(gsd?.description?.includes("upgrade"), "description should mention upgrade");
 });
 
 test("/gsd update is listed in completions with correct description", () => {
@@ -63,6 +85,46 @@ test("/gsd update is listed in completions with correct description", () => {
   assert.ok(
     updateEntry.description.toLowerCase().includes("update"),
     "completion description should mention updating",
+  );
+});
+
+test("/gsd upgrade routes through the update handler", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalVersion = process.env.GSD_VERSION;
+  const ctx = createMockCtx();
+
+  try {
+    process.env.GSD_VERSION = "1.2.3";
+    globalThis.fetch = async () => Response.json({ version: "1.2.3" });
+
+    const handled = await handleOpsCommand("upgrade", ctx as any, createMockPi() as any);
+
+    assert.equal(handled, true);
+    assert.ok(
+      ctx.notifications.some((notification) => notification.message.includes("Already up to date")),
+      "upgrade should call the shared update handler",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalVersion === undefined) {
+      delete process.env.GSD_VERSION;
+    } else {
+      process.env.GSD_VERSION = originalVersion;
+    }
+  }
+});
+
+test("/gsd upgrade is listed in completions with correct description", () => {
+  const pi = createMockPi();
+  registerGSDCommand(pi as any);
+
+  const gsd = pi.commands.get("gsd");
+  const completions = gsd.getArgumentCompletions("");
+  const upgradeEntry = completions.find((c: any) => c.value === "upgrade");
+  assert.ok(upgradeEntry, "upgrade should appear in full completion list");
+  assert.ok(
+    upgradeEntry.description.toLowerCase().includes("opengsd"),
+    "completion description should mention the new package scope",
   );
 });
 

--- a/src/tests/app-smoke.test.ts
+++ b/src/tests/app-smoke.test.ts
@@ -189,12 +189,12 @@ test("loader MIN_NODE_MAJOR matches package.json engines field exactly", async (
   );
 });
 
-test("gsd update bypasses the managed-resource-mismatch gate; non-update commands trigger it", async (t) => {
+test("gsd update and upgrade bypass the managed-resource-mismatch gate; other commands trigger it", async (t) => {
   // Real fixture: write an agentDir whose managed-resources.json claims a
   // version newer than the running binary. The mismatch gate
   // (getNewerManagedResourceVersion) must fire — proving the gate is "armed".
-  // shouldBypassManagedResourceMismatchGate('update') must return true,
-  // proving 'update' bypasses it. cli.ts wires the predicate before the gate
+  // shouldBypassManagedResourceMismatchGate('update'|'upgrade') must return true,
+  // proving self-upgrade commands bypass it. cli.ts wires the predicate before the gate
   // call, so update escapes the gate.
   const { getNewerManagedResourceVersion } = await import("../resource-loader.ts");
   const { shouldBypassManagedResourceMismatchGate } = await import("../cli-policy.ts");
@@ -210,7 +210,7 @@ test("gsd update bypasses the managed-resource-mismatch gate; non-update command
   const currentVersion = "1.0.0";
   writeFileSync(
     join(fakeAgentDir, "managed-resources.json"),
-    JSON.stringify({ gsdVersion: futureVersion, syncedAt: Date.now() }),
+    JSON.stringify({ gsdVersion: futureVersion, packageName: "@opengsd/gsd-pi", syncedAt: Date.now() }),
   );
 
   // Gate is armed: returns the newer version (cli.ts would print mismatch + exit 1)
@@ -218,7 +218,7 @@ test("gsd update bypasses the managed-resource-mismatch gate; non-update command
   assert.strictEqual(newer, futureVersion, "gate must surface a newer version when manifest is ahead");
 
   // For non-update commands the predicate is false → cli.ts falls through to the gate.
-  for (const nonUpdate of [undefined, "auto", "config", "doctor", "web", "headless", "updates" /* near-miss */]) {
+  for (const nonUpdate of [undefined, "auto", "config", "doctor", "web", "headless", "updates", "upgrades" /* near-misses */]) {
     assert.strictEqual(
       shouldBypassManagedResourceMismatchGate(nonUpdate),
       false,
@@ -226,11 +226,58 @@ test("gsd update bypasses the managed-resource-mismatch gate; non-update command
     );
   }
 
-  // For 'update' the predicate is true → cli.ts dispatches runUpdate() before the gate.
+  // For self-upgrade commands the predicate is true → cli.ts dispatches runUpdate() before the gate.
   assert.strictEqual(
     shouldBypassManagedResourceMismatchGate("update"),
     true,
     "'update' must bypass the gate so the user can escape a version-mismatched install",
+  );
+  assert.strictEqual(
+    shouldBypassManagedResourceMismatchGate("upgrade"),
+    true,
+    "'upgrade' must bypass the gate so old users can escape a version-mismatched install",
+  );
+});
+
+test("managed resource skew ignores legacy manifests from the old npm package", async (t) => {
+  const { getNewerManagedResourceVersion } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-legacy-resource-manifest-"));
+  const fakeAgentDir = join(tmp, "agent");
+  mkdirSync(fakeAgentDir, { recursive: true });
+
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(fakeAgentDir, "managed-resources.json"),
+    JSON.stringify({ gsdVersion: "3.0.0", syncedAt: Date.now() }),
+  );
+
+  assert.strictEqual(
+    getNewerManagedResourceVersion(fakeAgentDir, "1.0.1"),
+    null,
+    "old unscoped gsd-pi resource stamps must not block @opengsd/gsd-pi startup",
+  );
+});
+
+test("managed resource skew ignores manifests stamped by a different package", async (t) => {
+  const { getNewerManagedResourceVersion } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-other-package-resource-manifest-"));
+  const fakeAgentDir = join(tmp, "agent");
+  mkdirSync(fakeAgentDir, { recursive: true });
+
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(fakeAgentDir, "managed-resources.json"),
+    JSON.stringify({ gsdVersion: "3.0.0", packageName: "gsd-pi", syncedAt: Date.now() }),
+  );
+
+  assert.strictEqual(
+    getNewerManagedResourceVersion(fakeAgentDir, "1.0.1"),
+    null,
+    "old gsd-pi resource stamps must be refreshed instead of treated as newer @opengsd resources",
   );
 });
 
@@ -245,7 +292,7 @@ test("managed resource skew ignores dev/build suffixes on the same release line"
 
   writeFileSync(
     join(fakeAgentDir, "managed-resources.json"),
-    JSON.stringify({ gsdVersion: "2.78.1", syncedAt: Date.now() }),
+    JSON.stringify({ gsdVersion: "2.78.1", packageName: "@opengsd/gsd-pi", syncedAt: Date.now() }),
   );
 
   assert.strictEqual(

--- a/src/tests/integration/pack-install.test.ts
+++ b/src/tests/integration/pack-install.test.ts
@@ -251,7 +251,7 @@ test("gsd exits early with a clear message when synced resources are newer than 
   mkdirSync(fakeAgentDir, { recursive: true });
   writeFileSync(
     join(fakeAgentDir, "managed-resources.json"),
-    JSON.stringify({ gsdVersion: "999.0.0" }),
+    JSON.stringify({ gsdVersion: "999.0.0", packageName: "@opengsd/gsd-pi" }),
   );
 
   t.after(() => { rmSync(fakeHome, { recursive: true, force: true }); });
@@ -284,6 +284,6 @@ test("gsd exits early with a clear message when synced resources are newer than 
 
   assert.equal(result.code, 1, "startup exits with code 1 on version skew");
   assert.match(result.stderr, /Version mismatch detected/, "prints a friendly skew header");
-  assert.match(result.stderr, /npm install -g @opengsd\/gsd-pi@latest|gsd update/, "prints upgrade guidance");
+  assert.match(result.stderr, /npm install -g @opengsd\/gsd-pi@latest|gsd upgrade/, "prints upgrade guidance");
   assert.doesNotMatch(result.stderr, /\[gsd\] Extension load error/, "fails before extension loading");
 });

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -167,6 +167,12 @@ test("initResources manifest tracks all bundled extension subdirectories includi
     const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
     const installedDirs: string[] = manifest.installedExtensionDirs ?? [];
 
+    assert.equal(
+      manifest.packageName,
+      "@opengsd/gsd-pi",
+      "managed resource manifest should be scoped to the package that wrote it",
+    );
+
     // remote-questions uses mod.ts (not index.ts) as its entry point and has an
     // extension-manifest.json — it must still appear in the manifest so that
     // pruneRemovedBundledExtensions can track it across upgrades.

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -67,7 +67,17 @@ test('writeUpdateCache + readUpdateCache round-trips correctly', (t) => {
   const cache = { lastCheck: Date.now(), latestVersion: '3.0.0' }
   writeUpdateCache(cache, cachePath)
   const result = readUpdateCache(cachePath)
-  assert.deepEqual(result, cache)
+  assert.deepEqual(result, { ...cache, packageName: '@opengsd/gsd-pi' })
+})
+
+test('readUpdateCache ignores legacy cache entries without package identity', (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-update-cache-'))
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }) });
+
+  const cachePath = join(tmp, '.update-check')
+  writeFileSync(cachePath, JSON.stringify({ lastCheck: Date.now(), latestVersion: '3.0.0' }))
+  const result = readUpdateCache(cachePath)
+  assert.equal(result, null)
 })
 
 test('writeUpdateCache creates parent directories', (t) => {
@@ -224,6 +234,32 @@ test('checkForUpdates uses cache and skips fetch when checked recently', async (
 
   // Should use cached version (10.0.0), not the server's (20.0.0)
   assert.equal(reportedLatest, '10.0.0')
+})
+
+test('checkForUpdates ignores fresh legacy gsd-pi cache and fetches scoped package version', async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-update-'))
+  const cachePath = join(tmp, '.update-check')
+  writeFileSync(cachePath, JSON.stringify({ lastCheck: Date.now(), latestVersion: '3.0.0' }))
+
+  const registry = await startMockRegistry({ version: '1.0.1' })
+  t.after(async () => {
+    await registry.close()
+    rmSync(tmp, { recursive: true, force: true })
+  });
+
+  let called = false
+
+  await checkForUpdates({
+    currentVersion: '1.0.1',
+    cachePath,
+    registryUrl: registry.url,
+    checkIntervalMs: 60 * 60 * 1000,
+    fetchTimeoutMs: 5000,
+    onUpdate: () => { called = true },
+  })
+
+  assert.ok(!called, 'legacy 3.0.0 cache must not produce an update banner for @opengsd/gsd-pi')
+  assert.equal(readUpdateCache(cachePath)?.latestVersion, '1.0.1')
 })
 
 test('checkForUpdates skips notification when cache is fresh and versions match', async (t) => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -14,6 +14,7 @@ const DEFAULT_REGISTRY_URL = `https://registry.npmjs.org/@opengsd%2fgsd-pi/lates
 interface UpdateCheckCache {
   lastCheck: number
   latestVersion: string
+  packageName?: string
 }
 
 /**
@@ -31,19 +32,25 @@ export function compareSemver(a: string, b: string): number {
   return 0
 }
 
-export function readUpdateCache(cachePath: string = CACHE_FILE): UpdateCheckCache | null {
+export function readUpdateCache(cachePath: string = CACHE_FILE, packageName: string = NPM_PACKAGE_NAME): UpdateCheckCache | null {
   try {
     if (!existsSync(cachePath)) return null
-    return JSON.parse(readFileSync(cachePath, 'utf-8'))
+    const cache = JSON.parse(readFileSync(cachePath, 'utf-8')) as UpdateCheckCache
+    if (cache.packageName !== packageName) return null
+    return cache
   } catch {
     return null
   }
 }
 
-export function writeUpdateCache(cache: UpdateCheckCache, cachePath: string = CACHE_FILE): void {
+export function writeUpdateCache(
+  cache: Omit<UpdateCheckCache, 'packageName'> & { packageName?: string },
+  cachePath: string = CACHE_FILE,
+  packageName: string = NPM_PACKAGE_NAME,
+): void {
   try {
     mkdirSync(dirname(cachePath), { recursive: true })
-    writeFileSync(cachePath, JSON.stringify(cache))
+    writeFileSync(cachePath, JSON.stringify({ ...cache, packageName }))
   } catch {
     // Non-fatal — don't block startup if cache write fails
   }
@@ -102,10 +109,10 @@ export function resolveInstallCommand(pkg: string): string {
 }
 
 function printUpdateBanner(current: string, latest: string): void {
-  const installCmd = resolveInstallCommand('@opengsd/gsd-pi')
+  const installCmd = resolveInstallCommand('@opengsd/gsd-pi@latest')
   process.stderr.write(
     `  ${chalk.yellow('Update available:')} ${chalk.dim(`v${current}`)} → ${chalk.bold(`v${latest}`)}\n` +
-    `  ${chalk.dim('Run')} ${installCmd} ${chalk.dim('or')} /gsd update ${chalk.dim('to upgrade')}\n\n`,
+    `  ${chalk.dim('Run')} ${installCmd} ${chalk.dim('or')} /gsd upgrade ${chalk.dim('to upgrade')}\n\n`,
   )
 }
 
@@ -248,7 +255,7 @@ export async function checkAndPromptForUpdates(options: UpdateCheckOptions = {})
       process.stderr.write(`\n  ${chalk.yellow(`Update failed. You can run: ${installCmd}`)}\n\n`)
     }
   } else {
-    process.stderr.write(`  ${chalk.dim('Skipped. Run')} gsd update ${chalk.dim('anytime to upgrade.')}\n\n`)
+    process.stderr.write(`  ${chalk.dim('Skipped. Run')} gsd upgrade ${chalk.dim('anytime to upgrade.')}\n\n`)
   }
 
   return false


### PR DESCRIPTION
## Linked issue

Closes #14

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds `gsd upgrade` and moves update/recovery behavior to the scoped `@opengsd/gsd-pi` package path.
**Why:** Existing users can carry stale unscoped `gsd-pi@3.0.0` update and managed-resource state after installing the new package.
**How:** Routes `upgrade` through the update handler, stamps update/resource caches with package identity, ignores old-package state, and documents OS-specific recovery commands.

## What

This changes the CLI update path, slash-command catalog/help, update cache handling, managed-resource manifest handling, and README upgrade instructions.

## Why

After installing `@opengsd/gsd-pi`, users upgrading from the old package location could still see update guidance like `v1.0.1 -> v3.0.0` because local cache files were written by the old `gsd-pi` package identity. Old managed-resource manifests could create the same kind of mismatch for synced resources.

## How

- Adds `gsd upgrade` as an alias for `gsd update` across CLI gate bypass, TTY exemption, help, completions, and `/gsd` routing.
- Updates prompts and diagnostics to recommend `@opengsd/gsd-pi@latest` and `gsd upgrade`.
- Adds `packageName` to update cache and managed-resource manifest writes.
- Ignores cache/resource manifests that are missing package identity or were written by a different package.
- Adds README recovery commands for macOS/Linux, Windows PowerShell, and Windows Command Prompt.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual/local verification:

```bash
npm ci
npm run build:core
npm run typecheck:extensions
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/update-check.test.ts src/tests/app-smoke.test.ts src/tests/resource-loader.test.ts src/resources/extensions/gsd/tests/update-command.test.ts
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/update-command.test.ts src/tests/app-smoke.test.ts src/tests/update-cmd-diagnostics.test.ts src/tests/integration/pack-install.test.ts
npx --yes @opengsd/gsd-pi@latest --version
```

## AI disclosure

- [ ] This PR includes AI-assisted code
