### PR TITLE
fix(install): bundle extension-critical deps for clean global installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,12 @@
         "@gsd/pi-ai",
         "@gsd/pi-coding-agent",
         "@gsd/pi-tui",
-        "undici"
+        "@modelcontextprotocol/sdk",
+        "minimatch",
+        "picomatch",
+        "proper-lockfile",
+        "undici",
+        "yaml"
       ],
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,12 @@
     "@gsd/pi-ai",
     "@gsd/pi-coding-agent",
     "@gsd/pi-tui",
-    "undici"
+    "@modelcontextprotocol/sdk",
+    "minimatch",
+    "picomatch",
+    "proper-lockfile",
+    "undici",
+    "yaml"
   ],
   "devDependencies": {
     "@types/node": "^24.12.0",
@@ -223,6 +228,11 @@
     "@gsd/pi-ai",
     "@gsd/pi-coding-agent",
     "@gsd/pi-tui",
-    "undici"
+    "@modelcontextprotocol/sdk",
+    "minimatch",
+    "picomatch",
+    "proper-lockfile",
+    "undici",
+    "yaml"
   ]
 }

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -89,6 +89,15 @@ function getAliases(): Record<string, string> {
 
 	const piCodingAgentEntry = packageIndex;
 
+	const mcpClientEntry = require.resolve("@modelcontextprotocol/sdk/client/index.js");
+	const mcpStdioEntry = require.resolve("@modelcontextprotocol/sdk/client/stdio.js");
+	const mcpStreamableHttpEntry = require.resolve("@modelcontextprotocol/sdk/client/streamableHttp.js");
+	const mcpAuthEntry = require.resolve("@modelcontextprotocol/sdk/client/auth.js");
+	const yamlEntry = require.resolve("yaml");
+	const minimatchEntry = require.resolve("minimatch");
+	const properLockfileEntry = require.resolve("proper-lockfile");
+	const picomatchEntry = require.resolve("picomatch");
+
 	_aliases = {
 		"@gsd/pi-coding-agent": piCodingAgentEntry,
 		"@gsd/pi-agent-core": resolveWorkspaceOrImport("pi-agent-core/dist/index.js", "@gsd/pi-agent-core"),
@@ -104,6 +113,15 @@ function getAliases(): Record<string, string> {
 		"@sinclair/typebox/compile": typeboxCompileEntry,
 		"@sinclair/typebox/compiler": sinclairTypeboxCompilerEntry,
 		"@sinclair/typebox/value": typeboxValueEntry,
+		"@modelcontextprotocol/sdk/client": mcpClientEntry,
+		"@modelcontextprotocol/sdk/client/index.js": mcpClientEntry,
+		"@modelcontextprotocol/sdk/client/stdio.js": mcpStdioEntry,
+		"@modelcontextprotocol/sdk/client/streamableHttp.js": mcpStreamableHttpEntry,
+		"@modelcontextprotocol/sdk/client/auth.js": mcpAuthEntry,
+		yaml: yamlEntry,
+		minimatch: minimatchEntry,
+		"proper-lockfile": properLockfileEntry,
+		picomatch: picomatchEntry,
 	};
 
 	return _aliases;

--- a/scripts/__tests__/installer-packaging.test.mjs
+++ b/scripts/__tests__/installer-packaging.test.mjs
@@ -8,14 +8,32 @@ import test from "node:test";
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 const lockfile = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
-test("installer tarball bundles undici at the package root", () => {
-  assert.ok(pkg.dependencies.undici, "root package must depend on undici");
-  assert.ok(
-    pkg.bundledDependencies.includes("undici"),
-    "root bundledDependencies must include undici",
-  );
-  assert.ok(
-    lockfile.packages[""].bundleDependencies.includes("undici"),
-    "lockfile root bundleDependencies must include undici",
-  );
+/** External deps that must ship inside the tarball for --ignore-scripts global installs. */
+const REQUIRED_BUNDLED_EXTERNALS = [
+  "@modelcontextprotocol/sdk",
+  "minimatch",
+  "picomatch",
+  "proper-lockfile",
+  "undici",
+  "yaml",
+];
+
+test("installer deps module exposes postinstall orchestration", async () => {
+  const { runPostinstallDeps, linkWorkspacePackages } = await import("../install/deps.js");
+  assert.equal(typeof runPostinstallDeps, "function");
+  assert.equal(typeof linkWorkspacePackages, "function");
+});
+
+test("installer tarball bundles extension-critical externals at the package root", () => {
+  for (const dep of REQUIRED_BUNDLED_EXTERNALS) {
+    assert.ok(pkg.dependencies[dep], `root package must depend on ${dep}`);
+    assert.ok(
+      pkg.bundledDependencies.includes(dep),
+      `root bundledDependencies must include ${dep}`,
+    );
+    assert.ok(
+      lockfile.packages[""].bundleDependencies.includes(dep),
+      `lockfile root bundleDependencies must include ${dep}`,
+    );
+  }
 });

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -314,11 +314,11 @@ try {
     process.exit(1);
   }
 
-  // --- Global install smoke (catches empty node_modules/undici placeholder on npm -g) ---
-  console.log('==> Testing global install (undici resolution)...');
+  // --- Global install smoke (npx path: --ignore-scripts, then repair) ---
+  console.log('==> Testing global install (--ignore-scripts, bundled deps + repair)...');
   const globalPrefix = mkdtempSync(join(tmpdir(), 'validate-pack-global-'));
   try {
-    execFileSync(getNpmCommand(), ['install', '-g', tarball, '--prefix', globalPrefix], {
+    execFileSync(getNpmCommand(), ['install', '-g', tarball, '--ignore-scripts', '--prefix', globalPrefix], {
       encoding: 'utf8',
       shell: process.platform === 'win32',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -335,12 +335,52 @@ try {
       maxBuffer: DEFAULT_MAX_BUFFER,
     }).trim();
     const globalRoot = join(globalNodeModules, '@opengsd', 'gsd-pi');
-    const globalUndiciPkg = join(globalRoot, 'node_modules', 'undici', 'package.json');
-    if (!existsSync(globalUndiciPkg)) {
-      console.log('ERROR: Global install left node_modules/undici unresolved.');
-      console.log(`    Expected: ${globalUndiciPkg}`);
+
+    const bundledExternalDeps = [
+      '@modelcontextprotocol/sdk',
+      'minimatch',
+      'picomatch',
+      'proper-lockfile',
+      'undici',
+      'yaml',
+    ];
+    for (const dep of bundledExternalDeps) {
+      const segments = dep.startsWith('@') ? dep.split('/') : [dep];
+      const pkgJsonPath = join(globalRoot, 'node_modules', ...segments, 'package.json');
+      if (!existsSync(pkgJsonPath)) {
+        console.log(`ERROR: Global --ignore-scripts install left bundled dep unresolved: ${dep}`);
+        console.log(`    Expected: ${pkgJsonPath}`);
+        process.exit(1);
+      }
+    }
+
+    const linkScript = join(globalRoot, 'scripts', 'link-workspace-packages.cjs');
+    execFileSync(process.execPath, [linkScript], {
+      cwd: globalRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+    });
+    execFileSync(getNpmCommand(), ['install', '--ignore-scripts'], {
+      cwd: globalRoot,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: DEFAULT_MAX_BUFFER,
+      env: {
+        ...process.env,
+        npm_config_cache: npmCacheDir,
+      },
+    });
+
+    const globalOpenaiIndex = join(globalRoot, 'node_modules', 'openai', 'index.js');
+    if (!existsSync(globalOpenaiIndex)) {
+      console.log('ERROR: Global install left node_modules/openai unresolved after repair.');
+      console.log(`    Expected: ${globalOpenaiIndex}`);
       process.exit(1);
     }
+
     execFileSync(
       process.execPath,
       [
@@ -356,7 +396,37 @@ try {
         maxBuffer: DEFAULT_MAX_BUFFER,
       },
     );
-    console.log('    Global install resolves undici for pi-coding-agent.');
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `await import(${JSON.stringify('@modelcontextprotocol/sdk/client/index.js')}); await import('yaml'); await import('minimatch');`,
+      ],
+      {
+        cwd: globalRoot,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `await import(${JSON.stringify('file://' + join(globalRoot, 'node_modules', '@gsd', 'pi-ai', 'dist', 'providers', 'openai-responses.js').replace(/\\/g, '/'))});`,
+      ],
+      {
+        cwd: globalPrefix,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    Global --ignore-scripts install keeps bundled deps and repair resolves openai/pi-ai.');
   } catch (err) {
     console.log('ERROR: Global install smoke test failed.');
     if (err.stdout) console.log(err.stdout);

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -21,7 +21,7 @@ import {
 } from "@gsd/pi-coding-agent";
 import { Text } from "@gsd/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { Client } from "@modelcontextprotocol/sdk/client";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { buildHttpTransportOpts } from "./auth.js";

--- a/src/resources/extensions/mcp-client/manager.ts
+++ b/src/resources/extensions/mcp-client/manager.ts
@@ -5,7 +5,7 @@
  * for runtime tools, TUI commands, and app settings surfaces.
  */
 
-import { Client } from "@modelcontextprotocol/sdk/client";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";


### PR DESCRIPTION
## Summary
- Bundle `@modelcontextprotocol/sdk`, `yaml`, `minimatch`, `proper-lockfile`, and `picomatch` in the published tarball so `npm install -g --ignore-scripts` (the npx installer path) still has real packages for bundled extensions.
- Add jiti aliases for those modules in the extension loader and use explicit MCP client import paths.
- Extend installer packaging tests and `validate-pack` global smoke to simulate the npx install flow and verify bundled deps resolve before repair.

Fixes clean-install failures such as:
```
Extension load error: Cannot find module '@modelcontextprotocol/sdk/client'
```

## Test plan
- [x] `node --test scripts/__tests__/installer-packaging.test.mjs`
- [ ] `npm run validate-pack` (full publish gate)
- [ ] `npx @opengsd/gsd-pi@latest --yes` on a clean machine / prefix
- [ ] `gsd` starts without mcp-client extension load errors


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782568248&installation_id=134682257&pr_number=220&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F220&signature=e32c6f092ae386057de63202342bff07d8dd6a41a1739a66874aefb7660265ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to publish/install packaging, extension import paths, and validation smoke tests; no runtime auth or data-handling logic changes.
> 
> **Overview**
> This PR fixes **global / npx installs** that run with **`--ignore-scripts`**, where bundled extensions could not resolve **`@modelcontextprotocol/sdk`** and related modules.
> 
> The published tarball now **bundles** `@modelcontextprotocol/sdk`, `yaml`, `minimatch`, `proper-lockfile`, and `picomatch` alongside `undici` in root **`bundledDependencies`** / lockfile **`bundleDependencies`**. The pi-coding-agent extension **jiti loader** gains **aliases** for those packages (including explicit MCP client subpaths), and **mcp-client** imports switch to **`@modelcontextprotocol/sdk/client/index.js`** (and matching subpaths).
> 
> **Packaging tests** assert all extension-critical externals are declared and bundled; **`validate-pack`** global smoke now installs with **`--ignore-scripts`**, checks each bundled dep exists, runs workspace link + repair, and imports MCP/yaml/minimatch plus **openai** / **pi-ai** paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06228fa9c2bdeb2a3d3ce9398033074c5b1d61c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->