### PR TITLE
fix(installer): materialize deps after global --ignore-scripts install

### DIFF
--- a/scripts/__tests__/installer-packaging.test.mjs
+++ b/scripts/__tests__/installer-packaging.test.mjs
@@ -19,9 +19,11 @@ const REQUIRED_BUNDLED_EXTERNALS = [
 ];
 
 test("installer deps module exposes postinstall orchestration", async () => {
-  const { runPostinstallDeps, linkWorkspacePackages } = await import("../install/deps.js");
+  const { runPostinstallDeps, linkWorkspacePackages, repairPackageDependencies } =
+    await import("../install/deps.js");
   assert.equal(typeof runPostinstallDeps, "function");
   assert.equal(typeof linkWorkspacePackages, "function");
+  assert.equal(typeof repairPackageDependencies, "function");
 });
 
 test("installer tarball bundles extension-critical externals at the package root", () => {

--- a/scripts/install/deps.js
+++ b/scripts/install/deps.js
@@ -167,7 +167,7 @@ export async function repairPackageDependencies(packageRoot, { ui, quiet = false
   const pkgJson = join(packageRoot, 'package.json')
   if (!existsSync(pkgJson)) return
 
-  const stop = ui?.start?.(quiet ? undefined : 'Installing dependencies...')
+  const stop = quiet ? undefined : ui?.start?.('Installing dependencies...')
   const result = await execCommand('npm install --ignore-scripts', { cwd: packageRoot })
   stop?.()
 
@@ -329,8 +329,8 @@ export async function installRtk({ skip, ui, verifyOnly = false }) {
 
 export async function runPostinstallDeps(packageRoot, { skipChromium, skipRtk, quiet = true }) {
   const ui = quiet ? null : createPlainUi()
-  linkWorkspacePackages(packageRoot, ui)
   await repairPackageDependencies(packageRoot, { ui, quiet })
+  linkWorkspacePackages(packageRoot, ui)
   await installChromium({ skip: skipChromium, ui })
   await installRtk({ skip: skipRtk, ui })
 }
@@ -343,8 +343,8 @@ export async function runInteractiveDeps(packageRoot, {
   promptChromium,
   promptRtk,
 }) {
-  linkWorkspacePackages(packageRoot, ui)
   await repairPackageDependencies(packageRoot, { ui, quiet: false })
+  linkWorkspacePackages(packageRoot, ui)
 
   let installChromiumFlag = skipChromium
   if (!skipChromium && promptChromium) {

--- a/scripts/install/deps.js
+++ b/scripts/install/deps.js
@@ -158,6 +158,34 @@ function execCommand(command, opts = {}) {
   })
 }
 
+/**
+ * npm install -g --ignore-scripts leaves empty node_modules/* placeholders for
+ * hoisted deps (openai, @anthropic-ai/sdk, …). Run npm install in packageRoot
+ * to materialize the real packages without re-running lifecycle scripts.
+ */
+export async function repairPackageDependencies(packageRoot, { ui, quiet = false } = {}) {
+  const pkgJson = join(packageRoot, 'package.json')
+  if (!existsSync(pkgJson)) return
+
+  const stop = ui?.start?.(quiet ? undefined : 'Installing dependencies...')
+  const result = await execCommand('npm install --ignore-scripts', { cwd: packageRoot })
+  stop?.()
+
+  if (!result.ok) {
+    const output = (result.stderr + '\n' + result.stdout).trim()
+    const meaningful = output.split('\n')
+      .filter((line) => !line.includes('npm warn') && !line.includes('npm WARN') && line.trim())
+      .slice(-3)
+      .join('; ')
+    ui?.warn?.('Dependencies', meaningful || 'npm install failed')
+    return
+  }
+
+  if (!quiet) {
+    ui?.step?.('Dependencies', 'installed')
+  }
+}
+
 export function linkWorkspacePackages(packageRoot, ui) {
   const scriptPath = join(packageRoot, 'scripts', 'link-workspace-packages.cjs')
   if (!existsSync(scriptPath)) return
@@ -302,6 +330,7 @@ export async function installRtk({ skip, ui, verifyOnly = false }) {
 export async function runPostinstallDeps(packageRoot, { skipChromium, skipRtk, quiet = true }) {
   const ui = quiet ? null : createPlainUi()
   linkWorkspacePackages(packageRoot, ui)
+  await repairPackageDependencies(packageRoot, { ui, quiet })
   await installChromium({ skip: skipChromium, ui })
   await installRtk({ skip: skipRtk, ui })
 }
@@ -315,6 +344,7 @@ export async function runInteractiveDeps(packageRoot, {
   promptRtk,
 }) {
   linkWorkspacePackages(packageRoot, ui)
+  await repairPackageDependencies(packageRoot, { ui, quiet: false })
 
   let installChromiumFlag = skipChromium
   if (!skipChromium && promptChromium) {

--- a/scripts/link-workspace-packages.cjs
+++ b/scripts/link-workspace-packages.cjs
@@ -22,8 +22,8 @@ const { getLinkablePackages, REPO_ROOT } = require('./lib/workspace-manifest.cjs
 
 /**
  * npm install -g --ignore-scripts can leave empty node_modules/* placeholders.
- * install/deps.js runs `npm install --ignore-scripts` in packageRoot after linking
- * to materialize hoisted deps (openai, partial-json, …). This helper still seeds
+ * install/deps.js may run `npm install --ignore-scripts` in packageRoot to
+ * materialize hoisted deps (openai, partial-json, …). This helper still seeds
  * root undici from packages/pi-coding-agent when that repair has not run yet.
  */
 function ensureRootUndici() {

--- a/scripts/link-workspace-packages.cjs
+++ b/scripts/link-workspace-packages.cjs
@@ -21,9 +21,10 @@ const { resolve, join } = require('path')
 const { getLinkablePackages, REPO_ROOT } = require('./lib/workspace-manifest.cjs')
 
 /**
- * npm global installs can leave an empty node_modules/undici placeholder while the
- * bundled @gsd/pi-coding-agent copy (without nested deps) still imports undici.
- * Seed root undici from the shipped packages/pi-coding-agent copy when needed.
+ * npm install -g --ignore-scripts can leave empty node_modules/* placeholders.
+ * install/deps.js runs `npm install --ignore-scripts` in packageRoot after linking
+ * to materialize hoisted deps (openai, partial-json, …). This helper still seeds
+ * root undici from packages/pi-coding-agent when that repair has not run yet.
  */
 function ensureRootUndici() {
   const rootUndiciDir = join(REPO_ROOT, 'node_modules', 'undici')


### PR DESCRIPTION
npm install -g --ignore-scripts leaves empty node_modules placeholders (e.g. openai) that break @gsd/pi-ai at runtime. Run npm install --ignore-scripts in the installed package root after workspace linking so npx and postinstall paths match validate-pack expectations.

## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/open-gsd/gsd-pi/issues
-->

Closes #<!-- issue number — required -->

- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** <!-- One sentence — what does this change? -->
**Why:** <!-- One sentence — why is it needed? -->
**How:** <!-- One sentence — what's the approach? -->

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->

## Why

<!-- The motivation. What problem does this solve? -->

## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [ ] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782579667&installation_id=134682257&pr_number=225&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F225&signature=ef44f078603144aa1504abe3d57b7e80f9fb583b0949ba97e36965b45130fb02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the install/postinstall path for all global and interactive installs; failures are non-fatal warnings but wrong behavior could still break first-run resolution.
> 
> **Overview**
> After a global **`npm install -g --ignore-scripts`**, hoisted dependencies can remain as **empty `node_modules` placeholders**, which breaks runtime imports (e.g. **`openai`** for **`@gsd/pi-ai`**). This PR adds **`repairPackageDependencies`** in **`scripts/install/deps.js`**, which runs **`npm install --ignore-scripts`** in the installed package root to materialize those deps **without re-running lifecycle scripts**.
> 
> **`runPostinstallDeps`** and **`runInteractiveDeps`** now invoke that repair **before** workspace linking, Chromium, and RTK steps. The installer packaging test asserts the new export is available, and **`link-workspace-packages.cjs`** comments clarify that **`ensureRootUndici`** is still a fallback when repair has not populated root **`undici`** yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93fba08de7e80acb5c8698ea6ab33591381d039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->