### PR TITLE
Fix CI native fallback and artifact restore

### DIFF
--- a/packages/native/src/__tests__/function-fallback.test.mjs
+++ b/packages/native/src/__tests__/function-fallback.test.mjs
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("xxhash and grep helpers fall back to JS when native addon is unavailable", () => {
+  const script = `
+    const { xxHash32, xxHash32Fallback } = require("./dist/xxhash");
+    const { searchContent } = require("./dist/grep");
+    const input = "the quick brown fox jumps over the lazy dog";
+    const search = searchContent(Buffer.from("alpha\\nneedle-found-here\\ndelta"), {
+      pattern: "needle-found-here",
+    });
+    process.stdout.write(JSON.stringify({
+      hash: xxHash32(input, 0),
+      fallback: xxHash32Fallback(input, 0),
+      search,
+    }));
+  `;
+
+  const result = spawnSync(process.execPath, ["-e", script], {
+    cwd: packageRoot,
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.hash, output.fallback);
+  assert.equal(output.search.matchCount, 1);
+  assert.equal(output.search.limitReached, false);
+  assert.equal(output.search.matches[0].lineNumber, 2);
+  assert.equal(output.search.matches[0].line, "needle-found-here");
+});

--- a/packages/native/src/xxhash/index.ts
+++ b/packages/native/src/xxhash/index.ts
@@ -80,7 +80,7 @@ export function xxHash32Fallback(input: string, seed: number): number {
  * Compute xxHash32 of a UTF-8 string.
  *
  * Uses the native Rust implementation when available; falls back to a
- * pure-JS implementation if the addon is missing (proxy throws on call).
+ * pure-JS implementation if the addon is missing or throws on call.
  *
  * @param input  The string to hash (encoded as UTF-8 internally).
  * @param seed   32-bit seed value.

--- a/scripts/ci-pack-build-artifacts.sh
+++ b/scripts/ci-pack-build-artifacts.sh
@@ -18,5 +18,5 @@ done
 # Omit dist/web — Next.js standalone contains symlinks that break tar extract on
 # Windows runners. validate-pack runs in the build job before this pack step.
 
-tar czf "$OUT" "${paths[@]}"
+tar chzf "$OUT" "${paths[@]}"
 echo "ci-pack-build-artifacts: packed ${#paths[@]} path(s) into ${OUT} ($(du -h "$OUT" | cut -f1))"


### PR DESCRIPTION
## Summary\n- fall back to JS xxHash/search when native proxy reports missing platform symbols\n- dereference symlinks when packing CI build artifacts so Windows can restore them\n\n## Verification\n- npm run build -w @gsd/native\n- GSD_NATIVE_DISABLE=1 node --experimental-strip-types --test tests/e2e/native-abi.e2e.test.ts\n- git diff --check HEAD~1..HEAD