### PR TITLE
fix(gsd): guard stale pause callbacks

### DIFF
--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -23,6 +23,7 @@ import { closeoutUnit, type CloseoutOptions } from "./auto-unit-closeout.js";
 import { saveActivityLog } from "./activity-log.js";
 import { recoverTimedOutUnit, type RecoveryContext } from "./auto-timeout-recovery.js";
 import { resolveAgentEndCancelled } from "./auto/resolve.js";
+import type { PauseAutoOptions } from "./auto/loop-deps.js";
 import type { AutoSession } from "./auto/session.js";
 import { logWarning, logError } from "./workflow-logger.js";
 
@@ -35,7 +36,7 @@ export interface SupervisionContext {
   prefs: GSDPreferences | undefined;
   buildSnapshotOpts: () => CloseoutOptions & Record<string, unknown>;
   buildRecoveryContext: () => RecoveryContext;
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>;
+  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI, errorContext?: undefined, options?: PauseAutoOptions) => Promise<void>;
   /** Optional task estimate string (e.g. "30m", "2h") for timeout scaling (#2243). */
   taskEstimate?: string;
 }
@@ -181,6 +182,11 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
   s.idleWatchdogHandle = setInterval(async () => {
     try {
       if (!s.active || !s.currentUnit) return;
+      const expectedCurrentUnit = {
+        type: s.currentUnit.type,
+        id: s.currentUnit.id,
+        startedAt: s.currentUnit.startedAt,
+      };
       const runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
       if (!runtime) return;
       if (Date.now() - runtime.lastProgressAt < idleTimeoutMs) return;
@@ -250,7 +256,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
         `Unit ${unitType} ${unitId} made no meaningful progress for ${supervisor.idle_timeout_minutes}min. Pausing auto-mode.`,
         "warning",
       );
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, undefined, { expectedCurrentUnit });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logError("timer", `[idle-watchdog] Unhandled error: ${message}`);
@@ -269,6 +275,9 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     try {
       s.unitTimeoutHandle = null;
       if (!s.active) return;
+      const expectedCurrentUnit = s.currentUnit
+        ? { type: s.currentUnit.type, id: s.currentUnit.id, startedAt: s.currentUnit.startedAt }
+        : null;
       if (s.currentUnit) {
         writeUnitRuntimeRecord(s.basePath, unitType, unitId, s.currentUnit.startedAt, {
           phase: "timeout",
@@ -286,7 +295,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
         `Unit ${unitType} ${unitId} exceeded ${supervisor.hard_timeout_minutes}min hard timeout. Pausing auto-mode.`,
         "warning",
       );
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, undefined, { expectedCurrentUnit });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logError("timer", `[hard-timeout] Unhandled error: ${message}`);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -241,7 +241,7 @@ import { bootstrapAutoSession, openProjectDbIfPresent, type BootstrapDeps } from
 import { initHealthWidget } from "./health-widget.js";
 import { runLegacyAutoLoop, runUokKernelLoop } from "./auto/loop.js";
 import { resolveAgentEnd, resolveAgentEndCancelled, _resetPendingResolve, isSessionSwitchInFlight } from "./auto/resolve.js";
-import type { LoopDeps, StopAutoOptions } from "./auto/loop-deps.js";
+import type { LoopDeps, PauseAutoOptions, PauseAutoUnitIdentity, StopAutoOptions } from "./auto/loop-deps.js";
 import type { ErrorContext } from "./auto/types.js";
 import { runAutoLoopWithUok } from "./uok/kernel.js";
 import { resolveUokFlags } from "./uok/flags.js";
@@ -1039,6 +1039,23 @@ function currentUnitLabel(): string | null {
   return `${unitVerb(s.currentUnit.type)} ${s.currentUnit.id}`;
 }
 
+export function capturePauseAutoUnitIdentity(): PauseAutoUnitIdentity | null {
+  if (!s.currentUnit) return null;
+  return {
+    type: s.currentUnit.type,
+    id: s.currentUnit.id,
+    startedAt: s.currentUnit.startedAt,
+  };
+}
+
+function pauseAutoUnitIdentityMatches(expected: PauseAutoUnitIdentity | null): boolean {
+  if (!s.currentUnit) return expected === null;
+  return expected !== null &&
+    s.currentUnit.type === expected.type &&
+    s.currentUnit.id === expected.id &&
+    s.currentUnit.startedAt === expected.startedAt;
+}
+
 function setLifecycleOutcome(
   ctx: ExtensionContext | undefined,
   input: {
@@ -1759,8 +1776,19 @@ export async function pauseAuto(
   ctx?: ExtensionContext,
   _pi?: ExtensionAPI,
   _errorContext?: ErrorContext,
+  options: PauseAutoOptions = {},
 ): Promise<void> {
   if (!s.active) return;
+  if (
+    Object.prototype.hasOwnProperty.call(options, "expectedCurrentUnit") &&
+    !pauseAutoUnitIdentityMatches(options.expectedCurrentUnit ?? null)
+  ) {
+    debugLog("pause-auto-stale-unit-guard", {
+      expectedCurrentUnit: options.expectedCurrentUnit ?? null,
+      currentUnit: s.currentUnit,
+    });
+    return;
+  }
   s.active = false;
   clearUnitTimeout();
   stopAutoCommandPolling();

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -37,10 +37,21 @@ export interface StopAutoOptions {
   preserveCompletedMilestoneBranch?: boolean;
 }
 
+export type PauseAutoUnitIdentity = {
+  type: string;
+  id: string;
+  startedAt: number;
+};
+
+export interface PauseAutoOptions {
+  expectedCurrentUnit?: PauseAutoUnitIdentity | null;
+}
+
 type PauseAutoFn = (
   ctx?: ExtensionContext,
   pi?: ExtensionAPI,
   errorContext?: ErrorContext,
+  options?: PauseAutoOptions,
 ) => Promise<void>;
 
 /**

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -844,6 +844,7 @@ export async function runPreDispatch(
 
   // Pre-dispatch health gate
   try {
+    const expectedCurrentUnit = null;
     const healthGate = await deps.preDispatchHealthGate(s.basePath);
     if (healthGate.fixesApplied.length > 0) {
       ctx.ui.notify(
@@ -864,7 +865,7 @@ export async function runPreDispatch(
         healthGate.reason || "Pre-dispatch health check failed — run /gsd doctor for details.",
         "error",
       );
-      await deps.pauseAuto(ctx, pi);
+      await deps.pauseAuto(ctx, pi, undefined, { expectedCurrentUnit });
       debugLog("autoLoop", { phase: "exit", reason: "health-gate-failed" });
       return { action: "break", reason: "health-gate-failed" };
     }

--- a/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { pauseAuto, isAutoActive } from "../auto.ts";
+import { capturePauseAutoUnitIdentity, pauseAuto, isAutoActive } from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { _isPauseOriginCancelledResult } from "../auto/phases.ts";
 
@@ -73,4 +73,78 @@ test("transient-abort errorContext is not classified as pause-origin cancellatio
     false,
     "not paused = not pause-origin regardless of errorContext",
   );
+});
+
+test("pauseAuto ignores stale pre-dispatch pause once a new unit is active", async () => {
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.currentUnit = {
+    type: "research-slice",
+    id: "M011/S05",
+    startedAt: 500,
+  };
+
+  try {
+    await pauseAuto(undefined, undefined, undefined, { expectedCurrentUnit: null });
+
+    assert.equal(autoSession.active, true);
+    assert.equal(autoSession.paused, false);
+    assert.deepEqual(autoSession.currentUnit, {
+      type: "research-slice",
+      id: "M011/S05",
+      startedAt: 500,
+    });
+  } finally {
+    autoSession.reset();
+  }
+});
+
+test("pauseAuto ignores stale pause for a superseded unit identity", async () => {
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.currentUnit = {
+    type: "research-slice",
+    id: "M011/S05",
+    startedAt: 500,
+  };
+
+  try {
+    await pauseAuto(undefined, undefined, undefined, {
+      expectedCurrentUnit: {
+        type: "plan-slice",
+        id: "M011/S04",
+        startedAt: 100,
+      },
+    });
+
+    assert.equal(autoSession.active, true);
+    assert.equal(autoSession.paused, false);
+    assert.deepEqual(autoSession.currentUnit, {
+      type: "research-slice",
+      id: "M011/S05",
+      startedAt: 500,
+    });
+  } finally {
+    autoSession.reset();
+  }
+});
+
+test("pauseAuto still pauses when the expected unit identity matches", async () => {
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.currentUnit = {
+    type: "research-slice",
+    id: "M011/S05",
+    startedAt: 500,
+  };
+  const expectedCurrentUnit = capturePauseAutoUnitIdentity();
+
+  try {
+    await pauseAuto(undefined, undefined, undefined, { expectedCurrentUnit });
+
+    assert.equal(autoSession.active, false);
+    assert.equal(autoSession.paused, true);
+  } finally {
+    autoSession.reset();
+  }
 });


### PR DESCRIPTION
## Linked issue

Closes #33

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds an expected-current-unit guard for stale infrastructure pause callbacks.
**Why:** Late health-gate or timer pauses can otherwise cancel a newer freshly-dispatched unit.
**How:** `pauseAuto()` accepts an optional unit identity guard; pre-dispatch health checks and unit timers pass the unit state they observed before async work.

## What

Updates `pauseAuto()` to return without side effects when an optional `expectedCurrentUnit` no longer matches `autoSession.currentUnit`. Wires the guard into the pre-dispatch health gate and idle/hard timeout pause paths. Adds regression tests for stale no-unit pauses, superseded-unit pauses, and matching-unit pauses.

## Why

Issue #33 reports auto-mode stopping with `reason=pause` about 440-510ms after dispatch. A late async pause from a previous gate or timer must not cancel a different unit that has already started.

## How

The guard uses `{ type, id, startedAt }` because that identity already exists at dispatch and changes when a new unit starts. Callers that do not pass the guard keep existing behavior, preserving user-initiated and provider-error pauses.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual testing:

- `npm ci`
- `npm run build:pi`
- `npm run build:rpc-client && npm run build:mcp-server`
- `node scripts/compile-tests.mjs src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.js`
- `npm run typecheck:extensions`

## AI disclosure

- [ ] This PR includes AI-assisted code
