### PR TITLE
fix(gsd): resolve milestone artifacts from worktree projections

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -11,10 +11,6 @@ import {
   gsdProjectionRoot,
   resolveDir,
   resolveFile,
-  resolveMilestoneFile,
-  resolveMilestonePath,
-  resolveSliceFile,
-  resolveSlicePath,
   relMilestoneFile,
   relSliceFile,
   buildMilestoneFileName,
@@ -29,9 +25,9 @@ function resolveMilestoneArtifactPath(
   mid: string,
   suffix: string,
 ): string | null {
-  const existing = resolveProjectedMilestoneFile(base, mid, suffix) ?? resolveMilestoneFile(base, mid, suffix);
+  const existing = resolveProjectedMilestoneFile(base, mid, suffix) ?? resolveProjectMilestoneFile(base, mid, suffix);
   if (existing) return existing;
-  const dir = resolveProjectedMilestonePath(base, mid) ?? resolveMilestonePath(base, mid);
+  const dir = resolveProjectedMilestonePath(base, mid) ?? resolveProjectMilestonePath(base, mid);
   return dir ? join(dir, buildMilestoneFileName(mid, suffix)) : null;
 }
 
@@ -41,10 +37,38 @@ function resolveSliceArtifactPath(
   sid: string,
   suffix: string,
 ): string | null {
-  const existing = resolveProjectedSliceFile(base, mid, sid, suffix) ?? resolveSliceFile(base, mid, sid, suffix);
+  const existing = resolveProjectedSliceFile(base, mid, sid, suffix) ?? resolveProjectSliceFile(base, mid, sid, suffix);
   if (existing) return existing;
-  const dir = resolveProjectedSlicePath(base, mid, sid) ?? resolveSlicePath(base, mid, sid);
+  const dir = resolveProjectedSlicePath(base, mid, sid) ?? resolveProjectSlicePath(base, mid, sid);
   return dir ? join(dir, buildSliceFileName(sid, suffix)) : null;
+}
+
+function resolveProjectMilestonePath(base: string, mid: string): string | null {
+  const milestonesDir = join(gsdRoot(base), "milestones");
+  const dir = resolveDir(milestonesDir, mid);
+  return dir ? join(milestonesDir, dir) : null;
+}
+
+function resolveProjectMilestoneFile(base: string, mid: string, suffix: string): string | null {
+  const dir = resolveProjectMilestonePath(base, mid);
+  if (!dir) return null;
+  const file = resolveFile(dir, mid, suffix);
+  return file ? join(dir, file) : null;
+}
+
+function resolveProjectSlicePath(base: string, mid: string, sid: string): string | null {
+  const milestoneDir = resolveProjectMilestonePath(base, mid);
+  if (!milestoneDir) return null;
+  const slicesDir = join(milestoneDir, "slices");
+  const dir = resolveDir(slicesDir, sid);
+  return dir ? join(slicesDir, dir) : null;
+}
+
+function resolveProjectSliceFile(base: string, mid: string, sid: string, suffix: string): string | null {
+  const dir = resolveProjectSlicePath(base, mid, sid);
+  if (!dir) return null;
+  const file = resolveFile(dir, sid, suffix);
+  return file ? join(dir, file) : null;
 }
 
 function resolveProjectedMilestonePath(base: string, mid: string): string | null {
@@ -131,7 +155,7 @@ export function resolveExpectedArtifactPath(
       return resolveSliceArtifactPath(base, mid, sid!, "ASSESSMENT");
     }
     case "execute-task": {
-      const dir = resolveProjectedSlicePath(base, mid, sid!) ?? resolveSlicePath(base, mid, sid!);
+      const dir = resolveProjectedSlicePath(base, mid, sid!) ?? resolveProjectSlicePath(base, mid, sid!);
       return dir && tid
         ? join(dir, "tasks", buildTaskFileName(tid, "SUMMARY"))
         : null;

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -554,7 +554,7 @@ function probeGsdRoot(rawBasePath: string): string {
   return local;
 }
 export function milestonesDir(basePath: string): string {
-  return join(gsdRoot(basePath), "milestones");
+  return join(gsdProjectionRoot(basePath), "milestones");
 }
 
 export function resolveRuntimeFile(basePath: string): string {

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveExpectedArtifactPath } from "../auto-artifact-paths.ts";
+import { clearPathCache, _clearGsdRootCache } from "../paths.ts";
+
+test("worktree artifact resolution falls back to project .gsd artifacts", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-auto-artifact-")));
+  try {
+    const projectGsd = join(root, ".gsd");
+    const wtRoot = join(projectGsd, "worktrees", "M001");
+    const wtGsd = join(wtRoot, ".gsd");
+    const projectMilestoneDir = join(projectGsd, "milestones", "M001");
+    const projectSliceDir = join(projectMilestoneDir, "slices", "S01");
+
+    mkdirSync(projectSliceDir, { recursive: true });
+    mkdirSync(wtGsd, { recursive: true });
+    writeFileSync(join(projectMilestoneDir, "M001-ROADMAP.md"), "# roadmap\n");
+    writeFileSync(join(projectSliceDir, "S01-PLAN.md"), "# plan\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    assert.equal(
+      resolveExpectedArtifactPath("plan-milestone", "M001", wtRoot),
+      join(projectMilestoneDir, "M001-ROADMAP.md"),
+    );
+    assert.equal(
+      resolveExpectedArtifactPath("plan-slice", "M001/S01", wtRoot),
+      join(projectSliceDir, "S01-PLAN.md"),
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -1,11 +1,18 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
-import { gsdRoot, _clearGsdRootCache } from "../../paths.ts";
+import {
+  gsdProjectionRoot,
+  gsdRoot,
+  milestonesDir,
+  resolveSliceFile,
+  resolveTaskFile,
+  _clearGsdRootCache,
+} from "../../paths.ts";
 /** Create a tmp dir and resolve symlinks + 8.3 short names (macOS /var→/private/var, Windows RUNNER~1→runneradmin). */
 function tmp(): string {
   const p = mkdtempSync(join(tmpdir(), "gsd-paths-test-"));
@@ -94,5 +101,69 @@ describe('paths', () => {
       const result = gsdRoot(inner);
       assert.deepStrictEqual(result, join(inner, ".gsd"), "precedence: nearest .gsd wins over ancestor");
     } finally { cleanup(outer); }
+  });
+
+  test('Case 7: milestone artifact readers use worktree projection root', () => {
+    const root = tmp();
+    try {
+      initGit(root);
+      const projectGsd = join(root, ".gsd");
+      mkdirSync(projectGsd);
+      const wtRoot = join(projectGsd, "worktrees", "M001");
+      const wtGsd = join(wtRoot, ".gsd");
+      const tasksDir = join(wtGsd, "milestones", "M001", "slices", "S01", "tasks");
+      mkdirSync(tasksDir, { recursive: true });
+      writeFileSync(join(wtRoot, ".git"), `gitdir: ${join(root, ".git")}\n`, "utf-8");
+      writeFileSync(join(wtGsd, "milestones", "M001", "slices", "S01", "S01-PLAN.md"), "# slice plan\n");
+      writeFileSync(join(tasksDir, "T01-PLAN.md"), "# task plan\n");
+
+      _clearGsdRootCache();
+
+      assert.deepStrictEqual(gsdRoot(wtRoot), projectGsd, "runtime/control root stays project .gsd");
+      assert.deepStrictEqual(gsdProjectionRoot(wtRoot), wtGsd, "projection root is worktree .gsd");
+      assert.deepStrictEqual(milestonesDir(wtRoot), join(wtGsd, "milestones"));
+      assert.deepStrictEqual(
+        resolveSliceFile(wtRoot, "M001", "S01", "PLAN"),
+        join(wtGsd, "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+      );
+      assert.deepStrictEqual(
+        resolveTaskFile(wtRoot, "M001", "S01", "T01", "PLAN"),
+        join(tasksDir, "T01-PLAN.md"),
+      );
+    } finally { cleanup(root); }
+  });
+
+  test('Case 8: external-state worktree milestone readers use projection root', () => {
+    const root = tmp();
+    const originalStateDir = process.env.GSD_STATE_DIR;
+    try {
+      const stateDir = join(root, "state");
+      process.env.GSD_STATE_DIR = stateDir;
+      const projectGsd = join(stateDir, "projects", "abc123");
+      const wtRoot = join(projectGsd, "worktrees", "M002");
+      const wtGsd = join(wtRoot, ".gsd");
+      const tasksDir = join(wtGsd, "milestones", "M002", "slices", "S01", "tasks");
+      mkdirSync(tasksDir, { recursive: true });
+      writeFileSync(join(wtGsd, "milestones", "M002", "slices", "S01", "S01-PLAN.md"), "# slice plan\n");
+      writeFileSync(join(tasksDir, "T01-PLAN.md"), "# task plan\n");
+
+      _clearGsdRootCache();
+
+      assert.deepStrictEqual(gsdRoot(wtRoot), projectGsd, "external-state control root stays project store");
+      assert.deepStrictEqual(gsdProjectionRoot(wtRoot), wtGsd, "external-state projection root is worktree .gsd");
+      assert.deepStrictEqual(milestonesDir(wtRoot), join(wtGsd, "milestones"));
+      assert.deepStrictEqual(
+        resolveSliceFile(wtRoot, "M002", "S01", "PLAN"),
+        join(wtGsd, "milestones", "M002", "slices", "S01", "S01-PLAN.md"),
+      );
+      assert.deepStrictEqual(
+        resolveTaskFile(wtRoot, "M002", "S01", "T01", "PLAN"),
+        join(tasksDir, "T01-PLAN.md"),
+      );
+    } finally {
+      if (originalStateDir === undefined) delete process.env.GSD_STATE_DIR;
+      else process.env.GSD_STATE_DIR = originalStateDir;
+      cleanup(root);
+    }
   });
 });

--- a/src/resources/extensions/gsd/workspace.ts
+++ b/src/resources/extensions/gsd/workspace.ts
@@ -71,10 +71,11 @@ export function createWorkspace(rawBasePath: string): GsdWorkspace {
 
 /**
  * Bind a milestoneId to a workspace, producing an immutable MilestoneScope
- * with path-returning closures that resolve via the authoritative projectGsd.
+ * with path-returning closures for DB-authoritative project state.
  *
- * All milestone-content paths route to contract.projectGsd (canonical),
- * since that is the authoritative source of truth regardless of worktree mode.
+ * These scope paths intentionally route to contract.projectGsd. In-flight
+ * markdown artifact readers outside this scope use the projection-aware
+ * resolvers in paths.ts so worktree units can see worktree-local projections.
  */
 export function scopeMilestone(workspace: GsdWorkspace, milestoneId: string): MilestoneScope {
   const { contract } = workspace;


### PR DESCRIPTION
## TL;DR

**What:** Route milestone artifact readers through `gsdProjectionRoot` by changing the shared `milestonesDir` chokepoint.
**Why:** In worktree isolation, GSD tools write slice/task plans into worktree `.gsd`, while prompt builders read via `gsdRoot` from project `.gsd`, so execute-task prompts miss plan content and memory matching loses domain keywords.
**How:** Keep `gsdRoot` authoritative for runtime/control/DB state, make `milestonesDir` projection-aware for milestone markdown artifacts, and add direct plus external-state worktree regression coverage.

## What

- Changed `milestonesDir(basePath)` to resolve from `gsdProjectionRoot(basePath)`.
- Added regression coverage proving `resolveSliceFile` and `resolveTaskFile` find worktree-local plan artifacts while `gsdRoot` still points at the project/control `.gsd`.
- Clarified the `MilestoneScope` comment so its project-root DB/control contract is distinct from projection-aware artifact readers.

## Why

Closes #175.

The issue repro is confirmed: plan writers use `gsdProjectionRoot`, but prompt readers fan out from `milestonesDir -> gsdRoot`. In worktree mode this makes prompt composition miss `Sxx-PLAN.md` and `Txx-PLAN.md`, which also means `loadMemoryBlock` runs before those plan keywords enter the prompt.

An existing PR (#177) had the right one-line direction, but it was stale against current `main`, included unrelated history/package changes, and conflicted. This PR carries the focused current-main implementation only.

## How

`gsdRoot` remains unchanged for runtime/control paths such as DB, locks, state, preferences, runtime files, logs, and scoped DB writes. Only milestone markdown artifact resolution moves to the projection root through the shared `milestonesDir` helper.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gsdroot-worktree-detection.test.ts src/resources/extensions/gsd/tests/integration/paths.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/path-cache-decoupled.test.ts src/resources/extensions/gsd/tests/paths-cache.test.ts src/resources/extensions/gsd/tests/db-path-worktree-symlink.test.ts src/resources/extensions/gsd/tests/repo-identity-external-worktree.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workspace.test.ts src/resources/extensions/gsd/tests/validator-scope-parity.test.ts src/resources/extensions/gsd/tests/db-writer-scope.test.ts src/resources/extensions/gsd/tests/gsdroot-worktree-detection.test.ts src/resources/extensions/gsd/tests/integration/paths.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `npm run test:changed:src`
- [x] `git diff --check`

## Impact analysis

- Blast radius: moderate. `milestonesDir` is the shared base for milestone, slice, and task artifact readers.
- Affected workflows: worktree-isolated plan/execute prompt composition, artifact existence checks that use `resolveMilestoneFile`, `resolveSliceFile`, `resolveTaskFile`, and relative artifact path builders.
- Compatibility notes: runtime/control roots still use `gsdRoot`; `MilestoneScope` and DB-backed scope paths remain project-root authoritative.

## Notes

AI-assisted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782481685&installation_id=134682257&pr_number=179&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F179&signature=242731fbb82defae60453eeaeda579797a0486bd2a9e7ca2f75e18aec718a2b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `milestonesDir` is a shared base for milestone, slice, and task artifact readers; mis-scoping could affect prompt composition and verification in worktree mode, though runtime/control paths are unchanged.
> 
> **Overview**
> **Milestone markdown artifact resolution** now goes through the **worktree projection** root instead of the authoritative project `.gsd`, by changing `milestonesDir` to use `gsdProjectionRoot`. That aligns readers with writers that already store plans under worktree-local `.gsd`, so isolated worktrees can load `S##-PLAN.md` / `T##-PLAN.md` for prompts and related checks while **`gsdRoot` stays on the project store** for DB, runtime, and control paths.
> 
> `resolveExpectedArtifactPath` keeps **projection-first, project-fallback** behavior via local `resolveProject*` helpers (replacing shared `resolveMilestone*` / `resolveSlice*` imports for those fallbacks). **`MilestoneScope`** comments clarify that scoped paths remain **project-authoritative**; projection-aware reads live in `paths.ts`.
> 
> Regression tests cover worktree and external-state layouts, plus auto-artifact fallback when artifacts exist only under project `.gsd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3218fd61176096a2b6dc05d4711a429a771db2a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->