### PR TITLE
[codex] Isolate bundled skills under GSD agent dir

### DIFF
--- a/docs/dev/context-and-hooks/07-the-system-prompt-anatomy.md
+++ b/docs/dev/context-and-hooks/07-the-system-prompt-anatomy.md
@@ -174,7 +174,7 @@ When a skill file references a relative path, resolve it against the skill direc
   <skill>
     <name>commit-outstanding</name>
     <description>Commit all uncommitted files in logical groups</description>
-    <location>/Users/you/.agents/skills/commit-outstanding/SKILL.md</location>
+    <location>/Users/you/.gsd/agent/skills/commit-outstanding/SKILL.md</location>
   </skill>
 </available_skills>
 ```

--- a/docs/dev/what-is-pi/09-the-customization-stack.md
+++ b/docs/dev/what-is-pi/09-the-customization-stack.md
@@ -48,8 +48,10 @@ On-demand capability packages following the [Agent Skills standard](https://agen
 ```
 
 **Placement:**
+- `~/.gsd/agent/skills/` (GSD bundled, highest priority)
 - `~/.agents/skills/` (global — shared across all agents)
 - `.agents/skills/` (project, searched up to git root)
+- `~/.claude/skills/` and `.claude/skills/` (Claude Code compatibility, lower priority)
 
 **Skill structure:**
 ```

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -912,7 +912,7 @@ prefer_skills:
 avoid_skills: []
 ```
 
-Skills can be bare names (looked up in `~/.agents/skills/` and `.agents/skills/`) or absolute paths.
+Skills can be bare names (looked up in priority order from `~/.gsd/agent/skills/`, `~/.agents/skills/`, `.agents/skills/`, then Claude compatibility skill directories) or absolute paths.
 
 ### `skill_rules`
 

--- a/docs/user-docs/skills.md
+++ b/docs/user-docs/skills.md
@@ -6,16 +6,19 @@ Skills follow the open [Agent Skills standard](https://agentskills.io/) and are 
 
 ## Skill Directories
 
-GSD reads skills from two locations, in priority order:
+GSD reads skills from these locations, in priority order:
 
 | Location                          | Scope   | Description                                              |
 |-----------------------------------|---------|----------------------------------------------------------|
-| `~/.agents/skills/`              | Global  | Shared across all projects and all compatible agents     |
+| `~/.gsd/agent/skills/`           | Bundled | GSD-managed bundled skills synced during install/update  |
+| `~/.agents/skills/`              | Global  | User-global skills shared across compatible agents       |
 | `.agents/skills/` (project root) | Project | Project-specific skills, committable to version control  |
+| `~/.claude/skills/`              | Compat  | Claude Code compatibility source, lower priority         |
+| `.claude/skills/` (project root) | Compat  | Project-local Claude Code compatibility source           |
 
-Global skills take precedence over project skills when names collide.
+Earlier entries take precedence when names collide. Bundled GSD skills win over user-global and project skills; Claude Code compatibility directories are searched after the standard Agent Skills locations.
 
-> **Migration from `~/.gsd/agent/skills/`:** On first launch after upgrading, GSD automatically copies skills from the legacy `~/.gsd/agent/skills/` directory to `~/.agents/skills/`. The old directory is preserved for backward compatibility.
+> **Bundled vs user skills:** GSD bundled skills are managed in `~/.gsd/agent/skills/`. Install your own shared skills into `~/.agents/skills/`, or commit project-specific skills under `.agents/skills/`.
 
 ## Installing Skills
 
@@ -116,11 +119,11 @@ skill_rules:
 ### Resolution Order
 
 Skills can be referenced by:
-1. **Bare name** — e.g., `frontend-design` → scans `~/.agents/skills/` and project `.agents/skills/`
+1. **Bare name** — e.g., `frontend-design` → scans the skill directories above in priority order
 2. **Absolute path** — e.g., `/Users/you/.agents/skills/my-skill/SKILL.md`
 3. **Directory path** — e.g., `~/custom-skills/my-skill` → looks for `SKILL.md` inside
 
-Global skills (`~/.agents/skills/`) take precedence over project skills (`.agents/skills/`).
+Bundled skills (`~/.gsd/agent/skills/`) take precedence over user-global skills (`~/.agents/skills/`), project skills (`.agents/skills/`), and Claude compatibility directories.
 
 ## Custom Skills
 

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -656,7 +656,7 @@ prefer_skills:
 avoid_skills: []
 ```
 
-Skills 既可以写裸名称（去 `~/.agents/skills/` 和 `.agents/skills/` 查找），也可以写绝对路径。
+Skills 既可以写裸名称（按优先级从 `~/.gsd/agent/skills/`、`~/.agents/skills/`、`.agents/skills/`，再到 Claude 兼容技能目录查找），也可以写绝对路径。
 
 ### `skill_rules`
 

--- a/docs/zh-CN/user-docs/skills.md
+++ b/docs/zh-CN/user-docs/skills.md
@@ -6,16 +6,19 @@ Skills 遵循开放的 [Agent Skills 标准](https://agentskills.io/)，并且**
 
 ## 技能目录
 
-GSD 会按优先级顺序从两个位置读取技能：
+GSD 会按优先级顺序从这些位置读取技能：
 
 | 位置 | 范围 | 说明 |
 |------|------|------|
-| `~/.agents/skills/` | 全局 | 对所有项目和所有兼容 agent 共享 |
+| `~/.gsd/agent/skills/` | 内置 | GSD 管理的内置技能，会在安装或更新时同步 |
+| `~/.agents/skills/` | 全局 | 用户全局技能，对兼容 agent 共享 |
 | `.agents/skills/`（项目根目录） | 项目级 | 项目专用技能，可提交到版本控制 |
+| `~/.claude/skills/` | 兼容 | Claude Code 兼容来源，优先级较低 |
+| `.claude/skills/`（项目根目录） | 兼容 | 项目本地 Claude Code 兼容来源 |
 
-如果出现同名技能，全局技能优先于项目技能。
+如果出现同名技能，排在前面的目录优先。GSD 内置技能优先于用户全局和项目技能；Claude Code 兼容目录在标准 Agent Skills 目录之后搜索。
 
-> **从 `~/.gsd/agent/skills/` 迁移：** 升级后首次启动时，GSD 会自动把旧版 `~/.gsd/agent/skills/` 中的技能复制到 `~/.agents/skills/`。旧目录会保留，以兼容旧流程。
+> **内置技能与用户技能：** GSD 内置技能由 `~/.gsd/agent/skills/` 管理。你自己的共享技能应安装到 `~/.agents/skills/`，项目专用技能应提交到 `.agents/skills/`。
 
 ## 安装技能
 
@@ -122,11 +125,11 @@ skill_rules:
 
 技能可以通过以下几种方式引用：
 
-1. **裸名称**：例如 `frontend-design`，会扫描 `~/.agents/skills/` 和项目内的 `.agents/skills/`
+1. **裸名称**：例如 `frontend-design`，会按上面的优先级顺序扫描技能目录
 2. **绝对路径**：例如 `/Users/you/.agents/skills/my-skill/SKILL.md`
 3. **目录路径**：例如 `~/custom-skills/my-skill`，会在其中查找 `SKILL.md`
 
-全局技能（`~/.agents/skills/`）优先于项目技能（`.agents/skills/`）。
+内置技能（`~/.gsd/agent/skills/`）优先于用户全局技能（`~/.agents/skills/`）、项目技能（`.agents/skills/`）以及 Claude 兼容目录。
 
 ## 自定义技能
 

--- a/gitbook/features/skills.md
+++ b/gitbook/features/skills.md
@@ -8,10 +8,13 @@ Skills follow the open [Agent Skills standard](https://agentskills.io/) and work
 
 | Location | Scope | Description |
 |----------|-------|------------|
-| `~/.agents/skills/` | Global | Shared across all projects |
+| `~/.gsd/agent/skills/` | Bundled | GSD-managed bundled skills synced during install/update |
+| `~/.agents/skills/` | Global | User-global skills shared across compatible agents |
 | `.agents/skills/` (project root) | Project | Project-specific, committable to git |
+| `~/.claude/skills/` | Compat | Claude Code compatibility source, lower priority |
+| `.claude/skills/` (project root) | Compat | Project-local Claude Code compatibility source |
 
-Global skills take precedence when names collide.
+Earlier entries take precedence when names collide. Bundled GSD skills win over user-global and project skills; Claude Code compatibility directories are searched after the standard Agent Skills locations.
 
 ## Installing Skills
 

--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -1701,18 +1701,14 @@ export class DefaultPackageManager implements PackageManager {
 			);
 		}
 		{
-			// Ecosystem skills (~/.agents/skills/) take priority over legacy config-dir skills.
-			// Skip legacy dir entirely when migration has completed (marker file present).
-			const legacySkillsMigrated =
-				resolve(userDirs.skills) !== resolve(userAgentsSkillsDir) &&
-				existsSync(join(userDirs.skills, ".migrated-to-agents"));
-			const legacyUserSkillEntries =
-				!legacySkillsMigrated && userSubdirs.has("skills")
-					? collectAutoSkillEntries(userDirs.skills)
-					: [];
+			// GSD-owned bundled skills live in the config-dir skills folder and
+			// should remain visible regardless of obsolete migration markers.
+			const bundledUserSkillEntries = userSubdirs.has("skills")
+				? collectAutoSkillEntries(userDirs.skills)
+				: [];
 			const skillEntries = [
+				...bundledUserSkillEntries,
 				...collectAutoSkillEntries(userAgentsSkillsDir),
-				...legacyUserSkillEntries,
 			];
 			if (skillEntries.length > 0) {
 				addResources("skills", skillEntries, userMetadata, userOverrides.skills, globalBaseDir);

--- a/packages/pi-coding-agent/src/core/skills.test.ts
+++ b/packages/pi-coding-agent/src/core/skills.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, parse } from "node:path";
+import test from "node:test";
+
+function overrideHomeEnv(homeDir: string): () => void {
+	const original = {
+		HOME: process.env.HOME,
+		USERPROFILE: process.env.USERPROFILE,
+		HOMEDRIVE: process.env.HOMEDRIVE,
+		HOMEPATH: process.env.HOMEPATH,
+	};
+
+	process.env.HOME = homeDir;
+	process.env.USERPROFILE = homeDir;
+
+	if (process.platform === "win32") {
+		const parsedHome = parse(homeDir);
+		process.env.HOMEDRIVE = parsedHome.root.replace(/[\\/]+$/, "");
+		const homePath = homeDir.slice(parsedHome.root.length).replace(/\//g, "\\");
+		process.env.HOMEPATH = homePath.startsWith("\\") ? homePath : `\\${homePath}`;
+	}
+
+	return () => {
+		if (original.HOME === undefined) delete process.env.HOME; else process.env.HOME = original.HOME;
+		if (original.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = original.USERPROFILE;
+		if (original.HOMEDRIVE === undefined) delete process.env.HOMEDRIVE; else process.env.HOMEDRIVE = original.HOMEDRIVE;
+		if (original.HOMEPATH === undefined) delete process.env.HOMEPATH; else process.env.HOMEPATH = original.HOMEPATH;
+	};
+}
+
+function writeSkill(root: string, name: string, description: string): string {
+	const skillDir = join(root, name);
+	mkdirSync(skillDir, { recursive: true });
+	const skillPath = join(skillDir, "SKILL.md");
+	writeFileSync(skillPath, `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`);
+	return skillPath;
+}
+
+test("loadSkills prefers GSD bundled skills over user and project collisions", async (t) => {
+	const tmp = mkdtempSync(join(tmpdir(), "gsd-skills-precedence-"));
+	const restoreHomeEnv = overrideHomeEnv(tmp);
+	const originalGsdAgentDir = process.env.GSD_CODING_AGENT_DIR;
+	process.env.GSD_CODING_AGENT_DIR = join(tmp, ".gsd", "agent");
+
+	t.after(() => {
+		if (originalGsdAgentDir === undefined) delete process.env.GSD_CODING_AGENT_DIR; else process.env.GSD_CODING_AGENT_DIR = originalGsdAgentDir;
+		restoreHomeEnv();
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	const gsdSkillPath = writeSkill(join(tmp, ".gsd", "agent", "skills"), "lint", "GSD bundled lint.");
+	writeSkill(join(tmp, ".agents", "skills"), "lint", "User lint.");
+	writeSkill(join(tmp, "project", ".agents", "skills"), "lint", "Project lint.");
+
+	const { loadSkills } = await import("./skills.js");
+	const result = loadSkills({ cwd: join(tmp, "project") });
+
+	const lint = result.skills.find((skill) => skill.name === "lint");
+	assert.equal(lint?.filePath, gsdSkillPath);
+	assert.equal(
+		result.diagnostics.filter((diagnostic) => diagnostic.type === "collision").length,
+		2,
+		"user and project collisions should be reported while the GSD bundled copy wins",
+	);
+});

--- a/packages/pi-coding-agent/src/core/skills.ts
+++ b/packages/pi-coding-agent/src/core/skills.ts
@@ -5,7 +5,15 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "pat
 import { parseFrontmatter } from "../utils/frontmatter.js";
 import { toPosixPath } from "../utils/path-display.js";
 import type { ResourceDiagnostic } from "./diagnostics.js";
-import { CONFIG_DIR_NAME } from "../config.js";
+
+/**
+ * GSD-owned bundled skills directory. GSD writes its bundled skill set here
+ * instead of the shared Agent Skills ecosystem directory.
+ */
+export const GSD_BUNDLED_SKILLS_DIR = join(
+	process.env.GSD_CODING_AGENT_DIR || join(homedir(), ".gsd", "agent"),
+	"skills",
+);
 
 /**
  * The standard ecosystem skills directory used by skills.sh and the
@@ -20,10 +28,9 @@ export const ECOSYSTEM_SKILLS_DIR = join(homedir(), ".agents", "skills");
 export const ECOSYSTEM_PROJECT_SKILLS_DIR = ".agents";
 
 /**
- * Legacy skills directory (~/.gsd/agent/skills/ or ~/.pi/agent/skills/).
- * Read as a fallback so existing installs don't lose skills before migration runs.
+ * Claude Code's user-level skills directory. Read-only compatibility source.
  */
-const LEGACY_SKILLS_DIR = join(homedir(), CONFIG_DIR_NAME, "agent", "skills");
+export const CLAUDE_SKILLS_DIR = join(homedir(), ".claude", "skills");
 
 /** Max name length per spec */
 const MAX_NAME_LENGTH = 64;
@@ -349,7 +356,7 @@ function escapeXml(str: string): string {
 export interface LoadSkillsOptions {
 	/** Working directory for project-local skills. Default: process.cwd() */
 	cwd?: string;
-	/** @deprecated Skills now use ~/.agents/skills/ exclusively. This option is ignored. */
+	/** @deprecated GSD bundled skills resolve from ~/.gsd/agent/skills/. This option is ignored. */
 	agentDir?: string;
 	/** Explicit skill paths (files or directories) */
 	skillPaths?: string[];
@@ -419,18 +426,14 @@ export function loadSkills(options: LoadSkillsOptions = {}): LoadSkillsResult {
 	}
 
 	if (includeDefaults) {
-		// Primary: ~/.agents/skills/ — the industry-standard skills.sh location
+		// GSD-owned bundled skills win collisions inside GSD.
+		addSkills(loadSkillsFromDirInternal(GSD_BUNDLED_SKILLS_DIR, "bundled", true));
+		// User-global: ~/.agents/skills/ — the industry-standard skills.sh location
 		addSkills(loadSkillsFromDirInternal(ECOSYSTEM_SKILLS_DIR, "user", true));
-		// Primary project: .agents/skills/ — standard project-level location
+		// Project: .agents/skills/ — standard project-level location
 		addSkills(loadSkillsFromDirInternal(resolve(cwd, ECOSYSTEM_PROJECT_SKILLS_DIR, "skills"), "project", true));
-
-		// Legacy fallback: read skills from ~/.gsd/agent/skills/ so existing
-		// installs keep working until the one-time migration in resource-loader
-		// copies them to ~/.agents/skills/. Skip if migration has completed.
-		const legacyMigrated = existsSync(join(LEGACY_SKILLS_DIR, ".migrated-to-agents"));
-		if (LEGACY_SKILLS_DIR !== ECOSYSTEM_SKILLS_DIR && existsSync(LEGACY_SKILLS_DIR) && !legacyMigrated) {
-			addSkills(loadSkillsFromDirInternal(LEGACY_SKILLS_DIR, "user", true));
-		}
+		// Claude Code compatibility, read-only and lower priority.
+		addSkills(loadSkillsFromDirInternal(CLAUDE_SKILLS_DIR, "user", true));
 	}
 
 	const userSkillsDir = ECOSYSTEM_SKILLS_DIR;

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -253,9 +253,11 @@ export {
 } from "./core/resolve-config-value.js";
 // Skills
 export {
+	CLAUDE_SKILLS_DIR,
 	ECOSYSTEM_SKILLS_DIR,
 	ECOSYSTEM_PROJECT_SKILLS_DIR,
 	formatSkillsForPrompt,
+	GSD_BUNDLED_SKILLS_DIR,
 	getLoadedSkills,
 	type LoadSkillsFromDirOptions,
 	type LoadSkillsResult,

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -1,7 +1,7 @@
 import type { DefaultResourceLoader as DefaultResourceLoaderType } from '@gsd/pi-coding-agent'
 import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
-import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, openSync, closeSync, readFileSync, readlinkSync, readdirSync, rmSync, statSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, readdirSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
@@ -572,11 +572,8 @@ function pruneRemovedBundledExtensions(
  *
  * - extensions/ → ~/.gsd/agent/extensions/   (overwrite when version changes)
  * - agents/     → ~/.gsd/agent/agents/        (overwrite when version changes)
+ * - skills/     → ~/.gsd/agent/skills/        (overwrite when version changes)
  * - GSD-WORKFLOW.md → ~/.gsd/agent/GSD-WORKFLOW.md (fallback for env var miss)
- *
- * Skills are NOT synced here. They are installed by the user via the
- * skills.sh CLI (`npx skills add <repo>`) into ~/.agents/skills/ — the
- * industry-standard Agent Skills ecosystem directory.
  *
  * Skips the copy when the managed-resources.json version matches the current
  * GSD version, avoiding ~128ms of synchronous cpSync on every startup.
@@ -585,12 +582,13 @@ function pruneRemovedBundledExtensions(
  *
  * Inspectable: `ls ~/.gsd/agent/extensions/`
  */
-export function initResources(agentDir: string, skillsDir: string = join(homedir(), '.agents', 'skills')): void {
+export function initResources(agentDir: string, skillsDir: string = join(agentDir, 'skills')): void {
   mkdirSync(agentDir, { recursive: true })
 
   const currentVersion = getBundledGsdVersion()
   const manifest = readManagedResourceManifest(agentDir)
   const extensionsDir = join(agentDir, 'extensions')
+  const usingManagedSkillsDir = resolve(skillsDir) === resolve(join(agentDir, 'skills'))
 
   // Always prune root-level extension files that were removed from the bundle.
   // This is cheap (a few existence checks + at most one rmSync) and must run
@@ -604,9 +602,12 @@ export function initResources(agentDir: string, skillsDir: string = join(homedir
   // extensions fail to resolve @gsd/* packages, rendering GSD non-functional.
   ensureNodeModulesSymlink(agentDir)
 
-  // Migrate legacy skills on every launch (not gated by manifest) so that
-  // partial-failure retries don't wait for a version bump.
-  migrateSkillsToEcosystemDir(agentDir)
+  // Reclaim exact bundled skill copies from ~/.agents/skills/ on every launch
+  // so existing installs are cleaned up even when the managed-resource manifest
+  // is current. Ambiguous/user-modified copies are left untouched.
+  if (usingManagedSkillsDir) {
+    cleanupBundledSkillsFromEcosystemDir()
+  }
 
   // Skip the full copy when both version AND content fingerprint match.
   // Version-only checks miss same-version content changes (npm link dev workflow,
@@ -641,107 +642,52 @@ export function initResources(agentDir: string, skillsDir: string = join(homedir
   ensureRegistryEntries(join(agentDir, 'extensions'))
 }
 
-// ─── Legacy Skill Migration ──────────────────────────────────────────────────────
+// ─── Bundled Skill Ecosystem Cleanup ─────────────────────────────────────────────
 
-/**
- * One-time migration: copy user-customized skills from the old
- * ~/.gsd/agent/skills/ directory into ~/.agents/skills/.
- *
- * The migration is conservative:
- *  - Only skill directories containing a SKILL.md are considered.
- *  - Copies, does not move — the old directory stays intact so downgrading
- *    to a pre-migration GSD version still works.
- *  - Collision-safe — if a skill name already exists in the target, the
- *    existing ecosystem skill wins (user may have already installed a newer
- *    version via skills.sh).
- *  - Writes a `.migrated-to-agents` marker inside the legacy directory so
- *    the migration runs at most once.
- */
-function migrateSkillsToEcosystemDir(agentDir: string): void {
-  const legacyDir = join(agentDir, 'skills')
-  const markerPath = join(legacyDir, '.migrated-to-agents')
+function cleanupBundledSkillsFromEcosystemDir(): void {
+  const bundledSkillsDir = join(resourcesDir, 'skills')
+  const ecosystemDir = join(homedir(), '.agents', 'skills')
+  if (!existsSync(bundledSkillsDir) || !existsSync(ecosystemDir)) return
 
-  // Already migrated or no legacy dir — nothing to do
-  if (!existsSync(legacyDir)) return
+  for (const entry of readdirSync(bundledSkillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const sourcePath = join(bundledSkillsDir, entry.name)
+    const targetPath = join(ecosystemDir, entry.name)
+    if (!existsSync(targetPath)) continue
 
-  // Atomic marker check — 'wx' fails if file already exists, preventing races
-  // when two GSD processes start simultaneously.
-  let markerFd: number
-  try {
-    markerFd = openSync(markerPath, 'wx')
-  } catch {
-    return // marker already exists (another process won the race, or already migrated)
-  }
-
-  try {
-    const ecosystemDir = join(homedir(), '.agents', 'skills')
-    mkdirSync(ecosystemDir, { recursive: true })
-
-    const entries = readdirSync(legacyDir, { withFileTypes: true })
-    let migrated = 0
-    let candidates = 0
-    for (const entry of entries) {
-      // Handle both real directories and symlinks pointing to directories
-      const isDir = entry.isDirectory()
-      const isSymlink = entry.isSymbolicLink()
-      if (!isDir && !isSymlink) continue
-
-      const sourcePath = join(legacyDir, entry.name)
-
-      // For symlinks, verify the target is a directory
-      if (isSymlink) {
-        try {
-          const stat = statSync(sourcePath)
-          if (!stat.isDirectory()) continue
-        } catch {
-          continue // broken symlink — skip
-        }
+    try {
+      if (lstatSync(targetPath).isSymbolicLink()) continue
+      if (directoriesHaveExactFileContents(sourcePath, targetPath)) {
+        makeTreeWritable(targetPath)
+        rmSync(targetPath, { recursive: true, force: true })
+      } else {
+        console.warn(
+          `[GSD] Leaving ambiguous skill collision in ${targetPath}; ` +
+          `the bundled copy will be used from ~/.gsd/agent/skills/${entry.name}.`,
+        )
       }
-
-      const skillMd = join(sourcePath, 'SKILL.md')
-      if (!existsSync(skillMd)) continue
-
-      const target = join(ecosystemDir, entry.name)
-      if (existsSync(target)) continue // ecosystem version wins
-
-      candidates++
-      try {
-        if (isSymlink) {
-          // Recreate the symlink in the ecosystem directory using an absolute
-          // target. Relative symlinks would resolve from the new parent dir
-          // (~/.agents/skills/) instead of the original (~/.gsd/agent/skills/),
-          // pointing to the wrong location.
-          const rawTarget = readlinkSync(sourcePath)
-          const absTarget = resolve(dirname(sourcePath), rawTarget)
-          symlinkSync(absTarget, target)
-        } else {
-          cpSync(sourcePath, target, { recursive: true })
-        }
-        migrated++
-      } catch {
-        // non-fatal — skip this skill
-      }
+    } catch {
+      // Non-fatal: never let cleanup of the shared ecosystem dir block startup.
     }
-
-    // If any skills failed to copy, remove the marker so migration retries
-    // on the next launch.  This keeps the legacy dir as fallback until every
-    // skill has been successfully migrated.
-    if (migrated < candidates) {
-      try { closeSync(markerFd); markerFd = -1 } catch { /* non-fatal */ }
-      try { unlinkSync(markerPath) } catch { /* non-fatal */ }
-      return
-    }
-
-    // Write migration info to the marker
-    try { writeFileSync(markerFd, `Migrated ${migrated} skill(s) to ${ecosystemDir} on ${new Date().toISOString()}\n`) } catch { /* non-fatal */ }
-  } catch {
-    // can't create ecosystem dir or read legacy dir — close fd first (required on Windows
-    // where unlinkSync fails on open handles), then remove marker so we retry next launch
-    try { closeSync(markerFd); markerFd = -1 } catch { /* non-fatal */ }
-    try { unlinkSync(markerPath) } catch { /* non-fatal */ }
-  } finally {
-    if (markerFd !== -1) { try { closeSync(markerFd) } catch { /* non-fatal */ } }
   }
+}
+
+function directoriesHaveExactFileContents(sourceDir: string, targetDir: string): boolean {
+  const sourceFiles = collectRelativeFiles(sourceDir)
+  const targetFiles = collectRelativeFiles(targetDir)
+  if (sourceFiles.size !== targetFiles.size) return false
+
+  for (const relPath of sourceFiles) {
+    if (!targetFiles.has(relPath)) return false
+    const sourcePath = join(sourceDir, relPath)
+    const targetPath = join(targetDir, relPath)
+    try {
+      if (!readFileSync(sourcePath).equals(readFileSync(targetPath))) return false
+    } catch {
+      return false
+    }
+  }
+  return true
 }
 
 export function hasStaleCompiledExtensionSiblings(extensionsDir: string, sourceDir: string = bundledExtensionsDir): boolean {

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -81,7 +81,7 @@ function buildBundledSkillsTable(): string {
     rows.push(`| ${trigger} | \`${resolution.resolvedPath}\` |`);
   }
   if (rows.length === 0) {
-    return "*No bundled skills found. Install skills to `~/.agents/skills/` or `~/.claude/skills/`.*";
+    return "*No bundled skills found. Install or sync skills to `~/.gsd/agent/skills/`, `~/.agents/skills/`, or `~/.claude/skills/`.*";
   }
   return `| Trigger | Skill to load |\n|---|---|\n${rows.join("\n")}`;
 }

--- a/src/resources/extensions/gsd/preferences-skills.ts
+++ b/src/resources/extensions/gsd/preferences-skills.ts
@@ -24,24 +24,19 @@ export type { GSDSkillRule, SkillDiscoveryMode, SkillResolution, SkillResolution
 
 /**
  * Known skill directories, in priority order.
- * Searches both the skills.sh ecosystem directory (~/.agents/skills/) and
- * Claude Code's official directory (~/.claude/skills/). Project-level
- * directories for both conventions are included as well.
- * Legacy ~/.gsd/agent/skills/ is included as a fallback for pre-migration installs.
+ * GSD bundled skills live in ~/.gsd/agent/skills/ and win name collisions.
+ * User-global and project-local ecosystem directories remain available as
+ * read-only discovery sources, followed by Claude Code compatibility paths.
  */
 export function getSkillSearchDirs(cwd: string): Array<{ dir: string; method: SkillResolution["method"] }> {
   const dirs: Array<{ dir: string; method: SkillResolution["method"] }> = [
+    { dir: join(gsdHome(), "agent", "skills"), method: "user-skill" },
     { dir: join(homedir(), ".agents", "skills"), method: "user-skill" },
     { dir: join(cwd, ".agents", "skills"), method: "project-skill" },
     // Claude Code official skill directories
     { dir: join(homedir(), ".claude", "skills"), method: "user-skill" },
     { dir: join(cwd, ".claude", "skills"), method: "project-skill" },
   ];
-  // Legacy fallback — read skills from old GSD directory only if migration hasn't completed
-  const legacyDir = join(gsdHome(), "agent", "skills");
-  if (existsSync(legacyDir) && !existsSync(join(legacyDir, ".migrated-to-agents"))) {
-    dirs.push({ dir: legacyDir, method: "user-skill" });
-  }
   return dirs;
 }
 

--- a/src/resources/extensions/gsd/skill-catalog.ts
+++ b/src/resources/extensions/gsd/skill-catalog.ts
@@ -8,8 +8,9 @@
  * Installation is delegated entirely to the skills.sh CLI:
  *   npx skills add <repo> --skill <name> --skill <name> -y
  *
- * Skills are installed into ~/.agents/skills/ (the industry-standard
- * ecosystem directory shared across all agents).
+ * User-selected catalog skills are installed into ~/.agents/skills/ (the
+ * industry-standard ecosystem directory shared across all agents). GSD's own
+ * bundled skills are managed separately in ~/.gsd/agent/skills/.
  */
 
 import { execFile } from "node:child_process";
@@ -19,6 +20,7 @@ import { homedir } from "node:os";
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { showNextAction } from "../shared/tui.js";
 import type { ProjectSignals, XcodePlatform } from "./detection.js";
+import { gsdHome } from "./gsd-home.js";
 
 // ─── Catalog Types ────────────────────────────────────────────────────────────
 
@@ -935,10 +937,11 @@ export async function installPacksBatched(
 
 /**
  * Check if any skills from a pack are already installed.
- * Searches both the skills.sh ecosystem directory and Claude Code's official directory.
+ * Searches GSD bundled, skills.sh ecosystem, and Claude Code's official directory.
  */
 export function isPackInstalled(pack: SkillPack): boolean {
   const skillsDirs = [
+    join(gsdHome(), "agent", "skills"),
     join(homedir(), ".agents", "skills"),
     join(homedir(), ".claude", "skills"),
   ];

--- a/src/resources/extensions/gsd/skill-discovery.ts
+++ b/src/resources/extensions/gsd/skill-discovery.ts
@@ -11,8 +11,10 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { gsdHome } from "./gsd-home.js";
 
-/** Skills directories — skills.sh ecosystem + Claude Code official */
+/** Skills directories — GSD bundled, skills.sh ecosystem, and Claude Code official */
+const GSD_SKILLS_DIR = join(gsdHome(), "agent", "skills");
 const SKILLS_DIR = join(homedir(), ".agents", "skills");
 const CLAUDE_SKILLS_DIR = join(homedir(), ".claude", "skills");
 
@@ -112,6 +114,7 @@ function listSkillDirsFrom(dir: string): string[] {
 
 function listSkillDirs(): string[] {
   const names = new Set<string>();
+  for (const name of listSkillDirsFrom(GSD_SKILLS_DIR)) names.add(name);
   for (const name of listSkillDirsFrom(SKILLS_DIR)) names.add(name);
   for (const name of listSkillDirsFrom(CLAUDE_SKILLS_DIR)) names.add(name);
   return [...names];
@@ -141,7 +144,7 @@ function parseSkillFrontmatter(path: string): { name?: string; description?: str
 }
 
 function resolveSkillMdPath(skillName: string): string | null {
-  for (const dir of [SKILLS_DIR, CLAUDE_SKILLS_DIR]) {
+  for (const dir of [GSD_SKILLS_DIR, SKILLS_DIR, CLAUDE_SKILLS_DIR]) {
     const candidate = join(dir, skillName, "SKILL.md");
     if (existsSync(candidate)) return candidate;
   }

--- a/src/resources/extensions/gsd/skill-health.ts
+++ b/src/resources/extensions/gsd/skill-health.ts
@@ -19,6 +19,7 @@ import { homedir } from "node:os";
 import type { UnitMetrics, MetricsLedger } from "./metrics.js";
 import { formatCost, formatTokenCount, loadLedgerFromDisk } from "./metrics.js";
 import { getSkillLastUsed, detectStaleSkills } from "./skill-telemetry.js";
+import { gsdHome } from "./gsd-home.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -207,8 +208,9 @@ export function formatSkillDetail(basePath: string, skillName: string): string {
     lines.push(`  ${date}  ${u.id.padEnd(20)}  ${formatTokenCount(u.tokens.total).padStart(8)} tokens  ${formatCost(u.cost)}`);
   }
 
-  // Check for SKILL.md existence — search both ecosystem and Claude Code directories
+  // Check for SKILL.md existence across GSD bundled, ecosystem, and Claude directories.
   const candidatePaths = [
+    join(gsdHome(), "agent", "skills", skillName, "SKILL.md"),
     join(homedir(), ".agents", "skills", skillName, "SKILL.md"),
     join(homedir(), ".claude", "skills", skillName, "SKILL.md"),
   ];

--- a/src/resources/extensions/gsd/skill-telemetry.ts
+++ b/src/resources/extensions/gsd/skill-telemetry.ts
@@ -31,15 +31,13 @@ const activelyLoadedSkills = new Set<string>();
  * Called before each unit starts.
  */
 export function captureAvailableSkills(): void {
+  const gsdSkillsDir = join(gsdHome(), "agent", "skills");
   const skillsDir = join(homedir(), ".agents", "skills");
   const claudeSkillsDir = join(homedir(), ".claude", "skills");
-  const legacyDir = join(gsdHome(), "agent", "skills");
+  const gsdNames = listSkillNames(gsdSkillsDir);
   const names = listSkillNames(skillsDir);
   const claudeNames = listSkillNames(claudeSkillsDir);
-  // Include skills still in the legacy directory only if migration hasn't completed
-  const legacyMigrated = existsSync(join(legacyDir, ".migrated-to-agents"));
-  const legacyNames = legacyMigrated ? [] : listSkillNames(legacyDir);
-  const all = new Set([...names, ...claudeNames, ...legacyNames]);
+  const all = new Set([...gsdNames, ...names, ...claudeNames]);
   availableSkills = [...all];
   activelyLoadedSkills.clear();
 }
@@ -108,12 +106,14 @@ export function detectStaleSkills(
   const stale: string[] = [];
 
   // Check all installed skills, not just those with usage data
+  const gsdSkillsDir = join(gsdHome(), "agent", "skills");
   const skillsDir = join(homedir(), ".agents", "skills");
   const claudeSkillsDir = join(homedir(), ".claude", "skills");
-  const legacyDir = join(gsdHome(), "agent", "skills");
-  const legacyMigrated = existsSync(join(legacyDir, ".migrated-to-agents"));
-  const legacyNames = legacyMigrated ? [] : listSkillNames(legacyDir);
-  const installedSet = new Set([...listSkillNames(skillsDir), ...listSkillNames(claudeSkillsDir), ...legacyNames]);
+  const installedSet = new Set([
+    ...listSkillNames(gsdSkillsDir),
+    ...listSkillNames(skillsDir),
+    ...listSkillNames(claudeSkillsDir),
+  ]);
   const installed = [...installedSet];
 
   for (const skill of installed) {

--- a/src/resources/extensions/gsd/tests/claude-skill-dirs.test.ts
+++ b/src/resources/extensions/gsd/tests/claude-skill-dirs.test.ts
@@ -2,7 +2,8 @@
  * Tests for Claude Code skill directory support in getSkillSearchDirs().
  *
  * Verifies that ~/.claude/skills/ and .claude/skills/ are included in
- * the skill search path alongside ~/.agents/skills/ and .agents/skills/.
+ * the skill search path alongside GSD bundled skills, ~/.agents/skills/,
+ * and .agents/skills/.
  */
 
 import { describe, test } from "node:test";
@@ -10,9 +11,17 @@ import assert from "node:assert/strict";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { getSkillSearchDirs } from "../preferences-skills.ts";
+import { gsdHome } from "../gsd-home.ts";
 
 describe("getSkillSearchDirs — Claude Code directory support", () => {
   const cwd = "/tmp/test-project";
+
+  test("includes ~/.gsd/agent/skills/ as bundled user-skill", () => {
+    const dirs = getSkillSearchDirs(cwd);
+    const gsd = dirs.find((d) => d.dir === join(gsdHome(), "agent", "skills"));
+    assert.ok(gsd, "should include ~/.gsd/agent/skills/");
+    assert.equal(gsd!.method, "user-skill");
+  });
 
   test("includes ~/.agents/skills/ as user-skill", () => {
     const dirs = getSkillSearchDirs(cwd);
@@ -42,10 +51,12 @@ describe("getSkillSearchDirs — Claude Code directory support", () => {
     assert.equal(projectClaude!.method, "project-skill");
   });
 
-  test("~/.agents/skills/ appears before ~/.claude/skills/ (priority order)", () => {
+  test("~/.gsd/agent/skills/ appears before ecosystem and Claude dirs (priority order)", () => {
     const dirs = getSkillSearchDirs(cwd);
+    const gsdIdx = dirs.findIndex((d) => d.dir === join(gsdHome(), "agent", "skills"));
     const agentsIdx = dirs.findIndex((d) => d.dir === join(homedir(), ".agents", "skills"));
     const claudeIdx = dirs.findIndex((d) => d.dir === join(homedir(), ".claude", "skills"));
+    assert.ok(gsdIdx < agentsIdx, "~/.gsd/agent/skills/ should have higher priority than ~/.agents/skills/");
     assert.ok(agentsIdx < claudeIdx, "~/.agents/skills/ should have higher priority than ~/.claude/skills/");
   });
 });

--- a/src/resources/skills/create-skill/SKILL.md
+++ b/src/resources/skills/create-skill/SKILL.md
@@ -88,8 +88,11 @@ Then proceed directly to the workflow.
 ## Skill Structure Quick Reference
 
 **Skill directories:**
+- Bundled/read-only: `~/.gsd/agent/skills/{skill-name}/`
 - Global: `~/.agents/skills/{skill-name}/`
 - Project-local: `.agents/skills/{skill-name}/`
+
+User-authored skills should target the global or project-local directories; GSD manages the bundled directory during install/update.
 
 **Simple skill (single file):**
 ```yaml

--- a/src/resources/skills/create-skill/references/gsd-skill-ecosystem.md
+++ b/src/resources/skills/create-skill/references/gsd-skill-ecosystem.md
@@ -3,7 +3,12 @@ GSD-specific skill ecosystem details: directory conventions, discovery mechanics
 </overview>
 
 <skill_directories>
-GSD supports two skill directories, checked in order:
+GSD supports these skill directories, checked in order:
+
+**Bundled (GSD-managed):** `~/.gsd/agent/skills/`
+- Synced by GSD during install/update
+- Highest priority when names collide
+- Not the target for user-authored skills
 
 **User-scope (global):** `~/.agents/skills/`
 - Available in every GSD session regardless of working directory
@@ -14,17 +19,21 @@ GSD supports two skill directories, checked in order:
 - Committable to version control so team members share the same skill set
 - Ideal for project-specific workflows, deploy scripts, or conventions
 
-Skills in both directories follow the same SKILL.md format and router pattern conventions.
+**Claude Code compatibility:** `~/.claude/skills/` and `.claude/skills/`
+- Read after the standard Agent Skills directories
+- Useful for compatibility with existing Claude Code skill installs
+
+Skills in all directories follow the same SKILL.md format and router pattern conventions.
 </skill_directories>
 
 <skill_discovery>
 GSD auto-discovers skills at session start and during auto-mode:
 
-**Session start:** All skills in both directories are enumerated and their names + descriptions are injected into the system prompt as `<available_skills>`.
+**Session start:** All discovered skills are enumerated and their names + descriptions are injected into the system prompt as `<available_skills>`.
 
 **Auto-mode discovery:** `skill-discovery.ts` takes a snapshot of the skills directory at auto-mode start. On each unit boundary it diffs against the snapshot. Any new skills found are injected via a `<newly_discovered_skills>` XML block so the LLM sees them without requiring `/reload`.
 
-**Manual reload:** Running `/reload` re-scans both directories and updates the available skills list mid-session.
+**Manual reload:** Running `/reload` re-scans the skill directories and updates the available skills list mid-session.
 </skill_discovery>
 
 <skill_validation>

--- a/src/resources/skills/create-skill/workflows/create-new-skill.md
+++ b/src/resources/skills/create-skill/workflows/create-new-skill.md
@@ -18,6 +18,8 @@
 1. **Global** (`~/.agents/skills/`) — Available in all GSD sessions
 2. **Project-local** (`.agents/skills/`) — Available only in this project
 
+Do not create user-authored skills under `~/.gsd/agent/skills/`; GSD owns that bundled skills directory.
+
 ## Step 2: Adaptive Requirements Gathering
 
 **If user provided context** (e.g., "build a skill for X"):

--- a/src/tests/app-smoke.test.ts
+++ b/src/tests/app-smoke.test.ts
@@ -333,7 +333,8 @@ test("initResources syncs extensions, agents, and skills to target dir", async (
   // Agents synced
   assert.ok(existsSync(join(fakeAgentDir, "agents", "scout.md")), "scout agent synced");
 
-  // Skills are NOT synced here — they use ~/.agents/skills/ via skills.sh
+  // Bundled skills are synced to the GSD-owned agent dir, not ~/.agents/skills/.
+  assert.ok(existsSync(join(fakeAgentDir, "skills", "lint", "SKILL.md")), "bundled lint skill synced");
 
   // Version manifest synced
   const managedVersion = readManagedResourceVersion(fakeAgentDir);

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, parse } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -190,6 +190,87 @@ test("initResources manifest tracks all bundled extension subdirectories includi
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+});
+
+test("initResources syncs bundled skills to the GSD agent dir by default", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-skills-local-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(join(fakeAgentDir, "skills", "lint", "SKILL.md")),
+    true,
+    "bundled skills should sync under ~/.gsd/agent/skills by default",
+  );
+  assert.equal(
+    existsSync(join(tmp, ".agents", "skills", "lint", "SKILL.md")),
+    false,
+    "initResources should not write bundled skills to ~/.agents/skills by default",
+  );
+});
+
+test("initResources removes exact bundled skill orphans from the ecosystem dir", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-skills-clean-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemLintDir = join(tmp, ".agents", "skills", "lint");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(join(process.cwd(), "src", "resources", "skills", "lint"), ecosystemLintDir, { recursive: true });
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(join(fakeAgentDir, "skills", "lint", "SKILL.md")),
+    true,
+    "bundled skill should exist in the GSD-owned skills dir after cleanup",
+  );
+  assert.equal(
+    existsSync(ecosystemLintDir),
+    false,
+    "exact bundled skill copies should be removed from ~/.agents/skills",
+  );
+});
+
+test("initResources leaves ambiguous ecosystem skill name collisions in place", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-skills-ambiguous-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemLintDir = join(tmp, ".agents", "skills", "lint");
+  const ecosystemLintFile = join(ecosystemLintDir, "SKILL.md");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  mkdirSync(ecosystemLintDir, { recursive: true });
+  writeFileSync(
+    ecosystemLintFile,
+    "---\nname: lint\ndescription: User-owned lint skill.\n---\n\n# Custom lint\n",
+  );
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    readFileSync(ecosystemLintFile, "utf-8"),
+    "---\nname: lint\ndescription: User-owned lint skill.\n---\n\n# Custom lint\n",
+    "ambiguous user-owned skills in ~/.agents/skills should not be removed or overwritten",
+  );
 });
 
 test("initResources prunes stale top-level extension siblings next to bundled compiled extensions", async (t) => {


### PR DESCRIPTION
## Summary

- Sync bundled skills to `~/.gsd/agent/skills/` by default instead of the shared `~/.agents/skills/` ecosystem directory.
- Remove the old migration-to-ecosystem path and reclaim exact bundled skill copies from `~/.agents/skills/` while leaving ambiguous/user-edited collisions untouched.
- Prefer GSD-bundled skills in runtime and extension skill discovery paths, with user/project/Claude skills still available as lower-priority read-only sources.
- Add focused regression tests for default sync, conservative cleanup, and collision precedence.

Closes #85.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/resource-loader.test.ts src/tests/app-smoke.test.ts src/resources/extensions/gsd/tests/claude-skill-dirs.test.ts packages/pi-coding-agent/src/core/skills.test.ts`
- `npm run test:compile`
- `npm run typecheck:extensions`
- `npm run build:pi-coding-agent`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/tests/resource-loader.test.js dist-test/src/tests/app-smoke.test.js dist-test/src/resources/extensions/gsd/tests/claude-skill-dirs.test.js dist-test/packages/pi-coding-agent/src/core/skills.test.js`
- `git diff --check`
- `npm run test:changed:src`
- Clean detached worktree before restacking: `npm run verify:pr` -> 9473 passed, 0 failed, 9 skipped

Note: `npm run verify:pr` failed in the original local worktree because of unrelated pre-existing auto-mode edits; the same command passed in a clean detached worktree. This branch was then rebased onto `origin/main` so PR #87 contains only commit `89df356` for issue #85; the already-merged test-stabilization patch from `4f8345c` is not part of this PR.
