### PR TITLE
fix(issue): [Bug]: fileFingerprint crashes on git-tracked files larger than 2 GiB (ERR_FS_FILE_TOO_LARGE)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-command-errors.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-command-errors.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { Agent } from "@gsd/pi-agent-core";
+import { AgentSession } from "./agent-session.js";
+import { AuthStorage } from "./auth-storage.js";
+import type { ExtensionError } from "./extensions/types.js";
+import { ModelRegistry } from "./model-registry.js";
+import { DefaultResourceLoader } from "./resource-loader.js";
+import { SessionManager } from "./session-manager.js";
+import { SettingsManager } from "./settings-manager.js";
+
+let testDir: string;
+
+async function createSession() {
+	const agentDir = join(testDir, "agent-home");
+	const authStorage = AuthStorage.inMemory({});
+	const modelRegistry = new ModelRegistry(authStorage, join(agentDir, "models.json"));
+	const settingsManager = SettingsManager.inMemory();
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: testDir,
+		agentDir,
+		settingsManager,
+		noExtensions: true,
+		noPromptTemplates: true,
+		noThemes: true,
+	});
+	await resourceLoader.reload();
+
+	return new AgentSession({
+		agent: new Agent(),
+		sessionManager: SessionManager.inMemory(testDir),
+		settingsManager,
+		cwd: testDir,
+		resourceLoader,
+		modelRegistry,
+	});
+}
+
+describe("AgentSession command error reporting", () => {
+	beforeEach(() => {
+		testDir = mkdtempSync(join(tmpdir(), "agent-session-command-errors-"));
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("includes stack traces when extension commands throw", async () => {
+		const session = await createSession();
+		const emittedErrors: ExtensionError[] = [];
+		const commandError = new Error("command exploded");
+
+		(session as any)._extensionRunner = {
+			getCommand: (name: string) => name === "boom"
+				? {
+					handler: async () => {
+						throw commandError;
+					},
+				}
+				: undefined,
+			createCommandContext: () => ({}),
+			emitError: (error: ExtensionError) => {
+				emittedErrors.push(error);
+			},
+		};
+
+		await session.prompt("/boom");
+
+		assert.equal(emittedErrors.length, 1);
+		assert.equal(emittedErrors[0].extensionPath, "command:boom");
+		assert.equal(emittedErrors[0].event, "command");
+		assert.equal(emittedErrors[0].error, "command exploded");
+		assert.equal(emittedErrors[0].stack, commandError.stack);
+	});
+});

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1305,6 +1305,7 @@ export class AgentSession {
 				extensionPath: `command:${commandName}`,
 				event: "command",
 				error: getErrorMessage(err),
+				stack: err instanceof Error ? err.stack : undefined,
 			});
 			return true;
 		}

--- a/src/resources/extensions/gsd/root-write-leak-guard.ts
+++ b/src/resources/extensions/gsd/root-write-leak-guard.ts
@@ -6,6 +6,8 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+const MAX_SYNC_FINGERPRINT_BYTES = 1_500_000_000;
+
 export interface RootDirtyEntry {
   path: string;
   status: string;
@@ -31,6 +33,7 @@ function fileFingerprint(rootPath: string, relPath: string): string {
   if (!existsSync(absPath)) return "missing";
   const stat = statSync(absPath);
   if (!stat.isFile()) return `${stat.isDirectory() ? "dir" : "other"}:${stat.size}:${stat.mtimeMs}`;
+  if (stat.size > MAX_SYNC_FINGERPRINT_BYTES) return `large:${stat.size}:${stat.mtimeMs}`;
   return createHash("sha256").update(readFileSync(absPath)).digest("hex");
 }
 

--- a/src/resources/extensions/gsd/tests/root-write-leak-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/root-write-leak-guard.test.ts
@@ -1,0 +1,40 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for project-root dirty snapshot fingerprints.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { closeSync, ftruncateSync, openSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { captureRootDirtySnapshot } from "../root-write-leak-guard.ts";
+import { cleanup, git, makeTempRepo } from "./test-utils.ts";
+
+test("captureRootDirtySnapshot does not read dirty files larger than Node's Buffer limit", () => {
+  const base = makeTempRepo("gsd-root-dirty-large-");
+  try {
+    const relPath = "large.bin";
+    const absPath = join(base, relPath);
+
+    writeFileSync(absPath, "tracked\n", "utf-8");
+    git(base, "add", relPath);
+    git(base, "commit", "-m", "track large fixture");
+
+    const fd = openSync(absPath, "r+");
+    try {
+      ftruncateSync(fd, 2_200 * 1024 * 1024);
+    } finally {
+      closeSync(fd);
+    }
+
+    const size = statSync(absPath).size;
+    assert.ok(size > 2 * 1024 * 1024 * 1024, "fixture must exceed Node's readFileSync Buffer limit");
+
+    const snapshot = captureRootDirtySnapshot(base);
+    const entry = snapshot.get(relPath);
+
+    assert.equal(entry?.status, "M");
+    assert.match(entry?.fingerprint ?? "", /^large:\d+:/);
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## Summary
- Fixed large dirty-file fingerprint crashes and command stack reporting, verified with focused regression tests plus build/typecheck.

## Bugs Addressed
- [x] **fileFingerprint crashes on dirty files over 2 GiB**
- [x] **Command error reporting omits stack traces**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #91
- [#91 [Bug]: fileFingerprint crashes on git-tracked files larger than 2 GiB (ERR_FS_FILE_TOO_LARGE)](https://github.com/open-gsd/gsd-pi/issues/91)

## User
- @OfficialDelta

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/91-bug-filefingerprint-crashes-on-git-track-1779636352`