### PR TITLE
fix(pi-ai): unblock build by removing @smithy/types import

### DIFF
--- a/packages/pi-ai/src/providers/amazon-bedrock.ts
+++ b/packages/pi-ai/src/providers/amazon-bedrock.ts
@@ -21,7 +21,6 @@ import {
 	ToolResultStatus,
 } from "@aws-sdk/client-bedrock-runtime";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import type { DocumentType } from "@smithy/types";
 import { calculateCost } from "../models.js";
 import type {
 	Api,
@@ -785,7 +784,7 @@ function convertToolConfig(
 		toolSpec: {
 			name: tool.name,
 			description: tool.description,
-			inputSchema: { json: tool.parameters as unknown as DocumentType },
+			inputSchema: { json: tool.parameters as any }, // TypeBox already generates JSON Schema
 		},
 	}));
 

--- a/packages/pi-ai/test/bedrock-tool-config.test.ts
+++ b/packages/pi-ai/test/bedrock-tool-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { Type } from "typebox";
+
+const bedrockMock = vi.hoisted(() => ({
+	constructorCalls: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+
+	class BedrockRuntimeClient {
+		constructor(config: Record<string, unknown>) {
+			bedrockMock.constructorCalls.push(config);
+		}
+
+		send(): Promise<never> {
+			return Promise.reject(new Error("mock send"));
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { getModel } from "../src/models.ts";
+import { streamBedrock } from "../src/providers/amazon-bedrock.ts";
+import type { Context, Tool } from "../src/types.ts";
+
+const baseModel = getModel("amazon-bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+
+const echoSchema = Type.Object({
+	message: Type.String({ description: "Message to echo" }),
+});
+
+const echoTool: Tool<typeof echoSchema> = {
+	name: "echo",
+	description: "Echo a message",
+	parameters: echoSchema,
+};
+
+async function capturePayload(context: Context): Promise<unknown> {
+	let capturedPayload: unknown;
+	const s = streamBedrock(baseModel, context, {
+		cacheRetention: "none",
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			capturedPayload = payload;
+			return payload;
+		},
+	});
+	for await (const event of s) {
+		if (event.type === "error") break;
+	}
+	return capturedPayload;
+}
+
+describe("bedrock tool config", () => {
+	it("passes TypeBox tool parameters through as JSON schema", async () => {
+		const payload = await capturePayload({
+			messages: [{ role: "user", content: "echo hello", timestamp: Date.now() }],
+			tools: [echoTool],
+		});
+
+		expect(payload).toBeDefined();
+		const toolConfig = (payload as { toolConfig?: { tools?: Array<{ toolSpec?: { inputSchema?: { json?: unknown } } }> } })
+			.toolConfig;
+		expect(toolConfig?.tools).toHaveLength(1);
+		expect(toolConfig?.tools?.[0]?.toolSpec?.inputSchema?.json).toEqual(echoSchema);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a TypeScript build failure in `@gsd/pi-ai` where the Bedrock provider imported `DocumentType` from `@smithy/types`, a package that is not a direct dependency of the workspace and cannot be resolved by `tsc`.

The tool schema cast now uses `as any`, consistent with the existing OpenAI completions provider pattern for TypeBox-generated JSON Schema.

## Test plan

- [x] `npm run build -w @gsd/pi-ai`
- [ ] CI green on PR checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only change plus a mocked test; runtime Bedrock tool payload shape is unchanged aside from satisfying the compiler.
> 
> **Overview**
> Fixes a **TypeScript build break** in the Bedrock provider by dropping the `@smithy/types` `DocumentType` import (not a direct workspace dependency) and casting tool `inputSchema.json` with **`as any`**, matching how other providers treat TypeBox-generated JSON Schema.
> 
> Adds a **unit test** that hooks `streamBedrock`’s `onPayload` and asserts tool parameters are forwarded unchanged into `toolConfig.tools[].toolSpec.inputSchema.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c10a3920b01be41205e999fea7ba6ea613a378e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782574797&installation_id=134682257&pr_number=221&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F221&signature=8e73c16bb4bd695ef5ecc8d24d8f56ac6d2b9d31956eafa94355eaf9d49f80ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->