### PR TITLE
fix: dereference symlinks when resolving workflow CLI path (#74)

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -3,7 +3,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -187,6 +187,44 @@ test("detectWorkflowMcpLaunchConfig resolves the bundled server from GSD_BIN_PAT
   assert.equal(launch?.env?.GSD_WORKFLOW_PROJECT_ROOT, worktreeRoot);
   assert.match(launch?.env?.GSD_WORKFLOW_EXECUTORS_MODULE ?? "", /workflow-tool-executors\.(js|ts)$/);
   assert.match(launch?.env?.GSD_WORKFLOW_WRITE_GATE_MODULE ?? "", /write-gate\.(js|ts)$/);
+});
+
+test("detectWorkflowMcpLaunchConfig resolves the bundled server from a symlinked GSD_BIN_PATH", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-symlink-root-"));
+  const binDir = mkdtempSync(join(tmpdir(), "gsd-workflow-symlink-bin-"));
+  const worktreeRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-symlink-wt-"));
+  const cliPath = join(repoRoot, "packages", "mcp-server", "dist", "cli.js");
+  const devCliPath = join(repoRoot, "scripts", "dev-cli.js");
+  const symlinkPath = join(binDir, "gsd");
+
+  mkdirSync(join(repoRoot, "packages", "mcp-server", "dist"), { recursive: true });
+  mkdirSync(join(repoRoot, "scripts"), { recursive: true });
+  writeFileSync(cliPath, "#!/usr/bin/env node\n", "utf-8");
+  writeFileSync(devCliPath, "#!/usr/bin/env node\n", "utf-8");
+  symlinkSync(devCliPath, symlinkPath);
+
+  try {
+    const launch = detectWorkflowMcpLaunchConfig(worktreeRoot, {
+      GSD_BIN_PATH: symlinkPath,
+    });
+
+    assert.ok(launch, "expected a launch config when GSD_BIN_PATH is a symlink");
+    assert.deepEqual(launch, {
+      name: "gsd-workflow",
+      command: process.execPath,
+      args: [cliPath],
+      cwd: worktreeRoot,
+      env: launch?.env,
+    });
+    assert.equal(launch?.env?.GSD_CLI_PATH, symlinkPath);
+    assert.equal(launch?.env?.GSD_BIN_PATH, symlinkPath);
+    assert.equal(launch?.env?.GSD_PERSIST_WRITE_GATE_STATE, "1");
+    assert.equal(launch?.env?.GSD_WORKFLOW_PROJECT_ROOT, worktreeRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
+    rmSync(worktreeRoot, { recursive: true, force: true });
+  }
 });
 
 test("detectWorkflowMcpLaunchConfig resolves the bundled server relative to the installed GSD package", () => {

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -92,7 +92,12 @@ function lookupCommand(command: string, platform: NodeJS.Platform = process.plat
 }
 
 function findWorkflowCliFromAncestorPath(startPath: string): string | null {
-  let current = resolve(startPath);
+  let current: string;
+  try {
+    current = realpathSync(resolve(startPath));
+  } catch {
+    current = resolve(startPath);
+  }
 
   while (true) {
     const candidate = resolve(current, "packages", "mcp-server", "dist", "cli.js");


### PR DESCRIPTION
Fixes #74

## Problem

`findWorkflowCliFromAncestorPath` used `resolve()` to compute the starting
path, but `resolve()` does not dereference symlinks. When `GSD_BIN_PATH` (or
the script's own path) points through a symlink — common in global npm/pnpm
installs, nix, Homebrew, or `npm link` dev setups — the ancestor traversal
starts in the wrong directory and never finds `packages/mcp-server/dist/cli.js`,
causing the workflow MCP server to fail silently.

## Fix

Wrap the initial `resolve()` call in `realpathSync()` so the traversal starts
at the real filesystem path. A `try/catch` fallback preserves the original
behaviour if `realpathSync` fails (e.g. dangling symlink).

```ts
try {
  current = realpathSync(resolve(startPath));
} catch {
  current = resolve(startPath);
}
```

## Testing

Added a regression test in `workflow-mcp.test.ts` that creates a temp directory
with a symlinked `GSD_BIN_PATH` and verifies the CLI resolves correctly. All 29
tests pass.