### PR TITLE
fix(ci): use GitHub-hosted runners for npm publish provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,8 +43,8 @@ jobs:
   prerelease-publish:
     name: Publish @${{ github.event.inputs.channel }}
     if: ${{ github.event.inputs.channel != 'latest' }}
-    # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing + provenance require GitHub-hosted runners (not Blacksmith).
+    runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.channel }}
     container:
       image: ghcr.io/open-gsd/gsd-ci-builder:latest
@@ -200,8 +200,8 @@ jobs:
   prod-release:
     name: Production Release
     if: ${{ github.event.inputs.channel == 'latest' }}
-    # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing + provenance require GitHub-hosted runners (not Blacksmith).
+    runs-on: ubuntu-latest
     environment: prod
     steps:
       - uses: actions/checkout@v6

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -60,6 +60,11 @@ test("npm publish supports token auth fallback for prerelease", () => {
   );
 });
 
+test("publish jobs use GitHub-hosted runners for npm provenance", () => {
+  assert.equal(workflow.jobs["prerelease-publish"]["runs-on"], "ubuntu-latest");
+  assert.equal(workflow.jobs["prod-release"]["runs-on"], "ubuntu-latest");
+});
+
 test("main package publish verifies native engine packages first", () => {
   const prereleaseSteps = workflow.jobs["prerelease-publish"].steps;
   const prereleaseVerify = prereleaseSteps.find(


### PR DESCRIPTION
## Summary
- Move `prerelease-publish` and `prod-release` jobs to `ubuntu-latest`
- npm rejects provenance bundles from Blacksmith (`self-hosted`) with E422 during trusted publish

Fixes [NPM Publish run 26552293324](https://github.com/open-gsd/gsd-pi/actions/runs/26552293324/job/78216745980).

## Test plan
- [x] `node --test scripts/__tests__/npm-publish-workflow.test.mjs`
- [ ] Re-run NPM Publish `@dev` after merge

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner-only change for publish jobs; no application or auth logic changes, with low blast radius beyond publish workflow duration/cost.
> 
> **Overview**
> **NPM Publish** now runs the actual publish jobs (`prerelease-publish` and `prod-release`) on **`ubuntu-latest`** instead of **Blacksmith** (`blacksmith-4vcpu-ubuntu-2404`). Comments were updated to state that **npm trusted publishing and provenance** require **GitHub-hosted** runners.
> 
> A workflow regression test asserts both publish jobs use **`ubuntu-latest`**. Post-publish verification (`prerelease-verify`) is unchanged and still uses Blacksmith.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12808c45d8f9d092767e029be5e84fc54ffe2bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782530200&installation_id=134682257&pr_number=199&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F199&signature=357f30dcff6766b068cafbca0224faa02d5a9dc3b6a026012b7573d09ed59b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->