### PR TITLE
fix(gsd): report effective verdict after gate downgrade

### DIFF
--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -97,6 +97,13 @@ function extractSection(content: string, heading: string): string | undefined {
   return m[1].replace(/\s+$/, "");
 }
 
+function extractEffectiveVerdict(resultDetails: Record<string, unknown>, fallback: ValidationVerdict): ValidationVerdict {
+  const verdict = resultDetails.verdict;
+  return typeof verdict === "string" && isValidMilestoneVerdict(verdict)
+    ? verdict
+    : fallback;
+}
+
 export function parseValidationFile(content: string): ParsedValidation {
   return {
     verdict: extractVerdict(content),
@@ -215,12 +222,20 @@ export async function handleVerdict(
   }
 
   const prevVerdict = current.verdict ?? "unknown";
-  ctx.ui.notify(
-    `Milestone ${milestoneId} verdict: ${prevVerdict} -> ${parsed.verdict} (${existingValidation.source})`,
-    "success",
-  );
+  const effectiveVerdict = extractEffectiveVerdict(result.details, parsed.verdict);
+  if (effectiveVerdict !== parsed.verdict) {
+    ctx.ui.notify(
+      `Milestone ${milestoneId} verdict requested: ${parsed.verdict}, effective: ${effectiveVerdict} (${existingValidation.source})`,
+      "warning",
+    );
+  } else {
+    ctx.ui.notify(
+      `Milestone ${milestoneId} verdict: ${prevVerdict} -> ${effectiveVerdict} (${existingValidation.source})`,
+      "success",
+    );
+  }
 
-  if (parsed.verdict === "needs-remediation") {
+  if (effectiveVerdict === "needs-remediation") {
     ctx.ui.notify(
       "Follow up with gsd_reassess_roadmap to add remediation slices, then re-run /gsd auto.",
       "info",

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -66,7 +66,13 @@ function seedSlice(milestoneId: string, sliceId: string, status: string): void {
   ).run(milestoneId, sliceId, `Slice ${sliceId}`, status, new Date().toISOString());
 }
 
-function writeValidation(base: string, milestoneId: string, verdict: string, round = 0): string {
+function writeValidation(
+  base: string,
+  milestoneId: string,
+  verdict: string,
+  round = 0,
+  verificationClasses?: string,
+): string {
   const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
   mkdirSync(milestoneDir, { recursive: true });
   const path = join(milestoneDir, `${milestoneId}-VALIDATION.md`);
@@ -93,6 +99,13 @@ function writeValidation(base: string, milestoneId: string, verdict: string, rou
     "## Requirement Coverage",
     "All requirements covered.",
     "",
+    ...(verificationClasses
+      ? [
+        "## Verification Class Compliance",
+        verificationClasses,
+        "",
+      ]
+      : []),
     "## Verdict Rationale",
     `Initial verdict was ${verdict}.`,
     "",
@@ -265,6 +278,39 @@ test("handleVerdict pass override flips verdict and preserves sections", async (
     assert.ok(
       calls.some((c) => c.kind === "success" && /needs-attention.*->.*pass/.test(c.message)),
       `expected success notification, got: ${JSON.stringify(calls)}`,
+    );
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});
+
+test("handleVerdict reports downgraded effective verdict after validation gates", async () => {
+  const base = makeBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Browser-gated Milestone");
+    seedSlice("M001", "S01", "complete");
+    const db = _getAdapter();
+    assert.ok(db, "DB should be open");
+    db.prepare("UPDATE milestones SET verification_uat = ? WHERE id = ?")
+      .run("Browser UAT: click the primary button and verify visible text.", "M001");
+    const validationPath = writeValidation(base, "M001", "needs-attention", 0, "UAT: PASS");
+
+    const { ctx, calls } = makeMockCtx();
+    await handleVerdict("pass --milestone M001", ctx, base);
+
+    const rewritten = readFileSync(validationPath, "utf-8");
+    assert.match(rewritten, /^verdict: needs-attention$/m, "browser gate should downgrade pass");
+    assert.ok(
+      calls.some((c) => c.kind === "warning" &&
+        /requested: pass, effective: needs-attention/.test(c.message)),
+      `expected downgraded effective verdict warning, got: ${JSON.stringify(calls)}`,
+    );
+    assert.ok(
+      !calls.some((c) => c.kind === "success" && /->.*pass/.test(c.message)),
+      `must not report pass when effective verdict stayed needs-attention: ${JSON.stringify(calls)}`,
     );
   } finally {
     closeDatabase();


### PR DESCRIPTION
## Linked issue

Closes #153

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** `/gsd verdict` now reports the effective validation verdict when validation gates downgrade a requested verdict.
**Why:** The command could previously tell users `needs-attention -> pass` even when the milestone remained `needs-attention`.
**How:** The handler reads the effective verdict returned by validation, warns when it differs from the requested verdict, and covers the downgrade path with a regression test.

## What

This updates the GSD extension verdict command so the post-validation notification reflects the verdict that was actually persisted after gate checks. When a user requests `pass` but validation gates downgrade the milestone, the command now emits a warning that includes both the requested and effective verdict instead of reporting a successful pass transition.

The regression test covers a browser-UAT-gated milestone where a requested `pass` remains `needs-attention`.

## Why

Issue #153 reports a misleading success message from `/gsd verdict pass` when validation gates keep the milestone in `needs-attention`. That leaves the user with contradictory feedback: the file state is still attention-required, but the command output says the verdict moved to pass.

## How

After `executeValidateMilestone` succeeds, the command now extracts `result.details.verdict` as the effective verdict, falling back to the requested verdict only if the returned detail is absent or invalid. Notifications use the effective verdict, and downgrade cases are reported as warnings.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-verdict.test.ts` — 13 passed.
- `npm run verify:fast` — passed.
- `npm run verify:pr` — local unit suite failed with 17 failures that were reproduced on clean `upstream/main`; observed failure groups include closer prompt on-demand context expectations, deep project setup model policy/enterMilestone failures, key status handling, markdown renderer stale projection checks, planning-crossval, workflow MCP path normalization, isolation-disabled enterMilestone handling, and the prompt golden Phase 2 reduction gate.
- GitHub CI — passed all reported jobs on this PR.

## AI disclosure

- [x] This PR includes AI-assisted code. I used an AI coding assistant to implement the focused fix and run the local verification commands listed above.
