### PR TITLE
ci: extend build job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         run: node scripts/check-coderabbit-themes.mjs
 
   build:
-    timeout-minutes: 25
+    timeout-minutes: 45
     needs: [detect-changes, docs-check, lint]
     if: needs.detect-changes.outputs.heavy-code-changed == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Linked issue

Closes #45

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Extends the CI `build` job timeout from 25 minutes to 45 minutes.
**Why:** The full build job can time out during `npm run test:unit:compiled` after install, build, web build, typecheck, and package validation have already consumed several minutes.
**How:** Changes only the `build.timeout-minutes` value in `.github/workflows/ci.yml`.

## What

This updates the CI workflow build job timeout. No checks are skipped or weakened.

## Why

PR #42 showed the build job being canceled while unit tests were still running. Local verification passed, but GitHub killed the job at the 25-minute cap.

## How

Increase the build job timeout to 45 minutes so the existing full gate has enough room to finish on GitHub runners.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:

```bash
node -e "const fs=require('fs'); const text=fs.readFileSync('.github/workflows/ci.yml','utf8'); if (!/build:\\n    timeout-minutes: 45/.test(text)) { process.exit(1); }"
```

## AI disclosure

- [x] This PR includes AI-assisted code. The change was limited to the CI timeout and manually verified.
