### PR TITLE
fix(issue): [Bug]: Unusuable, unresponsive, fresh install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "extensions/*"
       ],
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.2.83",
         "@anthropic-ai/sdk": "^0.90.0",
         "@anthropic-ai/vertex-sdk": "^0.14.4",
         "@aws-sdk/client-bedrock-runtime": "^3.983.0",
@@ -66,7 +67,6 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.83",
         "@opengsd/engine-darwin-arm64": "1.0.2",
         "@opengsd/engine-darwin-x64": "1.0.2",
         "@opengsd/engine-linux-arm64-gnu": "1.0.2",
@@ -93,7 +93,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.83.tgz",
       "integrity": "sha512-O8g56htGMxrwbjCbqUqRBMNC0O98B7SkPnfQC7vmo3w2DVnUrBj3qat/IBLB8SI4sjVSZHeJrcK7+ozsCzStSw==",
       "license": "SEE LICENSE IN README.md",
-      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "test:e2e:docker": "node --experimental-strip-types --test \"tests/e2e/docker/**/*.e2e.test.ts\""
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.2.83",
     "@anthropic-ai/sdk": "^0.90.0",
     "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@aws-sdk/client-bedrock-runtime": "^3.983.0",
@@ -161,7 +162,6 @@
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.83",
     "@opengsd/engine-darwin-arm64": "1.0.2",
     "@opengsd/engine-darwin-x64": "1.0.2",
     "@opengsd/engine-linux-arm64-gnu": "1.0.2",


### PR DESCRIPTION
## Summary
- Made the Claude Agent SDK a required dependency and verified package resolution plus fast repo checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #138
- [#138 [Bug]: Unusuable, unresponsive, fresh install](https://github.com/open-gsd/gsd-pi/issues/138)

## User
- @RyRy79261

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/138-bug-unusuable-unresponsive-fresh-install-1779785224`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency classification change only; same package version, with slightly larger guaranteed install footprint.
> 
> **Overview**
> Moves **`@anthropic-ai/claude-agent-sdk`** (pinned at `0.2.83`) from **`optionalDependencies`** to **`dependencies`** in `package.json`, with the matching **`package-lock.json`** update so the package is no longer treated as optional at install time.
> 
> Fresh installs should always resolve and install the SDK, which the **claude-code-cli** extension uses for the official Claude Code routing path—addressing reports of an unusable or unresponsive app when the optional install was skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57548518db752e18fd073ee491fc6d01ce65ae09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->