### PR TITLE
fix: wire Layer 0 shell hooks in agent session

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-hooks-wiring.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-hooks-wiring.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for shell-hook wiring in AgentSession.
+ *
+ * Issue (from ~/Desktop/hooks-issue.md):
+ *   1. createHooksRunner was never called — the hooks key in settings was dead config.
+ *   2. ExtensionRunner was not created when no extensions existed, so even if
+ *      createHooksRunner were called, there was no runner to attach the hook bridge to.
+ *
+ * Both fixes are in _buildRuntime():
+ *   - ExtensionRunner is always created (empty extensions array when none found).
+ *   - createHooksRunner is always called when _extensionRunner exists.
+ *
+ * These tests verify that _hooksRunner is initialized and that SessionStart fires
+ * even when there are zero extensions loaded.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { Agent } from "@gsd/pi-agent-core";
+import { AgentSession } from "./agent-session.js";
+import { AuthStorage } from "./auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+import { DefaultResourceLoader } from "./resource-loader.js";
+import { SessionManager } from "./session-manager.js";
+import { SettingsManager } from "./settings-manager.js";
+
+let testDir: string;
+
+async function createSession(options: {
+	settingsManager?: SettingsManager;
+}): Promise<AgentSession> {
+	const agentDir = join(testDir, "agent-home");
+	const authStorage = AuthStorage.inMemory({});
+	const modelRegistry = new ModelRegistry(authStorage, join(agentDir, "models.json"));
+	const settingsManager =
+		options.settingsManager ?? SettingsManager.inMemory();
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: testDir,
+		agentDir,
+		settingsManager,
+		noExtensions: true,
+		noPromptTemplates: true,
+		noThemes: true,
+	});
+	await resourceLoader.reload();
+
+	return new AgentSession({
+		agent: new Agent(),
+		sessionManager: SessionManager.inMemory(testDir),
+		settingsManager,
+		cwd: testDir,
+		resourceLoader,
+		modelRegistry,
+	});
+}
+
+describe("AgentSession hooks wiring — regression for hooks-issue.md", () => {
+	beforeEach(() => {
+		testDir = mkdtempSync(join(tmpdir(), "agent-session-hooks-"));
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("_extensionRunner is created even when no extensions are loaded", async () => {
+		const session = await createSession({});
+		assert.notEqual(
+			(session as any)._extensionRunner,
+			undefined,
+			"_extensionRunner must exist even with zero extensions (fix for issue #2)",
+		);
+	});
+
+	it("_hooksRunner is initialized even when no extensions are loaded", async () => {
+		const session = await createSession({});
+		assert.notEqual(
+			(session as any)._hooksRunner,
+			undefined,
+			"_hooksRunner must be wired when _extensionRunner exists (fix for issue #1)",
+		);
+	});
+
+	it("SessionStart hook fires when configured in global settings with no extensions", async () => {
+		const markerFile = join(testDir, "session-start-fired");
+		const settingsManager = SettingsManager.inMemory();
+		// Inject a global hook that creates a marker file
+		(settingsManager as any).getGlobalSettings = () => ({
+			hooks: {
+				SessionStart: [
+					{
+						command: `node -e "require('fs').writeFileSync('${markerFile}','fired')"`,
+					},
+				],
+			},
+		});
+
+		const session = await createSession({ settingsManager });
+
+		// SessionStart fires in bindExtensions(), not in the constructor.
+		await session.bindExtensions({});
+
+		assert.ok(
+			existsSync(markerFile),
+			"SessionStart hook must fire and create the marker file",
+		);
+	});
+
+	it("_hooksRunner survives reload() with no extensions", async () => {
+		const session = await createSession({});
+		assert.notEqual(
+			(session as any)._hooksRunner,
+			undefined,
+			"_hooksRunner must exist before reload",
+		);
+
+		await session.reload();
+		assert.notEqual(
+			(session as any)._hooksRunner,
+			undefined,
+			"_hooksRunner must be re-created after reload() even with no extensions",
+		);
+	});
+});

--- a/packages/pi-coding-agent/src/core/agent-session-hooks-wiring.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-hooks-wiring.test.ts
@@ -125,4 +125,41 @@ describe("AgentSession hooks wiring — regression for hooks-issue.md", () => {
 			"_hooksRunner must be re-created after reload() even with no extensions",
 		);
 	});
+
+	it("old _hooksRunner is disposed before new one is created on reload", async () => {
+		const session = await createSession({});
+		const firstRunner = (session as any)._hooksRunner;
+		assert.notEqual(firstRunner, undefined, "_hooksRunner must exist before reload");
+
+		let disposed = false;
+		const origDispose = firstRunner.dispose.bind(firstRunner);
+		firstRunner.dispose = () => { disposed = true; origDispose(); };
+
+		await session.reload();
+
+		assert.ok(disposed, "old _hooksRunner.dispose() must be called during reload");
+		const secondRunner = (session as any)._hooksRunner;
+		assert.notEqual(secondRunner, undefined, "new _hooksRunner must exist after reload");
+		assert.notStrictEqual(secondRunner, firstRunner, "new runner must be a different instance");
+	});
+
+	it("fireSessionEnd is called during reload before the runner is replaced", async () => {
+		const session = await createSession({});
+		const firstRunner = (session as any)._hooksRunner;
+		assert.notEqual(firstRunner, undefined, "_hooksRunner must exist before reload");
+
+		let endFired = false;
+		let endReason: string | undefined;
+		const origFireEnd = firstRunner.fireSessionEnd.bind(firstRunner);
+		firstRunner.fireSessionEnd = async (reason: string) => {
+			endFired = true;
+			endReason = reason;
+			return origFireEnd(reason);
+		};
+
+		await session.reload();
+
+		assert.ok(endFired, "fireSessionEnd must be called during reload");
+		assert.equal(endReason, "programmatic", "reason must be 'programmatic' for reload");
+	});
 });

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -874,6 +874,8 @@ export class AgentSession {
 	dispose(): void {
 		this._extensionErrorUnsubscriber?.();
 		this._extensionErrorUnsubscriber = undefined;
+		this._hooksRunner?.dispose();
+		this._hooksRunner = undefined;
 		this._disconnectFromAgent();
 		this._eventListeners = [];
 	}
@@ -2478,6 +2480,7 @@ export class AgentSession {
 
 		// Layer 0: wire shell hooks from settings.json
 		if (this._extensionRunner) {
+			this._hooksRunner?.dispose();
 			this._hooksRunner = createHooksRunner({
 				extensionRunner: this._extensionRunner,
 				cwd: this._cwd,
@@ -2499,6 +2502,9 @@ export class AgentSession {
 	async reload(): Promise<void> {
 		const previousFlagValues = this._extensionRunner?.getFlagValues();
 		await this._extensionRunner?.emit({ type: "session_shutdown" });
+		if (this._hooksRunner) {
+			await this._hooksRunner.fireSessionEnd("programmatic");
+		}
 		this.settingsManager.reload();
 		resetApiProviders();
 		await this._resourceLoader.reload();

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -83,6 +83,7 @@ import { buildSystemPrompt } from "./system-prompt.js";
 import { emitTokenTelemetry } from "./token-telemetry.js";
 import type { BashOperations } from "./tools/bash.js";
 import { createAllTools } from "./tools/index.js";
+import { createHooksRunner, type HooksRunner } from "./hooks-runner.js";
 
 // ============================================================================
 // Skill Block Parsing
@@ -275,6 +276,7 @@ export class AgentSession {
 
 	// Extension system
 	private _extensionRunner: ExtensionRunner | undefined = undefined;
+	private _hooksRunner: HooksRunner | undefined = undefined;
 	private _turnIndex = 0;
 	private _processingAgentEnd = false;
 	/** True while newSession()/switchSession() is in progress; signals agent_end
@@ -2147,6 +2149,10 @@ export class AgentSession {
 			await this._extensionRunner.emit({ type: "session_start" });
 			await this.extendResourcesFromExtensions("startup");
 		}
+		// Layer 0: fire shell-hook SessionStart
+		if (this._hooksRunner) {
+			await this._hooksRunner.fireSessionStart();
+		}
 	}
 
 	private async extendResourcesFromExtensions(reason: "startup" | "reload"): Promise<void> {
@@ -2455,13 +2461,29 @@ export class AgentSession {
 						this.sessionManager,
 						this._modelRegistry,
 					)
-				: undefined;
+				: new ExtensionRunner(
+						[],
+						extensionsResult.runtime,
+						this._cwd,
+						this.sessionManager,
+						this._modelRegistry,
+					);
 		if (this._extensionRunnerRef) {
 			this._extensionRunnerRef.current = this._extensionRunner;
 		}
 		if (this._extensionRunner) {
 			this._bindExtensionCore(this._extensionRunner);
 			this._applyExtensionBindings(this._extensionRunner);
+		}
+
+		// Layer 0: wire shell hooks from settings.json
+		if (this._extensionRunner) {
+			this._hooksRunner = createHooksRunner({
+				extensionRunner: this._extensionRunner,
+				cwd: this._cwd,
+				getGlobalSettings: () => this.settingsManager.getGlobalSettings(),
+				getProjectSettings: () => this.settingsManager.getProjectSettings(),
+			});
 		}
 
 		const defaultActiveToolNames = this._baseToolsOverride
@@ -2495,6 +2517,10 @@ export class AgentSession {
 		if (this._extensionRunner && hasBindings) {
 			await this._extensionRunner.emit({ type: "session_start" });
 			await this.extendResourcesFromExtensions("reload");
+		}
+		// Layer 0: re-fire shell-hook SessionStart after reload
+		if (this._hooksRunner) {
+			await this._hooksRunner.fireSessionStart();
 		}
 	}
 

--- a/packages/pi-coding-agent/src/core/hooks-runner-base-payload.test.ts
+++ b/packages/pi-coding-agent/src/core/hooks-runner-base-payload.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for base fields (session_id, cwd) in dispatched hook payloads.
+ *
+ * These tests verify that every hook event receives session_id and cwd
+ * in its JSON payload on stdin — matching the contract that consumers
+ * (context-mode, agentmemory, notebook hooks) depend on.
+ *
+ * Pattern: configure a hook that echoes its stdin back to stdout,
+ * then inspect the captured invocation's stdout for expected fields.
+ */
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CONFIG_DIR_NAME } from "../config.js";
+import { ExtensionRunner } from "./extensions/runner.js";
+import { createHooksRunner } from "./hooks-runner.js";
+import type { ExtensionRuntime } from "./extensions/types.js";
+import type { Settings } from "./settings-manager.js";
+
+function makeTempProject() {
+	const base = mkdtempSync(join(tmpdir(), "hooks-base-payload-test-"));
+	mkdirSync(join(base, CONFIG_DIR_NAME), { recursive: true });
+	return base;
+}
+
+function stubRuntime(): ExtensionRuntime {
+	return {
+		flagValues: new Map(),
+		pendingProviderRegistrations: [],
+		registerProvider: () => {},
+		unregisterProvider: () => {},
+		emitBeforeModelSelect: async () => undefined,
+		emitAdjustToolSet: async () => undefined,
+		emitExtensionEvent: async () => undefined,
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		retryLastTurn: () => {},
+		appendEntry: () => {},
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		getVisibleSkills: () => undefined,
+		setVisibleSkills: () => {},
+		refreshTools: () => {},
+		getCommands: () => [],
+		setModel: async () => false,
+		getThinkingLevel: () => "off",
+		setThinkingLevel: () => {},
+	};
+}
+
+/**
+ * Create an ExtensionRunner with a mock sessionManager that returns a known sessionId.
+ */
+function makeRunnerWithSession(cwd: string, sessionId: string): ExtensionRunner {
+	const sessionManager = {
+		getSessionId: () => sessionId,
+	} as never;
+	return new ExtensionRunner(
+		[],
+		stubRuntime(),
+		cwd,
+		sessionManager,
+		{} as never,
+	);
+}
+
+/**
+ * Hook command that echoes stdin back to stdout as-is.
+ * This lets us inspect exactly what payload was sent to the hook.
+ */
+const ECHO_STDIN = `node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d))"`;
+
+describe("createHooksRunner — base payload fields", () => {
+	let tmpCwd: string | undefined;
+	afterEach(() => {
+		if (tmpCwd) rmSync(tmpCwd, { recursive: true, force: true });
+		tmpCwd = undefined;
+	});
+
+	it("includes session_id in SessionStart payload", async () => {
+		tmpCwd = makeTempProject();
+		const runner = makeRunnerWithSession(tmpCwd, "test-session-001");
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		const hooks = createHooksRunner({
+			extensionRunner: runner,
+			getGlobalSettings: (): Settings => ({
+				hooks: { SessionStart: [{ command: ECHO_STDIN }] },
+			}),
+			getProjectSettings: (): Settings => ({}),
+			cwd: tmpCwd,
+			onInvocation: (i) => {
+				try { capturedPayload = JSON.parse(i.stdout); } catch { /* ignore */ }
+			},
+		});
+
+		await hooks.fireSessionStart();
+		hooks.dispose();
+
+		assert.ok(capturedPayload, "hook should have been invoked");
+		assert.equal(capturedPayload!.session_id, "test-session-001",
+			"payload must include session_id from ExtensionRunner's sessionManager");
+	});
+
+	it("includes cwd in SessionStart payload", async () => {
+		tmpCwd = makeTempProject();
+		const runner = makeRunnerWithSession(tmpCwd, "s2");
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		const hooks = createHooksRunner({
+			extensionRunner: runner,
+			getGlobalSettings: (): Settings => ({
+				hooks: { SessionStart: [{ command: ECHO_STDIN }] },
+			}),
+			getProjectSettings: (): Settings => ({}),
+			cwd: tmpCwd,
+			onInvocation: (i) => {
+				try { capturedPayload = JSON.parse(i.stdout); } catch { /* ignore */ }
+			},
+		});
+
+		await hooks.fireSessionStart();
+		hooks.dispose();
+
+		assert.ok(capturedPayload, "hook should have been invoked");
+		assert.equal(capturedPayload!.cwd, tmpCwd,
+			"payload must include cwd from createHooksRunner options");
+	});
+
+	it("includes session_id and cwd in PreToolUse payload", async () => {
+		tmpCwd = makeTempProject();
+		const runner = makeRunnerWithSession(tmpCwd, "s3");
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		createHooksRunner({
+			extensionRunner: runner,
+			getGlobalSettings: (): Settings => ({
+				hooks: { PreToolUse: [{ command: ECHO_STDIN }] },
+			}),
+			getProjectSettings: (): Settings => ({}),
+			cwd: tmpCwd,
+			onInvocation: (i) => {
+				try { capturedPayload = JSON.parse(i.stdout); } catch { /* ignore */ }
+			},
+		});
+
+		await runner.emitToolCall({
+			type: "tool_call",
+			toolCallId: "tc1",
+			toolName: "bash",
+			input: { command: "ls" },
+		});
+
+		assert.ok(capturedPayload, "PreToolUse hook should have been invoked");
+		assert.equal(capturedPayload!.session_id, "s3",
+			"PreToolUse payload must include session_id");
+		assert.equal(capturedPayload!.cwd, tmpCwd,
+			"PreToolUse payload must include cwd");
+		// Also verify event-specific fields are still present
+		assert.equal(capturedPayload!.toolName, "bash");
+		assert.equal(capturedPayload!.toolCallId, "tc1");
+	});
+
+	it("includes session_id and cwd in PostToolUse payload", async () => {
+		tmpCwd = makeTempProject();
+		const runner = makeRunnerWithSession(tmpCwd, "s4");
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		createHooksRunner({
+			extensionRunner: runner,
+			getGlobalSettings: (): Settings => ({
+				hooks: { PostToolUse: [{ command: ECHO_STDIN }] },
+			}),
+			getProjectSettings: (): Settings => ({}),
+			cwd: tmpCwd,
+			onInvocation: (i) => {
+				try { capturedPayload = JSON.parse(i.stdout); } catch { /* ignore */ }
+			},
+		});
+
+		await runner.emitToolResult({
+			type: "tool_result",
+			toolCallId: "tc2",
+			toolName: "read",
+			input: { path: "/tmp/x" },
+			content: [{ type: "text", text: "file contents" }],
+			isError: false,
+			details: undefined,
+		});
+
+		assert.ok(capturedPayload, "PostToolUse hook should have been invoked");
+		assert.equal(capturedPayload!.session_id, "s4",
+			"PostToolUse payload must include session_id");
+		assert.equal(capturedPayload!.cwd, tmpCwd,
+			"PostToolUse payload must include cwd");
+	});
+
+	it("falls back to empty session_id when sessionManager lacks getSessionId", async () => {
+		tmpCwd = makeTempProject();
+		// Create runner with no sessionManager.getSessionId
+		const runner = new ExtensionRunner(
+			[],
+			stubRuntime(),
+			tmpCwd,
+			{} as never,
+			{} as never,
+		);
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		const hooks = createHooksRunner({
+			extensionRunner: runner,
+			getGlobalSettings: (): Settings => ({
+				hooks: { SessionStart: [{ command: ECHO_STDIN }] },
+			}),
+			getProjectSettings: (): Settings => ({}),
+			cwd: tmpCwd,
+			onInvocation: (i) => {
+				try { capturedPayload = JSON.parse(i.stdout); } catch { /* ignore */ }
+			},
+		});
+
+		await hooks.fireSessionStart();
+		hooks.dispose();
+
+		assert.ok(capturedPayload, "hook should have been invoked");
+		assert.equal(capturedPayload!.session_id, "",
+			"session_id should be empty string when sessionManager has no getSessionId");
+		assert.equal(capturedPayload!.cwd, tmpCwd,
+			"cwd should still be present even without session_id");
+	});
+});

--- a/packages/pi-coding-agent/src/core/hooks-runner.ts
+++ b/packages/pi-coding-agent/src/core/hooks-runner.ts
@@ -252,7 +252,10 @@ export function createHooksRunner(options: HooksRunnerOptions): HooksRunner {
 
 	// Base fields merged into every dispatched payload so consumers can key by
 	// session and determine project context without scanning.
-	const sessionId = (extensionRunner as unknown as { sessionManager?: { getSessionId?: () => string } })
+	interface RunnerWithSessionId {
+		sessionManager?: { getSessionId?(): string };
+	}
+	const sessionId = (extensionRunner as unknown as RunnerWithSessionId)
 		?.sessionManager?.getSessionId?.() ?? "";
 	const basePayload: Record<string, unknown> = { session_id: sessionId, cwd };
 

--- a/packages/pi-coding-agent/src/core/hooks-runner.ts
+++ b/packages/pi-coding-agent/src/core/hooks-runner.ts
@@ -250,7 +250,14 @@ type HandlerFn = (event: unknown, ctx: unknown) => Promise<unknown>;
 export function createHooksRunner(options: HooksRunnerOptions): HooksRunner {
 	const { extensionRunner, cwd, onInvocation } = options;
 
+	// Base fields merged into every dispatched payload so consumers can key by
+	// session and determine project context without scanning.
+	const sessionId = (extensionRunner as unknown as { sessionManager?: { getSessionId?: () => string } })
+		?.sessionManager?.getSessionId?.() ?? "";
+	const basePayload: Record<string, unknown> = { session_id: sessionId, cwd };
+
 	const dispatch = async (name: HookName, payload: Record<string, unknown>) => {
+		const merged = { ...basePayload, ...payload };
 		const hooks = collectHooks(
 			name,
 			options.getGlobalSettings(),
@@ -258,7 +265,7 @@ export function createHooksRunner(options: HooksRunnerOptions): HooksRunner {
 			cwd,
 		);
 		if (hooks.length === 0) return undefined;
-		return runChain(name, payload, hooks, cwd, onInvocation);
+		return runChain(name, merged, hooks, cwd, onInvocation);
 	};
 
 	const handlers = new Map<string, HandlerFn[]>();

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -517,6 +517,18 @@ export function registerHooks(
       const prefs = loadEffectiveGSDPreferences(basePath);
       process.env.GSD_SHOW_TOKEN_COST = prefs?.preferences.show_token_cost ? "1" : "";
     } catch { /* non-fatal */ }
+
+    // Enumerate configured MCP servers and surface awareness to the agent.
+    // Without this, the agent starts blind to available MCP integrations.
+    try {
+      const { readMcpServerConfigs } = await import("../../mcp-client/manager.js");
+      const servers = readMcpServerConfigs({ projectDir: basePath });
+      if (servers.length > 0) {
+        const names = servers.map((s) => s.name);
+        ctx.ui.setStatus("mcp-servers", `MCP servers: ${names.join(", ")}`);
+      }
+    } catch { /* non-fatal — MCP subsystem may not be available */ }
+
     await installWelcomeHeader(ctx);
     await loadToolApiKeysForSession();
     if (isAutoActive()) {

--- a/src/resources/extensions/gsd/tests/session-start-mcp-awareness.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-mcp-awareness.test.ts
@@ -1,0 +1,273 @@
+// Project/App: gsd-pi
+// File Purpose: Regression test — MCP server names must be injected into agent
+//               context during session initialization.
+//
+//               When MCP servers are configured in .mcp.json or ~/.gsd/mcp.json,
+//               the agent must learn about them without an explicit mcp_servers call.
+//               This test guards that:
+//
+//               1. (Structural) The session_start handler in register-hooks.ts
+//                  references MCP server enumeration.
+//               2. (Behavioral) Firing session_start with configured MCP servers
+//                  produces detectable MCP awareness in the resulting context.
+//
+//               Relates to the shell-hooks fix — SessionStart never fires (Layer 0
+//               bug), but even Layer 2 session_start doesn't enumerate MCP servers.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { autoSession } from "../auto-runtime-state.ts";
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const HOOKS_SOURCE = readFileSync(
+  join(__dirname, "..", "bootstrap", "register-hooks.ts"),
+  "utf-8",
+);
+
+// ─── Structural guard ───────────────────────────────────────────────────────
+
+test("session_start handler references MCP server enumeration (readMcpServerConfigs or mcp-client)", () => {
+  const sessionStartIdx = HOOKS_SOURCE.indexOf('"session_start"');
+  assert.ok(sessionStartIdx > -1, "session_start handler must exist");
+
+  // Find the end of the session_start handler — the next top-level pi.on
+  const nextOnIdx = HOOKS_SOURCE.indexOf("pi.on(", sessionStartIdx + 1);
+  assert.ok(nextOnIdx > sessionStartIdx, "session_start handler must be bounded by the next pi.on call");
+
+  const sessionStartBody = HOOKS_SOURCE.slice(sessionStartIdx, nextOnIdx);
+
+  // The handler must reference something from the MCP client subsystem
+  // that enumerates servers. Accepted patterns:
+  //   - readMcpServerConfigs (reads from all 3 tiers)
+  //   - readMcpManagementStatus (full status including servers list)
+  //   - mcp-client/manager (import path)
+  //   - mcp-client/index (alternative import path)
+  const hasMcpEnumeration =
+    sessionStartBody.includes("readMcpServerConfigs") ||
+    sessionStartBody.includes("readMcpManagementStatus") ||
+    sessionStartBody.includes("mcp-client/manager") ||
+    sessionStartBody.includes("mcp-client/index");
+
+  assert.ok(
+    hasMcpEnumeration,
+    [
+      "session_start handler must reference MCP server enumeration to inject",
+      "server awareness into agent context. Expected one of:",
+      "  - readMcpServerConfigs()",
+      "  - readMcpManagementStatus()",
+      "  - import from mcp-client/manager or mcp-client/index",
+      "",
+      "Without this, the agent starts blind to configured MCP servers.",
+    ].join("\n"),
+  );
+});
+
+// ─── Behavioral guard ────────────────────────────────────────────────────────
+
+test("session_start injects MCP server names into agent context when servers are configured", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-mcp-awareness-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const tempGsdHome = join(dir, "home");
+  mkdirSync(tempGsdHome, { recursive: true });
+
+  // Write global MCP config with a test server
+  writeFileSync(
+    join(tempGsdHome, "mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        "test-global-server": {
+          command: "node",
+          args: ["echo-server.js"],
+        },
+      },
+    }),
+    "utf-8",
+  );
+
+  // Write project MCP config with another test server
+  writeFileSync(
+    join(dir, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        "test-project-server": {
+          command: "node",
+          args: ["project-echo-server.js"],
+        },
+      },
+    }),
+    "utf-8",
+  );
+
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(dir);
+  autoSession.reset();
+
+  t.after(() => {
+    autoSession.reset();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  // Capture what gets injected into context
+  const contextInjections: string[] = [];
+  const statusMessages: Array<{ key: string; value: string }> = [];
+
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<unknown> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<unknown> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const sessionStart = handlers.get("session_start");
+  assert.ok(sessionStart, "session_start handler must be registered");
+
+  const ctx = {
+    hasUI: true,
+    cwd: dir,
+    ui: {
+      notify: () => {},
+      setStatus: (key: string, value: string) => {
+        statusMessages.push({ key, value });
+      },
+      setFooter: () => {},
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: () => {},
+    },
+    sessionManager: { getSessionId: () => "test-session-id" },
+    model: null,
+    setCompactionThresholdOverride: () => {},
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => false,
+    },
+  };
+
+  await sessionStart!({}, ctx);
+
+  // After session_start, at least one of these signals must contain MCP server names:
+  // 1. A status bar entry mentioning MCP servers
+  // 2. Context injection (system prompt augmentation)
+  // 3. A widget with MCP info
+  //
+  // The structural test above ensures the code path exists. This behavioral test
+  // checks that running the handler with configured servers produces detectable output.
+  //
+  // Currently this WILL FAIL because no MCP enumeration happens in session_start.
+
+  const allOutput = [
+    ...contextInjections,
+    ...statusMessages.map((s) => `${s.key}: ${s.value}`),
+  ].join(" ");
+
+  // Check if either server name appears anywhere in the handler's observable output
+  const mentionsGlobal = allOutput.includes("test-global-server");
+  const mentionsProject = allOutput.includes("test-project-server");
+
+  // If neither structural injection produced MCP names, also check that
+  // setStatus was called with an MCP-related key (indicating awareness was surfaced)
+  const hasMcpStatus = statusMessages.some(
+    (s) => {
+      const k = (s.key ?? "").toLowerCase();
+      const v = (s.value ?? "").toLowerCase();
+      return k.includes("mcp") || v.includes("mcp");
+    },
+  );
+
+  assert.ok(
+    mentionsGlobal || mentionsProject || hasMcpStatus,
+    [
+      "session_start must surface MCP server awareness when servers are configured.",
+      "Expected at least one of:",
+      "  - 'test-global-server' or 'test-project-server' in context output",
+      "  - An MCP-related status entry",
+      "",
+      "This means the agent starts without knowing about configured MCP servers.",
+      "Fix: call readMcpServerConfigs() in the session_start handler and inject",
+      "the server list into the system prompt or a status indicator.",
+    ].join("\n"),
+  );
+});
+
+// ─── Negative behavioral guard ───────────────────────────────────────────────
+
+test("session_start does not error when no MCP servers are configured", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-mcp-empty-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const tempGsdHome = join(dir, "home");
+  mkdirSync(tempGsdHome, { recursive: true });
+
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(dir);
+  autoSession.reset();
+
+  t.after(() => {
+    autoSession.reset();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<unknown> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<unknown> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const sessionStart = handlers.get("session_start");
+  assert.ok(sessionStart, "session_start handler must be registered");
+
+  const ctx = {
+    hasUI: true,
+    cwd: dir,
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setFooter: () => {},
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: () => {},
+    },
+    sessionManager: { getSessionId: () => "test-session-id" },
+    model: null,
+    setCompactionThresholdOverride: () => {},
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => false,
+    },
+  };
+
+  // Must not throw even with zero MCP config files
+  await assert.doesNotReject(
+    async () => sessionStart!({}, ctx),
+    "session_start must not error when no MCP servers are configured",
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #231

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Wires `createHooksRunner()` into the agent session so shell hooks from `settings.json` actually dispatch.
**Why:** All Layer 0 shell hooks (`PreToolUse`, `SessionStart`, etc.) are dead configuration — they never execute.
**How:** Always create `ExtensionRunner`, call `createHooksRunner` after extension binding, fire `SessionStart` at init/reload, add `session_id`+`cwd` to payloads, surface MCP server names in TUI footer.

## What

Three source files changed:

| File | Change |
|------|--------|
| `packages/pi-coding-agent/src/core/agent-session.ts` | Import `createHooksRunner`, add `_hooksRunner` property, always create `ExtensionRunner` (empty array when no extensions), wire hooks runner in `_buildRuntime()`, fire `SessionStart` at init and reload |
| `packages/pi-coding-agent/src/core/hooks-runner.ts` | Extract `session_id` from `sessionManager` and `cwd` from options; merge as base fields into every dispatched payload |
| `src/resources/extensions/gsd/bootstrap/register-hooks.ts` | Surface MCP server names in TUI footer via `ctx.ui.setStatus("mcp-servers", ...)` during `session_start` |

Three new test files:

| File | Covers |
|------|--------|
| `agent-session-hooks-wiring.test.ts` | ExtensionRunner always created, hooks runner wired, SessionStart fires, dispose on reload, fireSessionEnd on reload |
| `hooks-runner-base-payload.test.ts` | Every dispatched payload includes `session_id` and `cwd` |
| `session-start-mcp-awareness.test.ts` | MCP servers enumerated and surfaced during session init |

## Why

The extension system has two hook layers:

| Layer | Mechanism | Status before this PR |
|-------|-----------|----------------------|
| Layer 2 | `pi.on(event, handler)` — TypeScript extension events | ✅ Works |
| Layer 0 | `settings.json` → shell commands | ❌ Never initialized |

`createHooksRunner()` is the bridge — it subscribes to Layer 2 events and dispatches corresponding shell commands. It was fully implemented and exported but never called. Additionally, `ExtensionRunner` was only created when extensions existed, so users with no extensions had no runner for the hook bridge.

Downstream: because `SessionStart` never fired, MCP server names were not surfaced in the TUI footer at boot.

## How

1. **Always create `ExtensionRunner`** — even with an empty extensions array, so the hook bridge always has a target
2. **Wire `createHooksRunner`** after `_bindExtensionCore` and `_applyExtensionBindings` in `_buildRuntime()`
3. **Fire `SessionStart`** at session startup and after reload
4. **Add base payload fields** — `session_id` (from `sessionManager.getSessionId()`) and `cwd` merged into every dispatched hook payload
5. **Surface MCP server names in TUI footer** — calls `readMcpServerConfigs()` and displays available servers via `ctx.ui.setStatus("mcp-servers", ...)`

## Compliance fixes (follow-up commit)

- **F1:** Dispose old `_hooksRunner` before creating new one on reload (prevents leaked hook bridge)
- **F2:** Wire `fireSessionEnd("programmatic")` during reload and `dispose()` in `AgentSession.dispose()`
- **F3:** Named `RunnerWithSessionId` interface replaces anonymous type assertion
- **F5:** Two new tests: old runner disposed on reload, fireSessionEnd called during reload

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

Activates a documented-but-non-functional feature. Payloads gain new fields (`session_id`, `cwd`) — additive only.

## Test plan

- [x] New/updated tests included

Three test files covering:
- Hook runner wiring (ExtensionRunner creation, createHooksRunner invocation, SessionStart lifecycle, dispose on reload, fireSessionEnd on reload)
- Base payload fields (session_id and cwd present in all dispatched payloads)
- MCP server names surfaced in TUI footer (readMcpServerConfigs called during session_start)

Manual verification:
```bash
# 1. Configure hooks in ~/.gsd/agent/settings.json:
{ "hooks": { "SessionStart": [{ "command": "echo fired >> /tmp/hooks.log" }] } }

# 2. Start a new session
# 3. cat /tmp/hooks.log → should show "fired"
```

## AI disclosure

- [x] This PR includes AI-assisted code — issue analysis, root cause identification, and test authoring assisted by Claude. Fix logic verified against source.