### PR TITLE
fix(issue): discardMilestone skips DB cleanup when directory already deleted

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -16,6 +16,7 @@ import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
 import { findMilestoneIds } from "./milestone-ids.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { _getAdapter, isDbAvailable } from "./gsd-db.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
@@ -736,6 +737,37 @@ export async function checkRuntimeHealth(
     }
   } catch {
     // Non-fatal — orphan milestone directory check failed
+  }
+
+  // ── DB milestones missing on disk ──────────────────────────────────────
+  // Detect the inverse orphan direction: milestone rows present in DB while
+  // `.gsd/milestones/<id>/` is missing from disk.
+  try {
+    if (isDbAvailable()) {
+      const adapter = _getAdapter();
+      if (adapter) {
+        const dbMilestoneIds = adapter
+          .prepare("SELECT id FROM milestones")
+          .all()
+          .map((row) => String((row as { id: unknown }).id));
+
+        for (const mid of dbMilestoneIds) {
+          const milestonePath = join(milestonesDir(basePath), mid);
+          if (existsSync(milestonePath)) continue;
+          issues.push({
+            severity: "warning",
+            code: "db_orphaned_milestone_dir",
+            scope: "milestone",
+            unitId: mid,
+            message: `Milestone ${mid} exists in the database but its directory is missing on disk.`,
+            file: `.gsd/milestones/${mid}`,
+            fixable: false,
+          });
+        }
+      }
+    }
+  } catch {
+    // Non-fatal — DB milestone directory orphan check failed
   }
 }
 

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -82,6 +82,7 @@ export type DoctorIssueCode =
   // Engine health checks (Phase 4)
   | "db_orphaned_task"
   | "db_orphaned_slice"
+  | "db_orphaned_milestone_dir"
   | "db_done_task_no_summary"
   | "db_duplicate_id"
   | "db_unavailable"

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -154,7 +154,9 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     saveQueueOrder(basePath, order.filter(id => id !== milestoneId));
   }
 
-  if (isDbAvailable()) {
+  const dbAvailable = isDbAvailable();
+  const hadDbMilestone = dbAvailable && getMilestone(milestoneId) !== null;
+  if (dbAvailable) {
     try {
       deleteMilestone(milestoneId);
     } catch (err) {
@@ -163,7 +165,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
   }
 
   invalidateAllCaches();
-  return hasMilestoneDir || isDbAvailable();
+  return hasMilestoneDir || hadDbMilestone;
 }
 
 // ─── Query ─────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -133,18 +133,20 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
   const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir || !existsSync(mDir)) return false;
+  const hasMilestoneDir = !!mDir && existsSync(mDir);
 
-  try {
-    removeWorktree(basePath, milestoneId, {
-      branch: `milestone/${milestoneId}`,
-      deleteBranch: true,
-    });
-  } catch (err) {
-    logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
+  if (hasMilestoneDir) {
+    try {
+      removeWorktree(basePath, milestoneId, {
+        branch: `milestone/${milestoneId}`,
+        deleteBranch: true,
+      });
+    } catch (err) {
+      logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
+    }
+
+    rmSync(mDir, { recursive: true, force: true });
   }
-
-  rmSync(mDir, { recursive: true, force: true });
 
   // Prune from queue order if present
   const order = loadQueueOrder(basePath);
@@ -161,7 +163,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
   }
 
   invalidateAllCaches();
-  return true;
+  return hasMilestoneDir || isDbAvailable();
 }
 
 // ─── Query ─────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -97,4 +97,20 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
     assert.ok(!orphan, "queued DB row must block orphan report (in-flight race protection)");
   });
+
+  it("(e) DB milestone with missing directory is reported", async () => {
+    base = makeBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M007", status: "active" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "db_orphaned_milestone_dir" && i.unitId === "M007");
+    assert.ok(orphan, "should report DB milestone row whose directory is missing");
+    assert.equal(orphan?.severity, "warning");
+    assert.equal(orphan?.fixable, false);
+  });
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -287,4 +287,17 @@ test('discardMilestone removes DB rows when milestone directory is already missi
     }
 });
 
+test('discardMilestone returns false for a missing milestone when DB is open', () => {
+    const base = createFixtureBase();
+    try {
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+      assert.equal(getMilestone('M404'), null, 'milestone does not exist in DB before discard');
+
+      const success = discardMilestone(base, 'M404');
+      assert.equal(success, false, 'discardMilestone returns false for a missing milestone');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -260,4 +260,31 @@ test('discardMilestone removes DB rows, worktree, and milestone branch', () => {
     }
 });
 
+test('discardMilestone removes DB rows when milestone directory is already missing', () => {
+    const base = createFixtureBase();
+    try {
+      createMilestone(base, 'M001', { withRoadmap: true });
+      initGitRepo(base);
+      clearCaches();
+
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+      insertMilestone({ id: 'M001', title: 'Discard me', status: 'active' });
+      insertSlice({ milestoneId: 'M001', id: 'S01', title: 'Only slice', status: 'pending' });
+      insertTask({ milestoneId: 'M001', sliceId: 'S01', id: 'T01', title: 'Only task', status: 'pending' });
+
+      const mDir = join(base, '.gsd', 'milestones', 'M001');
+      rmSync(mDir, { recursive: true, force: true });
+      assert.ok(!existsSync(mDir), 'milestone dir removed before discard');
+
+      const success = discardMilestone(base, 'M001');
+      assert.ok(success, 'discardMilestone returns true when DB cleanup succeeds');
+
+      assert.equal(getMilestone('M001'), null, 'milestone row removed from DB');
+      assert.equal(getMilestoneSlices('M001').length, 0, 'slice rows removed from DB');
+      assert.equal(getSliceTasks('M001', 'S01').length, 0, 'task rows removed from DB');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## Summary
- Fixed discardMilestone to always clean DB state and added doctor detection for DB milestones missing on disk, with targeted regression tests.

## Bugs Addressed
- [x] **discardMilestone skips DB cleanup when milestone dir is missing**
- [x] **doctor-checks misses DB-orphaned milestones with missing directories**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #202
- [#202 discardMilestone skips DB cleanup when directory already deleted](https://github.com/open-gsd/gsd-pi/issues/202)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/202-discardmilestone-skips-db-cleanup-when-d-1779966822`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782559029&installation_id=134682257&pr_number=213&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F213&signature=a451532c162e3e3e955e168b38d95454656ed281bccdfb4ed926619cf2973746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes milestone discard semantics and DB deletion paths; mistakes could leave or remove wrong milestone state, though scope is localized and covered by new tests.
> 
> **Overview**
> **`discardMilestone`** no longer bails out when `.gsd/milestones/<id>/` is already gone: filesystem/worktree cleanup runs only if the directory exists, but **queue pruning** and **`deleteMilestone`** still run when the DB row is present. Success is **`true`** if either the dir or a DB milestone was removed; **`false`** only when neither exists.
> 
> Runtime health checks add the inverse of orphan milestone dirs: **`db_orphaned_milestone_dir`** warns when a milestone row exists in **`gsd.db`** but the on-disk milestone folder is missing (non-fixable). The new **`DoctorIssueCode`** is wired in **`doctor-types`**.
> 
> Regression tests cover doctor reporting for DB-without-dir and discard behavior with a pre-deleted directory or missing milestone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e2629b3b41297e9c698897c87dcbc627f67337f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->