### PR TITLE
docs: update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@opengsd/gsd-pi?label=npm&logo=npm)](https://www.npmjs.com/package/@opengsd/gsd-pi)
 [![npm downloads](https://img.shields.io/npm/dm/@opengsd/gsd-pi?label=downloads&logo=npm&color=red)](https://www.npmjs.com/package/@opengsd/gsd-pi)
 [![CI](https://img.shields.io/github/actions/workflow/status/open-gsd/gsd-pi/ci.yml?branch=main&label=tests&logo=github)](https://github.com/open-gsd/gsd-pi/actions/workflows/ci.yml)
-[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/nKXTsAcmbT)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/8NnkKuepmQ)
 [![GitHub stars](https://img.shields.io/github/stars/open-gsd/gsd-pi?label=stars&logo=github)](https://github.com/open-gsd/gsd-pi/stargazers)
 [![License: MIT](https://img.shields.io/github/license/open-gsd/gsd-pi?label=license)](https://github.com/open-gsd/gsd-pi/blob/main/LICENSE)
 
@@ -134,7 +134,7 @@ Historical tags and archived refs may exist for traceability, but active release
 
 ## Community
 
-Join the [GSD Discord community](https://discord.com/invite/nKXTsAcmbT).
+Join the [GSD Discord community](https://discord.gg/8NnkKuepmQ).
 
 ## Star History
 

--- a/docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md
+++ b/docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md
@@ -38,6 +38,6 @@ Or just use conventional directory names (`extensions/`, `skills/`, `prompts/`, 
 
 - [Package gallery](https://shittycodingagent.ai/packages)
 - [npm search](https://www.npmjs.com/search?q=keywords%3Api-package)
-- [Discord community](https://discord.com/invite/nKXTsAcmbT)
+- [Discord community](https://discord.gg/8NnkKuepmQ)
 
 ---

--- a/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
+++ b/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 const ROOT = process.cwd();
 
 /** Canonical Discord invite for the GSD community. */
-const VALID_INVITE = "https://discord.com/invite/nKXTsAcmbT";
+const VALID_INVITE = "https://discord.gg/8NnkKuepmQ";
 
 /** Files that contain user-facing Discord invite links. */
 const FILES_WITH_INVITE_LINKS: string[] = [


### PR DESCRIPTION
## Summary
Updates the community Discord invite to https://discord.gg/8NnkKuepmQ in:
- `README.md` (badge + community section)
- `docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md`
- `discord-invite-links.test.ts` canonical URL

## Test plan
- [x] `discord-invite-links.test.ts` passes locally


Made with [Cursor](https://cursor.com)