### PR TITLE
fix(ci): keep workspace links during dev version stamping

### DIFF
--- a/scripts/__tests__/version-sync.test.mjs
+++ b/scripts/__tests__/version-sync.test.mjs
@@ -1,0 +1,63 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for release version surface sync.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { RELEASE_WORKSPACE_PACKAGE_DIRS, syncVersionSurfaces } = require("../lib/version-sync.cjs");
+
+test("version sync includes cloud-mcp-gateway so dev stamps keep workspace links", () => {
+  assert.ok(
+    RELEASE_WORKSPACE_PACKAGE_DIRS.includes("packages/cloud-mcp-gateway"),
+    "cloud-mcp-gateway must be synced during dev version stamping",
+  );
+});
+
+test("syncVersionSurfaces rewrites internal deps to the stamped prerelease version", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-version-sync-"));
+  const devVersion = "1.0.2-dev.abc1234";
+
+  try {
+    writeFileSync(
+      join(root, "package.json"),
+      `${JSON.stringify({ name: "@opengsd/gsd-pi", version: "1.0.2" }, null, 2)}\n`,
+    );
+
+    mkdirSync(join(root, "packages", "mcp-server"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "mcp-server", "package.json"),
+      `${JSON.stringify({
+        name: "@opengsd/mcp-server",
+        version: "1.0.2",
+      }, null, 2)}\n`,
+    );
+
+    mkdirSync(join(root, "packages", "cloud-mcp-gateway"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "cloud-mcp-gateway", "package.json"),
+      `${JSON.stringify({
+        name: "@opengsd/cloud-mcp-gateway",
+        version: "1.0.2",
+        dependencies: {
+          "@opengsd/mcp-server": "^1.0.2",
+        },
+      }, null, 2)}\n`,
+    );
+
+    syncVersionSurfaces(root, devVersion);
+
+    const mcpServer = JSON.parse(readFileSync(join(root, "packages", "mcp-server", "package.json"), "utf8"));
+    const gateway = JSON.parse(readFileSync(join(root, "packages", "cloud-mcp-gateway", "package.json"), "utf8"));
+
+    assert.equal(mcpServer.version, devVersion);
+    assert.equal(gateway.version, devVersion);
+    assert.equal(gateway.dependencies["@opengsd/mcp-server"], `^${devVersion}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/version-sync.cjs
+++ b/scripts/lib/version-sync.cjs
@@ -5,8 +5,11 @@ const path = require("node:path");
 
 const RELEASE_WORKSPACE_PACKAGE_DIRS = [
   "extensions/google-search",
+  "packages/cloud-mcp-gateway",
   "packages/contracts",
   "packages/daemon",
+  "packages/gsd-agent-core",
+  "packages/gsd-agent-modes",
   "packages/mcp-server",
   "packages/native",
   "packages/pi-agent-core",
@@ -25,6 +28,9 @@ const PLATFORM_PACKAGE_DIRS = [
 ];
 
 const INTERNAL_PACKAGE_NAMES = new Set([
+  "@gsd/agent-core",
+  "@gsd/agent-modes",
+  "@opengsd/cloud-mcp-gateway",
   "@opengsd/contracts",
   "@opengsd/daemon",
   "@opengsd/mcp-server",


### PR DESCRIPTION
## Summary
- Fixes [NPM Publish @dev failure](https://github.com/open-gsd/gsd-pi/actions/runs/26549586694/job/78208734778) during `pipeline:version-stamp`
- Adds `packages/cloud-mcp-gateway` (and agent packages) to release version sync so internal deps track stamped prerelease versions
- Prevents `npm install --package-lock-only` from trying to fetch `@opengsd/mcp-server@^1.0.2` from npm when the workspace version is `1.0.2-dev.<sha>`

## Root cause
Prerelease versions like `1.0.2-dev.d78048b` do not satisfy `^1.0.2`. After stamping `@opengsd/mcp-server` to a dev version, `cloud-mcp-gateway` still required `^1.0.2`, so npm fell back to the public registry (404 — package not published yet).

## Test plan
- [x] `node --test scripts/__tests__/version-sync.test.mjs`
- [x] `VERSION_CHANNEL=dev npm run pipeline:version-stamp` completes locally
- [ ] Re-run NPM Publish @dev workflow after merge


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script and test-only changes; no runtime product behavior, with low blast radius beyond publish/version-stamp pipelines.
> 
> **Overview**
> Extends release **version sync** so dev prerelease stamping keeps monorepo packages wired together instead of resolving internal deps from npm.
> 
> `scripts/lib/version-sync.cjs` now includes **`packages/cloud-mcp-gateway`** and the **gsd-agent** packages in the workspace sync list, and treats **`@opengsd/cloud-mcp-gateway`** plus **`@gsd/agent-core`** / **`@gsd/agent-modes`** as internal packages whose dependency ranges are rewritten to **`^<stamped version>`** during `syncVersionSurfaces`. That closes a gap where `@opengsd/mcp-server` could be stamped to something like `1.0.2-dev.<sha>` while `cloud-mcp-gateway` still required `^1.0.2` (which prereleases do not satisfy), causing `npm install --package-lock-only` in **`pipeline:version-stamp`** to hit the public registry and fail.
> 
> New regression tests in **`scripts/__tests__/version-sync.test.mjs`** assert `cloud-mcp-gateway` is in the sync set and that internal deps are updated to the dev stamp on a minimal temp workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67ac2ca8de63dabdc4b3991a144211213ba529b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782525099&installation_id=134682257&pr_number=194&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F194&signature=fd1c04dc43175bc4923ab1a8b983dcb97e15c0492eed5a1b654a61d01890e2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->