### PR TITLE
fix pnpm install dependency coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "chokidar": "^5.0.0",
     "cross-spawn": "^7.0.6",
     "diff": "^8.0.2",
+    "discord.js": "^14.26.4",
     "extract-zip": "^2.0.1",
     "file-type": "^21.1.1",
     "glob": "^13.0.1",
@@ -184,7 +185,8 @@
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
     "typebox": "1.1.38",
-    "undici": "^8.3.0",
+    "undici": "^7.26.0",
+    "ws": "^8.21.0",
     "yaml": "^2.8.2",
     "zod": "^4.0.0"
   },
@@ -199,6 +201,7 @@
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {
+    "@mariozechner/clipboard": "0.3.6",
     "@opengsd/engine-darwin-arm64": "1.0.2",
     "@opengsd/engine-darwin-x64": "1.0.2",
     "@opengsd/engine-linux-arm64-gnu": "1.0.2",

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -51,7 +51,7 @@
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
     "typebox": "1.1.38",
-    "undici": "8.3.0",
+    "undici": "7.26.0",
     "yaml": "2.9.0",
     "@gsd/agent-core": "workspace:*",
     "@gsd/native": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       diff:
         specifier: ^8.0.2
         version: 8.0.4
+      discord.js:
+        specifier: ^14.26.4
+        version: 14.26.4
       extract-zip:
         specifier: ^2.0.1
         version: 2.0.1
@@ -141,8 +144,11 @@ importers:
         specifier: 1.1.38
         version: 1.1.38
       undici:
-        specifier: ^8.3.0
-        version: 8.3.0
+        specifier: ^7.26.0
+        version: 7.26.0
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
       yaml:
         specifier: ^2.8.2
         version: 2.9.0
@@ -175,6 +181,9 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
     optionalDependencies:
+      '@mariozechner/clipboard':
+        specifier: 0.3.6
+        version: 0.3.6
       '@opengsd/engine-darwin-arm64':
         specifier: 1.0.2
         version: 1.0.2
@@ -371,13 +380,13 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
-        version: 0.91.1(zod@3.25.76)
+        version: 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
       '@google/genai':
         specifier: 1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai':
         specifier: 2.2.1
         version: 2.2.1
@@ -392,7 +401,7 @@ importers:
         version: 7.0.6
       openai:
         specifier: 6.26.0
-        version: 6.26.0(ws@8.21.0)(zod@3.25.76)
+        version: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json:
         specifier: 0.1.7
         version: 0.1.7
@@ -485,8 +494,8 @@ importers:
         specifier: 1.1.38
         version: 1.1.38
       undici:
-        specifier: 8.3.0
-        version: 8.3.0
+        specifier: 7.26.0
+        version: 7.26.0
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -6102,9 +6111,9 @@ packages:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
-    engines: {node: '>=22.19.0'}
+  undici@7.26.0:
+    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -6424,12 +6433,6 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-
-  '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
@@ -7316,19 +7319,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.6.1
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
@@ -7644,29 +7634,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -9958,7 +9925,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -9991,7 +9958,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10006,7 +9973,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11588,11 +11555,6 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(ws@8.21.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 3.25.76
-
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
@@ -12596,7 +12558,7 @@ snapshots:
 
   undici@6.24.1: {}
 
-  undici@8.3.0: {}
+  undici@7.26.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -4,7 +4,7 @@
 // Exit 0 = safe to publish, Exit 1 = broken package.
 
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
@@ -112,6 +112,25 @@ function findPackedWorkspaceProtocolLeaks(packedPaths) {
   return leaks;
 }
 
+function getPackagedWorkspacePackages() {
+  const packagesDir = join(ROOT, 'packages');
+  if (!existsSync(packagesDir)) return [];
+  const packages = [];
+  for (const dir of readdirSync(packagesDir)) {
+    const packageDir = join(packagesDir, dir);
+    if (!statSync(packageDir).isDirectory()) continue;
+    const packageJsonPath = join(packageDir, 'package.json');
+    if (!existsSync(packageJsonPath)) continue;
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    packages.push({
+      dir,
+      packageName: pkg.name ?? dir,
+      packageJsonPath,
+    });
+  }
+  return packages.sort((a, b) => a.packageName.localeCompare(b.packageName));
+}
+
 try {
   npmCacheDir = mkdtempSync(join(tmpdir(), 'validate-pack-npm-cache-'));
   mkdirSync(npmCacheDir, { recursive: true });
@@ -145,35 +164,58 @@ try {
   }
   console.log('    No workspace: protocol leaks in published dependency fields.');
 
-  // --- Guard: linkable workspace external dependencies must be declared on the root ---
-  // @gsd/* (and @opengsd/*) workspace packages are NOT published to the public
-  // registry and are NOT root dependencies. They ship inside this tarball under
-  // packages/*/dist and are symlinked into node_modules at postinstall
-  // (link-workspace-packages.cjs). Their EXTERNAL (registry) deps must therefore be
-  // declared on the root package so `npm install` and the installer's
-  // `npm install --ignore-scripts` repair materialize them; the linked workspace
-  // packages then resolve those externals by walking up to the root node_modules.
-  console.log('==> Checking linkable workspace external dependency coverage on root...');
+  // --- Guard: packaged workspace external dependencies must be declared on the root ---
+  // Workspace packages are shipped inside the root tarball under
+  // packages/*/dist and packages/*/bin; linkable packages are symlinked into
+  // node_modules at postinstall (link-workspace-packages.cjs), and non-linkable
+  // packaged CLIs can still be executed from their shipped package directories.
+  // Their EXTERNAL (registry) deps must therefore be declared on the root package so
+  // `npm install` and the installer's `npm install --ignore-scripts` repair
+  // materialize them; shipped workspace packages then resolve those externals by
+  // walking up to the root node_modules.
+  console.log('==> Checking packaged workspace external dependency coverage on root...');
   const rootExternalDeps = new Set(Object.keys(rootPkg.dependencies || {}));
+  const rootOptionalExternalDeps = new Set(Object.keys(rootPkg.optionalDependencies || {}));
 
   const missingExternal = new Map();
-  for (const ws of getLinkablePackages()) {
+  const missingOptionalExternal = new Map();
+  for (const ws of getPackagedWorkspacePackages()) {
     const pkg = JSON.parse(readFileSync(ws.packageJsonPath, 'utf8'));
     for (const [dep, version] of Object.entries(pkg.dependencies || {})) {
       if (isInternalWorkspaceDep(dep)) continue;
-      if (!rootExternalDeps.has(dep)) missingExternal.set(dep, version);
+      if (!rootExternalDeps.has(dep)) {
+        const entry = missingExternal.get(dep) ?? { version, packages: new Set() };
+        entry.packages.add(ws.packageName);
+        missingExternal.set(dep, entry);
+      }
+    }
+    for (const [dep, version] of Object.entries(pkg.optionalDependencies || {})) {
+      if (isInternalWorkspaceDep(dep)) continue;
+      if (!rootExternalDeps.has(dep) && !rootOptionalExternalDeps.has(dep)) {
+        const entry = missingOptionalExternal.get(dep) ?? { version, packages: new Set() };
+        entry.packages.add(ws.packageName);
+        missingOptionalExternal.set(dep, entry);
+      }
     }
   }
 
   if (missingExternal.size > 0) {
-    console.log('ERROR: Linkable workspace packages depend on externals missing from root dependencies:');
-    for (const [dep, version] of [...missingExternal.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-      console.log(`    ${dep}@${version}`);
+    console.log('ERROR: Packaged workspace packages depend on externals missing from root dependencies:');
+    for (const [dep, entry] of [...missingExternal.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      console.log(`    ${dep}@${entry.version} (needed by ${[...entry.packages].sort().join(', ')})`);
     }
     console.log('    Add these to root package.json dependencies so installs resolve them at runtime.');
     process.exit(1);
   }
-  console.log('    Linkable workspace external dependency coverage is complete.');
+  if (missingOptionalExternal.size > 0) {
+    console.log('ERROR: Packaged workspace packages have optional externals missing from root dependencies/optionalDependencies:');
+    for (const [dep, entry] of [...missingOptionalExternal.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      console.log(`    ${dep}@${entry.version} (optional for ${[...entry.packages].sort().join(', ')})`);
+    }
+    console.log('    Add these to root package.json optionalDependencies so installs preserve optional runtime features.');
+    process.exit(1);
+  }
+  console.log('    Packaged workspace external dependency coverage is complete.');
 
   // --- Pack tarball ---
   // npm pack --ignore-scripts skips prepack; resolve workspace:* for publishable tarballs.
@@ -478,6 +520,43 @@ try {
     console.log('    install.js --help OK');
   } catch (err) {
     console.log('ERROR: install.js --help failed after install.');
+    if (err.stdout) console.log(err.stdout);
+    if (err.stderr) console.log(err.stderr);
+    process.exit(1);
+  }
+
+  // --- Verify packaged non-linkable CLIs resolve their root-provided deps ---
+  console.log('==> Verifying packaged daemon/cloud dependency resolution...');
+  try {
+    const daemonHelpOutput = execFileSync(process.execPath, [join(installedRoot, 'packages', 'daemon', 'bin', 'gsd-daemon.js'), '--help'], {
+      cwd: installDir,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 15000,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+    });
+    if (!daemonHelpOutput.includes('Usage: gsd-daemon')) {
+      console.log('ERROR: gsd-daemon --help returned unexpected output.');
+      process.exit(1);
+    }
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `await import(${JSON.stringify('file://' + join(installedRoot, 'packages', 'cloud-mcp-gateway', 'dist', 'server.js').replace(/\\/g, '/'))});`,
+      ],
+      {
+        cwd: installDir,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    daemon and cloud gateway package deps resolve.');
+  } catch (err) {
+    console.log('ERROR: packaged daemon/cloud dependency resolution failed after install.');
     if (err.stdout) console.log(err.stdout);
     if (err.stderr) console.log(err.stderr);
     process.exit(1);


### PR DESCRIPTION
## Summary
- add root runtime coverage for shipped daemon/cloud deps (`discord.js`, `ws`)
- add root optional coverage for the shipped pi-coding-agent clipboard addon (`@mariozechner/clipboard`)
- pin `undici` to 7.26.0 so Node 22.15 installs avoid the `undici@8` engine floor
- expand `validate-pack` to audit shipped workspace required/optional externals and smoke daemon/cloud dependency resolution

## Root cause
After the npm -> pnpm packaging change, root dependencies only covered linkable packages. Non-linkable shipped packages still execute from the tarball and need their external runtime deps materialized at the root. Optional workspace deps also need root optional coverage now that nested workspace package installs are not independently resolved by npm. `undici@8.3.0` also requires Node >=22.19.0, which is above the Node 22.15.0 install path that showed the warning.

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec tsc --pretty false --incremental false`
- `pnpm run validate-pack`
- `node --check scripts/validate-pack.js`
- `git diff --check -- package.json pnpm-lock.yaml scripts/validate-pack.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time dependency resolution and HTTP client version for the whole published package; mistakes could break daemon, cloud gateway, or pi-coding-agent at runtime on consumer installs.
> 
> **Overview**
> Ensures **published tarball installs** can resolve runtime modules for workspace packages that ship inside the root package but are not fully hoisted as linkable symlinks.
> 
> The root **`package.json`** now declares **`discord.js`** and **`ws`** so **`@opengsd/daemon`** and **`@opengsd/cloud-mcp-gateway`** can load from the root `node_modules`, and adds **`@mariozechner/clipboard`** under **`optionalDependencies`** for the pi-coding-agent clipboard addon. **`undici`** is pinned from **8.x to 7.26.0** on the root and **`@gsd/pi-coding-agent`** so installs on Node 22.15 stay within the package’s engine range (8.x requires Node ≥22.19). The lockfile updates follow those dependency moves.
> 
> **`scripts/validate-pack.js`** broadens pre-publish checks: it audits **all** packaged workspace packages (not only linkable ones) for missing required and optional externals on the root manifest, and adds post-install smoke tests that **`gsd-daemon --help`** runs and **`cloud-mcp-gateway`**’s server module imports successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 427d32390a9aadeea03afa620aca180b29557e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->