### PR TITLE
fix(installer): show GSD-Pi wordmark only once during guided install

### DIFF
--- a/scripts/install/banner.js
+++ b/scripts/install/banner.js
@@ -22,7 +22,7 @@ export function printBanner({ version, colors }) {
   }
 
   process.stdout.write(
-    `\n  ${c.bold}${logoModule?.GSD_PI_BRAND ?? 'GSD-Pi'}${c.reset}  ${c.dim}Git Ship Done · v${version}${c.reset}\n` +
+    `\n  ${c.dim}Git Ship Done · v${version}${c.reset}\n` +
     `  ${c.dim}${logoModule?.GSD_WEBSITE ?? 'https://opengsd.net'}${c.reset}\n\n`,
   )
 }

--- a/scripts/install/handoff.js
+++ b/scripts/install/handoff.js
@@ -3,6 +3,9 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { getGlobalPaths } from './npm-global.js'
 
+/** Set on `gsd config` spawned from the installer so loader/onboarding skip the wordmark. */
+export const GSD_SUPPRESS_LOGO_ENV = 'GSD_SUPPRESS_LOGO'
+
 export function resolveGsdBin({ isLocal, cwd = process.cwd() }) {
   if (isLocal) {
     const localBin = join(cwd, 'node_modules', '.bin', 'gsd')
@@ -25,6 +28,7 @@ export function runConfigHandoff({ bin, nonInteractive }) {
   const result = spawnSync(bin, ['config'], {
     stdio: 'inherit',
     timeout: 600_000,
+    env: { ...process.env, [GSD_SUPPRESS_LOGO_ENV]: '1' },
   })
 
   if (result.error || (result.status != null && result.status !== 0)) {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -92,7 +92,8 @@ process.title = 'gsd'
 
 // Print branded banner on first launch (before ~/.gsd/ exists).
 // Set GSD_FIRST_RUN_BANNER so cli.ts skips the duplicate welcome screen.
-if (!existsSync(appRoot)) {
+// GSD_SUPPRESS_LOGO is set when the npx installer already printed the wordmark.
+if (!existsSync(appRoot) && process.env.GSD_SUPPRESS_LOGO !== '1') {
   const cyan  = '\x1b[36m'
   const green = '\x1b[32m'
   const dim   = '\x1b[2m'

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -298,9 +298,11 @@ export async function runOnboarding(
   }
 
   // ── Intro ─────────────────────────────────────────────────────────────────
-  if (opts.showIntro !== false) {
+  if (opts.showIntro !== false && process.env.GSD_SUPPRESS_LOGO !== '1') {
     process.stderr.write(renderGsdPiLogo(pc.cyan))
     process.stderr.write(`  ${pc.bold(GSD_PI_BRAND)}  ${pc.dim(GSD_WEBSITE)}\n\n`)
+    p.intro(pc.bold('Welcome to GSD — let\'s get you set up'))
+  } else if (opts.showIntro !== false) {
     p.intro(pc.bold('Welcome to GSD — let\'s get you set up'))
   }
 

--- a/src/tests/installer-banner.test.ts
+++ b/src/tests/installer-banner.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+test('printBanner renders the GSD-Pi wordmark once', async () => {
+  const { printBanner, createColors } = await import('../../scripts/install/banner.js')
+
+  const chunks: string[] = []
+  const orig = process.stdout.write.bind(process.stdout)
+  ;(process.stdout as NodeJS.WriteStream).write = ((chunk: string) => {
+    chunks.push(String(chunk))
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    printBanner({ version: '9.9.9', colors: createColors() })
+  } finally {
+    ;(process.stdout as NodeJS.WriteStream).write = orig
+  }
+
+  const out = chunks.join('')
+  const strip = out.replace(/\x1b\[[0-9;]*m/g, '')
+  assert.equal(
+    strip.split('\n').filter((line) => line.includes('██████╗ ███████╗██████╗ ─ ██████╗ ██╗')).length,
+    1,
+    'expected a single GSD-Pi wordmark',
+  )
+  assert.match(strip, /Git Ship Done · v9\.9\.9/)
+  assert.doesNotMatch(strip, /\n\s+GSD-Pi\s+Git Ship Done/)
+})

--- a/src/tests/installer-handoff.test.ts
+++ b/src/tests/installer-handoff.test.ts
@@ -9,6 +9,15 @@ import { fileURLToPath } from 'node:url'
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
+test('runConfigHandoff suppresses duplicate logo in gsd config subprocess', () => {
+  const source = readFileSync(
+    join(projectRoot, 'scripts', 'install', 'handoff.js'),
+    'utf-8',
+  )
+  assert.match(source, /GSD_SUPPRESS_LOGO/)
+  assert.match(source, /spawnSync\(bin, \['config'\], \{[\s\S]*env: \{ \.\.\.process\.env, \[GSD_SUPPRESS_LOGO_ENV\]: '1' \}/)
+})
+
 test('promptLaunch does not time out the interactive agent session', () => {
   const source = readFileSync(
     join(projectRoot, 'scripts', 'install', 'handoff.js'),


### PR DESCRIPTION
## Summary

The redesigned npx installer printed the GSD-Pi ASCII wordmark, then showed it again when `gsd config` ran during the handoff (loader first-run banner and onboarding intro). This PR suppresses the duplicate branding in that subprocess while keeping the installer banner as the single wordmark for the install flow.

- Set `GSD_SUPPRESS_LOGO=1` when spawning `gsd config` from `runConfigHandoff`
- Skip loader and onboarding wordmark rendering when that env var is set
- Simplify installer tagline to `Git Ship Done · vX` under the wordmark (no redundant text brand line)

## Test plan

- [x] `node --test src/tests/installer-banner.test.ts src/tests/installer-handoff.test.ts`
- [ ] Run `node scripts/install.js` interactively and confirm the wordmark appears once before prereq checks
- [ ] Complete install through `gsd config` and confirm onboarding does not re-print the ASCII art


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install/onboarding display-only changes with a small env flag; no auth, data, or runtime behavior beyond suppressing duplicate logos.
> 
> **Overview**
> Guided **npx** install no longer shows the GSD-Pi ASCII wordmark twice: the installer keeps a single wordmark up front, while **`gsd config`** during handoff skips duplicate branding via **`GSD_SUPPRESS_LOGO=1`**.
> 
> The installer tagline under the logo is trimmed to **`Git Ship Done · vX`** (no extra **GSD-Pi** text line). **`loader.ts`** and **`onboarding.ts`** honor that env var so first-run banner and onboarding intro skip the wordmark but still show the welcome flow. Tests lock in one wordmark from **`printBanner`** and the handoff env wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6c5b9c5bb0250a0e283162e3e18899ca150568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782563812&installation_id=134682257&pr_number=218&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F218&signature=14aadf02e05a4027b573c3c020dca7b4ca7cad9ea73b7c392756819618f4a504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->