### PR TITLE
Gate Codex code review behind maintainer label

### DIFF
--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1,29 +1,72 @@
 name: Codex Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   code-review:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event.label.name == 'codex-review'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
+      - name: Check requester permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const username = context.actor;
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username,
+            });
+
+            const allowed = new Set(["admin", "maintain", "write"]);
+            if (!allowed.has(data.permission)) {
+              core.setFailed(
+                `@${username} cannot run Codex review: expected write, maintain, or admin; got ${data.permission}.`,
+              );
+            }
+
       - uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
-      - uses: openai/codex-action@v1
+      - id: codex-review
+        uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5
+          sandbox: read-only
           prompt: |
-            Review this pull request. Focus on:
+            This is pull request #${{ github.event.pull_request.number }} for ${{ github.repository }}.
+            Review only the changes introduced by this pull request.
+            Do not modify files, install dependencies, or run project code. Inspect the diff and source only.
+
+            Focus on:
             - Code correctness and potential bugs
             - Security issues
             - Performance concerns
             - Code style and readability
-            Post your review as GitHub PR review comments.
+
+            Return a concise Markdown review. Start with "## Codex Code Review".
+            If there are no findings, say so clearly.
+
+      - name: Post Codex review
+        if: steps.codex-review.outputs.final-message != ''
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE: ${{ steps.codex-review.outputs.final-message }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: process.env.CODEX_FINAL_MESSAGE,
+            });


### PR DESCRIPTION
## Summary
- run Codex code review only when a maintainer adds the `codex-review` label
- verify the triggering actor has write, maintain, or admin permission before secrets are used
- run Codex in read-only mode and post its final review through a trusted GitHub Script step

## Validation
- `node --test scripts/__tests__/github-workflows-runner-contract.test.mjs`
- `git diff --check`

Also created the `codex-review` repository label so maintainers can trigger the workflow after this lands.