### PR TITLE
fix(web): avoid phantom SSE shutdown on beforeExit

### DIFF
--- a/web/lib/shutdown-gate.ts
+++ b/web/lib/shutdown-gate.ts
@@ -68,7 +68,9 @@ export function drainStreams(): void {
   gate.activeStreams.clear();
 }
 
-// ── SIGTERM / beforeExit drain path (idempotent) ───────────────────────────
+// ── SIGTERM drain path (idempotent) ────────────────────────────────────────
+// Do not drain on beforeExit: route tests and serverless runtimes can quiesce
+// while an SSE stream is still valid, which would inject a phantom shutdown.
 
 function handleForcedExit(): void {
   drainStreams();
@@ -88,12 +90,10 @@ const hotModule =
 
 if (!gate.handlersRegistered) {
   process.on("SIGTERM", handleForcedExit);
-  process.on("beforeExit", handleForcedExit);
   gate.handlersRegistered = true;
 
   hotModule?.dispose(() => {
     process.off("SIGTERM", handleForcedExit);
-    process.off("beforeExit", handleForcedExit);
     gate.handlersRegistered = false;
   });
 }


### PR DESCRIPTION
## Summary
- stop the shutdown gate from draining active SSE streams from the ambient process beforeExit event
- keep explicit drain behavior for SIGTERM and scheduled shutdowns
- prevents the assembled web lifecycle integration test from seeing a phantom shutdown event before bridge SSE events

## Verification
- npx -y node@24 --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test web/lib/__tests__/shutdown-gate.test.ts
- npx -y node@24 --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=180000 src/tests/integration/web-mode-assembled.test.ts
- npx -y node@24 --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=180000 "src/tests/integration/*.test.ts" "src/resources/extensions/gsd/tests/integration/*.test.ts" "src/resources/extensions/async-jobs/*.test.ts" "src/resources/extensions/ollama/**/*.test.ts" "src/resources/extensions/ollama/*.test.ts" "src/resources/extensions/search-the-web/tests/*.test.ts" "src/resources/extensions/bg-shell/tests/*.test.ts" "src/resources/extensions/slash-commands/tests/*.test.ts" "src/resources/extensions/browser-tools/tests/*.test.mjs"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782669240&installation_id=134682257&pr_number=249&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F249&signature=6d7ce123e50211c826844dccf31709062c3f7a14986f074b0e54dd3755b54f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows when ambient process events drain SSE; explicit SIGTERM and tab-close shutdown scheduling are unchanged.
> 
> **Overview**
> Stops the web **shutdown gate** from calling `drainStreams()` on Node’s ambient **`beforeExit`** event, which could fire while SSE streams were still healthy (e.g. route/integration tests or quiescent serverless runtimes) and trigger a **phantom shutdown**.
> 
> **SIGTERM** handling and the existing **scheduled shutdown** timer path (`scheduleShutdown` → `drainStreams` → `process.exit`) are unchanged; HMR teardown now only unregisters the SIGTERM listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257c577bf66bf4d7a253fd152ae93ed705091f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->