### PR TITLE
fix(ci): make NPM Publish re-runs idempotent when dist-tag matches

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -127,8 +127,14 @@ jobs:
           CHANNEL: ${{ github.event.inputs.channel }}
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
-          if npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null; then
-            echo "::error::Version ${VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
+          EXISTING=$(npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null || true)
+          if [ -n "${EXISTING}" ]; then
+            TAGGED=$(npm view "@opengsd/gsd-pi" "dist-tags.${CHANNEL}" 2>/dev/null || true)
+            if [ "${TAGGED}" = "${VERSION}" ]; then
+              echo "Version ${VERSION} is already published and @${CHANNEL} points to it — skipping publish."
+              exit 0
+            fi
+            echo "::error::Version ${VERSION} already exists but @${CHANNEL} points to '${TAGGED:-<unset>}'. Trusted publishing only authenticates npm publish, not dist-tag mutation."
             echo "::error::Move the tag manually if intended: npm dist-tag add @opengsd/gsd-pi@${VERSION} ${CHANNEL}"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- When a stamped dev/next version already exists on npm and the channel dist-tag already points to it, skip `npm publish` and continue to verification instead of failing.
- Still fail with manual `npm dist-tag add` instructions when the version exists but the dist-tag points elsewhere (trusted publishing cannot move tags).

Fixes the failure in [NPM Publish #26](https://github.com/open-gsd/gsd-pi/actions/runs/26555332846) where `@opengsd/gsd-pi@1.0.2-dev.285f6a0` was already live and `@dev` already pointed to it, but the workflow exited before post-publish verification.

## Test plan
- [ ] Merge to `main`
- [ ] Re-run **NPM Publish** for channel `dev` at SHA `285f6a0`
- [ ] Confirm publish step logs "already published and @dev points to it — skipping publish"
- [ ] Confirm `prerelease-verify` completes successfully

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782536171&installation_id=134682257&pr_number=203&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F203&signature=dc175c818b357df2ceb2338954fbe1ad721eeeb56e77f2ebfa62691f1fa13399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow shell logic only; no runtime package or auth behavior changes beyond when publish is skipped.
> 
> **Overview**
> The **NPM Publish** prerelease publish step no longer fails when the stamped version is already on npm **and** the channel dist-tag (`dev` / `next`) already points at that version. In that case it logs a skip and exits successfully so later jobs (e.g. post-publish verification) can still run on workflow re-runs.
> 
> If the version exists but the channel tag points elsewhere (or is unset), the workflow still errors with the same trusted-publishing limitation and manual `npm dist-tag add` guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268cd1d9e689f549ce05d039a1b2e2db71ba65af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->