### PR TITLE
fix(packaging): resolve undici after npm global install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@gsd/pi-agent-core",
         "@gsd/pi-ai",
         "@gsd/pi-coding-agent",
-        "@gsd/pi-tui"
+        "@gsd/pi-tui",
+        "undici"
       ],
       "hasInstallScript": true,
       "license": "MIT",
@@ -61,7 +62,7 @@
         "sharp": "^0.34.5",
         "sql.js": "^1.14.1",
         "strip-ansi": "^7.1.0",
-        "undici": "^7.24.2",
+        "undici": "^8.3.0",
         "yaml": "^2.8.2"
       },
       "bin": {
@@ -7824,12 +7825,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -9129,6 +9131,7 @@
       "name": "@gsd/pi-coding-agent",
       "version": "1.0.2",
       "dependencies": {
+        "@gsd/agent-core": "^1.0.2",
         "@gsd/native": "^1.0.2",
         "@gsd/pi-agent-core": "^1.0.2",
         "@gsd/pi-ai": "^1.0.2",
@@ -9169,15 +9172,6 @@
       },
       "optionalDependencies": {
         "@mariozechner/clipboard": "0.3.6"
-      }
-    },
-    "packages/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
       }
     },
     "packages/pi-tui": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,12 @@
     "test:e2e:docker": "node --experimental-strip-types --test \"tests/e2e/docker/**/*.e2e.test.ts\""
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.2.83",
+    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/vertex-sdk": "^0.14.4",
+    "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+    "@clack/prompts": "^1.1.0",
+    "@google/genai": "^1.40.0",
     "@gsd/agent-core": "^1.0.2",
     "@gsd/agent-modes": "^1.0.2",
     "@gsd/native": "^1.0.2",
@@ -143,12 +149,6 @@
     "@gsd/pi-ai": "^1.0.2",
     "@gsd/pi-coding-agent": "^1.0.2",
     "@gsd/pi-tui": "^1.0.2",
-    "@anthropic-ai/claude-agent-sdk": "0.2.83",
-    "@anthropic-ai/sdk": "^0.90.0",
-    "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@aws-sdk/client-bedrock-runtime": "^3.983.0",
-    "@clack/prompts": "^1.1.0",
-    "@google/genai": "^1.40.0",
     "@mariozechner/jiti": "^2.6.2",
     "@mistralai/mistralai": "2.2.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -174,7 +174,7 @@
     "sharp": "^0.34.5",
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
-    "undici": "^7.24.2",
+    "undici": "^8.3.0",
     "yaml": "^2.8.2"
   },
   "bundledDependencies": [
@@ -184,7 +184,8 @@
     "@gsd/pi-agent-core",
     "@gsd/pi-ai",
     "@gsd/pi-coding-agent",
-    "@gsd/pi-tui"
+    "@gsd/pi-tui",
+    "undici"
   ],
   "devDependencies": {
     "@types/node": "^24.12.0",
@@ -211,5 +212,15 @@
     "c8": {
       "yargs": "^18.0.0"
     }
-  }
+  },
+  "bundleDependencies": [
+    "@gsd/agent-core",
+    "@gsd/agent-modes",
+    "@gsd/native",
+    "@gsd/pi-agent-core",
+    "@gsd/pi-ai",
+    "@gsd/pi-coding-agent",
+    "@gsd/pi-tui",
+    "undici"
+  ]
 }

--- a/scripts/link-workspace-packages.cjs
+++ b/scripts/link-workspace-packages.cjs
@@ -16,9 +16,42 @@
  * (even NTFS junctions) can fail with EPERM. In that case we fall back to
  * cpSync (directory copy) which works universally.
  */
-const { existsSync, mkdirSync, symlinkSync, cpSync, lstatSync, readlinkSync, unlinkSync } = require('fs')
+const { existsSync, mkdirSync, symlinkSync, cpSync, lstatSync, readlinkSync, unlinkSync, rmSync } = require('fs')
 const { resolve, join } = require('path')
 const { getLinkablePackages, REPO_ROOT } = require('./lib/workspace-manifest.cjs')
+
+/**
+ * npm global installs can leave an empty node_modules/undici placeholder while the
+ * bundled @gsd/pi-coding-agent copy (without nested deps) still imports undici.
+ * Seed root undici from the shipped packages/pi-coding-agent copy when needed.
+ */
+function ensureRootUndici() {
+  const rootUndiciDir = join(REPO_ROOT, 'node_modules', 'undici')
+  const rootUndiciPkg = join(rootUndiciDir, 'package.json')
+  if (existsSync(rootUndiciPkg)) return false
+
+  const shippedUndiciDir = join(REPO_ROOT, 'packages', 'pi-coding-agent', 'node_modules', 'undici')
+  const shippedUndiciPkg = join(shippedUndiciDir, 'package.json')
+  if (!existsSync(shippedUndiciPkg)) return false
+
+  if (existsSync(rootUndiciDir)) {
+    rmSync(rootUndiciDir, { recursive: true, force: true })
+  }
+
+  mkdirSync(join(REPO_ROOT, 'node_modules'), { recursive: true })
+
+  try {
+    symlinkSync(shippedUndiciDir, rootUndiciDir, 'junction')
+    return true
+  } catch {
+    try {
+      cpSync(shippedUndiciDir, rootUndiciDir, { recursive: true })
+      return true
+    } catch {
+      return false
+    }
+  }
+}
 
 const scopeDirs = {
   '@gsd': join(REPO_ROOT, 'node_modules', '@gsd'),
@@ -98,6 +131,10 @@ for (const name of ['pi-agent-core', 'pi-ai', 'pi-tui', 'pi-coding-agent']) {
       // non-fatal
     }
   }
+}
+
+if (ensureRootUndici()) {
+  process.stderr.write('  Linked undici from shipped pi-coding-agent bundle\n')
 }
 
 if (linked > 0) process.stderr.write(`  Linked ${linked} workspace package${linked !== 1 ? 's' : ''}\n`)

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -214,6 +214,41 @@ try {
     process.exit(1);
   }
 
+  // --- Verify undici resolves for bundled pi-coding-agent (global install regression) ---
+  console.log('==> Verifying undici resolves for pi-coding-agent/http-dispatcher...');
+  const httpDispatcherPath = join(
+    installedRoot,
+    'node_modules',
+    '@gsd',
+    'pi-coding-agent',
+    'dist',
+    'core',
+    'http-dispatcher.js',
+  );
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `await import(${JSON.stringify('file://' + httpDispatcherPath.replace(/\\/g, '/'))});`,
+      ],
+      {
+        cwd: installDir,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    pi-coding-agent/core/http-dispatcher resolves undici.');
+  } catch (err) {
+    console.log('ERROR: pi-coding-agent failed to resolve undici after install.');
+    if (err.stdout) console.log(err.stdout);
+    if (err.stderr) console.log(err.stderr);
+    process.exit(1);
+  }
+
   // --- Verify pi-coding-agent re-exports resolve bundled @gsd/agent-core ---
   // Relative ../../../gsd-agent-core paths break after npm install (folder is @gsd/agent-core).
   console.log('==> Verifying pi-coding-agent @gsd/agent-core re-exports...');
@@ -248,6 +283,52 @@ try {
     if (err.stdout) console.log(err.stdout);
     if (err.stderr) console.log(err.stderr);
     process.exit(1);
+  }
+
+  // --- Global install smoke (catches empty node_modules/undici placeholder on npm -g) ---
+  console.log('==> Testing global install (undici resolution)...');
+  const globalPrefix = mkdtempSync(join(tmpdir(), 'validate-pack-global-'));
+  try {
+    execFileSync(getNpmCommand(), ['install', '-g', tarball, '--prefix', globalPrefix], {
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: DEFAULT_MAX_BUFFER,
+      env: {
+        ...process.env,
+        npm_config_cache: npmCacheDir,
+      },
+    });
+    const globalRoot = join(globalPrefix, 'lib', 'node_modules', '@opengsd', 'gsd-pi');
+    const globalUndiciPkg = join(globalRoot, 'node_modules', 'undici', 'package.json');
+    if (!existsSync(globalUndiciPkg)) {
+      console.log('ERROR: Global install left node_modules/undici unresolved.');
+      console.log(`    Expected: ${globalUndiciPkg}`);
+      process.exit(1);
+    }
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `await import(${JSON.stringify('file://' + join(globalRoot, 'node_modules', '@gsd', 'pi-coding-agent', 'dist', 'core', 'http-dispatcher.js').replace(/\\/g, '/'))});`,
+      ],
+      {
+        cwd: globalPrefix,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    Global install resolves undici for pi-coding-agent.');
+  } catch (err) {
+    console.log('ERROR: Global install smoke test failed.');
+    if (err.stdout) console.log(err.stdout);
+    if (err.stderr) console.log(err.stderr);
+    process.exit(1);
+  } finally {
+    rmSync(globalPrefix, { recursive: true, force: true });
   }
 
   console.log('');


### PR DESCRIPTION
## Summary

- Fixes post-publish verification failures where `npm install -g @opengsd/gsd-pi` left an empty `node_modules/undici` directory, causing live regression tests to fail with `ERR_MODULE_NOT_FOUND` from `pi-coding-agent/dist/core/http-dispatcher.js`.
- Seeds root `undici` from the shipped `packages/pi-coding-agent/node_modules/undici` copy during postinstall when the global-install placeholder is broken.
- Bundles `undici@8.3.0` in the tarball and aligns the root dependency version with `@gsd/pi-coding-agent`.
- Extends `validate-pack` with `http-dispatcher` import and global-install smoke checks so this cannot ship again.

## Context

[NPM Publish run #27](https://github.com/open-gsd/gsd-pi/actions/runs/26555596273/job/78227485639) published from `main` at `52cc3dc` and still hit the same undici resolution failure. The earlier fix from this session was never merged to `main` (it only existed locally / was partially reworked on `feat/installer-redesign`).

## Test plan

- [x] `npm install undici@8.3.0` lockfile update
- [ ] `npm run validate-pack` (includes new global-install smoke)
- [ ] Merge to `main`, re-run **NPM Publish** workflow on `dev`
- [ ] Confirm **Verify @dev package → Run live regression tests** passes


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782536903&installation_id=134682257&pr_number=205&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F205&signature=94c6cad0c54234b5847d5da88ac251bd97ab1ba93a67c0619dd53f99f8ea20a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches publish-time bundling and postinstall for a core HTTP dependency (undici major bump); mitigated by new validate-pack global-install gates but still affects every install path.
> 
> **Overview**
> Fixes **`ERR_MODULE_NOT_FOUND` for `undici`** after **`npm install -g @opengsd/gsd-pi`**, where npm could leave an empty root **`node_modules/undici`** while bundled **`@gsd/pi-coding-agent`** still imports it from **`http-dispatcher.js`**.
> 
> The root dependency is bumped to **`undici@^8.3.0`** and **`undici`** is added to **`bundledDependencies`** / lockfile so it ships in the publish tarball (nested copy under **`pi-coding-agent`** is deduped). **Postinstall** now runs **`ensureRootUndici()`** in **`link-workspace-packages.cjs`**: if root **`undici`** has no **`package.json`**, it removes a broken placeholder and junctions or copies from **`packages/pi-coding-agent/node_modules/undici`**.
> 
> **`validate-pack`** gains a local install check that **`http-dispatcher.js`** imports cleanly, plus a **global-install smoke** that asserts **`node_modules/undici/package.json`** exists and the same import works under a temp **`npm_config_prefix`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49e42f0d5dfea1d6ee5ef7b48dd05f2a30b2f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->