### PR TITLE
fix(models): drop stale kimi-k2.5 maxTokens/cost override

### DIFF
--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -715,12 +715,6 @@ async function generateModels() {
 			candidate.maxTokens = 128000;
 		}
 		// Keep selected OpenRouter model metadata stable until upstream settles.
-		if (candidate.provider === "openrouter" && candidate.id === "moonshotai/kimi-k2.5") {
-			candidate.cost.input = 0.41;
-			candidate.cost.output = 2.06;
-			candidate.cost.cacheRead = 0.07;
-			candidate.maxTokens = 4096;
-		}
 		if (candidate.provider === "openrouter" && candidate.id === "z-ai/glm-5") {
 			candidate.cost.input = 0.6;
 			candidate.cost.output = 1.9;


### PR DESCRIPTION
## Problem

`generate-models.ts` pins `moonshotai/kimi-k2.5` metadata with a "keep stable until upstream settles" override:

```js
if (candidate.provider === "openrouter" && candidate.id === "moonshotai/kimi-k2.5") {
  candidate.cost.input = 0.41;
  candidate.cost.output = 2.06;
  candidate.cost.cacheRead = 0.07;
  candidate.maxTokens = 4096;
}
```

Upstream has since settled. OpenRouter's `/v1/models` now reports for kimi-k2.5:

- `context_length`: 262144
- `top_provider.max_completion_tokens`: **262144**
- pricing: **0.40 / 1.90** per 1M (in/out)

The override clamps `maxTokens` to **4096**, so generations are capped at ~4K output tokens despite the 256K context window (`gsd --list-models` shows `262.144K / 4.096K`). Anyone routing kimi-k2.5 to a planning/long-output phase gets silently truncated output. The pinned cost (0.41/2.06) is also now stale vs upstream (0.40/1.90).

## Fix

Remove the override so kimi-k2.5 derives `maxTokens` and cost from upstream like every other OpenRouter model — the generator already does this via `model.top_provider?.max_completion_tokens` and the pricing fields.

The committed `generated/openrouter.ts` will pick up `maxTokens: 262144` and the corrected pricing on the next model-sync. Verified locally: a regenerated registry yields `maxTokens: 262144`, and a real kimi-k2.5 generation produced ~6K output tokens (3000 integers) with no truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782425188&installation_id=134682257&pr_number=163&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F163&signature=f090c0b5a077ac334d9d20c3222cf31c07f872760af9c8d93c6c7cd1d4d6a174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->