### PR TITLE
fix(auto): wire ScheduleWakeup continuation

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -91,6 +91,16 @@ The sidecar unit types now have distinct manifest behavior: `triage-captures` ru
 
 Writes outside those allowed paths, unsafe bash commands, and subagent dispatch from non-dispatch planning units are blocked with a hard policy error instead of relying on prompt compliance. In `planning-dispatch` units, prompts steer the parent agent toward read-only specialists such as `scout`, `planner`, `researcher`, `reviewer`, `security`, or `tester`; implementation-tier agents still belong in `execute-task`.
 
+### ScheduleWakeup Continuations
+
+`ScheduleWakeup` is an auto-mode tool for long external waits inside `execute-task` units. It keeps the same unit session alive by scheduling a delayed follow-up prompt instead of ending the unit as incomplete.
+
+- Use it when a task kicked off external work (for example CI, deploy, or async jobs) and needs a later poll.
+- Include a concrete follow-up prompt that says what to check and what artifact to write when done.
+- Re-arm it on each poll turn while the external process is still running.
+
+Auto mode consumes the scheduled wakeup only for the same `basePath + unitType + unitId`, waits the requested delay, and then dispatches the follow-up prompt in the same session. For safety, wakeups are bounded per unit; hitting the cap stops the unit with a timeout-style cancellation.
+
 ### Pre-Dispatch Runtime Blocks
 
 Before auto mode launches a unit, the orchestration pipeline now enforces runtime invariants in this order: reconcile state, choose the next unit, compile the unit tool contract, validate the worktree or unit root, then persist the runtime transition. A failure in any pre-dispatch step returns a `blocked` result and records the block before a worker session starts.

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -26,9 +26,12 @@ import { debugLog } from "../debug-logger.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import { resolveAutoSupervisorConfig } from "../preferences.js";
 import { readUnitRuntimeRecord, type AutoUnitRuntimeRecord } from "../unit-runtime.js";
+import { consumeAutoWakeup } from "./schedule-wakeup.js";
 
 const UNIT_FAILSAFE_BUFFER_MS = 30_000;
 const UNIT_FAILSAFE_RECHECK_MS = 30_000;
+const WAKEUP_SLEEP_CHUNK_MS = 1_000;
+const MAX_WAKEUPS_PER_UNIT = 100;
 
 export function shouldDeferUnitFailsafeTimeout(
   runtime: AutoUnitRuntimeRecord | null,
@@ -49,6 +52,17 @@ export function shouldDeferUnitFailsafeTimeout(
   if (runtime.lastProgressKind.includes("recovery")) return true;
   if (runtime.recoveryAttempts && runtime.recoveryAttempts > 0) return true;
   return progressAgeMs >= 0 && progressAgeMs <= opts.freshProgressMs;
+}
+
+async function sleepForScheduledWakeup(s: AutoSession, delayMs: number): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, delayMs);
+  while (Date.now() < deadline) {
+    if (!s.active || s.paused) return false;
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, Math.min(WAKEUP_SLEEP_CHUNK_MS, deadline - Date.now())),
+    );
+  }
+  return s.active && !s.paused;
 }
 
 // Tracks the latest session-switch attempt so a late timeout settlement from an
@@ -226,56 +240,114 @@ export async function runUnit(
   let unitTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   let result: UnitResult;
   try {
+    const awaitAgentEndWithTimeout = (agentEndPromise: Promise<UnitResult>): Promise<UnitResult> => {
+      const timeoutResult = new Promise<UnitResult>((resolve) => {
+        const settleOrDefer = () => {
+          let runtime: AutoUnitRuntimeRecord | null;
+          try {
+            runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
+          } catch (error) {
+            debugLog("runUnit", {
+              phase: "unit-failsafe-runtime-read-failed",
+              unitType,
+              unitId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            resolve({
+              status: "cancelled",
+              errorContext: {
+                message: "Unit hard timeout — supervision may have failed; runtime progress could not be read",
+                category: "timeout",
+                isTransient: true,
+              },
+            });
+            return;
+          }
+          if (shouldDeferUnitFailsafeTimeout(runtime, {
+            nowMs: Date.now(),
+            currentUnitStartedAt: s.currentUnit?.startedAt,
+            freshProgressMs,
+          })) {
+            debugLog("runUnit", {
+              phase: "unit-failsafe-deferred",
+              unitType,
+              unitId,
+              runtimePhase: runtime?.phase,
+              lastProgressKind: runtime?.lastProgressKind,
+            });
+            unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_FAILSAFE_RECHECK_MS);
+            return;
+          }
+          resolve({ status: "cancelled", errorContext: { message: "Unit hard timeout — supervision may have failed", category: "timeout", isTransient: true } });
+        };
+        unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_HARD_TIMEOUT_MS);
+      });
+      return runWithTurnGeneration(capturedTurnGen, () =>
+        Promise.race([agentEndPromise, timeoutResult]),
+      );
+    };
+
     pi.sendMessage(
       { customType: "gsd-auto", content: prompt, display: s.verbose },
       { triggerTurn: true },
     );
 
     debugLog("runUnit", { phase: "awaiting-agent-end", unitType, unitId });
-    const timeoutResult = new Promise<UnitResult>((resolve) => {
-      const settleOrDefer = () => {
-        let runtime: AutoUnitRuntimeRecord | null;
-        try {
-          runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
-        } catch (error) {
-          debugLog("runUnit", {
-            phase: "unit-failsafe-runtime-read-failed",
-            unitType,
-            unitId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          resolve({
-            status: "cancelled",
-            errorContext: {
-              message: "Unit hard timeout — supervision may have failed; runtime progress could not be read",
-              category: "timeout",
-              isTransient: true,
-            },
-          });
-          return;
-        }
-        if (shouldDeferUnitFailsafeTimeout(runtime, {
-          nowMs: Date.now(),
-          currentUnitStartedAt: s.currentUnit?.startedAt,
-          freshProgressMs,
-        })) {
-          debugLog("runUnit", {
-            phase: "unit-failsafe-deferred",
-            unitType,
-            unitId,
-            runtimePhase: runtime?.phase,
-            lastProgressKind: runtime?.lastProgressKind,
-          });
-          unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_FAILSAFE_RECHECK_MS);
-          return;
-        }
-        resolve({ status: "cancelled", errorContext: { message: "Unit hard timeout — supervision may have failed", category: "timeout", isTransient: true } });
-      };
-      unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_HARD_TIMEOUT_MS);
-    });
-    result = await runWithTurnGeneration(capturedTurnGen, () =>
-      Promise.race([unitPromise, timeoutResult]),
-    );
+    result = await awaitAgentEndWithTimeout(unitPromise);
+    if (unitTimeoutHandle) {
+      clearTimeout(unitTimeoutHandle);
+      unitTimeoutHandle = undefined;
+    }
+
+    let wakeupCount = 0;
+    while (result.status === "completed" && s.active && !s.paused) {
+      const wakeup = consumeAutoWakeup(s.basePath, unitType, unitId);
+      if (!wakeup) break;
+      wakeupCount += 1;
+      if (wakeupCount > MAX_WAKEUPS_PER_UNIT) {
+        result = {
+          status: "cancelled",
+          errorContext: {
+            message: `ScheduleWakeup limit exceeded for ${unitType} ${unitId}`,
+            category: "timeout",
+            isTransient: false,
+          },
+        };
+        break;
+      }
+      debugLog("runUnit", {
+        phase: "schedule-wakeup-wait",
+        unitType,
+        unitId,
+        delayMs: wakeup.delayMs,
+        reason: wakeup.reason,
+      });
+      const slept = await sleepForScheduledWakeup(s, wakeup.delayMs);
+      if (!slept) {
+        result = {
+          status: "cancelled",
+          errorContext: {
+            message: `ScheduleWakeup interrupted for ${unitType} ${unitId}`,
+            category: "aborted",
+            isTransient: true,
+          },
+        };
+        break;
+      }
+      const continuationPromise = new Promise<UnitResult>((resolve) => {
+        _setCurrentResolve(resolve);
+      });
+      pi.sendMessage(
+        { customType: "gsd-auto", content: wakeup.prompt, display: s.verbose },
+        { triggerTurn: true },
+      );
+      debugLog("runUnit", { phase: "schedule-wakeup-awaiting-agent-end", unitType, unitId });
+      result = await awaitAgentEndWithTimeout(continuationPromise);
+      if (unitTimeoutHandle) {
+        clearTimeout(unitTimeoutHandle);
+        unitTimeoutHandle = undefined;
+      }
+    }
   } finally {
     if (unitTimeoutHandle) clearTimeout(unitTimeoutHandle);
     ctx.ui.setWorkingMessage?.(undefined);

--- a/src/resources/extensions/gsd/auto/schedule-wakeup.ts
+++ b/src/resources/extensions/gsd/auto/schedule-wakeup.ts
@@ -1,0 +1,40 @@
+// Project/App: GSD-2
+// File Purpose: Auto-mode ScheduleWakeup state shared between the tool and runUnit.
+
+export interface ScheduledWakeup {
+  basePath: string;
+  unitType: string;
+  unitId: string;
+  delayMs: number;
+  prompt: string;
+  reason: string;
+  createdAt: number;
+}
+
+function wakeupKey(basePath: string, unitType: string, unitId: string): string {
+  return `${basePath}\0${unitType}\0${unitId}`;
+}
+
+const pendingWakeups = new Map<string, ScheduledWakeup>();
+
+export function scheduleAutoWakeup(wakeup: ScheduledWakeup): void {
+  pendingWakeups.set(
+    wakeupKey(wakeup.basePath, wakeup.unitType, wakeup.unitId),
+    wakeup,
+  );
+}
+
+export function consumeAutoWakeup(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+): ScheduledWakeup | null {
+  const key = wakeupKey(basePath, unitType, unitId);
+  const wakeup = pendingWakeups.get(key) ?? null;
+  pendingWakeups.delete(key);
+  return wakeup;
+}
+
+export function _resetAutoWakeupsForTest(): void {
+  pendingWakeups.clear();
+}

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -11,6 +11,7 @@ import { registerExecTools } from "./exec-tools.js";
 import { registerJournalTools } from "./journal-tools.js";
 import { registerMemoryTools } from "./memory-tools.js";
 import { registerQueryTools } from "./query-tools.js";
+import { registerScheduleWakeupTool } from "./schedule-wakeup-tool.js";
 import { registerHooks } from "./register-hooks.js";
 import { registerShortcuts } from "./register-shortcuts.js";
 import { writeCrashLog } from "./crash-log.js";
@@ -123,6 +124,7 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["query-tools", () => registerQueryTools(pi)],
     ["memory-tools", () => registerMemoryTools(pi)],
     ["exec-tools", () => registerExecTools(pi)],
+    ["schedule-wakeup-tool", () => registerScheduleWakeupTool(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
     // cmux is a library (no pi), so gsd sets up the event listeners on its
     // behalf using the shared event channel contract. Registration is

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -844,6 +844,9 @@ export function registerHooks(
     // subagent dispatch. Closes the b23 bug class where a discuss-milestone
     // turn used the host Edit tool to modify user source files.
     const dash = getAutoRuntimeSnapshot();
+
+    // ScheduleWakeup is registered by the GSD extension so auto-mode can
+    // continue the same unit session after long external waits.
     const guidedUnit = getGuidedUnitContext(discussionBasePath);
     const activeUnitType = dash.currentUnit?.type ?? guidedUnit?.unitType;
     if (activeUnitType) {

--- a/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
+++ b/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
@@ -1,0 +1,81 @@
+// Project/App: GSD-2
+// File Purpose: Registers the auto-mode ScheduleWakeup continuation tool.
+
+import { Type } from "@sinclair/typebox";
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
+import { scheduleAutoWakeup } from "../auto/schedule-wakeup.js";
+import { resolveCtxCwd } from "./dynamic-tools.js";
+
+const MAX_WAKEUP_DELAY_SECONDS = 24 * 60 * 60;
+
+export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "ScheduleWakeup",
+    label: "Schedule Wakeup",
+    description:
+      "In GSD auto-mode, pause the current unit and continue the same session after a delay. " +
+      "Use this for long external processes that need polling without ending the unit as no-artifact.",
+    promptSnippet: "Schedule a same-session auto-mode wakeup after a delay.",
+    promptGuidelines: [
+      "Use ScheduleWakeup at the end of an execute-task turn when waiting for a long external process.",
+      "Include a prompt that says exactly what external state to check next and what artifact to write when done.",
+      "Re-arm ScheduleWakeup on each polling turn if the external process is still running.",
+    ],
+    parameters: Type.Object({
+      delaySeconds: Type.Number({
+        minimum: 1,
+        maximum: MAX_WAKEUP_DELAY_SECONDS,
+        description: "How many seconds to wait before continuing the same auto-mode session.",
+      }),
+      prompt: Type.String({
+        minLength: 1,
+        description: "Prompt to send when the session wakes up.",
+      }),
+      reason: Type.Optional(Type.String({
+        description: "Why this delay is appropriate.",
+      })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const dash = getAutoRuntimeSnapshot();
+      const currentUnit = dash.currentUnit;
+      const basePath = dash.basePath || resolveCtxCwd(ctx);
+
+      if (!dash.active || !currentUnit) {
+        return {
+          content: [{ type: "text", text: "ScheduleWakeup is only available during an active GSD auto-mode unit." }],
+          details: { operation: "schedule_wakeup", error: "auto_mode_inactive" },
+          isError: true,
+        };
+      }
+
+      const delaySeconds = Math.max(
+        1,
+        Math.min(MAX_WAKEUP_DELAY_SECONDS, Math.floor(params.delaySeconds)),
+      );
+      scheduleAutoWakeup({
+        basePath,
+        unitType: currentUnit.type,
+        unitId: currentUnit.id,
+        delayMs: delaySeconds * 1000,
+        prompt: params.prompt,
+        reason: params.reason ?? "",
+        createdAt: Date.now(),
+      });
+
+      return {
+        content: [{
+          type: "text",
+          text: `Wakeup scheduled for ${delaySeconds}s. Auto-mode will continue ${currentUnit.type} ${currentUnit.id} in the same session.`,
+        }],
+        details: {
+          operation: "schedule_wakeup",
+          delaySeconds,
+          unitType: currentUnit.type,
+          unitId: currentUnit.id,
+        },
+      };
+    },
+  });
+}

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -21,6 +21,7 @@ import {
   isSessionSwitchAbortGraceActive,
 } from "../auto/resolve.js";
 import { runUnit, shouldDeferUnitFailsafeTimeout } from "../auto/run-unit.js";
+import { scheduleAutoWakeup, _resetAutoWakeupsForTest } from "../auto/schedule-wakeup.js";
 import { writeUnitRuntimeRecord, readUnitRuntimeRecord } from "../unit-runtime.js";
 import { autoLoop } from "../auto/loop.js";
 import { runDispatch, runUnitPhase } from "../auto/phases.js";
@@ -185,6 +186,61 @@ test("resolveAgentEnd resolves a pending runUnit promise", async () => {
   const result = await resultPromise;
   assert.equal(result.status, "completed");
   assert.deepEqual(result.event, event);
+});
+
+test("runUnit honors ScheduleWakeup by continuing the same unit session", async () => {
+  _resetPendingResolve();
+  _resetAutoWakeupsForTest();
+
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession();
+  const firstEvent = makeEvent([{ role: "assistant", content: "submitted job" }]);
+  const secondEvent = makeEvent([{ role: "assistant", content: "job finished" }]);
+
+  const resultPromise = runUnit(
+    ctx,
+    pi,
+    s,
+    "execute-task",
+    "M001/S01/T01",
+    "submit external job",
+  );
+
+  await waitForMicrotasks(() => pi.calls.length === 1, "initial unit dispatch");
+  scheduleAutoWakeup({
+    basePath: s.basePath,
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    delayMs: 0,
+    prompt: "check external job and write the task summary if complete",
+    reason: "poll external job",
+    createdAt: Date.now(),
+  });
+  resolveAgentEnd(firstEvent);
+
+  await waitForMicrotasks(() => pi.calls.length === 2, "scheduled wakeup dispatch");
+  assert.equal((pi.calls[1] as any[])[0].content, "check external job and write the task summary if complete");
+  resolveAgentEnd(secondEvent);
+
+  const result = await resultPromise;
+  assert.equal(result.status, "completed");
+  assert.deepEqual(result.event, secondEvent);
+  assert.equal(pi.calls.length, 2);
 });
 
 test("runUnit suppresses the global working-message loader for auto dashboard runs", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Wires `ScheduleWakeup` as a GSD-owned auto-mode continuation tool.
**Why:** Long external processes need a same-session polling path instead of silently no-oping or finalizing the unit as `no-artifact`.
**How:** Registers a `ScheduleWakeup` tool, stores pending wakeups for the active unit, and teaches `runUnit` to sleep and send the wake prompt back into the same session.

## What

This ports the closed old-repo PR gsd-build/gsd-2#6436 into Open GSD.

- Registers `ScheduleWakeup` from the GSD extension.
- Records pending wakeups by base path and active unit.
- Lets `runUnit` consume a wakeup after `agent_end`, sleep in interruptible chunks, and continue the same unit session with the supplied prompt.
- Keeps ScheduleWakeup available during auto-mode instead of blocking it as incompatible.
- Adds a regression test proving a scheduled wakeup continues the same unit and returns the final agent result.

## Why

Closes #43.
Refs gsd-build/gsd-2#6328 and gsd-build/gsd-2#6436.

The old containment made `ScheduleWakeup` fail loud, which was safer than a silent no-op but still left long external processes without the expected same-session polling path. This restores a working wakeup path for external jobs while preserving a bounded loop and pause/stop interruption behavior.

## How

`ScheduleWakeup` now stores a pending wakeup for the current auto-mode unit. When the unit turn ends, `runUnit` checks for that wakeup before finalizing. If one exists, it waits for the requested delay, sends the wake prompt into the same session, and awaits the next `agent_end`. The tool is one-shot by design, so agents re-arm it on each polling turn when the external process is still running.

A per-unit cap prevents unbounded wake loops, and pause/stop state interrupts the sleep.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring, no behavior change
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] `npm run build:pi`
- [x] `npm run build:rpc-client && npm run build:mcp-server && npm run typecheck:extensions`
- [x] `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/auto-loop.test.js` — 102 passed
- [ ] `npm run verify:pr` — build and typecheck completed, then compiled unit suite hung with no reporter output and was terminated
