### PR TITLE
[codex] fix pnpm publish install flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,6 +39,12 @@ permissions:
   packages: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
+  NPM_CONFIG_LOGLEVEL: "error"
+
 jobs:
   prerelease-publish:
     name: Publish @${{ github.event.inputs.channel }}
@@ -124,6 +130,9 @@ jobs:
       - name: Verify native platform packages exist
         run: pnpm run verify:native-platform-packages
 
+      - name: Validate package is installable
+        run: pnpm run validate-pack
+
       - name: Publish @${{ github.event.inputs.channel }}
         env:
           CHANNEL: ${{ github.event.inputs.channel }}
@@ -140,7 +149,9 @@ jobs:
             echo "::error::Move the tag manually if intended: npm dist-tag add @opengsd/gsd-pi@${VERSION} ${CHANNEL}"
             exit 1
           fi
-          npm publish --tag "${CHANNEL}"
+          trap 'node scripts/postpack-restore-workspace.cjs' EXIT
+          node scripts/prepack-resolve-workspace.cjs
+          npm publish --ignore-scripts --tag "${CHANNEL}"
           echo "Verifying @opengsd/gsd-pi@${VERSION} is reachable on npm..."
           for i in 1 2 3 4 5; do
             npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null && echo "Confirmed: @opengsd/gsd-pi@${VERSION} is live." && exit 0
@@ -301,14 +312,19 @@ jobs:
       - name: Verify native platform packages for release version
         run: pnpm run verify:native-platform-packages
 
+      - name: Validate package is installable
+        run: pnpm run validate-pack
+
       - name: Publish release to npm @latest
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
-          if OUTPUT=$(npm publish 2>&1); then
+          trap 'node scripts/postpack-restore-workspace.cjs' EXIT
+          node scripts/prepack-resolve-workspace.cjs
+          if OUTPUT=$(npm publish --ignore-scripts --tag latest 2>&1); then
             echo "$OUTPUT"
           else
-            if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
+            if echo "$OUTPUT" | grep -q "cannot publish over the previously published\|You cannot publish over"; then
               echo "::error::Version ${RELEASE_VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
               echo "::error::Promote manually if intended: npm dist-tag add @opengsd/gsd-pi@${RELEASE_VERSION} latest"
               exit 1
@@ -317,6 +333,14 @@ jobs:
               exit 1
             fi
           fi
+          echo "Verifying @opengsd/gsd-pi@${RELEASE_VERSION} is reachable on npm..."
+          for i in 1 2 3 4 5; do
+            npm view "@opengsd/gsd-pi@${RELEASE_VERSION}" version 2>/dev/null && echo "Confirmed: @opengsd/gsd-pi@${RELEASE_VERSION} is live." && exit 0
+            echo "Attempt $i: not yet visible - waiting 10s..."
+            sleep 10
+          done
+          echo "::error::Publish step succeeded but @opengsd/gsd-pi@${RELEASE_VERSION} is not reachable on npm after 50s. Check trusted publishing and registry propagation."
+          exit 1
 
       - name: Push release commit and tag
         env:

--- a/packages/cloud-mcp-gateway/bin/gsd-cloud-mcp-gateway.js
+++ b/packages/cloud-mcp-gateway/bin/gsd-cloud-mcp-gateway.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const binDir = dirname(fileURLToPath(import.meta.url));
+const target = join(binDir, '..', 'dist', 'cli.js');
+
+if (!existsSync(target)) {
+  process.stderr.write('gsd-cloud-mcp-gateway: build output missing. Run `pnpm --filter @opengsd/cloud-mcp-gateway run build`.\n');
+  process.exit(1);
+}
+
+await import('../dist/cli.js');

--- a/packages/cloud-mcp-gateway/package.json
+++ b/packages/cloud-mcp-gateway/package.json
@@ -21,7 +21,7 @@
     }
   },
   "bin": {
-    "gsd-cloud-mcp-gateway": "./dist/cli.js"
+    "gsd-cloud-mcp-gateway": "./bin/gsd-cloud-mcp-gateway.js"
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc",
@@ -43,6 +43,7 @@
   },
   "files": [
     "README.md",
+    "bin",
     "dist",
     "!dist/**/*.test.*"
   ]

--- a/packages/mcp-server/bin/gsd-mcp-server.js
+++ b/packages/mcp-server/bin/gsd-mcp-server.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const binDir = dirname(fileURLToPath(import.meta.url));
+const target = join(binDir, '..', 'dist', 'cli.js');
+
+if (!existsSync(target)) {
+  process.stderr.write('gsd-mcp-server: build output missing. Run `pnpm --filter @opengsd/mcp-server run build`.\n');
+  process.exit(1);
+}
+
+await import('../dist/cli.js');

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -26,7 +26,7 @@
     }
   },
   "bin": {
-    "gsd-mcp-server": "./dist/cli.js"
+    "gsd-mcp-server": "./bin/gsd-mcp-server.js"
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc --incremental false",
@@ -47,6 +47,7 @@
     "node": ">=22.0.0"
   },
   "files": [
+    "bin",
     "dist",
     "!dist/**/*.test.*"
   ]

--- a/packages/pi-ai/bin/pi-ai.js
+++ b/packages/pi-ai/bin/pi-ai.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const binDir = dirname(fileURLToPath(import.meta.url));
+const target = join(binDir, '..', 'dist', 'cli.js');
+
+if (!existsSync(target)) {
+  process.stderr.write('pi-ai: build output missing. Run `pnpm --filter @gsd/pi-ai run build`.\n');
+  process.exit(1);
+}
+
+await import('../dist/cli.js');

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -57,9 +57,10 @@
     }
   },
   "bin": {
-    "pi-ai": "./dist/cli.js"
+    "pi-ai": "./bin/pi-ai.js"
   },
   "files": [
+    "bin",
     "dist",
     "README.md"
   ],

--- a/scripts/__tests__/github-workflows-runner-contract.test.mjs
+++ b/scripts/__tests__/github-workflows-runner-contract.test.mjs
@@ -104,6 +104,12 @@ test("ci workflow checkout does not depend on actor-scoped GitHub token auth", (
   }
 });
 
+test("ci workflow opts into Node 24 actions runtime", () => {
+  const workflow = YAML.parse(readFileSync(".github/workflows/ci.yml", "utf8"));
+
+  assert.equal(workflow.env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, "true");
+});
+
 test("native Linux ARM64 build matrix uses a Rust target triple", () => {
   const workflow = YAML.parse(readFileSync(".github/workflows/build-native.yml", "utf8"));
   const entries = workflow.jobs.build.strategy.matrix.include;

--- a/scripts/__tests__/installer-packaging.test.mjs
+++ b/scripts/__tests__/installer-packaging.test.mjs
@@ -2,7 +2,8 @@
 // File Purpose: Regression tests for installer package dependencies.
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import test from "node:test";
 
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
@@ -28,5 +29,27 @@ test("installer deps module exposes postinstall orchestration", async () => {
 test("installer tarball declares extension-critical externals at the package root", () => {
   for (const dep of REQUIRED_ROOT_EXTERNALS) {
     assert.ok(pkg.dependencies[dep], `root package must depend on ${dep}`);
+  }
+});
+
+test("workspace package bins point to checked-in shims instead of ignored dist output", () => {
+  const packages = [
+    "packages/pi-ai/package.json",
+    "packages/mcp-server/package.json",
+    "packages/cloud-mcp-gateway/package.json",
+    "packages/daemon/package.json",
+  ];
+
+  for (const packageJsonPath of packages) {
+    const workspacePkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    for (const [binName, binPath] of Object.entries(workspacePkg.bin ?? {})) {
+      assert.ok(
+        !String(binPath).startsWith("./dist/"),
+        `${workspacePkg.name} bin ${binName} must not target ignored dist output`,
+      );
+
+      const resolvedBin = join(dirname(packageJsonPath), String(binPath));
+      assert.ok(existsSync(resolvedBin), `${workspacePkg.name} bin ${binName} target must exist before build`);
+    }
   }
 });

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -65,6 +65,13 @@ test("publish jobs use GitHub-hosted runners for npm provenance", () => {
   assert.equal(workflow.jobs["prod-release"]["runs-on"], "ubuntu-latest");
 });
 
+test("npm publish opts into Node 24 actions runtime and quiet npm install noise", () => {
+  assert.equal(workflow.env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, "true");
+  assert.equal(workflow.env.NPM_CONFIG_AUDIT, "false");
+  assert.equal(workflow.env.NPM_CONFIG_FUND, "false");
+  assert.equal(workflow.env.NPM_CONFIG_LOGLEVEL, "error");
+});
+
 test("main package publish verifies native engine packages first", () => {
   const prereleaseSteps = workflow.jobs["prerelease-publish"].steps;
   const prereleaseVerify = prereleaseSteps.find(
@@ -92,4 +99,46 @@ test("main package publish verifies native engine packages first", () => {
   assert.ok(prodVerify, "production publish must verify native packages");
   assert.match(prodVerify.run, /npm run verify:native-platform-packages/);
   assert.ok(prodVerifyIndex > -1 && prodVerifyIndex < prodPublishIndex);
+});
+
+test("main package publish validates tarball before publishing", () => {
+  const prereleaseSteps = workflow.jobs["prerelease-publish"].steps;
+  const prereleaseValidate = prereleaseSteps.find(
+    (step) => step.name === "Validate package is installable",
+  );
+  const prereleasePublishIndex = prereleaseSteps.findIndex(
+    (step) => step.name === "Publish @${{ github.event.inputs.channel }}",
+  );
+
+  assert.ok(prereleaseValidate, "prerelease publish must run validate-pack");
+  assert.match(prereleaseValidate.run, /pnpm run validate-pack/);
+  assert.ok(prereleaseSteps.indexOf(prereleaseValidate) < prereleasePublishIndex);
+
+  const prodSteps = workflow.jobs["prod-release"].steps;
+  const prodValidate = prodSteps.find(
+    (step) => step.name === "Validate package is installable",
+  );
+  const prodPublishIndex = prodSteps.findIndex(
+    (step) => step.name === "Publish release to npm @latest",
+  );
+
+  assert.ok(prodValidate, "production publish must run validate-pack");
+  assert.match(prodValidate.run, /pnpm run validate-pack/);
+  assert.ok(prodSteps.indexOf(prodValidate) < prodPublishIndex);
+});
+
+test("main package publish uses explicit prepack and disables npm lifecycle reruns", () => {
+  const prereleasePublish = workflow.jobs["prerelease-publish"].steps.find(
+    (step) => step.name === "Publish @${{ github.event.inputs.channel }}",
+  );
+  assert.match(prereleasePublish.run, /prepack-resolve-workspace\.cjs/);
+  assert.match(prereleasePublish.run, /postpack-restore-workspace\.cjs/);
+  assert.match(prereleasePublish.run, /npm publish --ignore-scripts --tag "\$\{CHANNEL\}"/);
+
+  const prodPublish = workflow.jobs["prod-release"].steps.find(
+    (step) => step.name === "Publish release to npm @latest",
+  );
+  assert.match(prodPublish.run, /prepack-resolve-workspace\.cjs/);
+  assert.match(prodPublish.run, /postpack-restore-workspace\.cjs/);
+  assert.match(prodPublish.run, /npm publish --ignore-scripts --tag latest/);
 });

--- a/scripts/install/deps.js
+++ b/scripts/install/deps.js
@@ -164,6 +164,16 @@ function execCommand(command, opts = {}) {
  * to materialize the real packages without re-running lifecycle scripts.
  */
 export async function repairPackageDependencies(packageRoot, { ui, quiet = false } = {}) {
+  if (
+    process.env.GSD_SKIP_DEP_REPAIR === '1' ||
+    process.env.GSD_SKIP_DEP_REPAIR === 'true'
+  ) {
+    if (!quiet) {
+      ui?.skip?.('Dependencies', 'skipped by GSD_SKIP_DEP_REPAIR')
+    }
+    return
+  }
+
   const pkgJson = join(packageRoot, 'package.json')
   if (!existsSync(pkgJson)) return
 

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -26,7 +26,18 @@ function getNpmCommand() {
 }
 
 function cleanNpmEnv(extra = {}) {
-  const env = { ...process.env, ...extra };
+  const env = {
+    ...process.env,
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+    GSD_SKIP_RTK_INSTALL: '1',
+    NPM_CONFIG_AUDIT: 'false',
+    npm_config_audit: 'false',
+    NPM_CONFIG_FUND: 'false',
+    npm_config_fund: 'false',
+    NPM_CONFIG_LOGLEVEL: 'error',
+    npm_config_loglevel: 'error',
+    ...extra,
+  };
   for (const key of Object.keys(env)) {
     if (!key.startsWith('npm_config_')) continue;
     const setting = key.slice('npm_config_'.length).replace(/_/g, '-');
@@ -263,10 +274,15 @@ try {
   const requiredFiles = [
     'dist/loader.js',
     'packages/pi-coding-agent/dist/index.js',
+    'packages/pi-ai/bin/pi-ai.js',
+    'packages/pi-ai/dist/cli.js',
     'packages/daemon/bin/gsd-daemon.js',
     'packages/daemon/dist/cli.js',
     'packages/rpc-client/dist/index.js',
+    'packages/mcp-server/bin/gsd-mcp-server.js',
     'packages/mcp-server/dist/cli.js',
+    'packages/cloud-mcp-gateway/bin/gsd-cloud-mcp-gateway.js',
+    'packages/cloud-mcp-gateway/dist/cli.js',
     'scripts/link-workspace-packages.cjs',
     'dist/web/standalone/server.js',
   ];

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -59,6 +59,7 @@ import { debugLog } from "./debug-logger.js";
 import { logWarning, logError } from "./workflow-logger.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
+import { runWorktreePostCreateHook } from "./worktree-post-create-hook.js";
 import {
   nativeGetCurrentBranch,
   nativeDetectMainBranch,
@@ -912,62 +913,7 @@ export function syncWorktreeStateBack(
 ): { synced: string[] } {
   return _finalizeProjectionForMergeImpl(mainBasePath, worktreePath, milestoneId);
 }
-// ─── Worktree Post-Create Hook (#597) ────────────────────────────────────────
-
-/**
- * Run the user-configured post-create hook script after worktree creation.
- * The script receives SOURCE_DIR and WORKTREE_DIR as environment variables.
- * Failure is non-fatal — returns the error message or null on success.
- *
- * Reads the hook path from git.worktree_post_create in preferences.
- * Pass hookPath directly to bypass preference loading (useful for testing).
- */
-export function runWorktreePostCreateHook(
-  sourceDir: string,
-  worktreeDir: string,
-  hookPath?: string,
-): string | null {
-  if (hookPath === undefined) {
-    const prefs = loadEffectiveGSDPreferences()?.preferences?.git;
-    hookPath = prefs?.worktree_post_create;
-  }
-  if (!hookPath) return null;
-
-  // Resolve relative paths against the source project root.
-  // On Windows, convert 8.3 short paths (e.g. RUNNER~1) to long paths
-  // so execFileSync can locate the file correctly.
-  let resolved = isAbsolute(hookPath) ? hookPath : join(sourceDir, hookPath);
-  if (!existsSync(resolved)) {
-    return `Worktree post-create hook not found: ${resolved}`;
-  }
-  if (process.platform === "win32") {
-    try { resolved = realpathSync.native(resolved); } catch (err) { /* keep original */
-      logWarning("worktree", `realpath failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
-  try {
-    // .bat/.cmd files on Windows require shell mode — execFileSync cannot
-    // spawn them directly (EINVAL).
-    const needsShell = process.platform === "win32" && /\.(bat|cmd)$/i.test(resolved);
-    execFileSync(resolved, [], {
-      cwd: worktreeDir,
-      env: {
-        ...process.env,
-        SOURCE_DIR: sourceDir,
-        WORKTREE_DIR: worktreeDir,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-      timeout: 30_000, // 30 second timeout
-      shell: needsShell,
-    });
-    return null;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return `Worktree post-create hook failed: ${msg}`;
-  }
-}
+export { runWorktreePostCreateHook } from "./worktree-post-create-hook.js";
 
 // ─── Auto-Worktree Branch Naming ───────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/tests/worktree-post-create-hook.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-post-create-hook.test.ts
@@ -94,6 +94,106 @@ test("reads git.worktree_post_create from project preferences without loading au
   }
 });
 
+test("prefers canonical project PREFERENCES.md over legacy lowercase preferences.md", () => {
+  const src = makeTmpDir();
+  const wt = makeTmpDir();
+  const previousGsdHome = process.env.GSD_HOME;
+  try {
+    process.env.GSD_HOME = join(src, "empty-gsd-home");
+    const hooksDir = join(src, ".gsd", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(
+      join(src, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/canonical")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(src, ".gsd", "preferences.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/legacy")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeNodeHookScript(
+      hookPath(join(hooksDir, "canonical")),
+      `require("fs").writeFileSync(require("path").join(process.env.WORKTREE_DIR, "configured-hook-ran"), "canonical");`,
+    );
+    writeNodeHookScript(
+      hookPath(join(hooksDir, "legacy")),
+      `require("fs").writeFileSync(require("path").join(process.env.WORKTREE_DIR, "configured-hook-ran"), "legacy");`,
+    );
+
+    const result = runWorktreePostCreateHook(src, wt);
+
+    assert.equal(result, null);
+    assert.equal(readFileSync(join(wt, "configured-hook-ran"), "utf-8"), "canonical");
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(src, { recursive: true, force: true });
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("prefers canonical global PREFERENCES.md over legacy lowercase preferences.md", () => {
+  const src = makeTmpDir();
+  const wt = makeTmpDir();
+  const previousGsdHome = process.env.GSD_HOME;
+  try {
+    const gsdHomeDir = join(src, "global-gsd-home");
+    process.env.GSD_HOME = gsdHomeDir;
+    const hooksDir = join(src, ".gsd", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    mkdirSync(gsdHomeDir, { recursive: true });
+    writeFileSync(
+      join(gsdHomeDir, "PREFERENCES.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/canonical")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(gsdHomeDir, "preferences.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/legacy")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeNodeHookScript(
+      hookPath(join(hooksDir, "canonical")),
+      `require("fs").writeFileSync(require("path").join(process.env.WORKTREE_DIR, "configured-hook-ran"), "canonical");`,
+    );
+    writeNodeHookScript(
+      hookPath(join(hooksDir, "legacy")),
+      `require("fs").writeFileSync(require("path").join(process.env.WORKTREE_DIR, "configured-hook-ran"), "legacy");`,
+    );
+
+    const result = runWorktreePostCreateHook(src, wt);
+
+    assert.equal(result, null);
+    assert.equal(readFileSync(join(wt, "configured-hook-ran"), "utf-8"), "canonical");
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(src, { recursive: true, force: true });
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
 test("returns error when hook script does not exist", () => {
   const src = makeTmpDir();
   const wt = makeTmpDir();

--- a/src/resources/extensions/gsd/tests/worktree-post-create-hook.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-post-create-hook.test.ts
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { runWorktreePostCreateHook } from "../auto-worktree.ts";
+import { runWorktreePostCreateHook } from "../worktree-post-create-hook.ts";
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), "gsd-wt-hook-test-"));
@@ -45,10 +45,50 @@ function writeNodeHookScript(filePath: string, code: string): void {
 test("returns null when no hook path is provided", () => {
   const src = makeTmpDir();
   const wt = makeTmpDir();
+  const previousGsdHome = process.env.GSD_HOME;
   try {
+    process.env.GSD_HOME = join(src, "empty-gsd-home");
     const result = runWorktreePostCreateHook(src, wt, undefined);
     assert.equal(result, null);
   } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(src, { recursive: true, force: true });
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("reads git.worktree_post_create from project preferences without loading auto-worktree", () => {
+  const src = makeTmpDir();
+  const wt = makeTmpDir();
+  const previousGsdHome = process.env.GSD_HOME;
+  try {
+    process.env.GSD_HOME = join(src, "empty-gsd-home");
+    const hooksDir = join(src, ".gsd", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(
+      join(src, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/post-create")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    const hookFile = hookPath(join(hooksDir, "post-create"));
+    writeNodeHookScript(
+      hookFile,
+      `require("fs").writeFileSync(require("path").join(process.env.WORKTREE_DIR, "configured-hook-ran"), "ok");`,
+    );
+
+    const result = runWorktreePostCreateHook(src, wt);
+
+    assert.equal(result, null);
+    assert.ok(existsSync(join(wt, "configured-hook-ran")), "configured hook should run");
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
     rmSync(src, { recursive: true, force: true });
     rmSync(wt, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/worktree-post-create-hook.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-post-create-hook.test.ts
@@ -103,21 +103,21 @@ test("prefers canonical project PREFERENCES.md over legacy lowercase preferences
     const hooksDir = join(src, ".gsd", "hooks");
     mkdirSync(hooksDir, { recursive: true });
     writeFileSync(
-      join(src, ".gsd", "PREFERENCES.md"),
-      [
-        "---",
-        "git:",
-        `  worktree_post_create: ${hookPath(".gsd/hooks/canonical")}`,
-        "---",
-        "",
-      ].join("\n"),
-    );
-    writeFileSync(
       join(src, ".gsd", "preferences.md"),
       [
         "---",
         "git:",
         `  worktree_post_create: ${hookPath(".gsd/hooks/legacy")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(src, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/canonical")}`,
         "---",
         "",
       ].join("\n"),
@@ -154,21 +154,21 @@ test("prefers canonical global PREFERENCES.md over legacy lowercase preferences.
     mkdirSync(hooksDir, { recursive: true });
     mkdirSync(gsdHomeDir, { recursive: true });
     writeFileSync(
-      join(gsdHomeDir, "PREFERENCES.md"),
-      [
-        "---",
-        "git:",
-        `  worktree_post_create: ${hookPath(".gsd/hooks/canonical")}`,
-        "---",
-        "",
-      ].join("\n"),
-    );
-    writeFileSync(
       join(gsdHomeDir, "preferences.md"),
       [
         "---",
         "git:",
         `  worktree_post_create: ${hookPath(".gsd/hooks/legacy")}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(gsdHomeDir, "PREFERENCES.md"),
+      [
+        "---",
+        "git:",
+        `  worktree_post_create: ${hookPath(".gsd/hooks/canonical")}`,
         "---",
         "",
       ].join("\n"),

--- a/src/resources/extensions/gsd/worktree-post-create-hook.ts
+++ b/src/resources/extensions/gsd/worktree-post-create-hook.ts
@@ -61,11 +61,11 @@ function extractHookPath(preferences: Record<string, unknown> | null): string | 
 
 function resolveConfiguredHookPath(sourceDir: string): string | null {
   const paths = [
-    join(gsdHome(), "PREFERENCES.md"),
-    join(gsdHome(), "preferences.md"),
     join(homedir(), ".pi", "agent", "gsd-preferences.md"),
-    join(gsdRoot(sourceDir), "PREFERENCES.md"),
+    join(gsdHome(), "preferences.md"),
+    join(gsdHome(), "PREFERENCES.md"),
     join(gsdRoot(sourceDir), "preferences.md"),
+    join(gsdRoot(sourceDir), "PREFERENCES.md"),
   ];
 
   let hookPath: string | null = null;

--- a/src/resources/extensions/gsd/worktree-post-create-hook.ts
+++ b/src/resources/extensions/gsd/worktree-post-create-hook.ts
@@ -1,0 +1,127 @@
+// Project/App: gsd-pi
+// File Purpose: Lightweight worktree post-create hook runner.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import { parse as parseYaml } from "yaml";
+
+import { gsdHome } from "./gsd-home.js";
+import { gsdRoot } from "./paths.js";
+
+function readPreferencesObject(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) return null;
+
+  const content = readFileSync(path, "utf-8");
+  try {
+    const startMarker = content.startsWith("---\r\n") ? "---\r\n" : "---\n";
+    if (content.startsWith(startMarker)) {
+      const searchStart = startMarker.length;
+      const endIdx = content.indexOf("\n---", searchStart);
+      if (endIdx === -1) return null;
+
+      const parsed = parseYaml(content.slice(searchStart, endIdx).replace(/\r/g, ""));
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null;
+    }
+
+    const gitLines: string[] = [];
+    let inGitSection = false;
+    for (const rawLine of content.split("\n")) {
+      const line = rawLine.replace(/\r$/, "");
+      const heading = line.match(/^##\s+(.+)$/);
+      if (heading) {
+        inGitSection = heading[1].trim().toLowerCase().replace(/\s+/g, "_") === "git";
+        continue;
+      }
+      if (inGitSection && line.trim() && !line.trimStart().startsWith("#")) {
+        gitLines.push(line.replace(/^\s*-\s*/, ""));
+      }
+    }
+    if (gitLines.length === 0) return null;
+
+    const parsed = parseYaml(gitLines.join("\n"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? { git: parsed as Record<string, unknown> }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractHookPath(preferences: Record<string, unknown> | null): string | null {
+  const git = preferences?.git;
+  if (!git || typeof git !== "object" || Array.isArray(git)) return null;
+  const hookPath = (git as Record<string, unknown>).worktree_post_create;
+  return typeof hookPath === "string" && hookPath.trim() ? hookPath : null;
+}
+
+function resolveConfiguredHookPath(sourceDir: string): string | null {
+  const paths = [
+    join(gsdHome(), "PREFERENCES.md"),
+    join(gsdHome(), "preferences.md"),
+    join(homedir(), ".pi", "agent", "gsd-preferences.md"),
+    join(gsdRoot(sourceDir), "PREFERENCES.md"),
+    join(gsdRoot(sourceDir), "preferences.md"),
+  ];
+
+  let hookPath: string | null = null;
+  for (const path of paths) {
+    hookPath = extractHookPath(readPreferencesObject(path)) ?? hookPath;
+  }
+  return hookPath;
+}
+
+/**
+ * Run the user-configured post-create hook script after worktree creation.
+ * The script receives SOURCE_DIR and WORKTREE_DIR as environment variables.
+ * Failure is non-fatal -- returns the error message or null on success.
+ *
+ * Reads git.worktree_post_create from effective global/project preferences
+ * unless hookPath is provided directly.
+ */
+export function runWorktreePostCreateHook(
+  sourceDir: string,
+  worktreeDir: string,
+  hookPath?: string,
+): string | null {
+  if (hookPath === undefined) {
+    hookPath = resolveConfiguredHookPath(sourceDir) ?? undefined;
+  }
+  if (!hookPath) return null;
+
+  let resolved = isAbsolute(hookPath) ? hookPath : join(sourceDir, hookPath);
+  if (!existsSync(resolved)) {
+    return `Worktree post-create hook not found: ${resolved}`;
+  }
+  if (process.platform === "win32") {
+    try {
+      resolved = realpathSync.native(resolved);
+    } catch {
+      // Keep the original path; the exec error below will include the failure.
+    }
+  }
+
+  try {
+    const needsShell = process.platform === "win32" && /\.(bat|cmd)$/i.test(resolved);
+    execFileSync(resolved, [], {
+      cwd: worktreeDir,
+      env: {
+        ...process.env,
+        SOURCE_DIR: sourceDir,
+        WORKTREE_DIR: worktreeDir,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      timeout: 30_000,
+      shell: needsShell,
+    });
+    return null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `Worktree post-create hook failed: ${msg}`;
+  }
+}

--- a/src/tests/postinstall.test.ts
+++ b/src/tests/postinstall.test.ts
@@ -13,6 +13,7 @@ test("postinstall respects PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", () => {
     env: {
       ...process.env,
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1",
+      GSD_SKIP_DEP_REPAIR: "1",
       GSD_SKIP_RTK_INSTALL: "1",
     },
     encoding: "utf-8",

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -36,6 +36,7 @@ const gsdExtensionPath = (...segments: string[]) =>
 
 // Lazily-loaded extension modules (loaded once on first use via jiti)
 let _ext: ExtensionModules | null = null
+let _mergeExt: MergeModules | null = null
 
 interface ExtensionModules {
   createWorktree: (basePath: string, name: string) => { path: string; branch: string }
@@ -50,9 +51,12 @@ interface ExtensionModules {
   nativeHasChanges: (path: string) => boolean
   nativeDetectMainBranch: (basePath: string) => string
   nativeCommitCountBetween: (basePath: string, from: string, to: string) => number
+  resolveWorktreeProjectRoot: (basePath: string) => string
+}
+
+interface MergeModules {
   inferCommitType: (name: string) => string
   autoCommitCurrentBranch: (wtPath: string, reason: string, name: string) => void
-  resolveWorktreeProjectRoot: (basePath: string) => string
 }
 
 interface WorktreeDiff {
@@ -72,7 +76,7 @@ interface WorktreeManagerModule {
   worktreePath: ExtensionModules['worktreePath']
 }
 
-interface AutoWorktreeModule {
+interface WorktreePostCreateHookModule {
   runWorktreePostCreateHook: ExtensionModules['runWorktreePostCreateHook']
 }
 
@@ -83,11 +87,14 @@ interface NativeGitBridgeModule {
 }
 
 interface GitServiceModule {
-  inferCommitType: ExtensionModules['inferCommitType']
+  inferCommitType: MergeModules['inferCommitType']
 }
 
 interface WorktreeModule {
-  autoCommitCurrentBranch: ExtensionModules['autoCommitCurrentBranch']
+  autoCommitCurrentBranch: MergeModules['autoCommitCurrentBranch']
+}
+
+interface WorktreeRootModule {
   resolveWorktreeProjectRoot: ExtensionModules['resolveWorktreeProjectRoot']
 }
 
@@ -103,12 +110,11 @@ function logDebugFailure(scope: string, error: unknown): void {
 
 async function loadExtensionModules(): Promise<ExtensionModules> {
   if (_ext) return _ext
-  const [wtMgr, autoWt, gitBridge, gitSvc, wt] = await Promise.all([
+  const [wtMgr, hook, gitBridge, wtRoot] = await Promise.all([
     jiti.import(gsdExtensionPath('worktree-manager.ts'), {}) as Promise<WorktreeManagerModule>,
-    jiti.import(gsdExtensionPath('auto-worktree.ts'), {}) as Promise<AutoWorktreeModule>,
+    jiti.import(gsdExtensionPath('worktree-post-create-hook.ts'), {}) as Promise<WorktreePostCreateHookModule>,
     jiti.import(gsdExtensionPath('native-git-bridge.ts'), {}) as Promise<NativeGitBridgeModule>,
-    jiti.import(gsdExtensionPath('git-service.ts'), {}) as Promise<GitServiceModule>,
-    jiti.import(gsdExtensionPath('worktree.ts'), {}) as Promise<WorktreeModule>,
+    jiti.import(gsdExtensionPath('worktree-root.ts'), {}) as Promise<WorktreeRootModule>,
   ])
   _ext = {
     createWorktree: wtMgr.createWorktree,
@@ -119,15 +125,26 @@ async function loadExtensionModules(): Promise<ExtensionModules> {
     diffWorktreeNumstat: wtMgr.diffWorktreeNumstat,
     worktreeBranchName: wtMgr.worktreeBranchName,
     worktreePath: wtMgr.worktreePath,
-    runWorktreePostCreateHook: autoWt.runWorktreePostCreateHook,
+    runWorktreePostCreateHook: hook.runWorktreePostCreateHook,
     nativeHasChanges: gitBridge.nativeHasChanges,
     nativeDetectMainBranch: gitBridge.nativeDetectMainBranch,
     nativeCommitCountBetween: gitBridge.nativeCommitCountBetween,
-    inferCommitType: gitSvc.inferCommitType,
-    autoCommitCurrentBranch: wt.autoCommitCurrentBranch,
-    resolveWorktreeProjectRoot: wt.resolveWorktreeProjectRoot,
+    resolveWorktreeProjectRoot: wtRoot.resolveWorktreeProjectRoot,
   }
   return _ext
+}
+
+async function loadMergeModules(): Promise<MergeModules> {
+  if (_mergeExt) return _mergeExt
+  const [gitSvc, wt] = await Promise.all([
+    jiti.import(gsdExtensionPath('git-service.ts'), {}) as Promise<GitServiceModule>,
+    jiti.import(gsdExtensionPath('worktree.ts'), {}) as Promise<WorktreeModule>,
+  ])
+  _mergeExt = {
+    inferCommitType: gitSvc.inferCommitType,
+    autoCommitCurrentBranch: wt.autoCommitCurrentBranch,
+  }
+  return _mergeExt
 }
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -243,6 +260,7 @@ async function handleMerge(basePath: string, args: string[]): Promise<void> {
 }
 
 async function doMerge(ext: ExtensionModules, basePath: string, name: string): Promise<void> {
+  const mergeExt = await loadMergeModules()
   const worktrees = ext.listWorktrees(basePath)
   const wt = worktrees.find(w => w.name === name)
   if (!wt) {
@@ -262,14 +280,14 @@ async function doMerge(ext: ExtensionModules, basePath: string, name: string): P
   // Auto-commit dirty work before merge
   if (status.uncommitted) {
     try {
-      ext.autoCommitCurrentBranch(wt.path, 'worktree-merge', name)
+      mergeExt.autoCommitCurrentBranch(wt.path, 'worktree-merge', name)
       process.stderr.write(chalk.dim('  Auto-committed dirty work before merge.\n'))
     } catch (error) {
       process.stderr.write(chalk.yellow(`  Auto-commit before merge failed: ${toErrorMessage(error)}\n`))
     }
   }
 
-  const commitType = ext.inferCommitType(name)
+  const commitType = mergeExt.inferCommitType(name)
   const commitMessage = `${commitType}: merge worktree ${name}\n\nGSD-Worktree: ${name}`
 
   process.stderr.write(`\nMerging ${chalk.bold.cyan(name)} → ${chalk.magenta(ext.nativeDetectMainBranch(basePath))}\n`)


### PR DESCRIPTION
## Summary
- replace workspace package bin targets that pointed at ignored `dist/cli.js` with checked-in runtime shims
- harden the manual npm publish workflow so it validates the exact tarball before publishing and publishes with lifecycle scripts disabled
- quiet non-actionable npm/audit/action-runtime noise in publish validation while preserving real install failures
- add regression coverage for package bin targets and publish workflow safeguards

## Root Cause
The npm to pnpm migration exposed a few npm-specific assumptions: workspace packages advertised bins under ignored build output, publish relied on lifecycle scripts to rewrite workspace metadata at the right time, and validation output mixed real package failures with noisy side effects. PNPM links bins before `dist` exists in fresh CI installs, producing ENOENT warnings and making publish/install confidence too fragile.

## Verification
- `node --test scripts/__tests__/npm-publish-workflow.test.mjs`
- `node --test scripts/__tests__/installer-packaging.test.mjs`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run validate-pack`
- `pnpm exec pi-ai --help`
- `git diff --check`

## Notes
The remaining PNPM warning is the known workspace cycle between `@gsd/agent-core` and `@gsd/pi-coding-agent`. That is separate dependency graph cleanup and not a publish blocker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782674757&installation_id=134682257&pr_number=250&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F250&signature=cc44545a5a3e2494cfb219c8674ed85c8ba9e3b44fa7afd6cbf1b2bd12a0a767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production npm publish pipeline and global install repair behavior; mistakes could block releases or break CLI resolution after install, but scope is packaging/CI rather than runtime auth or data handling.
> 
> **Overview**
> Fixes **pnpm/npm install and publish** reliability by pointing workspace **CLI bins** at checked-in **`bin/*` shims** (instead of `dist/cli.js` that may be missing before build) and requiring those shims in **`validate-pack`**.
> 
> **NPM Publish** and **CI** now opt into the **Node 24 Actions runtime**, quiet non-actionable npm output, run **`validate-pack` before publish**, run **explicit prepack/postpack workspace resolution**, and publish with **`npm publish --ignore-scripts`** plus **post-publish registry reachability** checks on production releases.
> 
> **Install validation** sets skip flags during pack tests, adds **`GSD_SKIP_DEP_REPAIR`** for postinstall tests, and regression tests lock in workflow and bin-shim contracts.
> 
> **Worktree post-create hooks** move to a dedicated **`worktree-post-create-hook`** module with lighter preference resolution (canonical **`PREFERENCES.md`** over legacy files); **`worktree-cli`** loads that module separately from merge/heavy auto-worktree code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 008f103fc89d63f45103cc5c13c7b7d79dfa26fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->