### PR TITLE
feat(models): add dedicated uat model slot in preferences

### DIFF
--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -92,8 +92,10 @@ export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedMode
     case "complete-slice":
     case "complete-milestone":
     case "worktree-merge":
-    case "run-uat":
       phaseConfig = m.completion;
+      break;
+    case "run-uat":
+      phaseConfig = m.uat ?? m.completion;
       break;
     case "reassess-roadmap":
     case "rewrite-docs":

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -223,6 +223,7 @@ export interface GSDModelConfig {
   completion?: string;
   validation?: string;
   subagent?: string;
+  uat?: string;
 }
 
 /**
@@ -238,6 +239,7 @@ export interface GSDModelConfigV2 {
   completion?: string | GSDPhaseModelConfig;
   validation?: string | GSDPhaseModelConfig;
   subagent?: string | GSDPhaseModelConfig;
+  uat?: string | GSDPhaseModelConfig;
 }
 
 /** Normalized model selection with resolved fallbacks */

--- a/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
+++ b/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
@@ -33,6 +33,7 @@ function withModelPreferences<T>(fn: () => T): T {
       "  completion: completion-model",
       "  validation: validation-model",
       "  subagent: subagent-model",
+      "  uat: uat-model",
       "---",
       "",
     ].join("\n"));
@@ -63,6 +64,32 @@ test("worktree-merge routes to completion and is recognized as a unit label", ()
     assert.ok(KNOWN_UNIT_LABELS.includes("worktree-merge"));
     assert.equal(resolveModelWithFallbacksForUnit("worktree-merge")?.primary, "completion-model");
   });
+});
+
+test("run-uat routes to uat model bucket when configured", () => {
+  withModelPreferences(() => {
+    assert.equal(resolveModelWithFallbacksForUnit("run-uat")?.primary, "uat-model");
+  });
+});
+
+test("run-uat falls back to completion when uat bucket is not configured", () => {
+  const oldHome = process.env.GSD_HOME;
+  const home = mkdtempSync(join(tmpdir(), "gsd-model-map-uat-fallback-"));
+  try {
+    process.env.GSD_HOME = home;
+    writeFileSync(join(home, "preferences.md"), [
+      "---",
+      "models:",
+      "  completion: completion-model",
+      "---",
+      "",
+    ].join("\n"));
+    assert.equal(resolveModelWithFallbacksForUnit("run-uat")?.primary, "completion-model");
+  } finally {
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("every known unit label with a dispatch phase resolves when all model buckets are configured", () => {


### PR DESCRIPTION
## TL;DR

Add `models.uat` as a dedicated model slot for `run-uat` units, with fallback to `models.completion`. Closes #130.

## What

- `GSDModelConfig` (legacy) and `GSDModelConfigV2` both gain an optional `uat` field
- `run-uat` resolves from `m.uat ?? m.completion` instead of sharing the `completion` bucket
- Two new tests in `model-unittype-mapping.test.ts`: routing to `uat` bucket and fallback to `completion`

## Why

`run-uat` is dispatched after every slice when `uat_dispatch: true`. These runs are verification passes (execute commands, check output) that don't need the same heavy model used for `complete-slice`. Letting users route UAT to a lighter model reduces cost without sacrificing quality on the completion phase.

The `uat ?? completion` pattern mirrors the existing `execution_simple ?? execution` precedent.

## How

3 files changed, 32 insertions:

| File | Change |
|------|--------|
| `preferences-types.ts` | Added `uat?: string` to `GSDModelConfig`, `uat?: string \| GSDPhaseModelConfig` to `GSDModelConfigV2` |
| `preferences-models.ts` | Separated `run-uat` from `completion` group; uses `m.uat ?? m.completion` |
| `tests/model-unittype-mapping.test.ts` | Added `uat: uat-model` to helper; 2 new routing tests |

No breaking changes — omitting `uat` in preferences falls back to current `completion` behavior.