### PR TITLE
fix(issue): discardMilestone skips DB cleanup when directory already deleted

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
-import { milestonesDir, gsdRoot, resolveGsdRootFile } from "./paths.js";
+import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
@@ -746,8 +746,7 @@ export async function checkRuntimeHealth(
   try {
     const dbMilestones = getAllMilestones();
     for (const milestone of dbMilestones) {
-      const mPath = join(milestonesDir(basePath), milestone.id);
-      if (!existsSync(mPath)) {
+      if (!resolveMilestonePath(basePath, milestone.id)) {
         issues.push({
           severity: "warning",
           code: "db_milestone_missing_dir",

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -16,6 +16,7 @@ import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
 import { findMilestoneIds } from "./milestone-ids.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { getAllMilestones } from "./gsd-db.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
@@ -736,6 +737,30 @@ export async function checkRuntimeHealth(
     }
   } catch {
     // Non-fatal — orphan milestone directory check failed
+  }
+
+  // ── DB milestones with missing directories ────────────────────────────
+  // Detect inverse drift: milestone row exists in DB but milestone directory
+  // is missing on disk. This can happen after manual filesystem deletion and
+  // causes plan/discuss flows to treat a deleted milestone as active.
+  try {
+    const dbMilestones = getAllMilestones();
+    for (const milestone of dbMilestones) {
+      const mPath = join(milestonesDir(basePath), milestone.id);
+      if (!existsSync(mPath)) {
+        issues.push({
+          severity: "warning",
+          code: "db_milestone_missing_dir",
+          scope: "milestone",
+          unitId: milestone.id,
+          message: `Milestone ${milestone.id} exists in DB but its directory is missing on disk.`,
+          file: `.gsd/milestones/${milestone.id}`,
+          fixable: false,
+        });
+      }
+    }
+  } catch {
+    // Non-fatal — DB milestone directory drift check failed
   }
 }
 

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -87,7 +87,8 @@ export type DoctorIssueCode =
   | "db_unavailable"
   | "projection_drift"
   // Milestone filesystem/DB drift (#4996)
-  | "orphan_milestone_dir";
+  | "orphan_milestone_dir"
+  | "db_milestone_missing_dir";
 
 /**
  * Issue codes that represent global or completion-critical state.

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -133,7 +133,7 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
   const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir || !existsSync(mDir)) return false;
+  if (!mDir) return false;
 
   try {
     removeWorktree(basePath, milestoneId, {
@@ -144,7 +144,9 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
   }
 
-  rmSync(mDir, { recursive: true, force: true });
+  if (existsSync(mDir)) {
+    rmSync(mDir, { recursive: true, force: true });
+  }
 
   // Prune from queue order if present
   const order = loadQueueOrder(basePath);

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -17,6 +17,7 @@ import {
   resolveMilestonePath,
   resolveMilestoneFile,
   buildMilestoneFileName,
+  milestonesDir,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
 import { loadQueueOrder, saveQueueOrder } from "./queue-order.js";
@@ -132,8 +133,7 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
  */
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
-  const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir) return false;
+  const mDir = resolveMilestonePath(basePath, milestoneId) ?? join(milestonesDir(basePath), milestoneId);
 
   try {
     removeWorktree(basePath, milestoneId, {

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -134,6 +134,10 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
   const mDir = resolveMilestonePath(basePath, milestoneId) ?? join(milestonesDir(basePath), milestoneId);
+  const milestoneExistsOnDisk = existsSync(mDir);
+  const dbAvailable = isDbAvailable();
+  const milestoneExistsInDb = dbAvailable && getMilestone(milestoneId) !== null;
+  if (!milestoneExistsOnDisk && !milestoneExistsInDb) return false;
 
   try {
     removeWorktree(basePath, milestoneId, {
@@ -144,7 +148,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
   }
 
-  if (existsSync(mDir)) {
+  if (milestoneExistsOnDisk) {
     rmSync(mDir, { recursive: true, force: true });
   }
 
@@ -154,7 +158,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     saveQueueOrder(basePath, order.filter(id => id !== milestoneId));
   }
 
-  if (isDbAvailable()) {
+  if (dbAvailable) {
     try {
       deleteMilestone(milestoneId);
     } catch (err) {

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -113,4 +113,19 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     assert.equal(orphan?.severity, "warning");
     assert.equal(orphan?.fixable, false);
   });
+
+  it("(f) DB milestone with legacy descriptor directory is NOT reported as missing", async () => {
+    base = makeBase();
+    mkdirSync(join(base, ".gsd", "milestones", "M005-FLIGHT-SIMULATOR"), { recursive: true });
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M005", status: "active" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const missing = issues.find(i => i.code === "db_milestone_missing_dir" && i.unitId === "M005");
+    assert.ok(!missing, "legacy descriptor directory should satisfy DB milestone directory check");
+  });
 });

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -97,4 +97,20 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
     assert.ok(!orphan, "queued DB row must block orphan report (in-flight race protection)");
   });
+
+  it("(e) DB milestone with missing directory is reported", async () => {
+    base = makeBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M004", status: "active" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "db_milestone_missing_dir" && i.unitId === "M004");
+    assert.ok(orphan, "should report DB milestone whose directory is missing");
+    assert.equal(orphan?.severity, "warning");
+    assert.equal(orphan?.fixable, false);
+  });
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -260,4 +260,30 @@ test('discardMilestone removes DB rows, worktree, and milestone branch', () => {
     }
 });
 
+test('discardMilestone removes DB rows even when milestone directory is already missing', () => {
+    const base = createFixtureBase();
+    try {
+      createMilestone(base, 'M001', { withRoadmap: true });
+      clearCaches();
+
+      const mDir = join(base, '.gsd', 'milestones', 'M001');
+      rmSync(mDir, { recursive: true, force: true });
+      assert.ok(!existsSync(mDir), 'milestone dir missing before discard');
+
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+      insertMilestone({ id: 'M001', title: 'Discard me', status: 'active' });
+      insertSlice({ milestoneId: 'M001', id: 'S01', title: 'Only slice', status: 'pending' });
+      insertTask({ milestoneId: 'M001', sliceId: 'S01', id: 'T01', title: 'Only task', status: 'pending' });
+
+      const success = discardMilestone(base, 'M001');
+      assert.ok(success, 'discardMilestone returns true when directory is already missing');
+
+      assert.equal(getMilestone('M001'), null, 'milestone row removed from DB');
+      assert.equal(getMilestoneSlices('M001').length, 0, 'slice rows removed from DB');
+      assert.equal(getSliceTasks('M001', 'S01').length, 0, 'task rows removed from DB');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -286,4 +286,18 @@ test('discardMilestone removes DB rows even when milestone directory is already 
     }
 });
 
+test('discardMilestone returns false when milestone is absent from disk and DB', () => {
+    const base = createFixtureBase();
+    try {
+      clearCaches();
+
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+
+      const success = discardMilestone(base, 'M404');
+      assert.equal(success, false, 'discardMilestone returns false for missing milestone');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## Summary
- Fixed discard cleanup ordering and added doctor detection for DB milestones missing on-disk directories, with targeted regression tests added.

## Bugs Addressed
- [x] **discardMilestone skips DB cleanup when milestone dir is missing**
- [x] **doctor-checks misses DB-orphaned milestones with missing directories**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #202
- [#202 discardMilestone skips DB cleanup when directory already deleted](https://github.com/open-gsd/gsd-pi/issues/202)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/202-discardmilestone-skips-db-cleanup-when-d-1779964040`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782556930&installation_id=134682257&pr_number=211&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F211&signature=3639fdab51bbdb1a8e07b39772153d6f53602c8b0fa42d3860462a639a4a0d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes milestone discard and DB/filesystem consistency detection; incorrect path resolution could affect discard or false-positive doctor warnings, but scope is localized with new tests.
> 
> **Overview**
> Fixes **milestone discard** when the on-disk folder is already gone: `discardMilestone` now treats a DB row as sufficient to proceed, skips `rmSync` if the directory is missing, and still runs worktree cleanup, queue pruning, and `deleteMilestone`.
> 
> Adds a **doctor runtime check** for the inverse of orphan dirs—milestones present in the DB with no resolvable milestone directory (`db_milestone_missing_dir`, warning, not auto-fixable)—using `getAllMilestones` and `resolveMilestonePath` (including legacy descriptor dirs).
> 
> Regression tests cover doctor reporting and discard with missing dirs / fully absent milestones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1941a589cf4dff84ea2b2c3922e9666b8b6ac5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->