### PR TITLE
fix(issue): Auto-orchestrator: milestone status desync (planned after slices complete) + worker-lock self-collision

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1878,11 +1878,15 @@ export async function pauseAuto(
 
   if (s.workerId) {
     try {
+      if (s.currentMilestoneId && s.milestoneLeaseToken) {
+        releaseMilestoneLease(s.workerId, s.currentMilestoneId, s.milestoneLeaseToken);
+      }
       markWorkerStopping(s.workerId);
     } catch (err) {
       logWarning("engine", `pause worker cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
     }
     s.workerId = null;
+    s.milestoneLeaseToken = null;
   }
 
   deregisterSigtermHandler();

--- a/src/resources/extensions/gsd/db/milestone-leases.ts
+++ b/src/resources/extensions/gsd/db/milestone-leases.ts
@@ -123,10 +123,13 @@ export function claimMilestoneLease(
     }
 
     // Step 2: takeover. Conditional UPDATE — only succeeds if the existing
-    // lease is expired or explicitly released. Fencing token is incremented
-    // by SQL (`fencing_token + 1`) so the new holder's token monotonically
-    // exceeds the prior holder's. db.changes() === 1 confirms the takeover
-    // actually happened (vs. losing the race to another worker).
+    // lease is expired/released, or if the claimant is a re-entrant worker row
+    // for the same live host/PID/project. The latter prevents a single
+    // orchestrator process from blocking on its own previous worker token.
+    // Fencing token is incremented by SQL (`fencing_token + 1`) so the new
+    // holder's token monotonically exceeds the prior holder's. db.changes()
+    // === 1 confirms the takeover actually happened (vs. losing the race to
+    // another worker).
     const updateResult = db.prepare(
       `UPDATE milestone_leases
        SET worker_id = :worker_id,
@@ -136,7 +139,18 @@ export function claimMilestoneLease(
            status = 'held'
        WHERE milestone_id = :milestone_id
          AND (status IN ('expired','released')
-              OR datetime(expires_at) < datetime('now'))`,
+              OR datetime(expires_at) < datetime('now')
+              OR EXISTS (
+                SELECT 1
+                FROM workers holder
+                JOIN workers claimant ON claimant.worker_id = :worker_id
+                WHERE holder.worker_id = milestone_leases.worker_id
+                  AND holder.status = 'active'
+                  AND claimant.status = 'active'
+                  AND holder.host = claimant.host
+                  AND holder.pid = claimant.pid
+                  AND holder.project_root_realpath = claimant.project_root_realpath
+              ))`,
     ).run({
       ":milestone_id": milestoneId,
       ":worker_id": workerId,

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -11,6 +11,7 @@ import {
   insertSlice,
   insertTask,
   getSlice,
+  getMilestone,
   updateSliceStatus,
   getSliceTasks,
   setSliceSummaryMd,
@@ -264,6 +265,32 @@ console.log('\n=== complete-slice: handler happy path ===');
     assertEq(sliceAfter!.status, 'complete', 'slice status should be complete in DB');
     assertTrue(sliceAfter!.completed_at !== null, 'completed_at should be set in DB');
   }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: final slice promotes planned milestone before validation
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: final slice promotes planned milestone ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone', status: 'planned' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'medium', sequence: 1 });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+
+  const result = await handleCompleteSlice(makeValidSliceParams(), basePath);
+
+  assertTrue(!('error' in result), 'final slice completion should succeed');
+  const milestone = getMilestone('M001');
+  assertTrue(milestone !== null, 'milestone should exist after completion');
+  assertEq(milestone!.status, 'active', 'final slice should transition a planned milestone to active');
 
   cleanupDir(basePath);
   cleanup(dbPath);

--- a/src/resources/extensions/gsd/tests/milestone-leases.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-leases.test.ts
@@ -58,7 +58,7 @@ test("second claim by different worker is rejected while lease is held", (t) => 
   insertMilestone({ id: "M001", title: "Test", status: "active" });
 
   const w1 = registerAutoWorker({ projectRootRealpath: base });
-  const w2 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: join(base, "other-project") });
   const first = claimMilestoneLease(w1, "M001");
   assert.equal(first.ok, true);
 
@@ -68,6 +68,30 @@ test("second claim by different worker is rejected while lease is held", (t) => 
     assert.equal(second.error, "held_by");
     assert.equal(second.byWorker, w1);
   }
+});
+
+test("claim by another worker row from the same live process is re-entrant", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+  const first = claimMilestoneLease(w1, "M001");
+  assert.equal(first.ok, true);
+
+  const second = claimMilestoneLease(w2, "M001");
+  assert.equal(second.ok, true);
+  if (second.ok) {
+    assert.equal(second.token, 2, "same-process re-entry increments the fencing token");
+  }
+
+  const row = getMilestoneLease("M001");
+  assert.ok(row);
+  assert.equal(row!.worker_id, w2);
+  assert.equal(row!.fencing_token, 2);
+  assert.equal(row!.status, "held");
 });
 
 test("releaseMilestoneLease frees the lease for takeover", (t) => {

--- a/src/resources/extensions/gsd/tests/parallel-milestone-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-milestone-isolation.test.ts
@@ -41,7 +41,7 @@ test("two workers contesting the same milestone: only one wins the lease", (t) =
   insertMilestone({ id: "M001", title: "Contested", status: "active" });
 
   const w1 = registerAutoWorker({ projectRootRealpath: base });
-  const w2 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: join(base, "other-project") });
 
   const r1 = claimMilestoneLease(w1, "M001");
   const r2 = claimMilestoneLease(w2, "M001");

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -348,7 +348,7 @@ test("enterMilestone returns ok:false reason:lease-conflict when another worker 
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Test", status: "active" });
   const holder = registerAutoWorker({ projectRootRealpath: base });
-  const contender = registerAutoWorker({ projectRootRealpath: base });
+  const contender = registerAutoWorker({ projectRootRealpath: join(base, "other-project") });
   const claim = claimMilestoneLease(holder, "M001");
   assert.equal(claim.ok, true);
 

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -27,6 +27,8 @@ import {
   setSliceSummaryMd,
   saveGateResult,
   getPendingGatesForTurn,
+  getMilestoneSlices,
+  updateMilestoneStatus,
 } from "../gsd-db.js";
 import { getGatesForTurn } from "../gate-registry.js";
 import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../paths.js";
@@ -384,6 +386,15 @@ export async function handleCompleteSlice(
       insertSlice({ id: params.sliceId, milestoneId: params.milestoneId, title: params.sliceTitle || params.sliceId });
     }
     updateSliceStatus(params.milestoneId, params.sliceId, "complete", completedAt);
+
+    const updatedSlices = getMilestoneSlices(params.milestoneId);
+    if (
+      milestone?.status === "planned" &&
+      updatedSlices.length > 0 &&
+      updatedSlices.every((s) => isClosedStatus(s.status))
+    ) {
+      updateMilestoneStatus(params.milestoneId, "active");
+    }
   });
 
   if (duplicateComplete) {


### PR DESCRIPTION
## Summary
- Fixed milestone final-slice status promotion and same-process lease self-collision with focused regression tests passing.

## Bugs Addressed
- [x] **Milestone lifecycle desync: `status` stays `planned` after all slices complete**
- [x] **Worker-lock self-collision / lock leak across orchestrator iterations**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #71
- [#71 Auto-orchestrator: milestone status desync (planned after slices complete) + worker-lock self-collision](https://github.com/open-gsd/gsd-pi/issues/71)

## User
- @NilsR0711

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/71-auto-orchestrator-milestone-status-desyn-1779569784`