### PR TITLE
fix(packaging): resolve @gsd/agent-core imports in pi-coding-agent re-exports

### DIFF
--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -53,6 +53,7 @@
     "typebox": "1.1.38",
     "undici": "8.3.0",
     "yaml": "2.9.0",
+    "@gsd/agent-core": "^1.0.2",
     "@gsd/native": "^1.0.2",
     "@gsd/pi-agent-core": "^1.0.2",
     "@gsd/pi-ai": "^1.0.2",

--- a/packages/pi-coding-agent/src/core/artifact-manager.ts
+++ b/packages/pi-coding-agent/src/core/artifact-manager.ts
@@ -1,2 +1,2 @@
 /** Extension-stable re-export — implementation lives in @gsd/agent-core. */
-export { ArtifactManager } from "../../../gsd-agent-core/dist/artifact-manager.js";
+export { ArtifactManager } from "@gsd/agent-core/artifact-manager.js";

--- a/packages/pi-coding-agent/src/core/blob-store.ts
+++ b/packages/pi-coding-agent/src/core/blob-store.ts
@@ -6,4 +6,4 @@ export {
 	parseBlobRef,
 	resolveImageData,
 	type BlobPutResult,
-} from "../../../gsd-agent-core/dist/blob-store.js";
+} from "@gsd/agent-core/blob-store.js";

--- a/packages/pi-coding-agent/src/core/extension-session-types.ts
+++ b/packages/pi-coding-agent/src/core/extension-session-types.ts
@@ -11,6 +11,6 @@ export type {
 	ParsedSkillBlock,
 	PromptOptions,
 	SessionStats,
-} from "../../../gsd-agent-core/dist/agent-session.js";
+} from "@gsd/agent-core/agent-session.js";
 
-export { parseSkillBlock } from "../../../gsd-agent-core/dist/agent-session.js";
+export { parseSkillBlock } from "@gsd/agent-core/agent-session.js";

--- a/packages/pi-coding-agent/src/core/fallback-resolver.ts
+++ b/packages/pi-coding-agent/src/core/fallback-resolver.ts
@@ -1,2 +1,2 @@
 /** Extension-stable re-export — implementation lives in @gsd/agent-core. */
-export { FallbackResolver, type FallbackResult } from "../../../gsd-agent-core/dist/fallback-resolver.js";
+export { FallbackResolver, type FallbackResult } from "@gsd/agent-core/fallback-resolver.js";

--- a/packages/pi-coding-agent/src/core/keybindings.ts
+++ b/packages/pi-coding-agent/src/core/keybindings.ts
@@ -4,4 +4,4 @@ export {
 	type AppAction,
 	type AppKeybinding,
 	KeybindingsManager,
-} from "../../../gsd-agent-core/dist/keybindings.js";
+} from "@gsd/agent-core/keybindings.js";

--- a/packages/pi-coding-agent/src/core/lifecycle-hooks.ts
+++ b/packages/pi-coding-agent/src/core/lifecycle-hooks.ts
@@ -7,4 +7,4 @@ export {
 	verifyRuntimeDependencies,
 	resolveLocalSourcePath,
 	type PackageLifecycleHooksOptions,
-} from "../../../gsd-agent-core/dist/lifecycle-hooks.js";
+} from "@gsd/agent-core/lifecycle-hooks.js";

--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -1,2 +1,2 @@
 /** Extension-stable re-export — implementation lives in @gsd/agent-core. */
-export { buildSystemPrompt, type BuildSystemPromptOptions } from "../../../gsd-agent-core/dist/system-prompt.js";
+export { buildSystemPrompt, type BuildSystemPromptOptions } from "@gsd/agent-core/system-prompt.js";

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -214,6 +214,42 @@ try {
     process.exit(1);
   }
 
+  // --- Verify pi-coding-agent re-exports resolve bundled @gsd/agent-core ---
+  // Relative ../../../gsd-agent-core paths break after npm install (folder is @gsd/agent-core).
+  console.log('==> Verifying pi-coding-agent @gsd/agent-core re-exports...');
+  const lifecycleHooksPath = join(
+    installedRoot,
+    'node_modules',
+    '@gsd',
+    'pi-coding-agent',
+    'dist',
+    'core',
+    'lifecycle-hooks.js',
+  );
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `await import(${JSON.stringify('file://' + lifecycleHooksPath.replace(/\\/g, '/'))});`,
+      ],
+      {
+        cwd: installDir,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    pi-coding-agent/core/lifecycle-hooks resolves @gsd/agent-core.');
+  } catch (err) {
+    console.log('ERROR: pi-coding-agent re-export failed to resolve @gsd/agent-core after install.');
+    if (err.stdout) console.log(err.stdout);
+    if (err.stderr) console.log(err.stderr);
+    process.exit(1);
+  }
+
   console.log('');
   console.log('Package is installable. Safe to publish.');
   process.exit(0);


### PR DESCRIPTION
## Summary

- Fixes NPM Publish verify failure on `@opengsd/gsd-pi@1.0.2-dev.3c4e5dd` ([run 26552504056](https://github.com/open-gsd/gsd-pi/actions/runs/26552504056/job/78218334444))
- `pi-coding-agent` re-export shims used relative `../../../gsd-agent-core/dist/...` imports that resolve to `@gsd/gsd-agent-core` after install, but the bundled package is `@gsd/agent-core`
- Switched all 7 re-export files to `@gsd/agent-core/<module>.js` package imports and declared `@gsd/agent-core` in `pi-coding-agent` dependencies
- Extended `validate-pack` to dynamically import `lifecycle-hooks` after tarball install so this class of breakage is caught pre-publish

## Test plan

- [x] `npm run build`
- [x] `npm run validate-pack` (includes new lifecycle-hooks resolution check)
- [ ] Merge and re-run NPM Publish @dev workflow
- [ ] Optionally deprecate broken `@opengsd/gsd-pi@1.0.2-dev.3c4e5dd` on npm


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782531184&installation_id=134682257&pr_number=200&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F200&signature=2c48fd09a6d140a32d7b076599acf99e3ac8824072b2c73d0b7e903f0d9005c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and import-path fixes with a new pre-publish smoke test; no auth, data, or runtime behavior changes beyond fixing broken resolves.
> 
> **Overview**
> Fixes **post-install module resolution** for `pi-coding-agent` extension shims that re-export `@gsd/agent-core`.
> 
> Those seven `core/*` re-export files previously imported via relative `../../../gsd-agent-core/dist/...` paths, which do not match the installed package name **`@gsd/agent-core`** and caused publish/verify failures. Imports now use **`@gsd/agent-core/<module>.js`**, and **`@gsd/agent-core`** is listed in `pi-coding-agent` dependencies.
> 
> **`validate-pack`** gains a check that dynamically imports installed `lifecycle-hooks.js` so this breakage is caught before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0030babaa7d8964f116c718d0474070cf66d8b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->