### PR TITLE
fix(issue): Browser evidence gate false positive: full_uat_md + overly broad regex trigger on CLI-only milestones

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -6,6 +6,9 @@
 // had zero callers in production code — wiring it through
 // reconcileBeforeDispatch closes that gap.
 
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 import {
   detectStaleRenders,
   renderPlanCheckboxes,
@@ -14,6 +17,7 @@ import {
   renderTaskSummary,
 } from "../../markdown-renderer.js";
 import { getMilestone, getSlice, setSliceSummaryMd } from "../../gsd-db.js";
+import { buildSliceFileName } from "../../paths.js";
 import type { GSDState } from "../../types.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -127,7 +131,15 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: slice summary path missing milestone/slice segments: ${record.renderPath}`,
       );
     }
-    await renderSliceSummary(basePath, pathMatch[1], pathMatch[2]);
+    const milestoneId = pathMatch[1];
+    const sliceId = pathMatch[2];
+    const slice = getSlice(milestoneId, sliceId);
+    const uatPath = join(dirname(record.renderPath), buildSliceFileName(sliceId, "UAT"));
+    // renderSliceSummary writes both artifacts, so clear deleted UAT first.
+    if (slice?.full_uat_md && !existsSync(uatPath)) {
+      setSliceSummaryMd(milestoneId, sliceId, slice.full_summary_md ?? "", "");
+    }
+    await renderSliceSummary(basePath, milestoneId, sliceId);
     return;
   }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -13,7 +13,7 @@ import {
   renderSliceSummary,
   renderTaskSummary,
 } from "../../markdown-renderer.js";
-import { getMilestone } from "../../gsd-db.js";
+import { getMilestone, getSlice, setSliceSummaryMd } from "../../gsd-db.js";
 import type { GSDState } from "../../types.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -138,8 +138,17 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: UAT path missing milestone/slice segments: ${record.renderPath}`,
       );
     }
-    // renderSliceSummary handles both SUMMARY and UAT.
-    await renderSliceSummary(basePath, pathMatch[1], pathMatch[2]);
+    // When UAT.md is removed from disk, mirror that intent by clearing stale
+    // persisted UAT content instead of rehydrating it back onto disk.
+    const milestoneId = pathMatch[1];
+    const sliceId = pathMatch[2];
+    const slice = getSlice(milestoneId, sliceId);
+    if (!slice) {
+      throw new Error(
+        `stale-render drift: missing slice for UAT clear ${milestoneId}/${sliceId}`,
+      );
+    }
+    setSliceSummaryMd(milestoneId, sliceId, slice.full_summary_md ?? "", "");
     return;
   }
 

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -568,6 +568,11 @@ test("ADR-017 (#5702): missing UAT.md clears stale full_uat_md from DB", async (
 
   const updated = getSlice("M001", "S01");
   assert.equal(updated?.full_uat_md ?? "", "", "full_uat_md should be cleared after UAT deletion");
+  assert.equal(
+    existsSync(join(sliceDir, "S01-UAT.md")),
+    false,
+    "UAT.md should not be recreated while clearing stale UAT content",
+  );
 });
 
 // ─── #5703: stale-worker drift ───────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -545,6 +545,31 @@ test("ADR-017 (#5702): stale-render detector reason strings match repair contrac
   ].sort());
 });
 
+test("ADR-017 (#5702): missing UAT.md clears stale full_uat_md from DB", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-clear-uat-"));
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmTreeQuiet(base);
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  clearRendererCaches();
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "complete" });
+  setSliceSummaryMd("M001", "S01", "# S01 Summary\n", "# S01 UAT\nLegacy planning text\n");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+  assert.equal(result.ok, true);
+
+  const updated = getSlice("M001", "S01");
+  assert.equal(updated?.full_uat_md ?? "", "", "full_uat_md should be cleared after UAT deletion");
+});
+
 // ─── #5703: stale-worker drift ───────────────────────────────────────────────
 
 const DEAD_PID = 999_999_999; // far above any realistic system PID; process.kill(pid, 0) → ESRCH

--- a/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
@@ -368,4 +368,50 @@ describe("handleValidateMilestone write ordering (#2725)", () => {
     assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
     assert.equal(result.verdict, "pass");
   });
+
+  it("ignores slice full_uat_md planning text for browser requirement detection", async () => {
+    base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({
+      id: "M001",
+      planning: {
+        successCriteria: [
+          "CLI command exits zero",
+          "Unit tests pass",
+        ],
+        verificationUat: "Run CLI checks and inspect logs.",
+      },
+    });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      demo: "Run npm test and npm run build.",
+    });
+
+    const adapter = _getAdapter()!;
+    adapter.prepare(
+      `UPDATE slices SET full_uat_md = :uat WHERE milestone_id = 'M001' AND id = 'S01'`,
+    ).run({
+      ":uat": [
+        "# S01 UAT",
+        "",
+        "Current zero-warning state is a snapshot after cleanup.",
+        "Reload service and verify visible logs in CLI output.",
+        "DOM snapshot checks are optional in unit tests.",
+      ].join("\n"),
+    });
+
+    const result = await handleValidateMilestone(
+      {
+        ...VALID_PARAMS,
+        verificationClasses:
+          `${VALID_PARAMS.verificationClasses}\n- UAT: CLI-only checks complete`,
+      },
+      base,
+    );
+
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+    assert.equal(result.verdict, "pass");
+  });
 });

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -109,7 +109,6 @@ async function browserEvidenceGateRequiresAttention(
       slice.demo,
       slice.goal,
       slice.success_criteria,
-      slice.full_uat_md,
     ]),
   ]);
   if (!hasBrowserRequiredText(requirementText)) return false;


### PR DESCRIPTION
## Summary
- Removed `full_uat_md` from browser gate input and made missing slice UAT files clear stale `full_uat_md` in DB, with targeted regression tests added.

## Bugs Addressed
- [x] **Browser evidence gate scans UAT docs and misflags CLI milestones**
- [x] **Stale `full_uat_md` in DB is not cleared when UAT files are deleted**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #186
- [#186 Browser evidence gate false positive: full_uat_md + overly broad regex trigger on CLI-only milestones](https://github.com/open-gsd/gsd-pi/issues/186)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/186-browser-evidence-gate-false-positive-ful-1779924244`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782516753&installation_id=134682257&pr_number=192&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F192&signature=45f5423e6540f405456a9d2e8abce8d03ef2cadb28e6b84df317e8ff37d857b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes milestone validation verdict logic and state-reconciliation repair paths for slice UAT; incorrect behavior could wrongly pass validation or clear legitimate UAT content.
> 
> **Overview**
> Fixes false positives on the milestone **browser evidence gate** and keeps slice UAT state aligned when UAT files disappear from disk.
> 
> **`validate-milestone`** no longer feeds persisted slice `full_uat_md` into the text used to decide whether browser verification is required, so leftover UAT planning copy cannot force a browser check on CLI-only milestones.
> 
> **Stale-render drift repair** treats a missing slice `UAT.md` as intent to drop UAT: it clears `full_uat_md` in the DB instead of re-rendering UAT from stale content. When only `SUMMARY.md` is missing but UAT was deleted on disk, it clears `full_uat_md` before calling `renderSliceSummary` so both artifacts are not resurrected from old DB text.
> 
> Regression tests cover reconciliation clearing UAT in the DB without recreating `UAT.md`, and validation still passing when `full_uat_md` mentions browser-like wording but milestone criteria stay CLI-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d004d8057c930dc91ec5efcf9a8ca4a487f730aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->