### PR TITLE
[codex] remove user chat background

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/user-message-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/user-message-design.test.ts
@@ -41,13 +41,14 @@ function withEnv(values: Partial<Record<(typeof ENV_KEYS)[number], string | unde
 }
 
 describe("UserMessageComponent connected rail", () => {
-	test("renders a user message like GSD with a lighter blue connected card", () => {
+	test("renders a user message like GSD with a transparent connected card", () => {
 		const component = new UserMessageComponent(
 			"Can we make the transcript feel like chat?",
 			undefined,
 			1,
 			"date-time-iso",
 		);
+		const raw = component.render(100);
 		const plain = component
 			.render(100)
 			.map((line) => stripVTControlCharacters(line))
@@ -63,10 +64,11 @@ describe("UserMessageComponent connected rail", () => {
 		const topRuleIndex = plain.findIndex((line) => line.includes("YOU") && line.includes("─"));
 		const contentIndex = plain.findIndex((line) => line.includes("feel like chat"));
 		assert.ok(contentIndex > topRuleIndex, `expected content after the top rule:\n${joined}`);
+		assert.doesNotMatch(raw[contentIndex] ?? "", /\x1b\[48[;:]/, "user content rows should not paint a background");
 		assert.ok(plain[topRuleIndex]?.startsWith("    ╭─ YOU"), `user turn should indent for the connected bridge:\n${joined}`);
 		assert.ok(plain[contentIndex]?.startsWith("       "), `user content should keep inner padding:\n${joined}`);
 		assert.equal(plain[contentIndex]?.length, 100, `user content row should fill the card interior:\n${joined}`);
-		assert.match(plain[contentIndex] ?? "", /^    /, `user background should not bleed into the rail gutter:\n${joined}`);
+		assert.match(plain[contentIndex] ?? "", /^    /, `user content should remain aligned with the rail gutter:\n${joined}`);
 		assert.doesNotMatch(plain[contentIndex] ?? "", /[│┃╭╮╰╯]/, `content line must stay copy-clean:\n${joined}`);
 	});
 

--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/user-message-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/user-message-design.test.ts
@@ -49,11 +49,7 @@ describe("UserMessageComponent connected rail", () => {
 			"date-time-iso",
 		);
 		const raw = component.render(100);
-		const plain = component
-			.render(100)
-			.map((line) => stripVTControlCharacters(line))
-			.join("\n")
-			.split("\n");
+		const plain = raw.map((line) => stripVTControlCharacters(line)).join("\n").split("\n");
 
 		const joined = plain.join("\n");
 		assert.match(joined, /YOU/);

--- a/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
@@ -314,7 +314,6 @@ export function renderUserRail(
 		titleRight,
 		railColor: "border",
 		titleColor: "border",
-		bodyBg: "userMessageBg",
 		closeBottom: !opts.continuesToAssistant,
 	});
 }


### PR DESCRIPTION
## Summary

- Remove the `userMessageBg` body fill from the TUI `YOU` chat rail.
- Keep the existing connected rail, indentation, and copy-clean body layout.
- Update the user-message visual contract test to assert user content rows do not emit ANSI background color sequences.

## Root Cause

The TUI user rail passed `bodyBg: "userMessageBg"` into `renderConnectedCard`, which painted the full content row behind user messages. That produced the blue band visible behind `YOU` chat content.

## Validation

- `node --import ../../src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/modes/interactive/components/__tests__/user-message-design.test.ts src/modes/interactive/components/__tests__/assistant-message-design.test.ts`

Note: the PR branch was created in a clean worktree from `origin/main`; the validation command was run in the existing dependency-backed workspace with the same source diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782690049&installation_id=134682257&pr_number=259&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F259&signature=765bd56ad8c337203bf2abe9eafd426774c01402f0170a0c16afc71b5319e369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only TUI styling and test updates; no auth, data, or API behavior changes.
> 
> **Overview**
> The interactive TUI **YOU** turn rail no longer fills message body rows with the `userMessageBg` theme color. **`renderUserRail`** stops passing `bodyBg` into **`renderConnectedCard`**, so user text keeps the connected rail, indentation, and copy-clean layout but renders on a transparent background instead of the blue band.
> 
> The user-message design test is updated to match: it describes a transparent card, inspects raw ANSI output, and asserts content lines do not emit background (`\x1b[48…`) sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e299ee62fae657a3ef5533aad380714044da870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->