### PR TITLE
fix(issue): [Bug] execute-task re-dispatched after task is complete when verification gate fails with pre-existing errors

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -567,6 +567,7 @@ export async function runPostUnitVerification(
     // Write verification evidence JSON
     const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
     const attempt = s.verificationRetryCount.get(retryKey) ?? 0;
+    const taskAlreadyComplete = taskRow?.status === "complete" || taskRow?.status === "done";
     if (mid && sid && tid) {
       try {
         const sDir = resolveSlicePath(s.basePath, mid, sid);
@@ -578,6 +579,7 @@ export async function runPostUnitVerification(
             const nextAttempt = attempt + 1;
             const includeRetryMetadata =
               !result.passed &&
+              !taskAlreadyComplete &&
               verdict.retryable &&
               autoFixEnabled &&
               nextAttempt <= maxRetries;
@@ -818,6 +820,19 @@ export async function runPostUnitVerification(
         category: "unknown",
       });
       return "pause";
+    } else if (taskAlreadyComplete) {
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
+      s.pendingVerificationRetry = null;
+      logWarning(
+        "engine",
+        `Verification gate failed for completed task ${s.currentUnit.id}; treating failure as non-blocking to avoid re-dispatching an already-complete task.`,
+      );
+      ctx.ui.notify(
+        `Verification failed after ${tid ?? s.currentUnit.id} was already complete; continuing without retry.`,
+        "warning",
+      );
+      return "continue";
     } else if (autoFixEnabled && attempt + 1 <= maxRetries) {
       const { unitCostUsd, rollingAvgUsd } = getCurrentUnitCostStats(s.currentUnit.id);
       const perUnitCapUsd =

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -173,7 +173,7 @@ function createTaskWithoutVerify(): void {
   });
 }
 
-function createFailingVerifyTask(): void {
+function createFailingVerifyTask(status = "pending"): void {
   insertMilestone({ id: "M001" });
   insertSlice({
     id: "S01",
@@ -187,7 +187,7 @@ function createFailingVerifyTask(): void {
     sliceId: "S01",
     milestoneId: "M001",
     title: "Task with failing verification",
-    status: "pending",
+    status,
     planning: {
       description: "Task with deterministic failing verification",
       estimate: "1h",
@@ -472,6 +472,34 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(pauseAutoMock.mock.callCount(), 0);
     assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01/T01");
     assert.match(s.pendingVerificationRetry?.failureContext ?? "", /npm run test/);
+  });
+
+  test("completed execute-task verification failure continues without retry metadata", async () => {
+    createFailingVerifyTask("complete");
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: false,
+      verification_auto_fix: true,
+      verification_max_retries: 2,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "continue");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.equal(s.verificationRetryCount.size, 0);
+
+    const evidencePath = join(tempDir, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-VERIFY.json");
+    const evidence = JSON.parse(readFileSync(evidencePath, "utf-8"));
+    assert.equal(evidence.passed, false);
+    assert.ok(!("retryAttempt" in evidence), "completed task failure evidence must not request a retry");
+    assert.ok(!("maxRetries" in evidence), "completed task failure evidence must not carry retry budget");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed completed execute-task verification failures to continue without retry metadata and verified with focused regression tests plus extension typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #126
- [#126 [Bug] execute-task re-dispatched after task is complete when verification gate fails with pre-existing errors](https://github.com/open-gsd/gsd-pi/issues/126)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/126-bug-execute-task-re-dispatched-after-tas-1779732291`