### PR TITLE
fix(issue): checkoutBranchWithStashGuard fails when stash contains untracked files tracked on target branch

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1112,12 +1112,38 @@ export function checkoutBranchWithStashGuard(
     try {
       popStashByRef(basePath, stashMarker);
     } catch (popErr) {
+      const alreadyExists = stashAlreadyExistsFilesFromError(popErr);
+      const gsdAlreadyExists = alreadyExists.filter((f) => f.startsWith(".gsd/"));
+      const nonGsdAlreadyExists = alreadyExists.filter((f) => !f.startsWith(".gsd/"));
       const msg = popErr instanceof Error ? popErr.message : String(popErr);
+      const isUntrackedRestoreFailure = msg.includes("could not restore untracked files from stash");
+      const stashRef = stashRefFromError(popErr);
+
+      if (isUntrackedRestoreFailure && gsdAlreadyExists.length > 0 && nonGsdAlreadyExists.length === 0) {
+        for (const f of gsdAlreadyExists) {
+          execFileSync("git", ["checkout", "HEAD", "--", f], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+          });
+          nativeAddPaths(basePath, [f]);
+        }
+        if (stashRef) {
+          execFileSync("git", ["stash", "drop", stashRef], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+          });
+        } else {
+          logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic drop");
+        }
+        return;
+      }
+
       const wrapped = new Error(
         `checkout to '${branch}' succeeded but stash restore failed; working tree changes remain in the stash list. Original error: ${msg}`,
       );
-      const ref = (popErr as { stashRef?: string } | null)?.stashRef;
-      if (ref) (wrapped as { stashRef?: string }).stashRef = ref;
+      if (stashRef) (wrapped as { stashRef?: string }).stashRef = stashRef;
       throw wrapped;
     }
   }

--- a/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -83,5 +83,27 @@ describe("checkoutBranchWithStashGuard", () => {
     assert.equal(branch, "milestone/B");
     const stashList = git(["stash", "list"], repo).trim();
     assert.match(stashList, /gsd: checkout stash/);
+  });
+
+  test("auto-resolves .gsd untracked restore collisions after checkout", (t) => {
+    const repo = createRepo(t);
+    git(["checkout", "-b", "milestone/M001"], repo);
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "PROJECT.md"), "tracked on milestone\n");
+    git(["add", ".gsd/PROJECT.md"], repo);
+    git(["commit", "-m", "track gsd state"], repo);
+    git(["checkout", "main"], repo);
+
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "PROJECT.md"), "untracked on main\n");
+
+    checkoutBranchWithStashGuard(repo, "milestone/M001", "test-gsd-untracked-collision");
+
+    const branch = git(["branch", "--show-current"], repo).trim();
+    assert.equal(branch, "milestone/M001");
+    const content = readFileSync(join(repo, ".gsd", "PROJECT.md"), "utf8");
+    assert.equal(content, "tracked on milestone\n");
+    const stashList = git(["stash", "list"], repo).trim();
+    assert.equal(stashList, "");
   });
 });


### PR DESCRIPTION
## Summary
- Fixed checkout stash restoration for `.gsd/` untracked-file collisions and verified with the focused checkout stash guard test plus extension typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #134
- [#134 checkoutBranchWithStashGuard fails when stash contains untracked files tracked on target branch](https://github.com/open-gsd/gsd-pi/issues/134)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/134-checkoutbranchwithstashguard-fails-when--1779801073`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782393643&installation_id=134682257&pr_number=150&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F150&signature=81176d06877f6492cf715abeb1dc4e06765216aca5f108cedbf71362cc9d6c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow recovery path for a known git stash/untracked edge case in branch-mode checkout; non-.gsd failures unchanged and covered by a new regression test.
> 
> **Overview**
> **`checkoutBranchWithStashGuard`** no longer fails when checkout succeeds but **`git stash pop`** cannot restore untracked files because paths under **`.gsd/`** already exist on the target branch (e.g. untracked on `main`, tracked on `milestone/*`).
> 
> On that specific untracked-restore failure, the handler keeps only **`.gsd/`** “already exists” collisions, resets those files from **`HEAD`**, stages them, drops the marked stash, and returns cleanly. Non-**`.gsd/`** collisions still surface the existing “checkout succeeded but stash restore failed” error. Stash ref handling now goes through **`stashRefFromError`**.
> 
> A focused integration test covers the untracked-on-main / tracked-on-milestone **`.gsd/PROJECT.md`** scenario and expects an empty stash list after checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da58502ec8b876cbb5f8056a1308318f987c031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->