### PR TITLE
ci: extend integration test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
 
   integration-tests:
     name: integration-tests
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [fast-gates, build]
     if: needs.fast-gates.outputs.heavy-code-changed == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- increase the `integration-tests` GitHub Actions job timeout from 15 to 25 minutes
- preserve the existing job definition and test command

## Why
The `integration-tests` CI job was being cancelled by the workflow timeout after setup steps consumed part of the 15-minute budget, leaving too little time for `npm run test:integration` to complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only timing tweak with no application, auth, or data-path changes.
> 
> **Overview**
> Raises the **`integration-tests`** job **`timeout-minutes`** in `.github/workflows/ci.yml` from **15** to **25** so checkout, dependency install, artifact restore, and Next.js cache steps leave enough wall time for **`npm run test:integration`** instead of the job being cancelled by the workflow limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca78473dbb8c8424412c5ab8b9fb6a0750b98979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->