### PR TITLE
fix: burn-max cost-spike opt-out (#142) and DeepSeek reasoning_content replay (#209)

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -853,6 +853,12 @@ export function convertMessages(
 					if (model.provider === "opencode-go" && signature === "reasoning") {
 						signature = "reasoning_content";
 					}
+					// DeepSeek (including via OpenRouter, which normalises the inbound reasoning field
+					// to "reasoning") requires reasoning to be replayed under "reasoning_content";
+					// otherwise the backend rejects the next request with a 400.
+					if (compat.requiresReasoningContentOnAssistantMessages && signature === "reasoning") {
+						signature = "reasoning_content";
+					}
 					if (signature && signature.length > 0) {
 						(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join("\n");
 					}
@@ -1077,6 +1083,19 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
 	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
 	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
+	// Direct DeepSeek: provider "deepseek" or the deepseek.com endpoint. These own the
+	// non-standard endpoint flags (supportsStore/supportsDeveloperRole) and the "deepseek"
+	// thinking format.
+	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+	// A DeepSeek model routed through a gateway that rewrites the model id (OpenRouter
+	// "deepseek/...", Vercel AI Gateway "...deepseek...") is still served by a DeepSeek backend
+	// that requires reasoning to be replayed under `reasoning_content` on the next request.
+	// The gateway — not DeepSeek — owns the request/thinking format, so ONLY this replay flag
+	// applies to the gateway case (not isNonStandard or thinkingFormat).
+	const requiresReasoningContent =
+		isDeepSeek ||
+		(baseUrl.includes("openrouter.ai") && model.id.startsWith("deepseek/")) ||
+		(baseUrl.includes("gateway.ai.vercel") && model.id.includes("deepseek"));
 
 	const isNonStandard =
 		provider === "cerebras" ||
@@ -1085,7 +1104,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		baseUrl.includes("api.x.ai") ||
 		isTogether ||
 		baseUrl.includes("chutes.ai") ||
-		baseUrl.includes("deepseek.com") ||
+		isDeepSeek ||
 		isZai ||
 		isMoonshot ||
 		provider === "opencode" ||
@@ -1096,7 +1115,6 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const useMaxTokens = baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether;
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
-	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	return {
@@ -1108,7 +1126,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,
 		requiresThinkingAsText: false,
-		requiresReasoningContentOnAssistantMessages: isDeepSeek,
+		requiresReasoningContentOnAssistantMessages: requiresReasoningContent,
 		thinkingFormat: isDeepSeek
 			? "deepseek"
 			: isZai

--- a/packages/pi-ai/test/openai-completions-deepseek-reasoning.test.ts
+++ b/packages/pi-ai/test/openai-completions-deepseek-reasoning.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/providers/openai-completions.ts";
+import type { AssistantMessage, Context, Model, OpenAICompletionsCompat, Usage } from "../src/types.ts";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+// Full Required compat as detectCompat produces it for DeepSeek: replay reasoning
+// under reasoning_content. Mirrors the fixture shape used by the sibling
+// openai-completions tests in this directory.
+const deepseekCompat = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: true,
+	thinkingFormat: "deepseek",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	cacheControlFormat: undefined,
+	sendSessionAffinityHeaders: false,
+	supportsLongCacheRetention: true,
+} satisfies Required<Omit<OpenAICompletionsCompat, "cacheControlFormat">> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+};
+
+// Same wire shape, but the provider does NOT require reasoning_content (e.g. a
+// vanilla OpenAI-compatible endpoint): the captured field name must be preserved.
+const standardCompat = {
+	...deepseekCompat,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai" as const,
+};
+
+function buildDeepSeekModel(): Model<"openai-completions"> {
+	return {
+		id: "deepseek/deepseek-chat",
+		name: "DeepSeek Chat",
+		api: "openai-completions",
+		provider: "deepseek",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+}
+
+// OpenRouter normalises DeepSeek's reasoning to the "reasoning" field, so that is
+// the signature captured during streaming and carried into the next request.
+function buildContextWithCapturedReasoning(): Context {
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking: "internal chain", thinkingSignature: "reasoning" },
+			{ type: "text", text: "Hi" },
+		],
+		api: "openai-completions",
+		provider: "deepseek",
+		model: "deepseek/deepseek-chat",
+		usage: emptyUsage,
+		stopReason: "stop",
+		timestamp: 2,
+	};
+	return {
+		messages: [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{ role: "user", content: "continue", timestamp: 3 },
+		],
+	};
+}
+
+describe("openai-completions DeepSeek reasoning_content replay (#209)", () => {
+	it("replays reasoning under reasoning_content when the captured field was 'reasoning'", () => {
+		const messages = convertMessages(buildDeepSeekModel(), buildContextWithCapturedReasoning(), deepseekCompat);
+		const assistant = messages.find((m) => m.role === "assistant") as Record<string, unknown> | undefined;
+		expect(assistant).toBeDefined();
+		// The reasoning text must land in reasoning_content (what DeepSeek requires on replay),
+		// not the inbound "reasoning" field that OpenRouter happened to use.
+		expect(assistant?.reasoning_content).toBe("internal chain");
+		expect(assistant?.reasoning).toBeUndefined();
+	});
+
+	it("keeps the captured field name when the provider does not require reasoning_content", () => {
+		const messages = convertMessages(buildDeepSeekModel(), buildContextWithCapturedReasoning(), standardCompat);
+		const assistant = messages.find((m) => m.role === "assistant") as Record<string, unknown> | undefined;
+		expect(assistant).toBeDefined();
+		// No coercion for non-DeepSeek: the inbound field name is preserved unchanged.
+		expect(assistant?.reasoning).toBe("internal chain");
+		expect(assistant?.reasoning_content).toBeUndefined();
+	});
+});

--- a/src/resources/extensions/gsd/auto-budget.ts
+++ b/src/resources/extensions/gsd/auto-budget.ts
@@ -5,7 +5,7 @@
  * Pure functions — no module state or side effects.
  */
 
-import type { BudgetEnforcementMode } from "./types.js";
+import type { BudgetEnforcementMode, TokenProfile } from "./types.js";
 
 export type BudgetAlertLevel = 0 | 75 | 80 | 90 | 100;
 
@@ -42,6 +42,22 @@ export function getUnitCostSpikeAction(
   if (!Number.isFinite(rollingAvgUsd) || rollingAvgUsd <= 0) return "none";
   if (!Number.isFinite(multiplier) || multiplier <= 0) return "none";
   return unitCostUsd >= (rollingAvgUsd * multiplier) ? "pause" : "none";
+}
+
+/**
+ * Resolve the rolling-average cost-spike multiplier for `getUnitCostSpikeAction`
+ * from preferences. The `burn-max` token profile opts out of the spike pause
+ * entirely (returns Infinity, which `getUnitCostSpikeAction` treats as "none").
+ * An explicit finite, positive `unit_cost_spike_multiplier` overrides the
+ * default; otherwise the default of 3.0 applies.
+ */
+export function resolveUnitCostSpikeMultiplier(
+  prefs: { token_profile?: TokenProfile; unit_cost_spike_multiplier?: number } | null | undefined,
+): number {
+  if (prefs?.token_profile === "burn-max") return Infinity;
+  const override = prefs?.unit_cost_spike_multiplier;
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) return override;
+  return 3.0;
 }
 
 export function getContextPauseAction(

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -94,7 +94,7 @@ import {
 import { validateArtifact } from "./schemas/validate.js";
 import { verificationRetryKey } from "./auto/verification-retry-policy.js";
 import { getLedger } from "./metrics.js";
-import { getUnitCostSpikeAction } from "./auto-budget.js";
+import { getUnitCostSpikeAction, resolveUnitCostSpikeMultiplier } from "./auto-budget.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
@@ -1835,7 +1835,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             await pauseAuto(ctx, pi);
             return "dispatched";
           }
-          if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, 3.0) === "pause") {
+          if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, resolveUnitCostSpikeMultiplier(prefs)) === "pause") {
             s.pendingVerificationRetry = null;
             s.verificationRetryCount.delete(retryKey);
             s.verificationRetryFailureHashes.delete(retryKey);

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -50,7 +50,7 @@ import { createRepositoryRegistryFromPreferences, defaultRepositoryTargets } fro
 import type { SliceRow } from "./db-task-slice-rows.js";
 import { getSlice } from "./gsd-db.js";
 import { getLedger } from "./metrics.js";
-import { getUnitCostSpikeAction } from "./auto-budget.js";
+import { getUnitCostSpikeAction, resolveUnitCostSpikeMultiplier } from "./auto-budget.js";
 import { formatPostUnitStatusCard } from "./auto-status-message.js";
 
 export interface VerificationContext {
@@ -853,7 +853,7 @@ export async function runPostUnitVerification(
         });
         return "pause";
       }
-      if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, 3.0) === "pause") {
+      if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, resolveUnitCostSpikeMultiplier(prefs)) === "pause") {
         ctx.ui.notify(
           `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) during verification retry; keeping verification failure as the authoritative blocker.`,
           "warning",

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -125,6 +125,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "verification_auto_fix",
   "verification_max_retries",
   "per_unit_cost_cap_usd",
+  "unit_cost_spike_multiplier",
   "search_provider",
   "context_selection",
   "widget_mode",
@@ -416,6 +417,8 @@ export interface GSDPreferences {
   verification_auto_fix?: boolean;
   verification_max_retries?: number;
   per_unit_cost_cap_usd?: number;
+  /** Multiplier over the rolling per-unit cost average that triggers a cost-spike pause. Default: 3.0. The `burn-max` token profile ignores this and never pauses on spikes. */
+  unit_cost_spike_multiplier?: number;
   /** Search provider preference. "brave"/"tavily"/"ollama" force that backend and disable native Anthropic search. "native" forces native only. "auto" = current default behavior. */
   search_provider?: "brave" | "tavily" | "ollama" | "native" | "auto";
   /** Context selection mode for file inlining. "full" inlines entire files, "smart" uses semantic chunking. Default derived from token profile. */

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -938,6 +938,15 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  if (preferences.unit_cost_spike_multiplier !== undefined) {
+    const raw = preferences.unit_cost_spike_multiplier;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+      validated.unit_cost_spike_multiplier = raw;
+    } else {
+      errors.push("unit_cost_spike_multiplier must be a positive number");
+    }
+  }
+
   // ─── Git Preferences ───────────────────────────────────────────────────
   if (preferences.git && typeof preferences.git === "object") {
     const git: Record<string, unknown> = {};

--- a/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
@@ -9,6 +9,10 @@ import {
   resolveCompactionThresholdPercent,
   shouldRerootStepSessionForContext,
 } from "../auto.js";
+import {
+  getUnitCostSpikeAction,
+  resolveUnitCostSpikeMultiplier,
+} from "../auto-budget.js";
 
 test("getBudgetAlertLevel returns the expected threshold bucket", () => {
   assert.equal(getBudgetAlertLevel(0.10), 0);
@@ -74,4 +78,32 @@ test("shouldRerootStepSessionForContext uses compaction threshold pref", () => {
   assert.equal(shouldRerootStepSessionForContext(60, 0.6), true);
   assert.equal(shouldRerootStepSessionForContext(273.8, 0.6), true);
   assert.equal(shouldRerootStepSessionForContext(undefined, 0.6), false);
+});
+
+test("resolveUnitCostSpikeMultiplier disables the spike pause for burn-max", () => {
+  // burn-max -> Infinity, and getUnitCostSpikeAction treats a non-finite
+  // multiplier as "none" (no pause) regardless of how large the spike is.
+  const m = resolveUnitCostSpikeMultiplier({ token_profile: "burn-max" });
+  assert.equal(m, Infinity);
+  assert.equal(getUnitCostSpikeAction(40, 1, m), "none");
+});
+
+test("resolveUnitCostSpikeMultiplier honors an explicit unit_cost_spike_multiplier", () => {
+  const m = resolveUnitCostSpikeMultiplier({ unit_cost_spike_multiplier: 10 });
+  assert.equal(m, 10);
+  // 4x spike is below the configured 10x threshold -> no pause.
+  assert.equal(getUnitCostSpikeAction(4, 1, m), "none");
+  // 11x spike is at/above 10x -> pause.
+  assert.equal(getUnitCostSpikeAction(11, 1, m), "pause");
+});
+
+test("resolveUnitCostSpikeMultiplier defaults to 3.0 and still pauses at >=3x", () => {
+  assert.equal(resolveUnitCostSpikeMultiplier(undefined), 3.0);
+  assert.equal(resolveUnitCostSpikeMultiplier({}), 3.0);
+  // Non-positive / non-finite explicit values fall back to the 3.0 default.
+  assert.equal(resolveUnitCostSpikeMultiplier({ unit_cost_spike_multiplier: 0 }), 3.0);
+  const m = resolveUnitCostSpikeMultiplier({});
+  // Default profile still pauses on a 3x spike.
+  assert.equal(getUnitCostSpikeAction(3, 1, m), "pause");
+  assert.equal(getUnitCostSpikeAction(2.9, 1, m), "none");
 });

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -59,6 +59,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   verification_auto_fix: true,
   verification_max_retries: 1,
   per_unit_cost_cap_usd: 5,
+  unit_cost_spike_multiplier: 4,
   search_provider: "web",
   context_selection: "auto",
   widget_mode: "small",


### PR DESCRIPTION
## TL;DR

**What:** Two independent auto-mode/provider bug fixes — `burn-max` can't opt out of the cost-spike pause (#142), and DeepSeek via OpenRouter 400s on reasoning replay (#209).
**Why:** Both stall auto-mode — #142 pauses `burn-max` users on every cost spike; #209 traps DeepSeek units in a dispatch loop.
**How:** A preferences-resolved cost-spike multiplier (`Infinity` for `burn-max`), and replaying DeepSeek reasoning under `reasoning_content`.

## What

One commit per concern:

- **`fix(gsd)` — #142:** `auto-budget.ts` gains `resolveUnitCostSpikeMultiplier(prefs)`; both call sites (`auto-post-unit.ts` pause path, `auto-verification.ts` warning path) thread it instead of the hardcoded `3.0`. A new `unit_cost_spike_multiplier` preference is registered, typed on `GSDPreferences`, and validated.
- **`fix(pi-ai)` — #209:** `openai-completions.ts` replays assistant reasoning under `reasoning_content` when the resolved compat requires it, recognises a DeepSeek model routed through OpenRouter (`deepseek/…`) or the Vercel AI Gateway as needing that replay, and wires `provider: "deepseek"` into `isNonStandard`.

## Why

- **#142:** `burn-max` is documented as the "burn the budget" profile, but the `3× rolling-average` spike guard was hardcoded with no opt-out, repeatedly pausing users who explicitly chose it.
- **#209:** OpenRouter normalises DeepSeek's reasoning to the `reasoning` field; the replay wrote it back under that name, but the DeepSeek backend requires `reasoning_content` → `400 … reasoning_content … must be passed back` → endless re-dispatch.

Closes #142
Closes #209

## How

- **#142** reuses the existing non-finite-multiplier guard in `getUnitCostSpikeAction` (no signature change): `burn-max` resolves to `Infinity` → `"none"`; an explicit positive `unit_cost_spike_multiplier` overrides; otherwise `3.0`.
- **#209** decouples the *reasoning-replay* requirement (broad: includes gateway-routed DeepSeek) from the *thinking-format / endpoint* flags (narrow: direct DeepSeek only), so OpenRouter-routed models keep their `reasoning: { effort }` format while still getting `reasoning_content` on replay.

## Tests

- **#142** — `auto-budget-alerts.test.ts`: `burn-max` disables the pause, an explicit multiplier is honoured, and the default `3×` still pauses. (Fails before the fix on the missing export; passes after.)
- **#209** — `openai-completions-deepseek-reasoning.test.ts`: reasoning replays under `reasoning_content` for DeepSeek and the captured field is preserved otherwise. Verified failing before the fix (`expected '' to be 'internal chain'`) and passing after. The full pi-ai vitest suite was run to confirm no detection regression (the one regression this surfaced — OpenRouter reasoning format — was fixed by the broad/narrow decoupling above).

## Change type

- [x] `fix` — Bug fix

## Notes

- A third issue I filed, **#141** (orphaned queued milestone re-dispatch), is intentionally **not** in this PR. Its fix touches the `isReusableGhostMilestone` invariant that guards against #4996, so it warrants a dedicated, carefully-tested change; I'll follow up separately.
- **AI-assisted:** this change was developed with AI assistance. I have reviewed it, understand it, and verified the tests fail before / pass after each fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782659968&installation_id=134682257&pr_number=244&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F244&signature=d120d743a1c444a1a558a45493fd62552cade3275de484b2d65f7c84911d1589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->