### PR TITLE
fix(ci): avoid actor-scoped checkout token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,22 @@ jobs:
       windows-e2e-changed: ${{ steps.classify.outputs.windows-e2e-changed }}
       docker-changed: ${{ steps.classify.outputs.docker-changed }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '0'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            '+refs/tags/*:refs/tags/*' \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Prepare diff base for scans
         env:
@@ -82,7 +95,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -132,7 +158,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -158,7 +197,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -188,7 +240,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -212,7 +277,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -241,7 +319,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -279,7 +370,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -306,7 +410,20 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
+            "+${GITHUB_REF}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/scripts/__tests__/github-workflows-runner-contract.test.mjs
+++ b/scripts/__tests__/github-workflows-runner-contract.test.mjs
@@ -66,6 +66,41 @@ test("active workflows use the standard cache action", () => {
   }
 });
 
+test("ci workflow checkout does not depend on actor-scoped GitHub token auth", () => {
+  const workflow = YAML.parse(readFileSync(".github/workflows/ci.yml", "utf8"));
+  const checkoutSteps = [];
+
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      assert.doesNotMatch(
+        String(step.uses ?? ""),
+        /^actions\/checkout@/,
+        `.github/workflows/ci.yml job ${jobName} uses token-authenticated checkout`,
+      );
+
+      if (step.name === "Checkout repository without GITHUB_TOKEN") {
+        checkoutSteps.push({ jobName, step });
+      }
+    }
+  }
+
+  assert.ok(checkoutSteps.length > 0, "CI workflow has explicit checkout steps");
+
+  for (const { jobName, step } of checkoutSteps) {
+    assert.equal(step.shell, "bash", `CI job ${jobName} checkout runs under bash`);
+    assert.match(
+      step.run,
+      /https:\/\/github\.com\/\$\{GITHUB_REPOSITORY\}\.git/,
+      `CI job ${jobName} checkout uses the public HTTPS repository URL`,
+    );
+    assert.doesNotMatch(
+      step.run,
+      /github\.token|\$\{\{\s*github\.token\s*\}\}|GITHUB_TOKEN/,
+      `CI job ${jobName} checkout script does not reference GitHub token auth`,
+    );
+  }
+});
+
 test("native Linux ARM64 build matrix uses a Rust target triple", () => {
   const workflow = YAML.parse(readFileSync(".github/workflows/build-native.yml", "utf8"));
   const entries = workflow.jobs.build.strategy.matrix.include;


### PR DESCRIPTION
## Summary

- Replace `actions/checkout@v6` in the CI workflow with unauthenticated public `git fetch` checkout steps.
- Preserve full-history fetch behavior for `fast-gates` and shallow checkout behavior for the remaining CI jobs.
- Add a workflow contract test so CI does not regress back to actor-scoped checkout token auth.

## Root cause

The latest CI run on `main` failed before any repo code executed because `actions/checkout@v6` used the default `${{ github.token }}` and GitHub rejected that run's actor-scoped token with `Your account is suspended` / HTTP 403. Since this is a public repository and CI only needs read access, checkout should not depend on that token.

## Validation

- `npm run verify:fast`
- `node --test scripts/__tests__/github-workflows-runner-contract.test.mjs scripts/__tests__/pipeline-workflow.test.mjs scripts/__tests__/build-native-workflow.test.mjs scripts/__tests__/npm-publish-workflow.test.mjs`
- Parsed `.github/workflows/ci.yml` with the repo's `yaml` package.
- Locally simulated the new unauthenticated checkout for both `refs/heads/main` and `refs/pull/155/merge`.

`npm run verify:pr` was also attempted. It completed build/typecheck, then the existing full unit suite failed with 16 unrelated failures in auto-mode/planning/markdown/workflow-mcp/key-status areas. None of those failures touch this CI checkout change.

## AI disclosure

This PR was prepared with AI assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782414582&installation_id=134682257&pr_number=157&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F157&signature=a7f034fae5de194418ba6d4fc8d786396c7323c6a1e36ee6152c2b4bc1d2b26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->