### PR TITLE
fix(issue): [Bug]: verification-gate treats 'bash: <cmd>' prefix as command name — exit 127 triggers 5× re-dispatch loop

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -60,6 +60,18 @@ describe("verification-gate: discovery", () => {
     assert.equal(result.source, "task-plan");
   });
 
+  test("discoverCommands strips interpreter prefixes from task plan verify commands", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "bash: ls scripts/hooks/\npython3: python3 -m pytest tests/ -q",
+      cwd: tmp,
+    });
+    assert.deepStrictEqual(result.commands, [
+      "ls scripts/hooks/",
+      "python3 -m pytest tests/ -q",
+    ]);
+    assert.equal(result.source, "task-plan");
+  });
+
   test("discoverCommands from package.json scripts", () => {
     writeFileSync(
       join(tmp, "package.json"),

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -38,6 +38,7 @@ export interface DiscoveredCommands {
 
 /** Package.json script keys to probe, in order. */
 const PACKAGE_SCRIPT_KEYS = ["typecheck", "lint", "test"] as const;
+const INTERPRETER_PREFIX_RE = /^(bash|sh|zsh|node|python3?|ts-node|tsx):\s*/;
 
 /**
  * Discover verification commands using the first-non-empty-wins strategy (D003):
@@ -63,9 +64,10 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
       .map(c => c.trim())
       .filter(Boolean);
     for (const candidate of candidates) {
-      const validation = validateVerificationCommand(candidate);
+      const normalized = candidate.replace(INTERPRETER_PREFIX_RE, "").trim();
+      const validation = validateVerificationCommand(normalized);
       if (validation.ok) {
-        commands.push(candidate);
+        commands.push(normalized);
       } else if (validation.reason === "does not look like a runnable command") {
         hasTaskPlanProse = true;
       } else {


### PR DESCRIPTION
## Summary
- Fixed verification-gate task-plan command discovery to strip interpreter prefixes and verified the reported examples normalize correctly.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #123
- [#123 [Bug]: verification-gate treats 'bash: <cmd>' prefix as command name — exit 127 triggers 5× re-dispatch loop](https://github.com/open-gsd/gsd-pi/issues/123)

## User
- @mpeter

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/123-bug-verification-gate-treats-bash-cmd-pr-1779731690`