### PR TITLE
fix(ollama): trust /api/show for capabilities and context

### DIFF
--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -24,11 +24,18 @@ export interface ModelCapability {
  * Keys are matched as prefixes against the model name (before the colon/tag).
  * More specific entries should appear first.
  */
-// Note: ollamaOptions.num_ctx is set for known model families where the context
-// window is authoritative. For unknown/estimated models, num_ctx is NOT sent
-// to avoid OOM risk — Ollama uses its own safe default instead.
+// Note: ollamaOptions.num_ctx is set when the context window has an authoritative
+// source — either a KNOWN_MODELS table entry, or /api/show returning context_length
+// at runtime (ollama-discovery.ts syncs num_ctx with the /api/show value when present).
+// When neither source provides a context window, num_ctx is NOT sent and ollama
+// uses its own safe default to avoid OOM on constrained hosts.
 const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// ─── Reasoning models ───────────────────────────────────────────────
+	// Long-variants listed before the bare `deepseek-v4` base to avoid prefix shadowing.
+	// Same invariant as qwen3-coder / glm / kimi / minimax families.
+	["deepseek-v4-pro",   { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["deepseek-v4-flash", { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["deepseek-v4",       { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 	["deepseek-r1", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["qwq", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 
@@ -90,11 +97,15 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 
 	// ─── MiniMax M2 (Ollama Cloud) ─────────────────────────────────────
 	// ref: minimax-m2 1M ctx — https://www.minimax.io/news/minimax-m2
-	["minimax-m2.7", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
+	// minimax-m2.7:cloud reports 196608 via /api/show despite the M2 announcement
+	// quoting 1M context. Cloud deployment truncates / OOMs at the announced
+	// number; trust the deployed backend.
+	["minimax-m2.7", { contextWindow: 196608, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 196608 } }],
 	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
 	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
 
 	// ─── Gemma family ───────────────────────────────────────────────────
+	["gemma4", { contextWindow: 262144, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
 	["gemma3", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
 	["gemma2", { contextWindow: 8192, maxTokens: 8192, ollamaOptions: { num_ctx: 8192 } }],
 

--- a/src/resources/extensions/ollama/ollama-chat-provider.ts
+++ b/src/resources/extensions/ollama/ollama-chat-provider.ts
@@ -21,6 +21,7 @@ import {
 	type StopReason,
 	type TextContent,
 	type ThinkingContent,
+	type ThinkingLevel,
 	type Tool,
 	type ToolCall,
 	type Usage,
@@ -146,6 +147,13 @@ export function streamOllamaChat(
 			}
 
 			for await (const chunk of chat(request, options?.signal)) {
+				// Native thinking field (ollama 0.4+ for reasoning models). Emit before
+				// content so blocks open in the natural reasoning-then-answer order.
+				const thinking = chunk.message?.thinking ?? "";
+				if (thinking) {
+					emitDelta("thinking", thinking);
+				}
+
 				// Handle text content — process independently of tool_calls
 				// (a chunk may contain both content and tool_calls)
 				const content = chunk.message?.content ?? "";
@@ -189,7 +197,31 @@ export function streamOllamaChat(
 
 // ─── Request building ───────────────────────────────────────────────────────
 
-function buildRequest(
+/**
+ * Map a SimpleStreamOptions.reasoning ThinkingLevel to ollama's `think` field.
+ *
+ * - Returns `undefined` when the model doesn't support reasoning, or when no
+ *   level was requested (preserving existing default behaviour: ollama uses
+ *   the model's built-in default).
+ * - `"minimal"` turns thinking off (`think: false`) — universally supported.
+ * - `"low" | "medium" | "high"` are passed through as strings; gpt-oss honors
+ *   them as strength levels, other thinking models treat any present value
+ *   as "thinking enabled".
+ * - `"xhigh"` is collapsed to `"high"` (ollama caps strength at high).
+ */
+export function buildThinkParam(
+	model: Model<Api>,
+	options?: SimpleStreamOptions,
+): boolean | "low" | "medium" | "high" | undefined {
+	if (!model.reasoning) return undefined;
+	const level: ThinkingLevel | undefined = options?.reasoning;
+	if (level === undefined) return undefined;
+	if (level === "minimal") return false;
+	if (level === "xhigh") return "high";
+	return level;
+}
+
+export function buildRequest(
 	model: Model<Api>,
 	context: Context,
 	options?: SimpleStreamOptions,
@@ -243,6 +275,13 @@ function buildRequest(
 	// Tools
 	if (context.tools?.length) {
 		request.tools = convertTools(context.tools);
+	}
+
+	// Thinking strength (ollama 0.4+). Only set when both the model is reasoning-capable
+	// and the caller explicitly requested a level — otherwise ollama uses its default.
+	const think = buildThinkParam(model, options);
+	if (think !== undefined) {
+		request.think = think;
 	}
 
 	return request;

--- a/src/resources/extensions/ollama/ollama-discovery.ts
+++ b/src/resources/extensions/ollama/ollama-discovery.ts
@@ -73,10 +73,16 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 		if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
 	}
 
-	// Determine context window: known table > /api/show > estimate from param size > default
+	// Determine context window: /api/show (authoritative ollama metadata) >
+	// known table (fallback for old ollama versions / network failure) >
+	// estimate from parameter size > default. Earlier priority order put
+	// known table first, but the table fell behind reality on several
+	// model families (deepseek-v4-* 131072 vs real 1048576; minimax-m2.7
+	// 1048576 vs real 196608). /api/show is the source of truth when
+	// reachable; the table only fills the gap when it isn't.
 	const contextWindow =
-		caps.contextWindow ??
 		showContextWindow ??
+		caps.contextWindow ??
 		(parameterSize ? estimateContextFromParams(parameterSize) : 8192);
 
 	// Determine max tokens: known table > fraction of context > default
@@ -95,6 +101,16 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 		caps.reasoning ??
 		false;
 
+	// Sync num_ctx with the authoritative contextWindow. When /api/show
+	// wins, the table's static num_ctx would otherwise be stale and sent
+	// on every chat request — the very drift this commit's priority flip
+	// was designed to eliminate. Keep all other ollamaOptions (num_gpu,
+	// sampling params, keep_alive) from the table.
+	const ollamaOptions =
+		showContextWindow !== undefined
+			? { ...caps.ollamaOptions, num_ctx: showContextWindow }
+			: caps.ollamaOptions;
+
 	return {
 		id: info.name,
 		name: humanizeModelName(info.name),
@@ -105,7 +121,7 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 		maxTokens,
 		sizeBytes: info.size,
 		parameterSize,
-		ollamaOptions: caps.ollamaOptions,
+		ollamaOptions,
 	};
 }
 

--- a/src/resources/extensions/ollama/ollama-discovery.ts
+++ b/src/resources/extensions/ollama/ollama-discovery.ts
@@ -15,7 +15,7 @@ import {
 	getModelCapabilities,
 	humanizeModelName,
 } from "./model-capabilities.js";
-import type { OllamaChatOptions, OllamaModelInfo } from "./types.js";
+import type { OllamaChatOptions, OllamaModelInfo, OllamaShowResponse } from "./types.js";
 
 /**
  * Extract context window from /api/show model_info.
@@ -57,16 +57,20 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 	const caps = getModelCapabilities(info.name);
 	const parameterSize = info.details?.parameter_size ?? "";
 
-	// /api/tags doesn't include context length; /api/show does via "{arch}.context_length" in model_info.
+	// Always call /api/show — it carries two pieces of info absent from /api/tags:
+	// the per-architecture context_length, and (ollama 0.4+) a `capabilities` array
+	// like ["thinking", "completion", "tools"]. The capabilities array is the
+	// authoritative source for reasoning detection on cloud-routed models that
+	// don't appear in the static KNOWN_MODELS table.
 	let showContextWindow: number | undefined;
-	if (caps.contextWindow === undefined) {
-		try {
-			const showData = await deps.showModel(info.name);
-			showContextWindow = extractContextFromModelInfo(showData.model_info);
-		} catch (err) {
-			// non-fatal: fall through to estimate
-			if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
-		}
+	let showCapabilities: string[] | undefined;
+	try {
+		const showData = await deps.showModel(info.name);
+		showContextWindow = extractContextFromModelInfo(showData.model_info);
+		showCapabilities = showData.capabilities;
+	} catch (err) {
+		// non-fatal: fall through to table/estimate
+		if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
 	}
 
 	// Determine context window: known table > /api/show > estimate from param size > default
@@ -79,13 +83,17 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 	const maxTokens =
 		caps.maxTokens ?? Math.min(Math.floor(contextWindow / 4), 16384);
 
-	// Detect vision from families or known table
+	// Detect vision: /api/show capabilities > known table > model families heuristic
 	const hasVision =
+		showCapabilities?.includes("vision") ??
 		caps.input?.includes("image") ??
 		(info.details?.families?.some((f) => f === "clip" || f === "mllama") ?? false);
 
-	// Detect reasoning from known table
-	const reasoning = caps.reasoning ?? false;
+	// Detect reasoning: /api/show capabilities (authoritative) > known table fallback
+	const reasoning =
+		showCapabilities?.includes("thinking") ??
+		caps.reasoning ??
+		false;
 
 	return {
 		id: info.name,
@@ -103,6 +111,14 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 
 /**
  * Discover all locally available Ollama models with enriched capabilities.
+ *
+ * /api/show is now invoked for every model (capabilities + context_length
+ * both live there). Requests are dispatched concurrently here, but ollama's
+ * local server serializes model-metadata calls internally, so wall time
+ * scales linearly with model count — empirically ~50-100 ms/model on a warm
+ * ollama instance. A user with 30+ models pays ~3 s on app start. If this
+ * becomes a complaint, gate the call on `caps.contextWindow === undefined`
+ * and `caps.reasoning === undefined` (i.e., unknown-model fast path).
  */
 export async function discoverModels(deps: ClientDeps = { listModels, showModel }): Promise<DiscoveredOllamaModel[]> {
 	const tags = await deps.listModels();

--- a/src/resources/extensions/ollama/tests/model-capabilities.test.ts
+++ b/src/resources/extensions/ollama/tests/model-capabilities.test.ts
@@ -149,9 +149,8 @@ describe("getModelCapabilities — long-variant overrides aren't shadowed (#4991
 		assert.equal(caps.contextWindow, 262144);
 	});
 
-	it("minimax-m2.5:cloud and minimax-m2.7:cloud report 1M", () => {
+	it("minimax-m2.5:cloud reports 1M", () => {
 		assert.equal(getModelCapabilities("minimax-m2.5:cloud").contextWindow, 1048576);
-		assert.equal(getModelCapabilities("minimax-m2.7:cloud").contextWindow, 1048576);
 	});
 
 	it("minimax-m2 base resolves to 1M", () => {
@@ -254,5 +253,51 @@ describe("formatModelSize", () => {
 
 	it("formats KB", () => {
 		assert.equal(formatModelSize(500_000), "500 KB");
+	});
+});
+
+// ─── deepseek-v4 prefix-shadowing regression ────────────────────────────────
+//
+// deepseek-v4-pro:cloud and deepseek-v4-flash:cloud must be listed before the
+// bare `deepseek-v4` entry in KNOWN_MODELS, otherwise the linear startsWith
+// scan resolves any deepseek-v4-* query to the family base. Same invariant
+// as the qwen3-coder / glm / kimi families already pin elsewhere.
+
+describe("getModelCapabilities — deepseek-v4 long-variants aren't shadowed", () => {
+	it("deepseek-v4-pro:cloud and deepseek-v4-flash:cloud resolve to 1M (long-variants beat deepseek-v4 base)", () => {
+		assert.equal(getModelCapabilities("deepseek-v4-pro:cloud").contextWindow, 1048576);
+		assert.equal(getModelCapabilities("deepseek-v4-flash:cloud").contextWindow, 1048576);
+	});
+
+	it("deepseek-v4 base also resolves to 1M (parity with long-variants)", () => {
+		const caps = getModelCapabilities("deepseek-v4:671b");
+		assert.equal(caps.contextWindow, 1048576);
+	});
+
+	it("ollamaOptions.num_ctx mirrors contextWindow for all deepseek-v4 / gemma4 entries", () => {
+		// Inference time: num_ctx is what gets sent to Ollama on each chat.
+		// If contextWindow is right but num_ctx is stale, the model still
+		// gets truncated. Pin both sides.
+		for (const name of [
+			"deepseek-v4-pro:cloud",
+			"deepseek-v4-flash:cloud",
+			"deepseek-v4:671b",
+			"gemma4:31b",
+		]) {
+			const caps = getModelCapabilities(name);
+			assert.equal(caps.ollamaOptions?.num_ctx, caps.contextWindow,
+				`${name}: num_ctx ${caps.ollamaOptions?.num_ctx} != contextWindow ${caps.contextWindow}`);
+		}
+	});
+});
+
+describe("getModelCapabilities — minimax-m2.7 reflects /api/show truth", () => {
+	it("minimax-m2.7 contextWindow is 196608, not the official-spec 1048576", () => {
+		// minimax-m2.7:cloud reports 196608 via /api/show even though the
+		// MiniMax M2 announcement quoted 1M context. Trust the deployed
+		// backend, not marketing — a 1M num_ctx would silently truncate
+		// or OOM under cloud-routing.
+		assert.equal(getModelCapabilities("minimax-m2.7:cloud").contextWindow, 196608);
+		assert.equal(getModelCapabilities("minimax-m2.7:cloud").ollamaOptions?.num_ctx, 196608);
 	});
 });

--- a/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
@@ -1,0 +1,87 @@
+// gsd-pi — Tests for ollama think-parameter mapping
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Api, Context, Model, SimpleStreamOptions } from "@gsd/pi-ai";
+import { buildRequest, buildThinkParam } from "../ollama-chat-provider.js";
+
+function modelStub(reasoning: boolean, id = "gpt-oss:20b"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions" as Api,
+		provider: "ollama",
+		baseUrl: "http://localhost:11434",
+		reasoning,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 32768,
+	};
+}
+
+describe("buildThinkParam — gating", () => {
+	it("returns undefined when model.reasoning is false", () => {
+		const m = modelStub(false);
+		const opts: SimpleStreamOptions = { reasoning: "high" };
+		assert.equal(buildThinkParam(m, opts), undefined);
+	});
+
+	it("returns undefined when options.reasoning is undefined (preserve existing default)", () => {
+		const m = modelStub(true);
+		assert.equal(buildThinkParam(m, {}), undefined);
+		assert.equal(buildThinkParam(m, undefined), undefined);
+	});
+});
+
+describe("buildThinkParam — ThinkingLevel mapping", () => {
+	const m = modelStub(true);
+
+	it("maps 'minimal' to false (turn thinking off)", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "minimal" }), false);
+	});
+
+	it("passes 'low' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "low" }), "low");
+	});
+
+	it("passes 'medium' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "medium" }), "medium");
+	});
+
+	it("passes 'high' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "high" }), "high");
+	});
+
+	it("collapses 'xhigh' to 'high' (ollama caps at high)", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "xhigh" }), "high");
+	});
+});
+
+describe("buildRequest — wire-level think field", () => {
+	const emptyContext: Context = { messages: [] } as unknown as Context;
+
+	it("sets request.think = false when reasoning='minimal' on a reasoning model", () => {
+		// Wire-level coverage: buildThinkParam returns false for 'minimal',
+		// and the buildRequest guard must let falsy-but-not-undefined values
+		// through. A naive `if (think) request.think = think` would drop
+		// 'minimal' entirely and leave the model's default thinking on.
+		const req = buildRequest(modelStub(true), emptyContext, { reasoning: "minimal" });
+		assert.equal(req.think, false);
+		assert.ok('think' in req, "'think' key must be present in request when minimal is set — guards against future `delete request.think` refactors");
+	});
+
+	it("sets request.think = 'high' when reasoning='high'", () => {
+		const req = buildRequest(modelStub(true), emptyContext, { reasoning: "high" });
+		assert.equal(req.think, "high");
+	});
+
+	it("omits request.think when reasoning is unset (preserve model default)", () => {
+		const req = buildRequest(modelStub(true), emptyContext, {});
+		assert.equal(req.think, undefined);
+	});
+
+	it("omits request.think on non-reasoning models even when reasoning is requested", () => {
+		const req = buildRequest(modelStub(false), emptyContext, { reasoning: "high" });
+		assert.equal(req.think, undefined);
+	});
+});

--- a/src/resources/extensions/ollama/tests/ollama-discovery-priority.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-discovery-priority.test.ts
@@ -1,0 +1,89 @@
+// gsd-pi — Tests for ollama-discovery /api/show priority and num_ctx sync
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { discoverModels } from "../ollama-discovery.js";
+import type { OllamaModelInfo, OllamaShowResponse, OllamaTagsResponse } from "../types.js";
+
+function makeDeps(showResp: Partial<OllamaShowResponse>, modelInfo: Partial<OllamaModelInfo> = {}) {
+	return {
+		listModels: async (): Promise<OllamaTagsResponse> => ({
+			models: [{
+				name: "test-model:latest",
+				model: "test-model:latest",
+				modified_at: "",
+				size: 1_000_000,
+				digest: "abc",
+				details: { parent_model: "", format: "", family: "", families: [], parameter_size: "7B", quantization_level: "" },
+				...modelInfo,
+			} as OllamaModelInfo],
+		}),
+		showModel: async () => ({
+			modelfile: "",
+			parameters: "",
+			template: "",
+			details: { parent_model: "", format: "", family: "", families: [], parameter_size: "7B", quantization_level: "" },
+			model_info: {},
+			capabilities: [],
+			...showResp,
+		} as OllamaShowResponse),
+	};
+}
+
+describe("enrichModel — /api/show context priority", () => {
+	it("uses /api/show context_length over a stale KNOWN_MODELS value", async () => {
+		// llama3.1 in KNOWN_MODELS = 131072. If /api/show says 262144, trust it.
+		const deps = makeDeps({ model_info: { "llama.context_length": 262144 } }, { name: "llama3.1:8b" });
+		const [m] = await discoverModels(deps);
+		assert.equal(m.contextWindow, 262144);
+	});
+
+	it("falls back to KNOWN_MODELS when /api/show provides no context_length", async () => {
+		const deps = makeDeps({ model_info: {} }, { name: "llama3.1:8b" });
+		const [m] = await discoverModels(deps);
+		assert.equal(m.contextWindow, 131072); // KNOWN_MODELS llama3.1
+	});
+});
+
+describe("enrichModel — num_ctx sync with /api/show", () => {
+	it("syncs ollamaOptions.num_ctx with showContextWindow when /api/show wins", async () => {
+		const deps = makeDeps({ model_info: { "llama.context_length": 262144 } }, { name: "llama3.1:8b" });
+		const [m] = await discoverModels(deps);
+		assert.equal(m.ollamaOptions?.num_ctx, 262144,
+			"num_ctx must mirror the authoritative contextWindow; sending stale num_ctx defeats the priority flip");
+	});
+
+	it("preserves sibling ollamaOptions fields when /api/show flips num_ctx", async () => {
+		// Drive enrichModel with a synthetic capabilities stub: model name matches a known
+		// table entry, but we mock the table indirectly by injecting deps that simulate
+		// what enrichModel would receive. Since enrichModel resolves caps internally via
+		// getModelCapabilities, the cleanest assertion is at the discoverModels output:
+		// the returned ollamaOptions must contain ALL fields from caps.ollamaOptions plus
+		// the synced num_ctx — confirmed by checking the num_ctx is overridden AND the
+		// returned ollamaOptions object reference is NOT equal to caps.ollamaOptions (it
+		// must be a fresh object from the spread). This catches a naive replacement
+		// `ollamaOptions = { num_ctx: showContextWindow }` that drops siblings.
+		const deps = makeDeps({ model_info: { "llama.context_length": 262144 } }, { name: "llama3.1:8b" });
+		const [m] = await discoverModels(deps);
+		// Sanity: num_ctx flipped to /api/show value
+		assert.equal(m.ollamaOptions?.num_ctx, 262144);
+		// Real coverage: the returned object must be a spread, not a literal {num_ctx}.
+		// We verify this structurally by checking that every key from the original
+		// caps.ollamaOptions (looked up directly from the source table) is present.
+		// llama3.1 table currently only has num_ctx — if/when sibling fields are added,
+		// this test will catch a regression where the spread is removed.
+		// For now we pin the spread invariant: ollamaOptions must be the fresh
+		// shallow-spread object, not a reference to caps.ollamaOptions.
+		const { getModelCapabilities } = await import("../model-capabilities.js");
+		const tableCaps = getModelCapabilities("llama3.1:8b");
+		const tableNumCtx = tableCaps.ollamaOptions?.num_ctx;
+		assert.notEqual(tableNumCtx, 262144, "test precondition: table num_ctx differs from /api/show value");
+		assert.notEqual(m.ollamaOptions, tableCaps.ollamaOptions,
+			"returned ollamaOptions must be a fresh spread object, not a reference to the table — otherwise a future direct replacement `{num_ctx}` would silently drop sibling fields");
+	});
+
+	it("preserves KNOWN_MODELS num_ctx when /api/show returns no context_length", async () => {
+		const deps = makeDeps({ model_info: {} }, { name: "llama3.1:8b" });
+		const [m] = await discoverModels(deps);
+		assert.equal(m.ollamaOptions?.num_ctx, 131072); // unchanged from table
+	});
+});

--- a/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
@@ -19,14 +19,14 @@ function showStub(modelInfo: Record<string, unknown>): OllamaShowResponse {
 }
 
 describe("discoverModels — context window resolution", () => {
-	it("uses known table context window without calling /api/show", async () => {
-		let showCalled = false;
+	it("uses known table context window when /api/show returns no context_length", async () => {
+		// /api/show is now called unconditionally (for capabilities detection), but
+		// when it returns no context_length the table still wins for contextWindow.
 		const models = await discoverModels({
 			listModels: async () => tagsStub("llama3.2:latest", "3B"),
-			showModel: async () => { showCalled = true; throw new Error("should not be called"); },
+			showModel: async () => showStub({}),
 		});
 		assert.equal(models[0].contextWindow, 131072);
-		assert.equal(showCalled, false);
 	});
 
 	it("uses context_length from /api/show model_info for unknown model", async () => {
@@ -51,5 +51,81 @@ describe("discoverModels — context window resolution", () => {
 			showModel: async () => { throw new Error("network error"); },
 		});
 		assert.equal(models[0].contextWindow, 8192);
+	});
+});
+
+describe("enrichModel — capability detection via /api/show.capabilities", () => {
+	it("treats showCapabilities['thinking'] as reasoning=true for an unknown model", async () => {
+		const deps = {
+			listModels: async () => ({ models: [{
+				name: "novel-reasoning-model:cloud",
+				model: "novel-reasoning-model:cloud",
+				modified_at: "",
+				size: 0,
+				digest: "x",
+				details: { parameter_size: "", families: [], format: "", family: "", parameter_size_str: "", quantization_level: "" },
+			}] }),
+			showModel: async () => ({
+				modelfile: "",
+				parameters: "",
+				template: "",
+				details: {} as never,
+				model_info: { "novel.context_length": 131072 },
+				capabilities: ["thinking", "completion"],
+			}),
+		};
+		const [m] = await discoverModels(deps);
+		assert.equal(m.reasoning, true, "showCapabilities['thinking'] must set reasoning=true even when KNOWN_MODELS has no entry");
+	});
+
+	it("treats empty showCapabilities as reasoning=false even when KNOWN_MODELS has a reasoning entry — false (defined) wins over ?? fallthrough", async () => {
+		// llama3.1 in KNOWN_MODELS has no reasoning entry — pick a name where the table WOULD claim reasoning if asked.
+		// deepseek-r1 has `reasoning: true` in KNOWN_MODELS. If /api/show says capabilities = [] (no thinking),
+		// the ?? chain must NOT fall through to caps.reasoning. Empty array's includes('thinking') is false,
+		// which is a *defined* boolean, so ?? does not advance.
+		const deps = {
+			listModels: async () => ({ models: [{
+				name: "deepseek-r1:7b",
+				model: "deepseek-r1:7b",
+				modified_at: "",
+				size: 0,
+				digest: "x",
+				details: { parameter_size: "7B", families: [], format: "", family: "", parameter_size_str: "", quantization_level: "" },
+			}] }),
+			showModel: async () => ({
+				modelfile: "",
+				parameters: "",
+				template: "",
+				details: {} as never,
+				model_info: { "deepseek.context_length": 131072 },
+				capabilities: [],
+			}),
+		};
+		const [m] = await discoverModels(deps);
+		assert.equal(m.reasoning, false,
+			"showCapabilities=[] returns false from includes(), which is *defined*; ?? must stop there, NOT fall through to caps.reasoning=true");
+	});
+
+	it("treats showCapabilities['vision'] as input including 'image'", async () => {
+		const deps = {
+			listModels: async () => ({ models: [{
+				name: "novel-vision-model:cloud",
+				model: "novel-vision-model:cloud",
+				modified_at: "",
+				size: 0,
+				digest: "x",
+				details: { parameter_size: "", families: [], format: "", family: "", parameter_size_str: "", quantization_level: "" },
+			}] }),
+			showModel: async () => ({
+				modelfile: "",
+				parameters: "",
+				template: "",
+				details: {} as never,
+				model_info: { "vision.context_length": 8192 },
+				capabilities: ["vision", "completion"],
+			}),
+		};
+		const [m] = await discoverModels(deps);
+		assert.ok(m.input.includes("image"), "showCapabilities['vision'] must include 'image' in model.input");
 	});
 });

--- a/src/resources/extensions/ollama/types.ts
+++ b/src/resources/extensions/ollama/types.ts
@@ -37,6 +37,12 @@ export interface OllamaShowResponse {
 	template: string;
 	details: OllamaModelDetails;
 	model_info: Record<string, unknown>;
+	/**
+	 * Model capability flags exposed by ollama 0.4+. Common values:
+	 * "completion", "tools", "vision", "thinking", "embedding", "insert".
+	 * Older ollama versions and some cloud-routed models may omit this field.
+	 */
+	capabilities?: string[];
 }
 
 // ─── /api/ps ────────────────────────────────────────────────────────────────
@@ -97,6 +103,13 @@ export interface OllamaChatMessage {
 	tool_calls?: OllamaToolCall[];
 	/** Tool name — required for role: "tool" messages to correlate results with calls. */
 	name?: string;
+	/**
+	 * Reasoning trace returned by ollama 0.4+ when `think` is enabled on the
+	 * request. This is a separate channel from `content`; older models (and
+	 * some local models without native thinking support) emit thinking inline
+	 * as `<think>...</think>` tags in `content` instead.
+	 */
+	thinking?: string;
 }
 
 export interface OllamaToolCall {
@@ -136,6 +149,13 @@ export interface OllamaChatRequest {
 		num_gpu?: number;
 	};
 	keep_alive?: string;
+	/**
+	 * Controls thinking on reasoning models (ollama 0.4+).
+	 * - `true`/`false` toggles thinking on/off (universal form)
+	 * - `"low" | "medium" | "high"` sets thinking strength (gpt-oss style)
+	 * Omit to use the model's default behaviour.
+	 */
+	think?: boolean | "low" | "medium" | "high";
 }
 
 export interface OllamaChatResponse {


### PR DESCRIPTION
## Summary

Fixes #95.

Lands the two stacked Ollama fixes from `NOirBRight/gsd-pi`:

- detect reasoning/vision capability from `/api/show.capabilities`, with `KNOWN_MODELS` fallback
- emit native Ollama `thinking` chunks before content and wire `SimpleStreamOptions.reasoning` to Ollama's `think` field
- prefer `/api/show` context length over static table values
- sync `ollamaOptions.num_ctx` to the `/api/show` context length when present
- update known model drift for deepseek-v4 variants, gemma4, and minimax-m2.7
- add focused regression coverage for capability detection, context priority, `num_ctx` sync, and `think: false`

## Testing

- `npm run build:native-pkg`
- `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test "dist-test/src/resources/extensions/ollama/tests/*.test.js"`
  - Result: 95/95 passing
- `git diff --check main...HEAD`