### PR TITLE
fix(gsd): drop session switch abort cancellations

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -172,10 +172,9 @@ export function isBareClaudeCodeStreamAbortPlaceholder(lastMsg: unknown): boolea
  * "Auto-mode stopped — Unit aborted: Claude Code process aborted by user"
  * even though no user input occurred.
  *
- * Claude Code abort markers are intentionally ignored when the abort fires
- * while the session-switch is in flight: the abort is the expected side-effect
- * of the transition, not a user signal. Other branches (genuine `stopReason
- * === "aborted"` with explicit errorMessage) preserve the prior behavior.
+ * Abort markers are intentionally ignored when the abort fires while the
+ * session-switch is in flight: the abort belongs to the old turn being torn
+ * down by newSession(), not to the next unit.
  */
 export function _handleSessionSwitchAgentEnd(
   lastMsg: unknown,
@@ -199,10 +198,7 @@ export function _handleSessionSwitchAgentEnd(
   }
 
   if (m.stopReason === "aborted") {
-    const hasErrorMessage = !!m.errorMessage;
-    if (hasErrorMessage) {
-      resolveCancelled(_buildAbortedPauseContext(m as { errorMessage?: unknown }));
-    }
+    return;
   }
 }
 

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -13,7 +13,13 @@ import {
 } from "../bootstrap/agent-end-recovery.js";
 import { _setAutoActiveForTest } from "../auto.js";
 import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js";
-import { _resetPendingResolve, _setCurrentResolve } from "../auto/resolve.js";
+import {
+  _consumePendingSwitchCancellation,
+  _resetPendingResolve,
+  _setCurrentResolve,
+  _setSessionSwitchInFlight,
+  resolveAgentEndCancelled,
+} from "../auto/resolve.js";
 import type { ErrorContext } from "../auto/types.js";
 
 test.afterEach(() => {
@@ -45,9 +51,9 @@ test("user-abort message during session-switch is dropped (not propagated as can
   assert.equal(cancelledWith, null, "proxy user-abort during session-switch must not propagate cancellation");
 });
 
-test("genuine stopReason='aborted' with errorMessage during session-switch still propagates", () => {
-  // Regression guard for prior behavior: genuine aborts with diagnostic content
-  // continue to surface as cancellations so transient-pause recovery can run.
+test("aborted with errorMessage during session-switch is dropped instead of queued", () => {
+  // The abort belongs to the old session being torn down by newSession().
+  // Queueing it as pending cancellation kills the freshly-dispatched unit.
   let cancelledWith: { message: string; category: string; isTransient?: boolean } | null = null;
   const resolveCancelled = (ctx: ErrorContext) => {
     cancelledWith = ctx;
@@ -63,11 +69,22 @@ test("genuine stopReason='aborted' with errorMessage during session-switch still
     resolveCancelled,
   );
 
-  assert.deepEqual(cancelledWith, {
-    message: "stream torn down mid-flight",
-    category: "aborted",
-    isTransient: true,
-  });
+  assert.equal(cancelledWith, null);
+});
+
+test("aborted with errorMessage during session-switch does not cancel the next unit", () => {
+  _setSessionSwitchInFlight(true);
+
+  _handleSessionSwitchAgentEnd(
+    {
+      stopReason: "aborted",
+      errorMessage: "stream torn down mid-flight",
+      content: [{ type: "text", text: "partial output" }],
+    },
+    resolveAgentEndCancelled,
+  );
+
+  assert.equal(_consumePendingSwitchCancellation(), null);
 });
 
 test("Claude Code stream-aborted placeholder during session-switch is dropped", () => {


### PR DESCRIPTION
## Linked issue

Refs #33

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Drops session-switch `stopReason: "aborted"` events instead of queueing them as cancellation for the next unit.
**Why:** Old-session teardown aborts can otherwise pause a freshly-dispatched unit before it makes any tool calls.
**How:** Treat all aborted agent-end events observed during an in-flight session switch as old-turn cleanup and add regression coverage for the pending cancellation queue.

## What

Updates `bootstrap/agent-end-recovery.ts` so `_handleSessionSwitchAgentEnd()` returns for every `stopReason: "aborted"` event during session switch. Updates `session-switch-abort-misclassification.test.ts` to assert both helper behavior and that `_consumePendingSwitchCancellation()` remains empty for the next unit.

## Why

Issue #33 reports `dispatch-match` followed by `orchestrator-terminal reason=pause` about 500ms later. The stale session-switch cancellation path can produce that symptom by carrying an old aborted event into the freshly-dispatched unit.

## How

The fix keeps non-abort error handling unchanged and narrows the change to session-switch handling. Mid-unit aborts outside the session-switch path continue through the existing pause behavior.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual testing:

- `npm ci`
- `npm run build:pi`
- `npm run build:rpc-client && npm run build:mcp-server`
- `node scripts/compile-tests.mjs src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.js`
- `npm run typecheck:extensions`

## AI disclosure

- [ ] This PR includes AI-assisted code
