### PR TITLE
[codex] hide ambiguous skill collision warnings

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -676,7 +676,7 @@ function cleanupBundledSkillsFromEcosystemDir(): void {
       if (directoriesHaveExactFileContents(sourcePath, targetPath)) {
         makeTreeWritable(targetPath)
         rmSync(targetPath, { recursive: true, force: true })
-      } else {
+      } else if (process.env.GSD_RESOURCE_LOADER_DEBUG === '1') {
         console.warn(
           `[GSD] Leaving ambiguous skill collision in ${targetPath}; ` +
           `the bundled copy will be used from ~/.gsd/agent/skills/${entry.name}.`,

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -251,8 +251,17 @@ test("initResources leaves ambiguous ecosystem skill name collisions in place", 
   const ecosystemLintDir = join(tmp, ".agents", "skills", "lint");
   const ecosystemLintFile = join(ecosystemLintDir, "SKILL.md");
   const restoreHomeEnv = overrideHomeEnv(tmp);
+  const originalWarn = console.warn;
+  const originalResourceLoaderDebug = process.env.GSD_RESOURCE_LOADER_DEBUG;
+  const warnings: unknown[][] = [];
+
+  delete process.env.GSD_RESOURCE_LOADER_DEBUG;
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
 
   t.after(() => {
+    console.warn = originalWarn;
+    if (originalResourceLoaderDebug === undefined) delete process.env.GSD_RESOURCE_LOADER_DEBUG;
+    else process.env.GSD_RESOURCE_LOADER_DEBUG = originalResourceLoaderDebug;
     restoreHomeEnv();
     rmSync(tmp, { recursive: true, force: true });
   });
@@ -266,6 +275,11 @@ test("initResources leaves ambiguous ecosystem skill name collisions in place", 
   const { initResources } = await import("../resource-loader.ts");
   initResources(fakeAgentDir);
 
+  assert.deepEqual(
+    warnings,
+    [],
+    "ambiguous user-owned skill collisions should not warn during normal startup",
+  );
   assert.equal(
     readFileSync(ecosystemLintFile, "utf-8"),
     "---\nname: lint\ndescription: User-owned lint skill.\n---\n\n# Custom lint\n",


### PR DESCRIPTION
## Summary

Suppress the startup warning emitted for ambiguous bundled skill name collisions in `~/.agents/skills` during normal launches. The cleanup still removes exact bundled copies and still leaves user-modified collisions untouched, but the diagnostic is now opt-in with `GSD_RESOURCE_LOADER_DEBUG=1`.

## Root Cause

`cleanupBundledSkillsFromEcosystemDir()` warned unconditionally whenever a user-owned skill shared a bundled skill name but did not exactly match bundled contents. That made expected, non-fatal collisions show up on every launch.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/resource-loader.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782690031&installation_id=134682257&pr_number=258&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F258&signature=2ee40999bd4ea23e78ff890e649404a0a037999d0fee71927f05bafe6c63291a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; skill cleanup and collision handling behavior are unchanged.
> 
> **Overview**
> Startup no longer prints a **warning** when a user-owned skill in `~/.agents/skills` shares a bundled name but differs in content. **Exact** bundled copies are still removed from the ecosystem dir; **ambiguous** collisions are still left untouched and the bundled skill is still used from `~/.gsd/agent/skills`.
> 
> The collision message is now **opt-in** via `GSD_RESOURCE_LOADER_DEBUG=1`. Tests confirm normal launches emit **no** `console.warn` for that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d8d0bc54645cea6ca56b8025e821106a44679b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->