### PR TITLE
fix(ci): pin dev publishes to stable engine packages on npm

### DIFF
--- a/native/scripts/sync-platform-versions.cjs
+++ b/native/scripts/sync-platform-versions.cjs
@@ -9,6 +9,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { resolveEngineOptionalDependencyVersion } = require("../../scripts/lib/version-sync.cjs");
 
 const rootDir = path.resolve(__dirname, "..", "..");
 const npmDir = path.resolve(__dirname, "..", "npm");
@@ -16,8 +17,14 @@ const npmDir = path.resolve(__dirname, "..", "npm");
 const rootPkgPath = path.join(rootDir, "package.json");
 const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, "utf-8"));
 const version = rootPkg.version;
+const optionalDependencyVersion = resolveEngineOptionalDependencyVersion(version);
 
 console.log(`[sync-platform-versions] Syncing to version ${version}`);
+if (optionalDependencyVersion !== version) {
+  console.log(
+    `[sync-platform-versions] optionalDependencies pinned to stable engine version ${optionalDependencyVersion}`,
+  );
+}
 
 const platformPackages = [
   "darwin-arm64",
@@ -46,10 +53,10 @@ for (const platform of platformPackages) {
   }
 
   const dependencyName = `@opengsd/engine-${platform}`;
-  if (rootPkg.optionalDependencies?.[dependencyName] !== version) {
+  if (rootPkg.optionalDependencies?.[dependencyName] !== optionalDependencyVersion) {
     rootPkg.optionalDependencies = rootPkg.optionalDependencies || {};
-    rootPkg.optionalDependencies[dependencyName] = version;
-    console.log(`  root optionalDependencies.${dependencyName}: ${version}`);
+    rootPkg.optionalDependencies[dependencyName] = optionalDependencyVersion;
+    console.log(`  root optionalDependencies.${dependencyName}: ${optionalDependencyVersion}`);
   }
 }
 

--- a/scripts/__tests__/sync-platform-versions.test.mjs
+++ b/scripts/__tests__/sync-platform-versions.test.mjs
@@ -5,13 +5,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-test("sync-platform-versions keeps root native optional dependencies exact", () => {
+test("sync-platform-versions keeps dev optionalDependencies on stable engine semver", () => {
   const script = readFileSync("native/scripts/sync-platform-versions.cjs", "utf8");
 
-  assert.match(script, /optionalDependencies/);
-  assert.match(script, /`@opengsd\/engine-\$\{platform\}`/);
-  assert.doesNotMatch(script, /range specifiers/);
-  assert.doesNotMatch(script, />=/);
+  assert.match(script, /resolveEngineOptionalDependencyVersion/);
+  assert.match(script, /optionalDependencyVersion/);
+});
+
+test("verify-native-platform-packages checks pinned optionalDependency versions", () => {
+  const script = readFileSync("scripts/verify-native-platform-packages.mjs", "utf8");
+
+  assert.match(script, /optionalDependencies\[name\]/);
+  assert.doesNotMatch(script, /\$\{name\}@\$\{version\}/);
 });
 
 test("prepublish verifies matching native platform packages before publishing main package", () => {

--- a/scripts/__tests__/version-sync.test.mjs
+++ b/scripts/__tests__/version-sync.test.mjs
@@ -9,7 +9,13 @@ import { createRequire } from "node:module";
 import test from "node:test";
 
 const require = createRequire(import.meta.url);
-const { RELEASE_WORKSPACE_PACKAGE_DIRS, syncVersionSurfaces } = require("../lib/version-sync.cjs");
+const { RELEASE_WORKSPACE_PACKAGE_DIRS, resolveEngineOptionalDependencyVersion, syncVersionSurfaces } = require("../lib/version-sync.cjs");
+
+test("resolveEngineOptionalDependencyVersion keeps dev publishes on stable engine packages", () => {
+  assert.equal(resolveEngineOptionalDependencyVersion("1.0.2-dev.adee50b"), "1.0.2");
+  assert.equal(resolveEngineOptionalDependencyVersion("1.0.2"), "1.0.2");
+  assert.equal(resolveEngineOptionalDependencyVersion("1.0.2-next.3"), "1.0.2-next.3");
+});
 
 test("version sync includes cloud-mcp-gateway so dev stamps keep workspace links", () => {
   assert.ok(

--- a/scripts/lib/version-sync.cjs
+++ b/scripts/lib/version-sync.cjs
@@ -44,6 +44,15 @@ const INTERNAL_PACKAGE_NAMES = new Set([
 
 const NATIVE_CRATE_NAMES = new Set(["gsd-ast", "gsd-engine", "gsd-grep"]);
 
+/** Dev publishes reuse stable @opengsd/engine-* packages already on npm. */
+function resolveEngineOptionalDependencyVersion(rootVersion) {
+  const devMatch = rootVersion.match(/^(\d+\.\d+\.\d+)-dev\.[0-9a-f]+$/i);
+  if (devMatch) {
+    return devMatch[1];
+  }
+  return rootVersion;
+}
+
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
@@ -206,12 +215,13 @@ function verifyVersionSync(root) {
   verifyLockfile(root, expectedVersion, issues);
 
   const rootPkg = readJson(path.join(root, "package.json"));
+  const expectedOptionalDepVersion = resolveEngineOptionalDependencyVersion(expectedVersion);
   for (const platformDir of PLATFORM_PACKAGE_DIRS) {
     const platform = platformDir.replace("native/npm/", "");
     const depName = `@opengsd/engine-${platform}`;
     const pinned = rootPkg.optionalDependencies?.[depName];
-    if (pinned !== undefined && pinned !== expectedVersion) {
-      issues.push(`package.json optionalDependencies.${depName} is ${pinned}, expected ${expectedVersion}`);
+    if (pinned !== undefined && pinned !== expectedOptionalDepVersion) {
+      issues.push(`package.json optionalDependencies.${depName} is ${pinned}, expected ${expectedOptionalDepVersion}`);
     }
   }
 
@@ -231,6 +241,7 @@ function verifyVersionSync(root) {
 module.exports = {
   PLATFORM_PACKAGE_DIRS,
   RELEASE_WORKSPACE_PACKAGE_DIRS,
+  resolveEngineOptionalDependencyVersion,
   syncVersionSurfaces,
   verifyVersionSync,
 };

--- a/scripts/verify-native-platform-packages.mjs
+++ b/scripts/verify-native-platform-packages.mjs
@@ -4,7 +4,6 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
-const version = pkg.version;
 const optionalDependencies = pkg.optionalDependencies ?? {};
 const enginePackages = Object.keys(optionalDependencies)
   .filter((name) => name.startsWith("@opengsd/engine-"))
@@ -19,7 +18,8 @@ const allowAnyVersion = process.argv.includes("--any-version");
 const missing = [];
 
 for (const name of enginePackages) {
-  const spec = allowAnyVersion ? name : `${name}@${version}`;
+  const pinnedVersion = optionalDependencies[name];
+  const spec = allowAnyVersion ? name : `${name}@${pinnedVersion}`;
   const result = spawnSync("npm", ["view", spec, "version"], {
     encoding: "utf8",
     shell: process.platform === "win32",


### PR DESCRIPTION
## Summary
- Fix `@dev` NPM Publish failure when verifying native platform packages
- Dev stamps like `1.0.2-dev.adee50b` now keep `@opengsd/engine-*` optionalDependencies pinned to the stable base semver (`1.0.2`)
- `verify:native-platform-packages` checks the pinned optionalDependency versions instead of the stamped root version

Fixes [NPM Publish run 26552005226](https://github.com/open-gsd/gsd-pi/actions/runs/26552005226/job/78215842407).

## Test plan
- [x] `node --test scripts/__tests__/version-sync.test.mjs scripts/__tests__/sync-platform-versions.test.mjs`
- [x] Simulated dev stamp + `npm run verify:native-platform-packages` passes against npm
- [ ] Re-run NPM Publish `@dev` after merge

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782529635&installation_id=134682257&pr_number=198&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F198&signature=38cb7eba6e2d63e78cfe3dbb38823ec5289d2f1910a4abdda721e6eb535aa52e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/version-sync and prepublish verification only; no runtime product logic or auth changes.
> 
> **Overview**
> Fixes **`@dev` npm publish** prepublish checks that failed when the root package was stamped (e.g. `1.0.2-dev.adee50b`) but **`@opengsd/engine-*`** packages on npm only exist at the **stable base semver** (`1.0.2`).
> 
> Adds **`resolveEngineOptionalDependencyVersion`** in `version-sync.cjs` to map `X.Y.Z-dev.<hash>` → `X.Y.Z`, while leaving other prereleases (e.g. `1.0.2-next.3`) unchanged. **`sync-platform-versions`** and **`verifyVersionSync`** now pin/check root **`optionalDependencies`** against that resolved version; platform **`package.json`** versions still follow the full root version.
> 
> **`verify-native-platform-packages`** runs `npm view` against each engine package’s **pinned optionalDependency version**, not the root **`package.json`** version. Tests were updated to lock in this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf25e04ccb3cdb6d70ad600a0f6c6e980368d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->