### PR TITLE
fix(issue): OpenRouter model discovery 404s when baseUrl includes /api/v1 path prefix

### DIFF
--- a/packages/pi-coding-agent/src/core/model-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.test.ts
@@ -142,3 +142,25 @@ describe("supportsDiscoveryForApi", () => {
 		assert.equal(supportsDiscoveryForApi(undefined), false);
 	});
 });
+
+describe("OpenRouter discovery URL handling", () => {
+	it("does not duplicate /api/v1 when baseUrl already includes it", async () => {
+		const adapter = getDiscoveryAdapter("openrouter");
+		const prevFetch = globalThis.fetch;
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof globalThis.fetch;
+
+		try {
+			await adapter.fetchModels("test-key", "https://openrouter.ai/api/v1");
+			assert.equal(requestedUrl, "https://openrouter.ai/api/v1/models");
+		} finally {
+			globalThis.fetch = prevFetch;
+		}
+	});
+});

--- a/packages/pi-coding-agent/src/core/model-discovery.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.ts
@@ -124,6 +124,10 @@ function parseOpenAICompatibleModel(rawModel: Record<string, unknown>): Discover
 	};
 }
 
+function stripTrailingOpenAIPathPrefix(baseUrl: string): string {
+	return baseUrl.replace(/\/api\/v1\/?$/, "").replace(/\/v1\/?$/, "");
+}
+
 class OpenAIDiscoveryAdapter implements ProviderDiscoveryAdapter {
 	provider: string;
 	supportsDiscovery = true;
@@ -182,7 +186,8 @@ class OpenRouterDiscoveryAdapter implements ProviderDiscoveryAdapter {
 	supportsDiscovery = true;
 
 	async fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
-		const url = `${baseUrl ?? "https://openrouter.ai"}/api/v1/models`;
+		const origin = stripTrailingOpenAIPathPrefix(baseUrl ?? "https://openrouter.ai");
+		const url = `${origin}/api/v1/models`;
 		const response = await fetchWithTimeout(url, {
 			headers: { Authorization: `Bearer ${apiKey}` },
 		});


### PR DESCRIPTION
## Summary
- Normalized OpenRouter discovery base URLs to prevent `/api/v1/api/v1/models` and added a regression test, with targeted model-discovery tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #20
- [#20 OpenRouter model discovery 404s when baseUrl includes /api/v1 path prefix](https://github.com/open-gsd/gsd-pi/issues/20)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/20-openrouter-model-discovery-404s-when-bas-1779491312`