### PR TITLE
fix: set package-import-method=copy to prevent hard-link E415 on npm publish

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ engineStrict: true
 
 # npm registry rejects tarballs containing hard-linked files (E415). pnpm hard-links
 # by default; copy mode breaks those links so bundledDependencies pack cleanly.
-package-import-method: copy
+packageImportMethod: copy
 
 # Keep dist-test and compiled workspace imports resolvable from the repo root.
 publicHoistPattern:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,10 @@ autoInstallPeers: true
 strictPeerDependencies: false
 engineStrict: true
 
+# npm registry rejects tarballs containing hard-linked files (E415). pnpm hard-links
+# by default; copy mode breaks those links so bundledDependencies pack cleanly.
+package-import-method: copy
+
 # Keep dist-test and compiled workspace imports resolvable from the repo root.
 publicHoistPattern:
   - '*'


### PR DESCRIPTION
## Summary

- Adds `package-import-method: copy` to `pnpm-workspace.yaml`
- Fixes npm publish failing with `E415 Unsupported Media Type: Hard link is not allowed`

**Root cause:** pnpm hard-links files from its content-addressable store into `node_modules/.pnpm/`. When `npm publish` packs the tarball with `bundledDependencies`, those hard-linked files (link count > 1) cause the npm registry to reject the upload. This regressed in #222 (npm → pnpm migration).

**Fix:** `package-import-method: copy` makes pnpm copy files into the virtual store instead of hard-linking them, keeping link counts at 1 so the tarball passes the registry check.

**Trade-off:** Slightly slower `pnpm install` and more disk usage per project. Negligible in CI with fresh containers; in local dev the pnpm global store still caches downloads, only the final copy to `node_modules` isn't hard-linked.

## Test plan

- [ ] Re-trigger NPM Publish workflow on `dev` channel — should pass the `Publish @dev` step without E415
- [ ] Verify `pnpm install` still works locally after pulling this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782597192&installation_id=134682257&pr_number=228&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F228&signature=e16f1fa8bbf3b64174dfcd2d15d9b2bf0368d8ba6a18642c45be748430376475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workspace install setting with documented trade-off; no application or auth logic changes.
> 
> **Overview**
> Sets **`packageImportMethod: copy`** in `pnpm-workspace.yaml` so pnpm copies packages into the virtual store instead of hard-linking from its content store.
> 
> This unblocks **`npm publish`** when tarballs include **`bundledDependencies`**: the registry rejects hard-linked files (**E415**), which showed up after the pnpm migration. Install may use a bit more disk and time locally; CI impact is minor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fb2829ebaba24ab61556af62f1639ba84cd892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->