### PR TITLE
fix(issue): Artifact renderers use inconsistent gsdRoot vs gsdProjectionRoot when running inside a worktree causing stale-mirror verification failures

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -29,7 +29,6 @@ import type { MilestoneRow, ArtifactRow } from "./db-milestone-artifact-rows.js"
 import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { GateRow } from "./types.js";
 import {
-  resolveMilestoneFile,
   resolveDir,
   resolveFile,
   resolveSliceFile,
@@ -107,6 +106,15 @@ function loadArtifactContent(
   }
 
   return null;
+}
+
+function resolveRoadmapProjectionPath(basePath: string, milestoneId: string): string {
+  const projectionMilestonesDir = join(gsdProjectionRoot(basePath), "milestones");
+  const milestoneDirName = resolveDir(projectionMilestonesDir, milestoneId) ?? milestoneId;
+  const milestoneDir = join(projectionMilestonesDir, milestoneDirName);
+  const roadmapFileName = resolveFile(milestoneDir, milestoneId, "ROADMAP") ??
+    buildMilestoneFileName(milestoneId, "ROADMAP");
+  return join(milestoneDir, roadmapFileName);
 }
 
 /**
@@ -441,12 +449,7 @@ export async function renderRoadmapFromDb(
   }
 
   const slices = getMilestoneSlices(milestoneId);
-  const projectionMilestonesDir = join(gsdProjectionRoot(basePath), "milestones");
-  const milestoneDirName = resolveDir(projectionMilestonesDir, milestoneId) ?? milestoneId;
-  const milestoneDir = join(projectionMilestonesDir, milestoneDirName);
-  const roadmapFileName = resolveFile(milestoneDir, milestoneId, "ROADMAP") ??
-    buildMilestoneFileName(milestoneId, "ROADMAP");
-  const absPath = join(milestoneDir, roadmapFileName);
+  const absPath = resolveRoadmapProjectionPath(basePath, milestoneId);
   const artifactPath = toArtifactPath(absPath, basePath);
   const content = renderRoadmapMarkdown(milestone, slices);
 
@@ -768,8 +771,8 @@ export function detectStaleRenders(basePath: string): StaleEntry[] {
     const slices = getMilestoneSlices(milestone.id);
 
     // ── Check roadmap checkbox state ──────────────────────────────────
-    const roadmapPath = resolveMilestoneFile(basePath, milestone.id, "ROADMAP");
-    if (roadmapPath && existsSync(roadmapPath)) {
+    const roadmapPath = resolveRoadmapProjectionPath(basePath, milestone.id);
+    if (existsSync(roadmapPath)) {
       try {
         const content = readFileSync(roadmapPath, "utf-8");
         const parsed = parseRoadmap(content);

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -30,11 +30,13 @@ import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { GateRow } from "./types.js";
 import {
   resolveMilestoneFile,
+  resolveDir,
   resolveFile,
   resolveSliceFile,
   resolveSlicePath,
   gsdProjectionRoot,
   gsdRoot,
+  buildMilestoneFileName,
   buildTaskFileName,
   buildSliceFileName,
 } from "./paths.js";
@@ -439,9 +441,12 @@ export async function renderRoadmapFromDb(
   }
 
   const slices = getMilestoneSlices(milestoneId);
-  const milestoneDir = join(gsdProjectionRoot(basePath), "milestones", milestoneId);
-  const absPath = resolveFile(milestoneDir, milestoneId, "ROADMAP") ??
-    join(milestoneDir, `${milestoneId}-ROADMAP.md`);
+  const projectionMilestonesDir = join(gsdProjectionRoot(basePath), "milestones");
+  const milestoneDirName = resolveDir(projectionMilestonesDir, milestoneId) ?? milestoneId;
+  const milestoneDir = join(projectionMilestonesDir, milestoneDirName);
+  const roadmapFileName = resolveFile(milestoneDir, milestoneId, "ROADMAP") ??
+    buildMilestoneFileName(milestoneId, "ROADMAP");
+  const absPath = join(milestoneDir, roadmapFileName);
   const artifactPath = toArtifactPath(absPath, basePath);
   const content = renderRoadmapMarkdown(milestone, slices);
 

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -30,6 +30,7 @@ import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { GateRow } from "./types.js";
 import {
   resolveMilestoneFile,
+  resolveFile,
   resolveSliceFile,
   resolveSlicePath,
   gsdProjectionRoot,
@@ -438,8 +439,9 @@ export async function renderRoadmapFromDb(
   }
 
   const slices = getMilestoneSlices(milestoneId);
-  const absPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP") ??
-    join(gsdRoot(basePath), "milestones", milestoneId, `${milestoneId}-ROADMAP.md`);
+  const milestoneDir = join(gsdProjectionRoot(basePath), "milestones", milestoneId);
+  const absPath = resolveFile(milestoneDir, milestoneId, "ROADMAP") ??
+    join(milestoneDir, `${milestoneId}-ROADMAP.md`);
   const artifactPath = toArtifactPath(absPath, basePath);
   const content = renderRoadmapMarkdown(milestone, slices);
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -13,6 +13,7 @@ import {
   renderSliceSummary,
   renderTaskSummary,
 } from "../../markdown-renderer.js";
+import { getMilestone } from "../../gsd-db.js";
 import type { GSDState } from "../../types.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -56,6 +57,29 @@ function isRepairableStaleRenderReason(reason: string): boolean {
   );
 }
 
+function resolveRoadmapMilestoneIdFromPath(normPath: string): string {
+  const milestoneMatch = normPath.match(/milestones\/([^/]+)\//);
+  if (!milestoneMatch) {
+    throw new Error(
+      `stale-render drift: roadmap path missing milestone segment: ${normPath}`,
+    );
+  }
+
+  const fileMatch = normPath.match(/(?:^|\/)([^/]+)-ROADMAP\.md$/i);
+  const candidates = [
+    fileMatch?.[1],
+    milestoneMatch[1],
+    fileMatch?.[1]?.match(/^(M\d+)/i)?.[1],
+    milestoneMatch[1].match(/^(M\d+)/i)?.[1],
+  ].filter((candidate): candidate is string => !!candidate);
+
+  for (const candidate of candidates) {
+    if (getMilestone(candidate)) return candidate;
+  }
+
+  return fileMatch?.[1] ?? milestoneMatch[1];
+}
+
 async function repairStaleRenderFromBasePath(
   record: StaleRenderDrift,
   basePath: string,
@@ -64,14 +88,10 @@ async function repairStaleRenderFromBasePath(
   const reason = record.reason;
 
   if (reason.includes("in roadmap")) {
-    const milestoneMatch = normPath.match(/milestones\/([^/]+)\//);
-    if (!milestoneMatch) {
-      throw new Error(
-        `stale-render drift: roadmap path missing milestone segment: ${record.renderPath}`,
-      );
-    }
-    const fileMatch = normPath.match(/(?:^|\/)([^/]+)-ROADMAP\.md$/);
-    await renderRoadmapFromDb(basePath, fileMatch?.[1] ?? milestoneMatch[1]);
+    await renderRoadmapFromDb(
+      basePath,
+      resolveRoadmapMilestoneIdFromPath(normPath),
+    );
     return;
   }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -70,7 +70,8 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: roadmap path missing milestone segment: ${record.renderPath}`,
       );
     }
-    await renderRoadmapFromDb(basePath, milestoneMatch[1]);
+    const fileMatch = normPath.match(/(?:^|\/)([^/]+)-ROADMAP\.md$/);
+    await renderRoadmapFromDb(basePath, fileMatch?.[1] ?? milestoneMatch[1]);
     return;
   }
 

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -1208,6 +1208,47 @@ test('── markdown-renderer: repairStaleRenders handles descriptor roadmap pr
   }
 });
 
+test('── markdown-renderer: repairStaleRenders handles legacy descriptor roadmap filenames ──', async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    const milestoneDir = path.join(tmpDir, '.gsd', 'milestones', 'M001');
+    fs.mkdirSync(milestoneDir, { recursive: true });
+
+    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Core', status: 'complete' });
+
+    const staleRoadmap = makeRoadmapContent([
+      { id: 'S01', title: 'Core', done: false },
+    ]);
+    const legacyRoadmapPath = path.join(milestoneDir, 'M001-legacy-descriptor-ROADMAP.md');
+    fs.writeFileSync(legacyRoadmapPath, staleRoadmap);
+    clearAllCaches();
+
+    const staleBefore = detectStaleRenders(tmpDir);
+    assert.ok(
+      staleBefore.some(s => s.path === legacyRoadmapPath && s.reason.includes('S01')),
+      'legacy descriptor roadmap filename should be detected as stale',
+    );
+
+    const repaired = await repairStaleRenders(tmpDir);
+    assert.ok(repaired > 0, 'repairStaleRenders should repair the legacy descriptor roadmap');
+
+    clearAllCaches();
+    const staleAfter = detectStaleRenders(tmpDir);
+    assert.deepStrictEqual(staleAfter, [], 'legacy descriptor roadmap should be clear after repair');
+
+    const repairedContent = fs.readFileSync(legacyRoadmapPath, 'utf-8');
+    assert.ok(repairedContent.includes('[x] **S01:'), 'legacy descriptor roadmap is repaired');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Stale Detection — Missing Task Summary
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -1114,6 +1114,58 @@ test('── markdown-renderer: detectStaleRenders finds roadmap checkbox mismat
   }
 });
 
+test('── markdown-renderer: repairStaleRenders reads worktree roadmap projection ──', async () => {
+  const tmpDir = makeTmpDir();
+  const worktreeDir = path.join(tmpDir, '.gsd', 'worktrees', 'M001');
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    const projectMilestoneDir = path.join(tmpDir, '.gsd', 'milestones', 'M001');
+    const projectionMilestoneDir = path.join(worktreeDir, '.gsd', 'milestones', 'M001');
+    fs.mkdirSync(projectMilestoneDir, { recursive: true });
+    fs.mkdirSync(projectionMilestoneDir, { recursive: true });
+
+    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Core', status: 'complete' });
+
+    const staleRoadmap = makeRoadmapContent([
+      { id: 'S01', title: 'Core', done: false },
+    ]);
+    const projectRoadmapPath = path.join(projectMilestoneDir, 'M001-ROADMAP.md');
+    const projectionRoadmapPath = path.join(projectionMilestoneDir, 'M001-ROADMAP.md');
+    fs.writeFileSync(projectRoadmapPath, staleRoadmap);
+    fs.writeFileSync(projectionRoadmapPath, staleRoadmap);
+    clearAllCaches();
+
+    const staleBefore = detectStaleRenders(worktreeDir);
+    assert.ok(
+      staleBefore.some(s => s.path === projectionRoadmapPath && s.reason.includes('S01')),
+      'worktree projection roadmap should be detected as stale',
+    );
+    assert.ok(
+      staleBefore.every(s => s.path !== projectRoadmapPath),
+      'project mirror roadmap should not be used for worktree stale detection',
+    );
+
+    const repaired = await repairStaleRenders(worktreeDir);
+    assert.ok(repaired > 0, 'repairStaleRenders should repair the worktree projection');
+
+    clearAllCaches();
+    const staleAfter = detectStaleRenders(worktreeDir);
+    assert.deepStrictEqual(staleAfter, [], 'worktree stale roadmap should be clear after repair');
+
+    const projectContent = fs.readFileSync(projectRoadmapPath, 'utf-8');
+    const projectionContent = fs.readFileSync(projectionRoadmapPath, 'utf-8');
+    assert.ok(projectContent.includes('[ ] **S01:'), 'project mirror roadmap is left unchanged');
+    assert.ok(projectionContent.includes('[x] **S01:'), 'worktree projection roadmap is repaired');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Stale Detection — Missing Task Summary
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -1166,6 +1166,48 @@ test('── markdown-renderer: repairStaleRenders reads worktree roadmap projec
   }
 });
 
+test('── markdown-renderer: repairStaleRenders handles descriptor roadmap projection dirs ──', async () => {
+  const tmpDir = makeTmpDir();
+  const worktreeDir = path.join(tmpDir, '.gsd', 'worktrees', 'M001');
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    const projectionMilestoneDir = path.join(worktreeDir, '.gsd', 'milestones', 'M001-DESCRIPTOR');
+    fs.mkdirSync(projectionMilestoneDir, { recursive: true });
+
+    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Core', status: 'complete' });
+
+    const staleRoadmap = makeRoadmapContent([
+      { id: 'S01', title: 'Core', done: false },
+    ]);
+    const descriptorRoadmapPath = path.join(projectionMilestoneDir, 'M001-ROADMAP.md');
+    fs.writeFileSync(descriptorRoadmapPath, staleRoadmap);
+    clearAllCaches();
+
+    const staleBefore = detectStaleRenders(worktreeDir);
+    assert.ok(
+      staleBefore.some(s => s.path === descriptorRoadmapPath && s.reason.includes('S01')),
+      'descriptor worktree projection roadmap should be detected as stale',
+    );
+
+    const repaired = await repairStaleRenders(worktreeDir);
+    assert.ok(repaired > 0, 'repairStaleRenders should repair the descriptor projection');
+
+    clearAllCaches();
+    const staleAfter = detectStaleRenders(worktreeDir);
+    assert.deepStrictEqual(staleAfter, [], 'descriptor stale roadmap should be clear after repair');
+
+    const projectionContent = fs.readFileSync(descriptorRoadmapPath, 'utf-8');
+    assert.ok(projectionContent.includes('[x] **S01:'), 'descriptor projection roadmap is repaired');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Stale Detection — Missing Task Summary
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/planning-crossval.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-crossval.test.ts
@@ -349,4 +349,78 @@ console.log('\n=== planning-crossval Test 4: ROADMAP worktree projection path ==
   }
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Test 5: ROADMAP renderer preserves existing projection file path
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== planning-crossval Test 5: ROADMAP existing projection file path ===');
+{
+  const base = createFixtureBase();
+  const worktreeBase = join(base, '.gsd', 'worktrees', 'M001');
+  const worktreeGsd = join(worktreeBase, '.gsd');
+  const worktreeRoadmapPath = join(worktreeGsd, 'milestones', 'M001', 'M001-ROADMAP.md');
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  const originalCwd = process.cwd();
+
+  openDatabase(dbPath);
+  try {
+    process.chdir(base);
+    mkdirSync(join(worktreeGsd, 'milestones', 'M001'), { recursive: true });
+    writeFileSync(worktreeRoadmapPath, '# stale worktree roadmap\n');
+
+    insertMilestone({
+      id: 'M001',
+      title: 'Existing Projection',
+      status: 'active',
+      planning: { vision: 'Overwrite the existing projected roadmap.' },
+    });
+
+    const rendered = await renderRoadmapFromDb(worktreeBase, 'M001');
+
+    assertEq(rendered.roadmapPath, worktreeRoadmapPath, 'T5: existing roadmap path remains absolute');
+    assertTrue(existsSync(worktreeRoadmapPath), 'T5: worktree roadmap still exists');
+  } finally {
+    process.chdir(originalCwd);
+    closeDatabase();
+    cleanup(base);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test 6: ROADMAP renderer resolves descriptor-named projection milestone dirs
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== planning-crossval Test 6: ROADMAP descriptor projection dir ===');
+{
+  const base = createFixtureBase();
+  const worktreeBase = join(base, '.gsd', 'worktrees', 'M001');
+  const worktreeGsd = join(worktreeBase, '.gsd');
+  const descriptorMilestoneDir = join(worktreeGsd, 'milestones', 'M001-DESCRIPTOR');
+  const descriptorRoadmapPath = join(descriptorMilestoneDir, 'M001-ROADMAP.md');
+  const bareMilestoneDir = join(worktreeGsd, 'milestones', 'M001');
+  const dbPath = join(base, '.gsd', 'gsd.db');
+
+  openDatabase(dbPath);
+  try {
+    mkdirSync(descriptorMilestoneDir, { recursive: true });
+    writeFileSync(descriptorRoadmapPath, '# stale descriptor roadmap\n');
+
+    insertMilestone({
+      id: 'M001',
+      title: 'Descriptor Projection',
+      status: 'active',
+      planning: { vision: 'Render into the descriptor-named milestone dir.' },
+    });
+
+    const rendered = await renderRoadmapFromDb(worktreeBase, 'M001');
+
+    assertEq(rendered.roadmapPath, descriptorRoadmapPath, 'T6: roadmap path uses descriptor milestone dir');
+    assertTrue(existsSync(descriptorRoadmapPath), 'T6: descriptor roadmap exists');
+    assertEq(existsSync(bareMilestoneDir), false, 'T6: bare duplicate milestone dir is not created');
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+}
+
 report();

--- a/src/resources/extensions/gsd/tests/planning-crossval.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-crossval.test.ts
@@ -3,7 +3,7 @@
 // Each test seeds planning data into DB via insert functions, renders markdown via
 // renderers, parses back via existing parsers, and asserts field-by-field parity.
 
-import { mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -52,7 +52,7 @@ function cleanup(base: string): void {
 
 console.log('\n=== planning-crossval Test 1: ROADMAP round-trip parity ===');
 {
-  const base = createFixtureBase();
+  const base = realpathSync(createFixtureBase());
   const dbPath = join(base, '.gsd', 'gsd.db');
   openDatabase(dbPath);
   try {
@@ -296,6 +296,53 @@ console.log('\n=== planning-crossval Test 3: Sequence ordering parity ===');
       assertEq(parsedSlices[i].done, dbSlices[i].status === 'complete', `T3: round-trip slice[${i}].done`);
       assertEq(parsedSlices[i].title, dbSlices[i].title, `T3: round-trip slice[${i}].title`);
     }
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test 4: ROADMAP renders into worktree projection root
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== planning-crossval Test 4: ROADMAP worktree projection path ===');
+{
+  const base = createFixtureBase();
+  const worktreeBase = join(base, '.gsd', 'worktrees', 'M001');
+  const worktreeGsd = join(worktreeBase, '.gsd');
+  const projectRoadmapPath = join(base, '.gsd', 'milestones', 'M001', 'M001-ROADMAP.md');
+  const worktreeRoadmapPath = join(worktreeGsd, 'milestones', 'M001', 'M001-ROADMAP.md');
+  const dbPath = join(base, '.gsd', 'gsd.db');
+
+  openDatabase(dbPath);
+  try {
+    scaffoldDirs(base, 'M001', []);
+    mkdirSync(join(worktreeGsd, 'milestones', 'M001'), { recursive: true });
+    writeFileSync(projectRoadmapPath, '# stale project roadmap\n');
+
+    insertMilestone({
+      id: 'M001',
+      title: 'Worktree Projection',
+      status: 'active',
+      planning: { vision: 'Render into the projection root.' },
+    });
+
+    insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Projected Slice',
+      status: 'complete',
+      risk: 'low',
+      demo: 'Projection updated.',
+      sequence: 1,
+    });
+
+    const rendered = await renderRoadmapFromDb(worktreeBase, 'M001');
+
+    assertEq(rendered.roadmapPath, worktreeRoadmapPath, 'T4: roadmap path uses worktree projection');
+    assertTrue(existsSync(worktreeRoadmapPath), 'T4: worktree roadmap exists');
+    assertEq(readFileSync(projectRoadmapPath, 'utf-8'), '# stale project roadmap\n', 'T4: project roadmap remains stale');
   } finally {
     closeDatabase();
     cleanup(base);


### PR DESCRIPTION
## Summary
- Fixed roadmap artifact rendering to use the worktree projection root and verified with extension typecheck plus focused worktree path tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #136
- [#136 Artifact renderers use inconsistent gsdRoot vs gsdProjectionRoot when running inside a worktree causing stale-mirror verification failures](https://github.com/open-gsd/gsd-pi/issues/136)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/136-artifact-renderers-use-inconsistent-gsdr-1779772627`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which on-disk roadmap files are read/written during worktree execution and drift repair; behavior is well covered by new tests but affects reconciliation paths.
> 
> **Overview**
> Roadmap **render**, **stale detection**, and **stale repair** now target the **worktree projection** (via `gsdProjectionRoot`) instead of the project `gsdRoot`, so worktree runs no longer read or write the wrong roadmap mirror.
> 
> A shared **`resolveRoadmapProjectionPath`** picks the milestone directory and `ROADMAP` filename using `resolveDir` / `resolveFile` (descriptor dirs and legacy `*-ROADMAP.md` names). Stale-render repair resolves the milestone id from the path with **`getMilestone`** instead of only the directory segment.
> 
> Tests cover worktree-only stale/repair, descriptor projection dirs, legacy roadmap filenames, and cross-validation that project roadmaps stay untouched when rendering from a worktree base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd74106181ec93689e1058d10906abc222b038f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->