### PR TITLE
fix(gsd): keep diagnostics available during validation blocks

### DIFF
--- a/packages/mcp-server/src/readers/graph.test.ts
+++ b/packages/mcp-server/src/readers/graph.test.ts
@@ -16,6 +16,7 @@ import {
   graphDiff,
 } from './graph.js';
 import type { KnowledgeGraph } from './graph.js';
+import { _resetReaderCaches } from './paths.js';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -442,7 +443,11 @@ describe('graphStatus', () => {
   let projectDir: string;
 
   beforeEach(() => {
+    _resetReaderCaches();
     projectDir = tmpProject();
+    // Empty project-local .gsd prevents resolveGsdRoot from falling back to
+    // the checkout's .gsd when tmpdir lives inside the CI workspace.
+    mkdirSync(join(projectDir, '.gsd', 'graphs'), { recursive: true });
   });
 
   afterEach(() => rmSync(projectDir, { recursive: true, force: true }));

--- a/packages/pi-ai/src/utils/tests/agent-shim.test.ts
+++ b/packages/pi-ai/src/utils/tests/agent-shim.test.ts
@@ -91,6 +91,6 @@ describe("createAgentShimResult", () => {
 		});
 		assert.ok(result.content[0]?.text.includes("inline"));
 		assert.equal(result.details.agent, "scout");
-		assert.ok(result.details.task.includes("Scout codebase"));
+		assert.ok(result.details.task?.includes("Scout codebase"));
 	});
 });

--- a/packages/pi-ai/src/utils/tests/agent-shim.test.ts
+++ b/packages/pi-ai/src/utils/tests/agent-shim.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "vitest";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
 import {
 	createAgentShimResult,
 	extractNormalizedSubagentCall,
@@ -9,20 +10,20 @@ import {
 
 describe("isAgentToolName", () => {
 	test("matches Agent case-insensitively", () => {
-		expect(isAgentToolName("Agent")).toBe(true);
-		expect(isAgentToolName("agent")).toBe(true);
-		expect(isAgentToolName("subagent")).toBe(false);
+		assert.equal(isAgentToolName("Agent"), true);
+		assert.equal(isAgentToolName("agent"), true);
+		assert.equal(isAgentToolName("subagent"), false);
 	});
 });
 
 describe("mapSubagentTypeToGsdAgent", () => {
 	test("maps Claude Code Explore to scout", () => {
-		expect(mapSubagentTypeToGsdAgent("Explore")).toBe("scout");
+		assert.equal(mapSubagentTypeToGsdAgent("Explore"), "scout");
 	});
 
 	test("maps general-purpose variants to worker", () => {
-		expect(mapSubagentTypeToGsdAgent("general-purpose")).toBe("worker");
-		expect(mapSubagentTypeToGsdAgent("generalPurpose")).toBe("worker");
+		assert.equal(mapSubagentTypeToGsdAgent("general-purpose"), "worker");
+		assert.equal(mapSubagentTypeToGsdAgent("generalPurpose"), "worker");
 	});
 });
 
@@ -34,7 +35,7 @@ describe("normalizeClaudeCodeAgentArguments", () => {
 			prompt: "Read key files and summarize.",
 		};
 		normalizeClaudeCodeAgentArguments(args);
-		expect(args).toEqual({
+		assert.deepEqual(args, {
 			agent: "scout",
 			task: "Scout current project state\n\nRead key files and summarize.",
 		});
@@ -47,7 +48,7 @@ describe("normalizeClaudeCodeAgentArguments", () => {
 			prompt: "Ignored",
 		};
 		normalizeClaudeCodeAgentArguments(args);
-		expect(args).toEqual({
+		assert.deepEqual(args, {
 			agent: "scout",
 			task: "Existing task",
 		});
@@ -61,7 +62,7 @@ describe("normalizeClaudeCodeAgentArguments", () => {
 
 		normalizeClaudeCodeAgentArguments(args);
 
-		expect(args).toEqual({
+		assert.deepEqual(args, {
 			agent: "scout",
 			task: "Inspect repository",
 		});
@@ -70,13 +71,14 @@ describe("normalizeClaudeCodeAgentArguments", () => {
 
 describe("extractNormalizedSubagentCall", () => {
 	test("returns mapped agent and task", () => {
-		expect(
+		assert.deepEqual(
 			extractNormalizedSubagentCall({
 				subagent_type: "Explore",
 				description: "Scout",
 				prompt: "Go",
 			}),
-		).toEqual({ agent: "scout", task: "Scout\n\nGo" });
+			{ agent: "scout", task: "Scout\n\nGo" },
+		);
 	});
 });
 
@@ -87,8 +89,8 @@ describe("createAgentShimResult", () => {
 			description: "Scout codebase",
 			prompt: "Map modules",
 		});
-		expect(result.content[0]?.text).toContain("inline");
-		expect(result.details.agent).toBe("scout");
-		expect(result.details.task).toContain("Scout codebase");
+		assert.ok(result.content[0]?.text.includes("inline"));
+		assert.equal(result.details.agent, "scout");
+		assert.ok(result.details.task.includes("Scout codebase"));
 	});
 });

--- a/packages/pi-ai/src/utils/tests/mcp-tool-name.test.ts
+++ b/packages/pi-ai/src/utils/tests/mcp-tool-name.test.ts
@@ -1,38 +1,39 @@
-import { describe, expect, test } from "vitest";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
 import { parseMcpToolName, stripMcpToolPrefix } from "../mcp-tool-name.js";
 import { CLAUDE_CODE_TOOL_ALIASES, resolveAgentToolName } from "../tool-shims.js";
 
 describe("mcp-tool-name", () => {
 	test("parseMcpToolName splits server and tool", () => {
-		expect(parseMcpToolName("mcp__gsd-workflow__gsd_plan_milestone")).toEqual({
+		assert.deepEqual(parseMcpToolName("mcp__gsd-workflow__gsd_plan_milestone"), {
 			server: "gsd-workflow",
 			tool: "gsd_plan_milestone",
 		});
 	});
 
 	test("stripMcpToolPrefix returns canonical tool name", () => {
-		expect(stripMcpToolPrefix("mcp__gsd-workflow__gsd_milestone_status")).toBe("gsd_milestone_status");
-		expect(stripMcpToolPrefix("read")).toBe("read");
+		assert.equal(stripMcpToolPrefix("mcp__gsd-workflow__gsd_milestone_status"), "gsd_milestone_status");
+		assert.equal(stripMcpToolPrefix("read"), "read");
 	});
 });
 
 describe("resolveAgentToolName", () => {
 	test("maps Claude Code Grep to Pi grep when registered", () => {
-		expect(CLAUDE_CODE_TOOL_ALIASES.grep).toBe("grep");
-		expect(resolveAgentToolName("Grep")).toBe("grep");
+		assert.equal(CLAUDE_CODE_TOOL_ALIASES.grep, "grep");
+		assert.equal(resolveAgentToolName("Grep"), "grep");
 	});
 
 	test("maps Claude Code Glob to Pi find", () => {
-		expect(CLAUDE_CODE_TOOL_ALIASES.glob).toBe("find");
-		expect(resolveAgentToolName("Glob")).toBe("find");
+		assert.equal(CLAUDE_CODE_TOOL_ALIASES.glob, "find");
+		assert.equal(resolveAgentToolName("Glob"), "find");
 	});
 
 	test("maps Claude Code WebFetch and WebSearch to Pi extensions", () => {
-		expect(resolveAgentToolName("WebFetch")).toBe("fetch_page");
-		expect(resolveAgentToolName("WebSearch")).toBe("search-the-web");
+		assert.equal(resolveAgentToolName("WebFetch"), "fetch_page");
+		assert.equal(resolveAgentToolName("WebSearch"), "search-the-web");
 	});
 
 	test("strips MCP prefixes", () => {
-		expect(resolveAgentToolName("mcp__gsd-workflow__gsd_exec")).toBe("gsd_exec");
+		assert.equal(resolveAgentToolName("mcp__gsd-workflow__gsd_exec"), "gsd_exec");
 	});
 });

--- a/packages/pi-ai/src/utils/tests/tool-search-shim.test.ts
+++ b/packages/pi-ai/src/utils/tests/tool-search-shim.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "vitest";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
 import {
 	createToolSearchShimResult,
 	isToolSearchToolName,
@@ -7,7 +8,8 @@ import {
 
 describe("tool-search-shim", () => {
 	test("parseToolSearchSelectQuery extracts MCP tool name", () => {
-		expect(parseToolSearchSelectQuery("select:mcp__gsd-workflow__gsd_milestone_status")).toBe(
+		assert.equal(
+			parseToolSearchSelectQuery("select:mcp__gsd-workflow__gsd_milestone_status"),
 			"mcp__gsd-workflow__gsd_milestone_status",
 		);
 	});
@@ -16,13 +18,13 @@ describe("tool-search-shim", () => {
 		const result = createToolSearchShimResult({
 			query: "select:mcp__gsd-workflow__gsd_milestone_status",
 		});
-		expect(result.content[0]?.text).toContain("mcp__gsd-workflow__gsd_milestone_status");
-		expect(result.details.resolvedTool).toBe("mcp__gsd-workflow__gsd_milestone_status");
+		assert.ok(result.content[0]?.text.includes("mcp__gsd-workflow__gsd_milestone_status"));
+		assert.equal(result.details.resolvedTool, "mcp__gsd-workflow__gsd_milestone_status");
 	});
 
 	test("isToolSearchToolName is case insensitive", () => {
-		expect(isToolSearchToolName("ToolSearch")).toBe(true);
-		expect(isToolSearchToolName("toolsearch")).toBe(true);
-		expect(isToolSearchToolName("Read")).toBe(false);
+		assert.equal(isToolSearchToolName("ToolSearch"), true);
+		assert.equal(isToolSearchToolName("toolsearch"), true);
+		assert.equal(isToolSearchToolName("Read"), false);
 	});
 });

--- a/packages/pi-ai/vitest.config.ts
+++ b/packages/pi-ai/vitest.config.ts
@@ -5,14 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 30000, // 30 seconds for API calls
-    include: [
-      'src/utils/tests/agent-shim.test.ts',
-      'src/utils/tests/mcp-tool-name.test.ts',
-      'src/utils/tests/tool-search-shim.test.ts',
-      'dist/utils/tests/agent-shim.test.js',
-      'dist/utils/tests/mcp-tool-name.test.js',
-      'dist/utils/tests/tool-search-shim.test.js',
-    ],
+    include: ['test/**/*.test.ts'],
     exclude: ['**/node_modules/**'],
   }
 });

--- a/scripts/run-package-tests.cjs
+++ b/scripts/run-package-tests.cjs
@@ -163,27 +163,14 @@ function main() {
 	for (const pkg of packages) {
 		if (pkg.packageName === '@gsd/pi-ai') {
 			const files = findPiAiPackageTestFiles(pkg.path)
-			const vitestOnly = /(?:^|[\\/])(agent-shim|mcp-tool-name|tool-search-shim)\.test\.js$/i
-			const vitestFiles = files.filter((file) => vitestOnly.test(file))
-			const nodeTestFiles = files.filter((file) => !vitestOnly.test(file))
-			let ok = true
+			if (files.length === 0) {
+				process.stderr.write(`Skipping ${pkg.packageName}: no compiled test files found.\n`)
+				continue
+			}
 			process.stderr.write(`\nRunning ${pkg.packageName} package tests...\n`)
-			if (nodeTestFiles.length > 0) {
-				ok =
-					runCommand(process.execPath, ['--test', ...nodeTestFiles], REPO_ROOT, `${pkg.packageName} (node:test)`) ===
-					0 && ok
+			if (runCommand(process.execPath, ['--test', ...files], REPO_ROOT, pkg.packageName) !== 0) {
+				failureCount += 1
 			}
-			if (vitestFiles.length > 0) {
-				const vitestBin = join(REPO_ROOT, 'node_modules', 'vitest', 'vitest.mjs')
-				ok =
-					runCommand(
-						process.execPath,
-						[vitestBin, 'run', '--config', join(pkg.path, 'vitest.config.ts'), ...vitestFiles],
-						pkg.path,
-						`${pkg.packageName} (vitest)`,
-					) === 0 && ok
-			}
-			if (!ok) failureCount += 1
 			continue
 		}
 

--- a/src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts
@@ -172,3 +172,24 @@ test("dispatcher still allows recovery commands while validation is blocked", as
     cleanup(base);
   }
 });
+
+test("dispatcher allows diagnostic and knowledge commands while validation is blocked", async () => {
+  const base = makeBase();
+  try {
+    seedValidationBlockedMilestone(base);
+    const { ctx, calls } = makeMockCtx(base);
+    const { pi, messages } = makeMockPi();
+
+    await handleGSDCommand("capture investigating validation false positive", ctx, pi);
+
+    assert.equal(messages.length, 0);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].kind, "info");
+    assert.match(calls[0].message, /Captured:/);
+    assert.doesNotMatch(calls[0].message, /cannot run/);
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts
@@ -131,6 +131,7 @@ test("dispatcher blocks workflow-advancing aliases while validation is blocked",
     "do mark all complete",
     "dispatch complete",
     "workflow resume",
+    "workflow release-checklist",
   ];
 
   for (const command of blockedCommands) {

--- a/src/resources/extensions/gsd/tests/validation-block-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validation-block-guard.test.ts
@@ -46,7 +46,7 @@ test("validation block detection only matches validation blockers", () => {
   }), false);
 });
 
-test("validation block allows only recovery and inspection commands", () => {
+test("validation block allows recovery, diagnostics, and unrelated commands", () => {
   const allowed = [
     "help",
     "h",
@@ -61,6 +61,23 @@ test("validation block allows only recovery and inspection commands", () => {
     "notifications",
     "inspect",
     "doctor audit",
+    "forensics",
+    "capture validation false-positive on Android",
+    "knowledge lesson browser gate needs Android evidence",
+    "codebase update",
+    "prefs status",
+    "config",
+    "discuss M006",
+    "queue",
+    "quick fix docs typo",
+    "new-milestone",
+    "new-project",
+    "workflow list",
+    "workflow validate release-checklist",
+    "parallel status",
+    "parallel stop M007",
+    "parallel pause M007",
+    "parallel watch",
   ];
 
   for (const command of allowed) {
@@ -77,14 +94,15 @@ test("validation block rejects workflow-start and advancing commands", () => {
     "next M006",
     "do mark all complete",
     "start bugfix",
-    "quick fix button",
-    "new-milestone",
     "workflow resume",
+    "workflow run release-checklist",
     "parallel start",
     "parallel resume",
+    "parallel merge",
     "dispatch complete",
     "dispatch uat",
     "complete-milestone",
+    "ship",
   ];
 
   for (const command of blocked) {

--- a/src/resources/extensions/gsd/tests/validation-block-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validation-block-guard.test.ts
@@ -96,6 +96,8 @@ test("validation block rejects workflow-start and advancing commands", () => {
     "start bugfix",
     "workflow resume",
     "workflow run release-checklist",
+    "workflow release-checklist",
+    "workflow release-checklist env=prod",
     "parallel start",
     "parallel resume",
     "parallel merge",

--- a/src/resources/extensions/gsd/validation-block-guard.ts
+++ b/src/resources/extensions/gsd/validation-block-guard.ts
@@ -13,18 +13,30 @@ import { detectWorktreeName } from "./worktree.js";
 const VALIDATION_BLOCK_RE =
   /milestone validation returned needs-(?:attention|remediation)|validation verdict is needs-(?:attention|remediation)/i;
 
-const ALLOWED_COMMANDS = new Set([
-  "help",
-  "h",
-  "?",
-  "status",
-  "verdict",
+const VALIDATION_SAFE_DISPATCH_COMMANDS = new Set([
+  "validate",
   "validate-milestone",
-  "park",
-  "logs",
-  "notifications",
-  "inspect",
-  "doctor",
+]);
+
+const VALIDATION_BLOCKED_COMMANDS = new Set([
+  "auto",
+  "next",
+  "start",
+  "ship",
+  "complete-milestone",
+  "do",
+]);
+
+const VALIDATION_BLOCKED_PARALLEL_SUBCOMMANDS = new Set([
+  "",
+  "start",
+  "resume",
+  "merge",
+]);
+
+const VALIDATION_BLOCKED_WORKFLOW_SUBCOMMANDS = new Set([
+  "run",
+  "resume",
 ]);
 
 export function isValidationBlockedState(state: GSDState): boolean {
@@ -38,9 +50,15 @@ export function isValidationBlockAllowedCommand(trimmed: string): boolean {
 
   const [name, subcommand] = command.split(/\s+/, 2);
   if (name === "dispatch") {
-    return subcommand === "validate" || subcommand === "validate-milestone";
+    return VALIDATION_SAFE_DISPATCH_COMMANDS.has(subcommand ?? "");
   }
-  return ALLOWED_COMMANDS.has(name);
+  if (name === "parallel") {
+    return !VALIDATION_BLOCKED_PARALLEL_SUBCOMMANDS.has(subcommand ?? "");
+  }
+  if (name === "workflow") {
+    return !VALIDATION_BLOCKED_WORKFLOW_SUBCOMMANDS.has(subcommand ?? "");
+  }
+  return !VALIDATION_BLOCKED_COMMANDS.has(name);
 }
 
 export function formatValidationBlockedMessage(

--- a/src/resources/extensions/gsd/validation-block-guard.ts
+++ b/src/resources/extensions/gsd/validation-block-guard.ts
@@ -34,9 +34,15 @@ const VALIDATION_BLOCKED_PARALLEL_SUBCOMMANDS = new Set([
   "merge",
 ]);
 
-const VALIDATION_BLOCKED_WORKFLOW_SUBCOMMANDS = new Set([
-  "run",
-  "resume",
+const VALIDATION_SAFE_WORKFLOW_SUBCOMMANDS = new Set([
+  "",
+  "new",
+  "list",
+  "validate",
+  "pause",
+  "info",
+  "install",
+  "uninstall",
 ]);
 
 export function isValidationBlockedState(state: GSDState): boolean {
@@ -56,7 +62,7 @@ export function isValidationBlockAllowedCommand(trimmed: string): boolean {
     return !VALIDATION_BLOCKED_PARALLEL_SUBCOMMANDS.has(subcommand ?? "");
   }
   if (name === "workflow") {
-    return !VALIDATION_BLOCKED_WORKFLOW_SUBCOMMANDS.has(subcommand ?? "");
+    return VALIDATION_SAFE_WORKFLOW_SUBCOMMANDS.has(subcommand ?? "");
   }
   return !VALIDATION_BLOCKED_COMMANDS.has(name);
 }


### PR DESCRIPTION
## Summary

- Replace the validation-block closed allowlist with a milestone-mutating command blocklist.
- Keep recovery and diagnostic commands available while validation is needs-attention/needs-remediation.
- Add regression coverage for diagnostic command dispatch during validation blocks.

Closes #152

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/validation-block-guard.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `git diff --check`

## Impact analysis

- Blast radius: narrow.
- Affected workflows: `/gsd` command gating only when active milestone state is blocked by validation needs-attention/needs-remediation.
- Risks or compatibility notes: milestone-advancing commands still block, while diagnostic, knowledge, configuration, queue, and creation commands are no longer locked out.

## Notes

- Implemented in a clean worktree because the original checkout had unrelated issue-181 changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Command gating logic is inverted from allowlist to blocklist with new subcommand rules—incorrect classification could let milestone advancement through or block legitimate recovery, though scope is limited to validation-blocked state and is heavily regression-tested.
> 
> **Overview**
> When a milestone is blocked by validation **needs-attention** or **needs-remediation**, `/gsd` command gating no longer uses a short recovery-only allowlist. **`isValidationBlockAllowedCommand`** now defaults to allowing commands unless they are explicitly milestone-advancing: top-level names like `auto`, `next`, `start`, `ship`, `do`, and `complete-milestone`; unsafe `parallel` subcommands (`start`, `resume`, `merge`, and bare `parallel`); and `workflow` subcommands outside a safe set (`list`, `validate`, `pause`, `new`, etc.—so **`workflow release-checklist`** / **`workflow run`** stay blocked while **`workflow validate …`** stays allowed). Only **`dispatch validate`** / **`validate-milestone`** remain explicitly safe on the dispatch path.
> 
> Regression tests cover the expanded allow path (e.g. **`capture`**, knowledge, config, queue, **`workflow list`**) and still block advancing aliases; dispatcher tests assert **`capture`** succeeds during a validation block.
> 
> **Test harness changes (supporting CI, not product behavior):** `@gsd/pi-ai` shim tests move from Vitest to **`node:test`**; package test runner runs all compiled pi-ai tests via **`node --test`** only; Vitest config **`include`** narrows to `test/**/*.test.ts`. **`graphStatus`** tests reset reader caches and seed an empty project **`.gsd`** so temp dirs under the workspace do not pick up the checkout graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f23e8c4d986d659c31e92d43d8f4fb1606d89b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782527935&installation_id=134682257&pr_number=197&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F197&signature=1616167796d7fee9d57546c65ebeadd8221f55a5f84fd79170c7a9c02079c26f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->