### PR TITLE
ci: add builder image bootstrap workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,9 +1,13 @@
+# Open GSD - CI builder image pipeline
+# File Purpose: Bootstrap and refresh the GHCR CI builder image used by publish workflows.
+
 name: Pipeline
 
 # Rebuilds the CI builder Docker image when its build inputs change on main.
 # npm publishing lives in one trusted manual workflow (npm-publish.yml).
 
 on:
+  workflow_dispatch: {}
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -21,13 +25,14 @@ jobs:
   update-builder:
     name: Update CI Builder Image
     if: >-
-      ${{ github.event.workflow_run.conclusion == 'success' &&
-          github.event.workflow_run.head_branch == 'main' }}
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.event.workflow_run.head_sha }}
           fetch-depth: 2
 
       - name: Check for builder image changes
@@ -35,6 +40,11 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           CHANGED=$(git diff --name-only "${HEAD_SHA}~1" "${HEAD_SHA}" -- Dockerfile package.json .github/workflows/pipeline.yml || echo "")
           echo "changed=$([[ -n "$CHANGED" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
 

--- a/scripts/__tests__/pipeline-workflow.test.mjs
+++ b/scripts/__tests__/pipeline-workflow.test.mjs
@@ -1,0 +1,30 @@
+// Project/App: Open GSD
+// File Purpose: Regression tests for the CI builder image pipeline workflow.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+const workflow = YAML.parse(readFileSync(".github/workflows/pipeline.yml", "utf8"));
+const job = workflow.jobs["update-builder"];
+
+test("pipeline workflow can be manually dispatched to bootstrap the builder image", () => {
+  assert.deepEqual(workflow.on.workflow_dispatch, {});
+  assert.match(job.if, /github\.event_name == 'workflow_dispatch'/);
+});
+
+test("manual pipeline dispatch checks out main and forces a builder image push", () => {
+  const checkout = job.steps.find((step) => step.uses === "actions/checkout@v6");
+  const check = job.steps.find((step) => step.id === "check");
+
+  assert.match(checkout.with.ref, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(checkout.with.ref, /'main'/);
+  assert.match(check.run, /GITHUB_EVENT_NAME" = "workflow_dispatch"/);
+  assert.match(check.run, /changed=true/);
+});
+
+test("automatic pipeline runs still require successful CI on main", () => {
+  assert.match(job.if, /workflow_run\.conclusion == 'success'/);
+  assert.match(job.if, /workflow_run\.head_branch == 'main'/);
+});


### PR DESCRIPTION
## Linked issue

Closes #37

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds a manual bootstrap path for the CI builder image pipeline.
**Why:** Dev npm publishes currently fail before npm starts because `ghcr.io/open-gsd/gsd-ci-builder:latest` does not exist.
**How:** Enables `workflow_dispatch` for `Pipeline`, forces manual runs to build and push the image, and preserves the existing successful-CI-on-main refresh path.

## What

Updates `.github/workflows/pipeline.yml` so maintainers can manually dispatch the pipeline to build and push `ghcr.io/open-gsd/gsd-ci-builder:latest`. Adds `scripts/__tests__/pipeline-workflow.test.mjs` to cover the bootstrap trigger, checkout ref, forced build flag, and automatic CI guard.

## Why

The `NPM Publish` workflow runs prerelease publishes inside the GHCR builder image. The dev publish run failed during container initialization with `manifest unknown`, and GHCR currently has no `open-gsd/gsd-ci-builder` package to pull.

## How

Manual dispatch checks out `main` and marks the builder image as changed so the existing GHCR login, Docker build, and Docker push steps run. Workflow-run events still require successful CI on `main` and still use the file-change check before rebuilding.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual/local checks:

```text
node --test scripts/__tests__/pipeline-workflow.test.mjs scripts/__tests__/npm-publish-workflow.test.mjs
# 7 tests passed

npm run verify:pr
# Passed build:core, typecheck:extensions, and test:compile. Stopped during the broad compiled unit suite after it hung in visualizer-overlay.test.js under local Node 25.9.0.
```

## AI disclosure

- [ ] This PR includes AI-assisted code
