### PR TITLE
fix(issue): [Bug]: error on windows update from gsd-2

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -319,6 +319,41 @@ function findBinaryRecursively(rootDir, binaryName) {
   return null
 }
 
+function quotePowerShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function extractZipArchive(archivePath, extractDir) {
+  mkdirSync(extractDir, { recursive: true })
+
+  if (platform() === 'win32') {
+    const command = [
+      'Expand-Archive',
+      '-LiteralPath', quotePowerShellLiteral(archivePath),
+      '-DestinationPath', quotePowerShellLiteral(extractDir),
+      '-Force',
+    ].join(' ')
+    const result = spawnSync('powershell.exe', [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      command,
+    ], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    })
+    if (result.error || result.status !== 0) {
+      throw new Error(result.error?.message || result.stderr?.trim() || 'zip extraction failed')
+    }
+    return
+  }
+
+  return import('extract-zip').then(({ default: extractZip }) => extractZip(archivePath, { dir: extractDir }))
+}
+
 function validateRtkBinary(binaryPath) {
   const result = spawnSync(binaryPath, ['rewrite', 'git status'], {
     encoding: 'utf-8',
@@ -372,9 +407,7 @@ async function installRtk() {
 
     mkdirSync(extractDir, { recursive: true })
     if (assetName.endsWith('.zip')) {
-      // extract-zip may not be available when running via npx — use tar for .tar.gz
-      const extractZip = (await import('extract-zip')).default
-      await extractZip(archivePath, { dir: extractDir })
+      await extractZipArchive(archivePath, extractDir)
     } else {
       const extractResult = spawnSync('tar', ['xzf', archivePath, '-C', extractDir], {
         encoding: 'utf-8',


### PR DESCRIPTION
## Summary
- Fixed Windows RTK postinstall zip extraction to avoid unsettled top-level await failures and verified installer syntax plus the focused postinstall test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #53
- [#53 [Bug]: error on windows update from gsd-2](https://github.com/open-gsd/gsd-pi/issues/53)

## User
- @sharkpd

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/53-bug-error-on-windows-update-from-gsd-2-1779569190`