### PR TITLE
fix(paths): align milestonesDir with gsdProjectionRoot to resolve plan-not-found in worktree mode

### DIFF
--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -556,7 +556,7 @@ function probeGsdRoot(rawBasePath: string): string {
   return local;
 }
 export function milestonesDir(basePath: string): string {
-  return join(gsdRoot(basePath), "milestones");
+  return join(gsdProjectionRoot(basePath), "milestones");
 }
 
 export function resolveRuntimeFile(basePath: string): string {

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -1,11 +1,11 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
-import { gsdRoot, _clearGsdRootCache } from "../../paths.ts";
+import { gsdRoot, milestonesDir, _clearGsdRootCache } from "../../paths.ts";
 /** Create a tmp dir and resolve symlinks + 8.3 short names (macOS /var→/private/var, Windows RUNNER~1→runneradmin). */
 function tmp(): string {
   const p = mkdtempSync(join(tmpdir(), "gsd-paths-test-"));
@@ -94,5 +94,23 @@ describe('paths', () => {
       const result = gsdRoot(inner);
       assert.deepStrictEqual(result, join(inner, ".gsd"), "precedence: nearest .gsd wins over ancestor");
     } finally { cleanup(outer); }
+  });
+
+  test('Case 7: milestonesDir returns worktree .gsd when called from worktree path', () => {
+    const root = tmp();
+    try {
+      initGit(root);
+      mkdirSync(join(root, ".gsd"));
+      const wtRoot = join(root, ".gsd", "worktrees", "M001");
+      mkdirSync(wtRoot, { recursive: true });
+      mkdirSync(join(wtRoot, ".gsd"));
+      writeFileSync(join(wtRoot, ".git"), `gitdir: ${join(root, ".git")}\n`, "utf-8");
+      _clearGsdRootCache();
+      const result = milestonesDir(wtRoot);
+      assert.ok(result.includes(join("worktrees", "M001", ".gsd")),
+        "milestonesDir from worktree path must include worktrees/M001/.gsd");
+      assert.ok(result.endsWith("milestones"),
+        "milestonesDir must end with /milestones");
+    } finally { cleanup(root); }
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Fix `milestonesDir` to use `gsdProjectionRoot` instead of `gsdRoot` in `paths.ts`, aligning prompt-builder file resolution with GSD tool artifact writes.
**Why:** In worktree isolation mode, `gsdRoot` returns project-root `.gsd/` while `gsdProjectionRoot` (used by all GSD tools) returns worktree `.gsd/`. This mismatch causes "plan not found at dispatch time" for every execute-task unit.
**How:** One-line change in `paths.ts:559` — replace `gsdRoot(basePath)` with `gsdProjectionRoot(basePath)` in `milestonesDir`. All resolve functions cascade from this function. Includes regression test.

Fixes #175.

## What

`milestonesDir` (paths.ts line 558-560) was the single chokepoint connecting the prompt builder's artifact file resolution to `gsdRoot`. All GSD tools write artifacts via `gsdProjectionRoot` → worktree `.gsd/`. But `gsdRoot` → `probeGsdRoot` deliberately returns `contract.projectGsd` (project-root `.gsd/`) in worktree mode. This mismatch meant every artifact — slice plans, task plans, contexts, summaries, assessments, UATs, roadmaps — written by GSD tools was invisible to the prompt builder.

## Why

Confirmed on M006 (5/5 execute-task units) and M007 (6/6 units) — 100% of prompts showed "plan not found at dispatch time". Both plan-slice and execute-task units run in the same worktree with no teardown between them (per journal evidence). The plans exist on disk in worktree `.gsd/` but the prompt builder reads from project-root `.gsd/`.

## How

Single-line change in `paths.ts:559`:

```diff
 export function milestonesDir(basePath: string): string {
-  return join(gsdRoot(basePath), "milestones");
+  return join(gsdProjectionRoot(basePath), "milestones");
 }
```

No other code changes needed — all resolve functions cascade from `milestonesDir`. What stays on `gsdRoot` (unchanged): STATE.md, auto.lock, PREFERENCES.md, activity logs, debug logs, doctor history, metrics, RUNTIME.md.

### Regression Test

`Case 7: milestonesDir returns worktree .gsd when called from worktree path` in `paths.test.ts`. Creates mock worktree under `.gsd/worktrees/M001`, asserts `milestonesDir(wtRoot)` includes `worktrees/M001/.gsd`.

**Before fix (FAIL):** `AssertionError: milestonesDir from worktree path must include worktrees/M001/.gsd`
**After fix (PASS):** `✔ Case 7: milestonesDir returns worktree .gsd when called from worktree path`

---

*AI-assisted: root cause traced across paths.ts, auto-prompts.ts, and journal evidence.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782481431&installation_id=134682257&pr_number=178&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F178&signature=1f57efc75af7d35de47eee8386f5064b640332bcdb914aea3aa71ded8d047671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->