### PR TITLE
fix(issue): [Bug]: verification-gate splits task-plan verify on && — cd loses cwd, causing false failure + 5× re-dispatch loop

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -555,7 +555,7 @@ verification_max_retries: 2       # max retry attempts (default: 2)
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
 
-For task-level `verify` commands (`taskPlanVerify`), GSD splits command chains on `&&` and validates each segment independently. On Unix-like systems, commands run with `set -o pipefail` semantics, so any failing stage in a pipeline causes the verification command to fail.
+For task-level `verify` commands (`taskPlanVerify`), GSD splits checks on newlines. `&&` chains stay within a single shell invocation, so commands such as `cd path && npm test` preserve directory context.
 
 When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds files matching pytest's default test file patterns (`test_*.py` or `*_test.py`) under `tests/` or an explicit pytest configuration marker: `pytest.ini`, `[tool.pytest]`, `[tool.pytest.*]`, `[pytest]`, or `[tool:pytest]` in `pyproject.toml`.
 

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -162,7 +162,7 @@ verification_max_retries: 2       # max attempts (default: 2)
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
 
-For task-level `verify` commands (`taskPlanVerify`), GSD splits command chains on `&&` and validates each segment independently. On Unix-like systems, commands run with `set -o pipefail` semantics, so any failing stage in a pipeline causes the verification command to fail.
+For task-level `verify` commands (`taskPlanVerify`), GSD splits checks on newlines. `&&` chains stay within a single shell invocation, so commands such as `cd path && npm test` preserve directory context.
 
 When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds explicit pytest evidence: `pytest.ini`, a pytest configuration section in `pyproject.toml` such as `[tool.pytest.ini_options]`, or files matching pytest's default test file patterns (`test_*.py` or `*_test.py`) under `tests/`.
 

--- a/mintlify-docs/guides/configuration.mdx
+++ b/mintlify-docs/guides/configuration.mdx
@@ -202,7 +202,7 @@ verification_max_retries: 2
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`).
 
-For task-level `verify` commands (`taskPlanVerify`), GSD splits command chains on `&&` and validates each segment independently. On Unix-like systems, commands run with `set -o pipefail` semantics, so any failing stage in a pipeline causes the verification command to fail.
+For task-level `verify` commands (`taskPlanVerify`), GSD splits checks on newlines. `&&` chains stay within a single shell invocation, so commands such as `cd path && npm test` preserve directory context.
 
 ### Git
 

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -56,7 +56,7 @@ describe("verification-gate: discovery", () => {
       taskPlanVerify: "npm run lint && npm run test",
       cwd: tmp,
     });
-    assert.deepStrictEqual(result.commands, ["npm run lint", "npm run test"]);
+    assert.deepStrictEqual(result.commands, ["npm run lint && npm run test"]);
     assert.equal(result.source, "task-plan");
   });
 
@@ -159,6 +159,15 @@ describe("verification-gate: discovery", () => {
     assert.equal(result.source, "task-plan");
   });
 
+  test("taskPlanVerify preserves cd context in && chains", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "cd /tmp/project/subdir && uv run pytest tests/ -q --tb=short",
+      cwd: tmp,
+    });
+    assert.deepStrictEqual(result.commands, ["cd /tmp/project/subdir && uv run pytest tests/ -q --tb=short"]);
+    assert.equal(result.source, "task-plan");
+  });
+
   test("whitespace-only preference commands fall through", () => {
     writeFileSync(
       join(tmp, "package.json"),
@@ -217,12 +226,12 @@ describe("verification-gate: discovery", () => {
       cwd: tmp,
     });
     assert.equal(result.source, "task-plan");
-    assert.deepStrictEqual(result.commands, ["npm run lint", "npm run test"]);
+    assert.deepStrictEqual(result.commands, ["npm run lint && npm run test"]);
   });
 
-  test("mixed prose and commands in taskPlanVerify — only commands kept", () => {
+  test("mixed prose and commands in newline-delimited taskPlanVerify — only commands kept", () => {
     const result = discoverCommands({
-      taskPlanVerify: "Check that everything works && npm run test",
+      taskPlanVerify: "Check that everything works\nnpm run test",
       cwd: tmp,
     });
     // "Check that everything works" is prose (starts with capital, 4+ words)

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -41,7 +41,7 @@ const PACKAGE_SCRIPT_KEYS = ["typecheck", "lint", "test"] as const;
 
 /**
  * Discover verification commands using the first-non-empty-wins strategy (D003):
- *   1. Task plan verify field (split on && and newlines)
+ *   1. Task plan verify field (split on newlines)
  *   2. Explicit preference commands
  *   3. package.json scripts (typecheck, lint, test)
  *   4. Python pytest project markers
@@ -59,7 +59,7 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
   if (taskPlanVerify) {
     const commands: string[] = [];
     const candidates = taskPlanVerify
-      .split(/&&|\r?\n/)
+      .split(/\r?\n/)
       .map(c => c.trim())
       .filter(Boolean);
     for (const candidate of candidates) {


### PR DESCRIPTION
## Summary
- Fixed task-plan verification discovery to preserve && chains and verified with the focused verification-gate test plus verify:fast.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #64
- [#64 [Bug]: verification-gate splits task-plan verify on && — cd loses cwd, causing false failure + 5× re-dispatch loop](https://github.com/open-gsd/gsd-pi/issues/64)

## User
- @mpeter

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/64-bug-verification-gate-splits-task-plan-v-1779590567`