### PR TITLE
fix(pi-ai): normalize Claude tool schemas for Cloud Code Assist

### DIFF
--- a/packages/pi-ai/src/providers/google-shared.test.ts
+++ b/packages/pi-ai/src/providers/google-shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { sanitizeSchemaForGoogle } from "./google-shared.js";
+import { convertTools, normalizeClaudeToolSchemaForGoogle, sanitizeSchemaForGoogle } from "./google-shared.js";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // sanitizeSchemaForGoogle
@@ -55,6 +55,7 @@ describe("sanitizeSchemaForGoogle", () => {
 		const schema = { const: "fixed-value" };
 		const result = sanitizeSchemaForGoogle(schema) as Record<string, unknown>;
 		assert.deepEqual(result.enum, ["fixed-value"]);
+		assert.equal(result.type, "string");
 		assert.ok(!("const" in result));
 	});
 
@@ -63,8 +64,8 @@ describe("sanitizeSchemaForGoogle", () => {
 			anyOf: [{ const: "a" }, { const: "b" }, { type: "string" }],
 		};
 		const result = sanitizeSchemaForGoogle(schema) as any;
-		assert.deepEqual(result.anyOf[0], { enum: ["a"] });
-		assert.deepEqual(result.anyOf[1], { enum: ["b"] });
+		assert.deepEqual(result.anyOf[0], { enum: ["a"], type: "string" });
+		assert.deepEqual(result.anyOf[1], { enum: ["b"], type: "string" });
 		assert.deepEqual(result.anyOf[2], { type: "string" });
 	});
 
@@ -73,8 +74,8 @@ describe("sanitizeSchemaForGoogle", () => {
 			oneOf: [{ const: "x" }, { const: "y" }],
 		};
 		const result = sanitizeSchemaForGoogle(schema) as any;
-		assert.deepEqual(result.oneOf[0], { enum: ["x"] });
-		assert.deepEqual(result.oneOf[1], { enum: ["y"] });
+		assert.deepEqual(result.oneOf[0], { enum: ["x"], type: "string" });
+		assert.deepEqual(result.oneOf[1], { enum: ["y"], type: "string" });
 	});
 
 	it("recursively sanitizes deeply nested schemas", () => {
@@ -94,7 +95,7 @@ describe("sanitizeSchemaForGoogle", () => {
 		};
 		const result = sanitizeSchemaForGoogle(schema) as any;
 		const level2 = result.properties.level1.properties.level2;
-		assert.deepEqual(level2.anyOf[0], { enum: ["deep"] });
+		assert.deepEqual(level2.anyOf[0], { enum: ["deep"], type: "string" });
 		assert.ok(!("patternProperties" in level2));
 	});
 
@@ -106,22 +107,21 @@ describe("sanitizeSchemaForGoogle", () => {
 			},
 		};
 		const result = sanitizeSchemaForGoogle(schema) as any;
-		assert.deepEqual(result.items.anyOf[0], { enum: ["foo"] });
+		assert.deepEqual(result.items.anyOf[0], { enum: ["foo"], type: "string" });
 	});
 
 	it("sanitizes arrays of schemas", () => {
 		const input = [{ const: "a" }, { const: "b" }];
 		const result = sanitizeSchemaForGoogle(input) as any[];
-		assert.deepEqual(result[0], { enum: ["a"] });
-		assert.deepEqual(result[1], { enum: ["b"] });
+		assert.deepEqual(result[0], { enum: ["a"], type: "string" });
+		assert.deepEqual(result[1], { enum: ["b"], type: "string" });
 	});
 
-	it("preserves non-string const values unchanged", () => {
-		// Only string const values are converted; number const is passed through
+	it("converts non-string const values to enum", () => {
 		const schema = { const: 42 };
 		const result = sanitizeSchemaForGoogle(schema) as Record<string, unknown>;
-		assert.equal(result.const, 42);
-		assert.ok(!("enum" in result));
+		assert.deepEqual(result.enum, [42]);
+		assert.ok(!("const" in result));
 	});
 
 	it("sanitizes additionalProperties", () => {
@@ -133,5 +133,119 @@ describe("sanitizeSchemaForGoogle", () => {
 		};
 		const result = sanitizeSchemaForGoogle(schema) as any;
 		assert.ok(!("patternProperties" in result.additionalProperties));
+	});
+});
+
+describe("normalizeClaudeToolSchemaForGoogle", () => {
+	it("merges top-level anyOf object variants into an object-root schema", () => {
+		const schema = {
+			anyOf: [
+				{
+					type: "object",
+					properties: {
+						milestone_id: { type: "string" },
+						artifact_type: { type: "string" },
+						content: { type: "string" },
+					},
+					required: ["milestone_id", "artifact_type", "content"],
+				},
+				{
+					type: "object",
+					properties: {
+						artifact_type: { type: "string" },
+						content: { type: "string" },
+					},
+					required: ["artifact_type", "content"],
+				},
+			],
+		};
+
+		assert.deepEqual(normalizeClaudeToolSchemaForGoogle(schema), {
+			type: "object",
+			properties: {
+				milestone_id: { type: "string" },
+				artifact_type: { type: "string" },
+				content: { type: "string" },
+			},
+			required: ["milestone_id", "artifact_type", "content"],
+		});
+	});
+
+	it("forces object-root parameters for Claude tools on Cloud Code Assist", () => {
+		const result = convertTools(
+			[
+				{
+					name: "save_summary",
+					description: "Save a summary",
+					parameters: {
+						anyOf: [
+							{
+								type: "object",
+								properties: { kind: { const: "milestone" }, content: { type: "string" } },
+								required: ["kind", "content"],
+							},
+							{
+								type: "object",
+								properties: { kind: { const: "project" }, content: { type: "string" } },
+								required: ["kind", "content"],
+							},
+						],
+					},
+				},
+			] as any,
+			true,
+		);
+
+		assert.deepEqual(result, [
+			{
+				functionDeclarations: [
+					{
+						name: "save_summary",
+						description: "Save a summary",
+						parameters: {
+							type: "object",
+							properties: {
+								kind: { enum: ["milestone", "project"], type: "string" },
+								content: { type: "string" },
+							},
+							required: ["kind", "content"],
+						},
+					},
+				],
+			},
+		]);
+	});
+
+	it("omits empty required and closed-object keywords from Claude parameters", () => {
+		const result = convertTools(
+			[
+				{
+					name: "noop",
+					description: "Noop",
+					parameters: {
+						type: "object",
+						properties: {},
+						required: [],
+						additionalProperties: false,
+					},
+				},
+			] as any,
+			true,
+		);
+
+		assert.deepEqual(result, [
+			{
+				functionDeclarations: [
+					{
+						name: "noop",
+						description: "Noop",
+						parameters: {
+							type: "object",
+							properties: {},
+						},
+					},
+				],
+			},
+		]);
 	});
 });

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -232,7 +232,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
  *
  * This function recursively:
  * - Removes all `patternProperties` fields
- * - Converts `const: "value"` to `enum: ["value"]` in anyOf/oneOf blocks
+ * - Converts `const: value` to `enum: [value]` in anyOf/oneOf blocks
  *
  * This is needed for providers like `google-antigravity` when proxying Claude models,
  * since Google Cloud Code Assist uses a restricted subset of JSON Schema.
@@ -250,14 +250,26 @@ export function sanitizeSchemaForGoogle(schema: unknown): unknown {
 	const sanitized: Record<string, unknown> = {};
 
 	for (const [key, value] of Object.entries(obj)) {
-		// Skip patternProperties entirely — not supported by Google's API
-		if (key === "patternProperties") {
+		// Skip keywords not supported by Google's function declaration subset.
+		if (key === "patternProperties" || key === "$schema" || key === "$id" || key === "unevaluatedProperties") {
+			continue;
+		}
+
+		if (key === "additionalProperties" && value === false) {
+			continue;
+		}
+
+		if (key === "required" && Array.isArray(value) && value.length === 0) {
 			continue;
 		}
 
 		// Convert const to enum — Google's API rejects the const keyword
-		if (key === "const" && typeof value === "string") {
+		if (key === "const") {
 			sanitized.enum = [value];
+			const inferredType = inferJsonSchemaType(value);
+			if (inferredType) {
+				sanitized.type = inferredType;
+			}
 			continue;
 		}
 
@@ -270,6 +282,130 @@ export function sanitizeSchemaForGoogle(schema: unknown): unknown {
 	}
 
 	return sanitized;
+}
+
+function inferJsonSchemaType(value: unknown): string | undefined {
+	if (typeof value === "string") return "string";
+	if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+	if (typeof value === "boolean") return "boolean";
+	return undefined;
+}
+
+function mergePropertySchemas(a: unknown, b: unknown): unknown {
+	if (!a) return b;
+	if (!b) return a;
+	if (
+		typeof a !== "object"
+		|| typeof b !== "object"
+		|| Array.isArray(a)
+		|| Array.isArray(b)
+	) {
+		return b;
+	}
+
+	const left = a as Record<string, unknown>;
+	const right = b as Record<string, unknown>;
+	const leftConst = left.const;
+	const rightConst = right.const;
+	if (leftConst !== undefined && rightConst !== undefined) {
+		const enumValues = Array.from(new Set([leftConst, rightConst]));
+		const { const: _leftConst, ...leftWithoutConst } = left;
+		const { const: _rightConst, ...rightWithoutConst } = right;
+		return {
+			...leftWithoutConst,
+			...rightWithoutConst,
+			enum: enumValues,
+			type: enumValues.every((value) => typeof value === "string") ? "string" : right.type ?? left.type,
+		};
+	}
+
+	if (Array.isArray(left.enum) || Array.isArray(right.enum)) {
+		const enumValues = Array.from(new Set([...(Array.isArray(left.enum) ? left.enum : []), ...(Array.isArray(right.enum) ? right.enum : [])]));
+		return {
+			...left,
+			...right,
+			enum: enumValues,
+		};
+	}
+
+	return { ...left, ...right };
+}
+
+/**
+ * Cloud Code Assist translates Claude-model function declarations into
+ * Anthropic custom tool schemas. Keep that route on a conservative object-root
+ * schema, matching the Anthropic provider's conversion for top-level unions.
+ */
+export function normalizeClaudeToolSchemaForGoogle(schema: unknown): unknown {
+	if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+		return {
+			type: "object",
+			properties: {},
+			required: [],
+		};
+	}
+
+	const jsonSchema = schema as Record<string, unknown>;
+	const variants = Array.isArray(jsonSchema.anyOf)
+		? jsonSchema.anyOf
+		: Array.isArray(jsonSchema.oneOf)
+			? jsonSchema.oneOf
+			: [];
+	const objectVariants = variants.filter(
+		(candidate): candidate is Record<string, unknown> =>
+			!!candidate
+			&& typeof candidate === "object"
+			&& !Array.isArray(candidate)
+			&& candidate.type === "object"
+			&& typeof candidate.properties === "object"
+			&& candidate.properties !== null
+			&& !Array.isArray(candidate.properties),
+	);
+
+	if (objectVariants.length === 0) {
+		return {
+			...jsonSchema,
+			type: "object",
+			properties:
+				typeof jsonSchema.properties === "object" && jsonSchema.properties !== null && !Array.isArray(jsonSchema.properties)
+					? jsonSchema.properties
+					: {},
+			required: Array.isArray(jsonSchema.required)
+				? jsonSchema.required.filter((key): key is string => typeof key === "string")
+				: [],
+		};
+	}
+
+	const properties = objectVariants.reduce(
+		(acc: Record<string, unknown>, candidate) => ({
+			...acc,
+			...Object.fromEntries(
+				Object.entries(candidate.properties as Record<string, unknown>).map(([key, value]) => [
+					key,
+					mergePropertySchemas(acc[key], value),
+				]),
+			),
+		}),
+		{},
+	);
+	const required = Array.from(
+		new Set(
+			objectVariants.flatMap((candidate) =>
+				Array.isArray(candidate.required)
+					? candidate.required.filter((key): key is string => typeof key === "string")
+					: [],
+			),
+		),
+	);
+
+	const normalized: Record<string, unknown> = {
+		type: "object",
+		properties,
+	};
+	if (required.length > 0) {
+		normalized.required = required;
+	}
+	return normalized;
 }
 
 /**
@@ -294,7 +430,7 @@ export function convertTools(
 				name: tool.name,
 				description: tool.description,
 				...(useParameters
-					? { parameters: sanitizeSchemaForGoogle(tool.parameters) }
+					? { parameters: sanitizeSchemaForGoogle(normalizeClaudeToolSchemaForGoogle(tool.parameters)) }
 					: { parametersJsonSchema: sanitizeSchemaForGoogle(tool.parameters) }),
 			})),
 		},

--- a/src/resources/extensions/gsd/tests/dist-redirect.mjs
+++ b/src/resources/extensions/gsd/tests/dist-redirect.mjs
@@ -34,7 +34,12 @@ export function resolve(specifier, context, nextResolve) {
   //    Also handles local imports — skip rewrite for dist/ paths that are real compiled artifacts.
 
   else if (specifier.endsWith('.js') && (specifier.startsWith('./') || specifier.startsWith('../'))) {
-    if (context.parentURL && context.parentURL.includes('/src/')) {
+    if (
+      context.parentURL &&
+      context.parentURL.startsWith(ROOT.href) &&
+      !context.parentURL.includes('/node_modules/') &&
+      context.parentURL.includes('/src/')
+    ) {
       if (specifier.includes('/dist/')) {
         specifier = specifier.replace('/dist/', '/src/').replace(/\.js$/, '.ts');
       } else {

--- a/src/resources/extensions/gsd/tests/resolve-ts.mjs
+++ b/src/resources/extensions/gsd/tests/resolve-ts.mjs
@@ -1,5 +1,8 @@
-import { register } from 'node:module';
-import { pathToFileURL } from 'node:url';
+import { registerHooks } from 'node:module';
+import * as distRedirect from './dist-redirect.mjs';
 
 // Register hook to redirect imports to the dist directory
-register(new URL('./dist-redirect.mjs', import.meta.url), pathToFileURL('./'));
+registerHooks({
+  resolve: distRedirect.resolve,
+  load: distRedirect.load,
+});


### PR DESCRIPTION
## TL;DR

**What:** Normalizes Claude tool schemas on the Google Cloud Code Assist provider path and updates the Node 26 test resolver to avoid deprecated loader registration.
**Why:** Cloud Code Assist rejects some richer TypeBox/JSON Schema tool declarations with 400 invalid-argument errors, and the PR verification gate failed under Node 26 due to `module.register()` deprecation handling.
**How:** The Claude/CCA legacy `parameters` route now emits conservative object-root schemas, strips unsupported keywords, converts `const` to typed `enum`, and the GSD test resolver uses `registerHooks()`.

## What

This changes `packages/pi-ai/src/providers/google-shared.ts`, its provider tests, and the GSD test resolver used by the verification-gate test harness.

The Google shared schema sanitizer now removes additional Cloud Code Assist-hostile schema keywords, including closed-object and metadata keywords, and converts all JSON `const` values into typed `enum` values. For Claude models routed through Cloud Code Assist, tool parameters are normalized to an object-root schema before Google receives them.

The resolver used by `src/resources/extensions/gsd/tests/verification-gate.test.ts` now registers synchronous hooks with `module.registerHooks()` instead of the deprecated `module.register()`, and avoids rewriting dependency imports from `node_modules`.

## Why

Closes #106.

Cloud Code Assist can fail Claude tool requests with errors like:

- `tools.6.custom.input_schema: JSON schema is invalid`
- `Cloud Code Assist API error (400): Request contains an invalid argument`

The failure happens because CCA accepts function declarations, then translates them into Anthropic custom tool schemas. Some raw TypeBox/JSON Schema constructs are valid elsewhere but too rich for this translation path.

While preparing the PR, `npm run verify:pr` also exposed a Node 26-only failure in the test harness: `module.register()` emits a deprecation warning that becomes fatal under `--throw-deprecation`. Updating the resolver makes the existing deprecation regression test meaningful again on Node 26.

## How

The implementation keeps the richer `parametersJsonSchema` path for normal Gemini tool declarations. It only applies the stricter normalization when the Google provider is using the legacy `parameters` field for Claude models.

Key pieces:

- Force Claude/CCA tool schemas to an object-root parameter shape.
- Collapse top-level `anyOf`/`oneOf` object variants into merged properties and required keys.
- Merge repeated literal property schemas into a typed enum instead of letting the last variant win.
- Strip unsupported keywords such as `patternProperties`, `$schema`, `$id`, `unevaluatedProperties`, `additionalProperties: false`, and empty `required` arrays.
- Register the GSD test resolver with `module.registerHooks()` and fence source import rewrites away from `node_modules`.
- Add regression tests for sanitizer behavior and Claude/CCA conversion.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Testing

- [x] `npm run verify:fast`
- [x] `npm run build -w @gsd/pi-ai`
- [x] `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/packages/pi-ai/src/providers/google-shared.test.js dist-test/packages/pi-ai/src/providers/google-gemini-cli.test.js dist-test/packages/pi-ai/src/providers/anthropic-shared.test.js`
- [x] `node --experimental-strip-types --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/verification-gate.test.ts --test-name-pattern "no DEP0190"`
- [x] `npm run verify:pr`

## Breaking changes

None.

## AI assistance

This PR is AI-assisted. The generated code was inspected locally and tested with focused provider coverage plus the repository PR verification gate.
