### PR TITLE
fix(ci): harden native engine bootstrap and npm publish verification

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -15,13 +15,21 @@ on:
           - "false"
           - "true"
       publish_auth:
-        description: "npm publish auth mode"
+        description: "npm auth: token creates packages not on npm yet; trusted after first publish"
         required: false
         default: "trusted"
         type: choice
         options:
           - "trusted"
           - "token"
+      platform_packages_only:
+        description: "Publish @opengsd/engine-* only (skip @opengsd/gsd-pi; use to bootstrap missing platform packages)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 permissions:
   contents: read
@@ -166,25 +174,42 @@ jobs:
             echo "Stable release: ${VERSION} → publishing with --tag latest"
           fi
 
+      - name: Require token auth for packages not on npm yet
+        if: github.event.inputs.publish_auth != 'token'
+        run: |
+          MISSING=()
+          for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
+            PKG="@opengsd/engine-${platform}"
+            if ! npm view "${PKG}" name >/dev/null 2>&1; then
+              MISSING+=("${PKG}")
+            fi
+          done
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::These @opengsd/engine-* packages do not exist on npm yet:"
+            for pkg in "${MISSING[@]}"; do
+              echo "::error::  - ${pkg}"
+            done
+            echo "::error::Trusted publishing is configured after first publish. Re-run with publish_auth=token and NPM_TOKEN set (see docs/dev/ci-cd-pipeline.md)."
+            exit 1
+          fi
+
+      - name: Verify NPM_TOKEN is configured for token bootstrap
+        if: github.event.inputs.publish_auth == 'token'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::error::publish_auth=token requires the NPM_TOKEN repository secret."
+            echo "::error::Create an npm automation token with publish access to @opengsd, add it as NPM_TOKEN, then re-run."
+            exit 1
+          fi
+          npm whoami
+
       - name: Publish platform packages
         env:
           NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
-        run: |
-          for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
-            echo "Publishing @opengsd/engine-${platform}..."
-            cd "native/npm/${platform}"
-            if OUTPUT=$(npm publish --access public ${{ steps.version-check.outputs.tag_flag }} 2>&1); then
-              echo "$OUTPUT"
-            else
-              if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
-                echo "Already published, skipping"
-              else
-                echo "::error::Failed to publish ${platform}: $OUTPUT"
-                exit 1
-              fi
-            fi
-            cd "$GITHUB_WORKSPACE"
-          done
+          TAG_FLAG: ${{ steps.version-check.outputs.tag_flag }}
+        run: bash scripts/publish-engine-packages.sh
 
       - name: Verify platform packages are published
         run: |
@@ -226,18 +251,23 @@ jobs:
           done
 
       - name: Install dependencies
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: npm ci --omit=optional
 
       - name: Build
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: npm run build
 
       - name: Verify dist exists
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: test -s dist/loader.js || { echo "::error::dist/loader.js missing or empty after build"; exit 1; }
 
       - name: Validate package is installable
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: npm run validate-pack
 
       - name: Publish main package
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
         run: |
@@ -254,6 +284,7 @@ jobs:
           fi
 
       - name: Post-publish smoke test
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TMPDIR=$(mktemp -d)
@@ -306,7 +337,7 @@ jobs:
           exit 1
 
       - name: Verify dist-tag after publish
-        if: steps.version-check.outputs.is_prerelease == 'false'
+        if: (github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true') && steps.version-check.outputs.is_prerelease == 'false'
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "Verifying npm dist-tag 'latest' points to ${VERSION}..."

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,14 @@ on:
         description: "Branch or SHA for prerelease publishes (defaults: dev -> main, next -> next; latest always uses main)"
         required: false
         default: ""
+      publish_auth:
+        description: "npm auth: token uses NPM_TOKEN; trusted uses OIDC (default)"
+        required: false
+        default: "trusted"
+        type: choice
+        options:
+          - "trusted"
+          - "token"
 
 concurrency:
   group: npm-publish-${{ github.event.inputs.channel }}-${{ github.event.inputs.ref || 'default' }}
@@ -62,14 +70,27 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
+        env:
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify trusted publishing toolchain
+      - name: Verify npm publish toolchain
         run: |
-          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
-          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('npm publish requires Node >= 22.14.0'); }"
+          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('npm publish requires npm >= 11.5.1'); }"
+
+      - name: Verify NPM_TOKEN for token publish
+        if: github.event.inputs.publish_auth == 'token'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::error::publish_auth=token requires the NPM_TOKEN repository secret."
+            exit 1
+          fi
+          npm whoami
 
       - name: Install web host dependencies
         run: npm --prefix web ci

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -158,15 +158,52 @@ For `@dev` or `@next` rollbacks, the next successful merge will overwrite the ta
 
 | Setting | Value |
 |---------|-------|
-| npm Trusted Publisher workflow filename | `npm-publish.yml` |
+| npm Trusted Publisher workflow filename | `npm-publish.yml` (for `@opengsd/gsd-pi` only) |
 | Environment: `dev` | No protection rules |
 | Environment: `test` | No protection rules |
 | Environment: `prod` | Required reviewers: maintainers |
-| Secret: `NPM_TOKEN` | Not required for `npm-publish.yml`; only token-fallback workflows need it |
+| Secret: `NPM_TOKEN` | Not required for trusted publishing; set for token-fallback bootstrap (`build-native.yml` → `publish_auth=token`) |
 | Secret: `ANTHROPIC_API_KEY` | Prod environment only |
 | Secret: `OPENAI_API_KEY` | Prod environment only |
 | Variable: `RUN_LIVE_TESTS` | `false` (set to `true` to enable live LLM tests) |
 | GHCR | Enabled for the `open-gsd` org |
+
+### npm Trusted Publishing (all packages)
+
+npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) binds each package to a single GitHub Actions workflow filename. It can only be configured **after** a package already exists on npm — you cannot set it up for packages that return 404.
+
+#### First-time packages (bootstrap with token)
+
+Use this when any `@opengsd/engine-*` package is missing from npm (today: `@opengsd/engine-darwin-x64`, `@opengsd/engine-linux-x64-gnu`).
+
+1. Create an npm [automation token](https://www.npmjs.com/settings/opengsd/tokens) with **Publish** access to the `@opengsd` scope (must be allowed to create new packages under the org).
+2. Add the token as repository secret **`NPM_TOKEN`** (GitHub → repo → Settings → Secrets and variables → Actions).
+3. Run [Build Native Binaries](https://github.com/open-gsd/gsd-pi/actions/workflows/build-native.yml):
+   - `publish`: **true**
+   - `platform_packages_only`: **true**
+   - `publish_auth`: **token** ← required for packages that do not exist yet
+4. Confirm all five packages resolve: `npm view @opengsd/engine-darwin-x64 version` (and the other four).
+5. **Then** configure trusted publishing on each package (table below).
+6. Re-run **NPM Publish** with the desired channel.
+
+The publish step skips packages already on npm and attempts all five platforms before failing, so one error does not leave the rest unpublished.
+
+#### Trusted publishing (after first publish)
+
+Configure **every** package on [npm package settings](https://www.npmjs.com/settings/opengsd/packages) → package → **Publishing access** → **Trusted Publisher**:
+
+| npm package | Trusted Publisher workflow |
+|-------------|---------------------------|
+| `@opengsd/gsd-pi` | `npm-publish.yml` |
+| `@opengsd/engine-darwin-arm64` | `build-native.yml` |
+| `@opengsd/engine-darwin-x64` | `build-native.yml` |
+| `@opengsd/engine-linux-x64-gnu` | `build-native.yml` |
+| `@opengsd/engine-linux-arm64-gnu` | `build-native.yml` |
+| `@opengsd/engine-win32-x64-msvc` | `build-native.yml` |
+
+For all packages: repository **`open-gsd/gsd-pi`**, environment **(none)**.
+
+After trusted publishing is configured, use `publish_auth=trusted` (default) for routine native publishes.
 
 ### Docker Images
 

--- a/scripts/__tests__/build-native-workflow.test.mjs
+++ b/scripts/__tests__/build-native-workflow.test.mjs
@@ -1,0 +1,77 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for native binary publish workflow resilience.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+const workflow = YAML.parse(
+  readFileSync(".github/workflows/build-native.yml", "utf8"),
+);
+const publishJob = workflow.jobs.publish;
+
+test("build-native exposes platform_packages_only bootstrap input", () => {
+  const input = workflow.on.workflow_dispatch.inputs.platform_packages_only;
+
+  assert.equal(input.default, "false");
+  assert.deepEqual(input.options, ["false", "true"]);
+});
+
+test("build-native publish uses resilient engine package script", () => {
+  const step = publishJob.steps.find(
+    (entry) => entry.name === "Publish platform packages",
+  );
+
+  assert.ok(step, "publish job must publish platform packages");
+  assert.match(step.run, /publish-engine-packages\.sh/);
+  assert.equal(step.env.TAG_FLAG, "${{ steps.version-check.outputs.tag_flag }}");
+});
+
+test("build-native can skip main package when bootstrapping engine packages", () => {
+  const gatedSteps = [
+    "Install dependencies",
+    "Build",
+    "Verify dist exists",
+    "Validate package is installable",
+    "Publish main package",
+    "Post-publish smoke test",
+  ];
+
+  for (const name of gatedSteps) {
+    const step = publishJob.steps.find((entry) => entry.name === name);
+    assert.ok(step, `expected publish job step ${name}`);
+    assert.match(
+      step.if,
+      /platform_packages_only != 'true'/,
+      `${name} must skip when platform_packages_only=true`,
+    );
+  }
+});
+
+test("build-native requires token auth when engine packages are missing from npm", () => {
+  const step = publishJob.steps.find(
+    (entry) => entry.name === "Require token auth for packages not on npm yet",
+  );
+  const tokenCheck = publishJob.steps.find(
+    (entry) => entry.name === "Verify NPM_TOKEN is configured for token bootstrap",
+  );
+
+  assert.ok(step, "publish job must guard trusted auth when packages are new");
+  assert.equal(step.if, "github.event.inputs.publish_auth != 'token'");
+  assert.match(step.run, /do not exist on npm yet/);
+  assert.match(step.run, /publish_auth=token/);
+
+  assert.ok(tokenCheck, "publish job must verify NPM_TOKEN for token bootstrap");
+  assert.equal(tokenCheck.if, "github.event.inputs.publish_auth == 'token'");
+  assert.match(tokenCheck.run, /NPM_TOKEN/);
+});
+
+test("publish-engine-packages script continues through all platforms", () => {
+  const script = readFileSync("scripts/publish-engine-packages.sh", "utf8");
+
+  assert.match(script, /FAILED=\(\)/);
+  assert.match(script, /for platform in "\$\{PLATFORMS\[@\]\}"/);
+  assert.doesNotMatch(script, /exit 1\s*\n\s*fi\s*\n\s*cd "\$GITHUB_WORKSPACE"/);
+  assert.match(script, /already on npm, skipping/);
+});

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -45,6 +45,21 @@ test("prerelease publish preserves channel-specific default refs", () => {
   assert.match(checkout.with.ref, /'main'/);
 });
 
+test("npm publish supports token auth fallback for prerelease", () => {
+  const input = workflow.on.workflow_dispatch.inputs.publish_auth;
+
+  assert.equal(input.default, "trusted");
+  assert.deepEqual(input.options, ["trusted", "token"]);
+
+  const setupNode = workflow.jobs["prerelease-publish"].steps.find(
+    (step) => step.uses === "actions/setup-node@v6",
+  );
+  assert.equal(
+    setupNode.env.NODE_AUTH_TOKEN,
+    "${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}",
+  );
+});
+
 test("main package publish verifies native engine packages first", () => {
   const prereleaseSteps = workflow.jobs["prerelease-publish"].steps;
   const prereleaseVerify = prereleaseSteps.find(

--- a/scripts/publish-engine-packages.sh
+++ b/scripts/publish-engine-packages.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Publish all @opengsd/engine-* platform packages for the root package version.
+# Skips packages already on npm; continues on per-platform failure and reports a summary at the end (avoids leaving platforms unpublished after an early exit).
+
+set -euo pipefail
+
+PLATFORMS=(darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="$(node -p "require('./package.json').version")"
+TAG_FLAG="${TAG_FLAG:-}"
+
+FAILED=()
+SKIPPED=()
+PUBLISHED=()
+
+for platform in "${PLATFORMS[@]}"; do
+  PKG="@opengsd/engine-${platform}"
+  EXISTING="$(npm view "${PKG}@${VERSION}" version 2>/dev/null || true)"
+
+  if [ "${EXISTING}" = "${VERSION}" ]; then
+    echo "✓ ${PKG}@${VERSION} already on npm, skipping"
+    SKIPPED+=("${platform}")
+    continue
+  fi
+
+  echo "Publishing ${PKG}@${VERSION}..."
+  cd "${ROOT}/native/npm/${platform}"
+  # shellcheck disable=SC2086
+  if OUTPUT="$(npm publish --access public ${TAG_FLAG} 2>&1)"; then
+    echo "${OUTPUT}"
+    PUBLISHED+=("${platform}")
+  elif echo "${OUTPUT}" | grep -qE "cannot publish over the previously published|You cannot publish over"; then
+    echo "Already published ${PKG}, skipping"
+    SKIPPED+=("${platform}")
+  else
+    echo "::error::Failed to publish ${platform}:"
+    echo "${OUTPUT}"
+    FAILED+=("${platform}")
+  fi
+  cd "${ROOT}"
+done
+
+echo ""
+echo "Engine package publish summary for ${VERSION}:"
+echo "  published: ${PUBLISHED[*]:-none}"
+echo "  skipped:   ${SKIPPED[*]:-none}"
+echo "  failed:    ${FAILED[*]:-none}"
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  echo "::error::${#FAILED[@]} platform package(s) failed to publish: ${FAILED[*]}"
+  echo "::error::If packages do not exist on npm yet, re-run with publish_auth=token and NPM_TOKEN set. See docs/dev/ci-cd-pipeline.md."
+  exit 1
+fi

--- a/scripts/verify-native-platform-packages.mjs
+++ b/scripts/verify-native-platform-packages.mjs
@@ -44,7 +44,7 @@ for (const spec of missing) {
 }
 process.stderr.write(
   allowAnyVersion
-    ? "Publish the missing @opengsd/engine-* packages before publishing @opengsd/gsd-pi.\n"
+    ? "Publish the missing @opengsd/engine-* packages before publishing @opengsd/gsd-pi.\nRun Build Native Binaries (build-native.yml) with publish=true, platform_packages_only=true, publish_auth=token.\nPackages must exist on npm before trusted publishing can be configured — see docs/dev/ci-cd-pipeline.md.\n"
     : "Run the native binary publish workflow for this version before publishing @opengsd/gsd-pi.\n",
 );
 process.exit(1);

--- a/tests/live-regression/run.ts
+++ b/tests/live-regression/run.ts
@@ -503,7 +503,7 @@ run("version skew is detected and named in stderr", () => {
     mkdirSync(join(fakeHome, ".gsd", "agent"), { recursive: true });
     writeFileSync(
       join(fakeHome, ".gsd", "agent", "managed-resources.json"),
-      JSON.stringify({ gsdVersion: "999.0.0" }),
+      JSON.stringify({ gsdVersion: "999.0.0", packageName: "@opengsd/gsd-pi" }),
     );
 
     const result = gsd([], dir, { HOME: fakeHome });
@@ -512,8 +512,7 @@ run("version skew is detected and named in stderr", () => {
     const stderr = result.stderr;
     const hitVersionSkew =
       stderr.includes("999.0.0") ||
-      /version\s*(skew|mismatch)/i.test(stderr) ||
-      /managed-resources/i.test(stderr);
+      /version\s*mismatch/i.test(stderr);
     assert(
       hitVersionSkew,
       `expected stderr to mention version skew / 999.0.0 / managed-resources; got: ${stderr.slice(0, 400)}`,


### PR DESCRIPTION
## Summary
- Resilient `@opengsd/engine-*` publish: skip already-published platforms, continue through all five, summarize failures at the end
- `build-native.yml`: `platform_packages_only` bootstrap mode, token preflight when packages do not exist on npm yet
- `npm-publish.yml`: optional `publish_auth=token` fallback for prerelease publishes
- Docs: token-first bootstrap before trusted publishing can be configured
- Fix live regression version-skew test (`packageName` required in fixture)

## Test plan
- [x] `node --test scripts/__tests__/build-native-workflow.test.mjs scripts/__tests__/npm-publish-workflow.test.mjs`
- [x] `GSD_SMOKE_BINARY=gsd node --experimental-strip-types tests/live-regression/run.ts` (version skew test passes)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)