### PR TITLE
docs: consolidate install and upgrade guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,53 +14,15 @@ Older release history has been archived outside the active changelog so new work
 
 ## Install
 
-GSD installs and updates from the scoped npm package `@opengsd/gsd-pi`.
+Install from npm (not by cloning this repo):
 
 ```bash
 npm install -g @opengsd/gsd-pi@latest
 ```
 
-The source repository is [`open-gsd/gsd-pi`](https://github.com/open-gsd/gsd-pi), but user installs should use npm rather than cloning the repo.
+Source: [`open-gsd/gsd-pi`](https://github.com/open-gsd/gsd-pi).
 
-## Upgrade From Older GSD-2 Installs
-
-If your existing `gsd` command came from the old package location, clear stale local update/resource state and install the scoped package directly:
-
-macOS / Linux:
-
-```bash
-rm -f ~/.gsd/.update-check ~/.gsd/agent/managed-resources.json
-npm install -g @opengsd/gsd-pi@latest
-```
-
-Windows PowerShell:
-
-```powershell
-Remove-Item "$env:USERPROFILE\.gsd\.update-check" -Force -ErrorAction SilentlyContinue
-Remove-Item "$env:USERPROFILE\.gsd\agent\managed-resources.json" -Force -ErrorAction SilentlyContinue
-npm install -g @opengsd/gsd-pi@latest
-```
-
-Windows Command Prompt:
-
-```bat
-del "%USERPROFILE%\.gsd\.update-check" 2>nul
-del "%USERPROFILE%\.gsd\agent\managed-resources.json" 2>nul
-npm install -g @opengsd/gsd-pi@latest
-```
-
-Or run the installer from the new package on any OS:
-
-```bash
-npx @opengsd/gsd-pi@latest
-```
-
-After that, future upgrades can use either command:
-
-```bash
-gsd upgrade
-gsd update
-```
+Upgrading or migrating from an older install? See [Upgrade GSD Pi](./docs/user-docs/getting-started.md#upgrade-gsd-pi) and, if needed, [Upgrade from older GSD-2 installs](./docs/user-docs/troubleshooting.md#upgrade-from-older-gsd-2-installs).
 
 ## Quick Start
 

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -27,10 +27,10 @@ git --version
 
 ## Install GSD Pi
 
-Install the CLI globally:
+Install the CLI globally from the scoped npm package:
 
 ```bash
-npm install -g gsd-pi
+npm install -g @opengsd/gsd-pi@latest
 ```
 
 Confirm the command is available:
@@ -46,6 +46,18 @@ npm prefix -g
 ```
 
 Add that directory's `bin` folder to your shell profile, then open a new terminal.
+
+## Upgrade GSD Pi
+
+After the first install, upgrade to the latest release from your shell:
+
+```bash
+gsd upgrade
+```
+
+`gsd update` is an alias for the same command. Inside a GSD session, use `/gsd update` instead.
+
+If `gsd` reports a version mismatch with synced resources, or you previously installed the unscoped `gsd-pi` package, see [Upgrade from older GSD-2 installs](./troubleshooting.md#upgrade-from-older-gsd-2-installs) in Troubleshooting.
 
 ## Configure GSD
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -18,6 +18,43 @@ It checks:
 
 ## Common Issues
 
+### Upgrade from older GSD-2 installs
+
+**Symptoms:** `gsd` exits with a version or managed-resource mismatch, or an old global `gsd-pi` install still shadows the new package.
+
+**Fix:** Clear stale local update/resource state, then install the scoped package:
+
+macOS / Linux:
+
+```bash
+rm -f ~/.gsd/.update-check ~/.gsd/agent/managed-resources.json
+npm install -g @opengsd/gsd-pi@latest
+```
+
+Windows PowerShell:
+
+```powershell
+Remove-Item "$env:USERPROFILE\.gsd\.update-check" -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:USERPROFILE\.gsd\agent\managed-resources.json" -Force -ErrorAction SilentlyContinue
+npm install -g @opengsd/gsd-pi@latest
+```
+
+Windows Command Prompt:
+
+```bat
+del "%USERPROFILE%\.gsd\.update-check" 2>nul
+del "%USERPROFILE%\.gsd\agent\managed-resources.json" 2>nul
+npm install -g @opengsd/gsd-pi@latest
+```
+
+Or run the installer from the new package on any OS:
+
+```bash
+npx @opengsd/gsd-pi@latest
+```
+
+After that, routine upgrades use `gsd upgrade`, `gsd update`, or `/gsd update` in a session.
+
 ### Auto mode loops on the same unit
 
 **Symptoms:** The same unit (e.g., `research-slice` or `plan-slice`) dispatches repeatedly, then auto mode pauses with an "Artifact still missing..." error after 3 artifact verification retries.
@@ -87,7 +124,7 @@ It checks:
 
 ### `command not found: gsd` after install
 
-**Symptoms:** `npm install -g gsd-pi` succeeds but `gsd` isn't found.
+**Symptoms:** `npm install -g @opengsd/gsd-pi@latest` succeeds but `gsd` isn't found.
 
 **Cause:** npm's global bin directory isn't in your shell's `$PATH`.
 
@@ -103,14 +140,14 @@ echo 'export PATH="$(npm prefix -g)/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
-**Workaround:** Run `npx gsd-pi` or `$(npm prefix -g)/bin/gsd` directly.
+**Workaround:** Run `npx @opengsd/gsd-pi@latest` or `$(npm prefix -g)/bin/gsd` directly.
 
 **Common causes:**
 - **Homebrew Node** — `/opt/homebrew/bin` should be in PATH but sometimes isn't if Homebrew init is missing from your shell profile
 - **Version manager (nvm, fnm, mise)** — global bin is version-specific; ensure your version manager initializes in your shell config
 - **oh-my-zsh** — the `gitfast` plugin aliases `gsd` to `git svn dcommit`. Check with `alias gsd` and unalias if needed
 
-### `npm install -g gsd-pi` fails
+### `npm install -g @opengsd/gsd-pi@latest` fails
 
 **Common causes:**
 - Missing workspace packages — fixed in v2.10.4+

--- a/gitbook/README.md
+++ b/gitbook/README.md
@@ -38,7 +38,7 @@ You can stay hands-on with **step mode** (reviewing each step) or let GSD run au
 
 ```bash
 # Install
-npm install -g gsd-pi
+npm install -g @opengsd/gsd-pi@latest
 
 # Launch
 gsd

--- a/gitbook/getting-started/installation.md
+++ b/gitbook/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Install GSD
 
 ```bash
-npm install -g gsd-pi
+npm install -g @opengsd/gsd-pi@latest
 ```
 
 Requires **Node.js 22.0.0 or later** (24 LTS recommended) and **Git**.


### PR DESCRIPTION
## Summary

- Keeps the README install section minimal (`npm install -g @opengsd/gsd-pi@latest`) with links into user docs.
- Adds **Upgrade GSD Pi** to `docs/user-docs/getting-started.md` for routine upgrades (`gsd upgrade`, `gsd update`, `/gsd update`).
- Moves legacy migration steps (clearing `~/.gsd/.update-check` and `managed-resources.json`) to `docs/user-docs/troubleshooting.md`.
- Aligns GitBook install/quick-start copy to `@opengsd/gsd-pi@latest`.

## Test plan

- [x] Reviewed markdown links from README to getting-started and troubleshooting anchors.
- [ ] Maintainer skim: install/upgrade paths read correctly for new and migrating users.


Made with [Cursor](https://cursor.com)