### PR TITLE
fix(issue): [Bug]: Don't touch GIT

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -107,6 +107,12 @@ const MAX_VERIFICATION_RETRIES = 3;
 const MAX_NOTIFICATION_DETAILS = 3;
 const NOTIFICATION_BULLET = "•";
 
+export function resolveCloseoutGitAction(
+  uokFlags: ReturnType<typeof resolveUokFlags>,
+): TurnGitActionMode | null {
+  return uokFlags.gitops ? uokFlags.gitopsTurnAction : null;
+}
+
 function agentEndMessagesIncludeToolCall(messages: unknown[] | undefined, toolName: string): boolean {
   if (!Array.isArray(messages)) return false;
   for (const message of messages) {
@@ -848,6 +854,12 @@ export async function autoCommitUnit(
   ctx?: ExtensionContext,
 ): Promise<string | null> {
   try {
+    const prefs = loadEffectiveGSDPreferences()?.preferences;
+    const uokFlags = resolveUokFlags(prefs);
+    if (!uokFlags.gitops) {
+      return null;
+    }
+
     let taskContext: TaskCommitContext | undefined;
 
     if (unitType === "execute-task") {
@@ -887,12 +899,22 @@ async function runCloseoutGitAction(
   const { s, ctx, pi, pauseAuto } = pctx;
   const prefs = loadEffectiveGSDPreferences()?.preferences;
   const uokFlags = resolveUokFlags(prefs);
-  const turnAction: TurnGitActionMode = uokFlags.gitops ? uokFlags.gitopsTurnAction : "commit";
+  const turnAction = resolveCloseoutGitAction(uokFlags);
   const traceId = s.currentTraceId ?? `turn:${unit.startedAt}`;
   const turnId = s.currentTurnId ?? `${unit.type}/${unit.id}/${unit.startedAt}`;
 
   s.lastGitActionFailure = null;
   s.lastGitActionStatus = null;
+
+  if (!turnAction) {
+    debugLog("postUnit", {
+      phase: "git-action-skipped",
+      reason: "gitops-disabled",
+      unitType: unit.type,
+      unitId: unit.id,
+    });
+    return "continue";
+  }
 
   try {
     let taskContext: TaskCommitContext | undefined;

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -18,6 +18,7 @@ import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { logWarning } from "./workflow-logger.js";
 import { createRepositoryRegistryFromPreferences } from "./repository-registry.js";
+import { isGsdGitignored } from "./gitignore.js";
 
 
 import {
@@ -778,7 +779,11 @@ export class GitServiceImpl {
     //
     // If .gsd/ IS in .gitignore (the default for external state projects),
     // git add -A already skips it and the exclusions are harmless no-ops.
-    const allExclusions = [...RUNTIME_EXCLUSION_PATHS, ...extraExclusions];
+    const allExclusions = [
+      ...RUNTIME_EXCLUSION_PATHS,
+      ...(isGsdGitignored(this.basePath) ? [".gsd/**"] : []),
+      ...extraExclusions,
+    ];
 
     // ── Parallel worker milestone scope (#1991) ──
     // When GSD_MILESTONE_LOCK is set, this process is a parallel worker that
@@ -812,7 +817,11 @@ export class GitServiceImpl {
     const keyFiles = taskContext.keyFiles ?? [];
     if (keyFiles.length === 0) return false;
 
-    const allExclusions = [...RUNTIME_EXCLUSION_PATHS, ...extraExclusions];
+    const allExclusions = [
+      ...RUNTIME_EXCLUSION_PATHS,
+      ...(isGsdGitignored(this.basePath) ? [".gsd/**"] : []),
+      ...extraExclusions,
+    ];
     const normalized = keyFiles
       .map(file => normalizeRepoRelativePath(this.basePath, file))
       .filter((file): file is string => file !== null)

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -110,9 +110,10 @@ const BASELINE_PATTERNS = [
 /**
  * Check whether `.gsd` is covered by the project's `.gitignore`.
  *
- * Uses `git check-ignore` for accurate evaluation — this respects nested
- * .gitignore files, global gitignore, and negation patterns. Returns true
- * only when git would actually ignore `.gsd/`.
+ * Uses `git check-ignore --no-index` for accurate evaluation — this respects
+ * nested .gitignore files, global gitignore, and negation patterns, even when
+ * `.gsd` files were already tracked before the ignore rule was added. Returns
+ * true only when git would actually ignore `.gsd/`.
  *
  * Returns false (not ignored) if:
  *   - No `.gitignore` exists
@@ -126,7 +127,7 @@ export function isGsdGitignored(basePath: string): boolean {
   for (const path of [".gsd", ".gsd/"]) {
     try {
       // git check-ignore exits 0 when the path IS ignored, 1 when it is NOT.
-      execFileSync("git", ["check-ignore", "-q", path], {
+      execFileSync("git", ["check-ignore", "--no-index", "-q", path], {
         cwd: basePath,
         stdio: "pipe",
         env: GIT_NO_PROMPT_ENV,

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -17,6 +17,7 @@ import { gsdRoot } from "./paths.js";
 import { GitServiceImpl, runGit } from "./git-service.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { nativeHasStagedChanges } from "./native-git-bridge.js";
+import { resolveUokFlags } from "./uok/flags.js";
 
 interface QuickReturnState {
   basePath: string;
@@ -158,6 +159,11 @@ function hasStagedChanges(basePath: string): boolean {
   return nativeHasStagedChanges(basePath);
 }
 
+function isGitOpsEnabled(): boolean {
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+  return resolveUokFlags(prefs).gitops;
+}
+
 export function cleanupQuickBranch(basePath = process.cwd()): boolean {
   const state = readPendingReturn(basePath);
   if (!state) return false;
@@ -165,6 +171,10 @@ export function cleanupQuickBranch(basePath = process.cwd()): boolean {
   const repoPath = state.basePath;
   const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
   const git = new GitServiceImpl(repoPath, gitPrefs);
+  if (!isGitOpsEnabled()) {
+    clearPendingReturn(repoPath);
+    return false;
+  }
 
   if (git.getCurrentBranch() === state.quickBranch) {
     try {
@@ -233,7 +243,7 @@ export async function handleQuick(
   let originalBranch = git.getCurrentBranch();
 
   const { getIsolationMode } = await import("./preferences.js");
-  const usesBranch = getIsolationMode() !== "none";
+  const usesBranch = getIsolationMode() !== "none" && isGitOpsEnabled();
 
   let branchCreated = false;
   if (usesBranch) {
@@ -242,7 +252,9 @@ export async function handleQuick(
       if (current !== branchName) {
         // Auto-commit any dirty state before switching
         try {
-          git.autoCommit("quick-task", `Q${taskNum}`, []);
+          if (isGitOpsEnabled()) {
+            git.autoCommit("quick-task", `Q${taskNum}`, []);
+          }
         } catch { /* nothing to commit — fine */ }
 
         runGit(basePath, ["checkout", "-b", branchName]);

--- a/src/resources/extensions/gsd/tests/integration/gitignore-staging-2570.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/gitignore-staging-2570.test.ts
@@ -148,3 +148,33 @@ test("smartStage does not stage .gsd/ files when .gsd is gitignored (#2570)", as
     `gitignored .gsd/ files must NOT be staged by smartStage.\nCommitted files: ${committed}`,
   );
 });
+
+test("smartStage does not update already tracked .gsd/ files when .gsd is gitignored", async (t) => {
+  const { GitServiceImpl } = await import("../../git-service.ts");
+
+  const dir = makeTempRepo();
+  t.after(() => { cleanup(dir); });
+
+  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(dir, ".gsd", "milestones", "M001", "PLAN.md"), "tracked plan v1\n");
+  git(dir, "add", ".gsd/milestones/M001/PLAN.md");
+  git(dir, "commit", "-m", "track gsd plan");
+
+  writeFileSync(join(dir, ".gitignore"), ".gsd\n");
+  git(dir, "add", ".gitignore");
+  git(dir, "commit", "-m", "ignore gsd");
+
+  writeFileSync(join(dir, ".gsd", "milestones", "M001", "PLAN.md"), "tracked plan v2\n");
+  writeFileSync(join(dir, "src.ts"), "export const y = 2;\n");
+
+  const svc = new GitServiceImpl(dir);
+  const msg = svc.commit({ message: "test: respect ignored tracked gsd" });
+  assert.ok(msg !== null, "commit should include non-gsd source changes");
+
+  const committed = git(dir, "show", "--name-only", "HEAD");
+  assert.ok(committed.includes("src.ts"), "source files ARE committed");
+  assert.ok(
+    !committed.includes(".gsd/"),
+    `tracked gitignored .gsd/ files must NOT be staged by smartStage.\nCommitted files: ${committed}`,
+  );
+});

--- a/src/resources/extensions/gsd/tests/uok-gitops-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-wiring.test.ts
@@ -13,6 +13,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { resolveCloseoutGitAction } from "../auto-post-unit.ts";
 import { resolveUokFlags } from "../uok/flags.ts";
 
 test("turn action defaults to commit when uok.gitops is enabled with no override", () => {
@@ -55,4 +56,12 @@ test("gitops disabled when uok.gitops.enabled is explicitly false", () => {
   assert.equal(flags.gitops, false);
   // Turn_action is still surfaced so callers can read their policy cleanly.
   assert.equal(flags.gitopsTurnAction, "snapshot");
+});
+
+test("closeout git action is skipped when uok gitops is disabled", () => {
+  const flags = resolveUokFlags({
+    uok: { gitops: { enabled: false, turn_action: "commit" } },
+  } as any);
+
+  assert.equal(resolveCloseoutGitAction(flags), null);
 });


### PR DESCRIPTION
## Summary
- Fixed disabled-GitOps commit paths and gitignored `.gsd` staging, with focused tests and extension typecheck verified.

## Bugs Addressed
- [x] **GitOps disabled still creates commits**
- [x] **Generated files ignore .gitignore rules**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #110
- [#110 [Bug]: Don't touch GIT](https://github.com/open-gsd/gsd-pi/issues/110)

## User
- @denis-susan

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/110-bug-don-t-touch-git-1779713518`