### PR TITLE
ci: restore GitHub-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,0 @@
-self-hosted-runner:
-  labels:
-    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/agent-workflow-guard.yml
+++ b/.github/workflows/agent-workflow-guard.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   non-write-users:
     name: Check non-write-user trigger expansion
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout base

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   triage:
     if: ${{ github.event_name != 'issue_comment' || (github.event.comment.user.type != 'Bot' && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR') && contains(github.event.comment.body, '/rerun-triage')) }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -43,7 +43,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
           - os: ubuntu-latest
-            target: blacksmith-4vcpu-ubuntu-2404-arm
+            target: aarch64-unknown-linux-gnu
             platform: linux-arm64-gnu
             cross: true
           - os: windows-latest
@@ -111,7 +111,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
     # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     name: Publish platform packages
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   detect-changes:
     timeout-minutes: 2
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       heavy-code-changed: ${{ steps.check.outputs.heavy-code-changed }}
       portability-changed: ${{ steps.check.outputs.portability-changed }}
@@ -142,7 +142,7 @@ jobs:
 
   docs-check:
     timeout-minutes: 5
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -153,7 +153,7 @@ jobs:
 
   lint:
     timeout-minutes: 5
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -217,7 +217,7 @@ jobs:
     timeout-minutes: 25
     needs: [detect-changes, docs-check, lint]
     if: needs.detect-changes.outputs.heavy-code-changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -236,7 +236,7 @@ jobs:
         run: npm --prefix web ci
 
       - name: Cache Next.js build
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
@@ -274,7 +274,7 @@ jobs:
     timeout-minutes: 15
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.heavy-code-changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -298,7 +298,7 @@ jobs:
         run: npm --prefix web ci
 
       - name: Cache Next.js build
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
@@ -321,7 +321,7 @@ jobs:
     timeout-minutes: 15
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.heavy-code-changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -365,7 +365,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.detect-changes.outputs.docker-changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -399,7 +399,7 @@ jobs:
       needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       (needs.detect-changes.outputs.portability-changed == 'true' ||
        needs.detect-changes.outputs.windows-e2e-changed == 'true')
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/cleanup-dev-versions.yml
+++ b/.github/workflows/cleanup-dev-versions.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   cleanup:
     name: Remove stale -dev versions
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/forensics-check.yml
+++ b/.github/workflows/forensics-check.yml
@@ -11,7 +11,7 @@ jobs:
   check-forensics:
     # Only run on bug reports
     if: contains(github.event.issue.labels.*.name, 'bug')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Check for forensics output and comment if missing
         uses: actions/github-script@v7

--- a/.github/workflows/issue-dedupe.yml
+++ b/.github/workflows/issue-dedupe.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   suggest-duplicates:
     name: Suggest duplicate candidates
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout base

--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -22,7 +22,7 @@ jobs:
   comment:
     name: Comment on lifecycle labels
     if: ${{ github.event_name == 'issues' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout base
@@ -42,7 +42,7 @@ jobs:
   sweep:
     name: Recycle stale needs-info issues
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout base

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
     name: Publish @${{ github.event.inputs.channel }}
     if: ${{ github.event.inputs.channel != 'latest' }}
     # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.channel }}
     container:
       image: ghcr.io/open-gsd/gsd-ci-builder:latest
@@ -75,7 +75,7 @@ jobs:
         run: npm --prefix web ci
 
       - name: Cache Next.js build
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
@@ -129,7 +129,7 @@ jobs:
     name: Verify @${{ github.event.inputs.channel }} package
     if: ${{ github.event.inputs.channel != 'latest' }}
     needs: prerelease-publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -184,7 +184,7 @@ jobs:
     name: Production Release
     if: ${{ github.event.inputs.channel == 'latest' }}
     # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: prod
     steps:
       - uses: actions/checkout@v6
@@ -208,7 +208,7 @@ jobs:
           node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
       - name: Cache Next.js build
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success' &&
           github.event.workflow_run.head_branch == 'main' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   risk-check:
     name: Classify changed files and assess risk
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       # Checkout the BASE branch — our trusted script and map, not fork code.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   npm-audit:
     name: npm audit (${{ matrix.workspace }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +111,7 @@ jobs:
 
   cargo-audit:
     name: cargo audit
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   check-version:
     if: ${{ github.event_name == 'issues' && contains(github.event.issue.body, 'GSD version') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Check GSD version and comment if outdated
         uses: actions/github-script@v7

--- a/scripts/__tests__/github-workflows-runner-contract.test.mjs
+++ b/scripts/__tests__/github-workflows-runner-contract.test.mjs
@@ -1,0 +1,75 @@
+// Open GSD - GitHub workflow runner contract tests.
+// File Purpose: Ensure active workflows use GitHub-hosted runners and cache actions.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import YAML from "yaml";
+
+const WORKFLOW_DIR = ".github/workflows";
+const GITHUB_HOSTED_RUNNERS = new Set([
+  "ubuntu-latest",
+  "windows-latest",
+  "macos-14",
+]);
+
+function loadWorkflows() {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml"))
+    .map((entry) => {
+      const path = join(WORKFLOW_DIR, entry);
+      return {
+        path,
+        document: YAML.parse(readFileSync(path, "utf8")),
+      };
+    });
+}
+
+function visit(value, onValue) {
+  onValue(value);
+  if (Array.isArray(value)) {
+    for (const item of value) visit(item, onValue);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) visit(item, onValue);
+  }
+}
+
+test("active workflows use GitHub-hosted runners", () => {
+  for (const workflow of loadWorkflows()) {
+    const jobs = workflow.document.jobs ?? {};
+    for (const [jobName, job] of Object.entries(jobs)) {
+      const runner = job["runs-on"];
+      if (!runner || String(runner).includes("${{")) continue;
+
+      assert.ok(
+        GITHUB_HOSTED_RUNNERS.has(runner),
+        `${workflow.path} job ${jobName} uses non-hosted runner ${runner}`,
+      );
+    }
+  }
+});
+
+test("active workflows use the standard cache action", () => {
+  for (const workflow of loadWorkflows()) {
+    visit(workflow.document, (value) => {
+      if (!value || typeof value !== "object" || !("uses" in value)) return;
+
+      assert.notEqual(
+        value.uses,
+        "useblacksmith/cache@v5",
+        `${workflow.path} still uses the custom cache action`,
+      );
+    });
+  }
+});
+
+test("native Linux ARM64 build matrix uses a Rust target triple", () => {
+  const workflow = YAML.parse(readFileSync(".github/workflows/build-native.yml", "utf8"));
+  const entries = workflow.jobs.build.strategy.matrix.include;
+  const linuxArm64 = entries.find((entry) => entry.platform === "linux-arm64-gnu");
+
+  assert.equal(linuxArm64.target, "aarch64-unknown-linux-gnu");
+});


### PR DESCRIPTION
## Linked issue

Closes #30

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Restores active workflows to GitHub-hosted runners and standard cache actions.
**Why:** Current PR and issue workflows are created but remain queued on unavailable custom runner labels.
**How:** Replaces custom runner labels with hosted runner labels, restores the Linux ARM64 Rust target triple, removes the custom runner actionlint allowlist, and adds a structured workflow contract test.

## What

Updates active workflow files under `.github/workflows` to use `ubuntu-latest`, `windows-latest`, and `actions/cache@v4` instead of unavailable custom runner/cache labels. Also fixes `build-native.yml` so the Linux ARM64 matrix target is `aarch64-unknown-linux-gnu` again.

Adds `scripts/__tests__/github-workflows-runner-contract.test.mjs` to parse workflow YAML and verify hosted runner/cache expectations.

## Why

CI, PR risk, triage, and issue helper jobs are currently stuck queued because no runner is picking up the custom labels. GitHub-hosted runners unblock PR validation while custom runner access is sorted out separately.

## How

This is a mechanical workflow rollback plus one regression test. The test parses workflows as YAML rather than grepping source text and checks direct `runs-on` values, cache action usage, and the native Linux ARM64 target triple.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual checks:

- `node --test scripts/__tests__/github-workflows-runner-contract.test.mjs scripts/__tests__/npm-publish-workflow.test.mjs scripts/__tests__/workflow-non-write-users-check.test.mjs`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
- `rg -n "blacksmith|useblacksmith" .github` returns no workflow/config matches

Note: local `actionlint` currently reports pre-existing shellcheck warnings in workflow scripts unrelated to this runner rollback.

## AI disclosure

- [x] This PR includes AI-assisted code
