### PR TITLE
fix(compaction): reframe prompts as state-snapshot handoff briefings

### DIFF
--- a/packages/gsd-agent-core/src/compaction/compaction-prompts.test.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction-prompts.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { SUMMARIZATION_SYSTEM_PROMPT } from "./utils.js";
+
+describe("compaction state-snapshot prompts", () => {
+	it("uses a handoff-briefing system prompt", () => {
+		assert.match(SUMMARIZATION_SYSTEM_PROMPT, /handoff briefing writer/i);
+		assert.match(SUMMARIZATION_SYSTEM_PROMPT, /state snapshot/i);
+	});
+
+	it("requires state-snapshot sections in compaction summarization prompts", () => {
+		const source = readFileSync(join(import.meta.dirname, "compaction.ts"), "utf8");
+		assert.match(source, /## Current Direction/);
+		assert.match(source, /## Next Action/);
+		assert.match(source, /## Failed Approaches/);
+		assert.match(source, /STATE SNAPSHOT/);
+	});
+
+	it("wraps injected compaction summaries as authoritative briefings", () => {
+		const messagesSource = readFileSync(
+			join(import.meta.dirname, "../../../pi-coding-agent/src/core/messages.ts"),
+			"utf8",
+		);
+		assert.match(messagesSource, /handoff briefing/i);
+		assert.match(messagesSource, /Next Action/);
+		assert.match(messagesSource, /<briefing>/);
+		assert.match(messagesSource, /<\/briefing>/);
+	});
+});

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -465,77 +465,76 @@ export function findCutPoint(
 // Summarization
 // ============================================================================
 
-const SUMMARIZATION_PROMPT = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another LLM will use to continue the work.
+const SUMMARIZATION_PROMPT = `The messages above are a conversation to hand off. Write a briefing that gets a successor productive in 30 seconds. This is a STATE SNAPSHOT, not a conversation summary — capture where things ARE, not the story of how they got there.
+
+If the conversation shifted direction (e.g., started on problem A, pivoted to problem B), lead with the CURRENT direction. Resolved problems are background, not headline.
 
 Use this EXACT format:
 
-## Goal
-[What is the user trying to accomplish? Can be multiple items if the session covers different tasks.]
+## Current Direction
+[What is actively being worked on RIGHT NOW. This may differ from the original request — if so, state the current focus, not the original ask. Be specific: name the task, the approach being taken, and where in that approach we are.]
+
+## Next Action
+[The single most immediate thing to do when resuming. Be concrete — "run the test suite for X" not "continue working."]
+
+## Decided
+- **[Decision]**: [rationale in one line]
+[Only decisions that constrain future work. Skip deliberation, just verdicts.]
+
+## Done
+- [x] [Completed work, especially file paths modified and what changed in them]
+[Include resolved problems briefly so they are not re-investigated.]
+
+## Failed Approaches
+- [Approaches tried that did NOT work and why — so the successor does not retry them]
+- [Or "(none)" if all approaches succeeded]
 
 ## Constraints & Preferences
-- [Any constraints, preferences, or requirements mentioned by user]
+- [Requirements, preferences, or rules the user stated]
 - [Or "(none)" if none were mentioned]
 
-## Progress
-### Done
-- [x] [Completed tasks/changes]
+## Background
+- [Context from earlier in the conversation that is still load-bearing for the current direction]
+- [Omit anything fully resolved that does not affect current work]
 
-### In Progress
-- [ ] [Current work]
+Preserve exact file paths, function names, and error messages. Be concise — every line should help the successor act, not just understand history.`;
 
-### Blocked
-- [Issues preventing progress, if any]
+const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages. Update the existing briefing (in <previous-summary> tags) to reflect the CURRENT state of the work.
 
-## Key Decisions
-- **[Decision]**: [Brief rationale]
-
-## Next Steps
-1. [Ordered list of what should happen next]
-
-## Critical Context
-- [Any data, examples, or references needed to continue]
-- [Or "(none)" if not applicable]
-
-Keep each section concise. Preserve exact file paths, function names, and error messages.`;
-
-const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
-
-Update the existing structured summary with new information. RULES:
-- PRESERVE all existing information from the previous summary
-- ADD new progress, decisions, and context from the new messages
-- UPDATE the Progress section: move items from "In Progress" to "Done" when completed
-- UPDATE "Next Steps" based on what was accomplished
+This is a living state snapshot, not an append-only log. RULES:
+- UPDATE "Current Direction" to reflect where the work is NOW — if the direction shifted, the new direction leads
+- UPDATE "Next Action" to the most immediate next step based on latest progress
+- MOVE completed work to "Done" — add newly completed items, keep previous ones
+- ADD new decisions to "Decided"
+- ADD failed approaches to "Failed Approaches" so they are not retried
+- DEMOTE or DROP information from the previous briefing that is no longer relevant to active work — do not preserve resolved context that does not affect the current direction
 - PRESERVE exact file paths, function names, and error messages
-- If something is no longer relevant, you may remove it
 
 Use this EXACT format:
 
-## Goal
-[Preserve existing goals, add new ones if the task expanded]
+## Current Direction
+[Update to reflect the current focus — may have shifted from previous briefing]
+
+## Next Action
+[The single most immediate thing to do now]
+
+## Decided
+- **[Decision]**: [rationale in one line]
+[Preserve previous decisions that still constrain work, add new ones]
+
+## Done
+- [x] [All completed work — previous and new]
+
+## Failed Approaches
+- [Preserve previous, add any new failed approaches from these messages]
 
 ## Constraints & Preferences
 - [Preserve existing, add new ones discovered]
 
-## Progress
-### Done
-- [x] [Include previously done items AND newly completed items]
+## Background
+- [Only context that is still load-bearing for the current direction — drop resolved items]
 
-### In Progress
-- [ ] [Current work - update based on progress]
-
-### Blocked
-- [Current blockers - remove if resolved]
-
-## Key Decisions
-- **[Decision]**: [Brief rationale] (preserve all previous, add new)
-
-## Next Steps
-1. [Update based on current state]
-
-## Critical Context
-- [Preserve important context, add new if needed]
-
-Keep each section concise. Preserve exact file paths, function names, and error messages.`;
+Preserve exact file paths, function names, and error messages. Be concise.`;
 
 type SummaryCompleteFn = (
 	model: Model<any>,
@@ -874,18 +873,19 @@ export function prepareCompaction(
 
 const TURN_PREFIX_SUMMARIZATION_PROMPT = `This is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.
 
-Summarize the prefix to provide context for the retained suffix:
+Write a brief state snapshot of the prefix so the retained suffix makes sense:
 
-## Original Request
-[What did the user ask for in this turn?]
+## What Was Requested
+[The user's ask that started this turn — one sentence]
 
-## Early Progress
-- [Key decisions and work done in the prefix]
+## Work Done in Prefix
+- [Concrete actions taken and their outcomes, especially file paths modified]
+- [Decisions made that affect the retained suffix]
 
-## Context for Suffix
-- [Information needed to understand the retained recent work]
+## Failed Approaches
+- [Anything tried in the prefix that failed — so it is not retried in the suffix]
 
-Be concise. Focus on what's needed to understand the kept suffix.`;
+Be concise. Only include what the successor needs to understand the kept suffix.`;
 
 /**
  * Generate summaries for compaction using prepared data.

--- a/packages/gsd-agent-core/src/compaction/utils.ts
+++ b/packages/gsd-agent-core/src/compaction/utils.ts
@@ -228,6 +228,8 @@ export function serializeConversation(messages: Message[]): string {
 // Summarization System Prompt
 // ============================================================================
 
-export const SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI coding assistant, then produce a structured summary following the exact format specified.
+export const SUMMARIZATION_SYSTEM_PROMPT = `You are a handoff briefing writer. Your task is to read a conversation between a user and an AI coding assistant, then produce a state snapshot that enables a successor to continue the work immediately.
 
-Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
+Write from the perspective of "what does the next person need to know to keep going?" — not "what happened in this conversation." Prioritize current direction and next actions over historical narrative. If the conversation shifted goals, lead with the CURRENT goal — the original goal is background context only if still relevant.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured briefing.`;

--- a/packages/pi-coding-agent/src/core/messages.ts
+++ b/packages/pi-coding-agent/src/core/messages.ts
@@ -8,13 +8,13 @@
 import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { ImageContent, Message, TextContent } from "@gsd/pi-ai";
 
-export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
+export const COMPACTION_SUMMARY_PREFIX = `The conversation before this point was compacted. The following is a handoff briefing — treat it as authoritative working state. Continue from the "Next Action" section. Do not re-derive decisions or re-read files already listed as processed.
 
-<summary>
+<briefing>
 `;
 
 export const COMPACTION_SUMMARY_SUFFIX = `
-</summary>`;
+</briefing>`;
 
 export const BRANCH_SUMMARY_PREFIX = `The following is a summary of a branch that this conversation came back from:
 


### PR DESCRIPTION
## Summary

- **Problem:** Compaction summaries are structured as retrospective conversation summaries. When a session pivots from problem A to problem B, the summary over-weights the "dramatic first problem" (more message volume) and under-represents the current direction. Post-compaction, the agent behaves as if it lost its memory — re-investigating resolved issues, missing the active task, and retrying failed approaches.
- **Root cause:** The summarization prompt says "Create a structured context checkpoint summary" with "PRESERVE all existing information" — this is backward-looking and creates a ratchet that locks in early context while current direction gets appended as a footnote.
- **Fix:** Reframe compaction from "summarize this conversation" to "write a handoff briefing for your successor" — a state snapshot, not a narrative.

## Changes

### Prompt restructure (inverted priority)

**Before:** Goal → Constraints → Progress (Done/In Progress/Blocked) → Key Decisions → Next Steps → Critical Context

**After:** Current Direction → Next Action → Decided → Done → Failed Approaches → Constraints → Background

Key differences:
- "Current Direction" leads instead of "Goal" — captures what's happening NOW, explicitly noting when it differs from the original request
- "Next Action" is second (singular, concrete) instead of "Next Steps" buried at the bottom
- "Failed Approaches" is new — prevents post-compaction agents from retrying dead ends
- "Background" replaces "Critical Context" — only load-bearing context for the current direction, with explicit permission to drop resolved items

### System prompt reframing

- From: "context summarization assistant... produce a structured summary"
- To: "handoff briefing writer... produce a state snapshot that enables a successor to continue immediately"
- Added: "If the conversation shifted goals, lead with the CURRENT goal"

### UPDATE prompt: stop preserving everything

- From: "PRESERVE all existing information from the previous summary"
- To: "DEMOTE or DROP information from the previous briefing that is no longer relevant to active work"
- Framed as "living state snapshot, not an append-only log"

### Injection prefix: instruct the successor

- From: "The conversation history before this point was compacted into the following summary: `<summary>`"
- To: "The following is a handoff briefing — treat it as authoritative working state. Continue from the 'Next Action' section. Do not re-derive decisions or re-read files already listed as processed. `<briefing>`"

## Files changed

- `packages/pi-coding-agent/src/core/compaction/compaction.ts` — SUMMARIZATION_PROMPT, UPDATE_SUMMARIZATION_PROMPT, TURN_PREFIX_SUMMARIZATION_PROMPT
- `packages/pi-coding-agent/src/core/compaction/utils.ts` — SUMMARIZATION_SYSTEM_PROMPT
- `packages/pi-coding-agent/src/core/messages.ts` — COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX

## Test plan

- [ ] Existing compaction unit tests pass (prompt content is not asserted in tests — only structure/flow)
- [ ] Manual test: run a long session that pivots topics, trigger compaction, verify the briefing leads with current direction
- [ ] Verify degenerate summary detection still works (length threshold unchanged at 100 chars)
- [ ] Chunked summarization: verify UPDATE prompt correctly demotes resolved items across chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782422476&installation_id=134682257&pr_number=162&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F162&signature=47bcdad773510aaf688e4a4432812444107d7b7a1bf788a8c81a0ad868094cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->