### PR TITLE
fix(release): keep version surfaces in sync

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -243,6 +243,7 @@ jobs:
           node -e "require('./package.json')" && \
           node -e "require('./packages/pi-coding-agent/package.json')" && \
           node -e "require('./pkg/package.json')" && \
+          npm run verify:version-sync && \
           echo "All package.json files are valid"
 
       - name: Update CHANGELOG.md
@@ -254,7 +255,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json web/package-lock.json CHANGELOG.md native/npm/*/package.json pkg/package.json packages/*/package.json
+          git add package.json package-lock.json web/package-lock.json CHANGELOG.md native/Cargo.toml native/Cargo.lock native/npm/*/package.json pkg/package.json packages/*/package.json extensions/google-search/package.json
           git commit -m "release: v${RELEASE_VERSION}"
           git pull --rebase origin main
           git tag "v${RELEASE_VERSION}"

--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,14 +1,19 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
-  "keywords": ["pi-package", "gsd-extension"],
+  "keywords": [
+    "pi-package",
+    "gsd-extension"
+  ],
   "gsd": {
     "extension": true
   },
   "pi": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "peerDependencies": {
     "@gsd/pi-coding-agent": "*",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "arboard",
  "dashmap",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opengsd/gsd-pi",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -78,7 +78,7 @@
     },
     "extensions/google-search": {
       "name": "@gsd-extensions/google-search",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@google/genai": "^1.40.0",
         "@sinclair/typebox": "^0.34.41"
@@ -2238,6 +2238,61 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@opengsd/engine-darwin-arm64": {
+      "version": "1.0.0",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opengsd/engine-darwin-x64": {
+      "version": "1.0.0",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opengsd/engine-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opengsd/engine-linux-x64-gnu": {
+      "version": "1.0.0",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opengsd/engine-win32-x64-msvc": {
+      "version": "1.0.0",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -6249,7 +6304,7 @@
     },
     "packages/contracts": {
       "name": "@gsd-build/contracts",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -6257,12 +6312,12 @@
     },
     "packages/daemon": {
       "name": "@gsd-build/daemon",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
-        "@gsd-build/contracts": "^1.0.0",
-        "@gsd-build/rpc-client": "^1.0.0",
+        "@gsd-build/contracts": "^1.0.1",
+        "@gsd-build/rpc-client": "^1.0.1",
         "discord.js": "^14.25.1",
         "yaml": "^2.8.0",
         "zod": "^3.24.0"
@@ -6298,11 +6353,11 @@
     },
     "packages/mcp-server": {
       "name": "@gsd-build/mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@gsd-build/contracts": "^1.0.0",
-        "@gsd-build/rpc-client": "^1.0.0",
+        "@gsd-build/contracts": "^1.0.1",
+        "@gsd-build/rpc-client": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0"
       },
@@ -6319,16 +6374,16 @@
     },
     "packages/native": {
       "name": "@gsd/native",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT"
     },
     "packages/pi-agent-core": {
       "name": "@gsd/pi-agent-core",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     "packages/pi-ai": {
       "name": "@gsd/pi-ai",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@anthropic-ai/vertex-sdk": "^0.14.4",
@@ -6350,9 +6405,9 @@
     },
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@gsd-build/contracts": "^1.0.0",
+        "@gsd-build/contracts": "^1.0.1",
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
@@ -6379,7 +6434,7 @@
     },
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",
@@ -6395,69 +6450,14 @@
     },
     "packages/rpc-client": {
       "name": "@gsd-build/rpc-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@gsd-build/contracts": "^1.0.0"
+        "@gsd-build/contracts": "^1.0.1"
       },
       "engines": {
         "node": ">=22.0.0"
       }
-    },
-    "node_modules/@opengsd/engine-darwin-arm64": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "cpu": [
-        "arm64"
-      ]
-    },
-    "node_modules/@opengsd/engine-darwin-x64": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "cpu": [
-        "x64"
-      ]
-    },
-    "node_modules/@opengsd/engine-linux-arm64-gnu": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ]
-    },
-    "node_modules/@opengsd/engine-linux-x64-gnu": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ]
-    },
-    "node_modules/@opengsd/engine-win32-x64-msvc": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "x64"
-      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -96,6 +96,7 @@
     "pi:uninstall-global": "node scripts/uninstall-pi-global.js",
     "sync-pkg-version": "node scripts/sync-pkg-version.cjs",
     "sync-platform-versions": "node native/scripts/sync-platform-versions.cjs",
+    "verify:version-sync": "node scripts/verify-version-sync.cjs",
     "validate-pack": "node scripts/validate-pack.js",
     "typecheck:extensions": "tsc --noEmit --project tsconfig.extensions.json",
     "verify:pr": "npm run build:core && npm run typecheck:extensions && npm run test:unit",
@@ -105,7 +106,7 @@
     "release:update-changelog": "node scripts/update-changelog.mjs",
     "docker:build-runtime": "docker build --target runtime -t ghcr.io/open-gsd/gsd-pi .",
     "docker:build-builder": "docker build --target builder -t ghcr.io/open-gsd/gsd-ci-builder .",
-    "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && node scripts/prepublish-check.mjs && npm run build && npm run typecheck:extensions && npm run validate-pack",
+    "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && npm run verify:version-sync && node scripts/prepublish-check.mjs && npm run build && npm run typecheck:extensions && npm run validate-pack",
     "test:live-regression": "node --experimental-strip-types tests/live-regression/run.ts",
     "test:e2e": "node --experimental-strip-types --test --test-concurrency=1 \"tests/e2e/*.e2e.test.ts\"",
     "test:e2e:windows-smoke": "node --experimental-strip-types --test tests/e2e/sanity.e2e.test.ts tests/e2e/migration.e2e.test.ts tests/e2e/native-abi.e2e.test.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/daemon",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@gsd-build/contracts": "^1.0.0",
-    "@gsd-build/rpc-client": "^1.0.0",
+    "@gsd-build/contracts": "^1.0.1",
+    "@gsd-build/rpc-client": "^1.0.1",
     "discord.js": "^14.25.1",
     "yaml": "^2.8.0",
     "zod": "^3.24.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {
@@ -34,8 +34,8 @@
     "test": "npm run build:test && node --test dist/mcp-server.test.js dist/remote-questions.test.js"
   },
   "dependencies": {
-    "@gsd-build/contracts": "^1.0.0",
-    "@gsd-build/rpc-client": "^1.0.0",
+    "@gsd-build/contracts": "^1.0.1",
+    "@gsd-build/rpc-client": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "General-purpose agent core (vendored from pi-mono)",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Unified LLM API (vendored from pi-mono)",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Coding agent CLI (vendored from pi-mono)",
   "type": "module",
   "gsd": {
@@ -25,7 +25,7 @@
     "copy-assets": "node scripts/copy-assets.cjs"
   },
   "dependencies": {
-    "@gsd-build/contracts": "^1.0.0",
+    "@gsd-build/contracts": "^1.0.1",
     "@mariozechner/jiti": "^2.6.2",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "chalk": "^5.5.0",

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Terminal User Interface library (vendored from pi-mono)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/rpc-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {
@@ -34,7 +34,7 @@
     "test": "node --test dist/rpc-client.test.js"
   },
   "dependencies": {
-    "@gsd-build/contracts": "^1.0.0"
+    "@gsd-build/contracts": "^1.0.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Project/App: Open GSD
+// File Purpose: Release version bump entry point.
 /**
  * Bump version in package.json, then sync platform packages and pkg/package.json.
  * Usage: node scripts/bump-version.mjs <new-version>
@@ -7,9 +9,11 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
+import versionSync from "./lib/version-sync.cjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
+const { syncVersionSurfaces } = versionSync;
 
 const newVersion = process.argv[2];
 if (!newVersion || !/^\d+\.\d+\.\d+$/.test(newVersion)) {
@@ -25,51 +29,16 @@ pkg.version = newVersion;
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 console.log(`[bump-version] package.json: ${oldVersion} → ${newVersion}`);
 
-// 2. Update all non-private workspace packages under packages/
-//    These share the root version to keep the repo's source of truth coherent
-//    with what ships. Private packages (studio, web) are skipped — they're not
-//    published and have their own lifecycle.
-const workspacePackages = [
-  "daemon",
-  "mcp-server",
-  "native",
-  "pi-agent-core",
-  "pi-ai",
-  "pi-coding-agent",
-  "pi-tui",
-  "rpc-client",
-];
-for (const name of workspacePackages) {
-  const wsPath = resolve(root, "packages", name, "package.json");
-  if (!existsSync(wsPath)) continue;
-  const ws = JSON.parse(readFileSync(wsPath, "utf-8"));
-  const wsOld = ws.version;
-  ws.version = newVersion;
-  // Bump any internal @gsd-build/* or @gsd/* dep references to match.
-  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
-    if (!ws[field]) continue;
-    for (const dep of Object.keys(ws[field])) {
-      if (workspacePackages.some((n) => dep === `@gsd-build/${n}` || dep === `@gsd/${n}`)) {
-        ws[field][dep] = `^${newVersion}`;
-      }
-    }
-  }
-  writeFileSync(wsPath, JSON.stringify(ws, null, 2) + "\n");
-  console.log(`[bump-version] ${name}: ${wsOld} → ${newVersion}`);
-}
+// 2. Update release-owned package, native, and bridge version surfaces.
+syncVersionSurfaces(root, newVersion, { updateRoot: false });
+console.log(`[bump-version] release version surfaces synced to ${newVersion}`);
 
-// 3. Sync platform package versions (reads from root package.json)
-execSync("node native/scripts/sync-platform-versions.cjs", { cwd: root, stdio: "inherit" });
-
-// 4. Sync pkg/package.json (reads from pi-coding-agent)
-execSync("node scripts/sync-pkg-version.cjs", { cwd: root, stdio: "inherit" });
-
-// 5. Regenerate root package-lock.json to match the new version.
+// 3. Regenerate root package-lock.json to match the new version.
 //    --package-lock-only updates the lockfile in-place without touching node_modules.
 execSync("npm install --package-lock-only --ignore-scripts", { cwd: root, stdio: "inherit" });
 console.log(`[bump-version] package-lock.json regenerated at ${newVersion}`);
 
-// 6. Regenerate web/package-lock.json if the web app is present.
+// 4. Regenerate web/package-lock.json if the web app is present.
 const webDir = resolve(root, "web");
 if (existsSync(webDir)) {
   execSync("npm install --package-lock-only --ignore-scripts", { cwd: webDir, stdio: "inherit" });

--- a/scripts/lib/version-sync.cjs
+++ b/scripts/lib/version-sync.cjs
@@ -1,0 +1,220 @@
+// Project/App: Open GSD
+// File Purpose: Shared helpers for syncing and verifying release version surfaces.
+const fs = require("node:fs");
+const path = require("node:path");
+
+const RELEASE_WORKSPACE_PACKAGE_DIRS = [
+  "extensions/google-search",
+  "packages/contracts",
+  "packages/daemon",
+  "packages/mcp-server",
+  "packages/native",
+  "packages/pi-agent-core",
+  "packages/pi-ai",
+  "packages/pi-coding-agent",
+  "packages/pi-tui",
+  "packages/rpc-client",
+];
+
+const PLATFORM_PACKAGE_DIRS = [
+  "native/npm/darwin-arm64",
+  "native/npm/darwin-x64",
+  "native/npm/linux-arm64-gnu",
+  "native/npm/linux-x64-gnu",
+  "native/npm/win32-x64-msvc",
+];
+
+const INTERNAL_PACKAGE_NAMES = new Set([
+  "@gsd-build/contracts",
+  "@gsd-build/daemon",
+  "@gsd-build/mcp-server",
+  "@gsd-build/rpc-client",
+  "@gsd/native",
+  "@gsd/pi-agent-core",
+  "@gsd/pi-ai",
+  "@gsd/pi-coding-agent",
+  "@gsd/pi-tui",
+]);
+
+const NATIVE_CRATE_NAMES = new Set(["gsd-ast", "gsd-engine", "gsd-grep"]);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function packagePath(root, packageDir) {
+  return path.join(root, packageDir, "package.json");
+}
+
+function setPackageVersion(root, packageDir, version) {
+  const filePath = packagePath(root, packageDir);
+  if (!fs.existsSync(filePath)) return false;
+  const pkg = readJson(filePath);
+  let changed = false;
+  if (pkg.version !== version) {
+    pkg.version = version;
+    changed = true;
+  }
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    if (!pkg[field]) continue;
+    for (const dep of Object.keys(pkg[field])) {
+      if (INTERNAL_PACKAGE_NAMES.has(dep) && pkg[field][dep] !== "*" && pkg[field][dep] !== `^${version}`) {
+        pkg[field][dep] = `^${version}`;
+        changed = true;
+      }
+    }
+  }
+  if (changed) {
+    writeJson(filePath, pkg);
+  }
+  return true;
+}
+
+function syncNativeCargoVersion(root, version) {
+  const manifestPath = path.join(root, "native", "Cargo.toml");
+  if (fs.existsSync(manifestPath)) {
+    const manifest = fs.readFileSync(manifestPath, "utf8");
+    const versionPattern = /(\[workspace\.package\][\s\S]*?\nversion = )"[^"]+"/;
+    if (!versionPattern.test(manifest)) {
+      throw new Error("Could not find native workspace package version in native/Cargo.toml");
+    }
+    const nextManifest = manifest.replace(
+      versionPattern,
+      `$1"${version}"`,
+    );
+    if (nextManifest !== manifest) {
+      fs.writeFileSync(manifestPath, nextManifest);
+    }
+  }
+
+  const lockPath = path.join(root, "native", "Cargo.lock");
+  if (fs.existsSync(lockPath)) {
+    const packages = fs.readFileSync(lockPath, "utf8").split(/\n(?=\[\[package\]\]\n)/);
+    const nextPackages = packages.map((entry) => {
+      const name = entry.match(/^name = "([^"]+)"/m)?.[1];
+      if (!name || !NATIVE_CRATE_NAMES.has(name)) return entry;
+      return entry.replace(/^version = "[^"]+"/m, `version = "${version}"`);
+    });
+    fs.writeFileSync(lockPath, nextPackages.join("\n"));
+  }
+}
+
+function syncVersionSurfaces(root, version, options = {}) {
+  if (options.updateRoot !== false) {
+    const rootPkgPath = path.join(root, "package.json");
+    const rootPkg = readJson(rootPkgPath);
+    rootPkg.version = version;
+    writeJson(rootPkgPath, rootPkg);
+  }
+
+  for (const packageDir of RELEASE_WORKSPACE_PACKAGE_DIRS) {
+    setPackageVersion(root, packageDir, version);
+  }
+
+  for (const packageDir of PLATFORM_PACKAGE_DIRS) {
+    setPackageVersion(root, packageDir, version);
+  }
+
+  setPackageVersion(root, "pkg", version);
+  syncNativeCargoVersion(root, version);
+}
+
+function getNativeCargoVersion(root) {
+  const manifestPath = path.join(root, "native", "Cargo.toml");
+  if (!fs.existsSync(manifestPath)) return undefined;
+  const manifest = fs.readFileSync(manifestPath, "utf8");
+  return manifest.match(/\[workspace\.package\][\s\S]*?\nversion = "([^"]+)"/)?.[1];
+}
+
+function getNativeLockVersions(root) {
+  const lockPath = path.join(root, "native", "Cargo.lock");
+  if (!fs.existsSync(lockPath)) return new Map();
+  const versions = new Map();
+  for (const entry of fs.readFileSync(lockPath, "utf8").split(/\n(?=\[\[package\]\]\n)/)) {
+    const name = entry.match(/^name = "([^"]+)"/m)?.[1];
+    if (!name || !NATIVE_CRATE_NAMES.has(name)) continue;
+    versions.set(name, entry.match(/^version = "([^"]+)"/m)?.[1]);
+  }
+  return versions;
+}
+
+function verifyPackage(root, packageDir, expectedVersion, issues) {
+  const filePath = packagePath(root, packageDir);
+  if (!fs.existsSync(filePath)) {
+    issues.push(`${packageDir}/package.json is missing`);
+    return;
+  }
+
+  const pkg = readJson(filePath);
+  if (pkg.version !== expectedVersion) {
+    issues.push(`${packageDir}/package.json version is ${pkg.version}, expected ${expectedVersion}`);
+  }
+
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    if (!pkg[field]) continue;
+    for (const [dep, range] of Object.entries(pkg[field])) {
+      if (INTERNAL_PACKAGE_NAMES.has(dep) && range !== "*" && range !== `^${expectedVersion}`) {
+        issues.push(`${packageDir}/package.json ${field}.${dep} is ${range}, expected ^${expectedVersion}`);
+      }
+    }
+  }
+}
+
+function verifyLockfile(root, expectedVersion, issues) {
+  const lockPath = path.join(root, "package-lock.json");
+  if (!fs.existsSync(lockPath)) {
+    issues.push("package-lock.json is missing");
+    return;
+  }
+
+  const lock = readJson(lockPath);
+  if (lock.version !== expectedVersion) {
+    issues.push(`package-lock.json version is ${lock.version}, expected ${expectedVersion}`);
+  }
+  if (lock.packages?.[""]?.version !== expectedVersion) {
+    issues.push(`package-lock.json root package version is ${lock.packages?.[""]?.version}, expected ${expectedVersion}`);
+  }
+  for (const packageDir of RELEASE_WORKSPACE_PACKAGE_DIRS) {
+    const version = lock.packages?.[packageDir]?.version;
+    if (version !== undefined && version !== expectedVersion) {
+      issues.push(`package-lock.json ${packageDir} version is ${version}, expected ${expectedVersion}`);
+    }
+  }
+}
+
+function verifyVersionSync(root) {
+  const expectedVersion = readJson(path.join(root, "package.json")).version;
+  const issues = [];
+
+  for (const packageDir of RELEASE_WORKSPACE_PACKAGE_DIRS) {
+    verifyPackage(root, packageDir, expectedVersion, issues);
+  }
+  for (const packageDir of PLATFORM_PACKAGE_DIRS) {
+    verifyPackage(root, packageDir, expectedVersion, issues);
+  }
+  verifyPackage(root, "pkg", expectedVersion, issues);
+  verifyLockfile(root, expectedVersion, issues);
+
+  const nativeCargoVersion = getNativeCargoVersion(root);
+  if (nativeCargoVersion !== undefined && nativeCargoVersion !== expectedVersion) {
+    issues.push(`native/Cargo.toml workspace package version is ${nativeCargoVersion}, expected ${expectedVersion}`);
+  }
+  for (const [name, version] of getNativeLockVersions(root)) {
+    if (version !== expectedVersion) {
+      issues.push(`native/Cargo.lock ${name} version is ${version}, expected ${expectedVersion}`);
+    }
+  }
+
+  return issues;
+}
+
+module.exports = {
+  PLATFORM_PACKAGE_DIRS,
+  RELEASE_WORKSPACE_PACKAGE_DIRS,
+  syncVersionSurfaces,
+  verifyVersionSync,
+};

--- a/scripts/verify-version-sync.cjs
+++ b/scripts/verify-version-sync.cjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// Project/App: Open GSD
+// File Purpose: Command-line guard for release version surface alignment.
+const path = require("node:path");
+const { verifyVersionSync } = require("./lib/version-sync.cjs");
+
+const root = path.resolve(__dirname, "..");
+const issues = verifyVersionSync(root);
+
+if (issues.length > 0) {
+  console.error("Version sync check failed:");
+  for (const issue of issues) {
+    console.error(`- ${issue}`);
+  }
+  process.exit(1);
+}
+
+console.log("Version sync check passed.");

--- a/scripts/version-stamp.mjs
+++ b/scripts/version-stamp.mjs
@@ -1,10 +1,14 @@
+// Project/App: Open GSD
+// File Purpose: Development prerelease version stamping.
 import { readFileSync, writeFileSync } from "fs";
 import { execFileSync, execSync } from "child_process";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
+import versionSync from "./lib/version-sync.cjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
+const { syncVersionSurfaces } = versionSync;
 
 const pkgPath = new URL("../package.json", import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
@@ -16,6 +20,9 @@ const devVersion = `${pkg.version}-${channel}.${shortSha}`;
 pkg.version = devVersion;
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 console.log(`Stamped version: ${devVersion}`);
+
+syncVersionSurfaces(root, devVersion, { updateRoot: false });
+console.log(`[version-stamp] release version surfaces synced to ${devVersion}`);
 
 // Regenerate package-lock.json to reflect the stamped dev version.
 // --package-lock-only updates the lockfile in-place without touching node_modules.

--- a/src/tests/ci-builder-image-config.test.ts
+++ b/src/tests/ci-builder-image-config.test.ts
@@ -1,4 +1,4 @@
-// Project/App: GSD-2
+// Project/App: Open GSD
 // File Purpose: Regression tests for CI builder image workflow configuration.
 
 import assert from "node:assert/strict";
@@ -11,7 +11,7 @@ import { parse } from "yaml";
 const BUILDER_IMAGE = "ghcr.io/open-gsd/gsd-ci-builder";
 
 test("publish workflows use the builder image produced by pipeline", () => {
-  const prereleasePublish = readWorkflow("prerelease-publish.yml");
+  const prereleasePublish = readWorkflow("npm-publish.yml");
   const pipeline = readWorkflow("pipeline.yml");
 
   assert.equal(prereleasePublish.jobs["prerelease-publish"].container.image, `${BUILDER_IMAGE}:latest`);

--- a/src/tests/version-sync.test.ts
+++ b/src/tests/version-sync.test.ts
@@ -1,0 +1,148 @@
+// Project/App: Open GSD
+// File Purpose: Tests for release version surface synchronization.
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { syncVersionSurfaces, verifyVersionSync } = require(join(process.cwd(), "scripts/lib/version-sync.cjs")) as {
+  syncVersionSurfaces: (root: string, version: string, options?: { updateRoot?: boolean }) => void;
+  verifyVersionSync: (root: string) => string[];
+};
+
+function writeJson(root: string, relativePath: string, value: unknown): void {
+  const filePath = join(root, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson<T>(root: string, relativePath: string): T {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8")) as T;
+}
+
+function writeText(root: string, relativePath: string, value: string): void {
+  const filePath = join(root, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+}
+
+function createFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "open-gsd-version-sync-"));
+  writeJson(root, "package.json", { name: "@opengsd/gsd-pi", version: "1.0.0" });
+  writeJson(root, "package-lock.json", {
+    name: "@opengsd/gsd-pi",
+    version: "1.0.0",
+    packages: {
+      "": { name: "@opengsd/gsd-pi", version: "1.0.0" },
+      "extensions/google-search": { name: "@gsd-extensions/google-search", version: "1.0.0" },
+      "packages/pi-coding-agent": { name: "@gsd/pi-coding-agent", version: "1.0.0" },
+    },
+  });
+  writeJson(root, "extensions/google-search/package.json", {
+    name: "@gsd-extensions/google-search",
+    version: "1.0.0",
+    peerDependencies: {
+      "@gsd/pi-coding-agent": "*",
+      "@gsd/pi-tui": "*",
+    },
+  });
+  writeJson(root, "packages/pi-coding-agent/package.json", {
+    name: "@gsd/pi-coding-agent",
+    version: "1.0.0",
+    dependencies: { "@gsd-build/contracts": "^1.0.0" },
+  });
+  writeJson(root, "packages/contracts/package.json", {
+    name: "@gsd-build/contracts",
+    version: "1.0.0",
+  });
+  writeJson(root, "pkg/package.json", { name: "@glittercowboy/gsd", version: "1.0.0" });
+  writeJson(root, "native/npm/darwin-arm64/package.json", {
+    name: "@opengsd/engine-darwin-arm64",
+    version: "1.0.0",
+  });
+  writeText(
+    root,
+    "native/Cargo.toml",
+    `[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"
+edition = "2021"
+`,
+  );
+  writeText(
+    root,
+    "native/Cargo.lock",
+    `[[package]]
+name = "gsd-ast"
+version = "1.0.0"
+
+[[package]]
+name = "some-dependency"
+version = "0.1.0"
+
+[[package]]
+name = "gsd-engine"
+version = "1.0.0"
+
+[[package]]
+name = "gsd-grep"
+version = "1.0.0"
+`,
+  );
+  return root;
+}
+
+test("verifyVersionSync reports every release-owned surface that drifts from root", () => {
+  const root = createFixture();
+  writeJson(root, "package.json", { name: "@opengsd/gsd-pi", version: "2.0.0" });
+
+  const issues = verifyVersionSync(root);
+
+  assert.match(issues.join("\n"), /extensions\/google-search\/package\.json version is 1\.0\.0, expected 2\.0\.0/);
+  assert.match(issues.join("\n"), /packages\/contracts\/package\.json version is 1\.0\.0, expected 2\.0\.0/);
+  assert.match(issues.join("\n"), /packages\/pi-coding-agent\/package\.json version is 1\.0\.0, expected 2\.0\.0/);
+  assert.match(
+    issues.join("\n"),
+    /packages\/pi-coding-agent\/package\.json dependencies\.@gsd-build\/contracts is \^1\.0\.0, expected \^2\.0\.0/,
+  );
+  assert.match(issues.join("\n"), /native\/Cargo\.toml workspace package version is 1\.0\.0, expected 2\.0\.0/);
+  assert.match(issues.join("\n"), /native\/Cargo\.lock gsd-engine version is 1\.0\.0, expected 2\.0\.0/);
+});
+
+test("syncVersionSurfaces updates package, native, and bridge versions together", () => {
+  const root = createFixture();
+
+  syncVersionSurfaces(root, "2.1.0-dev.abc123");
+
+  assert.equal(readJson<{ version: string }>(root, "package.json").version, "2.1.0-dev.abc123");
+  assert.equal(readJson<{ version: string }>(root, "extensions/google-search/package.json").version, "2.1.0-dev.abc123");
+  assert.equal(readJson<{ version: string }>(root, "packages/contracts/package.json").version, "2.1.0-dev.abc123");
+  assert.equal(readJson<{ version: string }>(root, "pkg/package.json").version, "2.1.0-dev.abc123");
+  assert.equal(
+    readJson<{ dependencies: Record<string, string> }>(root, "packages/pi-coding-agent/package.json").dependencies[
+      "@gsd-build/contracts"
+    ],
+    "^2.1.0-dev.abc123",
+  );
+  assert.deepEqual(readJson<{ peerDependencies: Record<string, string> }>(root, "extensions/google-search/package.json").peerDependencies, {
+    "@gsd/pi-coding-agent": "*",
+    "@gsd/pi-tui": "*",
+  });
+  assert.match(readFileSync(join(root, "native/Cargo.toml"), "utf8"), /version = "2\.1\.0-dev\.abc123"/);
+  assert.match(readFileSync(join(root, "native/Cargo.lock"), "utf8"), /name = "gsd-engine"\nversion = "2\.1\.0-dev\.abc123"/);
+});
+
+test("syncVersionSurfaces is safe to rerun at the same native version", () => {
+  const root = createFixture();
+
+  syncVersionSurfaces(root, "1.0.0");
+  syncVersionSurfaces(root, "1.0.0");
+
+  assert.match(readFileSync(join(root, "native/Cargo.toml"), "utf8"), /version = "1\.0\.0"/);
+  assert.match(readFileSync(join(root, "native/Cargo.lock"), "utf8"), /name = "gsd-engine"\nversion = "1\.0\.0"/);
+});


### PR DESCRIPTION
## Linked issue

Closes #41

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Keeps release-owned package, native, and bridge version surfaces synchronized with the current `@opengsd/gsd-pi@1.0.1` npm release.
**Why:** Release artifacts can drift when a version surface is missed.
**How:** Adds a shared sync/verify helper, wires release and prerelease version entry points through it, and gates publish validation with a version-sync check.

## What

- Adds `scripts/lib/version-sync.cjs` and `scripts/verify-version-sync.cjs`.
- Updates `release:bump` and prerelease stamping to sync release-owned workspace packages, platform packages, `pkg`, and native Cargo metadata.
- Aligns current release-owned metadata with the npm `1.0.1` version.
- Adds regression coverage for sync, drift detection, `packages/contracts`, and idempotent native version sync.
- Updates the CI builder workflow test to target the current unified npm publish workflow.

## Why

Version bumps should fail loudly if any release-owned surface lags behind the root package version. npm latest is currently `@opengsd/gsd-pi@1.0.1`, so the checked-in release metadata should match that.

## How

The shared helper owns the list of release version surfaces and verifies each one against root `package.json`. Publish validation now runs `npm run verify:version-sync`, and the release commit stages all files that can be changed by the bump.

Note: root optional native binary dependency ranges remain `>=1.0.0` intentionally so installs can fall back while native package publishes catch up.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [x] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Commands run:

```bash
npm view @opengsd/gsd-pi version
npm ci
npm run build:core
npm run verify:version-sync
node --check scripts/bump-version.mjs
node --check scripts/version-stamp.mjs
node --check scripts/lib/version-sync.cjs
node --check scripts/verify-version-sync.cjs
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/ci-builder-image-config.test.ts src/tests/version-sync.test.ts
npm run test:unit
```

Result: `npm view @opengsd/gsd-pi version` returned `1.0.1`; `npm run test:unit` passed with 9463 passed, 0 failed, 9 skipped.

## AI disclosure

- [x] This PR includes AI-assisted code. The changes were built and tested with the commands above.
