### PR TITLE
fix(gsd): preserve planning tree migration inputs

### DIFF
--- a/docs/user-docs/migration.md
+++ b/docs/user-docs/migration.md
@@ -16,7 +16,7 @@ If you have projects with `.planning` directories from the original Get Shit Don
 
 The migration tool:
 
-- Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
+- Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, research, top-level `decisions/`, and top-level `seeds/`
 - Maps phases → slices, plans → tasks, milestones → milestones
 - Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
 - Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
@@ -25,7 +25,7 @@ The migration tool:
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
 - Records `.gsd/migration/MIGRATION.md` and `.gsd/migration/manifest.json` audit artifacts
-- Shows a preview before writing anything
+- Shows a preview before writing anything, including requirement status totals (validated, active, deferred, out of scope) and legacy-input counts (milestone phase dirs, decision files, seed files)
 - Optionally runs a read-only review of the output for quality assurance
 
 ## Supported Formats
@@ -35,8 +35,11 @@ The migration handles various v1 format variations:
 - Milestone-sectioned roadmaps with `<details>` blocks
 - Bold phase entries
 - Bullet-format requirements
+- Emoji requirement markers (`✅`, `✓`, `⏳`, `✗`) with IDs like `R12` and `ABC-123`
 - Decimal phase numbering
 - Duplicate phase numbers across milestones
+- Milestone-scoped legacy phase trees like `<milestone>-phases/01-.../`
+- Legacy phase plan/summary files in both `NN-NN-PLAN.md` and short `NN-PLAN.md` styles
 
 ## Requirements
 

--- a/gitbook/reference/migration.md
+++ b/gitbook/reference/migration.md
@@ -16,7 +16,7 @@ If you have projects with `.planning` directories from the original Get Shit Don
 
 The migration tool:
 
-- Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
+- Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, research, top-level `decisions/`, and top-level `seeds/`
 - Maps phases → slices, plans → tasks, milestones → milestones
 - Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
 - Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
@@ -25,7 +25,7 @@ The migration tool:
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
 - Records `.gsd/migration/MIGRATION.md` and `.gsd/migration/manifest.json` audit artifacts
-- Shows a preview before writing anything
+- Shows a preview before writing anything, including requirement status totals (validated, active, deferred, out of scope) and legacy-input counts (milestone phase dirs, decision files, seed files)
 - Optionally runs a read-only review for quality assurance
 
 ## Supported Formats
@@ -35,8 +35,11 @@ The migration handles various v1 format variations:
 - Milestone-sectioned roadmaps with `<details>` blocks
 - Bold phase entries
 - Bullet-format requirements
+- Emoji requirement markers (`✅`, `✓`, `⏳`, `✗`) with IDs like `R12` and `ABC-123`
 - Decimal phase numbering
 - Duplicate phase numbers across milestones
+- Milestone-scoped legacy phase trees like `<milestone>-phases/01-.../`
+- Legacy phase plan/summary files in both `NN-NN-PLAN.md` and short `NN-PLAN.md` styles
 
 ## Requirements
 

--- a/mintlify-docs/guides/migration.mdx
+++ b/mintlify-docs/guides/migration.mdx
@@ -19,7 +19,7 @@ If you have projects with `.planning` directories from the original Get Shit Don
 
 The migration tool:
 
-- Parses `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
+- Parses `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, research, top-level `decisions/`, and top-level `seeds/`
 - Maps phases → slices, plans → tasks, milestones → milestones
 - Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
 - Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
@@ -28,7 +28,7 @@ The migration tool:
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
 - Records `.gsd/migration/MIGRATION.md` and `.gsd/migration/manifest.json` audit artifacts
-- Shows a preview before writing anything
+- Shows a preview before writing anything, including requirement status totals (validated, active, deferred, out of scope) and legacy-input counts (milestone phase dirs, decision files, seed files)
 - Optionally runs a read-only review of the output
 
 ## Supported formats
@@ -38,8 +38,11 @@ The migration handles various v1 format variations:
 - Milestone-sectioned roadmaps with `<details>` blocks
 - Bold phase entries
 - Bullet-format requirements
+- Emoji requirement markers (`✅`, `✓`, `⏳`, `✗`) with IDs like `R12` and `ABC-123`
 - Decimal phase numbering
 - Duplicate phase numbers across milestones
+- Milestone-scoped legacy phase trees like `<milestone>-phases/01-.../`
+- Legacy phase plan/summary files in both `NN-NN-PLAN.md` and short `NN-PLAN.md` styles
 
 ## Post-migration
 

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -175,8 +175,8 @@ export function parseRequirementsSections(content: string): Requirement[] {
       continue;
     }
 
-    // Check for requirement heading (### RXXX — Title)
-    const reqMatch = line.match(/^###\s+(R\d+)\s*[—–-]\s*(.+)/);
+    // Check for requirement heading (### RXXX — Title or ### NET-01 — Title)
+    const reqMatch = line.match(/^###\s+([A-Z][A-Z0-9]*-\d+|R\d+)\s*[—–-]\s*(.+)/i);
     if (reqMatch) {
       flushReq();
       if (currentSectionStatus !== null) {

--- a/src/resources/extensions/gsd/migrate/command.ts
+++ b/src/resources/extensions/gsd/migrate/command.ts
@@ -164,8 +164,11 @@ function formatPreviewStats(preview: MigrationPreview): string {
   ];
   if (preview.requirements.total > 0) {
     lines.push(
-      `- Requirements: ${preview.requirements.total} (${preview.requirements.validated} validated, ${preview.requirements.active} active, ${preview.requirements.deferred} deferred)`,
+      `- Requirements: ${preview.requirements.total} (${preview.requirements.validated} validated, ${preview.requirements.active} active, ${preview.requirements.deferred} deferred, ${preview.requirements.outOfScope} out of scope)`,
     );
+  }
+  if (preview.migrationInputs) {
+    lines.push(`- Legacy inputs: ${preview.migrationInputs.milestonePhaseDirs} milestone phase dir(s), ${preview.migrationInputs.decisions} decision file(s), ${preview.migrationInputs.seeds} seed file(s)`);
   }
   return lines.join("\n");
 }
@@ -268,8 +271,11 @@ export async function handleMigrate(
 
   if (preview.requirements.total > 0) {
     lines.push(
-      `Requirements: ${preview.requirements.total} (${preview.requirements.validated} validated, ${preview.requirements.active} active, ${preview.requirements.deferred} deferred)`,
+      `Requirements: ${preview.requirements.total} (${preview.requirements.validated} validated, ${preview.requirements.active} active, ${preview.requirements.deferred} deferred, ${preview.requirements.outOfScope} out of scope)`,
     );
+  }
+  if (preview.migrationInputs) {
+    lines.push(`Legacy inputs: ${preview.migrationInputs.milestonePhaseDirs} milestone phase dir(s), ${preview.migrationInputs.decisions} decision file(s), ${preview.migrationInputs.seeds} seed file(s)`);
   }
 
   const targetGsdExists = existsSync(gsdRoot(targetRoot));

--- a/src/resources/extensions/gsd/migrate/parser.ts
+++ b/src/resources/extensions/gsd/migrate/parser.ts
@@ -23,6 +23,8 @@ import type {
   PlanningQuickTask,
   PlanningMilestone,
   PlanningResearch,
+  PlanningDecision,
+  PlanningSeed,
   PlanningPhaseFile,
 } from './types.js';
 
@@ -73,9 +75,11 @@ function parseQuickDir(dirName: string): { number: number; slug: string } | null
 
 /** Plan file pattern: NN-NN-PLAN.md (e.g. 29-01-PLAN.md) or NN-NNb-PLAN.md. */
 const PLAN_RE = /^(\d+(?:\.\d+)?)-(\d+[a-z]?)-PLAN\.md$/i;
+const SHORT_PLAN_RE = /^(\d+[a-z]?)-PLAN\.md$/i;
 
 /** Summary file pattern: NN-NN-SUMMARY.md (e.g. 29-01-SUMMARY.md) or NN-NNb-SUMMARY.md. */
 const SUMMARY_RE = /^(\d+(?:\.\d+)?)-(\d+[a-z]?)-SUMMARY\.md$/i;
+const SHORT_SUMMARY_RE = /^(\d+[a-z]?)-SUMMARY\.md$/i;
 
 /** Research file pattern: contains RESEARCH (case-insensitive) */
 const RESEARCH_RE = /research/i;
@@ -103,17 +107,17 @@ function scanPhaseDirectory(phaseDir: string, dirName: string, parsed: ReturnTyp
     // Skip directories within phase dirs
     if (isDir(entryPath)) continue;
 
-    const planMatch = entry.match(PLAN_RE);
+    const planMatch = entry.match(PLAN_RE) ?? entry.match(SHORT_PLAN_RE);
     if (planMatch) {
-      const planNumber = planMatch[2];
+      const planNumber = planMatch[2] ?? planMatch[1];
       const content = readFileSync(entryPath, 'utf-8');
       phase.plans[planNumber] = parseOldPlan(content, entry, planNumber);
       continue;
     }
 
-    const summaryMatch = entry.match(SUMMARY_RE);
+    const summaryMatch = entry.match(SUMMARY_RE) ?? entry.match(SHORT_SUMMARY_RE);
     if (summaryMatch) {
-      const planNumber = summaryMatch[2];
+      const planNumber = summaryMatch[2] ?? summaryMatch[1];
       const content = readFileSync(entryPath, 'utf-8');
       phase.summaries[planNumber] = parseOldSummary(content, entry, planNumber);
       continue;
@@ -184,19 +188,37 @@ function scanMilestonesDirectory(msDir: string): PlanningMilestone[] {
   if (entries.length === 0) return [];
 
   // Group files by milestone ID prefix (e.g. "v2.2" from "v2.2-ROADMAP.md")
-  const grouped = new Map<string, { requirements: string | null; roadmap: string | null; extraFiles: PlanningPhaseFile[] }>();
+  const grouped = new Map<string, { requirements: string | null; roadmap: string | null; phases: Record<string, PlanningPhase>; extraFiles: PlanningPhaseFile[] }>();
+
+  function ensureMilestone(id: string) {
+    if (!grouped.has(id)) grouped.set(id, { requirements: null, roadmap: null, phases: {}, extraFiles: [] });
+    return grouped.get(id)!;
+  }
 
   for (const entry of entries) {
     const entryPath = join(msDir, entry);
-    if (isDir(entryPath)) continue;
+    if (isDir(entryPath)) {
+      const phasesMatch = entry.match(/^(.+)-phases$/i);
+      if (!phasesMatch) continue;
+      const ms = ensureMilestone(phasesMatch[1]);
+      const phaseDirs = listDir(entryPath).sort();
+      for (const dirName of phaseDirs) {
+        if (dirName.startsWith('.')) continue;
+        const dirPath = join(entryPath, dirName);
+        if (!isDir(dirPath)) continue;
+        const parsed = parsePhaseDir(dirName);
+        if (!parsed) continue;
+        ms.phases[dirName] = scanPhaseDirectory(dirPath, dirName, parsed);
+      }
+      continue;
+    }
 
     // Extract milestone ID: everything before the first dash-followed-by-uppercase or common suffix
     const idMatch = entry.match(/^(.+?)-(ROADMAP|REQUIREMENTS|SUMMARY)\.md$/i);
     if (idMatch) {
       const id = idMatch[1];
       const type = idMatch[2].toUpperCase();
-      if (!grouped.has(id)) grouped.set(id, { requirements: null, roadmap: null, extraFiles: [] });
-      const ms = grouped.get(id)!;
+      const ms = ensureMilestone(id);
       const content = readFileSync(entryPath, 'utf-8');
 
       if (type === 'REQUIREMENTS') ms.requirements = content;
@@ -206,9 +228,9 @@ function scanMilestonesDirectory(msDir: string): PlanningMilestone[] {
       // Non-standard file — try to extract ID from filename
       const simpleMatch = entry.match(/^(.+?)\./);
       const id = simpleMatch ? simpleMatch[1] : entry;
-      if (!grouped.has(id)) grouped.set(id, { requirements: null, roadmap: null, extraFiles: [] });
+      const ms = ensureMilestone(id);
       const content = readFileSync(entryPath, 'utf-8');
-      grouped.get(id)!.extraFiles.push({ fileName: entry, content });
+      ms.extraFiles.push({ fileName: entry, content });
     }
   }
 
@@ -216,6 +238,7 @@ function scanMilestonesDirectory(msDir: string): PlanningMilestone[] {
     id,
     requirements: data.requirements,
     roadmap: data.roadmap,
+    phases: data.phases,
     extraFiles: data.extraFiles,
   }));
 }
@@ -234,6 +257,28 @@ function scanResearchDirectory(researchDir: string): PlanningResearch[] {
   }
 
   return research;
+}
+
+function scanDecisionDirectory(decisionsDir: string): PlanningDecision[] {
+  return scanFlatMarkdownDirectory(decisionsDir);
+}
+
+function scanSeedDirectory(seedsDir: string): PlanningSeed[] {
+  return scanFlatMarkdownDirectory(seedsDir);
+}
+
+function scanFlatMarkdownDirectory<T extends PlanningPhaseFile>(dir: string): T[] {
+  const entries = listDir(dir).sort();
+  const files: T[] = [];
+
+  for (const entry of entries) {
+    const entryPath = join(dir, entry);
+    if (isDir(entryPath)) continue;
+    const content = readFileSync(entryPath, 'utf-8');
+    files.push({ fileName: entry, content } as T);
+  }
+
+  return files;
 }
 
 // ─── Main Orchestrator ─────────────────────────────────────────────────────
@@ -307,6 +352,12 @@ export async function parsePlanningDirectory(path: string): Promise<PlanningProj
   const researchDir = join(path, 'research');
   const research = isDir(researchDir) ? scanResearchDirectory(researchDir) : [];
 
+  const decisionsDir = join(path, 'decisions');
+  const decisions = isDir(decisionsDir) ? scanDecisionDirectory(decisionsDir) : [];
+
+  const seedsDir = join(path, 'seeds');
+  const seeds = isDir(seedsDir) ? scanSeedDirectory(seedsDir) : [];
+
   return {
     path,
     project,
@@ -318,6 +369,8 @@ export async function parsePlanningDirectory(path: string): Promise<PlanningProj
     quickTasks,
     milestones,
     research,
+    decisions,
+    seeds,
     validation,
   };
 }

--- a/src/resources/extensions/gsd/migrate/parsers.ts
+++ b/src/resources/extensions/gsd/migrate/parsers.ts
@@ -610,6 +610,23 @@ export function parseOldRequirements(content: string): PlanningRequirement[] {
       continue;
     }
 
+    const emojiReqMatch = line.match(/^-\s+(✅|✓|⏳|✗)\s+([A-Z][A-Z0-9]*-\d+|R\d+)\s*:\s*(.+)$/i);
+    if (emojiReqMatch) {
+      flushReq();
+      const marker = emojiReqMatch[1];
+      const id = emojiReqMatch[2].trim();
+      const desc = emojiReqMatch[3].trim();
+      const status = marker === '✗' ? 'rejected' : marker === '⏳' ? 'active' : 'validated';
+      requirements.push({
+        id,
+        title: desc,
+        status,
+        description: desc,
+        raw: line,
+      });
+      continue;
+    }
+
     // Description or metadata within a requirement
     if (currentReq) {
       currentRaw.push(line);

--- a/src/resources/extensions/gsd/migrate/preview.ts
+++ b/src/resources/extensions/gsd/migrate/preview.ts
@@ -46,6 +46,7 @@ export function generatePreview(project: GSDProject): MigrationPreview {
     decisions: {
       total: countCanonicalDecisionRows(project.decisionsContent),
     },
+    migrationInputs: project.migrationInputs,
     milestoneCount: project.milestones.length,
     totalSlices,
     totalTasks,

--- a/src/resources/extensions/gsd/migrate/transformer.ts
+++ b/src/resources/extensions/gsd/migrate/transformer.ts
@@ -10,6 +10,7 @@ import type {
   PlanningRoadmapMilestone,
   PlanningResearch,
   PlanningRequirement,
+  PlanningMilestone,
   GSDProject,
   GSDMilestone,
   GSDSlice,
@@ -19,6 +20,7 @@ import type {
   GSDTaskSummaryData,
   GSDBoundaryEntry,
 } from './types.js';
+import { parseOldRequirements } from './parsers.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -241,18 +243,22 @@ function buildMilestoneFromEntries(
 
 const VALID_STATUSES = new Set(['active', 'validated', 'deferred']);
 const COMPLETE_ALIASES = new Set(['complete', 'completed', 'done', 'shipped']);
+const OUT_OF_SCOPE_ALIASES = new Set(['rejected', 'reject', 'out-of-scope', 'out of scope']);
 
-function normalizeStatus(status: string): 'active' | 'validated' | 'deferred' {
+function normalizeStatus(status: string): 'active' | 'validated' | 'deferred' | 'out-of-scope' {
   const lower = status.toLowerCase().trim();
   if (VALID_STATUSES.has(lower)) return lower as 'active' | 'validated' | 'deferred';
   if (COMPLETE_ALIASES.has(lower)) return 'validated';
+  if (OUT_OF_SCOPE_ALIASES.has(lower)) return 'out-of-scope';
   return 'active';
 }
 
 function normalizeRequirementId(id: string): string | null {
-  const match = id.trim().match(/^R(\d+)$/i);
-  if (!match) return null;
-  return `R${match[1].padStart(3, '0')}`;
+  const trimmed = id.trim().toUpperCase();
+  const rMatch = trimmed.match(/^R(\d+)$/);
+  if (rMatch) return `R${rMatch[1].padStart(3, '0')}`;
+  if (/^[A-Z][A-Z0-9]*-\d+$/.test(trimmed)) return trimmed;
+  return null;
 }
 
 function mapRequirements(reqs: PlanningRequirement[]): GSDRequirement[] {
@@ -302,6 +308,16 @@ function mapRequirements(reqs: PlanningRequirement[]): GSDRequirement[] {
   });
 }
 
+function collectRequirements(parsed: PlanningProject): PlanningRequirement[] {
+  const requirements = [...parsed.requirements];
+  for (const milestone of parsed.milestones) {
+    if (milestone.requirements) {
+      requirements.push(...parseOldRequirements(milestone.requirements));
+    }
+  }
+  return requirements;
+}
+
 // ─── Project-Level Derivation ──────────────────────────────────────────────
 
 function deriveVision(parsed: PlanningProject): string {
@@ -327,6 +343,10 @@ function deriveVision(parsed: PlanningProject): string {
 function deriveDecisions(parsed: PlanningProject): string {
   // Extract key decisions from phase summaries if available
   const decisions: string[] = [];
+  const decisionFiles = [...parsed.decisions].sort((a, b) => a.fileName.localeCompare(b.fileName));
+  for (const decision of decisionFiles) {
+    decisions.push(extractDecisionTitle(decision.fileName, decision.content));
+  }
   for (const phase of Object.values(parsed.phases)) {
     for (const summary of Object.values(phase.summaries)) {
       const kd = summary.frontmatter['key-decisions'] ?? [];
@@ -354,16 +374,66 @@ function deriveDecisions(parsed: PlanningProject): string {
   return lines.join('\n') + '\n';
 }
 
+function extractDecisionTitle(fileName: string, content: string): string {
+  const heading = content.split('\n').find((line) => /^#\s+/.test(line.trim()));
+  if (heading) return heading.replace(/^#\s+/, '').trim();
+  return fileName.replace(/\.md$/i, '').replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/-/g, ' ');
+}
+
+function buildMilestoneFromLegacyMilestone(source: PlanningMilestone, index: number): GSDMilestone {
+  const entries: PlanningRoadmapEntry[] = [];
+  if (source.roadmap) {
+    entries.push(...parseRoadmapEntries(source.roadmap));
+  }
+
+  const phases = source.phases;
+  if (entries.length === 0) {
+    for (const phase of Object.values(phases).sort((a, b) => a.number - b.number)) {
+      entries.push({
+        number: phase.number,
+        title: phase.slug,
+        done: Object.keys(phase.summaries).length > 0,
+        raw: '',
+      });
+    }
+  }
+
+  const title = `${source.id} Migration`;
+  return buildMilestoneFromEntries(milestoneId(index + 1), title, entries, phases, []);
+}
+
+function parseRoadmapEntries(content: string): PlanningRoadmapEntry[] {
+  const entries: PlanningRoadmapEntry[] = [];
+  for (const line of content.split('\n')) {
+    const match = line.match(/^-\s+\[([ xX])\]\s+(\d+(?:\.\d+)?)\s+[—–-]\s+(.+)$/);
+    if (!match) continue;
+    entries.push({
+      number: Number(match[2]),
+      title: match[3].trim(),
+      done: match[1].toLowerCase() === 'x',
+      raw: line,
+    });
+  }
+  return entries;
+}
+
 // ─── Main Entry Point ──────────────────────────────────────────────────────
 
 export function transformToGSD(parsed: PlanningProject): GSDProject {
   const milestones: GSDMilestone[] = [];
 
   const roadmap = parsed.roadmap;
+  const legacyMilestonesWithPhases = parsed.milestones.filter((milestone) => Object.keys(milestone.phases).length > 0);
+  const hasMilestoneDirectories = legacyMilestonesWithPhases.length > 0;
   const isMultiMilestone = roadmap !== null && roadmap.milestones.length > 0;
   const hasFlatPhases = roadmap !== null && roadmap.phases.length > 0;
 
-  if (isMultiMilestone) {
+  if (hasMilestoneDirectories) {
+    const sorted = [...legacyMilestonesWithPhases].sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' }));
+    for (let mi = 0; mi < sorted.length; mi++) {
+      milestones.push(buildMilestoneFromLegacyMilestone(sorted[mi], mi));
+    }
+  } else if (isMultiMilestone) {
     // Multi-milestone mode: each roadmap milestone section → one GSDMilestone
     for (let mi = 0; mi < roadmap!.milestones.length; mi++) {
       const rm = roadmap!.milestones[mi];
@@ -405,7 +475,12 @@ export function transformToGSD(parsed: PlanningProject): GSDProject {
   return {
     milestones,
     projectContent: parsed.project ?? '',
-    requirements: mapRequirements(parsed.requirements),
+    requirements: mapRequirements(collectRequirements(parsed)),
     decisionsContent: deriveDecisions(parsed),
+    migrationInputs: {
+      milestonePhaseDirs: parsed.milestones.filter((milestone) => Object.keys(milestone.phases).length > 0).length,
+      decisions: parsed.decisions.length,
+      seeds: parsed.seeds.length,
+    },
   };
 }

--- a/src/resources/extensions/gsd/migrate/types.ts
+++ b/src/resources/extensions/gsd/migrate/types.ts
@@ -40,6 +40,10 @@ export interface PlanningProject {
   milestones: PlanningMilestone[];
   /** Research files from top-level research/ directory */
   research: PlanningResearch[];
+  /** Decision files from decisions/ directory */
+  decisions: PlanningDecision[];
+  /** Seed files from seeds/ directory */
+  seeds: PlanningSeed[];
   /** Validation result from pre-flight checks */
   validation: ValidationResult;
 }
@@ -198,6 +202,20 @@ export interface PlanningResearch {
   content: string;
 }
 
+export interface PlanningDecision {
+  /** File name */
+  fileName: string;
+  /** Raw content */
+  content: string;
+}
+
+export interface PlanningSeed {
+  /** File name */
+  fileName: string;
+  /** Raw content */
+  content: string;
+}
+
 // ─── Config ────────────────────────────────────────────────────────────────
 
 export interface PlanningConfig {
@@ -231,6 +249,8 @@ export interface PlanningMilestone {
   requirements: string | null;
   /** Roadmap file content, null if missing */
   roadmap: string | null;
+  /** Per-milestone phase directories keyed by full directory name */
+  phases: Record<string, PlanningPhase>;
   /** Any other files */
   extraFiles: PlanningPhaseFile[];
 }
@@ -267,6 +287,14 @@ export interface GSDProject {
   requirements: GSDRequirement[];
   /** Empty or pass-through from old project key decisions */
   decisionsContent: string;
+  /** Counts surfaced in preview/audit for legacy inputs that used to be skipped. */
+  migrationInputs?: GSDMigrationInputs;
+}
+
+export interface GSDMigrationInputs {
+  milestonePhaseDirs: number;
+  decisions: number;
+  seeds: number;
 }
 
 export interface GSDMilestone {

--- a/src/resources/extensions/gsd/migrate/validator.ts
+++ b/src/resources/extensions/gsd/migrate/validator.ts
@@ -2,13 +2,21 @@
 // Pre-flight checks for minimum viable .planning directory.
 // Pure functions, zero Pi dependencies — uses only Node built-ins + exported helpers.
 
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { ValidationResult, ValidationIssue, ValidationSeverity } from './types.js';
 
 function issue(file: string, severity: ValidationSeverity, message: string): ValidationIssue {
   return { file, severity, message };
+}
+
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -48,6 +56,22 @@ export async function validatePlanningDirectory(path: string): Promise<Validatio
 
   if (!existsSync(join(path, 'phases')) || !statSync(join(path, 'phases')).isDirectory()) {
     issues.push(issue('phases/', 'warning', 'phases/ directory not found — no phase data will be parsed'));
+  }
+
+  const milestonesDir = join(path, 'milestones');
+  if (isDir(milestonesDir)) {
+    const milestonePhaseDirs = readdirSync(milestonesDir).filter((entry) => isDir(join(milestonesDir, entry)) && /-phases$/i.test(entry));
+    if (milestonePhaseDirs.length > 0) {
+      issues.push(issue('milestones/', 'warning', `${milestonePhaseDirs.length} milestone phase dir(s) will be migrated`));
+    }
+  }
+
+  if (isDir(join(path, 'decisions'))) {
+    issues.push(issue('decisions/', 'warning', 'decisions/ files will be migrated into DECISIONS.md'));
+  }
+
+  if (isDir(join(path, 'seeds'))) {
+    issues.push(issue('seeds/', 'warning', 'seeds/ files will be preserved in the migration legacy archive'));
   }
 
   const hasFatal = issues.some(i => i.severity === 'fatal');

--- a/src/resources/extensions/gsd/migrate/writer.ts
+++ b/src/resources/extensions/gsd/migrate/writer.ts
@@ -40,6 +40,11 @@ export interface MigrationPreview {
   decisions: {
     total: number;
   };
+  migrationInputs?: {
+    milestonePhaseDirs: number;
+    decisions: number;
+    seeds: number;
+  };
   milestoneCount: number;
   totalSlices: number;
   totalTasks: number;

--- a/src/resources/extensions/gsd/tests/integration/migrate-command.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/migrate-command.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../migrate/index.ts';
 import { importWrittenMigrationToDb } from '../../migrate/command.ts';
 import { deriveState } from '../../state.ts';
-import { closeDatabase, getDecisionById, getRequirementCounts } from '../../gsd-db.ts';
+import { closeDatabase, getDecisionById, getRequirementById, getRequirementCounts } from '../../gsd-db.ts';
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -62,6 +62,22 @@ const SAMPLE_REQUIREMENTS_LEGACY_IDS = `# Requirements
 - [ ] **OUTPUT-FORMAT**: Output matches GSD format.
 - [ ] **IMPORT-DB**: Migration imports requirements into the DB.
 - [ ] **STATUS-WIDGET**: Status can query migrated requirements.
+`;
+
+const SAMPLE_REQUIREMENTS_CATEGORICAL_IDS = `# Requirements
+
+## Validated
+
+- ✅ NET-01: Network baseline is validated.
+- ✓ OBF-10: Obfuscation compatibility is code-complete.
+
+## Active
+
+- ⏳ WIZARD-04: Wizard migration is still active.
+
+## Out of Scope
+
+- ✗ DEPR-01: Deprecated path is intentionally rejected.
 `;
 
 const SAMPLE_STATE = `# State
@@ -325,6 +341,7 @@ test('Full pipeline: parse → transform → preview → write → deriveState',
       // (e) Write
       const result = await writeGSDDirectory(project, writeTarget);
       assert.ok(result.paths.length > 0, 'pipeline: files written');
+      await importWrittenMigrationToDb(writeTarget, preview);
 
       // Key files exist
       const gsd = join(writeTarget, '.gsd');
@@ -350,6 +367,7 @@ test('Full pipeline: parse → transform → preview → write → deriveState',
       assert.ok(state.progress!.tasks !== undefined, 'pipeline: deriveState has tasks progress');
 
     } finally {
+      closeDatabase();
       rmSync(base, { recursive: true, force: true });
       rmSync(writeTarget, { recursive: true, force: true });
     }
@@ -381,6 +399,66 @@ test('Full pipeline: legacy requirement IDs import into DB with canonical IDs', 
       assert.deepStrictEqual(imported.requirements, 4, 'legacy-reqs: DB import count matches preview');
       assert.ok(getDecisionById('D001') !== null, 'legacy-reqs: migrated decision is queryable');
       assert.deepStrictEqual(counts.total, 4, 'legacy-reqs: DB stores all migrated requirements');
+    } finally {
+      closeDatabase();
+      rmSync(base, { recursive: true, force: true });
+      rmSync(writeTarget, { recursive: true, force: true });
+    }
+});
+
+test('Full pipeline: milestone phase dirs and categorical requirements import into DB', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-cmd-milestone-dirs-'));
+    const planning = join(base, '.planning');
+    const writeTarget = mkdtempSync(join(tmpdir(), 'gsd-cmd-milestone-dirs-write-'));
+    try {
+      mkdirSync(join(planning, 'milestones', 'v1.0-phases', '01-foundation'), { recursive: true });
+      mkdirSync(join(planning, 'milestones', 'v2.0-phases', '01-polish'), { recursive: true });
+      mkdirSync(join(planning, 'decisions'), { recursive: true });
+      mkdirSync(join(planning, 'seeds'), { recursive: true });
+
+      writeFileSync(join(planning, 'PROJECT.md'), SAMPLE_PROJECT);
+      writeFileSync(join(planning, 'REQUIREMENTS.md'), SAMPLE_REQUIREMENTS_CATEGORICAL_IDS);
+      writeFileSync(join(planning, 'milestones', 'v1.0-ROADMAP.md'), `# v1.0 Roadmap
+
+## Phases
+
+- [x] 01 — Foundation
+`);
+      writeFileSync(join(planning, 'milestones', 'v1.0-phases', '01-foundation', '01-PLAN.md'), SAMPLE_PLAN_10_01.replaceAll('10-foundation', '01-foundation'));
+      writeFileSync(join(planning, 'milestones', 'v1.0-phases', '01-foundation', '01-SUMMARY.md'), SAMPLE_SUMMARY_10_01.replaceAll('10-foundation', '01-foundation'));
+      writeFileSync(join(planning, 'milestones', 'v2.0-ROADMAP.md'), `# v2.0 Roadmap
+
+## Phases
+
+- [ ] 01 — Polish
+`);
+      writeFileSync(join(planning, 'milestones', 'v2.0-phases', '01-polish', '01-PLAN.md'), SAMPLE_PLAN_20_01.replaceAll('20-features', '01-polish'));
+      writeFileSync(join(planning, 'decisions', '2026-05-11-parser-shape.md'), '# Parser Shape\n\nPrefer milestone-local phases.');
+      writeFileSync(join(planning, 'seeds', 'SEED-001-feature.md'), '# Feature Seed\n\nSeed content.');
+
+      const parsed = await parsePlanningDirectory(planning);
+      const project = transformToGSD(parsed);
+      const preview = generatePreview(project);
+
+      assert.deepStrictEqual(preview.milestoneCount, 2, 'milestone dirs pipeline: preview milestone count');
+      assert.deepStrictEqual(preview.totalSlices, 2, 'milestone dirs pipeline: preview slice count');
+      assert.deepStrictEqual(preview.totalTasks, 2, 'milestone dirs pipeline: preview task count');
+      assert.deepStrictEqual(preview.decisions.total, 1, 'milestone dirs pipeline: decision file counted');
+      assert.deepStrictEqual(preview.requirements.total, 4, 'milestone dirs pipeline: categorical requirements counted');
+      assert.deepStrictEqual(preview.requirements.outOfScope, 1, 'milestone dirs pipeline: rejected requirement counted out-of-scope');
+      assert.deepStrictEqual(preview.migrationInputs?.seeds, 1, 'milestone dirs pipeline: seed count visible');
+
+      await writeGSDDirectory(project, writeTarget);
+      const imported = await importWrittenMigrationToDb(writeTarget, preview);
+      const counts = getRequirementCounts();
+
+      assert.deepStrictEqual(imported.hierarchy.milestones, 2, 'milestone dirs pipeline: DB imports two milestones');
+      assert.deepStrictEqual(imported.hierarchy.slices, 2, 'milestone dirs pipeline: DB imports two slices');
+      assert.deepStrictEqual(imported.hierarchy.tasks, 2, 'milestone dirs pipeline: DB imports two tasks');
+      assert.deepStrictEqual(imported.decisions, 1, 'milestone dirs pipeline: DB imports decision file row');
+      assert.deepStrictEqual(imported.requirements, 4, 'milestone dirs pipeline: DB import matches categorical requirement preview');
+      assert.ok(getRequirementById('NET-01') !== null, 'milestone dirs pipeline: categorical requirement ID queryable');
+      assert.deepStrictEqual(counts.outOfScope, 1, 'milestone dirs pipeline: rejected requirement persists as out-of-scope');
     } finally {
       closeDatabase();
       rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -247,6 +247,29 @@ test('md-importer: parseRequirementsSections', () => {
   assert.deepStrictEqual(r040?.class, 'anti-feature', 'R040 class');
 });
 
+test('md-importer: parseRequirementsSections accepts categorical requirement IDs', () => {
+  const content = `# Requirements
+
+## Validated
+
+### NET-01 — Bench validated networking
+- Status: validated
+- Description: Network path has been validated.
+
+## Out of Scope
+
+### OBF-10 — Rejected obfuscation path
+- Status: out-of-scope
+- Description: This path was intentionally rejected.
+`;
+
+  const reqs = parseRequirementsSections(content);
+
+  assert.deepStrictEqual(reqs.map((req) => req.id), ['NET-01', 'OBF-10'], 'categorical reqs: IDs parsed');
+  assert.deepStrictEqual(reqs[0]?.status, 'validated', 'categorical reqs: validated status');
+  assert.deepStrictEqual(reqs[1]?.status, 'out-of-scope', 'categorical reqs: out-of-scope status');
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // md-importer: migrateFromMarkdown orchestrator
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/migrate-parser.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-parser.test.ts
@@ -525,6 +525,80 @@ subsystem: "api"
     }
 });
 
+test('Milestone phase directories, decisions, and seeds are parsed', async () => {
+    const base = createFixtureBase();
+    try {
+      const planning = createPlanningDir(base);
+
+      const milestonesDir = join(planning, 'milestones');
+      mkdirSync(join(milestonesDir, 'v1.0-phases', '01-foundation'), { recursive: true });
+      mkdirSync(join(milestonesDir, 'v2.0-phases', '01-polish'), { recursive: true });
+
+      writeFileSync(join(milestonesDir, 'v1.0-ROADMAP.md'), `# v1.0 Roadmap
+
+## Phases
+
+- [x] 01 — Foundation
+`);
+      writeFileSync(join(milestonesDir, 'v1.0-REQUIREMENTS.md'), `# v1 Requirements
+
+## Validated
+
+- ✅ NET-01: Network baseline is validated
+`);
+      writeFileSync(join(milestonesDir, 'v1.0-phases', '01-foundation', '01-PLAN.md'), `---
+phase: "01-foundation"
+plan: "01"
+---
+
+<objective>Build the foundation.</objective>
+`);
+      writeFileSync(join(milestonesDir, 'v1.0-phases', '01-foundation', '01-SUMMARY.md'), `---
+phase: "01-foundation"
+plan: "01"
+completed: "2026-05-01"
+---
+
+# Foundation summary
+`);
+      writeFileSync(join(milestonesDir, 'v2.0-ROADMAP.md'), `# v2.0 Roadmap
+
+## Phases
+
+- [ ] 01 — Polish
+`);
+      writeFileSync(join(milestonesDir, 'v2.0-phases', '01-polish', '01-PLAN.md'), `---
+phase: "01-polish"
+plan: "01"
+---
+
+<objective>Polish the migration.</objective>
+`);
+
+      mkdirSync(join(planning, 'decisions'), { recursive: true });
+      writeFileSync(join(planning, 'decisions', '2026-05-11-parser-shape.md'), '# Parser Shape\n\nPrefer milestone-local phases.');
+
+      mkdirSync(join(planning, 'seeds'), { recursive: true });
+      writeFileSync(join(planning, 'seeds', 'SEED-001-feature.md'), '# Feature Seed\n\nSeed content.');
+
+      const project = await parsePlanningDirectory(planning);
+
+      assert.deepStrictEqual(project.milestones.length, 2, 'milestone dirs: two legacy milestones parsed');
+      assert.deepStrictEqual(project.milestones[0]?.id, 'v1.0', 'milestone dirs: first legacy ID preserved in parser');
+      assert.ok(project.milestones[0]?.roadmap !== null, 'milestone dirs: roadmap content parsed');
+      assert.ok(project.milestones[0]?.requirements !== null, 'milestone dirs: requirements content parsed');
+      assert.ok('01-foundation' in (project.milestones[0]?.phases ?? {}), 'milestone dirs: v1 phase dir parsed');
+      assert.ok(project.milestones[0]?.phases['01-foundation']?.plans['01'] !== undefined, 'milestone dirs: short plan filename parsed');
+      assert.ok(project.milestones[0]?.phases['01-foundation']?.summaries['01'] !== undefined, 'milestone dirs: short summary filename parsed');
+      assert.deepStrictEqual(project.decisions.length, 1, 'decisions dir: decision file parsed');
+      assert.deepStrictEqual(project.decisions[0]?.fileName, '2026-05-11-parser-shape.md', 'decisions dir: filename preserved');
+      assert.deepStrictEqual(project.seeds.length, 1, 'seeds dir: seed file parsed');
+      assert.deepStrictEqual(project.seeds[0]?.fileName, 'SEED-001-feature.md', 'seeds dir: filename preserved');
+    } finally {
+      cleanup(base);
+    }
+});
+
   // ─── Test 6: Summary file with YAML frontmatter ───────────────────────
 
 test('Summary file with YAML frontmatter', async () => {

--- a/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
@@ -36,6 +36,8 @@ function emptyProject(overrides: Partial<PlanningProject> = {}): PlanningProject
     quickTasks: [],
     milestones: [],
     research: [],
+    decisions: [],
+    seeds: [],
     validation: { valid: true, issues: [] },
     ...overrides,
   };
@@ -245,6 +247,47 @@ test('Scenario 2: Multi-milestone', () => {
   assert.ok(result.milestones[1]?.title.length > 0, 'multi: M002 has title');
 });
 
+test('Scenario 2b: Milestone directory layout drives canonical M output with legacy provenance', () => {
+  const plan01 = makePlan('01');
+  const project = emptyProject({
+    milestones: [
+      {
+        id: 'v1.0',
+        requirements: '# v1 Requirements',
+        roadmap: '# v1 Roadmap',
+        phases: {
+          '01-foundation': makePhase('01-foundation', 1, 'foundation', {
+            plans: { '01': { ...plan01, frontmatter: { ...plan01.frontmatter, phase: '01-foundation' } } },
+            summaries: { '01': makeSummary('01') },
+          }),
+        },
+        extraFiles: [],
+      },
+      {
+        id: 'v2.0',
+        requirements: null,
+        roadmap: '# v2 Roadmap',
+        phases: {
+          '01-polish': makePhase('01-polish', 1, 'polish', {
+            plans: { '01': { ...plan01, frontmatter: { ...plan01.frontmatter, phase: '01-polish' } } },
+          }),
+        },
+        extraFiles: [],
+      },
+    ],
+  });
+
+  const result = transformToGSD(project);
+
+  assert.deepStrictEqual(result.milestones.length, 2, 'milestone dirs: two GSD milestones');
+  assert.deepStrictEqual(result.milestones.map((m) => m.id), ['M001', 'M002'], 'milestone dirs: canonical GSD IDs');
+  assert.ok(result.milestones[0]?.title.includes('v1.0'), 'milestone dirs: legacy ID visible in title');
+  assert.deepStrictEqual(result.milestones[0]?.slices.length, 1, 'milestone dirs: first milestone has one slice');
+  assert.deepStrictEqual(result.milestones[0]?.slices[0]?.tasks.length, 1, 'milestone dirs: first slice has task');
+  assert.deepStrictEqual(result.milestones[0]?.slices[0]?.done, true, 'milestone dirs: summary marks slice done');
+  assert.deepStrictEqual(result.migrationInputs?.milestonePhaseDirs, 2, 'milestone dirs: preview metadata counts phase dirs');
+});
+
 // ─── Scenario 3: Decimal Phase Ordering (1, 2, 2.1, 2.2, 3 → S01–S05) ──
 
 test('Scenario 3: Decimal phase ordering', () => {
@@ -399,6 +442,22 @@ test('Scenario 6: Requirements classification', () => {
   assert.deepStrictEqual(result.requirements[0]?.primarySlice, 'none yet', 'requirements: default primarySlice');
 });
 
+test('Scenario 6b: Categorical requirement IDs and rejected status are preserved', () => {
+  const project = emptyProject({
+    requirements: [
+      makeRequirement('NET-01', 'Bench validated networking', 'validated'),
+      makeRequirement('OBF-10', 'Rejected obfuscation path', 'rejected'),
+    ],
+  });
+
+  const result = transformToGSD(project);
+
+  assert.deepStrictEqual(result.requirements.map((req) => req.id), ['NET-01', 'OBF-10'], 'categorical reqs: IDs preserved');
+  assert.deepStrictEqual(result.requirements[0]?.status, 'validated', 'categorical reqs: validated status preserved');
+  assert.deepStrictEqual(result.requirements[1]?.status, 'out-of-scope', 'categorical reqs: rejected maps to out-of-scope');
+  assert.ok(!result.requirements[0]?.description.includes('Legacy ID:'), 'categorical reqs: no legacy ID fallback');
+});
+
 // ─── Scenario 7: Empty Phase (no plans → slice with 0 tasks) ───────────────
 
 test('Scenario 7: Empty phase', () => {
@@ -539,8 +598,8 @@ test('Scenario 11: Requirements edge cases', () => {
   assert.deepStrictEqual(result.requirements[2]?.id, 'R005', 'req-edge: existing id preserved');
   assert.deepStrictEqual(result.requirements[2]?.status, 'active', 'req-edge: unknown status normalized to active');
   assert.deepStrictEqual(result.requirements[3]?.status, 'deferred', 'req-edge: uppercase DEFERRED normalized');
-  assert.deepStrictEqual(result.requirements[4]?.id, 'R003', 'req-edge: non-R legacy id gets next canonical id');
-  assert.ok(result.requirements[4]?.description.includes('Legacy ID: AUTH-7'), 'req-edge: original legacy id is preserved in description');
+  assert.deepStrictEqual(result.requirements[4]?.id, 'AUTH-7', 'req-edge: categorical legacy id is preserved');
+  assert.ok(!result.requirements[4]?.description.includes('Legacy ID: AUTH-7'), 'req-edge: categorical legacy id is not duplicated in description');
 });
 
 // ─── Scenario 12: Vision derivation ────────────────────────────────────────


### PR DESCRIPTION
## Linked issue

Closes #21

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserves per-milestone phase dirs, decision files, seed visibility, and categorical requirement IDs during `/gsd migrate`.
**Why:** Multi-milestone `.planning/` trees were collapsing into an empty synthetic migration milestone and silently dropping planning state.
**How:** Extends migration parsing/transform/import paths and adds regression coverage across parser, transformer, importer, and pipeline import counts.

## What

This updates the GSD migration pipeline to:

- Parse `.planning/milestones/<legacy-id>-phases/` directories and short `01-PLAN.md` / `01-SUMMARY.md` filenames.
- Prefer milestone-local phase groups when transforming migrated milestones, while keeping canonical `M###` output IDs.
- Parse `.planning/decisions/*.md` into `DECISIONS.md` rows.
- Surface legacy input counts for milestone phase dirs, decisions, and seeds in migration preview metadata.
- Parse emoji-status requirement bullets and preserve categorical IDs such as `NET-01` and `OBF-10` through DB import.
- Map rejected requirements to `out-of-scope`.

## Why

Issue #21 is a silent data-loss migration bug. A valid multi-milestone `.planning/` tree could migrate into one empty `M001 Migration` stub with missing decisions and skipped requirements.

## How

The parser now scans milestone phase subdirectories plus decisions/seeds directories. The transformer treats milestone groups with phase dirs as the authoritative migrated structure and widens requirement ID normalization. The markdown importer now accepts categorical requirement headings so DB import verification remains aligned with preview counts.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- `npm ci`
- `npm run build:core`
- `npm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-parser.test.ts src/resources/extensions/gsd/tests/migrate-transformer.test.ts src/resources/extensions/gsd/tests/md-importer.test.ts src/resources/extensions/gsd/tests/integration/migrate-command.test.ts`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/migrate-parser.test.js dist-test/src/resources/extensions/gsd/tests/migrate-transformer.test.js dist-test/src/resources/extensions/gsd/tests/md-importer.test.js dist-test/src/resources/extensions/gsd/tests/integration/migrate-command.test.js`
- `npm run test:changed:src`

Note: `npm run verify:pr` completed `build:core` and `typecheck:extensions`, then hung in the full compiled unit runner with no failures emitted; I stopped that hung process and ran the changed-source and targeted compiled suites above.

## AI disclosure

- [ ] This PR includes AI-assisted code
