### PR TITLE
fix(issue): worktree isolation: agent writes code to project root instead of worktree (missing path-rewriting instruction in prompts)

### DIFF
--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -4,7 +4,9 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-Work only in `{{workingDirectory}}`. Do not `cd` elsewhere.
+All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
 
 ## Your Role in the Pipeline
 

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -4,7 +4,7 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
 If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
 

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -4,9 +4,9 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-Work only in `{{workingDirectory}}`; do not `cd` elsewhere.
+Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
-Treat any inlined absolute path outside `{{workingDirectory}}` as stale. Convert it to the matching relative path under `{{workingDirectory}}`; if none exists, record a verification failure and stop without editing or running commands in another checkout.
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
 
 ## Your Role in the Pipeline
 
@@ -27,8 +27,8 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 3. Run all slice-level verification through `gsd_exec` / Context Mode evidence; refresh current state if needed. Do not use direct `bash` for verification commands.
 4. Complete only when every required check passes. If verification fails or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
 5. If verification fails:
-   - Task-specific regressions: if the failure is in files the task touched and was absent before it ran, call `gsd_task_reopen` with that task and reason.
-   - Inherited/out-of-scope failures: do **not** reopen completed tasks; call `gsd_replan_slice` with adjusted verification scope or follow-up tasks.
+   - Task-specific regressions: if the failure is in files the task touched and pre-task verification evidence shows it was absent before that task ran, call `gsd_task_reopen` with that task and reason.
+   - Inherited/out-of-scope failures, including failures present before the task ran or failures without pre-task evidence: do **not** reopen completed tasks; call `gsd_replan_slice` with adjusted verification scope or follow-up tasks.
    - Other plan-invalidating failures: call `gsd_replan_slice` with the blocker and updated execution tasks.
    Then stop with: "Slice {{sliceId}} needs execution follow-up."
 6. Task summaries use a flat file layout under `tasks/` such as `T01-SUMMARY.md`, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. Never use `tasks/*/SUMMARY.md`.

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -4,9 +4,9 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+Work only in `{{workingDirectory}}`; do not `cd` elsewhere.
 
-If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+Treat any inlined absolute path outside `{{workingDirectory}}` as stale. Convert it to the matching relative path under `{{workingDirectory}}`; if none exists, record a verification failure and stop without editing or running commands in another checkout.
 
 ## Your Role in the Pipeline
 
@@ -16,29 +16,29 @@ You are the closer: verify assembled task work delivers the slice goal, then com
 
 {{gatesToClose}}
 
-Match effort to complexity. Simple 1-2 task slices need brief summary and light verification; multi-subsystem slices need stronger verification and detail.
+Match effort to complexity. Simple slices need brief summary and light verification; multi-subsystem slices need stronger verification and detail.
 
-Use `subagent` only when useful: reviewer (cross-cutting code/abstractions), security (auth/network/IO/crypto), tester (coverage). Subagents report; you apply findings before completion.
+Use `subagent` only when useful: reviewer, security, or tester. Apply findings before completion.
 
 ## Completion Rules
 
 1. Use the inlined Slice Summary and UAT templates.
 2. {{skillActivation}}
-3. Run all slice-level verification checks from the slice plan through the closeout-safe verification surface (`gsd_exec` / Context Mode verification evidence); refresh current state if needed. Do not use direct `bash` for verification commands.
-4. Complete the slice only when every required verification check passes. If verification fails or the fix requires source changes, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
+3. Run all slice-level verification through `gsd_exec` / Context Mode evidence; refresh current state if needed. Do not use direct `bash` for verification commands.
+4. Complete only when every required check passes. If verification fails or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
 5. If verification fails:
-   - For task-specific regressions (failure in files this task touched, absent before it ran — confirm via git diff and pre-task verification output; if present before task ran, it is NOT task-specific): call `gsd_task_reopen` with that task and a concrete reason.
-   - For inherited/out-of-scope failures (pre-existed this slice or affects files outside it — e.g., CI baseline, upstream regressions; plan is sound, only scope needs adjusting): do **not** reopen completed tasks; call `gsd_replan_slice` with the blocker and adjusted verification scope or follow-up tasks.
-   - For other plan-invalidating failures (new failure that breaks execution assumptions — e.g., API contract changed, required dependency missing; execution tasks need reworking): call `gsd_replan_slice` with the blocker and updated execution tasks.
+   - Task-specific regressions: if the failure is in files the task touched and was absent before it ran, call `gsd_task_reopen` with that task and reason.
+   - Inherited/out-of-scope failures: do **not** reopen completed tasks; call `gsd_replan_slice` with adjusted verification scope or follow-up tasks.
+   - Other plan-invalidating failures: call `gsd_replan_slice` with the blocker and updated execution tasks.
    Then stop with: "Slice {{sliceId}} needs execution follow-up."
 6. Task summaries use a flat file layout under `tasks/` such as `T01-SUMMARY.md`, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. Never use `tasks/*/SUMMARY.md`.
 7. If observability/diagnostics were planned, verify them unless the slice is simple.
-8. Address every gate in Gates to Close. Q8 = **Operational Readiness**: health signal, failure signal, recovery procedure, monitoring gaps. Empty sections are omitted.
+8. Address every Gate to Close. Q8 = **Operational Readiness**: health signal, failure signal, recovery, monitoring gaps. Omit empty sections.
 9. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
 10. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
 11. Draft concrete UAT with preconditions, steps, expected outcomes, edge cases, and UAT Type.
-12. Review the inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions and gotchas. Read full `*-SUMMARY.md` only when an excerpt is absent, truncated, or lacks needed evidence. Capture with `capture_thought`; do not append knowledge files directly.
-13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes; the tool renders files and updates projections.
+12. Review the inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions and gotchas. Read full `*-SUMMARY.md` only if needed. Capture with `capture_thought`; do not append knowledge files.
+13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes.
 14. Do not run git commands.
 15. If the current project state needs refresh, call `gsd_summary_save` with `artifact_type: "PROJECT"` and the full updated project markdown as `content`; omit `milestone_id`. Do not write or edit `.gsd/PROJECT.md` directly.
 

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -4,7 +4,9 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-Work only in `{{workingDirectory}}`. Do not `cd` elsewhere.
+All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
 
 You execute. The inlined task plan is authoritative. Verify referenced files and surrounding code before edits. Adapt minor local mismatches; use `blocker_discovered: true` only when the slice contract or downstream graph is invalid.
 

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -4,9 +4,9 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
-If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, do not edit or run commands in another checkout; call `gsd_task_complete` with camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, `verificationEvidence`, and `blockerDiscovered: true`, then stop.
 
 You execute. The inlined task plan is authoritative. Verify referenced files and surrounding code before edits. Adapt minor local mismatches; use `blocker_discovered: true` only when the slice contract or downstream graph is invalid.
 
@@ -62,7 +62,7 @@ Keep about **{{verificationBudget}}** for verification and summary. If context i
 - For downstream-impacting ambiguity that cannot be resolved from code, plans, or decisions, include an `escalation` object with question, options, recommendation, rationale, and `continueWithDefault`.
 - Capture meaningful architecture/pattern/observability decisions with `capture_thought`; capture non-obvious gotchas or conventions only when they save future investigation.
 - Use the inlined Task Summary template below. Read `{{taskSummaryTemplatePath}}` only if the inlined template is absent or visibly truncated.
-- Call `gsd_task_complete` with camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`.
+- Call `gsd_task_complete` with camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`. Include `blockerDiscovered: true` when a stale-path safety failure or other plan-invalidating blocker prevents execution.
 - The DB-backed tool is the canonical write path. Do **not** manually write `{{taskSummaryPath}}` or edit PLAN.md checkboxes; the tool renders the summary and updates state.
 - Do not run git commands; the system commits from your summary.
 
@@ -70,6 +70,6 @@ Keep about **{{verificationBudget}}** for verification and summary. If context i
 
 **Autonomous execution:** no human is available. Do not call `ask_user_questions` or `secure_env_collect`; make reasonable assumptions and document them.
 
-**You MUST call `gsd_task_complete` before finishing.**
+**You MUST call `gsd_task_complete` before finishing, including when the stale-path safety rule stops execution.**
 
 When done, say: "Task {{taskId}} complete."

--- a/src/resources/extensions/gsd/prompts/plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/plan-milestone.md
@@ -6,6 +6,8 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
 All relevant context is preloaded below. Start immediately without re-reading these files.
 
 {{inlinedContext}}

--- a/src/resources/extensions/gsd/prompts/plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/plan-slice.md
@@ -4,7 +4,11 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-Work only in `{{workingDirectory}}`. Do not `cd` elsewhere. Relevant context is preloaded; start without re-reading it.
+All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
+Relevant context is preloaded; start without re-reading it.
 
 {{inlinedContext}}
 

--- a/src/resources/extensions/gsd/prompts/plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/plan-slice.md
@@ -4,9 +4,9 @@ You are executing GSD auto-mode.
 
 ## Working Directory
 
-All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
-If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, do not edit or run commands in another checkout; this stale-path safety rule overrides normal planning. Stop without calling `gsd_plan_slice`, and report the stale path as the verification failure.
 
 Relevant context is preloaded; start without re-reading it.
 
@@ -54,6 +54,6 @@ The slice directory already exists. Do not mkdir.
 
 **Autonomous execution:** no human is available. Do not call `ask_user_questions` or `secure_env_collect`; make reasonable assumptions and document them.
 
-**You MUST call `gsd_plan_slice` to persist planning state before finishing.**
+**You MUST call `gsd_plan_slice` to persist planning state before finishing, unless the stale-path safety rule above stops the unit before safe planning can occur.**
 
 When done, say: "Slice {{sliceId}} planned."

--- a/src/resources/extensions/gsd/prompts/reassess-roadmap.md
+++ b/src/resources/extensions/gsd/prompts/reassess-roadmap.md
@@ -6,6 +6,8 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
 ## Your Role in the Pipeline
 
 A slice just completed. The **complete-slice agent** verified the work and wrote a slice summary. You decide whether the remaining roadmap still makes sense given what was actually built. If you change the roadmap, the next slice's **researcher** and **planner** agents work from your updated version. If you confirm it's fine, the pipeline moves to the next slice immediately.

--- a/src/resources/extensions/gsd/prompts/replan-slice.md
+++ b/src/resources/extensions/gsd/prompts/replan-slice.md
@@ -6,6 +6,8 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
 A completed task reported `blocker_discovered: true`, meaning the current slice plan cannot be executed as-is. Your job is to rewrite the remaining tasks in the slice plan to address the blocker while preserving all completed work.
 
 All relevant context has been preloaded below — the roadmap, current slice plan, blocker task summary excerpt, and decisions are inlined. Start working immediately without re-reading these files.

--- a/src/resources/extensions/gsd/prompts/research-milestone.md
+++ b/src/resources/extensions/gsd/prompts/research-milestone.md
@@ -6,6 +6,8 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
 All relevant context has been preloaded below — start working immediately without re-reading these files.
 
 {{inlinedContext}}

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -6,6 +6,8 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
 All relevant context has been preloaded below. Start working immediately without re-reading these files.
 
 {{inlinedContext}}

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -246,6 +246,18 @@ test("complete-slice prompt keeps source fixes in execution units", () => {
   assert.doesNotMatch(prompt, /Fix failures before marking done/i);
 });
 
+test("complete-slice prompt binds all file operations to workingDirectory", () => {
+  const prompt = readPrompt("complete-slice");
+  assert.match(prompt, /Your working directory is `\{\{workingDirectory\}\}`/);
+  assert.match(prompt, /All file reads, writes, and shell commands MUST operate relative to this directory/);
+});
+
+test("complete-slice prompt disambiguates task-specific regressions from inherited failures", () => {
+  const prompt = readPrompt("complete-slice");
+  assert.match(prompt, /pre-task verification evidence shows it was absent before that task ran/i);
+  assert.match(prompt, /failures present before the task ran/i);
+});
+
 test("complete-slice prompt instructs writing summary and UAT files before tool call", () => {
   const prompt = readPrompt("complete-slice");
   assert.match(prompt, /\{\{sliceSummaryPath\}\}/);


### PR DESCRIPTION
## Summary
- Added worktree path-rewriting safety instructions to the affected prompts and verified them with a focused prompt check plus npm run verify:fast.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #145
- [#145 worktree isolation: agent writes code to project root instead of worktree (missing path-rewriting instruction in prompts)](https://github.com/open-gsd/gsd-pi/issues/145)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/145-worktree-isolation-agent-writes-code-to--1779799562`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782391670&installation_id=134682257&pr_number=146&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F146&signature=3619ecc1036216c8bfaef68ba0663af929be1919fbbbdc51e83e6588d4a21610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches merge-gating CI, release/publish workflows, and native build matrix; tokenless checkout and ARM64 target/runner contract mismatches can break builds or npm OIDC assumptions noted in workflow comments.
> 
> **Overview**
> This diff is **CI and GitHub Actions infrastructure**, not the worktree/prompt changes described in the PR title.
> 
> Most workflows switch **`runs-on`** from GitHub-hosted labels (`ubuntu-latest`, `windows-latest`) to **Blacksmith** runners (`blacksmith-4vcpu-ubuntu-2404`, `blacksmith-4vcpu-windows-2025`). **`ci.yml`** replaces **`actions/checkout`** on many jobs with a **manual `git fetch` over public HTTPS** so checkout does not rely on **`GITHUB_TOKEN`** / actor-scoped auth (full history on `fast-gates`, shallow elsewhere).
> 
> **`scripts/__tests__/github-workflows-runner-contract.test.mjs`** adds a test that enforces the token-free CI checkout pattern. **`build-native.yml`** changes the linux-arm64 matrix **`target`** field to a Blacksmith label while the same test file still asserts **`aarch64-unknown-linux-gnu`**—and the existing “GitHub-hosted runners only” test is **not** updated for Blacksmith **`runs-on`**, which may break CI unless addressed elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96b095219284531c9ccb69e194012305e370648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->