### PR TITLE
fix(auto): complete-slice reopen handoff when DB is unavailable

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -190,6 +190,27 @@ function unitActivityMentionsTool(basePath: string, unitType: string, unitId: st
   return false;
 }
 
+function completeSliceReopenReplanHandoffDetected(
+  s: AutoSession,
+  agentEndMessages: unknown[] | undefined,
+): boolean {
+  if (s.currentUnit?.type !== "complete-slice") return false;
+  const unitType = s.currentUnit.type;
+  const unitId = s.currentUnit.id;
+  return (
+    agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_task_reopen") ||
+    agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_task_reopen") ||
+    agentEndMessagesMentionTool(agentEndMessages, "gsd_task_reopen") ||
+    unitActivityMentionsTool(s.basePath, unitType, unitId, "gsd_task_reopen") ||
+    unitActivityMentionsTool(s.canonicalProjectRoot, unitType, unitId, "gsd_task_reopen") ||
+    agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_replan_slice") ||
+    agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_replan_slice") ||
+    agentEndMessagesMentionTool(agentEndMessages, "gsd_replan_slice") ||
+    unitActivityMentionsTool(s.basePath, unitType, unitId, "gsd_replan_slice") ||
+    unitActivityMentionsTool(s.canonicalProjectRoot, unitType, unitId, "gsd_replan_slice")
+  );
+}
+
 function formatPreExecutionCheckDetail(check: PreExecutionCheckJSON): string {
   const category = check.category?.trim() || "unknown category";
   const target = check.target?.trim() || "unknown target";
@@ -1738,6 +1759,24 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         );
         await pauseAuto(ctx, pi);
         return "dispatched";
+      } else if (
+        !triggerArtifactVerified &&
+        completeSliceReopenReplanHandoffDetected(s, opts?.agentEndMessages)
+      ) {
+        const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+        s.pendingVerificationRetry = null;
+        s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
+        debugLog("postUnit", {
+          phase: "artifact-verify-complete-slice-handoff",
+          unitType: s.currentUnit.type,
+          unitId: s.currentUnit.id,
+        });
+        ctx.ui.notify(
+          `complete-slice ${s.currentUnit.id} intentionally handed off via reopen/replan; continuing orchestration instead of retrying closeout.`,
+          "warning",
+        );
+        return "continue";
       } else if (!triggerArtifactVerified && !isDbAvailable()) {
         debugLog("postUnit", { phase: "artifact-verify-skip-db-unavailable", unitType: s.currentUnit.type, unitId: s.currentUnit.id });
         const dbSkipDiag = diagnoseExpectedArtifact(s.currentUnit.type, s.currentUnit.id, verificationBasePath);
@@ -1761,35 +1800,6 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         const hasExpectedArtifact = resolveExpectedArtifactPath(s.currentUnit.type, s.currentUnit.id, verificationBasePath) !== null;
         if (hasExpectedArtifact) {
           const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
-          if (
-            s.currentUnit.type === "complete-slice" &&
-            (
-              agentEndMessagesIncludeSuccessfulToolResult(opts?.agentEndMessages, "gsd_task_reopen") ||
-              agentEndMessagesIncludeToolCall(opts?.agentEndMessages, "gsd_task_reopen") ||
-              agentEndMessagesMentionTool(opts?.agentEndMessages, "gsd_task_reopen") ||
-              unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_task_reopen") ||
-              unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_task_reopen") ||
-              agentEndMessagesIncludeSuccessfulToolResult(opts?.agentEndMessages, "gsd_replan_slice") ||
-              agentEndMessagesIncludeToolCall(opts?.agentEndMessages, "gsd_replan_slice") ||
-              agentEndMessagesMentionTool(opts?.agentEndMessages, "gsd_replan_slice") ||
-              unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice") ||
-              unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice")
-            )
-          ) {
-            s.pendingVerificationRetry = null;
-            s.verificationRetryCount.delete(retryKey);
-            s.verificationRetryFailureHashes.delete(retryKey);
-            debugLog("postUnit", {
-              phase: "artifact-verify-complete-slice-handoff",
-              unitType: s.currentUnit.type,
-              unitId: s.currentUnit.id,
-            });
-            ctx.ui.notify(
-              `complete-slice ${s.currentUnit.id} intentionally handed off via reopen/replan; continuing orchestration instead of retrying closeout.`,
-              "warning",
-            );
-            return "continue";
-          }
           const verificationFailureMarker = resolveVerificationFailureMarkerPath(s.currentUnit.type, s.currentUnit.id, s.basePath);
           if (verificationFailureMarker && existsSync(verificationFailureMarker)) {
             s.pendingVerificationRetry = null;


### PR DESCRIPTION
## Summary
- Fixes failing `test-unit` on main after #194 merge: `complete-slice-reopen-handoff.test.ts` (2 failures)
- Runs reopen/replan handoff detection before the DB-unavailable artifact branch in `postUnitPreVerification`
- Clears stale `pendingVerificationRetry` / retry counters when the agent intentionally hands off via `gsd_task_reopen` or `gsd_replan_slice`

## Root cause
Handoff logic lived inside the DB-available artifact-retry path. When no DB is open (unit tests, early setup), the code took the DB-unavailable branch, returned `continue`, and left retry state uncleared.

## Test plan
- [x] `node --test src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts`
- [ ] CI `test-unit` green


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782525538&installation_id=134682257&pr_number=195&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F195&signature=89b48212e2636df8bb7192f39586f9c85782bd9e19c20e674b5efe3a6cf3e482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized reordering and extraction in auto post-unit verification; behavior change only affects complete-slice units with reopen/replan signals and missing artifacts.
> 
> **Overview**
> **complete-slice** closeout can end without the expected artifact when the agent deliberately hands off via **`gsd_task_reopen`** or **`gsd_replan_slice`**. That handoff was only handled inside the DB-available artifact-retry path, so runs with no DB (including unit tests) hit the “DB unavailable, skip retry” branch and never cleared **`pendingVerificationRetry`** / retry counters.
> 
> This change extracts **`completeSliceReopenReplanHandoffDetected`** and evaluates it **before** the DB-unavailable branch in **`postUnitPreVerification`**. When reopen/replan is detected, retry state is cleared and orchestration **`continue`**s with the existing warning instead of treating the unit as a failed closeout retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0cb37c2df55a47153d8c22be0031d21bf39679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->