### PR TITLE
chore(ci): bump cache and artifact actions to v5

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -101,7 +101,7 @@ jobs:
           copy native\target\${{ matrix.target }}\release\gsd_engine.dll artifacts\gsd_engine.node
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: native-${{ matrix.platform }}
           path: artifacts/gsd_engine.node
@@ -137,7 +137,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         run: npm --prefix web ci
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
@@ -116,7 +116,7 @@ jobs:
         run: bash scripts/ci-pack-build-artifacts.sh
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ci-build-artifacts
           path: ci-build-artifacts.tar.gz
@@ -151,7 +151,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -183,7 +183,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -219,7 +219,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -249,7 +249,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -260,7 +260,7 @@ jobs:
         run: npm --prefix web ci
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
@@ -291,7 +291,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -306,7 +306,7 @@ jobs:
 
       - name: Upload e2e artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-artifacts
           path: test-results/e2e
@@ -335,7 +335,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -372,7 +372,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ci-build-artifacts
 
@@ -409,7 +409,7 @@ jobs:
 
       - name: Upload Windows e2e artifacts on failure
         if: steps.windows-smoke-e2e.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-artifacts-windows
           path: test-results/e2e

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -75,7 +75,7 @@ jobs:
         run: npm --prefix web ci
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
@@ -211,7 +211,7 @@ jobs:
           node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: web/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload npm audit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-audit-${{ matrix.artifact }}
           path: |
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload cargo audit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cargo-audit
           path: |


### PR DESCRIPTION
## Summary

Silences the GitHub Actions deprecation warning on job completion:

> Node.js 20 actions are deprecated: `actions/cache@v4`, `actions/upload-artifact@v4`

Bumps to **v5** (Node 24 runtime) across all workflows:

- `ci.yml` — cache, upload-artifact, download-artifact
- `npm-publish.yml` — cache
- `build-native.yml` — upload-artifact, download-artifact
- `security-audit.yml` — upload-artifact

## Risk

Low — we download artifacts by **name** (not single `artifact-ids`), so [download-artifact v5 path behavior](https://github.com/actions/download-artifact/releases/tag/v5.0.0) does not apply.

## Test plan

- [ ] CI passes on this PR (validates cache + artifact round-trip)


Made with [Cursor](https://cursor.com)