### PR TITLE
fix(issue): verification-gate: pipes (|) in task-plan Verify commands are rejected as unsafe, causing false 'no-host-checks' pause

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -287,7 +287,7 @@ verification_max_retries: 2    # max retry attempts (default: 2)
 
 Failures trigger auto-fix retries — the agent sees the verification output and attempts to fix the issues before advancing. This ensures code quality gates are enforced mechanically, not by LLM compliance.
 
-Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD rejects shell composition and control syntax in verification commands, including pipes, redirects, semicolons, backticks, and command substitution, so a piped command like `python3 -m pytest 2>&1 | tail -5` must be replaced with the underlying test command.
+Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD supports single shell pipelines with `|`, so commands like `python3 -m pytest | tail -5` are valid. Logical OR fallbacks (`||`) are rejected, and GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution because verification is run as a controlled command list, not as an arbitrary shell program.
 
 If you do not configure commands and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -497,9 +497,9 @@ For non-TTY environments (CI, cron, scripted automation), v2.79 adds `gsd headle
 
 **Symptoms:** Pre-execution checks fail with `Unsafe or non-runnable Verify command`, often for a command that works in an interactive shell.
 
-**Cause:** GSD only accepts mechanically executable verification commands. Shell control syntax such as pipes (`|`), redirects (`>` or `<`), semicolons, backticks, and command substitution (`$(...)`) is rejected so verification cannot hide failures by trimming or reshaping output.
+**Cause:** GSD only accepts mechanically executable verification commands. Single shell pipelines with `|` are supported, but logical OR fallbacks (`||`), redirects (`>` or `<`), semicolons, backticks, and command substitution (`$(...)`) are rejected so verification cannot hide failures or run arbitrary shell programs.
 
-**Fix:** Put the direct check in the verify field or `verification_commands`. For example, use `python3 -m pytest tests -q --tb=short` instead of `python3 -m pytest tests -q --tb=short 2>&1 | tail -5`.
+**Fix:** Put a direct check or single pipeline in the verify field or `verification_commands`. For example, `python3 -m pytest tests -q --tb=short | tail -5` is valid, but `python3 -m pytest tests -q --tb=short 2>&1 | tail -5` is rejected because it uses a redirect.
 
 ## LSP (Language Server Protocol)
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -211,7 +211,7 @@ verification_max_retries: 2    # max retry attempts
 
 If verification fails, the AI sees the output and attempts to fix the issues before advancing. This ensures quality gates are enforced mechanically.
 
-Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD rejects shell composition and control syntax in verification commands, including pipes, redirects, semicolons, backticks, and command substitution, so a piped command like `python3 -m pytest 2>&1 | tail -5` must be replaced with the underlying test command.
+Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD supports single shell pipelines with `|`, so commands like `python3 -m pytest | tail -5` are valid. Logical OR fallbacks (`||`) are rejected, and GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution because verification is run as a controlled command list, not as an arbitrary shell program.
 
 If no verification commands are configured and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: a `tests/` directory containing files that match `test_*.py` or `*_test.py` at any nested depth, `pytest.ini`, or pytest configuration sections in `pyproject.toml` such as `[tool.pytest.ini_options]`; equivalent pytest markers under `[tool.pytest]`, `[tool.pytest.*]`, `[pytest]`, or `[tool:pytest]` are also treated as explicit pytest evidence.
 

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -60,6 +60,15 @@ describe("verification-gate: discovery", () => {
     assert.equal(result.source, "task-plan");
   });
 
+  test("discoverCommands accepts task plan verify pipelines", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "npm test | tail -5",
+      cwd: tmp,
+    });
+    assert.deepStrictEqual(result.commands, ["npm test | tail -5"]);
+    assert.equal(result.source, "task-plan");
+  });
+
   test("discoverCommands strips interpreter prefixes from task plan verify commands", () => {
     const result = discoverCommands({
       taskPlanVerify: "bash: ls scripts/hooks/\npython3: python3 -m pytest tests/ -q",
@@ -270,7 +279,7 @@ describe("verification-gate: discovery", () => {
     assert.deepStrictEqual(result.commands, ["! grep 'needle' file.txt", "npm run test"]);
   });
 
-  test("taskPlanVerify rejects piped pytest command", () => {
+  test("taskPlanVerify rejects redirected pytest command", () => {
     const result = discoverCommands({
       taskPlanVerify: "python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5",
       cwd: tmp,
@@ -677,9 +686,14 @@ test("isLikelyCommand: bash negation with known command is accepted", () => {
   assert.equal(isLikelyCommand("! grep needle file.txt"), true);
 });
 
-test("validateVerificationCommand rejects shell control syntax", () => {
+test("validateVerificationCommand allows shell pipelines", () => {
   assert.deepEqual(validateVerificationCommand("python3 -m pytest tests/ -q --tb=short").ok, true);
-  const result = validateVerificationCommand("python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5");
+  const result = validateVerificationCommand("python3 -m pytest tests/ -q --tb=short | tail -5");
+  assert.equal(result.ok, true);
+});
+
+test("validateVerificationCommand rejects shell control syntax", () => {
+  const result = validateVerificationCommand("python3 -m pytest tests/ -q --tb=short > output.log");
   assert.equal(result.ok, false);
   if (!result.ok) {
     assert.match(result.reason, /shell control syntax/);

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -247,7 +247,7 @@ export function formatFailureContext(result: VerificationResult): string {
 // ─── Gate Execution ─────────────────────────────────────────────────────────
 
 /** Characters that indicate shell control syntax when unquoted in a command string. */
-const UNQUOTED_SHELL_CONTROL_CHARS = new Set([";", "|", "<", ">"]);
+const UNQUOTED_SHELL_CONTROL_CHARS = new Set([";", "<", ">"]);
 const EXIT_CODE_ECHO_SUFFIX = /^;\s*echo\s+(?:"exit:\$\?"|'exit:\$\?'|exit:\$\?)\s*$/;
 
 function isAllowedExitCodeEchoSuffix(suffix: string): boolean {
@@ -280,6 +280,9 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
     if (ch === "\"" && !inSingle) {
       inDouble = !inDouble;
       continue;
+    }
+    if (!inSingle && !inDouble && ch === "|" && cmd[i + 1] === "|") {
+      return true;
     }
     if (!inSingle && !inDouble && UNQUOTED_SHELL_CONTROL_CHARS.has(ch)) {
       if (ch === ";" && isAllowedExitCodeEchoSuffix(cmd.slice(i))) {
@@ -371,7 +374,7 @@ export function isLikelyCommand(cmd: string): boolean {
  */
 export function validateVerificationCommand(cmd: string): { ok: true } | { ok: false; reason: string } {
   if (hasUnsafeShellSyntax(cmd)) {
-    return { ok: false, reason: "contains shell control syntax such as pipes, `||` fallbacks, redirects, semicolons, backticks, or command substitution" };
+    return { ok: false, reason: "contains shell control syntax such as `||` fallbacks, redirects, semicolons, backticks, or command substitution" };
   }
   if (!isLikelyCommand(cmd)) {
     return { ok: false, reason: "does not look like a runnable command" };


### PR DESCRIPTION
## Summary
- Allowed verification task-plan pipelines while preserving unsafe shell guards, with focused verification-gate tests and extension typecheck passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #165
- [#165 verification-gate: pipes (|) in task-plan Verify commands are rejected as unsafe, causing false 'no-host-checks' pause](https://github.com/open-gsd/gsd-pi/issues/165)

## User
- @scottsweep

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/165-verification-gate-pipes-in-task-plan-ver-1779839287`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782431865&installation_id=134682257&pr_number=166&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F166&signature=3a197b712a53ff871317e749f879111bc8ba4349e6a5b5f2ab01fb8458c003ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows pre-execution rejection for verification only, keeps `||`/redirect/substitution guards, and adds focused tests; behavior change is intentional for #165.
> 
> **Overview**
> Fixes verification-gate treating **single `|` pipelines** in task-plan `verify` commands as unsafe, which could drop checks and trigger a false **no-host-checks** pause ([#165](https://github.com/open-gsd/gsd-pi/issues/165)).
> 
> **Runtime:** `hasUnsafeShellSyntax` no longer flags unquoted `|`; it still rejects **`||`**, redirects, semicolons (outside allowed patterns), and substitution. `validateVerificationCommand` and discovery now accept commands like `npm test | tail -5` while still rejecting `2>&1 | …` when a redirect is present.
> 
> **Tests:** Coverage for accepted pipelines, redirected commands still rejected, and updated validation messages.
> 
> **Docs:** User and GitBook auto-mode / troubleshooting text now describe **single pipelines as allowed** and clarify what remains blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a109a61a2a3601366b1bca40e107a9362ca397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->