### PR TITLE
fix(issue): auto-mode: synchronous pauseAuto() aborts in-flight units (re-file of archived gsd-2#6443)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1790,6 +1790,7 @@ export async function pauseAuto(
     return;
   }
   s.active = false;
+  s.paused = true;
   clearUnitTimeout();
   stopAutoCommandPolling();
 
@@ -1891,17 +1892,12 @@ export async function pauseAuto(
 
   deregisterSigtermHandler();
 
-  // Unblock pending unitPromise so autoLoop exits cleanly (#1799)
-  resolveAgentEnd({ messages: [] });
-  _resetPendingResolve();
-
   try {
     await s.orchestration?.stop("pause");
   } catch (err) {
     debugLog("pause-orchestration-stop", { error: err instanceof Error ? err.message : String(err) });
   }
 
-  s.paused = true;
   deactivateGSD();
   restoreProjectRootEnv();
   restoreMilestoneLockEnv();

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -908,6 +908,11 @@ export async function autoLoop(
           phaseReporter.report("pre-dispatch", preDispatchResult.action);
           if (preDispatchResult.action === "break") {
             finishTurn("stopped", "manual-attention", "pre-dispatch-break");
+            finishIncompleteIteration({
+              status: "stopped",
+              reason: "pre-dispatch-break",
+              failureClass: "manual-attention",
+            });
             break;
           }
           if (preDispatchResult.action === "continue") {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -77,6 +77,7 @@ import {
   getRequiredWorkflowToolsForAutoUnit,
   supportsStructuredQuestions,
 } from "../workflow-mcp.js";
+import type { DispatchAction } from "../auto-dispatch.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { createWorktreeSafetyModule, type WorktreeSafetyResult } from "../worktree-safety.js";
 import { isSuspiciousGhostCompletion } from "../auto-unit-closeout.js";
@@ -1395,6 +1396,13 @@ export async function runPreDispatch(
 
 // ─── runDispatch ──────────────────────────────────────────────────────────────
 
+function isUnhandledPhaseWarning(dispatchResult: DispatchAction): dispatchResult is Extract<DispatchAction, { action: "stop" }> {
+  return dispatchResult.action === "stop" &&
+    dispatchResult.level === "warning" &&
+    dispatchResult.matchedRule === "<no-match>" &&
+    /^Unhandled phase "/.test(dispatchResult.reason);
+}
+
 /**
  * Phase 3: Dispatch resolution — resolve next unit, stuck detection, pre-dispatch hooks.
  * Returns break/continue to control the loop, or next with IterationData on success.
@@ -1423,7 +1431,7 @@ export async function runDispatch(
       }) ? "true" : "false";
 
   debugLog("autoLoop", { phase: "dispatch-resolve", iteration: ic.iteration });
-  const dispatchResult = await deps.resolveDispatch({
+  let dispatchResult = await deps.resolveDispatch({
     basePath: s.basePath,
     mid,
     midTitle,
@@ -1435,6 +1443,30 @@ export async function runDispatch(
     sessionProvider: ctx.model?.provider,
     modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
   });
+  if (isUnhandledPhaseWarning(dispatchResult)) {
+    deps.invalidateAllCaches();
+    const freshState = await deps.deriveState(s.canonicalProjectRoot);
+    const freshMid = freshState.activeMilestone?.id ?? mid;
+    const freshMidTitle = freshState.activeMilestone?.title ?? freshMid ?? midTitle;
+    debugLog("autoLoop", {
+      phase: "dispatch-unhandled-phase-retry",
+      iteration: ic.iteration,
+      stalePhase: state.phase,
+      freshPhase: freshState.phase,
+    });
+    dispatchResult = await deps.resolveDispatch({
+      basePath: s.basePath,
+      mid: freshMid,
+      midTitle: freshMidTitle,
+      state: freshState,
+      prefs,
+      session: s,
+      structuredQuestionsAvailable,
+      sessionContextWindow: ctx.model?.contextWindow,
+      sessionProvider: ctx.model?.provider,
+      modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
+    });
+  }
 
   if (dispatchResult.action === "stop") {
     deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "dispatch-stop", rule: dispatchResult.matchedRule, data: { reason: dispatchResult.reason } });

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2681,6 +2681,62 @@ test("autoLoop pauses instead of stopping for warning-level dispatch stop", asyn
   );
 });
 
+test("autoLoop retries warning-level unhandled phase with fresh state before pausing", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  const states = [
+    {
+      phase: "planning",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: null,
+      activeTask: null,
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    },
+    {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice 1" },
+      activeTask: { id: "T01" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    },
+  ];
+  const seenPhases: string[] = [];
+  let deriveCalls = 0;
+
+  const deps = makeMockDeps({
+    deriveState: async () => states[Math.min(deriveCalls++, states.length - 1)] as any,
+    resolveDispatch: async (dctx) => {
+      seenPhases.push(dctx.state.phase);
+      if (dctx.state.phase === "planning") {
+        return {
+          action: "stop" as const,
+          reason: 'Unhandled phase "planning" — run /gsd doctor to diagnose.',
+          level: "warning" as const,
+          matchedRule: "<no-match>",
+        };
+      }
+      return {
+        action: "stop" as const,
+        reason: "fresh state reached terminal stop",
+        level: "info" as const,
+      };
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.deepEqual(seenPhases, ["planning", "executing"]);
+  assert.equal(deriveCalls, 2, "unhandled warning should re-derive state once");
+  assert.equal(deps.callLog.includes("pauseAuto"), false);
+  assert.equal(deps.callLog.includes("stopAuto"), true);
+});
+
 // #2474: error-level dispatch stop should still hard-stop
 test("autoLoop hard-stops for error-level dispatch stop", async (t) => {
   _resetPendingResolve();
@@ -2710,6 +2766,41 @@ test("autoLoop hard-stops for error-level dispatch stop", async (t) => {
   assert.ok(
     !deps.callLog.includes("pauseAuto"),
     "error-level stop should NOT call pauseAuto",
+  );
+});
+
+test("autoLoop closes journal iteration on pre-dispatch health-gate break", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  const journalEvents: Array<{ eventType: string; data?: any }> = [];
+  let pauseOptions: unknown;
+
+  const deps = makeMockDeps({
+    preDispatchHealthGate: async () => ({
+      proceed: false,
+      reason: "health gate failed",
+      fixesApplied: [],
+    }),
+    pauseAuto: async (_ctx, _pi, _errorContext, options) => {
+      pauseOptions = options;
+      deps.callLog.push("pauseAuto");
+    },
+    emitJournalEvent: (event: any) => {
+      journalEvents.push(event);
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.equal(deps.callLog.includes("pauseAuto"), true);
+  assert.deepEqual(pauseOptions, { expectedCurrentUnit: null });
+  assert.ok(
+    journalEvents.some((event) => event.eventType === "iteration-end" && event.data?.reason === "pre-dispatch-break"),
+    "pre-dispatch break must close the started iteration",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { capturePauseAutoUnitIdentity, pauseAuto, isAutoActive } from "../auto.ts";
+import { _resetPendingResolve, _setCurrentResolve } from "../auto/resolve.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { _isPauseOriginCancelledResult } from "../auto/phases.ts";
 
@@ -50,6 +51,32 @@ test("pauseAuto sets s.active = false synchronously before first await (blocks c
     autoSession.reset();
     process.chdir(previousCwd);
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("pauseAuto marks paused and cancels the in-flight unit before first await", async () => {
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.currentUnit = {
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: 500,
+  };
+  let cancelledResult: unknown;
+  _setCurrentResolve((result) => {
+    cancelledResult = result;
+  });
+
+  try {
+    const pausePromise = pauseAuto();
+
+    assert.equal(autoSession.paused, true);
+    assert.deepEqual(cancelledResult, { status: "cancelled" });
+
+    await pausePromise.catch(() => {});
+  } finally {
+    _resetPendingResolve();
+    autoSession.reset();
   }
 });
 


### PR DESCRIPTION
## Summary
- Fixed auto-mode pause races and ghost iteration closure with focused auto-loop regressions and verification.

## Bugs Addressed
- [x] **pauseAuto aborts in-flight units after dispatch**
- [x] **Unhandled-phase warnings pause instead of retrying fresh state**
- [x] **Pre-dispatch break leaves ghost iterations open**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #39
- [#39 auto-mode: synchronous pauseAuto() aborts in-flight units (re-file of archived gsd-2#6443)](https://github.com/open-gsd/gsd-pi/issues/39)

## User
- @davePlug

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/39-auto-mode-synchronous-pauseauto-aborts-i-1779635139`