### PR TITLE
refactor(ci): extract composite actions for artifact restore and Next.js cache

### DIFF
--- a/.github/actions/cache-nextjs/action.yml
+++ b/.github/actions/cache-nextjs/action.yml
@@ -1,0 +1,14 @@
+name: Cache Next.js build
+description: Restore or save web/.next/cache keyed by web lockfile and source hashes.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Next.js build
+      uses: actions/cache@v5
+      with:
+        path: web/.next/cache
+        key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+        restore-keys: |
+          nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+          nextjs-${{ runner.os }}-

--- a/.github/actions/restore-ci-build-artifacts/action.yml
+++ b/.github/actions/restore-ci-build-artifacts/action.yml
@@ -1,0 +1,20 @@
+name: Restore CI build artifacts
+description: Download ci-build-artifacts from the workflow run and unpack into the workspace.
+
+inputs:
+  artifact-name:
+    description: Artifact name to download
+    required: false
+    default: ci-build-artifacts
+
+runs:
+  using: composite
+  steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v5
+      with:
+        name: ${{ inputs.artifact-name }}
+
+    - name: Restore build artifacts
+      shell: bash
+      run: bash scripts/ci-unpack-build-artifacts.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,7 @@ jobs:
       - name: Install web host dependencies
         run: npm --prefix web ci
 
-      - name: Cache Next.js build
-        uses: actions/cache@v5
-        with:
-          path: web/.next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
-            nextjs-${{ runner.os }}-
+      - uses: ./.github/actions/cache-nextjs
 
       # validate-pack requires dist/web/standalone/server.js in the tarball (package.json files).
       - name: Build web host
@@ -150,13 +143,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Run unit tests
         run: |
@@ -182,13 +169,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Run package tests
         run: npm run test:packages:compiled
@@ -218,13 +199,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Check test coverage thresholds
         run: npm run test:coverage
@@ -248,25 +223,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Install web host dependencies
         run: npm --prefix web ci
 
-      - name: Cache Next.js build
-        uses: actions/cache@v5
-        with:
-          path: web/.next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
-            nextjs-${{ runner.os }}-
+      - uses: ./.github/actions/cache-nextjs
 
       - name: Run integration tests
         run: npm run test:integration
@@ -290,13 +252,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Run e2e suite (against built binary)
         run: |
@@ -334,13 +290,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Run docker e2e suite
         run: npm run test:e2e:docker
@@ -371,14 +321,7 @@ jobs:
           GSD_SKIP_RTK_INSTALL: '1'
         run: npm ci --ignore-scripts
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: ci-build-artifacts
-
-      - name: Restore build artifacts
-        shell: bash
-        run: bash scripts/ci-unpack-build-artifacts.sh
+      - uses: ./.github/actions/restore-ci-build-artifacts
 
       - name: Typecheck extensions
         if: needs.fast-gates.outputs.portability-changed == 'true'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,14 +74,7 @@ jobs:
       - name: Install web host dependencies
         run: npm --prefix web ci
 
-      - name: Cache Next.js build
-        uses: actions/cache@v5
-        with:
-          path: web/.next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
-            nextjs-${{ runner.os }}-
+      - uses: ./.github/actions/cache-nextjs
 
       - name: Build core
         run: npm run build:core
@@ -210,14 +203,7 @@ jobs:
           node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
           node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
-      - name: Cache Next.js build
-        uses: actions/cache@v5
-        with:
-          path: web/.next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
-            nextjs-${{ runner.os }}-
+      - uses: ./.github/actions/cache-nextjs
 
       - name: Run live LLM tests (optional)
         continue-on-error: true
@@ -322,7 +308,7 @@ jobs:
             -d "$(jq -n --arg c "**GSD v${RELEASE_VERSION} Released**\n\n${NOTES}\n\n\`npm i @opengsd/gsd-pi@${RELEASE_VERSION}\`" '{content:$c}')"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.check.outputs.changed == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -66,7 +66,7 @@ jobs:
           body-includes: PR Risk Report
 
       - name: Post or update risk comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Add `.github/actions/restore-ci-build-artifacts` and use it in 7 CI jobs that download/unpack build artifacts
- Add `.github/actions/cache-nextjs` and use it in 4 places across `ci.yml` and `npm-publish.yml`
- Pin `docker/login-action@v4.1.0` (Node 24 runtime) and bump `peter-evans/create-or-update-comment` to v5

## Test plan
- [ ] CI workflow runs green on this PR (composite actions resolve from repo root)
- [ ] Build job uploads artifacts; downstream test jobs restore them successfully
- [ ] Integration tests still hit Next.js cache on `web/.next/cache`
- [ ] PR risk comment still posts/updates on opened PRs


Made with [Cursor](https://cursor.com)