### PR TITLE
ci: publish MCP server in native release workflow

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -207,8 +207,15 @@ jobs:
               MISSING+=("${PKG}")
             fi
           done
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ] || [ "${{ github.event.inputs.platform_packages_only }}" != "true" ]; then
+            for pkg in @opengsd/contracts @opengsd/rpc-client @opengsd/mcp-server; do
+              if ! npm view "${pkg}" name >/dev/null 2>&1; then
+                MISSING+=("${pkg}")
+              fi
+            done
+          fi
           if [ "${#MISSING[@]}" -gt 0 ]; then
-            echo "::error::These @opengsd/engine-* packages do not exist on npm yet:"
+            echo "::error::These npm packages do not exist on npm yet:"
             for pkg in "${MISSING[@]}"; do
               echo "::error::  - ${pkg}"
             done
@@ -295,6 +302,21 @@ jobs:
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: npm run validate-pack
 
+      - name: Publish workspace packages
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
+          TAG_FLAG: ${{ steps.version-check.outputs.tag_flag }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          for workspace in @opengsd/contracts @opengsd/rpc-client @opengsd/mcp-server; do
+            if npm view "${workspace}@${VERSION}" version >/dev/null 2>&1; then
+              echo "${workspace}@${VERSION} already published, skipping"
+              continue
+            fi
+            npm publish --workspace "${workspace}" --ignore-scripts ${TAG_FLAG}
+          done
+
       - name: Publish main package
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         env:
@@ -363,6 +385,31 @@ jobs:
             DELAY=$((DELAY * 2))
           done
           echo "::error::Smoke test failed — @opengsd/gsd-pi@${VERSION} not installable"
+          exit 1
+
+      - name: Post-publish MCP server smoke test
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TMPDIR=$(mktemp -d)
+          cd "$TMPDIR"
+          npm init -y > /dev/null 2>&1
+
+          echo "Installing @opengsd/mcp-server@${VERSION}..."
+          DELAY=5
+          for attempt in 1 2 3; do
+            if npm install "@opengsd/mcp-server@${VERSION}" 2>&1 | tee /tmp/mcp-install-output.txt; then
+              test -x node_modules/.bin/gsd-mcp-server || { echo "::error::gsd-mcp-server bin missing"; exit 1; }
+              node -e "import('@opengsd/mcp-server').then((mod) => { if (!Object.keys(mod).length) throw new Error('empty @opengsd/mcp-server exports'); })"
+              echo "Published MCP server package is functional"
+              exit 0
+            fi
+            echo "MCP server install attempt ${attempt}/3 failed, retrying in ${DELAY}s..."
+            cat /tmp/mcp-install-output.txt
+            sleep "$DELAY"
+            DELAY=$((DELAY * 2))
+          done
+          echo "::error::Smoke test failed — @opengsd/mcp-server@${VERSION} not installable"
           exit 1
 
       - name: Verify dist-tag after publish

--- a/scripts/__tests__/build-native-workflow.test.mjs
+++ b/scripts/__tests__/build-native-workflow.test.mjs
@@ -34,8 +34,10 @@ test("build-native can skip main package when bootstrapping engine packages", ()
     "Build",
     "Verify dist exists",
     "Validate package is installable",
+    "Publish workspace packages",
     "Publish main package",
     "Post-publish smoke test",
+    "Post-publish MCP server smoke test",
   ];
 
   for (const name of gatedSteps) {
@@ -59,12 +61,38 @@ test("build-native requires token auth when engine packages are missing from npm
 
   assert.ok(step, "publish job must guard trusted auth when packages are new");
   assert.equal(step.if, "github.event.inputs.publish_auth != 'token'");
+  assert.match(step.run, /@opengsd\/mcp-server/);
   assert.match(step.run, /do not exist on npm yet/);
   assert.match(step.run, /publish_auth=token/);
 
   assert.ok(tokenCheck, "publish job must verify NPM_TOKEN for token bootstrap");
   assert.equal(tokenCheck.if, "github.event.inputs.publish_auth == 'token'");
   assert.match(tokenCheck.run, /NPM_TOKEN/);
+});
+
+test("build-native publishes MCP server workspace to npm before the main package", () => {
+  const steps = publishJob.steps;
+  const workspacePublish = steps.find(
+    (entry) => entry.name === "Publish workspace packages",
+  );
+  const mainPublishIndex = steps.findIndex(
+    (entry) => entry.name === "Publish main package",
+  );
+  const workspacePublishIndex = steps.indexOf(workspacePublish);
+  const smoke = steps.find(
+    (entry) => entry.name === "Post-publish MCP server smoke test",
+  );
+
+  assert.ok(workspacePublish, "workflow must publish workspace packages");
+  assert.ok(workspacePublishIndex > -1 && workspacePublishIndex < mainPublishIndex);
+  assert.match(workspacePublish.run, /@opengsd\/contracts/);
+  assert.match(workspacePublish.run, /@opengsd\/rpc-client/);
+  assert.match(workspacePublish.run, /@opengsd\/mcp-server/);
+  assert.match(workspacePublish.run, /npm publish --workspace "\$\{workspace\}"/);
+
+  assert.ok(smoke, "workflow must smoke-test the standalone MCP server package");
+  assert.match(smoke.run, /npm install "@opengsd\/mcp-server@\$\{VERSION\}"/);
+  assert.match(smoke.run, /gsd-mcp-server/);
 });
 
 test("publish-engine-packages script continues through all platforms", () => {


### PR DESCRIPTION
## Summary
- publish @opengsd/contracts, @opengsd/rpc-client, and @opengsd/mcp-server from the native binary workflow before the main package
- add token-bootstrap guarding for missing workspace packages
- smoke-test the standalone @opengsd/mcp-server package after publish

## Verification
- node --test scripts/__tests__/build-native-workflow.test.mjs
- npm pack --workspace @opengsd/mcp-server --dry-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect npm publish order and release gates for multiple @opengsd packages; mistakes could block releases or publish incomplete artifacts, but scope is CI-only with added tests.
> 
> **Overview**
> The **Build Native Binaries** publish job now treats **`@opengsd/contracts`**, **`@opengsd/rpc-client`**, and **`@opengsd/mcp-server`** as first-class release artifacts alongside engine binaries and **`@opengsd/gsd-pi`**.
> 
> When trusted publishing is used, the workflow **fails early** if any of those workspace packages are missing on npm (unless **`platform_packages_only`** is set for engine-only bootstrap). A new **Publish workspace packages** step publishes each workspace at the repo version with **`--tag`** alignment and skips versions already on the registry, **before** the main package publish.
> 
> A **Post-publish MCP server smoke test** installs **`@opengsd/mcp-server`** from npm, checks the **`gsd-mcp-server`** binary, and validates the package exports. Workflow regression tests were updated to lock step ordering, gating, and token-bootstrap checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b508838b82e1756333599d96d9f048014d472047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->