### PR TITLE
ci: use github token for prerelease checkout

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref != '' && github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ github.token }}
           fetch-depth: 0
 
       - name: Mark workspace safe for git

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -39,6 +39,7 @@ test("prerelease publish preserves channel-specific default refs", () => {
   );
 
   assert.equal(workflow.on.workflow_dispatch.inputs.ref.default, "");
+  assert.equal(checkout.with.token, "${{ github.token }}");
   assert.match(checkout.with.ref, /github\.event\.inputs\.channel == 'next'/);
   assert.match(checkout.with.ref, /'next'/);
   assert.match(checkout.with.ref, /'main'/);


### PR DESCRIPTION
## TL;DR

**What:** Uses the built-in GitHub token for prerelease publish checkout.
**Why:** `NPM Publish` now reaches checkout but fails because `secrets.RELEASE_PAT` resolves empty for the prerelease job.
**How:** Switches only the prerelease checkout token to `${{ github.token }}` and adds a workflow regression assertion.

## What

Updates `.github/workflows/npm-publish.yml` so the `prerelease-publish` checkout uses the guaranteed built-in token. The production release checkout remains unchanged because it still needs release credentials for pushing release commits and tags.

## Why

The failing run reached `actions/checkout@v6` and stopped with `Input required and not supplied: token`. The prerelease job only needs to checkout code before building and publishing; it does not push back to the repo.

## How

Uses `${{ github.token }}` for the prerelease checkout and extends `scripts/__tests__/npm-publish-workflow.test.mjs` to lock that in.

## Tests

- `node --test scripts/__tests__/npm-publish-workflow.test.mjs`
- `bash scripts/check-source-grep-tests.sh`
- `bash scripts/require-tests.sh`

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking changes

None.