### PR TITLE
fix(paths): align milestonesDir with gsdProjectionRoot to resolve plan-not-found in worktree mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.0.2",
+  "version": "1.0.2-dev",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -556,7 +556,7 @@ function probeGsdRoot(rawBasePath: string): string {
   return local;
 }
 export function milestonesDir(basePath: string): string {
-  return join(gsdRoot(basePath), "milestones");
+  return join(gsdProjectionRoot(basePath), "milestones");
 }
 
 export function resolveRuntimeFile(basePath: string): string {

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -1,11 +1,11 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
-import { gsdRoot, _clearGsdRootCache } from "../../paths.ts";
+import { gsdRoot, milestonesDir, _clearGsdRootCache } from "../../paths.ts";
 /** Create a tmp dir and resolve symlinks + 8.3 short names (macOS /var→/private/var, Windows RUNNER~1→runneradmin). */
 function tmp(): string {
   const p = mkdtempSync(join(tmpdir(), "gsd-paths-test-"));
@@ -94,5 +94,23 @@ describe('paths', () => {
       const result = gsdRoot(inner);
       assert.deepStrictEqual(result, join(inner, ".gsd"), "precedence: nearest .gsd wins over ancestor");
     } finally { cleanup(outer); }
+  });
+
+  test('Case 7: milestonesDir returns worktree .gsd when called from worktree path', () => {
+    const root = tmp();
+    try {
+      initGit(root);
+      mkdirSync(join(root, ".gsd"));
+      const wtRoot = join(root, ".gsd", "worktrees", "M001");
+      mkdirSync(wtRoot, { recursive: true });
+      mkdirSync(join(wtRoot, ".gsd"));
+      writeFileSync(join(wtRoot, ".git"), `gitdir: ${join(root, ".git")}\n`, "utf-8");
+      _clearGsdRootCache();
+      const result = milestonesDir(wtRoot);
+      assert.ok(result.includes(join("worktrees", "M001", ".gsd")),
+        "milestonesDir from worktree path must include worktrees/M001/.gsd");
+      assert.ok(result.endsWith("milestones"),
+        "milestonesDir must end with /milestones");
+    } finally { cleanup(root); }
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Fix `milestonesDir` to use `gsdProjectionRoot` instead of `gsdRoot` in `paths.ts`, aligning prompt-builder file resolution with GSD tool artifact writes.
**Why:** In worktree isolation mode, `gsdRoot` returns project-root `.gsd/` while `gsdProjectionRoot` (used by all GSD tools) returns worktree `.gsd/`. This mismatch causes "plan not found at dispatch time" for every execute-task unit.
**How:** One-line change in `paths.ts:559` — replace `gsdRoot(basePath)` with `gsdProjectionRoot(basePath)` in `milestonesDir`. All resolve functions cascade from this function.

Fixes #175.

## What

`milestonesDir` (paths.ts line 558-560) was the single chokepoint connecting the prompt builder's artifact file resolution to `gsdRoot`. All GSD tools write artifacts via `gsdProjectionRoot` → worktree `.gsd/`. But `gsdRoot` → `probeGsdRoot` deliberately returns `contract.projectGsd` (project-root `.gsd/`) in worktree mode. This mismatch meant every artifact — slice plans, task plans, contexts, summaries, assessments, UATs, roadmaps — written by GSD tools was invisible to the prompt builder.

## Why

Confirmed on M006 (5/5 execute-task units) and M007 (6/6 units) — 100% of prompts showed "plan not found at dispatch time". Both plan-slice and execute-task units run in the same worktree with no teardown between them (per journal evidence). The plans exist on disk in worktree `.gsd/` but the prompt builder reads from project-root `.gsd/`.

Beyond the user-visible error message, this has a cascade impact: plans not inlined means their content never enters the system prompt → `loadMemoryBlock` FTS5 keyword matching runs on an impoverished prompt → pattern memories that would match domain-specific keywords never get injected.

## How

Single-line change in `paths.ts:559`:

```diff
 export function milestonesDir(basePath: string): string {
-  return join(gsdRoot(basePath), "milestones");
+  return join(gsdProjectionRoot(basePath), "milestones");
 }
```

No other code changes needed — all resolve functions cascade from `milestonesDir`. What stays on `gsdRoot` (unchanged): STATE.md, auto.lock, PREFERENCES.md, activity logs, debug logs, doctor history, metrics, RUNTIME.md.

### Regression Test

Added `Case 7: milestonesDir returns worktree .gsd when called from worktree path` to `paths.test.ts`. Creates a mock worktree under `.gsd/worktrees/M001`, asserts `milestonesDir(wtRoot)` returns a path containing `worktrees/M001/.gsd`.

**Before fix (FAIL):**
```
✖ Case 7: milestonesDir returns worktree .gsd when called from worktree path
  AssertionError: milestonesDir from worktree path must include worktrees/M001/.gsd
```

**After fix (PASS):**
```
✔ Case 7: milestonesDir returns worktree .gsd when called from worktree path
```

---

*AI-assisted: root cause traced across paths.ts, auto-prompts.ts, and journal evidence.*