### PR TITLE
fix(issue): align milestonesDir with gsdProjectionRoot to resolve plan-not-found in worktree mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.0.2",
+  "version": "1.0.2-dev",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -556,7 +556,7 @@ function probeGsdRoot(rawBasePath: string): string {
   return local;
 }
 export function milestonesDir(basePath: string): string {
-  return join(gsdRoot(basePath), "milestones");
+  return join(gsdProjectionRoot(basePath), "milestones");
 }
 
 export function resolveRuntimeFile(basePath: string): string {


### PR DESCRIPTION
Fixes #175.

One-line fix: `milestonesDir` was using `gsdRoot` which returns project-root `.gsd/` in worktree mode, while all GSD tools write artifacts via `gsdProjectionRoot` → worktree `.gsd/`. This mismatch caused 'plan not found at dispatch time' for every execute-task unit in worktree-isolated milestones.