### PR TITLE
fix(issue): execute-task: cross-session recovery counter reset causes infinite 30-min stall loop; estimate timeout scaling uses wrong unitType string

### DIFF
--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -114,7 +114,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
   // If the task has an est: annotation, use it to extend the hard and soft timeouts
   // so longer tasks don't get prematurely timed out.
   let taskEstimate = sctx.taskEstimate;
-  if (!taskEstimate && unitType === "task" && isDbAvailable()) {
+  if (!taskEstimate && unitType === "execute-task" && isDbAvailable()) {
     // Look up the task estimate from the DB (#2243).
     try {
       if (s.currentMilestoneId) {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -92,6 +92,16 @@ import {
 export const STUCK_WINDOW_SIZE = 6;
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
 
+export function resolveDispatchRecoveryAttempts(
+  unitRecoveryCount: Map<string, number>,
+  unitType: string,
+  unitId: string,
+): number | undefined {
+  return (unitRecoveryCount.get(`${unitType}/${unitId}`) ?? 0) > 0
+    ? 0
+    : undefined;
+}
+
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
 function isSamePathLocal(a: string, b: string): boolean {
@@ -2262,7 +2272,7 @@ export async function runUnitPhase(
       lastProgressAt: unitStartedAt,
       progressCount: 0,
       lastProgressKind: "dispatch",
-      recoveryAttempts: 0, // Reset so re-dispatched units get full recovery budget (#2322)
+      recoveryAttempts: resolveDispatchRecoveryAttempts(s.unitRecoveryCount, unitType, unitId),
     },
   );
 

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -7,7 +7,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { runFinalize } from "../auto/phases.ts";
+import { resolveDispatchRecoveryAttempts, runFinalize } from "../auto/phases.ts";
 import { AutoSession } from "../auto/session.ts";
 import { readUnitRuntimeRecord, writeUnitRuntimeRecord } from "../unit-runtime.ts";
 import { captureRootDirtySnapshot } from "../root-write-leak-guard.ts";
@@ -24,6 +24,26 @@ function initRepo(root: string): void {
   runGit(root, ["add", "."]);
   runGit(root, ["commit", "-m", "chore: init"]);
 }
+
+test("resolveDispatchRecoveryAttempts preserves cross-session recovery attempts before in-session recovery", () => {
+  const recoveryCounts = new Map<string, number>();
+
+  assert.equal(
+    resolveDispatchRecoveryAttempts(recoveryCounts, "execute-task", "M001/S01/T01"),
+    undefined,
+  );
+});
+
+test("resolveDispatchRecoveryAttempts resets after recovery ran in the current session", () => {
+  const recoveryCounts = new Map<string, number>([
+    ["execute-task/M001/S01/T01", 1],
+  ]);
+
+  assert.equal(
+    resolveDispatchRecoveryAttempts(recoveryCounts, "execute-task", "M001/S01/T01"),
+    0,
+  );
+});
 
 async function runSuccessfulFinalize(s: AutoSession) {
   const unit = s.currentUnit;


### PR DESCRIPTION
## Summary
- Fixed cross-session recovery preservation and execute-task estimate timeout lookup, verified with focused tests and extension typecheck.

## Bugs Addressed
- [x] **Cross-session recovery counter unconditionally reset at dispatch (`auto/phases.js`)**
- [x] **Wrong `unitType` string in estimate-based timeout scaling (`auto-timers.js`)**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #50
- [#50 execute-task: cross-session recovery counter reset causes infinite 30-min stall loop; estimate timeout scaling uses wrong unitType string](https://github.com/open-gsd/gsd-pi/issues/50)

## User
- @mpeter

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/50-execute-task-cross-session-recovery-coun-1779564943`