### PR TITLE
fix(ci): always build web host before validate-pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,22 @@ jobs:
       - name: Build core
         run: npm run build:core
 
+      - name: Install web host dependencies
+        run: npm --prefix web ci
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+            nextjs-${{ runner.os }}-
+
+      # validate-pack requires dist/web/standalone/server.js in the tarball (package.json files).
+      - name: Build web host
+        run: npm run build:web-host
+
       - name: Pack build artifacts
         run: bash scripts/ci-pack-build-artifacts.sh
 
@@ -105,24 +121,6 @@ jobs:
           name: ci-build-artifacts
           path: ci-build-artifacts.tar.gz
           retention-days: 1
-
-      - name: Install web host dependencies
-        if: needs.fast-gates.outputs.web-changed == 'true'
-        run: npm --prefix web ci
-
-      - name: Cache Next.js build
-        if: needs.fast-gates.outputs.web-changed == 'true'
-        uses: actions/cache@v4
-        with:
-          path: web/.next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
-            nextjs-${{ runner.os }}-
-
-      - name: Build web host
-        if: needs.fast-gates.outputs.web-changed == 'true'
-        run: npm run build:web-host
 
       - name: Typecheck extensions
         run: npm run typecheck:extensions

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -100,7 +100,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/open-gsd/gsd-pi:latest --version
 
 - **Skipped when doc/metadata only:** `build`, `test-*`, `integration-tests`, `e2e`, `docker-e2e`, `windows-portability`
 - **Still runs:** `fast-gates` (all security and policy scans)
-- **`web-changed`:** gates `build:web-host` inside `build` (core still builds)
+- **`web-changed`:** reserved for future path gating (web host always builds in `build` because `validate-pack` requires `dist/web/standalone/server.js`)
 
 ### Prompt Injection Scan
 

--- a/scripts/ci-pack-build-artifacts.sh
+++ b/scripts/ci-pack-build-artifacts.sh
@@ -15,6 +15,10 @@ paths=(dist)
 for pkg_dist in packages/*/dist; do
   [ -d "$pkg_dist" ] && paths+=("$pkg_dist")
 done
+# dist/web is produced by build:web-host (required for validate-pack / npm pack).
+if [ -d dist/web ]; then
+  paths+=(dist/web)
+fi
 
 tar czf "$OUT" "${paths[@]}"
 echo "ci-pack-build-artifacts: packed ${#paths[@]} path(s) into ${OUT} ($(du -h "$OUT" | cut -f1))"


### PR DESCRIPTION
## Summary

PR #62 merged without this follow-up. On `main`, the `build` job gates `build:web-host` on `web-changed`, but `validate-pack` always requires `dist/web/standalone/server.js` in the npm tarball — so CI-only or core-only PRs fail at pack validation.

- Always run web install + `build:web-host` in the `build` job (before `validate-pack`)
- Pack CI artifacts after web build; include `dist/web` in the artifact tarball

## Test plan

- [ ] CI `build` job passes on this PR
- [ ] `validate-pack` reports critical files present


Made with [Cursor](https://cursor.com)