### PR TITLE
fix: resolve extension deps for scoped global installs

### DIFF
--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -8,7 +8,7 @@ import { copyFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync,
 import { tmpdir } from 'node:os';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -596,6 +596,36 @@ try {
         maxBuffer: DEFAULT_MAX_BUFFER,
       },
     );
+    console.log('==> Verifying copied extension resolves hoisted externals...');
+    const localYamlDir = join(globalRoot, 'node_modules', 'yaml');
+    const hoistedYamlDir = join(globalNodeModules, 'yaml');
+    if (existsSync(localYamlDir)) {
+      if (!existsSync(hoistedYamlDir)) {
+        cpSync(localYamlDir, hoistedYamlDir, { recursive: true, dereference: true });
+      }
+      rmSync(localYamlDir, { recursive: true, force: true });
+    }
+    const agentDir = join(globalPrefix, 'agent-home');
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        [
+          `const { initResources } = await import(${JSON.stringify(pathToFileURL(join(globalRoot, 'dist', 'resource-loader.js')).href)});`,
+          `initResources(${JSON.stringify(agentDir)});`,
+          `await import(${JSON.stringify(pathToFileURL(join(agentDir, 'extensions', 'gsd', 'commands', 'handlers', 'workflow.js')).href)});`,
+        ].join('\n'),
+      ],
+      {
+        cwd: globalRoot,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    Copied /gsd workflow handler resolves hoisted yaml.');
     console.log('    Global --ignore-scripts install + repair resolves externals and pi-ai/pi-coding-agent.');
   } catch (err) {
     console.log('ERROR: Global install smoke test failed.');

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -352,17 +352,16 @@ function copyDirRecursive(src: string, dest: string): void {
  * them without requiring every call site to use jiti.
  *
  * Layout differences by install method:
- * - Source/monorepo: packageRoot/node_modules has everything → simple symlink
- * - Global install (npm/bun/pnpm): merge hoisted dirname(packageRoot)/node_modules with
- *   packageRoot/node_modules so package-local deps like @sinclair/typebox resolve (#3529, #3564)
+ * - Source/monorepo: packageRoot/node_modules has everything -> simple symlink
+ * - Global install (npm/bun/pnpm): merge the nearest ancestor node_modules
+ *   with packageRoot/node_modules so both hoisted deps like yaml and
+ *   package-local deps like @sinclair/typebox resolve (#3529, #3564).
  */
 function ensureNodeModulesSymlink(agentDir: string): void {
   const agentNodeModules = join(agentDir, 'node_modules')
-  const internalNodeModules = join(packageRoot, 'node_modules')
-  const hoistedNodeModules = dirname(packageRoot)
-  const isGlobalInstall = basename(hoistedNodeModules) === 'node_modules'
+  const { internalNodeModules, hoistedNodeModules } = resolvePackageNodeModulesLayout(packageRoot)
 
-  if (!isGlobalInstall) {
+  if (!hoistedNodeModules) {
     // Source/monorepo: internal node_modules has everything
     reconcileSymlink(agentNodeModules, internalNodeModules)
     return
@@ -372,6 +371,26 @@ function ensureNodeModulesSymlink(agentDir: string): void {
   // npm often keeps runtime deps (e.g. @sinclair/typebox) package-local even when
   // @gsd/* scopes are hoisted — a hoisted-only symlink breaks extension imports.
   reconcileMergedNodeModules(agentNodeModules, hoistedNodeModules, internalNodeModules)
+}
+
+export function resolvePackageNodeModulesLayout(root: string): {
+  internalNodeModules: string
+  hoistedNodeModules: string | null
+} {
+  return {
+    internalNodeModules: join(root, 'node_modules'),
+    hoistedNodeModules: findNearestNodeModulesAncestor(root),
+  }
+}
+
+export function findNearestNodeModulesAncestor(startPath: string): string | null {
+  let current = resolve(startPath)
+  while (true) {
+    if (basename(current) === 'node_modules') return current
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
 }
 
 /** Check if any GSD workspace scopes exist in internal but not in hoisted node_modules */

--- a/src/tests/node-modules-symlink.test.ts
+++ b/src/tests/node-modules-symlink.test.ts
@@ -27,9 +27,11 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 import {
+  findNearestNodeModulesAncestor,
   hasMissingWorkspaceScopes,
   mergedFingerprint,
   reconcileMergedNodeModules,
+  resolvePackageNodeModulesLayout,
 } from "../resource-loader.ts";
 
 // The real module captures packageRoot at load time — the merged-node-modules
@@ -90,6 +92,54 @@ test("initResources replaces a real directory blocking node_modules with a symli
 // --- Unit tests for pnpm-style merged node_modules (#3564) ---
 // These exercise the real reconcileMergedNodeModules helper against
 // test-controlled hoisted/internal directories.
+
+test("global layout detection handles scoped package installs", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-scoped-global-layout-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const hoisted = join(tmp, "lib", "node_modules");
+  const scopedPackageRoot = join(hoisted, "@opengsd", "gsd-pi");
+  mkdirSync(scopedPackageRoot, { recursive: true });
+
+  assert.equal(
+    findNearestNodeModulesAncestor(scopedPackageRoot),
+    hoisted,
+    "scoped packages should resolve the hoisted node_modules above the scope directory",
+  );
+  assert.deepEqual(resolvePackageNodeModulesLayout(scopedPackageRoot), {
+    internalNodeModules: join(scopedPackageRoot, "node_modules"),
+    hoistedNodeModules: hoisted,
+  });
+});
+
+test("global layout detection handles unscoped package installs", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-unscoped-global-layout-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const hoisted = join(tmp, "lib", "node_modules");
+  const packageRoot = join(hoisted, "gsd-pi");
+  mkdirSync(packageRoot, { recursive: true });
+
+  assert.equal(findNearestNodeModulesAncestor(packageRoot), hoisted);
+  assert.deepEqual(resolvePackageNodeModulesLayout(packageRoot), {
+    internalNodeModules: join(packageRoot, "node_modules"),
+    hoistedNodeModules: hoisted,
+  });
+});
+
+test("source layout detection keeps monorepo installs on package-local node_modules", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-source-layout-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const packageRoot = join(tmp, "open-gsd", "gsd-pi");
+  mkdirSync(packageRoot, { recursive: true });
+
+  assert.equal(findNearestNodeModulesAncestor(packageRoot), null);
+  assert.deepEqual(resolvePackageNodeModulesLayout(packageRoot), {
+    internalNodeModules: join(packageRoot, "node_modules"),
+    hoistedNodeModules: null,
+  });
+});
 
 test("pnpm layout: merged node_modules contains entries from both hoisted and internal", (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-pnpm-merge-"));


### PR DESCRIPTION
## Summary
- detect scoped global installs by walking up to the nearest ancestor node_modules
- rebuild ~/.gsd/agent/node_modules as a merged hoisted + package-local dependency view so copied extensions can import yaml
- add validate-pack coverage that imports the copied /gsd workflow handler with yaml forced to a hoisted-only location

## Verification
- NODE24 + node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/node-modules-symlink.test.ts
- NODE24 + pnpm run test:compile
- NODE24 + node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/tests/node-modules-symlink.test.js
- NODE24 + pnpm run build:core
- NODE24 + pnpm run validate-pack
- NODE24 + node --test scripts/__tests__/installer-packaging.test.mjs
- NODE24 + node --test scripts/__tests__/npm-publish-workflow.test.mjs
- NODE24 + node --test scripts/__tests__/github-workflows-runner-contract.test.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup dependency layout for global installs (affects all extension imports) but is narrowly scoped to path detection and covered by unit and validate-pack smoke tests.
> 
> **Overview**
> Fixes **global install detection** for scoped packages (e.g. `@opengsd/gsd-pi`) by walking up to the **nearest ancestor `node_modules`** instead of assuming the parent directory is hoisted. That drives the existing **merged `~/.gsd/agent/node_modules`** view (hoisted + package-local) so synced extensions can resolve deps like **`yaml`** when they only exist at the global hoist.
> 
> Adds **`resolvePackageNodeModulesLayout`** / **`findNearestNodeModulesAncestor`** with unit tests for scoped global, unscoped global, and monorepo layouts. **`validate-pack`** now smoke-tests **`initResources`** plus importing the copied **`/gsd` workflow handler** with **`yaml` forced to a hoisted-only location**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d825b2fbf392231befe9fa5e02ca32ded07a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782683758&installation_id=134682257&pr_number=253&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F253&signature=d34577637d074688a08525d93f123e11d7e95a869612fee834e6e4d01c0b05c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->