### PR TITLE
fix(issue): complete-slice retry loop silently drops a reopened task via empty replan

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1752,6 +1752,35 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         const hasExpectedArtifact = resolveExpectedArtifactPath(s.currentUnit.type, s.currentUnit.id, verificationBasePath) !== null;
         if (hasExpectedArtifact) {
           const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+          if (
+            s.currentUnit.type === "complete-slice" &&
+            (
+              agentEndMessagesIncludeSuccessfulToolResult(opts?.agentEndMessages, "gsd_task_reopen") ||
+              agentEndMessagesIncludeToolCall(opts?.agentEndMessages, "gsd_task_reopen") ||
+              agentEndMessagesMentionTool(opts?.agentEndMessages, "gsd_task_reopen") ||
+              unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_task_reopen") ||
+              unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_task_reopen") ||
+              agentEndMessagesIncludeSuccessfulToolResult(opts?.agentEndMessages, "gsd_replan_slice") ||
+              agentEndMessagesIncludeToolCall(opts?.agentEndMessages, "gsd_replan_slice") ||
+              agentEndMessagesMentionTool(opts?.agentEndMessages, "gsd_replan_slice") ||
+              unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice") ||
+              unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice")
+            )
+          ) {
+            s.pendingVerificationRetry = null;
+            s.verificationRetryCount.delete(retryKey);
+            s.verificationRetryFailureHashes.delete(retryKey);
+            debugLog("postUnit", {
+              phase: "artifact-verify-complete-slice-handoff",
+              unitType: s.currentUnit.type,
+              unitId: s.currentUnit.id,
+            });
+            ctx.ui.notify(
+              `complete-slice ${s.currentUnit.id} intentionally handed off via reopen/replan; continuing orchestration instead of retrying closeout.`,
+              "warning",
+            );
+            return "continue";
+          }
           const verificationFailureMarker = resolveVerificationFailureMarkerPath(s.currentUnit.type, s.currentUnit.id, s.basePath);
           if (verificationFailureMarker && existsSync(verificationFailureMarker)) {
             s.pendingVerificationRetry = null;

--- a/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
@@ -1,0 +1,112 @@
+// Regression: complete-slice reopen/replan handoff must not artifact-retry (#183)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { postUnitPreVerification } from "../auto-post-unit.ts";
+import { AutoSession } from "../auto/session.ts";
+import { cleanup, makeTempRepo } from "./test-utils.ts";
+
+function makePostUnitContext(base: string, s: AutoSession, notifications: string[]) {
+  return {
+    s,
+    ctx: { ui: { notify: (message: string) => notifications.push(message) } } as any,
+    pi: {} as any,
+    buildSnapshotOpts: () => ({}) as any,
+    lockBase: () => base,
+    stopAuto: async () => {},
+    pauseAuto: async () => {},
+    updateProgressWidget: () => {},
+  };
+}
+
+test("complete-slice with gsd_task_reopen handoff continues instead of artifact-retrying", async () => {
+  const base = makeTempRepo("gsd-complete-slice-reopen-");
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.canonicalProjectRoot = base;
+    s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+    const retryKey = "complete-slice:M001/S01";
+    s.verificationRetryCount.set(retryKey, 2);
+    s.pendingVerificationRetry = {
+      unitId: "M001/S01",
+      failureContext: "Missing expected artifact (attempt 2/3).",
+      attempt: 2,
+    };
+
+    const notifications: string[] = [];
+    const result = await postUnitPreVerification(
+      makePostUnitContext(base, s, notifications),
+      {
+        skipSettleDelay: true,
+        skipWorktreeSync: true,
+        agentEndMessages: [
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", name: "gsd_task_reopen", arguments: { taskId: "T01" } }],
+          },
+        ],
+      },
+    );
+
+    assert.equal(result, "continue");
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.equal(s.verificationRetryCount.has(retryKey), false);
+    assert.ok(
+      notifications.some((message) => message.includes("handed off via reopen/replan")),
+      `expected handoff notification, got: ${notifications.join("\n")}`,
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("complete-slice with gsd_replan_slice tool result continues instead of artifact-retrying", async () => {
+  const base = makeTempRepo("gsd-complete-slice-replan-");
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.canonicalProjectRoot = base;
+    s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+    const retryKey = "complete-slice:M001/S01";
+    s.verificationRetryCount.set(retryKey, 1);
+
+    const notifications: string[] = [];
+    const result = await postUnitPreVerification(
+      makePostUnitContext(base, s, notifications),
+      {
+        skipSettleDelay: true,
+        skipWorktreeSync: true,
+        agentEndMessages: [
+          {
+            role: "toolResult",
+            toolName: "gsd_replan_slice",
+            isError: false,
+            content: "Slice replanned with reopened task T02.",
+          },
+        ],
+      },
+    );
+
+    assert.equal(result, "continue");
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.equal(s.verificationRetryCount.has(retryKey), false);
+    assert.ok(
+      notifications.some((message) => message.includes("handed off via reopen/replan")),
+      `expected handoff notification, got: ${notifications.join("\n")}`,
+    );
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
@@ -30,7 +30,6 @@ test("complete-slice with gsd_task_reopen handoff continues instead of artifact-
     const s = new AutoSession();
     s.active = true;
     s.basePath = base;
-    s.canonicalProjectRoot = base;
     s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
 
     const retryKey = "complete-slice:M001/S01";
@@ -76,7 +75,6 @@ test("complete-slice with gsd_replan_slice tool result continues instead of arti
     const s = new AutoSession();
     s.active = true;
     s.basePath = base;
-    s.canonicalProjectRoot = base;
     s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
 
     const retryKey = "complete-slice:M001/S01";


### PR DESCRIPTION
## Summary
- Added a complete-slice handoff guard in post-unit artifact verification so reopen/replan signals continue orchestration instead of retrying complete-slice, and verified with focused post-unit test execution.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #183
- [#183 complete-slice retry loop silently drops a reopened task via empty replan](https://github.com/open-gsd/gsd-pi/issues/183)

## User
- @m1dm4n

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/183-complete-slice-retry-loop-silently-drops-1779914022`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782506115&installation_id=134682257&pr_number=184&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F184&signature=40e621a931b94c9309f8a0a4ab23cf568de956b23afbe65d14fde2bfa8e2cbd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auto-orchestration guard with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> When **complete-slice** finishes without the expected closeout artifact, post-unit verification used to **artifact-retry** the unit. That fought intentional **reopen/replan** flows (`gsd_task_reopen`, `gsd_replan_slice`), which can leave slice closeout incomplete on purpose and led to retry loops (e.g. #183).
> 
> **`postUnitPreVerification`** now detects those tools in agent-end messages or unit activity (same pattern as validate-milestone reassessment handoffs). It clears pending verification retries and returns **`continue`** so orchestration moves on, with a warning instead of re-dispatching complete-slice.
> 
> Regression tests in **`complete-slice-reopen-handoff.test.ts`** cover reopen tool calls and successful replan tool results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4613a48790691a0b7668cf258b3b8dbe495413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->