### PR TITLE
fix(gsd): preserve CODEBASE cache timestamp

### DIFF
--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -107,7 +107,6 @@ const DEFAULT_EXCLUDES = [
 const DEFAULT_MAX_FILES = 500;
 const DEFAULT_COLLAPSE_THRESHOLD = 20;
 const DEFAULT_REFRESH_TTL_MS = 30_000;
-const DEFAULT_MAX_AGE_MS = 15 * 60_000;
 const CODEBASE_METADATA_PREFIX = "<!-- gsd:codebase-meta ";
 
 const freshnessCache = new Map<string, { checkedAt: number; result: EnsureCodebaseMapResult }>();
@@ -470,7 +469,6 @@ export function ensureCodebaseMapFresh(
   const resolved = resolveGeneratorOptions(options);
   const cacheKey = `${basePath}::${resolved.optionSignature}`;
   const ttlMs = ensureOptions?.ttlMs ?? DEFAULT_REFRESH_TTL_MS;
-  const maxAgeMs = ensureOptions?.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
   const force = ensureOptions?.force === true;
   const now = Date.now();
 
@@ -515,13 +513,11 @@ export function ensureCodebaseMapFresh(
 
   const metadata = parseCodebaseMapMetadata(existing);
   const existingDescriptions = parseCodebaseMap(existing);
-  const ageMs = metadata ? now - Date.parse(metadata.generatedAt) : Number.POSITIVE_INFINITY;
   const staleReason =
     !metadata ? "missing-metadata"
     : metadata.fingerprint !== fingerprint ? "files-changed"
     : metadata.fileCount !== listed.files.length ? "file-count-changed"
     : metadata.truncated !== listed.truncated ? "truncation-changed"
-    : maxAgeMs > 0 && Number.isFinite(ageMs) && ageMs > maxAgeMs ? "expired"
     : undefined;
 
   if (!staleReason) {

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -667,3 +667,32 @@ test("ensureCodebaseMapFresh: returns fresh when metadata matches repository sta
     cleanup(base);
   }
 });
+
+test("ensureCodebaseMapFresh: does not rewrite expired metadata when fingerprint is unchanged", () => {
+  const base = makeTmpRepo();
+  try {
+    addFile(base, "src/main.ts");
+    ensureCodebaseMapFresh(base, undefined, { ttlMs: 0, force: true });
+
+    const staleGeneratedAt = "2026-01-01T00:00:00Z";
+    const original = readCodebaseMap(base);
+    assert.ok(original);
+    const staleContent = original
+      .replace(/Generated: \S+/, `Generated: ${staleGeneratedAt}`)
+      .replace(/"generatedAt":"[^"]+"/, `"generatedAt":"${staleGeneratedAt}"`);
+    writeCodebaseMap(base, staleContent);
+
+    const refreshed = ensureCodebaseMapFresh(base, undefined, {
+      ttlMs: 0,
+      maxAgeMs: 1,
+      force: true,
+    });
+    const written = readCodebaseMap(base);
+
+    assert.equal(refreshed.status, "fresh");
+    assert.equal(refreshed.generatedAt, staleGeneratedAt);
+    assert.equal(written, staleContent);
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Stop `ensureCodebaseMapFresh()` from rewriting `.gsd/CODEBASE.md` solely because its metadata age expired.
**Why:** Rewriting unchanged CODEBASE content changes the generated timestamp embedded in the system prompt, invalidating local LLM KV cache prefixes.
**How:** Treat matching fingerprint/file-count/truncation metadata as fresh regardless of age, and add a regression test that verifies expired-but-identical metadata is not rewritten.

## What

- Removes the age-only stale condition from the CODEBASE freshness check.
- Keeps CODEBASE refreshes for missing metadata, file changes, file count changes, and truncation changes.
- Adds a regression test proving stale timestamps are preserved when the repository fingerprint is unchanged.

Closes #108

## Why

Issue #108 reports that CODEBASE regeneration changes prompt bytes between turns even when tracked files have not changed. Because the generated timestamp is injected into the system prompt, age-only rewrites break provider/KV prompt-cache stability.

## How

`ensureCodebaseMapFresh()` already computes a fingerprint from tracked files and generator options. This change makes that fingerprint the freshness contract: if metadata exists and still matches the current repository state, the existing file is returned as `fresh` without rewriting it.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/codebase-generator.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `npm run verify:fast`
- [ ] `npm run verify:pr` - blocked by two existing path-normalization failures in `detectWorkflowMcpLaunchConfig` (`/private/var/...` vs `/var/...`), unrelated to CODEBASE generation.

## Impact analysis

- Blast radius: narrow. Only `.gsd/CODEBASE.md` freshness decisions change.
- Affected workflows: automatic CODEBASE injection before prompt construction and post-unit CODEBASE refresh.
- Compatibility notes: CODEBASE still regenerates when tracked files/options materially change; age alone no longer forces a timestamp rewrite.

## Notes

- AI-assisted implementation.
