### PR TITLE
fix(issue): /gsd memory missing from autocomplete catalog

### DIFF
--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -65,6 +65,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "steer", desc: "Hard-steer plan documents during execution" },
   { cmd: "inspect", desc: "Show SQLite DB diagnostics" },
   { cmd: "knowledge", desc: "Add persistent project knowledge (rule, pattern, or lesson)" },
+  { cmd: "memory", desc: "Query/forget project memories" },
   { cmd: "new-milestone", desc: "Create a milestone from a specification document (headless)" },
   { cmd: "new-project", desc: "Bootstrap a new project (use --deep for staged project-level discovery)" },
   { cmd: "parallel", desc: "Parallel milestone orchestration (start, status, stop, merge, watch)" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -105,6 +105,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "",
     "PROJECT KNOWLEDGE",
     "  /gsd knowledge <type> <text>   Add a rule to KNOWLEDGE.md or capture a pattern/lesson to memories",
+    "  /gsd memory         Query/forget project memories",
     "  /gsd codebase [generate|update|stats]   Manage the CODEBASE.md cache used in prompt context",
     "",
     "SHIPPING & BACKLOG",

--- a/src/resources/extensions/gsd/tests/memory-command.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-command.test.ts
@@ -1,0 +1,22 @@
+// gsd-pi — /gsd memory command catalog coverage
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GSD_COMMAND_DESCRIPTION, getGsdArgumentCompletions, TOP_LEVEL_SUBCOMMANDS } from "../commands/catalog.ts";
+
+test("/gsd memory appears in the command description and top-level completions", () => {
+  assert.match(GSD_COMMAND_DESCRIPTION, /\|memory\|/);
+
+  const completions = getGsdArgumentCompletions("mem");
+  const entry = completions.find((completion) => completion.value === "memory");
+
+  assert.ok(entry, "memory should appear in top-level completions");
+  assert.match(entry.description, /memor/i);
+});
+
+test("memory is registered in TOP_LEVEL_SUBCOMMANDS", () => {
+  const entry = TOP_LEVEL_SUBCOMMANDS.find((command) => command.cmd === "memory");
+  assert.ok(entry, "memory must be present in TOP_LEVEL_SUBCOMMANDS");
+  assert.match(entry?.desc ?? "", /memor/i);
+});


### PR DESCRIPTION
## Summary
- Added `memory` to the `/gsd` command autocomplete catalog and verified the exact file diff, with tests blocked by local Node engine/dependency constraints.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #171
- [#171 /gsd memory missing from autocomplete catalog](https://github.com/open-gsd/gsd-pi/issues/171)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/171-gsd-memory-missing-from-autocomplete-cat-1779924258`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782516590&installation_id=134682257&pr_number=189&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F189&signature=a2136e03fc9df990cf105204bb5c3e87633dfeddd93981ecbad6ae13d8fd16f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to command catalog and help strings plus tests; no runtime behavior or security paths modified.
> 
> **Overview**
> Registers **`/gsd memory`** in the GSD command **autocomplete catalog** so it shows up when typing `/gsd` (it was missing from discovery even if the handler existed).
> 
> **`catalog.ts`** adds `memory` to the pipe-delimited `GSD_COMMAND_DESCRIPTION` string and to `TOP_LEVEL_SUBCOMMANDS` with description *Query/forget project memories*. **`core.ts`** adds the same line under **PROJECT KNOWLEDGE** in the full help reference.
> 
> A new **`memory-command.test.ts`** asserts `memory` appears in the description, top-level completions for prefix `mem`, and `TOP_LEVEL_SUBCOMMANDS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491219a45197d6836f6e7fc8a802687824519ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->