### PR TITLE
fix(issue): discardMilestone skips DB cleanup when directory already deleted

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -16,6 +16,7 @@ import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
 import { findMilestoneIds } from "./milestone-ids.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { getAllMilestones, isDbAvailable } from "./gsd-db.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
@@ -708,6 +709,7 @@ export async function checkRuntimeHealth(
   // for a phantom forward-reference. Surface as a fixable warning.
   try {
     const milestoneIds = findMilestoneIds(basePath);
+    const milestoneIdSet = new Set(milestoneIds);
     const hasDbFile = existsSync(join(root, "gsd.db"));
     for (const mid of milestoneIds) {
       const isOrphan = isReusableGhostMilestone(basePath, mid)
@@ -732,6 +734,23 @@ export async function checkRuntimeHealth(
             // Non-fatal — leave for manual cleanup
           }
         }
+      }
+    }
+
+    // Inverse orphan direction: DB milestone row exists but milestone directory
+    // is missing on disk, which can happen after manual filesystem deletion.
+    if (isDbAvailable()) {
+      for (const row of getAllMilestones()) {
+        if (milestoneIdSet.has(row.id)) continue;
+        issues.push({
+          severity: "warning",
+          code: "orphan_milestone_dir",
+          scope: "milestone",
+          unitId: row.id,
+          message: `Milestone ${row.id} exists in DB but its directory is missing on disk (.gsd/milestones/${row.id}).`,
+          file: ".gsd/gsd.db",
+          fixable: false,
+        });
       }
     }
   } catch {

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -133,7 +133,7 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
 export function discardMilestone(basePath: string, milestoneId: string): boolean {
   assertNotAutoActive("discard milestone");
   const mDir = resolveMilestonePath(basePath, milestoneId);
-  if (!mDir || !existsSync(mDir)) return false;
+  const hasMilestoneDir = !!mDir && existsSync(mDir);
 
   try {
     removeWorktree(basePath, milestoneId, {
@@ -144,7 +144,9 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     logWarning("engine", `discardMilestone worktree cleanup failed for ${milestoneId}: ${(err as Error).message}`);
   }
 
-  rmSync(mDir, { recursive: true, force: true });
+  if (hasMilestoneDir && mDir) {
+    rmSync(mDir, { recursive: true, force: true });
+  }
 
   // Prune from queue order if present
   const order = loadQueueOrder(basePath);
@@ -161,7 +163,7 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
   }
 
   invalidateAllCaches();
-  return true;
+  return hasMilestoneDir || isDbAvailable();
 }
 
 // ─── Query ─────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -97,4 +97,19 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
     assert.ok(!orphan, "queued DB row must block orphan report (in-flight race protection)");
   });
+
+  it("(e) DB milestone row with missing directory is reported", async () => {
+    base = makeBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M004", status: "active" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M004");
+    assert.ok(orphan, "DB milestone without directory should be reported");
+    assert.ok(orphan?.message.includes("exists in DB"), "message should describe DB-only milestone");
+  });
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -260,4 +260,27 @@ test('discardMilestone removes DB rows, worktree, and milestone branch', () => {
     }
 });
 
+test('discardMilestone cleans DB rows even when milestone directory is already missing', () => {
+    const base = createFixtureBase();
+    try {
+      createMilestone(base, 'M001', { withRoadmap: true });
+      clearCaches();
+
+      const mDir = join(base, '.gsd', 'milestones', 'M001');
+      assert.ok(openDatabase(join(base, '.gsd', 'gsd.db')), 'database opens');
+      insertMilestone({ id: 'M001', title: 'Discard me', status: 'active' });
+      insertSlice({ milestoneId: 'M001', id: 'S01', title: 'Only slice', status: 'pending' });
+      insertTask({ milestoneId: 'M001', sliceId: 'S01', id: 'T01', title: 'Only task', status: 'pending' });
+      rmSync(mDir, { recursive: true, force: true });
+
+      const success = discardMilestone(base, 'M001');
+      assert.ok(success, 'discardMilestone returns true when DB cleanup succeeds');
+      assert.equal(getMilestone('M001'), null, 'milestone row removed from DB');
+      assert.equal(getMilestoneSlices('M001').length, 0, 'slice rows removed from DB');
+      assert.equal(getSliceTasks('M001', 'S01').length, 0, 'task rows removed from DB');
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## Summary
- Fixed discardMilestone to always clean DB state and added doctor detection for DB-only milestones, with regression tests for both.

## Bugs Addressed
- [x] **discardMilestone skips DB cleanup when milestone dir is missing**
- [x] **doctor-checks misses DB-orphaned milestones without directories**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #202
- [#202 discardMilestone skips DB cleanup when directory already deleted](https://github.com/open-gsd/gsd-pi/issues/202)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/202-discardmilestone-skips-db-cleanup-when-d-1779967141`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782559665&installation_id=134682257&pr_number=214&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F214&signature=92d4061a3bd760b8b948d92d64786a21c61efd19c36b6dee9b4d044f76aafb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes milestone discard and doctor orphan logic that affect DB/filesystem consistency; scope is limited to GSD milestone lifecycle with new regression tests.
> 
> **Overview**
> **`discardMilestone`** no longer bails out when the milestone folder is already gone. It still cleans up worktrees, queue order, and **`gsd.db`** rows, and reports success when the DB is available even without an on-disk directory.
> 
> **Runtime doctor** now flags the opposite orphan case: a milestone row in the DB with no matching **`.gsd/milestones/<id>`** directory (non-fixable warning, same **`orphan_milestone_dir`** code).
> 
> Regression tests cover DB-only doctor warnings and discard after manual directory deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07a13767683338b99294f86032aadf19104b915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->