### PR TITLE
fix(ci): use GitHub-hosted runners for build-native npm publish

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -122,8 +122,8 @@ jobs:
   publish:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
-    # npm trusted publishing requires GitHub-hosted runners for OIDC.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing + provenance require GitHub-hosted runners (not Blacksmith).
+    runs-on: ubuntu-latest
     name: Publish platform packages
 
     steps:

--- a/scripts/__tests__/build-native-workflow.test.mjs
+++ b/scripts/__tests__/build-native-workflow.test.mjs
@@ -11,6 +11,10 @@ const workflow = YAML.parse(
 );
 const publishJob = workflow.jobs.publish;
 
+test("build-native publish uses GitHub-hosted runners for npm provenance", () => {
+  assert.equal(publishJob["runs-on"], "ubuntu-latest");
+});
+
 test("build-native exposes platform_packages_only bootstrap input", () => {
   const input = workflow.on.workflow_dispatch.inputs.platform_packages_only;
 


### PR DESCRIPTION
## Summary

- Moves the `build-native.yml` publish job from Blacksmith to `ubuntu-latest`
- Matches the fix already applied in `npm-publish.yml` (#199): Blacksmith is treated as self-hosted by npm sigstore, which breaks trusted publishing with provenance (E422)
- Adds a regression test to lock the publish runner choice

## Test plan

- [x] `node --test scripts/__tests__/build-native-workflow.test.mjs`
- [ ] Trigger Build Native Binaries with `publish=true` and confirm npm publish succeeds with trusted auth


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782561291&installation_id=134682257&pr_number=216&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F216&signature=c31ed4c6a4569b38fe052f35b406ca0f8cce50ecb271a77fc37f0acfba1ea61b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner change for the publish job; no application runtime or auth logic changes.
> 
> **Overview**
> The **Build Native Binaries** workflow’s `publish` job now runs on **`ubuntu-latest`** instead of a Blacksmith runner, with a comment that **npm trusted publishing and provenance** need GitHub-hosted runners (Blacksmith is treated like self-hosted by sigstore, which can break publish with E422—same pattern as `npm-publish.yml`).
> 
> A workflow regression test asserts `jobs.publish.runs-on` stays **`ubuntu-latest`** so this doesn’t drift back to Blacksmith.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51fce9b9c7ce36d9e94fe8dc6af76575c17b96ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->