### PR TITLE
fix(issue): [Feature]: No uninstallation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ gsd upgrade
 
 You can also run `npx @opengsd/gsd-pi@latest` to launch the installer from the new package. For deeper recovery steps, see [Upgrade GSD Pi](./docs/user-docs/getting-started.md#upgrade-gsd-pi) and [Upgrade from older gsd-pi installs](./docs/user-docs/troubleshooting.md#upgrade-from-older-gsd-pi-installs).
 
+## Uninstall
+
+Remove the global package and optional local GSD state files.
+
+macOS / Linux:
+
+```bash
+npm uninstall -g @opengsd/gsd-pi gsd-pi
+rm -rf ~/.gsd
+```
+
+Windows PowerShell:
+
+```powershell
+npm uninstall -g @opengsd/gsd-pi gsd-pi
+Remove-Item "$env:USERPROFILE\.gsd" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
 ## Quick Start
 
 Need help choosing settings? Use the [GSD Pi web configurator](https://pi.opengsd.net/) to build a configuration in your browser.

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -27,7 +27,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 // packageRoot is always relative to this script — it's the @opengsd/gsd-pi package directory.
 // This is correct whether running as postinstall (inside node_modules/@opengsd/gsd-pi) or
 // via npx (inside a transient cache), since __dirname resolves to the script's location.
-const IS_POSTINSTALL = !!process.env.npm_lifecycle_event
+const IS_POSTINSTALL =
+  process.env.npm_lifecycle_event === 'postinstall' ||
+  process.env.GSD_POSTINSTALL === '1'
 const packageRoot = resolve(__dirname, '..')
 
 // ── Feature flags ──────────────────────────────────────────────────────────

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -8,4 +8,5 @@
  */
 
 process.env.npm_lifecycle_event = process.env.npm_lifecycle_event || 'postinstall'
+process.env.GSD_POSTINSTALL = '1'
 import('./install.js')

--- a/src/tests/postinstall.test.ts
+++ b/src/tests/postinstall.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -18,4 +19,16 @@ test("postinstall respects PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", () => {
   });
 
   assert.equal(result.status, 0, `postinstall exits cleanly: ${result.stderr}`);
+});
+
+test("install script only treats npm postinstall as postinstall mode", () => {
+  const installScript = readFileSync(join(projectRoot, "scripts", "install.js"), "utf-8");
+  assert.match(
+    installScript,
+    /process\.env\.npm_lifecycle_event === 'postinstall'/,
+  );
+  assert.match(
+    installScript,
+    /process\.env\.GSD_POSTINSTALL === '1'/,
+  );
 });


### PR DESCRIPTION
## Summary
- Corrected fresh-install mode detection and added README uninstall instructions, then verified with postinstall tests.

## Bugs Addressed
- [x] **Fresh install is non-functional**
- [x] **Missing uninstall instructions in README**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #139
- [#139 [Feature]: No uninstallation steps](https://github.com/open-gsd/gsd-pi/issues/139)

## User
- @RyRy79261

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/139-feature-no-uninstallation-steps-1779883342`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782476050&installation_id=134682257&pr_number=173&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F173&signature=1669d16e5858f036e60e5d2aab4970c52fcb70b644f5d6d0e3d0a90800810770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README and installer env gating only; no auth, data, or core runtime behavior beyond install scripts.
> 
> **Overview**
> Adds an **Uninstall** section to the README with `npm uninstall` for `@opengsd/gsd-pi` and legacy `gsd-pi`, plus removal of `~/.gsd` (or the Windows user profile equivalent).
> 
> **Install detection** in `install.js` no longer treats any set `npm_lifecycle_event` as postinstall-only mode. Postinstall behavior (workspace link, Chromium, RTK—no global/local npm install) runs only when the lifecycle is exactly `postinstall` or `GSD_POSTINSTALL=1`. `postinstall.js` sets that flag when it delegates, so `npx` / direct `install.js` runs get the full interactive global/local install again.
> 
> A unit test locks in the stricter env checks in `install.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e01c98767698c8a49c4fad7f02ffbdd0ba48542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->