### PR TITLE
ci: restore docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,24 @@
+# Open GSD - Docker images
+# File Purpose: Define runtime and CI builder container images.
+
+# ──────────────────────────────────────────────
+# CI Builder
+# Image: ghcr.io/open-gsd/gsd-ci-builder
+# Used by: publish workflows that need Rust and Linux cross-compilers
+# ──────────────────────────────────────────────
+FROM node:24-bookworm AS builder
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    && rustup target add aarch64-unknown-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN node --version && rustc --version && cargo --version
+
 # ──────────────────────────────────────────────
 # Runtime
 # Image: ghcr.io/open-gsd/gsd-pi

--- a/tests/e2e/docker/runtime.e2e.test.ts
+++ b/tests/e2e/docker/runtime.e2e.test.ts
@@ -86,6 +86,16 @@ function dockerBuildLocal(tarballName: string, tag: string): void {
 	);
 }
 
+function dockerBuildBuilder(tag: string): void {
+	const root = repoRoot();
+	execFileSync("docker", ["build", "--target", "builder", "-t", tag, "."], {
+		cwd: root,
+		stdio: "pipe",
+		encoding: "utf8",
+		timeout: 900_000,
+	});
+}
+
 function dockerRun(tag: string, args: string[]): { stdout: string; code: number } {
 	const result = spawnSync("docker", ["run", "--rm", tag, ...args], {
 		stdio: "pipe",
@@ -107,11 +117,22 @@ function dockerRmImage(tag: string): void {
 }
 
 const TAG = `gsd-pi:e2e-${process.pid}`;
+const BUILDER_TAG = `gsd-ci-builder:e2e-${process.pid}`;
 
 describe("docker runtime e2e", () => {
 	const skipReason = dockerAvailable()
 		? null
 		: "docker not available (set up Docker Desktop or run in CI to exercise this suite)";
+
+	test(
+		"CI builder image target builds for publish workflow bootstrap",
+		{ skip: skipReason ?? false, timeout: 900_000 },
+		(t) => {
+			t.after(() => dockerRmImage(BUILDER_TAG));
+
+			assert.doesNotThrow(() => dockerBuildBuilder(BUILDER_TAG));
+		},
+	);
 
 	test(
 		"`gsd --version` inside runtime-local container exits 0 with semver",


### PR DESCRIPTION
## TL;DR

**What:** Restores the Dockerfile `builder` target used by the CI builder image pipeline.
**Why:** Manual npm publish jobs cannot start because `ghcr.io/open-gsd/gsd-ci-builder:latest` is missing and the bootstrap pipeline cannot build it without a `builder` stage.
**How:** Re-adds the Node 24 Bookworm builder stage with Rust and the Linux arm64 cross-compilers, plus a Docker e2e regression that builds the `builder` target.

## What

Restores `FROM node:24-bookworm AS builder` in `Dockerfile` for `ghcr.io/open-gsd/gsd-ci-builder`. Updates the Docker e2e suite to build the builder target so the publish pipeline dependency is covered.

## Why

`NPM Publish` fails before checkout while pulling `ghcr.io/open-gsd/gsd-ci-builder:latest`. The package is missing from GHCR, and the manual `Pipeline` bootstrap run fails with `target stage "builder" could not be found`.

## How

The restored builder image includes Node 24, Rust stable, and the `aarch64-unknown-linux-gnu` target plus matching cross-compilers. The regression test shells out to Docker to build `--target builder`, matching the pipeline command.

## Tests

- `node --test scripts/__tests__/npm-publish-workflow.test.mjs`
- `bash scripts/check-source-grep-tests.sh`
- `bash scripts/require-tests.sh`
- `npm run test:e2e:docker` (loads cleanly; skipped locally because Docker daemon is not running)

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking changes

None.