### PR TITLE
fix(issue): KNOWLEDGE.md projection duplicates rows with same P###/L### ID — readKnowledgeMemories lacks deduplication by sourceKnowledgeId

### DIFF
--- a/src/resources/extensions/gsd/knowledge-projection.ts
+++ b/src/resources/extensions/gsd/knowledge-projection.ts
@@ -75,7 +75,7 @@ function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryR
   try {
     const rows = adapter
       .prepare(
-        "SELECT structured_fields FROM memories WHERE category = :cat AND structured_fields IS NOT NULL",
+        "SELECT structured_fields FROM memories WHERE category = :cat AND structured_fields IS NOT NULL AND superseded_by IS NULL",
       )
       .all({ ":cat": category }) as Array<{ structured_fields: string | null }>;
 

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -638,6 +638,41 @@ function doCreateMemory(
   const seq = row['seq'] as number;
   const realId = `MEM${String(seq).padStart(3, '0')}`;
   rewriteMemoryId(placeholder, realId);
+
+  const sourceKnowledgeId =
+    fields.structuredFields &&
+    typeof fields.structuredFields['sourceKnowledgeId'] === 'string' &&
+    fields.structuredFields['sourceKnowledgeId'].length > 0
+      ? (fields.structuredFields['sourceKnowledgeId'] as string)
+      : null;
+
+  if (sourceKnowledgeId) {
+    const priorRows = adapter
+      .prepare(
+        `SELECT id, structured_fields
+         FROM memories
+         WHERE category = :category
+           AND superseded_by IS NULL
+           AND structured_fields IS NOT NULL
+           AND id <> :newId`,
+      )
+      .all({ ':category': fields.category, ':newId': realId }) as Array<{
+      id: string;
+      structured_fields: string | null;
+    }>;
+
+    for (const prior of priorRows) {
+      if (!prior.structured_fields) continue;
+      try {
+        const parsed = JSON.parse(prior.structured_fields) as Record<string, unknown>;
+        if (parsed['sourceKnowledgeId'] === sourceKnowledgeId) {
+          supersedeMemoryRow(prior.id, realId, now);
+        }
+      } catch {
+        // Ignore malformed legacy structured_fields during supersession scan.
+      }
+    }
+  }
   return realId;
 }
 

--- a/src/resources/extensions/gsd/tests/knowledge-backfill-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-backfill-projection.test.ts
@@ -225,6 +225,44 @@ test("projection renders Patterns + Lessons from memories", () => {
   }
 });
 
+test("projection excludes superseded knowledge memories", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+    backfillKnowledgeToMemories(base);
+
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    adapter
+      .prepare(
+        `INSERT INTO memories (
+          id, category, content, confidence, source_unit_type, source_unit_id,
+          created_at, updated_at, superseded_by, hit_count, scope, tags, structured_fields, last_hit_at
+        ) VALUES (
+          'MEM999', 'pattern', 'legacy duplicate', 0.8, NULL, NULL,
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z', 'MEM001', 0,
+          'project', '[]', :sf, NULL
+        )`,
+      )
+      .run({
+        ':sf': JSON.stringify({
+          sourceKnowledgeId: 'P001',
+          pattern: 'stale pattern content',
+          where: 'old/path',
+          notes: 'stale',
+        }),
+      });
+
+    renderKnowledgeProjection(base);
+    const rendered = readFileSync(knowledgeMdPath(base), "utf-8");
+
+    assert.match(rendered, /\| P001 \| Repository pattern \| services\/ \| guards \|/);
+    assert.ok(!rendered.includes("stale pattern content"), "superseded duplicate must not be projected");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("projection is idempotent when nothing has changed", () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -124,6 +124,36 @@ test('memory-store: supersede', () => {
   closeDatabase();
 });
 
+test('memory-store: createMemory supersedes prior active row for same sourceKnowledgeId in category', () => {
+  openDatabase(':memory:');
+
+  const first = createMemory({
+    category: 'pattern',
+    content: 'old pattern row',
+    structuredFields: { sourceKnowledgeId: 'P005', pattern: 'old' },
+  });
+  const second = createMemory({
+    category: 'pattern',
+    content: 'new pattern row',
+    structuredFields: { sourceKnowledgeId: 'P005', pattern: 'new' },
+  });
+
+  assert.equal(first, 'MEM001');
+  assert.equal(second, 'MEM002');
+
+  const adapter = _getAdapter()!;
+  const oldRow = adapter
+    .prepare('SELECT superseded_by FROM memories WHERE id = :id')
+    .get({ ':id': first }) as { superseded_by: string | null } | undefined;
+  assert.equal(oldRow?.superseded_by, second, 'older row should be superseded by the newly inserted row');
+
+  const active = getActiveMemories();
+  assert.equal(active.length, 1);
+  assert.equal(active[0]?.id, second);
+
+  closeDatabase();
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // memory-store: ranked query ordering
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Added sourceKnowledgeId-based supersession on capture and filtered superseded rows from KNOWLEDGE projection, with regression tests added and verification attempts documented.

## Bugs Addressed
- [x] **`capture_thought` never supersedes old rows**
- [x] **Projection doesn't filter superseeded rows**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #169
- [#169 KNOWLEDGE.md projection duplicates rows with same P###/L### ID — readKnowledgeMemories lacks deduplication by sourceKnowledgeId](https://github.com/open-gsd/gsd-pi/issues/169)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/169-knowledge-md-projection-duplicates-rows--1779883230`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782475671&installation_id=134682257&pr_number=172&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F172&signature=d84294019dac71450c0ee3db5df8c5cb11068d7a6fb0a0c5920a6754a33e9212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to memory create and KNOWLEDGE projection queries; uses existing supersede_by semantics with new regression tests.
> 
> **Overview**
> Fixes duplicate **P###** / **L###** rows in `KNOWLEDGE.md` when multiple active memory rows share the same `sourceKnowledgeId`.
> 
> **On capture**, `createMemory` now marks older active rows in the same category with a matching `structuredFields.sourceKnowledgeId` as superseded by the new row (same transaction as insert).
> 
> **On projection**, `readKnowledgeMemories` only loads rows where `superseded_by IS NULL`, so stale duplicates no longer render in Patterns or Lessons.
> 
> Regression tests cover automatic supersession on create and projection ignoring superseded rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2198b986cca478e56b29ffda98fd85a01f943b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->