### PR TITLE
fix(issue): checkoutBranchWithStashGuard fails when stash contains untracked files tracked on target branch

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1112,11 +1112,50 @@ export function checkoutBranchWithStashGuard(
     try {
       popStashByRef(basePath, stashMarker);
     } catch (popErr) {
+      const alreadyExists = stashAlreadyExistsFilesFromError(popErr);
+      const gsdAlreadyExists = alreadyExists.filter((f) => f.startsWith(".gsd/"));
+      const nonGsdAlreadyExists = alreadyExists.filter((f) => !f.startsWith(".gsd/"));
+      const stashPopMessage = popErr instanceof Error ? popErr.message : String(popErr);
+      const isUntrackedRestoreFailure = stashPopMessage.includes("could not restore untracked files from stash");
+      const stashRefForDrop = stashRefFromError(popErr);
+      const nonGsdUnmerged = nativeConflictFiles(basePath).filter((f) => !f.startsWith(".gsd/"));
+
+      if (
+        isUntrackedRestoreFailure &&
+        gsdAlreadyExists.length > 0 &&
+        nonGsdAlreadyExists.length === 0 &&
+        nonGsdUnmerged.length === 0
+      ) {
+        for (const f of gsdAlreadyExists) {
+          execFileSync("git", ["checkout", "HEAD", "--", f], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+          });
+          nativeAddPaths(basePath, [f]);
+        }
+
+        if (stashRefForDrop) {
+          try {
+            execFileSync("git", ["stash", "drop", stashRefForDrop], {
+              cwd: basePath,
+              stdio: ["ignore", "pipe", "pipe"],
+              encoding: "utf-8",
+            });
+          } catch (err) { /* stash may already be consumed */
+            logWarning("worktree", `git stash drop failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        } else {
+          logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic drop");
+        }
+        return;
+      }
+
       const msg = popErr instanceof Error ? popErr.message : String(popErr);
       const wrapped = new Error(
         `checkout to '${branch}' succeeded but stash restore failed; working tree changes remain in the stash list. Original error: ${msg}`,
       );
-      const ref = (popErr as { stashRef?: string } | null)?.stashRef;
+      const ref = stashRefForDrop;
       if (ref) (wrapped as { stashRef?: string }).stashRef = ref;
       throw wrapped;
     }

--- a/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -83,5 +83,29 @@ describe("checkoutBranchWithStashGuard", () => {
     assert.equal(branch, "milestone/B");
     const stashList = git(["stash", "list"], repo).trim();
     assert.match(stashList, /gsd: checkout stash/);
+  });
+
+  test("auto-resolves .gsd untracked restore collisions after checkout", (t) => {
+    const repo = createRepo(t);
+    git(["checkout", "-b", "milestone/GSD"], repo);
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "DECISIONS.md"), "tracked\n");
+    git(["add", ".gsd/DECISIONS.md"], repo);
+    git(["commit", "-m", "add gsd state"], repo);
+    git(["checkout", "main"], repo);
+
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "DECISIONS.md"), "untracked local\n");
+
+    checkoutBranchWithStashGuard(repo, "milestone/GSD", "test-gsd-untracked-collision");
+
+    const branch = git(["branch", "--show-current"], repo).trim();
+    assert.equal(branch, "milestone/GSD");
+    const wtContent = readFileSync(join(repo, ".gsd", "DECISIONS.md"), "utf8");
+    assert.equal(wtContent, "tracked\n");
+    const status = git(["status", "--porcelain"], repo).trim();
+    assert.equal(status, "");
+    const stashList = git(["stash", "list"], repo).trim();
+    assert.equal(stashList, "");
   });
 });


### PR DESCRIPTION
## Summary
- Fixed checkout stash restore handling for tracked .gsd collisions and verified with the focused checkout-branch stash guard regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #134
- [#134 checkoutBranchWithStashGuard fails when stash contains untracked files tracked on target branch](https://github.com/open-gsd/gsd-pi/issues/134)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/134-checkoutbranchwithstashguard-fails-when--1779800217`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow recovery path in milestone/branch checkout with a focused regression test; non-.gsd collisions still fail with the existing error.
> 
> **Overview**
> **`checkoutBranchWithStashGuard`** no longer treats every failed stash pop after a successful branch switch as fatal. When Git reports it **could not restore untracked files from stash** and the only collisions are under **`.gsd/`** (with no other path conflicts or unmerged non-`.gsd` files), the flow **restores those paths from `HEAD`**, stages them, **drops the targeted stash entry**, and completes checkout instead of leaving the stash and throwing.
> 
> A regression test covers checking out a milestone branch while **local untracked `.gsd/DECISIONS.md`** conflicts with the **tracked** version on that branch—expecting the branch tip content, a clean working tree, and an empty stash list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3ac689e08bfa5bdf6bb83027298a90f550cbe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782392790&installation_id=134682257&pr_number=147&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F147&signature=f9a1cbd2b26591eeddacbe0a3d3f4f293759de0fc3f8e44a485db9a0d7142687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->