### PR TITLE
fix(issue): crash/: unbounded EPIPE crash logs bloat ~/.gsd by millions of files (21GB+)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/crash-log.ts
+++ b/src/resources/extensions/gsd/bootstrap/crash-log.ts
@@ -1,5 +1,5 @@
 /**
- * crash-log.ts — Write crash diagnostics to ~/.gsd/crash/<timestamp>.log
+ * crash-log.ts — Write crash diagnostics to ~/.gsd/crash/pid-<pid>.log
  *
  * Zero cross-dependencies: only uses Node.js built-ins so it can be imported
  * safely from uncaughtException / unhandledRejection handlers and from tests
@@ -11,15 +11,14 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /**
- * Write a crash log to ~/.gsd/crash/<timestamp>.log (or $GSD_HOME/crash/).
+ * Write a crash log to ~/.gsd/crash/pid-<pid>.log (or $GSD_HOME/crash/).
  * Never throws — must be safe to call from any error handler.
  */
 export function writeCrashLog(err: Error, source: string): void {
   try {
     const crashDir = join(process.env.GSD_HOME ?? join(homedir(), ".gsd"), "crash");
     mkdirSync(crashDir, { recursive: true });
-    const ts = new Date().toISOString().replace(/[:.]/g, "-");
-    const logPath = join(crashDir, `${ts}.log`);
+    const logPath = join(crashDir, `pid-${process.pid}.log`);
     const lines = [
       `[gsd] ${source}: ${err.message}`,
       `timestamp: ${new Date().toISOString()}`,

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -28,13 +28,12 @@ export { writeCrashLog } from "./crash-log.js";
 
 export function handleRecoverableExtensionProcessError(err: Error): boolean {
   if ((err as NodeJS.ErrnoException).code === "EPIPE") {
-    writeCrashLog(err, "EPIPE");
     const stdoutGone = process.stdout.destroyed || process.stdout.writableEnded;
     if (stdoutGone) {
       process.exit(0);
     }
     process.stderr.write(
-      `[gsd] swallowed EPIPE (syscall=${(err as NodeJS.ErrnoException).syscall ?? "?"}); see ~/.gsd/crash/ for details\n`,
+      `[gsd] swallowed EPIPE (syscall=${(err as NodeJS.ErrnoException).syscall ?? "?"})\n`,
     );
     return true;
   }

--- a/src/resources/extensions/gsd/tests/crash-handler-secondary.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-handler-secondary.test.ts
@@ -49,6 +49,28 @@ describe('register-extension crash handler secondary fixes (#3348)', () => {
     }
   });
 
+  test('writeCrashLog appends repeated crashes from one process to a single file', async () => {
+    const tmpHome = join(tmpdir(), `gsd-crash-test-${randomUUID()}`);
+    const origHome = process.env.GSD_HOME;
+    process.env.GSD_HOME = tmpHome;
+    try {
+      const { writeCrashLog } = await import('../bootstrap/crash-log.ts');
+      writeCrashLog(new Error('first crash'), 'uncaughtException');
+      writeCrashLog(new Error('second crash'), 'unhandledRejection');
+
+      const crashDir = join(tmpHome, 'crash');
+      const logs = readdirSync(crashDir).filter((f) => f.endsWith('.log'));
+      assert.equal(logs.length, 1, 'repeated writes in one process should share one crash log');
+
+      const content = readFileSync(join(crashDir, logs[0]), 'utf-8');
+      assert.ok(content.includes('first crash'), 'log should contain first error message');
+      assert.ok(content.includes('second crash'), 'log should contain second error message');
+    } finally {
+      process.env.GSD_HOME = origHome;
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   test('_gsdRejectionGuard is registered for unhandledRejection', () => {
     installEpipeGuard();
     const listener = process.listeners("unhandledRejection").find((candidate) =>

--- a/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
 import { handleRecoverableExtensionProcessError } from "../bootstrap/register-extension.ts";
@@ -94,7 +94,7 @@ test("handleRecoverableExtensionProcessError leaves unrelated errors unhandled",
   assert.equal(handled, false);
 });
 
-test("handleRecoverableExtensionProcessError swallows EPIPE, warns, and writes crash log when stdout is alive", () => {
+test("handleRecoverableExtensionProcessError swallows EPIPE without writing a crash log", () => {
   const tmpHome = join(tmpdir(), `gsd-epipe-test-${randomUUID()}`);
   const origHome = process.env.GSD_HOME;
   process.env.GSD_HOME = tmpHome;
@@ -116,8 +116,7 @@ test("handleRecoverableExtensionProcessError swallows EPIPE, warns, and writes c
     assert.equal(handled, true);
     assert.match(stderr, /swallowed EPIPE/);
     const crashDir = join(tmpHome, "crash");
-    assert.equal(existsSync(crashDir), true);
-    assert.equal(readdirSync(crashDir).some((f) => f.endsWith(".log")), true);
+    assert.equal(existsSync(crashDir), false);
   } finally {
     process.stderr.write = originalWrite;
     process.env.GSD_HOME = origHome;


### PR DESCRIPTION
## Summary
- Fixed recoverable EPIPE crash logging and bounded crash-log file creation with focused tests and typecheck passing.

## Bugs Addressed
- [x] **Recoverable EPIPE events write crash logs**
- [x] **Crash logs use unbounded per-call filenames**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #99
- [#99 crash/: unbounded EPIPE crash logs bloat ~/.gsd by millions of files (21GB+)](https://github.com/open-gsd/gsd-pi/issues/99)

## User
- @mattiaverio

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/99-crash-unbounded-epipe-crash-logs-bloat-g-1779675494`