### PR TITLE
fix(tests): keep relative .js in dist-redirect when no .ts source exists

### DIFF
--- a/src/resources/extensions/gsd/tests/dist-redirect.mjs
+++ b/src/resources/extensions/gsd/tests/dist-redirect.mjs
@@ -70,7 +70,10 @@ export function resolve(specifier, context, nextResolve) {
       if (specifier.includes('/dist/')) {
         specifier = specifier.replace('/dist/', '/src/').replace(/\.js$/, '.ts');
       } else {
-        specifier = specifier.replace(/\.js$/, '.ts');
+        const candidate = new URL(specifier.replace(/\.js$/, '.ts'), context.parentURL);
+        if (existsSync(fileURLToPath(candidate))) {
+          specifier = candidate.href;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- `dist-redirect.mjs` was unconditionally rewriting `./foo.js` → `./foo.ts` for any relative import whose parent lives under `/src/`.
- This broke `src/tests/installer-*.test.ts` after the pnpm merge: those tests import real JS files from `scripts/install/` (`banner.js`, `prereqs.js`, `detect-existing.js`) — files that have no `.ts` source — so resolution failed with `ERR_MODULE_NOT_FOUND` for the synthesized `.ts` path.
- Fix: probe the candidate `.ts` on disk before rewriting; fall through to the original `.js` when the source-of-truth is JS.

Failing job: https://github.com/open-gsd/gsd-pi/actions/runs/26599412487/job/78380482128

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/installer-banner.test.ts src/tests/installer-detect-existing.test.ts src/tests/installer-prereqs.test.ts` — passes locally
- [ ] CI `test-coverage` job

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782592488&installation_id=134682257&pr_number=227&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F227&signature=a67fb86e1866cf7902c686a74dd3e91c62f17c7ecd131ee9c46604a7d0d11281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-only loader behavior change with an on-disk existence guard; no production runtime or security paths affected.
> 
> **Overview**
> The test loader’s **relative `.js` → `.ts` redirect** under `/src/` no longer assumes every import has a TypeScript twin. It now **checks that the `.ts` path exists** before rewriting; otherwise resolution keeps the original **`.js`** specifier.
> 
> That restores **installer tests** that import real JavaScript under `scripts/install/` (e.g. `banner.js`, `prereqs.js`), which were failing with **`ERR_MODULE_NOT_FOUND`** after unconditional `.ts` rewriting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871910a65cbef41b6958dba9843520e55becc881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->