### PR TITLE
fix(issue): discardMilestone skips DB cleanup when directory already deleted

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -16,6 +16,7 @@ import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
 import { findMilestoneIds } from "./milestone-ids.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { getAllMilestones, isDbAvailable } from "./gsd-db.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
@@ -736,6 +737,31 @@ export async function checkRuntimeHealth(
     }
   } catch {
     // Non-fatal — orphan milestone directory check failed
+  }
+
+  // ── DB milestones with missing directories (#202) ─────────────────────
+  // Detect the inverse mismatch: a milestone row exists in DB, but its
+  // milestone directory is missing from disk. This stale DB state can cause
+  // incorrect "resume existing milestone" behavior.
+  try {
+    if (isDbAvailable()) {
+      for (const milestone of getAllMilestones()) {
+        const milestoneDir = join(milestonesDir(basePath), milestone.id);
+        if (!existsSync(milestoneDir)) {
+          issues.push({
+            severity: "warning",
+            code: "db_milestone_missing_dir",
+            scope: "milestone",
+            unitId: milestone.id,
+            message: `Milestone ${milestone.id} exists in DB but .gsd/milestones/${milestone.id} is missing on disk. This stale DB row can force incorrect milestone continuation.`,
+            file: ".gsd/gsd.db",
+            fixable: false,
+          });
+        }
+      }
+    }
+  } catch {
+    // Non-fatal — DB milestone directory drift check failed
   }
 }
 

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -87,7 +87,8 @@ export type DoctorIssueCode =
   | "db_unavailable"
   | "projection_drift"
   // Milestone filesystem/DB drift (#4996)
-  | "orphan_milestone_dir";
+  | "orphan_milestone_dir"
+  | "db_milestone_missing_dir";
 
 /**
  * Issue codes that represent global or completion-critical state.

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -17,6 +17,7 @@ import {
   resolveMilestonePath,
   resolveMilestoneFile,
   buildMilestoneFileName,
+  milestonesDir,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
 import { loadQueueOrder, saveQueueOrder } from "./queue-order.js";
@@ -132,9 +133,11 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
  */
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
+  const dbAvailable = isDbAvailable();
   const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir) return false;
-  const hasMilestoneDir = existsSync(mDir);
+  if (!mDir && (!dbAvailable || !getMilestone(milestoneId))) return false;
+  const milestoneDir = mDir ?? join(milestonesDir(basePath), milestoneId);
+  const hasMilestoneDir = existsSync(milestoneDir);
 
   try {
     removeWorktree(basePath, milestoneId, {
@@ -146,7 +149,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
   }
 
   if (hasMilestoneDir) {
-    rmSync(mDir, { recursive: true, force: true });
+    rmSync(milestoneDir, { recursive: true, force: true });
   }
 
   // Prune from queue order if present
@@ -155,7 +158,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     saveQueueOrder(basePath, order.filter(id => id !== milestoneId));
   }
 
-  if (isDbAvailable()) {
+  if (dbAvailable) {
     try {
       deleteMilestone(milestoneId);
     } catch (err) {

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -133,7 +133,8 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
   const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir || !existsSync(mDir)) return false;
+  if (!mDir) return false;
+  const hasMilestoneDir = existsSync(mDir);
 
   try {
     removeWorktree(basePath, milestoneId, {
@@ -144,7 +145,9 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
   }
 
-  rmSync(mDir, { recursive: true, force: true });
+  if (hasMilestoneDir) {
+    rmSync(mDir, { recursive: true, force: true });
+  }
 
   // Prune from queue order if present
   const order = loadQueueOrder(basePath);

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -97,4 +97,20 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
     assert.ok(!orphan, "queued DB row must block orphan report (in-flight race protection)");
   });
+
+  it("(e) DB milestone with missing directory is reported", async () => {
+    base = makeBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M004", status: "active" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const mismatch = issues.find(i => i.code === "db_milestone_missing_dir" && i.unitId === "M004");
+    assert.ok(mismatch, "should report DB milestone that is missing its directory");
+    assert.equal(mismatch?.severity, "warning");
+    assert.equal(mismatch?.fixable, false);
+  });
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -260,4 +260,29 @@ test('discardMilestone removes DB rows, worktree, and milestone branch', () => {
     }
 });
 
+test('discardMilestone removes DB rows when milestone directory is already missing', () => {
+    const base = createFixtureBase();
+    try {
+      createMilestone(base, 'M001', { withRoadmap: true });
+      clearCaches();
+
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+      insertMilestone({ id: 'M001', title: 'Discard me', status: 'active' });
+      insertSlice({ milestoneId: 'M001', id: 'S01', title: 'Only slice', status: 'pending' });
+      insertTask({ milestoneId: 'M001', sliceId: 'S01', id: 'T01', title: 'Only task', status: 'pending' });
+
+      const mDir = join(base, '.gsd', 'milestones', 'M001');
+      rmSync(mDir, { recursive: true, force: true });
+      assert.ok(!existsSync(mDir), 'milestone dir is missing before discard');
+
+      const success = discardMilestone(base, 'M001');
+      assert.ok(success, 'discardMilestone returns true when DB cleanup succeeds');
+      assert.equal(getMilestone('M001'), null, 'milestone row removed from DB');
+      assert.equal(getMilestoneSlices('M001').length, 0, 'slice rows removed from DB');
+      assert.equal(getSliceTasks('M001', 'S01').length, 0, 'task rows removed from DB');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## Summary
- Fixed discardMilestone to always clean DB without requiring a milestone directory and added doctor detection/tests for DB milestones missing on disk.

## Bugs Addressed
- [x] **discardMilestone skips DB cleanup when milestone dir is missing**
- [x] **doctor-checks misses DB-orphaned milestones with missing directories**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #202
- [#202 discardMilestone skips DB cleanup when directory already deleted](https://github.com/open-gsd/gsd-pi/issues/202)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/202-discardmilestone-skips-db-cleanup-when-d-1779966658`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes discard and milestone DB cleanup paths—incorrect logic could delete wrong milestones or leave stale DB state; scope is bounded with targeted tests.
> 
> **Overview**
> Fixes milestone **filesystem vs DB drift** when the on-disk milestone folder is gone but `gsd.db` still has the milestone (and related rows).
> 
> **`discardMilestone`** no longer bails out when `resolveMilestonePath` is missing: it can succeed if the milestone exists in the DB, skips `rmSync` when the directory is already absent, and still runs worktree cleanup, queue pruning, and **`deleteMilestone`**.
> 
> **Runtime doctor** adds the inverse of orphan-dir detection: for each DB milestone, it warns with **`db_milestone_missing_dir`** when `.gsd/milestones/<id>` is missing (non-fixable). **`DoctorIssueCode`** includes the new code.
> 
> Tests cover doctor reporting for DB-without-dir and discard cleaning DB rows when the directory was deleted first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189d1b2ead360c16ba5c54243378f55303f8a750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782558965&installation_id=134682257&pr_number=212&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F212&signature=dc87bf6bf5b4add9e29d330dbcb044c88cf0b404fb79aacb147df9e0f4c11032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->