### PR TITLE
feat(gsd): add /gsd usage and /gsd context observability commands

### DIFF
--- a/src/resources/extensions/gsd/commands-bootstrap.ts
+++ b/src/resources/extensions/gsd/commands-bootstrap.ts
@@ -31,6 +31,8 @@ const TOP_LEVEL_SUBCOMMANDS = [
   { cmd: "skill-health", desc: "Skill lifecycle dashboard" },
   { cmd: "doctor", desc: "Runtime health checks with auto-fix" },
   { cmd: "logs", desc: "Browse activity logs, debug logs, and metrics" },
+  { cmd: "usage", desc: "Current LLM context window usage and session token totals" },
+  { cmd: "context", desc: "Context breakdown chart (skills, injections, history)" },
   { cmd: "forensics", desc: "Examine execution logs" },
   { cmd: "init", desc: "Project init wizard" },
   { cmd: "setup", desc: "Global setup status and configuration" },

--- a/src/resources/extensions/gsd/commands-context.ts
+++ b/src/resources/extensions/gsd/commands-context.ts
@@ -489,7 +489,7 @@ export function formatContextReport(report: ContextBreakdownReport): string {
   return lines.join("\n");
 }
 
-export async function handleContext(args: string, ctx: ExtensionCommandContext): Promise<void> {
+export async function handleContext(args: string, ctx: ExtensionCommandContext, basePath = process.cwd()): Promise<void> {
   const model = ctx.model;
   const modelLabel = model ? `${model.provider}/${model.id}` : null;
   const provider = resolveProvider(model?.provider);
@@ -511,7 +511,7 @@ export async function handleContext(args: string, ctx: ExtensionCommandContext):
   }
 
   if (args.includes("--open")) {
-    const outPath = writeContextChartHtml(process.cwd(), report);
+    const outPath = writeContextChartHtml(basePath, report);
     openInBrowser(outPath);
     ctx.ui.notify(`Context chart saved: ${outPath}`, "info");
     return;

--- a/src/resources/extensions/gsd/commands-context.ts
+++ b/src/resources/extensions/gsd/commands-context.ts
@@ -1,0 +1,553 @@
+/**
+ * GSD Command — /gsd context
+ *
+ * Breaks down what's consuming the current LLM context window:
+ * system prompt sections, GSD injections, skills, subagents, and history.
+ */
+
+import type { ExtensionCommandContext, ContextUsage, SessionEntry, SessionMessageEntry } from "@gsd/pi-coding-agent";
+
+import { formatTokenCount } from "./metrics.js";
+import { countTokensSync, type TokenProvider } from "./token-counter.js";
+import { writeContextChartHtml } from "./context-chart-html.js";
+import { openInBrowser } from "./export.js";
+
+export interface ContextSectionBreakdown {
+  label: string;
+  tokens: number;
+  detail?: string;
+}
+
+export interface SkillContextInfo {
+  available: string[];
+  loaded: string[];
+  prefer: string[];
+  avoid: string[];
+}
+
+export interface ContextBreakdownReport {
+  modelLabel: string | null;
+  contextUsage: ContextUsage | undefined;
+  systemSections: ContextSectionBreakdown[];
+  conversationSections: ContextSectionBreakdown[];
+  skills: SkillContextInfo;
+  subagentSpawns: number;
+}
+
+
+function resolveProvider(provider: string | undefined): TokenProvider {
+  const normalized = (provider ?? "unknown").toLowerCase();
+  if (normalized === "anthropic" || normalized === "claude-code") return normalized as TokenProvider;
+  if (normalized === "openai" || normalized === "google" || normalized === "mistral" || normalized === "bedrock") {
+    return normalized;
+  }
+  return "unknown";
+}
+
+function countTextTokens(text: string, provider: TokenProvider): number {
+  if (!text) return 0;
+  return countTokensSync(text, provider);
+}
+
+function extractXmlBlock(text: string, tag: string): string {
+  const open = `<${tag}>`;
+  const close = `</${tag}>`;
+  const start = text.indexOf(open);
+  if (start < 0) return "";
+  const end = text.indexOf(close, start);
+  if (end < 0) return text.slice(start);
+  return text.slice(start, end + close.length);
+}
+
+function parseSkillNamesFromXml(xml: string): string[] {
+  const names: string[] = [];
+  const re = /<name>([^<]+)<\/name>/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(xml)) !== null) {
+    names.push(match[1]!.trim());
+  }
+  return names;
+}
+
+function parseSkillPreferences(systemPrompt: string): { prefer: string[]; avoid: string[] } {
+  const prefer: string[] = [];
+  const avoid: string[] = [];
+  const preferMatch = systemPrompt.match(/prefer_skills:\s*\[([^\]]*)\]/i);
+  const avoidMatch = systemPrompt.match(/avoid_skills:\s*\[([^\]]*)\]/i);
+  if (preferMatch?.[1]) {
+    for (const item of preferMatch[1].split(",")) {
+      const name = item.trim().replace(/^["']|["']$/g, "");
+      if (name) prefer.push(name);
+    }
+  }
+  if (avoidMatch?.[1]) {
+    for (const item of avoidMatch[1].split(",")) {
+      const name = item.trim().replace(/^["']|["']$/g, "");
+      if (name) avoid.push(name);
+    }
+  }
+  return { prefer, avoid };
+}
+
+function sliceBetween(text: string, startMarker: string, endMarkers: string[]): string {
+  const start = text.indexOf(startMarker);
+  if (start < 0) return "";
+  let end = text.length;
+  for (const marker of endMarkers) {
+    const idx = text.indexOf(marker, start + startMarker.length);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+  return text.slice(start, end);
+}
+
+export function parseSystemPromptSections(systemPrompt: string, provider: TokenProvider): ContextSectionBreakdown[] {
+  if (!systemPrompt.trim()) return [];
+
+  const sections: ContextSectionBreakdown[] = [];
+  const gsdMarker = "[SYSTEM CONTEXT — GSD]";
+  const gsdIdx = systemPrompt.indexOf(gsdMarker);
+
+  const piBase = gsdIdx >= 0 ? systemPrompt.slice(0, gsdIdx) : systemPrompt;
+  if (piBase.trim()) {
+    const availableSkillsXml = extractXmlBlock(piBase, "available_skills");
+    const piWithoutSkills = availableSkillsXml
+      ? piBase.replace(availableSkillsXml, "")
+      : piBase;
+    if (piWithoutSkills.trim()) {
+      sections.push({
+        label: "Pi base prompt",
+        tokens: countTextTokens(piWithoutSkills, provider),
+      });
+    }
+    if (availableSkillsXml) {
+      const skillNames = parseSkillNamesFromXml(availableSkillsXml);
+      sections.push({
+        label: "Available skills catalog",
+        tokens: countTextTokens(availableSkillsXml, provider),
+        detail: skillNames.length > 0 ? `${skillNames.length} skills` : undefined,
+      });
+    }
+  }
+
+  if (gsdIdx < 0) return sections;
+
+  const gsdTail = systemPrompt.slice(gsdIdx);
+  const gsdCoreEndMarkers = [
+    "\n\n[KNOWLEDGE —",
+    "\n\n[PROJECT CODEBASE —",
+    "[WORKTREE CONTEXT —",
+    "\n\n## Subagent Model",
+    "GSD Skill Preferences",
+  ];
+  const gsdCore = sliceBetween(gsdTail, gsdMarker, gsdCoreEndMarkers);
+  if (gsdCore.trim()) {
+    sections.push({
+      label: "GSD system prompt",
+      tokens: countTextTokens(gsdCore, provider),
+    });
+  }
+
+  const prefsBlock = systemPrompt.includes("GSD Skill Preferences")
+    ? sliceBetween(
+        systemPrompt,
+        "GSD Skill Preferences",
+        ["\n\n[KNOWLEDGE —", "\n\n[PROJECT CODEBASE —", "[WORKTREE CONTEXT —", "\n\n## Subagent Model"],
+      )
+    : "";
+  if (prefsBlock.trim()) {
+    sections.push({
+      label: "Skill preferences",
+      tokens: countTextTokens(prefsBlock, provider),
+    });
+  }
+
+  const knowledge = sliceBetween(systemPrompt, "[KNOWLEDGE —", ["\n\n[PROJECT CODEBASE —", "[WORKTREE CONTEXT —", "\n\n## Subagent Model"]);
+  if (knowledge.trim()) {
+    sections.push({
+      label: "Knowledge rules",
+      tokens: countTextTokens(knowledge, provider),
+    });
+  }
+
+  const codebase = sliceBetween(systemPrompt, "[PROJECT CODEBASE —", ["[WORKTREE CONTEXT —", "\n\n## Subagent Model"]);
+  if (codebase.trim()) {
+    sections.push({
+      label: "Codebase map",
+      tokens: countTextTokens(codebase, provider),
+      detail: codebase.includes("truncated") ? "truncated" : undefined,
+    });
+  }
+
+  const worktree = sliceBetween(systemPrompt, "[WORKTREE CONTEXT —", ["\n\n## Subagent Model"]);
+  if (worktree.trim()) {
+    sections.push({
+      label: "Worktree context",
+      tokens: countTextTokens(worktree, provider),
+    });
+  }
+
+  const subagent = sliceBetween(systemPrompt, "## Subagent Model", []);
+  if (subagent.trim()) {
+    sections.push({
+      label: "Subagent model hint",
+      tokens: countTextTokens(subagent, provider),
+    });
+  }
+
+  const mcpToolCount = (systemPrompt.match(/mcp__[^_\s]+__/g) ?? []).length;
+  if (mcpToolCount > 0) {
+    sections.push({
+      label: "MCP tool schemas",
+      tokens: 0,
+      detail: `${mcpToolCount} tool references in prompt`,
+    });
+  }
+
+  return sections;
+}
+
+function messageToText(message: SessionMessageEntry["message"]): string {
+  const role = message.role;
+
+  if (role === "assistant") {
+    const parts: string[] = [];
+    const content = message.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== "object") continue;
+        const typed = block as { type?: string; text?: string; thinking?: string; name?: string; arguments?: unknown };
+        if (typed.type === "text" && typed.text) parts.push(typed.text);
+        if (typed.type === "thinking" && typed.thinking) parts.push(typed.thinking);
+        if (typed.type === "toolCall") {
+          parts.push(typed.name ?? "tool");
+          parts.push(JSON.stringify(typed.arguments ?? {}));
+        }
+      }
+    }
+    return parts.join("\n");
+  }
+
+  if (role === "custom") {
+    const content = message.content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .filter((block) => block && typeof block === "object" && (block as { type?: string }).type === "text")
+        .map((block) => (block as { text?: string }).text ?? "")
+        .join("\n");
+    }
+    return "";
+  }
+
+  if (role === "bashExecution") {
+    return `${String(message.command ?? "")}\n${String(message.output ?? "")}`;
+  }
+
+  if (role === "compactionSummary" || role === "branchSummary") {
+    return String(message.summary ?? "");
+  }
+
+  if ("content" in message) {
+    const content = message.content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .filter((block) => block && typeof block === "object" && (block as { type?: string }).type === "text")
+        .map((block) => (block as { text?: string }).text ?? "")
+        .join("\n");
+    }
+  }
+
+  return "";
+}
+
+function customTypeLabel(customType: string): string {
+  const labels: Record<string, string> = {
+    "gsd-memory": "Memory injection",
+    "gsd-guided-context": "Guided execute context",
+    "gsd-forensics": "Forensics context",
+    "gsd-run": "GSD dispatch prompt",
+    "gsd-discuss": "GSD discuss prompt",
+    "gsd-debug-start": "Debug session prompt",
+    "gsd-debug-continue": "Debug continue prompt",
+    "gsd-debug-diagnose": "Debug diagnose prompt",
+    "gsd-quick-task": "Quick task prompt",
+    "gsd-doctor-heal": "Doctor heal prompt",
+  };
+  if (labels[customType]) return labels[customType];
+  if (customType.startsWith("gsd-")) return `GSD injection (${customType})`;
+  return `Custom (${customType})`;
+}
+
+function extractSkillNameFromPath(path: string): string | null {
+  const normalized = path.replace(/\\/g, "/");
+  const match = normalized.match(/\/skills\/([^/]+)\/SKILL\.md$/i)
+    ?? normalized.match(/\/([^/]+)\/SKILL\.md$/i);
+  return match?.[1] ?? null;
+}
+
+export function analyzeSessionContext(
+  entries: ReadonlyArray<SessionEntry> | null | undefined,
+  provider: TokenProvider,
+): {
+  conversationSections: ContextSectionBreakdown[];
+  skills: SkillContextInfo;
+  subagentSpawns: number;
+} {
+  const buckets = new Map<string, { tokens: number; count: number; details: Set<string> }>();
+  const loadedSkills = new Set<string>();
+  let subagentSpawns = 0;
+
+  const addBucket = (label: string, text: string, detail?: string) => {
+    const tokens = countTextTokens(text, provider);
+    if (tokens <= 0 && !detail) return;
+    const existing = buckets.get(label) ?? { tokens: 0, count: 0, details: new Set<string>() };
+    existing.tokens += tokens;
+    existing.count += 1;
+    if (detail) existing.details.add(detail);
+    buckets.set(label, existing);
+  };
+
+  if (!entries) {
+    return {
+      conversationSections: [],
+      skills: { available: [], loaded: [], prefer: [], avoid: [] },
+      subagentSpawns: 0,
+    };
+  }
+
+  for (const entry of entries) {
+    if (entry.type !== "message" || !entry.message) continue;
+    const msg = entry.message;
+    const role = msg.role;
+    const text = messageToText(msg);
+
+    if (role === "user") {
+      addBucket("User messages", text);
+      continue;
+    }
+
+    if (role === "custom") {
+      const customType = String(msg.customType ?? "custom");
+      addBucket(customTypeLabel(customType), text, customType);
+      continue;
+    }
+
+    if (role === "toolResult") {
+      addBucket("Tool results", text);
+      continue;
+    }
+
+    if (role === "assistant") {
+      addBucket("Assistant responses", text);
+      const content = msg.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== "object") continue;
+          const typed = block as { type?: string; name?: string; arguments?: Record<string, unknown> };
+          if (typed.type !== "toolCall") continue;
+          if (typed.name === "subagent") subagentSpawns += 1;
+          if (typed.name === "read" && typed.arguments && typeof typed.arguments.path === "string") {
+            const skillName = extractSkillNameFromPath(typed.arguments.path);
+            if (skillName) loadedSkills.add(skillName);
+          }
+        }
+      }
+      continue;
+    }
+
+    if (role === "compactionSummary") {
+      addBucket("Compaction summaries", text);
+      continue;
+    }
+
+    if (role === "branchSummary") {
+      addBucket("Branch summaries", text);
+      continue;
+    }
+
+    if (role === "bashExecution") {
+      addBucket("Bash output", text);
+    }
+  }
+
+  const conversationSections = [...buckets.entries()]
+    .map(([label, value]) => ({
+      label,
+      tokens: value.tokens,
+      detail: value.details.size > 0
+        ? `${value.count} message${value.count === 1 ? "" : "s"}`
+        : value.count > 1
+          ? `${value.count} messages`
+          : undefined,
+    }))
+    .sort((a, b) => b.tokens - a.tokens);
+
+  return {
+    conversationSections,
+    skills: { available: [], loaded: [...loadedSkills].sort(), prefer: [], avoid: [] },
+    subagentSpawns,
+  };
+}
+
+export function buildContextBreakdown(options: {
+  modelLabel: string | null;
+  provider: TokenProvider;
+  contextUsage: ContextUsage | undefined;
+  systemPrompt: string;
+  entries: ReadonlyArray<SessionEntry> | null | undefined;
+}): ContextBreakdownReport {
+  const systemSections = parseSystemPromptSections(options.systemPrompt, options.provider);
+  const session = analyzeSessionContext(options.entries, options.provider);
+
+  const availableSkillsXml = extractXmlBlock(options.systemPrompt, "available_skills");
+  const available = parseSkillNamesFromXml(availableSkillsXml);
+  const prefs = parseSkillPreferences(options.systemPrompt);
+
+  return {
+    modelLabel: options.modelLabel,
+    contextUsage: options.contextUsage,
+    systemSections,
+    conversationSections: session.conversationSections,
+    skills: {
+      available: [...new Set(available)].sort(),
+      loaded: session.skills.loaded,
+      prefer: prefs.prefer,
+      avoid: prefs.avoid,
+    },
+    subagentSpawns: session.subagentSpawns,
+  };
+}
+
+function formatPercent(percent: number): string {
+  if (percent >= 100) return percent.toFixed(1);
+  if (percent >= 10) return percent.toFixed(1);
+  return percent.toFixed(2);
+}
+
+function formatSectionLines(sections: ContextSectionBreakdown[], totalKnown: number | null): string[] {
+  if (sections.length === 0) return ["  (none)"];
+  return sections.map((section) => {
+    const pct = totalKnown && totalKnown > 0
+      ? ` (${formatPercent((section.tokens / totalKnown) * 100)}%)`
+      : "";
+    const detail = section.detail ? ` — ${section.detail}` : "";
+    return `  ${section.label}: ${formatTokenCount(section.tokens)} tokens${pct}${detail}`;
+  });
+}
+
+export function formatContextReport(report: ContextBreakdownReport): string {
+  const lines: string[] = ["Context Breakdown", ""];
+
+  if (report.modelLabel) lines.push(`Model: ${report.modelLabel}`);
+
+  const usage = report.contextUsage;
+  if (usage) {
+    if (usage.tokens != null && usage.percent != null) {
+      lines.push(`In context: ${formatTokenCount(usage.tokens)} / ${formatTokenCount(usage.contextWindow)} (${formatPercent(usage.percent)}%)`);
+    } else {
+      lines.push(`Window: ${formatTokenCount(usage.contextWindow)} tokens (usage unknown until next model response)`);
+    }
+  }
+
+  const estimatedTotal = [
+    ...report.systemSections,
+    ...report.conversationSections,
+  ].reduce((sum, section) => sum + section.tokens, 0);
+
+  lines.push("");
+  lines.push("System prompt");
+  lines.push(...formatSectionLines(report.systemSections, usage?.tokens ?? estimatedTotal));
+
+  lines.push("");
+  lines.push("Conversation history");
+  lines.push(...formatSectionLines(report.conversationSections, usage?.tokens ?? estimatedTotal));
+
+  lines.push("");
+  lines.push("Skills");
+  if (report.skills.available.length > 0) {
+    lines.push(`  Available (${report.skills.available.length}): ${report.skills.available.slice(0, 12).join(", ")}${report.skills.available.length > 12 ? "…" : ""}`);
+  } else {
+    lines.push("  Available: none in prompt");
+  }
+  if (report.skills.loaded.length > 0) {
+    lines.push(`  Loaded this session: ${report.skills.loaded.join(", ")}`);
+  } else {
+    lines.push("  Loaded this session: none");
+  }
+  if (report.skills.prefer.length > 0) {
+    lines.push(`  Prefer: ${report.skills.prefer.join(", ")}`);
+  }
+  if (report.skills.avoid.length > 0) {
+    lines.push(`  Avoid: ${report.skills.avoid.join(", ")}`);
+  }
+
+  lines.push("");
+  lines.push("Agents");
+  lines.push(`  Subagent spawns this session: ${report.subagentSpawns}`);
+
+  if (estimatedTotal > 0 && (usage?.tokens == null || Math.abs(estimatedTotal - usage.tokens) > usage.tokens * 0.15)) {
+    lines.push("");
+    lines.push(`Estimated from content: ${formatTokenCount(estimatedTotal)} tokens`);
+    lines.push("Note: tool schemas and provider overhead may not be fully reflected.");
+  }
+
+  return lines.join("\n");
+}
+
+export async function handleContext(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const model = ctx.model;
+  const modelLabel = model ? `${model.provider}/${model.id}` : null;
+  const provider = resolveProvider(model?.provider);
+  const contextUsage = ctx.getContextUsage?.();
+  const systemPrompt = typeof ctx.getSystemPrompt === "function" ? ctx.getSystemPrompt() : "";
+  const entries = ctx.sessionManager.getBranch?.() ?? ctx.sessionManager.getEntries();
+
+  const report = buildContextBreakdown({
+    modelLabel,
+    provider,
+    contextUsage,
+    systemPrompt,
+    entries,
+  });
+
+  if (args.includes("--json")) {
+    ctx.ui.notify(JSON.stringify(report, null, 2), "info");
+    return;
+  }
+
+  if (args.includes("--open")) {
+    const outPath = writeContextChartHtml(process.cwd(), report);
+    openInBrowser(outPath);
+    ctx.ui.notify(`Context chart saved: ${outPath}`, "info");
+    return;
+  }
+
+  if (args.includes("--text")) {
+    ctx.ui.notify(formatContextReport(report), "info");
+    return;
+  }
+
+  if (ctx.hasUI) {
+    const { GSDContextOverlay } = await import("./context-overlay.js");
+    const result = await ctx.ui.custom<boolean>(
+      (tui, theme, _kb, done) => new GSDContextOverlay(tui, theme, report, () => done(true)),
+      {
+        overlay: true,
+        overlayOptions: {
+          width: "88%",
+          minWidth: 72,
+          maxHeight: "90%",
+          anchor: "center",
+        },
+      },
+    );
+    if (result === undefined) {
+      const { formatContextChartText } = await import("./context-overlay.js");
+      ctx.ui.notify(formatContextChartText(report), "info");
+    }
+    return;
+  }
+
+  ctx.ui.notify(formatContextReport(report), "info");
+}

--- a/src/resources/extensions/gsd/commands-context.ts
+++ b/src/resources/extensions/gsd/commands-context.ts
@@ -7,7 +7,7 @@
 
 import type { ExtensionCommandContext, ContextUsage, SessionEntry, SessionMessageEntry } from "@gsd/pi-coding-agent";
 
-import { formatTokenCount } from "./metrics.js";
+import { formatPercent, formatTokenCount } from "./metrics.js";
 import { countTokensSync, type TokenProvider } from "./token-counter.js";
 import { writeContextChartHtml } from "./context-chart-html.js";
 import { openInBrowser } from "./export.js";
@@ -417,12 +417,6 @@ export function buildContextBreakdown(options: {
     },
     subagentSpawns: session.subagentSpawns,
   };
-}
-
-function formatPercent(percent: number): string {
-  if (percent >= 100) return percent.toFixed(1);
-  if (percent >= 10) return percent.toFixed(1);
-  return percent.toFixed(2);
 }
 
 function formatSectionLines(sections: ContextSectionBreakdown[], totalKnown: number | null): string[] {

--- a/src/resources/extensions/gsd/commands-do.ts
+++ b/src/resources/extensions/gsd/commands-do.ts
@@ -30,6 +30,8 @@ const ROUTES: Route[] = [
   { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture" },
   { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
   { keywords: ["knowledge", "rule", "pattern", "lesson"], command: "knowledge" },
+  { keywords: ["context usage", "context window", "how much context", "token usage", "tokens used"], command: "usage" },
+  { keywords: ["context breakdown", "what is using context", "skills in context", "agents in context"], command: "context" },
   { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report" },
   { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
   { keywords: ["pr branch", "clean branch", "filter commits"], command: "pr-branch" },

--- a/src/resources/extensions/gsd/commands-usage.ts
+++ b/src/resources/extensions/gsd/commands-usage.ts
@@ -6,7 +6,7 @@
 
 import type { ExtensionCommandContext, ContextUsage, SessionEntry } from "@gsd/pi-coding-agent";
 
-import { formatCost, formatTokenCount } from "./metrics.js";
+import { formatCost, formatPercent, formatTokenCount } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 export interface SessionTokenTotals {
@@ -78,12 +78,6 @@ export function scanSessionTokenTotals(
   }
 
   return totals;
-}
-
-function formatPercent(percent: number): string {
-  if (percent >= 100) return percent.toFixed(1);
-  if (percent >= 10) return percent.toFixed(1);
-  return percent.toFixed(2);
 }
 
 function formatContextLine(usage: ContextUsage | undefined): string[] {
@@ -173,6 +167,7 @@ export async function handleUsage(args: string, ctx: ExtensionCommandContext): P
   const modelLabel = model ? `${model.provider}/${model.id}` : null;
 
   if (args.includes("--json")) {
+    const prefs = loadEffectiveGSDPreferences()?.preferences;
     ctx.ui.notify(
       JSON.stringify(
         {
@@ -180,8 +175,8 @@ export async function handleUsage(args: string, ctx: ExtensionCommandContext): P
           contextUsage: contextUsage ?? null,
           sessionTotals,
           thresholds: {
-            contextPause: loadEffectiveGSDPreferences()?.preferences?.context_pause_threshold ?? null,
-            compaction: loadEffectiveGSDPreferences()?.preferences?.context_management?.compaction_threshold_percent ?? null,
+            contextPause: prefs?.context_pause_threshold ?? null,
+            compaction: prefs?.context_management?.compaction_threshold_percent ?? null,
           },
         },
         null,

--- a/src/resources/extensions/gsd/commands-usage.ts
+++ b/src/resources/extensions/gsd/commands-usage.ts
@@ -1,0 +1,199 @@
+/**
+ * GSD Command — /gsd usage
+ *
+ * Shows current LLM context window usage and session token totals.
+ */
+
+import type { ExtensionCommandContext, ContextUsage, SessionEntry } from "@gsd/pi-coding-agent";
+
+import { formatCost, formatTokenCount } from "./metrics.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
+
+export interface SessionTokenTotals {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  cost: number;
+  userMessages: number;
+  assistantMessages: number;
+  toolCalls: number;
+}
+
+export function scanSessionTokenTotals(
+  entries: ReadonlyArray<SessionEntry> | null | undefined,
+): SessionTokenTotals {
+  const totals: SessionTokenTotals = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+    cost: 0,
+    userMessages: 0,
+    assistantMessages: 0,
+    toolCalls: 0,
+  };
+
+  if (!entries || entries.length === 0) return totals;
+
+  for (const entry of entries) {
+    if (entry.type !== "message") continue;
+    const msg = entry.message;
+    if (!msg) continue;
+
+    if (msg.role === "user") {
+      totals.userMessages++;
+      continue;
+    }
+
+    if (msg.role !== "assistant") continue;
+
+    totals.assistantMessages++;
+    const usage = msg.usage;
+    if (usage) {
+      totals.input += Number(usage.input ?? 0);
+      totals.output += Number(usage.output ?? 0);
+      totals.cacheRead += Number(usage.cacheRead ?? 0);
+      totals.cacheWrite += Number(usage.cacheWrite ?? 0);
+      totals.total += Number(usage.totalTokens ?? 0);
+      const rawCost = usage.cost;
+      if (rawCost != null) {
+        totals.cost += typeof rawCost === "number" ? rawCost : Number((rawCost as { total?: number }).total ?? 0);
+      }
+    }
+
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block && typeof block === "object" && (block as { type?: string }).type === "toolCall") {
+          totals.toolCalls++;
+        }
+      }
+    }
+  }
+
+  if (totals.total === 0) {
+    totals.total = totals.input + totals.output + totals.cacheRead + totals.cacheWrite;
+  }
+
+  return totals;
+}
+
+function formatPercent(percent: number): string {
+  if (percent >= 100) return percent.toFixed(1);
+  if (percent >= 10) return percent.toFixed(1);
+  return percent.toFixed(2);
+}
+
+function formatContextLine(usage: ContextUsage | undefined): string[] {
+  if (!usage) {
+    return ["Context: unavailable (no active model)"];
+  }
+
+  const windowTokens = usage.contextWindow;
+  const lines: string[] = [`Window: ${formatTokenCount(windowTokens)} tokens`];
+
+  if (usage.tokens == null || usage.percent == null) {
+    lines.push("In context: unknown (after compaction — wait for the next model response)");
+    return lines;
+  }
+
+  const remaining = Math.max(0, windowTokens - usage.tokens);
+  lines.push(`In context: ${formatTokenCount(usage.tokens)} tokens (${formatPercent(usage.percent)}%)`);
+  lines.push(`Remaining: ${formatTokenCount(remaining)} tokens`);
+  return lines;
+}
+
+function formatThresholdLines(): string[] {
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+  const lines: string[] = [];
+
+  const pauseThreshold = prefs?.context_pause_threshold;
+  if (typeof pauseThreshold === "number" && pauseThreshold > 0) {
+    lines.push(`Auto pause: ${pauseThreshold}%`);
+  }
+
+  const compactionThreshold = prefs?.context_management?.compaction_threshold_percent;
+  if (typeof compactionThreshold === "number") {
+    lines.push(`Compaction: ${Math.round(compactionThreshold * 100)}%`);
+  }
+
+  return lines;
+}
+
+export function formatUsageReport(options: {
+  modelLabel: string | null;
+  contextUsage: ContextUsage | undefined;
+  sessionTotals: SessionTokenTotals;
+}): string {
+  const lines: string[] = ["Context Usage", ""];
+
+  if (options.modelLabel) {
+    lines.push(`Model: ${options.modelLabel}`);
+  }
+
+  lines.push(...formatContextLine(options.contextUsage));
+  lines.push("");
+
+  const { sessionTotals } = options;
+  lines.push("Session totals");
+  lines.push(`  Input: ${formatTokenCount(sessionTotals.input)}  Output: ${formatTokenCount(sessionTotals.output)}`);
+  if (sessionTotals.cacheRead > 0 || sessionTotals.cacheWrite > 0) {
+    lines.push(
+      `  Cache read: ${formatTokenCount(sessionTotals.cacheRead)}  Cache write: ${formatTokenCount(sessionTotals.cacheWrite)}`,
+    );
+  }
+  if (sessionTotals.cost > 0) {
+    lines.push(`  Cost: ${formatCost(sessionTotals.cost)}`);
+  }
+  lines.push(
+    `  Messages: ${sessionTotals.userMessages} user / ${sessionTotals.assistantMessages} assistant`,
+  );
+  if (sessionTotals.toolCalls > 0) {
+    lines.push(`  Tool calls: ${sessionTotals.toolCalls}`);
+  }
+
+  const thresholdLines = formatThresholdLines();
+  if (thresholdLines.length > 0) {
+    lines.push("");
+    lines.push("Thresholds");
+    for (const line of thresholdLines) {
+      lines.push(`  ${line}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function handleUsage(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const contextUsage = ctx.getContextUsage?.();
+  const sessionTotals = scanSessionTokenTotals(ctx.sessionManager.getEntries());
+  const model = ctx.model;
+  const modelLabel = model ? `${model.provider}/${model.id}` : null;
+
+  if (args.includes("--json")) {
+    ctx.ui.notify(
+      JSON.stringify(
+        {
+          model: modelLabel,
+          contextUsage: contextUsage ?? null,
+          sessionTotals,
+          thresholds: {
+            contextPause: loadEffectiveGSDPreferences()?.preferences?.context_pause_threshold ?? null,
+            compaction: loadEffectiveGSDPreferences()?.preferences?.context_management?.compaction_threshold_percent ?? null,
+          },
+        },
+        null,
+        2,
+      ),
+      "info",
+    );
+    return;
+  }
+
+  ctx.ui.notify(
+    formatUsageReport({ modelLabel, contextUsage, sessionTotals }),
+    "info",
+  );
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -55,6 +55,8 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "notifications", desc: "View, filter, and clear persistent notification history" },
   { cmd: "doctor", desc: "Runtime health checks with auto-fix" },
   { cmd: "logs", desc: "Browse activity logs, debug logs, and metrics" },
+  { cmd: "usage", desc: "Current LLM context window usage and session token totals" },
+  { cmd: "context", desc: "Context breakdown chart (skills, injections, history)" },
   { cmd: "debug", desc: "Create and inspect persistent /gsd debug sessions" },
   { cmd: "forensics", desc: "Examine execution logs" },
   { cmd: "init", desc: "Project init wizard — detect, configure, bootstrap .gsd/" },
@@ -308,6 +310,14 @@ const NESTED_COMPLETIONS: CompletionMap = {
   "session-report": [
     { cmd: "--json", desc: "Machine-readable JSON output" },
     { cmd: "--save", desc: "Save report to .gsd/reports/" },
+  ],
+  usage: [
+    { cmd: "--json", desc: "Machine-readable JSON output" },
+  ],
+  context: [
+    { cmd: "--open", desc: "Open a browser chart saved to .gsd/reports/" },
+    { cmd: "--text", desc: "Plain-text breakdown" },
+    { cmd: "--json", desc: "Machine-readable JSON output" },
   ],
   backlog: [
     { cmd: "add", desc: "Add item to backlog" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -42,6 +42,8 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd rethink        Conversational project reorganization",
     "",
     "OBSERVABILITY",
+    "  /gsd usage          Current LLM context window usage and session tokens",
+    "  /gsd context        Context breakdown chart (skills, injections, history)",
     "  /gsd logs           Browse activity and debug logs",
     "  /gsd debug          Create/list/continue persistent debug sessions",
     "",
@@ -87,6 +89,8 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd history        View execution history  [--cost] [--phase] [--model] [N]",
     "  /gsd changelog      Show categorized release notes  [version]",
     `  /gsd notifications  View persistent notification history  [clear|tail|filter]  (${formattedShortcutPair("notifications")})`,
+    "  /gsd usage          Current LLM context window usage and session tokens  [--json]",
+    "  /gsd context        Context breakdown chart  [--open|--text|--json]",
     "  /gsd logs           Browse activity logs, debug logs, and metrics  [debug|tail|clear]",
     "  /gsd debug          Create/list/continue persistent debug sessions",
     "",
@@ -509,6 +513,16 @@ export async function handleCoreCommand(
   }
   if (trimmed === "cmux" || trimmed.startsWith("cmux ")) {
     await handleCmux(trimmed.replace(/^cmux\s*/, "").trim(), ctx);
+    return true;
+  }
+  if (trimmed === "usage" || trimmed.startsWith("usage ")) {
+    const { handleUsage } = await import("../../commands-usage.js");
+    await handleUsage(trimmed.replace(/^usage\s*/, "").trim(), ctx);
+    return true;
+  }
+  if (trimmed === "context" || trimmed.startsWith("context ")) {
+    const { handleContext } = await import("../../commands-context.js");
+    await handleContext(trimmed.replace(/^context\s*/, "").trim(), ctx);
     return true;
   }
   if (trimmed === "show-config") {

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -522,7 +522,7 @@ export async function handleCoreCommand(
   }
   if (trimmed === "context" || trimmed.startsWith("context ")) {
     const { handleContext } = await import("../../commands-context.js");
-    await handleContext(trimmed.replace(/^context\s*/, "").trim(), ctx);
+    await handleContext(trimmed.replace(/^context\s*/, "").trim(), ctx, projectRoot());
     return true;
   }
   if (trimmed === "show-config") {

--- a/src/resources/extensions/gsd/context-chart-html.ts
+++ b/src/resources/extensions/gsd/context-chart-html.ts
@@ -22,8 +22,8 @@ function esc(value: string | number | null | undefined): string {
     .replace(/"/g, "&quot;");
 }
 
-function buildDonutSvg(systemTokens: number, conversationTokens: number, remaining: number): string {
-  const total = Math.max(systemTokens + conversationTokens + remaining, 1);
+function buildDonutSvg(systemTokens: number, conversationTokens: number, otherTokens: number, remaining: number): string {
+  const total = Math.max(systemTokens + conversationTokens + otherTokens + remaining, 1);
   const radius = 54;
   const stroke = 16;
   const center = 70;
@@ -32,6 +32,7 @@ function buildDonutSvg(systemTokens: number, conversationTokens: number, remaini
   const segments = [
     { value: systemTokens, color: "#5e6ad2", label: "System" },
     { value: conversationTokens, color: "#3ecf8e", label: "History" },
+    { value: otherTokens, color: "#f59e0b", label: "Other" },
     { value: remaining, color: "#2b2e38", label: "Free" },
   ].filter((segment) => segment.value > 0);
 
@@ -89,6 +90,7 @@ function renderSkillChips(names: string[], loaded: Set<string>, tone: "available
 export function buildContextChartHtml(report: ContextBreakdownReport): string {
   const totals = getContextChartTotals(report);
   const chartTotal = Math.max(totals.inContext, totals.estimated, 1);
+  const otherTokens = Math.max(0, totals.inContext - totals.estimated);
   const loaded = new Set(report.skills.loaded);
   const generated = new Date().toISOString();
 
@@ -140,13 +142,14 @@ body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 var(--font)}
 <body>
 <div class="wrap">
   <section class="hero">
-    <div>${buildDonutSvg(totals.systemTokens, totals.conversationTokens, totals.remaining)}</div>
+    <div>${buildDonutSvg(totals.systemTokens, totals.conversationTokens, otherTokens, totals.remaining)}</div>
     <div>
       <h1>Context Breakdown</h1>
       <div class="meta">${report.modelLabel ? esc(report.modelLabel) : "No model"} · Generated ${esc(generated)}</div>
       <div class="legend">
         <span><i class="dot" style="background:#5e6ad2"></i>System ${esc(formatTokenCount(totals.systemTokens))}</span>
         <span><i class="dot" style="background:#3ecf8e"></i>History ${esc(formatTokenCount(totals.conversationTokens))}</span>
+        ${otherTokens > 0 ? `<span><i class="dot" style="background:#f59e0b"></i>Other ${esc(formatTokenCount(otherTokens))}</span>` : ""}
         <span><i class="dot" style="background:#2b2e38;border:1px solid #3b3f4c"></i>Free ${esc(formatTokenCount(totals.remaining))}</span>
       </div>
       <div class="stat-grid">

--- a/src/resources/extensions/gsd/context-chart-html.ts
+++ b/src/resources/extensions/gsd/context-chart-html.ts
@@ -1,0 +1,192 @@
+/**
+ * Self-contained HTML chart for /gsd context --open
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ContextBreakdownReport, ContextSectionBreakdown } from "./commands-context.js";
+import { getContextChartTotals } from "./context-overlay.js";
+import { formatTokenCount } from "./metrics.js";
+import { gsdRoot } from "./paths.js";
+
+const SYSTEM_COLORS = ["#5e6ad2", "#7c89ff", "#9aa5ff", "#b8c0ff", "#d4d9ff"];
+const HISTORY_COLORS = ["#3ecf8e", "#56d89a", "#72e2ad", "#8eebc1", "#aaf4d4"];
+
+function esc(value: string | number | null | undefined): string {
+  if (value == null) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildDonutSvg(systemTokens: number, conversationTokens: number, remaining: number): string {
+  const total = Math.max(systemTokens + conversationTokens + remaining, 1);
+  const radius = 54;
+  const stroke = 16;
+  const center = 70;
+  const circumference = 2 * Math.PI * radius;
+
+  const segments = [
+    { value: systemTokens, color: "#5e6ad2", label: "System" },
+    { value: conversationTokens, color: "#3ecf8e", label: "History" },
+    { value: remaining, color: "#2b2e38", label: "Free" },
+  ].filter((segment) => segment.value > 0);
+
+  let offset = 0;
+  const arcs = segments.map((segment) => {
+    const length = (segment.value / total) * circumference;
+    const dash = `${length} ${circumference - length}`;
+    const rotate = (offset / total) * 360 - 90;
+    offset += segment.value;
+    return `<circle cx="${center}" cy="${center}" r="${radius}" fill="none" stroke="${segment.color}" stroke-width="${stroke}" stroke-dasharray="${dash}" transform="rotate(${rotate} ${center} ${center})"><title>${esc(segment.label)} — ${esc(formatTokenCount(segment.value))}</title></circle>`;
+  }).join("\n");
+
+  return `
+    <svg viewBox="0 0 140 140" width="140" height="140" class="donut">
+      <circle cx="${center}" cy="${center}" r="${radius}" fill="none" stroke="#1e2028" stroke-width="${stroke}" />
+      ${arcs}
+    </svg>`;
+}
+
+function renderBarRows(
+  sections: ContextSectionBreakdown[],
+  total: number,
+  colors: string[],
+): string {
+  if (sections.length === 0) {
+    return `<div class="empty">None</div>`;
+  }
+
+  const max = Math.max(...sections.map((section) => section.tokens), 1);
+  return sections.map((section, index) => {
+    const width = Math.max(4, Math.round((section.tokens / max) * 100));
+    const pct = total > 0 ? ((section.tokens / total) * 100).toFixed(1) : "0.0";
+    const color = colors[index % colors.length]!;
+    return `
+      <div class="bar-row">
+        <div class="bar-label" title="${esc(section.label)}">${esc(section.label)}</div>
+        <div class="bar-track">
+          <div class="bar-fill" style="width:${width}%;background:${color}"></div>
+        </div>
+        <div class="bar-meta">${esc(formatTokenCount(section.tokens))}<span>${pct}%</span></div>
+        ${section.detail ? `<div class="bar-detail">${esc(section.detail)}</div>` : ""}
+      </div>`;
+  }).join("");
+}
+
+function renderSkillChips(names: string[], loaded: Set<string>, tone: "available" | "loaded"): string {
+  if (names.length === 0) return `<div class="empty">None</div>`;
+  return `<div class="chips">${names.map((name) => {
+    const isLoaded = loaded.has(name);
+    const cls = tone === "loaded" || isLoaded ? "chip chip-loaded" : "chip";
+    return `<span class="${cls}">${esc(name)}</span>`;
+  }).join("")}</div>`;
+}
+
+export function buildContextChartHtml(report: ContextBreakdownReport): string {
+  const totals = getContextChartTotals(report);
+  const chartTotal = Math.max(totals.inContext, totals.estimated, 1);
+  const loaded = new Set(report.skills.loaded);
+  const generated = new Date().toISOString();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>GSD Context Breakdown</title>
+<style>
+:root{
+  --bg:#0f1115;--panel:#16181d;--panel-2:#1e2028;--border:#2b2e38;
+  --text:#ededef;--muted:#a1a1aa;--dim:#71717a;--accent:#5e6ad2;--success:#3ecf8e;
+  --font:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  --mono:JetBrains Mono,ui-monospace,monospace;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 var(--font)}
+.wrap{max-width:980px;margin:0 auto;padding:32px 24px 48px}
+.hero{display:grid;grid-template-columns:160px 1fr;gap:24px;align-items:center;margin-bottom:28px}
+.hero h1{margin:0 0 8px;font-size:28px;font-weight:650;letter-spacing:-.02em}
+.meta{color:var(--muted);font-size:13px}
+.stat-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:18px}
+.stat{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:14px 16px}
+.stat-label{color:var(--dim);font-size:11px;text-transform:uppercase;letter-spacing:.08em}
+.stat-value{margin-top:4px;font-size:22px;font-weight:650;font-family:var(--mono)}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+.panel{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:18px 18px 12px}
+.panel h2{margin:0 0 14px;font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+.bar-row{display:grid;grid-template-columns:150px 1fr 110px;gap:12px;align-items:center;margin-bottom:12px}
+.bar-label{font-size:13px;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.bar-track{height:10px;background:var(--panel-2);border-radius:999px;overflow:hidden}
+.bar-fill{height:100%;border-radius:999px}
+.bar-meta{font-family:var(--mono);font-size:12px;color:var(--muted);text-align:right;white-space:nowrap}
+.bar-meta span{margin-left:8px;color:var(--dim)}
+.bar-detail{grid-column:1/-1;margin:-4px 0 0 162px;color:var(--dim);font-size:12px}
+.empty{color:var(--dim);font-size:13px;padding:8px 0}
+.skills{margin-top:18px}
+.chips{display:flex;flex-wrap:wrap;gap:8px}
+.chip{display:inline-flex;align-items:center;padding:6px 10px;border-radius:999px;background:var(--panel-2);border:1px solid var(--border);font-size:12px;color:var(--muted)}
+.chip-loaded{color:var(--text);border-color:rgba(62,207,142,.35);background:rgba(62,207,142,.08)}
+.legend{display:flex;gap:16px;margin-top:10px;color:var(--dim);font-size:12px}
+.legend span{display:inline-flex;align-items:center;gap:6px}
+.dot{width:10px;height:10px;border-radius:50%;display:inline-block}
+.footer{margin-top:24px;color:var(--dim);font-size:12px}
+@media (max-width:860px){.hero,.grid{grid-template-columns:1fr}.stat-grid{grid-template-columns:1fr}.bar-row{grid-template-columns:1fr}.bar-meta{text-align:left}.bar-detail{margin-left:0}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <section class="hero">
+    <div>${buildDonutSvg(totals.systemTokens, totals.conversationTokens, totals.remaining)}</div>
+    <div>
+      <h1>Context Breakdown</h1>
+      <div class="meta">${report.modelLabel ? esc(report.modelLabel) : "No model"} · Generated ${esc(generated)}</div>
+      <div class="legend">
+        <span><i class="dot" style="background:#5e6ad2"></i>System ${esc(formatTokenCount(totals.systemTokens))}</span>
+        <span><i class="dot" style="background:#3ecf8e"></i>History ${esc(formatTokenCount(totals.conversationTokens))}</span>
+        <span><i class="dot" style="background:#2b2e38;border:1px solid #3b3f4c"></i>Free ${esc(formatTokenCount(totals.remaining))}</span>
+      </div>
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-label">In context</div><div class="stat-value">${esc(formatTokenCount(totals.inContext))}</div></div>
+        <div class="stat"><div class="stat-label">Window</div><div class="stat-value">${totals.window != null ? esc(formatTokenCount(totals.window)) : "—"}</div></div>
+        <div class="stat"><div class="stat-label">Subagents</div><div class="stat-value">${report.subagentSpawns}</div></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="grid">
+    <div class="panel">
+      <h2>System prompt</h2>
+      ${renderBarRows(report.systemSections, chartTotal, SYSTEM_COLORS)}
+    </div>
+    <div class="panel">
+      <h2>Conversation history</h2>
+      ${renderBarRows(report.conversationSections, chartTotal, HISTORY_COLORS)}
+    </div>
+  </section>
+
+  <section class="panel skills">
+    <h2>Skills</h2>
+    <div class="meta" style="margin-bottom:10px">Available (${report.skills.available.length})</div>
+    ${renderSkillChips(report.skills.available, loaded, "available")}
+    ${report.skills.loaded.length > 0 ? `<div class="meta" style="margin:14px 0 10px">Loaded this session</div>${renderSkillChips(report.skills.loaded, loaded, "loaded")}` : ""}
+    ${report.skills.prefer.length > 0 ? `<div class="meta" style="margin:14px 0 10px">Prefer</div>${renderSkillChips(report.skills.prefer, loaded, "loaded")}` : ""}
+  </section>
+
+  <div class="footer">Generated by /gsd context · Token estimates from content size; tool schema overhead may differ.</div>
+</div>
+</body>
+</html>`;
+}
+
+export function writeContextChartHtml(basePath: string, report: ContextBreakdownReport): string {
+  const reportsDir = join(gsdRoot(basePath), "reports");
+  mkdirSync(reportsDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outPath = join(reportsDir, `context-${timestamp}.html`);
+  writeFileSync(outPath, buildContextChartHtml(report), "utf-8");
+  return outPath;
+}

--- a/src/resources/extensions/gsd/context-overlay.ts
+++ b/src/resources/extensions/gsd/context-overlay.ts
@@ -1,0 +1,207 @@
+/**
+ * GSD Context Overlay — TUI chart for /gsd context
+ */
+
+import type { Theme, ThemeColor } from "@gsd/pi-coding-agent";
+import { matchesKey, Key, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+
+import type { ContextBreakdownReport, ContextSectionBreakdown } from "./commands-context.js";
+import { formatTokenCount } from "./metrics.js";
+import { renderProgressBar, rightAlign } from "./tui/render-kit.js";
+
+const SECTION_COLORS: ThemeColor[] = ["accent", "success", "warning", "borderAccent", "text"];
+
+export function getContextChartTotals(report: ContextBreakdownReport): {
+  systemTokens: number;
+  conversationTokens: number;
+  estimated: number;
+  window: number | null;
+  inContext: number;
+  remaining: number;
+} {
+  const systemTokens = report.systemSections.reduce((sum, section) => sum + section.tokens, 0);
+  const conversationTokens = report.conversationSections.reduce((sum, section) => sum + section.tokens, 0);
+  const estimated = systemTokens + conversationTokens;
+  const window = report.contextUsage?.contextWindow ?? null;
+  const inContext = report.contextUsage?.tokens ?? estimated;
+  const remaining = window != null ? Math.max(0, window - inContext) : 0;
+  return { systemTokens, conversationTokens, estimated, window, inContext, remaining };
+}
+
+function formatPct(value: number, total: number): string {
+  if (total <= 0) return "0%";
+  return `${((value / total) * 100).toFixed(total >= 10_000 ? 0 : 1)}%`;
+}
+
+function renderSectionBars(
+  theme: Theme,
+  sections: ContextSectionBreakdown[],
+  total: number,
+  width: number,
+  labelWidth: number,
+): string[] {
+  if (sections.length === 0) return [theme.fg("dim", "    (none)")];
+
+  const maxTokens = Math.max(...sections.map((section) => section.tokens), 1);
+  const barWidth = Math.max(12, width - labelWidth - 22);
+  const lines: string[] = [];
+
+  for (const [index, section] of sections.entries()) {
+    const color = SECTION_COLORS[index % SECTION_COLORS.length]!;
+    const label = truncateToWidth(section.label, labelWidth, "…").padEnd(labelWidth);
+    const bar = renderProgressBar(theme, section.tokens, maxTokens, barWidth, {
+      filledColor: color,
+      filledChar: "█",
+      emptyChar: "░",
+    });
+    const meta = `${formatTokenCount(section.tokens)} ${formatPct(section.tokens, total)}`;
+    lines.push(`    ${theme.fg("muted", label)} ${bar} ${theme.fg(color, meta)}`);
+    if (section.detail) {
+      lines.push(theme.fg("dim", `      ${section.detail}`));
+    }
+  }
+
+  return lines;
+}
+
+export class GSDContextOverlay {
+  private tui: { requestRender: () => void };
+  private theme: Theme;
+  private onClose: () => void;
+  private report: ContextBreakdownReport;
+  private cachedLines?: string[];
+  private scrollOffset = 0;
+  private disposed = false;
+
+  constructor(
+    tui: { requestRender: () => void },
+    theme: Theme,
+    report: ContextBreakdownReport,
+    onClose: () => void,
+  ) {
+    this.tui = tui;
+    this.theme = theme;
+    this.report = report;
+    this.onClose = onClose;
+  }
+
+  invalidate(): void {
+    this.cachedLines = undefined;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || data === "q") {
+      this.dispose();
+      this.onClose();
+      return;
+    }
+    if (matchesKey(data, Key.down) || data === "j") {
+      this.scrollOffset++;
+      this.cachedLines = undefined;
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.up) || data === "k") {
+      this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+      this.cachedLines = undefined;
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.pageDown)) {
+      this.scrollOffset += 12;
+      this.cachedLines = undefined;
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.pageUp)) {
+      this.scrollOffset = Math.max(0, this.scrollOffset - 12);
+      this.cachedLines = undefined;
+      this.tui.requestRender();
+    }
+  }
+
+  render(width: number): string[] {
+    if (this.cachedLines) return this.cachedLines;
+
+    const theme = this.theme;
+    const w = Math.max(width, 60);
+    const totals = getContextChartTotals(this.report);
+    const chartTotal = Math.max(totals.inContext, totals.estimated, 1);
+    const lines: string[] = [];
+
+    lines.push(theme.bold(theme.fg("accent", " Context Breakdown ")));
+    lines.push(theme.fg("muted", "─".repeat(w)));
+
+    if (this.report.modelLabel) {
+      lines.push(rightAlign(theme.fg("muted", "Model"), theme.fg("text", this.report.modelLabel), w));
+    }
+
+    lines.push("");
+    if (totals.window != null) {
+      const usageBarWidth = Math.max(20, w - 28);
+      const usageBar = renderProgressBar(theme, totals.inContext, totals.window, usageBarWidth, {
+        filledColor: totals.inContext / totals.window > 0.85 ? "warning" : "accent",
+      });
+      lines.push(`  ${theme.fg("muted", "Window")} ${usageBar} ${theme.fg("text", `${formatTokenCount(totals.inContext)} / ${formatTokenCount(totals.window)}`)}`);
+    } else {
+      lines.push(`  ${theme.fg("muted", "Estimated")} ${theme.fg("text", formatTokenCount(chartTotal))}`);
+    }
+
+    const splitWidth = Math.max(16, Math.floor((w - 8) / 2));
+    const systemBar = renderProgressBar(theme, totals.systemTokens, chartTotal, splitWidth, { filledColor: "accent" });
+    const convBar = renderProgressBar(theme, totals.conversationTokens, chartTotal, splitWidth, { filledColor: "success" });
+    lines.push("");
+    lines.push(`  ${theme.fg("accent", "System")} ${systemBar} ${theme.fg("muted", formatPct(totals.systemTokens, chartTotal))}`);
+    lines.push(`  ${theme.fg("success", "History")} ${convBar} ${theme.fg("muted", formatPct(totals.conversationTokens, chartTotal))}`);
+
+    lines.push("");
+    lines.push(theme.bold(theme.fg("accent", "  System prompt")));
+    lines.push(...renderSectionBars(theme, this.report.systemSections, chartTotal, w, 22));
+
+    lines.push("");
+    lines.push(theme.bold(theme.fg("accent", "  Conversation")));
+    lines.push(...renderSectionBars(theme, this.report.conversationSections, chartTotal, w, 22));
+
+    lines.push("");
+    lines.push(theme.bold(theme.fg("accent", "  Skills")));
+    const { skills } = this.report;
+    if (skills.available.length > 0) {
+      lines.push(`    ${theme.fg("muted", "Available")} ${theme.fg("text", `${skills.available.length}`)}`);
+      const preview = skills.available.slice(0, 8).join(", ");
+      lines.push(truncateToWidth(`      ${preview}${skills.available.length > 8 ? "…" : ""}`, w));
+    } else {
+      lines.push(theme.fg("dim", "    none in prompt"));
+    }
+    if (skills.loaded.length > 0) {
+      lines.push(`    ${theme.fg("muted", "Loaded")} ${theme.fg("success", skills.loaded.join(", "))}`);
+    }
+    if (skills.prefer.length > 0) {
+      lines.push(`    ${theme.fg("muted", "Prefer")} ${theme.fg("accent", skills.prefer.join(", "))}`);
+    }
+
+    lines.push("");
+    lines.push(theme.bold(theme.fg("accent", "  Agents")));
+    lines.push(`    ${theme.fg("muted", "Subagent spawns")} ${theme.fg("text", String(this.report.subagentSpawns))}`);
+
+    lines.push("");
+    lines.push(theme.fg("muted", `  ${"─".repeat(Math.max(0, w - 4))}`));
+    lines.push(theme.fg("muted", "  esc/q close  │  ↑↓ scroll  │  /gsd context --open for browser chart"));
+
+    const maxScroll = Math.max(0, lines.length - 24);
+    this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
+    this.cachedLines = lines.slice(this.scrollOffset);
+    return this.cachedLines;
+  }
+}
+
+export function formatContextChartText(report: ContextBreakdownReport, width = 72): string {
+  const overlay = new GSDContextOverlay({ requestRender: () => {} }, {
+    fg: (_c, t) => t,
+    bold: (t) => t,
+  } as Theme, report, () => {});
+  return overlay.render(width).join("\n");
+}

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -745,6 +745,11 @@ export function formatCost(cost: number): string {
   return `$${n.toFixed(2)}`;
 }
 
+export function formatPercent(percent: number): string {
+  if (percent >= 10) return percent.toFixed(1);
+  return percent.toFixed(2);
+}
+
 // ─── Budget Prediction ────────────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/tests/commands-context.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-context.test.ts
@@ -4,6 +4,8 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { SessionEntry } from "@gsd/pi-coding-agent";
+
 import {
   analyzeSessionContext,
   buildContextBreakdown,
@@ -13,6 +15,17 @@ import {
 } from "../commands-context.ts";
 
 const PROVIDER = "openai" as const;
+const TS = 1;
+
+function sessionEntries(...messages: unknown[]): SessionEntry[] {
+  return messages.map((message, i) => ({
+    type: "message",
+    id: `entry-${i}`,
+    parentId: i > 0 ? `entry-${i - 1}` : null,
+    timestamp: new Date(TS).toISOString(),
+    message,
+  })) as unknown as SessionEntry[];
+}
 
 test("parseSystemPromptSections splits pi base, skills catalog, and GSD blocks", () => {
   const systemPrompt = [
@@ -46,41 +59,41 @@ test("parseSystemPromptSections splits pi base, skills catalog, and GSD blocks",
 });
 
 test("analyzeSessionContext buckets injections, tool results, and loaded skills", () => {
-  const result = analyzeSessionContext([
+  const result = analyzeSessionContext(sessionEntries(
     {
-      type: "message",
-      message: {
-        role: "custom",
-        customType: "gsd-memory",
-        content: "Memory block about auth patterns",
-      },
+      role: "custom",
+      customType: "gsd-memory",
+      content: "Memory block about auth patterns",
+      display: false,
+      timestamp: TS,
     },
     {
-      type: "message",
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            name: "read",
-            arguments: { path: "/home/user/.agents/skills/tdd/SKILL.md" },
-          },
-          {
-            type: "toolCall",
-            name: "subagent",
-            arguments: { task: "scout the repo" },
-          },
-        ],
-      },
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "tc-read",
+          name: "read",
+          arguments: { path: "/home/user/.agents/skills/tdd/SKILL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "tc-subagent",
+          name: "subagent",
+          arguments: { task: "scout the repo" },
+        },
+      ],
+      timestamp: TS,
     },
     {
-      type: "message",
-      message: {
-        role: "toolResult",
-        content: "skill file contents here",
-      },
+      role: "toolResult",
+      toolCallId: "tc-read",
+      toolName: "read",
+      content: [{ type: "text", text: "skill file contents here" }],
+      isError: false,
+      timestamp: TS,
     },
-  ], PROVIDER);
+  ), PROVIDER);
 
   assert.ok(result.conversationSections.some((section) => section.label === "Memory injection"));
   assert.ok(result.conversationSections.some((section) => section.label === "Tool results"));
@@ -99,15 +112,11 @@ test("formatContextReport lists skills and subagents", () => {
       "[SYSTEM CONTEXT — GSD]",
       "core",
     ].join("\n"),
-    entries: [
-      {
-        type: "message",
-        message: {
-          role: "assistant",
-          content: [{ type: "toolCall", name: "subagent", arguments: {} }],
-        },
-      },
-    ],
+    entries: sessionEntries({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "tc-subagent", name: "subagent", arguments: {} }],
+      timestamp: TS,
+    }),
   });
 
   const output = formatContextReport(report);

--- a/src/resources/extensions/gsd/tests/commands-context.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-context.test.ts
@@ -1,0 +1,131 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  analyzeSessionContext,
+  buildContextBreakdown,
+  formatContextReport,
+  parseSystemPromptSections,
+} from "../commands-context.ts";
+
+const PROVIDER = "openai" as const;
+
+test("parseSystemPromptSections splits pi base, skills catalog, and GSD blocks", () => {
+  const systemPrompt = [
+    "You are Pi.",
+    "<available_skills>",
+    "  <skill><name>frontend-design</name><description>UI</description></skill>",
+    "  <skill><name>tdd</name><description>Tests</description></skill>",
+    "</available_skills>",
+    "[SYSTEM CONTEXT — GSD]",
+    "GSD core instructions here.",
+    "GSD Skill Preferences",
+    "prefer_skills: [\"tdd\"]",
+    "[KNOWLEDGE — Rules from KNOWLEDGE.md]",
+    "Always write tests.",
+    "[PROJECT CODEBASE — File structure]",
+    "src/index.ts",
+  ].join("\n");
+
+  const sections = parseSystemPromptSections(systemPrompt, PROVIDER);
+  const labels = sections.map((section) => section.label);
+
+  assert.ok(labels.includes("Pi base prompt"));
+  assert.ok(labels.includes("Available skills catalog"));
+  assert.ok(labels.includes("GSD system prompt"));
+  assert.ok(labels.includes("Skill preferences"));
+  assert.ok(labels.includes("Knowledge rules"));
+  assert.ok(labels.includes("Codebase map"));
+
+  const skills = sections.find((section) => section.label === "Available skills catalog");
+  assert.equal(skills?.detail, "2 skills");
+});
+
+test("analyzeSessionContext buckets injections, tool results, and loaded skills", () => {
+  const result = analyzeSessionContext([
+    {
+      type: "message",
+      message: {
+        role: "custom",
+        customType: "gsd-memory",
+        content: "Memory block about auth patterns",
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "read",
+            arguments: { path: "/home/user/.agents/skills/tdd/SKILL.md" },
+          },
+          {
+            type: "toolCall",
+            name: "subagent",
+            arguments: { task: "scout the repo" },
+          },
+        ],
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "toolResult",
+        content: "skill file contents here",
+      },
+    },
+  ], PROVIDER);
+
+  assert.ok(result.conversationSections.some((section) => section.label === "Memory injection"));
+  assert.ok(result.conversationSections.some((section) => section.label === "Tool results"));
+  assert.deepEqual(result.skills.loaded, ["tdd"]);
+  assert.equal(result.subagentSpawns, 1);
+});
+
+test("formatContextReport lists skills and subagents", () => {
+  const report = buildContextBreakdown({
+    modelLabel: "claude-code/claude-sonnet-4-6",
+    provider: "claude-code",
+    contextUsage: { tokens: 80_000, contextWindow: 200_000, percent: 40 },
+    systemPrompt: [
+      "Pi base",
+      "<available_skills><skill><name>review</name></skill></available_skills>",
+      "[SYSTEM CONTEXT — GSD]",
+      "core",
+    ].join("\n"),
+    entries: [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", name: "subagent", arguments: {} }],
+        },
+      },
+    ],
+  });
+
+  const output = formatContextReport(report);
+  assert.match(output, /Context Breakdown/);
+  assert.match(output, /Available \(1\): review/);
+  assert.match(output, /Subagent spawns this session: 1/);
+});
+
+test("buildContextBreakdown supports --json shape via handleContext data", () => {
+  const report = buildContextBreakdown({
+    modelLabel: null,
+    provider: PROVIDER,
+    contextUsage: undefined,
+    systemPrompt: "",
+    entries: [],
+  });
+
+  assert.deepEqual(report.skills, {
+    available: [],
+    loaded: [],
+    prefer: [],
+    avoid: [],
+  });
+  assert.equal(report.subagentSpawns, 0);
+});

--- a/src/resources/extensions/gsd/tests/commands-context.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-context.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   analyzeSessionContext,
   buildContextBreakdown,
   formatContextReport,
+  handleContext,
   parseSystemPromptSections,
 } from "../commands-context.ts";
 
@@ -128,4 +132,50 @@ test("buildContextBreakdown supports --json shape via handleContext data", () =>
     avoid: [],
   });
   assert.equal(report.subagentSpawns, 0);
+});
+
+test("handleContext writes open reports under the command project root", async () => {
+  const intendedProject = mkdtempSync(join(tmpdir(), "gsd-context-project-"));
+  const processProject = mkdtempSync(join(tmpdir(), "gsd-context-cwd-"));
+  for (const dir of [intendedProject, processProject]) {
+    mkdirSync(join(dir, ".gsd"), { recursive: true });
+    writeFileSync(join(dir, ".gsd", "PREFERENCES.md"), "");
+  }
+
+  const originalCwd = process.cwd();
+  const originalPath = process.env.PATH;
+  process.chdir(processProject);
+  try {
+    const binDir = mkdtempSync(join(tmpdir(), "gsd-context-bin-"));
+    const xdgOpen = join(binDir, "xdg-open");
+    writeFileSync(xdgOpen, "#!/bin/sh\nexit 0\n");
+    chmodSync(xdgOpen, 0o755);
+    process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+
+    const notifications: string[] = [];
+    const ctx = {
+      model: undefined,
+      getContextUsage: () => undefined,
+      getSystemPrompt: () => "",
+      hasUI: false,
+      sessionManager: { getEntries: () => [] },
+      ui: {
+        notify: (message: string) => notifications.push(message),
+      },
+    } as any;
+
+    await handleContext("--open", ctx, intendedProject);
+
+    assert.ok(existsSync(join(intendedProject, ".gsd", "reports")));
+    assert.equal(
+      existsSync(join(processProject, ".gsd", "reports")),
+      false,
+      "must not write reports under process.cwd() when command cwd differs",
+    );
+    assert.ok(readdirSync(join(intendedProject, ".gsd", "reports")).some((name) => /^context-.*\.html$/.test(name)));
+    assert.match(notifications[0] ?? "", new RegExp(intendedProject.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  } finally {
+    process.env.PATH = originalPath;
+    process.chdir(originalCwd);
+  }
 });

--- a/src/resources/extensions/gsd/tests/commands-do.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-do.test.ts
@@ -36,6 +36,8 @@ const ROUTES: Route[] = [
   { keywords: ["visualize", "viz", "graph", "chart", "show graph"], command: "visualize" },
   { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture" },
   { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
+  { keywords: ["context usage", "context window", "how much context", "token usage", "tokens used"], command: "usage" },
+  { keywords: ["context breakdown", "what is using context", "skills in context", "agents in context"], command: "context" },
   { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report" },
   { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
   { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests" },
@@ -138,6 +140,18 @@ test("/gsd do: routes 'session report' to session-report", () => {
   const match = matchRoute("show me the session report");
   assert.ok(match);
   assert.equal(match.command, "session-report");
+});
+
+test("/gsd do: routes 'context usage' to usage", () => {
+  const match = matchRoute("what is my context usage");
+  assert.ok(match);
+  assert.equal(match.command, "usage");
+});
+
+test("/gsd do: routes 'context breakdown' to context", () => {
+  const match = matchRoute("show me a context breakdown");
+  assert.ok(match);
+  assert.equal(match.command, "context");
 });
 
 test("/gsd do: routes 'diagnose issue' to debug (not doctor)", () => {

--- a/src/resources/extensions/gsd/tests/commands-usage.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-usage.test.ts
@@ -1,36 +1,50 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import type { SessionEntry } from "@gsd/pi-coding-agent";
+
 import {
   formatUsageReport,
   scanSessionTokenTotals,
   handleUsage,
 } from "../commands-usage.ts";
 
+const TS = 1;
+
+function sessionEntries(...messages: unknown[]): SessionEntry[] {
+  return messages.map((message, i) => ({
+    type: "message",
+    id: `entry-${i}`,
+    parentId: i > 0 ? `entry-${i - 1}` : null,
+    timestamp: new Date(TS).toISOString(),
+    message,
+  })) as unknown as SessionEntry[];
+}
+
 test("scanSessionTokenTotals aggregates assistant usage and tool calls", () => {
-  const totals = scanSessionTokenTotals([
+  const totals = scanSessionTokenTotals(sessionEntries(
     {
-      type: "message",
-      message: {
-        role: "user",
-      },
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: TS,
     },
     {
-      type: "message",
-      message: {
-        role: "assistant",
-        usage: {
-          input: 1000,
-          output: 200,
-          cacheRead: 500,
-          cacheWrite: 100,
-          totalTokens: 1800,
-          cost: { total: 0.05 },
-        },
-        content: [{ type: "toolCall" }, { type: "text" }],
+      role: "assistant",
+      usage: {
+        input: 1000,
+        output: 200,
+        cacheRead: 500,
+        cacheWrite: 100,
+        totalTokens: 1800,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.05 },
       },
+      content: [
+        { type: "toolCall", id: "tc-1", name: "read", arguments: {} },
+        { type: "text", text: "done" },
+      ],
+      timestamp: TS,
     },
-  ]);
+  ));
 
   assert.equal(totals.userMessages, 1);
   assert.equal(totals.assistantMessages, 1);

--- a/src/resources/extensions/gsd/tests/commands-usage.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-usage.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatUsageReport,
+  scanSessionTokenTotals,
+  handleUsage,
+} from "../commands-usage.ts";
+
+test("scanSessionTokenTotals aggregates assistant usage and tool calls", () => {
+  const totals = scanSessionTokenTotals([
+    {
+      type: "message",
+      message: {
+        role: "user",
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        usage: {
+          input: 1000,
+          output: 200,
+          cacheRead: 500,
+          cacheWrite: 100,
+          totalTokens: 1800,
+          cost: { total: 0.05 },
+        },
+        content: [{ type: "toolCall" }, { type: "text" }],
+      },
+    },
+  ]);
+
+  assert.equal(totals.userMessages, 1);
+  assert.equal(totals.assistantMessages, 1);
+  assert.equal(totals.input, 1000);
+  assert.equal(totals.output, 200);
+  assert.equal(totals.cacheRead, 500);
+  assert.equal(totals.cacheWrite, 100);
+  assert.equal(totals.total, 1800);
+  assert.equal(totals.cost, 0.05);
+  assert.equal(totals.toolCalls, 1);
+});
+
+test("formatUsageReport shows context percent and remaining tokens", () => {
+  const report = formatUsageReport({
+    modelLabel: "claude-code/claude-sonnet-4-6",
+    contextUsage: {
+      tokens: 50_000,
+      contextWindow: 200_000,
+      percent: 25,
+    },
+    sessionTotals: scanSessionTokenTotals([]),
+  });
+
+  assert.match(report, /Model: claude-code\/claude-sonnet-4-6/);
+  assert.match(report, /In context: 50\.0k tokens \(25\.0%\)/);
+  assert.match(report, /Remaining: 150\.0k tokens/);
+});
+
+test("formatUsageReport explains unknown context after compaction", () => {
+  const report = formatUsageReport({
+    modelLabel: "openai/gpt-5",
+    contextUsage: {
+      tokens: null,
+      contextWindow: 200_000,
+      percent: null,
+    },
+    sessionTotals: scanSessionTokenTotals([]),
+  });
+
+  assert.match(report, /In context: unknown \(after compaction/);
+});
+
+test("handleUsage emits JSON when --json is passed", async () => {
+  const messages: string[] = [];
+  const ctx = {
+    model: { provider: "claude-code", id: "claude-sonnet-4-6", contextWindow: 200_000 },
+    getContextUsage: () => ({ tokens: 10_000, contextWindow: 200_000, percent: 5 }),
+    sessionManager: { getEntries: () => [] },
+    ui: {
+      notify(message: string) {
+        messages.push(message);
+      },
+    },
+  };
+
+  await handleUsage("--json", ctx as any);
+
+  assert.equal(messages.length, 1);
+  const parsed = JSON.parse(messages[0]!);
+  assert.equal(parsed.model, "claude-code/claude-sonnet-4-6");
+  assert.equal(parsed.contextUsage.tokens, 10_000);
+  assert.equal(parsed.sessionTotals.input, 0);
+});

--- a/src/resources/extensions/gsd/tests/context-chart.test.ts
+++ b/src/resources/extensions/gsd/tests/context-chart.test.ts
@@ -4,9 +4,23 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+import type { SessionEntry } from "@gsd/pi-coding-agent";
+
 import { buildContextChartHtml, writeContextChartHtml } from "../context-chart-html.ts";
 import { formatContextChartText, getContextChartTotals } from "../context-overlay.ts";
 import { buildContextBreakdown } from "../commands-context.ts";
+
+const TS = 1;
+
+function sessionEntries(...messages: unknown[]): SessionEntry[] {
+  return messages.map((message, i) => ({
+    type: "message",
+    id: `entry-${i}`,
+    parentId: i > 0 ? `entry-${i - 1}` : null,
+    timestamp: new Date(TS).toISOString(),
+    message,
+  })) as unknown as SessionEntry[];
+}
 
 const SAMPLE_REPORT = buildContextBreakdown({
   modelLabel: "claude-code/claude-sonnet-4-6",
@@ -20,23 +34,23 @@ const SAMPLE_REPORT = buildContextBreakdown({
     "[KNOWLEDGE — Rules]",
     "rule one",
   ].join("\n"),
-  entries: [
+  entries: sessionEntries(
     {
-      type: "message",
-      message: {
-        role: "custom",
-        customType: "gsd-memory",
-        content: "auth memory block",
-      },
+      role: "custom",
+      customType: "gsd-memory",
+      content: "auth memory block",
+      display: false,
+      timestamp: TS,
     },
     {
-      type: "message",
-      message: {
-        role: "toolResult",
-        content: "large tool output ".repeat(20),
-      },
+      role: "toolResult",
+      toolCallId: "tc-1",
+      toolName: "read",
+      content: [{ type: "text", text: "large tool output ".repeat(20) }],
+      isError: false,
+      timestamp: TS,
     },
-  ],
+  ),
 });
 
 test("getContextChartTotals aggregates system and conversation buckets", () => {

--- a/src/resources/extensions/gsd/tests/context-chart.test.ts
+++ b/src/resources/extensions/gsd/tests/context-chart.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 
 import type { SessionEntry } from "@gsd/pi-coding-agent";
 
+import type { ContextBreakdownReport } from "../commands-context.ts";
 import { buildContextChartHtml, writeContextChartHtml } from "../context-chart-html.ts";
 import { formatContextChartText, getContextChartTotals } from "../context-overlay.ts";
 import { buildContextBreakdown } from "../commands-context.ts";
@@ -69,6 +70,22 @@ test("buildContextChartHtml renders donut and bar chart markup", () => {
   assert.match(html, /Conversation history/);
   assert.match(html, /class="bar-row"/);
   assert.match(html, /chip-loaded/);
+});
+
+test("buildContextChartHtml accounts for model-reported overhead in donut", () => {
+  const report: ContextBreakdownReport = {
+    modelLabel: "model",
+    contextUsage: { tokens: 80, contextWindow: 200, percent: 40 },
+    systemSections: [{ label: "System", tokens: 50 }],
+    conversationSections: [{ label: "History", tokens: 10 }],
+    skills: { available: [], loaded: [], prefer: [], avoid: [] },
+    subagentSpawns: 0,
+  };
+
+  const html = buildContextChartHtml(report);
+
+  assert.match(html, /Other — 20/);
+  assert.match(html, /Free — 120/);
 });
 
 test("writeContextChartHtml saves under .gsd/reports", () => {

--- a/src/resources/extensions/gsd/tests/context-chart.test.ts
+++ b/src/resources/extensions/gsd/tests/context-chart.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildContextChartHtml, writeContextChartHtml } from "../context-chart-html.ts";
+import { formatContextChartText, getContextChartTotals } from "../context-overlay.ts";
+import { buildContextBreakdown } from "../commands-context.ts";
+
+const SAMPLE_REPORT = buildContextBreakdown({
+  modelLabel: "claude-code/claude-sonnet-4-6",
+  provider: "claude-code",
+  contextUsage: { tokens: 80_000, contextWindow: 200_000, percent: 40 },
+  systemPrompt: [
+    "Pi base",
+    "<available_skills><skill><name>review</name></skill></available_skills>",
+    "[SYSTEM CONTEXT — GSD]",
+    "core",
+    "[KNOWLEDGE — Rules]",
+    "rule one",
+  ].join("\n"),
+  entries: [
+    {
+      type: "message",
+      message: {
+        role: "custom",
+        customType: "gsd-memory",
+        content: "auth memory block",
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "toolResult",
+        content: "large tool output ".repeat(20),
+      },
+    },
+  ],
+});
+
+test("getContextChartTotals aggregates system and conversation buckets", () => {
+  const totals = getContextChartTotals(SAMPLE_REPORT);
+  assert.ok(totals.systemTokens > 0);
+  assert.ok(totals.conversationTokens > 0);
+  assert.equal(totals.inContext, 80_000);
+  assert.equal(totals.remaining, 120_000);
+});
+
+test("buildContextChartHtml renders donut and bar chart markup", () => {
+  const html = buildContextChartHtml(SAMPLE_REPORT);
+  assert.match(html, /Context Breakdown/);
+  assert.match(html, /class="donut"/);
+  assert.match(html, /System prompt/);
+  assert.match(html, /Conversation history/);
+  assert.match(html, /class="bar-row"/);
+  assert.match(html, /chip-loaded/);
+});
+
+test("writeContextChartHtml saves under .gsd/reports", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-context-chart-"));
+  const outPath = writeContextChartHtml(base, SAMPLE_REPORT);
+  assert.match(outPath, /context-.*\.html$/);
+  const saved = readFileSync(outPath, "utf-8");
+  assert.match(saved, /Context Breakdown/);
+});
+
+test("formatContextChartText includes chart sections", () => {
+  const text = formatContextChartText(SAMPLE_REPORT, 80);
+  assert.match(text, /Context Breakdown/);
+  assert.match(text, /System prompt/);
+  assert.match(text, /Conversation/);
+  assert.match(text, /█/);
+});


### PR DESCRIPTION
## Summary

- Adds `/gsd usage` to show current context window fill, session token/cost totals, and auto-pause/compaction thresholds from preferences.
- Adds `/gsd context` to break down what's consuming context: system prompt sections (skills catalog, GSD injections, knowledge, codebase map), conversation history buckets, loaded skills, and subagent spawns.
- Default `/gsd context` opens a TUI bar-chart overlay; `--open` writes an HTML chart to `.gsd/reports/` and opens it in the browser; `--text` and `--json` are also supported.
- Wired into help, tab completion, and `/gsd do` natural-language routing.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-context.test.ts src/resources/extensions/gsd/tests/commands-usage.test.ts src/resources/extensions/gsd/tests/context-chart.test.ts src/resources/extensions/gsd/tests/commands-do.test.ts src/resources/extensions/gsd/tests/help-menu-coverage.test.ts`
- [ ] Manual: run `/gsd usage` in an active session and confirm window % + session totals
- [ ] Manual: run `/gsd context` and confirm TUI overlay renders
- [ ] Manual: run `/gsd context --open` and confirm HTML report opens in browser


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782567719&installation_id=134682257&pr_number=219&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F219&signature=c6047f9b2d5ec0209a75a50bf0a5774966dcd1ba6d11ee791386c103a4471aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostics and local report files; no auth or execution-path changes beyond new command handlers.
> 
> **Overview**
> Adds two GSD observability commands: **`/gsd usage`** reports live context-window fill, session token/cost totals, and preference thresholds (`--json` supported); **`/gsd context`** estimates what fills the window by splitting the system prompt (Pi base, skills catalog, GSD blocks, knowledge, codebase map) and conversation history (injections, tool results, loaded skills, subagent spawns).
> 
> Default **`/gsd context`** opens a scrollable TUI overlay; **`--text`**, **`--json`**, and **`--open`** (HTML chart under `.gsd/reports/` via `projectRoot()`, not `process.cwd()`) are also available. Commands are registered in help, tab completion, bootstrap lists, and **`/gsd do`** NL routing. Shared **`formatPercent`** in `metrics.ts` supports display; unit tests cover parsing, reports, charts, and report path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6332b6d6076b23ebf5eaab71d4e361dfce4b818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->