### PR TITLE
fix(issue): pre_dispatch_hooks and post_unit_hooks silently ignored in worktree isolation mode — resolvePreDispatchHooks/resolvePostUnitHooks drop basePath

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -649,8 +649,8 @@ export function renderPreferencesForSystemPrompt(preferences: GSDPreferences, re
  * Resolve enabled post-unit hooks from effective preferences.
  * Returns an empty array when no hooks are configured.
  */
-export function resolvePostUnitHooks(): PostUnitHookConfig[] {
-  const prefs = loadEffectiveGSDPreferences();
+export function resolvePostUnitHooks(basePath?: string): PostUnitHookConfig[] {
+  const prefs = loadEffectiveGSDPreferences(basePath);
   return (prefs?.preferences.post_unit_hooks ?? [])
     .filter(h => h.enabled !== false);
 }
@@ -659,8 +659,8 @@ export function resolvePostUnitHooks(): PostUnitHookConfig[] {
  * Resolve enabled pre-dispatch hooks from effective preferences.
  * Returns an empty array when no hooks are configured.
  */
-export function resolvePreDispatchHooks(): PreDispatchHookConfig[] {
-  const prefs = loadEffectiveGSDPreferences();
+export function resolvePreDispatchHooks(basePath?: string): PreDispatchHookConfig[] {
+  const prefs = loadEffectiveGSDPreferences(basePath);
   return (prefs?.preferences.pre_dispatch_hooks ?? [])
     .filter(h => h.enabled !== false);
 }

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -169,7 +169,7 @@ export class RuleRegistry {
     }
 
     // Check if any hooks are configured for this unit type
-    const hooks = resolvePostUnitHooks().filter(h =>
+    const hooks = resolvePostUnitHooks(basePath).filter(h =>
       h.after.includes(completedUnitType),
     );
     if (hooks.length === 0) return null;
@@ -237,7 +237,7 @@ export class RuleRegistry {
 
   private _handleHookCompletion(basePath: string): HookDispatchResult | null {
     const hook = this.activeHook!;
-    const hooks = resolvePostUnitHooks();
+    const hooks = resolvePostUnitHooks(basePath);
     const config = hooks.find(h => h.name === hook.hookName);
 
     // Check if retry was requested via retry_on artifact
@@ -284,7 +284,7 @@ export class RuleRegistry {
       return { action: "proceed", prompt, firedHooks: [] };
     }
 
-    const hooks = resolvePreDispatchHooks().filter(h =>
+    const hooks = resolvePreDispatchHooks(basePath).filter(h =>
       h.before.includes(unitType),
     );
     if (hooks.length === 0) {
@@ -476,7 +476,7 @@ export class RuleRegistry {
     unitId: string,
     basePath: string,
   ): HookDispatchResult | null {
-    const hook = resolvePostUnitHooks().find(h => h.name === hookName);
+    const hook = resolvePostUnitHooks(basePath).find(h => h.name === hookName);
     if (!hook) {
       console.error(`[triggerHookManually] Hook "${hookName}" not found in post_unit_hooks`);
       return null;

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -5,6 +5,9 @@
 
 import assert from 'node:assert/strict';
 import { test, describe, beforeEach } from "node:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   RuleRegistry,
   getRegistry,
@@ -381,6 +384,63 @@ describe("RuleRegistry", () => {
     const result = registry.evaluatePreDispatch("execute-task", "M001/S01/T01", "original prompt", "/tmp/test");
     assert.deepStrictEqual(result.action, "proceed", "proceeds when no hooks");
     assert.deepStrictEqual(result.prompt, "original prompt", "prompt unchanged");
+  });
+
+  test("hook evaluation loads preferences from explicit basePath when cwd is an isolated worktree", () => {
+    const originalCwd = process.cwd();
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-base-"));
+    const worktreeRoot = mkdtempSync(join(tmpdir(), "gsd-hook-worktree-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+
+    try {
+      mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+      writeFileSync(
+        join(projectRoot, ".gsd", "PREFERENCES.md"),
+        [
+          "---",
+          "version: 1",
+          "pre_dispatch_hooks:",
+          "  - name: policy-prepend",
+          "    before: [complete-slice]",
+          "    action: modify",
+          "    prepend: POLICY TEXT HERE",
+          "post_unit_hooks:",
+          "  - name: review-after-task",
+          "    after: [execute-task]",
+          "    prompt: Review {taskId}",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      process.env.GSD_HOME = tempGsdHome;
+      process.chdir(worktreeRoot);
+
+      const registry = new RuleRegistry([]);
+      const preResult = registry.evaluatePreDispatch(
+        "complete-slice",
+        "M001/S01",
+        "original prompt",
+        projectRoot,
+      );
+
+      assert.deepStrictEqual(preResult.action, "proceed");
+      assert.ok(preResult.prompt?.startsWith("POLICY TEXT HERE"), "pre-dispatch hook prepends policy text");
+      assert.deepStrictEqual(preResult.firedHooks, ["policy-prepend"]);
+
+      const postResult = registry.evaluatePostUnit("execute-task", "M001/S01/T01", projectRoot);
+      assert.notEqual(postResult, null, "post-unit hook dispatches from basePath preferences");
+      assert.deepStrictEqual(postResult!.hookName, "review-after-task");
+      assert.equal(postResult!.prompt.includes("Review T01"), true);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(worktreeRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
   });
 
   // ── matchedRule provenance (S02 journal support) ───────────────────


### PR DESCRIPTION
## Summary
- Fixed hook preference resolution to preserve basePath in worktree isolation and verified with the focused rule-registry regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #149
- [#149 pre_dispatch_hooks and post_unit_hooks silently ignored in worktree isolation mode — resolvePreDispatchHooks/resolvePostUnitHooks drop basePath](https://github.com/open-gsd/gsd-pi/issues/149)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/149-pre-dispatch-hooks-and-post-unit-hooks-s-1779802775`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782395313&installation_id=134682257&pr_number=151&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F151&signature=7cd09acee32609a8d11573d7d7a2108f08ebaf1271b3e8fb788f9a24ff954ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted preference-loading fix with a focused regression test; execution behavior only changes when hooks were previously skipped in worktree mode.
> 
> **Overview**
> **Fixes hook preferences being ignored when execution runs from a git worktree** whose `cwd` is not the project root. `resolvePostUnitHooks` and `resolvePreDispatchHooks` now accept an optional `basePath` and pass it through to `loadEffectiveGSDPreferences`, and `RuleRegistry` forwards the `basePath` it already receives on post-unit, pre-dispatch, completion, and manual hook paths.
> 
> A regression test sets `cwd` to an empty worktree while hook config lives under the real project’s `.gsd/PREFERENCES.md`, confirming pre-dispatch modify hooks and post-unit dispatch still fire when `basePath` is the project root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdc07f5a73b21301cd2771774492881f8658546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->