### PR TITLE
fix(gsd): allow safe verify metacharacters

### DIFF
--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -917,6 +917,25 @@ describe("checkVerificationCommands", () => {
     assert.equal(results[0]?.blocking, true);
     assert.match(results[0]?.message ?? "", /shell control syntax/);
   });
+
+  test("accepts quoted grep metacharacters and exit-code echo suffixes", () => {
+    const results = checkVerificationCommands([
+      createTask({
+        id: "T01",
+        verify: 'grep -q "| " output.md',
+      }),
+      createTask({
+        id: "T02",
+        verify: "grep -c '^## SectionA\\|^### Sub1\\|^### Sub2' notes.md",
+      }),
+      createTask({
+        id: "T03",
+        verify: 'python3 tools/check-status.py; echo "exit:$?"',
+      }),
+    ]);
+
+    assert.deepEqual(results, []);
+  });
 });
 
 // ─── runPreExecutionChecks Integration Tests ─────────────────────────────────

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -679,6 +679,17 @@ test("validateVerificationCommand allows semicolons inside quoted python -c code
   assert.equal(result.ok, true);
 });
 
+test("validateVerificationCommand allows grep patterns with quoted pipes", () => {
+  assert.equal(validateVerificationCommand('grep -q "| " output.md').ok, true);
+  assert.equal(validateVerificationCommand("grep -c '^## SectionA\\|^### Sub1\\|^### Sub2' notes.md").ok, true);
+});
+
+test("validateVerificationCommand allows exit-code echo diagnostic suffix", () => {
+  assert.equal(validateVerificationCommand('python3 tools/check-status.py; echo "exit:$?"').ok, true);
+  assert.equal(validateVerificationCommand("python3 tools/check-status.py; echo 'exit:$?'").ok, true);
+  assert.equal(validateVerificationCommand("python3 tools/check-status.py; echo exit:$?").ok, true);
+});
+
 test("validateVerificationCommand rejects shell operators after single-quote backslash desync patterns", () => {
   const result = validateVerificationCommand("echo 'x\\'; ls");
   assert.equal(result.ok, false);
@@ -689,6 +700,14 @@ test("validateVerificationCommand rejects shell operators after single-quote bac
 
 test("validateVerificationCommand rejects logical OR fallback syntax", () => {
   const result = validateVerificationCommand("npm test || true");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /shell control syntax/);
+  }
+});
+
+test("validateVerificationCommand rejects arbitrary semicolon command chaining", () => {
+  const result = validateVerificationCommand("python3 tools/check-status.py; rm -rf output");
   assert.equal(result.ok, false);
   if (!result.ok) {
     assert.match(result.reason, /shell control syntax/);

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -246,6 +246,11 @@ export function formatFailureContext(result: VerificationResult): string {
 
 /** Characters that indicate shell control syntax when unquoted in a command string. */
 const UNQUOTED_SHELL_CONTROL_CHARS = new Set([";", "|", "<", ">"]);
+const EXIT_CODE_ECHO_SUFFIX = /^;\s*echo\s+(?:"exit:\$\?"|'exit:\$\?'|exit:\$\?)\s*$/;
+
+function isAllowedExitCodeEchoSuffix(suffix: string): boolean {
+  return EXIT_CODE_ECHO_SUFFIX.test(suffix);
+}
 
 /** Returns true when command text contains unquoted shell control syntax. */
 function hasUnsafeShellSyntax(cmd: string): boolean {
@@ -256,7 +261,8 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
   let inDouble = false;
   let escaped = false;
 
-  for (const ch of cmd) {
+  for (let i = 0; i < cmd.length; i += 1) {
+    const ch = cmd[i];
     if (escaped) {
       escaped = false;
       continue;
@@ -274,6 +280,9 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
       continue;
     }
     if (!inSingle && !inDouble && UNQUOTED_SHELL_CONTROL_CHARS.has(ch)) {
+      if (ch === ";" && isAllowedExitCodeEchoSuffix(cmd.slice(i))) {
+        return hasUnsafeShellSyntax(cmd.slice(0, i).trim());
+      }
       return true;
     }
   }


### PR DESCRIPTION
## TL;DR

**What:** Allows GSD verify command validation to accept quoted grep pipe patterns and the common `; echo "exit:$?"` diagnostic suffix.
**Why:** GSD-generated verify commands were being rejected by the pre-execution checker even when the metacharacters were not shell pipes or unsafe command chaining.
**How:** Keeps quote-aware control syntax scanning fail-closed, but whitelists the exact exit-code echo suffix and adds regression coverage at the validator and pre-execution layers.

## What

This updates the GSD verification command safety check in `src/resources/extensions/gsd/verification-gate.ts` so an unquoted semicolon is still rejected by default, except for a narrowly matched `; echo exit:$?` diagnostic suffix. Existing quote awareness continues to allow grep expressions such as `grep -q "| " output.md` and `grep -c '^A\|^B' notes.md`.

Test coverage was added in:

- `src/resources/extensions/gsd/tests/verification-gate.test.ts`
- `src/resources/extensions/gsd/tests/pre-execution-checks.test.ts`

## Why

Refs #78

Issue #78 reports a planner/checker mismatch where valid verify commands generated by GSD were blocked before execution. This patch covers the reported quoted grep pipe cases and the generated exit-code suffix case without broadly allowing arbitrary shell command chaining.

## How

The checker now recognizes the exact diagnostic suffix forms:

- `; echo "exit:$?"`
- `; echo 'exit:$?'`
- `; echo exit:$?`

When that suffix is found, validation recursively checks the prefix command and still rejects any other unquoted control syntax. Arbitrary semicolon chaining such as `cmd; rm -rf output` remains blocked.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-gate.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `npm run verify:fast`

## Impact analysis

- Blast radius: narrow to GSD verification command validation and pre-execution checks.
- Affected workflows: `/gsd auto` task verification discovery, pre-execution plan validation, and task-plan verify command filtering.
- Risks or compatibility notes: arbitrary shell control syntax remains blocked; this deliberately does not make semicolon chaining generally valid.

## Notes

AI-assisted implementation.
