### PR TITLE
[codex] fix dev publish workspace protocol leak

### DIFF
--- a/scripts/prepack-resolve-workspace.cjs
+++ b/scripts/prepack-resolve-workspace.cjs
@@ -13,10 +13,16 @@ const {
 } = require('./lib/version-sync.cjs');
 
 const ROOT_PACKAGE_JSON = path.join(ROOT, 'package.json');
+const STANDALONE_WEB_PACKAGE_JSON = path.join(ROOT, 'dist', 'web', 'standalone', 'package.json');
 const TARGET_PACKAGE_JSONS = [
   ROOT_PACKAGE_JSON,
+  STANDALONE_WEB_PACKAGE_JSON,
   ...RELEASE_WORKSPACE_PACKAGE_DIRS.map((dir) => path.join(ROOT, dir, 'package.json')),
 ];
+const DROP_INTERNAL_DEPS_PACKAGE_JSONS = new Set([
+  ROOT_PACKAGE_JSON,
+  STANDALONE_WEB_PACKAGE_JSON,
+]);
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -44,7 +50,7 @@ function resolvePackageJson(filePath) {
   if (!usesWorkspaceProtocol(pkg)) return false;
 
   const version = pkg.version;
-  const isRoot = filePath === ROOT_PACKAGE_JSON;
+  const dropInternalDeps = DROP_INTERNAL_DEPS_PACKAGE_JSONS.has(filePath);
   const relPath = path.relative(ROOT, filePath);
   const backupPath = path.join(BACKUP_DIR, relPath);
   fs.mkdirSync(path.dirname(backupPath), { recursive: true });
@@ -56,13 +62,15 @@ function resolvePackageJson(filePath) {
     for (const [dep, range] of Object.entries(pkg[field])) {
       if (!INTERNAL_PACKAGE_NAMES.has(dep)) continue;
       if (range !== 'workspace:*' && range !== '*') continue;
-      if (isRoot) {
+      if (dropInternalDeps) {
         // The published root no longer bundles workspace packages. Internal @gsd/@opengsd
         // packages are NOT on the public registry — they ship inside this tarball under
         // packages/*/dist and are symlinked into node_modules at postinstall by
-        // link-workspace-packages.cjs. Leaving them in `dependencies` would make
-        // `npm install` (and the installer's repair step) try to fetch them from the
-        // registry and fail. Drop them; runtime resolution goes through the symlinks.
+        // link-workspace-packages.cjs. The staged Next standalone package.json is also
+        // packed under dist/web/standalone and is scanned by npm during global install.
+        // Leaving internal workspace ranges in either manifest makes npm fail before
+        // postinstall can repair links. Drop them; runtime resolution goes through the
+        // root package and generated standalone server bundle.
         delete pkg[field][dep];
         changed = true;
       } else {
@@ -80,7 +88,7 @@ function resolvePackageJson(filePath) {
   if (changed) {
     writeJson(filePath, pkg);
     console.log(
-      isRoot
+      dropInternalDeps
         ? `[prepack] Removed internal workspace deps from ${relPath} (shipped via files + postinstall link)`
         : `[prepack] Resolved workspace:* internal deps in ${relPath} to ^${version}`,
     );

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -89,6 +89,18 @@ function seedGlobalDependencyFromLocal(globalRoot, globalNodeModules, localPacka
   return true;
 }
 
+function findPackedWorkspaceProtocolLeaks(packedPaths) {
+  const leaks = [];
+  for (const packedPath of packedPaths) {
+    if (!packedPath.endsWith('package.json')) continue;
+    const localPath = join(ROOT, packedPath);
+    if (!existsSync(localPath)) continue;
+    const content = readFileSync(localPath, 'utf8');
+    if (content.includes('workspace:')) leaks.push(packedPath);
+  }
+  return leaks;
+}
+
 try {
   npmCacheDir = mkdtempSync(join(tmpdir(), 'validate-pack-npm-cache-'));
   mkdirSync(npmCacheDir, { recursive: true });
@@ -185,6 +197,7 @@ try {
   const allPackedPaths = packEntry.files.map((entry) => entry.path);
   const pnpmStorePaths = allPackedPaths.filter((p) => p.startsWith('node_modules/.pnpm/'));
   const nestedNmPaths = allPackedPaths.filter((p) => /^packages\/[^/]+\/node_modules\//.test(p));
+  const workspaceProtocolLeaks = findPackedWorkspaceProtocolLeaks(allPackedPaths);
   const bloatErrors = [];
   if (entryCount > MAX_ENTRY_COUNT) {
     bloatErrors.push(`entry count ${entryCount} exceeds ${MAX_ENTRY_COUNT} (pnpm store or nested node_modules likely leaked)`);
@@ -198,8 +211,11 @@ try {
   if (nestedNmPaths.length > 0) {
     bloatErrors.push(`${nestedNmPaths.length} packages/*/node_modules/* entries packed (e.g. ${nestedNmPaths[0]}) — files[] is shipping workspace node_modules`);
   }
+  if (workspaceProtocolLeaks.length > 0) {
+    bloatErrors.push(`${workspaceProtocolLeaks.length} packed package.json file(s) still contain workspace: protocol ranges (e.g. ${workspaceProtocolLeaks[0]})`);
+  }
   if (bloatErrors.length) {
-    console.log('ERROR: Tarball bloat guard tripped:');
+    console.log('ERROR: Tarball guard tripped:');
     for (const e of bloatErrors) console.log(`    ${e}`);
     console.log('    See package.json "files" and workspace package outputs.');
     process.exit(1);


### PR DESCRIPTION
## What changed

Fixes the post-publish `Verify @dev package` failure from the NPM Publish workflow.

The published dev tarball for `1.0.2-dev.235ebf3` still contained `workspace:*` in `dist/web/standalone/package.json`, so `npm install -g @opengsd/gsd-pi@1.0.2-dev.235ebf3` failed with `EUNSUPPORTEDPROTOCOL` before postinstall could run.

This PR:

- sanitizes `dist/web/standalone/package.json` during prepack, alongside the root package manifest
- restores that generated manifest after pack/postpack
- adds a `validate-pack` guard that fails if any packed `package.json` still contains `workspace:`

## Validation

- Reproduced the published failure locally: `npm install -g @opengsd/gsd-pi@1.0.2-dev.235ebf3` fails with `Unsupported URL Type "workspace:"`.
- `pnpm run validate-pack`
- Focused prepack check confirmed `dist/web/standalone/package.json` is stripped during pack and restored afterward.
- Packed a local tarball, confirmed the standalone manifest no longer contains `workspace:`, then installed it with plain `npm install -g` into a temp prefix and verified `gsd -v` returned `1.0.2`.
- `node --check scripts/prepack-resolve-workspace.cjs && node --check scripts/validate-pack.js`
- `node --test scripts/__tests__/npm-publish-workflow.test.mjs scripts/__tests__/build-native-workflow.test.mjs scripts/__tests__/sync-platform-versions.test.mjs`

## Release note

The already-published `1.0.2-dev.235ebf3` tarball is immutable and still broken. After this merges, rerun the NPM Publish workflow to publish a new dev version. Consider deprecating `1.0.2-dev.235ebf3` on npm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782665023&installation_id=134682257&pr_number=247&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F247&signature=925b16760d07aaef636c1177d00ce032de32ff5a8fc142fbd7f823335f6d42eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/packaging script changes only; no runtime app logic, with a guard that reduces publish risk.
> 
> **Overview**
> Fixes **global dev installs** failing with `EUNSUPPORTEDPROTOCOL` because the packed Next **standalone** manifest still listed internal deps as `workspace:*`.
> 
> **Prepack** now treats `dist/web/standalone/package.json` like the root manifest: it is included in workspace resolution, and internal `@gsd` / `@opengsd` workspace ranges are **removed** (not only pinned on the root). Logging and comments reflect that npm reads this file during install, not just the root `package.json`.
> 
> **validate-pack** scans every packed `package.json` for leftover `workspace:` strings and fails the tarball guard if any leak remains, so broken dev tarballs are caught before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a676b0e9bf07b4d399134ea6352022432ec4bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->