### PR TITLE
fix(compaction): preserve history on empty summaries

### DIFF
--- a/packages/pi-coding-agent/src/core/compaction-orchestrator.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction-orchestrator.test.ts
@@ -57,6 +57,8 @@ function createHarness(overrides?: {
 	cancelResult?: boolean;
 	willRetry?: boolean;
 	hasQueuedMessages?: boolean;
+	keepRecentTokens?: number;
+	thresholdPercent?: number;
 }) {
 	const dir = mkdtempSync(join(tmpdir(), "compaction-orchestrator-test-"));
 	const sessionManager = SessionManager.create(dir, dir);
@@ -81,7 +83,10 @@ function createHarness(overrides?: {
 		hasQueuedMessages: () => overrides?.hasQueuedMessages ?? false,
 	} as unknown as Agent;
 
-	const extensionRunner = {
+	const extensionRunner: {
+		hasHandlers: ReturnType<typeof mock.fn>;
+		emit: ReturnType<typeof mock.fn>;
+	} = {
 		hasHandlers: mock.fn(() => true),
 		emit: mock.fn(async () => ({ cancel: overrides?.cancelResult ?? true })),
 	};
@@ -93,7 +98,8 @@ function createHarness(overrides?: {
 			getCompactionSettings: () => ({
 				enabled: true,
 				reserveTokens: 16_384,
-				keepRecentTokens: 1,
+				keepRecentTokens: overrides?.keepRecentTokens ?? 1,
+				thresholdPercent: overrides?.thresholdPercent,
 			}),
 		} as any,
 		modelRegistry: {
@@ -112,6 +118,7 @@ function createHarness(overrides?: {
 	return {
 		dir,
 		agent,
+		sessionManager,
 		continueFn,
 		replaceMessages,
 		emittedEvents,
@@ -150,5 +157,71 @@ describe("CompactionOrchestrator", () => {
 		assert.equal(endEvent?.willRetry, false, "threshold cancel should stay non-retrying");
 		assert.equal(harness.continueFn.mock.callCount(), 0, "threshold cancel should not resume the agent without queued work");
 		assert.equal(harness.replaceMessages.mock.callCount(), 0, "non-retry cancel should not trim messages");
+	});
+
+	it("(#109) empty prepared input aborts before session_before_compact hooks", async (t) => {
+		const harness = createHarness({ keepRecentTokens: 1_000_000 });
+		t.after(harness.cleanup);
+		const before = harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length;
+
+		await (harness.orchestrator as any)._runAutoCompaction("threshold", false);
+
+		assert.equal(harness.extensionRunner.emit.mock.callCount(), 0, "invalid compaction must not reach hooks");
+		assert.equal(
+			harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length,
+			before,
+			"invalid compaction must not append a compaction entry",
+		);
+		const endEvent = harness.emittedEvents.find((event) => event.type === "auto_compaction_end");
+		assert.match(String(endEvent?.errorMessage), /history preserved as-is/);
+	});
+
+	it("(#109) degenerate extension summaries abort without appending compaction", async (t) => {
+		const harness = createHarness();
+		t.after(harness.cleanup);
+		const firstKeptEntryId = harness.sessionManager.getBranch()[0]?.id;
+		assert.ok(firstKeptEntryId, "test session should have an entry id");
+		harness.extensionRunner.emit.mock.mockImplementation(async () => ({
+			compaction: {
+				summary:
+					"The conversation block you've handed me is empty: there's nothing between the <conversation> tags to summarize.",
+				firstKeptEntryId,
+				tokensBefore: 123,
+			},
+		}));
+		const before = harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length;
+
+		await (harness.orchestrator as any)._runAutoCompaction("threshold", false);
+
+		assert.equal(
+			harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length,
+			before,
+			"degenerate extension compaction must not be committed",
+		);
+		const endEvent = harness.emittedEvents.find((event) => event.type === "auto_compaction_end");
+		assert.match(String(endEvent?.errorMessage), /history preserved as-is/);
+	});
+
+	it("(#109) cumulative totalTokens alone does not trigger threshold compaction", async (t) => {
+		const harness = createHarness({ thresholdPercent: 0.6 });
+		t.after(harness.cleanup);
+		const assistant = createAssistantMessage("stop", "small live prompt");
+		assistant.usage = {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 4_623_740,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		await harness.orchestrator.checkCompaction(assistant);
+
+		assert.equal(
+			harness.emittedEvents.some((event) => event.type === "auto_compaction_start"),
+			false,
+			"huge cumulative totalTokens must not drive threshold compaction",
+		);
+		assert.equal(harness.extensionRunner.emit.mock.callCount(), 0);
 	});
 });

--- a/packages/pi-coding-agent/src/core/compaction-orchestrator.ts
+++ b/packages/pi-coding-agent/src/core/compaction-orchestrator.ts
@@ -14,10 +14,13 @@ import type { AssistantMessage, Model } from "@gsd/pi-ai";
 import { isContextOverflow } from "@gsd/pi-ai";
 import {
 	type CompactionResult,
+	type CompactionPreparation,
+	CompactionInvalidInputError,
 	CompactionProducedNoSummaryError,
 	calculateContextTokens,
 	compact,
 	estimateContextTokens,
+	isDegenerateSummary,
 	prepareCompaction,
 	shouldCompact,
 } from "./compaction/index.js";
@@ -42,6 +45,20 @@ export interface CompactionOrchestratorDeps {
 	disconnectFromAgent: () => void;
 	reconnectToAgent: () => void;
 	abort: () => Promise<void>;
+}
+
+function assertValidCompactionInput(preparation: CompactionPreparation): void {
+	if (preparation.messagesToSummarize.length === 0 && preparation.turnPrefixMessages.length === 0) {
+		throw new CompactionInvalidInputError();
+	}
+}
+
+function assertValidCompactionResult(result: CompactionResult): void {
+	if (isDegenerateSummary(result.summary)) {
+		throw new CompactionProducedNoSummaryError(
+			"Compaction produced no usable summary; session history preserved as-is.",
+		);
+	}
 }
 
 export class CompactionOrchestrator {
@@ -112,6 +129,7 @@ export class CompactionOrchestrator {
 				}
 				throw new Error("Nothing to compact (session too small)");
 			}
+			assertValidCompactionInput(preparation);
 
 			let extensionCompaction: CompactionResult | undefined;
 			let fromExtension = false;
@@ -159,6 +177,7 @@ export class CompactionOrchestrator {
 				tokensBefore = result.tokensBefore;
 				details = result.details;
 			}
+			assertValidCompactionResult({ summary, firstKeptEntryId, tokensBefore, details });
 
 			if (this._compactionAbortController.signal.aborted) {
 				throw new Error("Compaction cancelled");
@@ -314,6 +333,7 @@ export class CompactionOrchestrator {
 				this._deps.emit({ type: "auto_compaction_end", result: undefined, aborted: false, willRetry: false });
 				return;
 			}
+			assertValidCompactionInput(preparation);
 
 			let extensionCompaction: CompactionResult | undefined;
 			let fromExtension = false;
@@ -368,6 +388,7 @@ export class CompactionOrchestrator {
 				tokensBefore = compactResult.tokensBefore;
 				details = compactResult.details;
 			}
+			assertValidCompactionResult({ summary, firstKeptEntryId, tokensBefore, details });
 
 			if (this._autoCompactionAbortController.signal.aborted) {
 				this._deps.emit({ type: "auto_compaction_end", result: undefined, aborted: true, willRetry: false });
@@ -399,7 +420,7 @@ export class CompactionOrchestrator {
 			// can surface a clearer message than a generic compaction failure.
 			// Either way we drop the would-be compaction entry rather than writing
 			// an empty string to the session history.
-			const errorMessage = error instanceof CompactionProducedNoSummaryError
+			const errorMessage = error instanceof CompactionProducedNoSummaryError || error instanceof CompactionInvalidInputError
 				? `Compaction produced no usable summary — session history preserved as-is. (${error.message})`
 				: getErrorMessage(error);
 			this._deps.emit({

--- a/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
@@ -10,12 +10,15 @@ import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { Model, AssistantMessage } from "@gsd/pi-ai";
 
 import {
+	compact,
 	generateSummary,
 	estimateTokens,
 	chunkMessages,
 	isDegenerateSummary,
+	CompactionInvalidInputError,
 	CompactionProducedNoSummaryError,
 	calculateContextTokens,
+	type CompactionPreparation,
 } from "./compaction.js";
 import { estimateSerializedTokens } from "./utils.js";
 
@@ -376,10 +379,54 @@ describe("(#4665) degenerate summary guard", () => {
 		);
 		assert.equal(
 			isDegenerateSummary(
+				"The conversation block you've handed me is empty: there's nothing between the <conversation> tags to summarize.",
+			),
+			true,
+			"known issue #109 refusal is degenerate",
+		);
+		assert.equal(
+			isDegenerateSummary(
 				"## Goal\nRefactor the compaction pipeline.\n## Done\n- Updated utils.ts\n- Added tests for #4665 regression path",
 			),
 			false,
 			"a real multi-section summary over 100 chars is not degenerate",
+		);
+	});
+
+	it("(#109) compact refuses empty prepared input before summarization", async () => {
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "entry-1",
+			messagesToSummarize: [],
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 42,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
+		};
+
+		await assert.rejects(
+			() => compact(preparation, makeModel(200_000), undefined),
+			(err: unknown) => err instanceof CompactionInvalidInputError,
+		);
+	});
+
+	it("(#109) compact refuses degenerate single-pass summaries", async () => {
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "entry-2",
+			messagesToSummarize: [makeUserMessage(10)],
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
+		};
+		const refusal =
+			"The conversation block you've handed me is empty: there's nothing between the <conversation> tags to summarize.";
+		const complete = mock.fn(async () => makeFakeResponse(refusal));
+
+		await assert.rejects(
+			() => compact(preparation, makeModel(200_000), undefined, undefined, undefined, complete as any),
+			(err: unknown) => err instanceof CompactionProducedNoSummaryError,
 		);
 	});
 

--- a/packages/pi-coding-agent/src/core/compaction/compaction.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.ts
@@ -575,6 +575,8 @@ export function isDegenerateSummary(summary: string | undefined): boolean {
 	if (summary === undefined) return false;
 	const lower = summary.toLowerCase();
 	if (lower.includes("empty conversation")) return true;
+	if (lower.includes("conversation block") && lower.includes("empty")) return true;
+	if (lower.includes("nothing between") && lower.includes("conversation")) return true;
 	if (lower.includes("no conversation to summarize")) return true;
 	if (lower.includes("no messages to summarize")) return true;
 	// Length guard: any summary shorter than 100 chars is almost certainly
@@ -717,6 +719,13 @@ export class CompactionProducedNoSummaryError extends Error {
 	constructor(message: string) {
 		super(message);
 		this.name = "CompactionProducedNoSummaryError";
+	}
+}
+
+export class CompactionInvalidInputError extends Error {
+	constructor(message = "Compaction input had no conversation history to summarize; session history preserved as-is.") {
+		super(message);
+		this.name = "CompactionInvalidInputError";
 	}
 }
 
@@ -895,6 +904,7 @@ export async function compact(
 	apiKey: string | undefined,
 	customInstructions?: string,
 	signal?: AbortSignal,
+	_completeFn?: CompleteFn,
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -906,6 +916,10 @@ export async function compact(
 		fileOps,
 		settings,
 	} = preparation;
+
+	if (messagesToSummarize.length === 0 && turnPrefixMessages.length === 0) {
+		throw new CompactionInvalidInputError();
+	}
 
 	// Generate summaries (can be parallel if both needed) and merge into one
 	let summary: string;
@@ -922,6 +936,7 @@ export async function compact(
 						signal,
 						customInstructions,
 						previousSummary,
+						_completeFn,
 					)
 				: Promise.resolve("No prior history."),
 			generateTurnPrefixSummary(turnPrefixMessages, model, settings.reserveTokens, apiKey, signal),
@@ -938,6 +953,13 @@ export async function compact(
 			signal,
 			customInstructions,
 			previousSummary,
+			_completeFn,
+		);
+	}
+
+	if (isDegenerateSummary(summary)) {
+		throw new CompactionProducedNoSummaryError(
+			"Compaction produced no usable summary; session history preserved as-is.",
 		);
 	}
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -652,11 +652,20 @@ export function registerHooks(
     }
   });
 
-  pi.on("session_before_compact", async (_event, ctx) => {
+  pi.on("session_before_compact", async (event, ctx) => {
     const basePath = contextBasePath(ctx);
     // Context Mode is default-on. Write the resumable snapshot before any
     // active-auto cancel return so auto sessions still leave re-entry context.
     await writeContextModeCompactionSnapshot(basePath);
+
+    const prep = event?.preparation;
+    if (prep && prep.messagesToSummarize?.length === 0 && prep.turnPrefixMessages?.length === 0) {
+      ctx.ui.notify(
+        "Skipped compaction because there was no conversation history to summarize; history preserved.",
+        "warning",
+      );
+      return { cancel: true };
+    }
 
     // Only cancel compaction while auto-mode is actively running.
     // Paused auto-mode should allow compaction — the user may be doing

--- a/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
@@ -88,4 +88,42 @@ describe('register-hooks session_before_compact (#3696)', () => {
       _setAutoActiveForTest(false);
     }
   });
+
+  test('registered hook cancels empty compaction input defensively (#109)', async () => {
+    const handlers = new Map<string, Function>();
+    registerHooks({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as any, []);
+
+    const compact = handlers.get('session_before_compact');
+    assert.ok(compact, 'session_before_compact hook should be registered');
+    const notifications: string[] = [];
+    const base = mkdtempSync(join(tmpdir(), 'gsd-compact-empty-'));
+    try {
+      const result = await compact(
+        {
+          preparation: {
+            messagesToSummarize: [],
+            turnPrefixMessages: [],
+          },
+        },
+        {
+          cwd: base,
+          ui: {
+            notify(message: string) {
+              notifications.push(message);
+            },
+            setWidget() {},
+          },
+        },
+      );
+
+      assert.deepEqual(result, { cancel: true });
+      assert.match(notifications.join('\n'), /history preserved/);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #109 by making compaction fail closed when it would otherwise discard history with no usable summary.

- reject compaction preparations with no `messagesToSummarize` and no `turnPrefixMessages`
- reject degenerate/refusal-shaped summaries before appending compaction entries
- apply the commit-time guard to both core-generated and extension-provided compactions
- add a GSD hook defense-in-depth cancel for empty compaction input
- pin trigger behavior so cumulative `totalTokens` alone cannot drive threshold compaction

## Verification

- `NODE_PATH=/Users/jeremymcspadden/github/open-gsd/gsd-pi/node_modules node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/compaction/compaction.test.ts packages/pi-coding-agent/src/core/compaction-orchestrator.test.ts src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts`
- `npm run -s typecheck:extensions`
- `npx tsc --noEmit --project packages/pi-coding-agent/tsconfig.json`
- `git diff --check`
