### PR TITLE
fix(release): sync package-lock with engine optionalDependencies on bump

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -279,7 +279,9 @@ jobs:
 
       - name: Install dependencies
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
-        run: npm ci --omit=optional
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          npm ci --omit=optional
 
       - name: Build
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,11 +67,11 @@
       },
       "optionalDependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.83",
-        "@opengsd/engine-darwin-arm64": "1.0.1",
-        "@opengsd/engine-darwin-x64": "1.0.1",
-        "@opengsd/engine-linux-arm64-gnu": "1.0.1",
-        "@opengsd/engine-linux-x64-gnu": "1.0.1",
-        "@opengsd/engine-win32-x64-msvc": "1.0.1",
+        "@opengsd/engine-darwin-arm64": "1.0.2",
+        "@opengsd/engine-darwin-x64": "1.0.2",
+        "@opengsd/engine-linux-arm64-gnu": "1.0.2",
+        "@opengsd/engine-linux-x64-gnu": "1.0.2",
+        "@opengsd/engine-win32-x64-msvc": "1.0.2",
         "fsevents": "~2.3.3",
         "koffi": "^2.9.0"
       }
@@ -2240,7 +2240,9 @@
       "license": "MIT"
     },
     "node_modules/@opengsd/engine-darwin-arm64": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@opengsd/engine-darwin-arm64/-/engine-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-9MR6V9YwLKhYrk4AKNWbFxqluA7InBtY8oiB+a92XIMBGN6ZvVn3VaC1jqsuylf4exv08ozEsP/AKoffG4OQXQ==",
       "cpu": [
         "arm64"
       ],
@@ -2251,7 +2253,9 @@
       ]
     },
     "node_modules/@opengsd/engine-darwin-x64": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@opengsd/engine-darwin-x64/-/engine-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-H8ZfZBzouQYSOUrk09G5DqMOK4pMyP8zBg1wGd9rchsT3orDfhRG9IzUnFIgU/6rWBgqM1K+5slD5JF5Elrh5A==",
       "cpu": [
         "x64"
       ],
@@ -2262,7 +2266,9 @@
       ]
     },
     "node_modules/@opengsd/engine-linux-arm64-gnu": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@opengsd/engine-linux-arm64-gnu/-/engine-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-h9lveRIgWA/LlYsV39SoFgPUkJJNtLl/gZfN08DErEtr/Mb3ZDa0C1/WPMOI4XVahkrD8yYCjXGcrDMS11MmeQ==",
       "cpu": [
         "arm64"
       ],
@@ -2273,7 +2279,9 @@
       ]
     },
     "node_modules/@opengsd/engine-linux-x64-gnu": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@opengsd/engine-linux-x64-gnu/-/engine-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-tBE3/pklHky59FQK+KjYr/ch7uG6rtnkPlcr+EOv6jVoLEIqlVxa/M+5vNdCB4BtPjhPsRrLLiz3xtwu+bRb3g==",
       "cpu": [
         "x64"
       ],
@@ -2284,7 +2292,9 @@
       ]
     },
     "node_modules/@opengsd/engine-win32-x64-msvc": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@opengsd/engine-win32-x64-msvc/-/engine-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-DQw9vJZKmi6bksWy0BnebIMHLj2r0q0XuHC7foS2lcmTocRpkKfXWDnM9Ii2X/rnP5jAHKskQh3rLq1JvaMR7w==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -161,11 +161,11 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.83",
-    "@opengsd/engine-darwin-arm64": "1.0.1",
-    "@opengsd/engine-darwin-x64": "1.0.1",
-    "@opengsd/engine-linux-arm64-gnu": "1.0.1",
-    "@opengsd/engine-linux-x64-gnu": "1.0.1",
-    "@opengsd/engine-win32-x64-msvc": "1.0.1",
+    "@opengsd/engine-darwin-arm64": "1.0.2",
+    "@opengsd/engine-darwin-x64": "1.0.2",
+    "@opengsd/engine-linux-arm64-gnu": "1.0.2",
+    "@opengsd/engine-linux-x64-gnu": "1.0.2",
+    "@opengsd/engine-win32-x64-msvc": "1.0.2",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0"
   },

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -33,6 +33,10 @@ console.log(`[bump-version] package.json: ${oldVersion} → ${newVersion}`);
 syncVersionSurfaces(root, newVersion, { updateRoot: false });
 console.log(`[bump-version] release version surfaces synced to ${newVersion}`);
 
+// 2b. Pin root optionalDependencies to the same engine version as the release.
+execSync("node native/scripts/sync-platform-versions.cjs", { cwd: root, stdio: "inherit" });
+console.log(`[bump-version] optionalDependencies pinned to ${newVersion}`);
+
 // 3. Regenerate root package-lock.json to match the new version.
 //    --package-lock-only updates the lockfile in-place without touching node_modules.
 execSync("npm install --package-lock-only --ignore-scripts", { cwd: root, stdio: "inherit" });

--- a/scripts/lib/version-sync.cjs
+++ b/scripts/lib/version-sync.cjs
@@ -199,6 +199,16 @@ function verifyVersionSync(root) {
   verifyPackage(root, "pkg", expectedVersion, issues);
   verifyLockfile(root, expectedVersion, issues);
 
+  const rootPkg = readJson(path.join(root, "package.json"));
+  for (const platformDir of PLATFORM_PACKAGE_DIRS) {
+    const platform = platformDir.replace("native/npm/", "");
+    const depName = `@opengsd/engine-${platform}`;
+    const pinned = rootPkg.optionalDependencies?.[depName];
+    if (pinned !== undefined && pinned !== expectedVersion) {
+      issues.push(`package.json optionalDependencies.${depName} is ${pinned}, expected ${expectedVersion}`);
+    }
+  }
+
   const nativeCargoVersion = getNativeCargoVersion(root);
   if (nativeCargoVersion !== undefined && nativeCargoVersion !== expectedVersion) {
     issues.push(`native/Cargo.toml workspace package version is ${nativeCargoVersion}, expected ${expectedVersion}`);


### PR DESCRIPTION
## Summary
- `bump-version.mjs` runs `sync-platform-versions` before lockfile regen so optional `@opengsd/engine-*` pins match the release semver
- `build-native.yml` refreshes `package-lock.json` after platform version sync before `npm ci`
- Repairs current `main` drift (`package.json`/`package-lock.json` at 1.0.2 with engine pins still at 1.0.1)
- `verify:version-sync` now fails if optional engine deps drift from root version

Fixes [release: v1.0.2 build-native failure](https://github.com/open-gsd/gsd-pi/actions/runs/26351024446/job/77569317828) where `npm ci` failed after `sync-platform-versions` updated `package.json` but not the lockfile.

## Test plan
- [x] `npm run verify:version-sync`
- [ ] Merge and re-run Build Native Binaries on `v1.0.2` (move tag to merge commit first)


Made with [Cursor](https://cursor.com)