### PR TITLE
fix: answer headless approval gates

### DIFF
--- a/src/headless-answers.ts
+++ b/src/headless-answers.ts
@@ -33,6 +33,34 @@ export interface AnswerInjectorStats {
   secretsProvided: number
 }
 
+export function normalizeQuestionId(id: string): string {
+  return id.trim().toLowerCase().replace(/[-\s]+/g, '_').replace(/_confirm$/, '')
+}
+
+export function findConfiguredQuestionAnswer(
+  questions: Record<string, string | string[]> | undefined,
+  questionId: string,
+): { key: string; answer: string | string[] } | undefined {
+  if (!questions) return undefined
+  const normalizedQuestionId = normalizeQuestionId(questionId)
+
+  for (const [key, answer] of Object.entries(questions)) {
+    if (normalizeQuestionId(key) === normalizedQuestionId) return { key, answer }
+  }
+
+  for (const [key, answer] of Object.entries(questions)) {
+    const normalizedKey = normalizeQuestionId(key)
+    if (
+      normalizedQuestionId.startsWith(`${normalizedKey}_`) ||
+      normalizedKey.startsWith(`${normalizedQuestionId}_`)
+    ) {
+      return { key, answer }
+    }
+  }
+
+  return undefined
+}
+
 // ---------------------------------------------------------------------------
 // Answer File Loader
 // ---------------------------------------------------------------------------
@@ -241,10 +269,11 @@ export class AnswerInjector {
     const meta = this.questionMetaByTitle.get(title)
     if (!meta) return false
 
-    const answer = this.answerFile.questions?.[meta.id]
+    const matchedAnswer = findConfiguredQuestionAnswer(this.answerFile.questions, meta.id)
+    const answer = matchedAnswer?.answer
     const eventOptions = event.options as string[] | undefined
 
-    if (answer !== undefined) {
+    if (matchedAnswer && answer !== undefined) {
       if (meta.allowMultiple) {
         // Multi-select: answer must be an array
         const values = Array.isArray(answer) ? answer : [answer]
@@ -252,7 +281,7 @@ export class AnswerInjector {
         if (valid) {
           const response = { type: 'extension_ui_response', id: event.id, values }
           writeToStdin(serializeJsonLine(response))
-          this.usedQuestionIds.add(meta.id)
+          this.usedQuestionIds.add(matchedAnswer.key)
           this.stats.questionsAnswered++
           return true
         }
@@ -262,7 +291,7 @@ export class AnswerInjector {
         if (eventOptions?.includes(value)) {
           const response = { type: 'extension_ui_response', id: event.id, value }
           writeToStdin(serializeJsonLine(response))
-          this.usedQuestionIds.add(meta.id)
+          this.usedQuestionIds.add(matchedAnswer.key)
           this.stats.questionsAnswered++
           return true
         }

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -311,9 +311,11 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Load answer injection file
   let injector: AnswerInjector | undefined
+  let answerFilePath: string | undefined
   if (options.answers) {
     try {
-      const answerFile = loadAndValidateAnswerFile(resolve(options.answers))
+      answerFilePath = resolve(options.answers)
+      const answerFile = loadAndValidateAnswerFile(answerFilePath)
       injector = new AnswerInjector(answerFile)
       if (!options.json) {
         process.stderr.write(`[headless] Loaded answer file: ${options.answers}\n`)
@@ -431,6 +433,9 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   }
   // Signal headless mode to the GSD extension (skips UAT human pause, etc.)
   clientOptions.env = { ...(clientOptions.env as Record<string, string> || {}), GSD_HEADLESS: '1' }
+  if (answerFilePath) {
+    clientOptions.env = { ...(clientOptions.env as Record<string, string> || {}), GSD_HEADLESS_ANSWERS_PATH: answerFilePath }
+  }
   // Propagate --bare to the child process
   if (options.bare) {
     clientOptions.args = [...((clientOptions.args as string[]) || []), '--bare']

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -130,6 +130,11 @@ interface ParsedElicitationQuestion extends Question {
 	noteFieldId?: string;
 }
 
+interface HeadlessAnswersFile {
+	questions?: Record<string, string | string[]>;
+	defaults?: { strategy?: "first_option" | "cancel" };
+}
+
 /** Descriptor for a single free-text input field parsed from an SDK elicitation form schema. */
 interface ParsedTextInputField {
 	id: string;
@@ -501,6 +506,99 @@ function readElicitationChoices(options: SdkElicitationRequestOption[] | undefin
 	return options
 		.map((option) => (typeof option?.const === "string" ? option.const : typeof option?.title === "string" ? option.title : ""))
 		.filter((option): option is string => option.length > 0);
+}
+
+let cachedHeadlessAnswersPath: string | undefined;
+let cachedHeadlessAnswers: HeadlessAnswersFile | null | undefined;
+
+function loadHeadlessAnswers(env: NodeJS.ProcessEnv = process.env): HeadlessAnswersFile | null {
+	const filePath = env.GSD_HEADLESS_ANSWERS_PATH?.trim();
+	if (!filePath) return null;
+	if (cachedHeadlessAnswersPath === filePath) return cachedHeadlessAnswers ?? null;
+
+	cachedHeadlessAnswersPath = filePath;
+	cachedHeadlessAnswers = null;
+	try {
+		const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		cachedHeadlessAnswers = parsed as HeadlessAnswersFile;
+		return cachedHeadlessAnswers;
+	} catch {
+		return null;
+	}
+}
+
+function normalizeHeadlessQuestionId(id: string): string {
+	return id.trim().toLowerCase().replace(/[-\s]+/g, "_").replace(/_confirm$/, "");
+}
+
+function findHeadlessAnswer(
+	answers: Record<string, string | string[]> | undefined,
+	questionId: string,
+): string | string[] | undefined {
+	if (!answers) return undefined;
+	const normalizedQuestionId = normalizeHeadlessQuestionId(questionId);
+
+	for (const [key, answer] of Object.entries(answers)) {
+		if (normalizeHeadlessQuestionId(key) === normalizedQuestionId) return answer;
+	}
+
+	for (const [key, answer] of Object.entries(answers)) {
+		const normalizedKey = normalizeHeadlessQuestionId(key);
+		if (normalizedQuestionId.startsWith(`${normalizedKey}_`) || normalizedKey.startsWith(`${normalizedQuestionId}_`)) {
+			return answer;
+		}
+	}
+
+	return undefined;
+}
+
+function answerValueForQuestion(
+	question: ParsedElicitationQuestion,
+	answers: HeadlessAnswersFile,
+): string | string[] | undefined {
+	const explicit = findHeadlessAnswer(answers.questions, question.id);
+	if (explicit !== undefined) return explicit;
+
+	const strategy = answers.defaults?.strategy ?? "first_option";
+	if (strategy === "cancel") return undefined;
+	return question.allowMultiple ? [question.options[0]?.label ?? ""] : question.options[0]?.label;
+}
+
+function answerElicitationFromHeadlessAnswers(
+	questions: ParsedElicitationQuestion[],
+	answers: HeadlessAnswersFile | null,
+): SdkElicitationResult | null {
+	if (!answers) return null;
+	if (answers.defaults?.strategy === "cancel" && !answers.questions) return { action: "cancel" };
+
+	const content: Record<string, string | string[]> = {};
+	for (const question of questions) {
+		const rawAnswer = answerValueForQuestion(question, answers);
+		if (rawAnswer === undefined) return { action: "cancel" };
+
+		const labels = new Set(question.options.map((option) => option.label));
+		if (question.allowMultiple) {
+			const selected = (Array.isArray(rawAnswer) ? rawAnswer : [rawAnswer]).filter((value) => labels.has(value));
+			if (selected.length > 0) {
+				content[question.id] = selected;
+				continue;
+			}
+			if ((answers.defaults?.strategy ?? "first_option") === "cancel") return { action: "cancel" };
+			content[question.id] = [question.options[0]?.label ?? ""];
+			continue;
+		}
+
+		const selected = Array.isArray(rawAnswer) ? rawAnswer[0] : rawAnswer;
+		if (typeof selected === "string" && labels.has(selected)) {
+			content[question.id] = selected;
+			continue;
+		}
+		if ((answers.defaults?.strategy ?? "first_option") === "cancel") return { action: "cancel" };
+		content[question.id] = question.options[0]?.label ?? "";
+	}
+
+	return { action: "accept", content };
 }
 
 /** Parse an SDK elicitation request into structured multiple-choice questions, or null if the schema is unsupported. */
@@ -1213,6 +1311,9 @@ export function createClaudeCodeElicitationHandler(
 
 		const questions = parseAskUserQuestionsElicitation(request);
 		if (questions) {
+			const headlessAnswer = answerElicitationFromHeadlessAnswers(questions, loadHeadlessAnswers());
+			if (headlessAnswer) return headlessAnswer;
+
 			const interviewResult = await showInterviewRound(questions, { signal }, { ui } as any).catch(() => undefined);
 			if (interviewResult && Object.keys(interviewResult.answers).length > 0) {
 				return {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1183,6 +1183,96 @@ describe("stream-adapter — MCP elicitation bridge", () => {
 		});
 	});
 
+	test("createClaudeCodeElicitationHandler applies headless answers before UI prompts", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "gsd-headless-answers-"));
+		const previous = process.env.GSD_HEADLESS_ANSWERS_PATH;
+		try {
+			const answersPath = join(tmp, "answers.json");
+			writeFileSync(answersPath, JSON.stringify({
+				questions: {
+					storage_scope: "Cloud-synced",
+					platform: ["Desktop", "Mobile"],
+				},
+				defaults: { strategy: "first_option" },
+			}));
+			process.env.GSD_HEADLESS_ANSWERS_PATH = answersPath;
+
+			let customCalls = 0;
+			const handler = createClaudeCodeElicitationHandler({
+				custom: async () => {
+					customCalls++;
+					return undefined;
+				},
+				select: async () => {
+					throw new Error("select should not be called when headless answers match");
+				},
+			} as any);
+			assert.ok(handler);
+
+			const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+			assert.equal(customCalls, 0);
+			assert.deepEqual(result, {
+				action: "accept",
+				content: {
+					storage_scope: "Cloud-synced",
+					platform: ["Desktop", "Mobile"],
+				},
+			});
+		} finally {
+			if (previous === undefined) delete process.env.GSD_HEADLESS_ANSWERS_PATH;
+			else process.env.GSD_HEADLESS_ANSWERS_PATH = previous;
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("createClaudeCodeElicitationHandler defaults dynamic depth gate IDs to the first option", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "gsd-headless-gate-answers-"));
+		const previous = process.env.GSD_HEADLESS_ANSWERS_PATH;
+		try {
+			const answersPath = join(tmp, "answers.json");
+			writeFileSync(answersPath, JSON.stringify({
+				questions: {
+					depth_verification_M001: "Proceed with planning (Recommended)",
+				},
+				defaults: { strategy: "first_option" },
+			}));
+			process.env.GSD_HEADLESS_ANSWERS_PATH = answersPath;
+
+			const handler = createClaudeCodeElicitationHandler({ custom: async () => undefined } as any);
+			assert.ok(handler);
+			const result = await handler!({
+				serverName: "gsd-workflow",
+				message: "Please answer the following question(s).",
+				mode: "form" as const,
+				requestedSchema: {
+					type: "object" as const,
+					properties: {
+						depth_verification_m001_confirm: {
+							type: "string",
+							title: "Depth",
+							description: "Proceed with this headless milestone plan?",
+							oneOf: [
+								{ const: "Yes, you got it (Recommended)", title: "Yes, you got it (Recommended)" },
+								{ const: "Not yet", title: "Not yet" },
+							],
+						},
+					},
+				},
+			}, { signal: new AbortController().signal });
+
+			assert.deepEqual(result, {
+				action: "accept",
+				content: {
+					depth_verification_m001_confirm: "Yes, you got it (Recommended)",
+				},
+			});
+		} finally {
+			if (previous === undefined) delete process.env.GSD_HEADLESS_ANSWERS_PATH;
+			else process.env.GSD_HEADLESS_ANSWERS_PATH = previous;
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
 	test("createClaudeCodeElicitationHandler falls back to dialog prompts when custom UI is unavailable", async () => {
 		const ui = {
 			custom: async () => undefined,

--- a/src/resources/extensions/gsd/tests/headless-answers.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-answers.test.ts
@@ -164,6 +164,35 @@ test('tryHandle matches by question ID — single select', (t) => {
   assert.strictEqual(injector.getStats().questionsAnswered, 1);
 });
 
+test('tryHandle matches dynamic approval-gate question aliases', (t) => {
+  const injector = new AnswerInjector({
+    questions: { depth_verification_M001: 'Yes, you got it (Recommended)' },
+  });
+
+  injector.observeEvent(makeToolExecutionStart([{
+    id: 'depth_verification_m001_confirm',
+    header: 'Depth',
+    question: 'Proceed with this headless milestone plan?',
+    options: [
+      { label: 'Yes, you got it (Recommended)' },
+      { label: 'Not yet' },
+    ],
+  }]));
+
+  const captured: string[] = [];
+  const captureStdin = (data: string) => { captured.push(data); };
+  const event = makeSelectEvent(
+    'req-gate',
+    'Depth: Proceed with this headless milestone plan?',
+    ['Yes, you got it (Recommended)', 'Not yet'],
+  );
+  const handled = injector.tryHandle(event, captureStdin);
+
+  assert.strictEqual(handled, true);
+  assert.strictEqual(JSON.parse(captured[0].trim()).value, 'Yes, you got it (Recommended)');
+  assert.deepStrictEqual(injector.getUnusedWarnings(), []);
+});
+
 test('tryHandle unknown question deferred — first_option timeout', (t) => {
   // Use Node's MockTimers instead of a real-time setTimeout race. The
   // production class schedules an internal setTimeout to default the


### PR DESCRIPTION
## Linked issue

Closes #105

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Applies `--answers` files to headless MCP approval-gate elicitation.
**Why:** `new-milestone --auto` could loop on depth-verification gates and report success without producing artifacts.
**How:** Passes the validated answers path into the headless child, resolves MCP `ask_user_questions` elicitation from that file before UI prompts, and tolerates dynamic gate IDs/casing/`_confirm` suffixes.

## What

This updates headless answer handling across:

- `src/headless.ts` to propagate the answer-file path to the child process.
- `src/resources/extensions/claude-code-cli/stream-adapter.ts` to answer MCP form elicitation directly from the headless answers file.
- `src/headless-answers.ts` to share tolerant question-ID matching for the existing UI-request injector path.
- Regression tests for MCP elicitation and dynamic approval-gate aliases.

## Why

Approval gates use the MCP `ask_user_questions` form-elicitation path, so the existing `extension_ui_request` answer injector could miss them. In headless runs, that left `depth_verification*` gates pending, caused repeated cancelled tool results, and allowed the wrapper to finish with no milestone artifacts.

## How

The headless parent continues validating the answers file before launch, then exposes its absolute path as `GSD_HEADLESS_ANSWERS_PATH` to the child. The Claude Code elicitation bridge loads that file, matches exact and dynamic gate IDs, validates answers against the current options, and falls back to `defaults.strategy: first_option` when explicit labels do not match LLM-authored option text.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included
- [x] Manual testing — steps described above

Verification run locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/headless-answers.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- `npm run test:compile`
- `npm run typecheck:extensions`

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented with Codex and verified with the commands above.

## Impact analysis

Blast radius: moderate. This touches headless CLI process env propagation and the Claude Code MCP elicitation bridge used for `ask_user_questions` forms.

Affected workflows: `gsd headless --answers ...`, especially `new-milestone --auto` depth-verification approval gates; existing extension UI select injection keeps working with more tolerant ID matching.

Risks or compatibility notes: invalid explicit answers still do not bypass current option validation; with `defaults.strategy: first_option`, dynamic approval gate labels resolve to the current first option by design.