### PR TITLE
fix(issue): discardMilestone skips DB cleanup when directory already deleted

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
-import { milestonesDir, gsdRoot, resolveGsdRootFile } from "./paths.js";
+import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
@@ -15,6 +15,7 @@ import { readAllSessionStatuses, isSessionStale, removeSessionStatus } from "./s
 import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
 import { findMilestoneIds } from "./milestone-ids.js";
+import { getAllMilestones, isDbAvailable } from "./gsd-db.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 const MAX_UAT_ATTEMPTS = 3;
@@ -736,6 +737,30 @@ export async function checkRuntimeHealth(
     }
   } catch {
     // Non-fatal — orphan milestone directory check failed
+  }
+
+  // ── Orphan milestone DB rows (DB present, filesystem missing) ─────────
+  // A milestone row without a corresponding milestone directory can keep
+  // stale milestones "active" and trigger unwanted continuation behavior.
+  try {
+    if (isDbAvailable()) {
+      for (const milestone of getAllMilestones()) {
+        if (milestone.status === "queued") continue;
+        if (!resolveMilestonePath(basePath, milestone.id)) {
+          issues.push({
+            severity: "warning",
+            code: "orphan_milestone_db",
+            scope: "milestone",
+            unitId: milestone.id,
+            message: `Orphan milestone DB row: ${milestone.id} — DB row exists but milestone directory is missing from disk. This can cause stale milestone continuation.`,
+            file: `.gsd/gsd.db`,
+            fixable: false,
+          });
+        }
+      }
+    }
+  } catch {
+    // Non-fatal — orphan milestone DB row check failed
   }
 }
 

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -87,7 +87,8 @@ export type DoctorIssueCode =
   | "db_unavailable"
   | "projection_drift"
   // Milestone filesystem/DB drift (#4996)
-  | "orphan_milestone_dir";
+  | "orphan_milestone_dir"
+  | "orphan_milestone_db";
 
 /**
  * Issue codes that represent global or completion-critical state.

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -133,7 +133,9 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
   const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir || !existsSync(mDir)) return false;
+  const hasMilestoneDir = !!mDir && existsSync(mDir);
+  const hasDbMilestone = isDbAvailable() && getMilestone(milestoneId) !== null;
+  if (!hasMilestoneDir && !hasDbMilestone) return false;
 
   try {
     removeWorktree(basePath, milestoneId, {
@@ -144,7 +146,9 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
   }
 
-  rmSync(mDir, { recursive: true, force: true });
+  if (hasMilestoneDir && mDir) {
+    rmSync(mDir, { recursive: true, force: true });
+  }
 
   // Prune from queue order if present
   const order = loadQueueOrder(basePath);

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -97,4 +97,20 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
     assert.ok(!orphan, "queued DB row must block orphan report (in-flight race protection)");
   });
+
+  it("(e) DB milestone row with missing milestone directory is reported as orphan_milestone_db", async () => {
+    base = makeBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M004", status: "active" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_db" && i.unitId === "M004");
+    assert.ok(orphan, "missing milestone directory with DB row should be reported");
+    assert.equal(orphan?.severity, "warning");
+    assert.equal(orphan?.fixable, false);
+  });
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -260,4 +260,29 @@ test('discardMilestone removes DB rows, worktree, and milestone branch', () => {
     }
 });
 
+test('discardMilestone removes DB rows when milestone directory is already missing', () => {
+    const base = createFixtureBase();
+    try {
+      createMilestone(base, 'M001', { withRoadmap: true });
+      clearCaches();
+
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+      insertMilestone({ id: 'M001', title: 'Discard me', status: 'active' });
+      insertSlice({ milestoneId: 'M001', id: 'S01', title: 'Only slice', status: 'pending' });
+      insertTask({ milestoneId: 'M001', sliceId: 'S01', id: 'T01', title: 'Only task', status: 'pending' });
+
+      const mDir = join(base, '.gsd', 'milestones', 'M001');
+      rmSync(mDir, { recursive: true, force: true });
+      assert.ok(!existsSync(mDir), 'milestone dir removed before discard');
+
+      const success = discardMilestone(base, 'M001');
+      assert.ok(success, 'discardMilestone returns true when DB cleanup succeeds');
+      assert.equal(getMilestone('M001'), null, 'milestone row removed from DB');
+      assert.equal(getMilestoneSlices('M001').length, 0, 'slice rows removed from DB');
+      assert.equal(getSliceTasks('M001', 'S01').length, 0, 'task rows removed from DB');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## Summary
- Fixed discardMilestone DB cleanup on missing dirs and added doctor detection for milestone DB rows missing directories, with focused regression tests added.

## Bugs Addressed
- [x] **discardMilestone skips DB cleanup when milestone dir is missing**
- [x] **doctor-checks misses DB-present/filesystem-missing orphan state**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #202
- [#202 discardMilestone skips DB cleanup when directory already deleted](https://github.com/open-gsd/gsd-pi/issues/202)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/202-discardmilestone-skips-db-cleanup-when-d-1779946008`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782538554&installation_id=134682257&pr_number=206&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F206&signature=fab8668b75c3d9d8e8ee0b5df3f4f3d4af09d17e81e499d56076bc6d439800b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches milestone discard and state-derivation health checks; incorrect logic could delete valid DB data or miss stale active milestones, but changes are narrow with targeted tests.
> 
> **Overview**
> **`discardMilestone`** no longer bails out when the milestone folder is already gone. If a row still exists in **`gsd.db`**, discard still runs worktree/queue cleanup and **`deleteMilestone`** instead of returning false and leaving stale DB state.
> 
> Runtime doctor checks now flag the opposite drift: non-**`queued`** milestones in the DB with no resolved milestone directory emit a new **`orphan_milestone_db`** warning (not auto-fixable), complementing the existing orphan-directory check. Regression tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeb4828316647edbceb2eff641457ad769a1ef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->