### PR TITLE
[codex] fix gsd next custom workflow step mode

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -106,6 +106,7 @@ import {
 import { handleCustomEngineReconcile } from "./workflow-custom-engine-reconcile.js";
 import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-reconcile-outcome.js";
 import { formatLeaseConflictNotice } from "./lease-conflict-notice.js";
+import { setAutoOutcomeWidget, unitVerb } from "../auto-dashboard.js";
 
 /**
  * Returns true if workerId is an active worker in this project whose OS
@@ -834,6 +835,27 @@ export async function autoLoop(
           },
         });
         if (reconcileFlow.action === "break") break;
+        if (s.stepMode) {
+          if (ctx.hasUI) {
+            ctx.ui.setWidget?.("gsd-progress", undefined);
+            setAutoOutcomeWidget(ctx, {
+              status: "step",
+              title: "Step complete",
+              detail: `Completed ${unitVerb(iterData.unitType)} ${iterData.unitId}.`,
+              unitLabel: `${unitVerb(iterData.unitType)} ${iterData.unitId}`,
+              nextAction: "Advance one step, or resume automatic mode.",
+              commands: ["/gsd next", "/gsd auto", "/gsd status for overview"],
+              startedAt: s.autoStartTime,
+            });
+          }
+          ctx.ui.setStatus("gsd-auto", "next");
+          ctx.ui.notify(
+            `Step complete: ${unitVerb(iterData.unitType)} ${iterData.unitId}. Run /gsd next for the next step, or /gsd auto to continue automatically.`,
+            "info",
+          );
+          s.preserveStepSurfaceAfterLoopExit = true;
+          break;
+        }
         continue;
       }
 

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -2072,7 +2072,7 @@ export async function runUnitPhase(
   const nextDispatchCount = (s.unitDispatchCount.get(dispatchKey) ?? 0) + 1;
 
   // Status bar (widget + preconditions deferred until after model selection — see #2899)
-  ctx.ui.setStatus("gsd-auto", "auto");
+  ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
   if (mid)
     deps.updateSliceProgressCache(s.basePath, mid, state.activeSlice?.id);
 

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -344,6 +344,70 @@ describe("Custom engine loop integration", () => {
     );
   });
 
+  it("step mode stops after one custom workflow step", async () => {
+    _resetPendingResolve();
+
+    const runDir = makeTmpDir();
+    const graph = makeGraph([
+      makeStep({ id: "step-a" }),
+      makeStep({ id: "step-b", dependsOn: ["step-a"] }),
+      makeStep({ id: "step-c", dependsOn: ["step-b"] }),
+    ], "step-mode-custom");
+    writeGraph(runDir, graph);
+    writeDefinition(runDir, graph.steps, "step-mode-custom");
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const s = makeLoopSession({
+      activeEngineId: "custom",
+      activeRunDir: runDir,
+      basePath: runDir,
+      stepMode: true,
+    });
+
+    const deps = makeMockDeps({
+      stopAuto: async (_ctx, _pi, reason) => {
+        deps.callLog.push(`stopAuto:${reason ?? "no-reason"}`);
+        s.active = false;
+      },
+    });
+
+    const loopPromise = autoLoop(ctx, pi, s, deps);
+    await resolveNextAgentEnd();
+
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        loopPromise,
+        new Promise((_, reject) =>
+          timeout = setTimeout(() => {
+            s.active = false;
+            if (_hasPendingResolveForTest()) {
+              resolveAgentEnd({ messages: [{ role: "assistant" }] });
+            }
+            reject(new Error(
+              `step mode did not stop after one custom workflow step; calls=${pi.calls.length}; log=${deps.callLog.join(",")}`,
+            ));
+          }, 1_000),
+        ),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+
+    const finalGraph = readGraph(runDir);
+    assert.equal(pi.calls.length, 1, "step mode should dispatch exactly one custom step");
+    assert.equal(finalGraph.steps[0]?.status, "complete", "first step should complete");
+    assert.equal(finalGraph.steps[1]?.status, "pending", "second step should wait for the next /gsd next");
+    assert.equal(finalGraph.steps[2]?.status, "pending", "third step should wait for a later step");
+    assert.equal(
+      deps.callLog.some((e: string) => e.startsWith("stopAuto:")),
+      false,
+      "step-mode pause should not complete or stop the whole workflow",
+    );
+    assert.equal(s.preserveStepSurfaceAfterLoopExit, true);
+  });
+
   it("stops when engine reports isComplete on first derive", async () => {
     _resetPendingResolve();
 


### PR DESCRIPTION
## Summary

Fixes `/gsd next` step mode for custom workflow engine runs so it stops after one reconciled workflow step instead of continuing like `/gsd auto`.

## Root Cause

The standard GSD unit path returned a step-wizard break after a completed step-mode unit, but the custom workflow engine path bypassed that post-unit step-mode branch and immediately continued the loop after reconcile.

## Changes

- Break the custom workflow engine loop after one completed step when `s.stepMode` is true.
- Preserve the step completion surface and `/gsd next` guidance for custom workflow steps.
- Keep the `gsd-auto` status badge as `next` while step-mode units execute.
- Add a regression test proving a three-step custom workflow dispatches only one step under step mode.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts`
- `pnpm run typecheck:extensions`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782692052&installation_id=134682257&pr_number=261&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F261&signature=f86ff047c0adbc0eb56bb1db963f538f2d89743fdf830d568b0c33078119b479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted auto-loop and status-bar behavior for step mode on the custom engine path, with a focused integration test and no auth or data-model changes.
> 
> **Overview**
> Fixes **`/gsd next` step mode** for **custom workflow engine** runs: after one reconciled graph step, the loop **stops** instead of behaving like continuous **`/gsd auto`**.
> 
> The **custom-engine** path in `autoLoop` now mirrors the dev finalize **step-wizard** behavior—when **`s.stepMode`** is set after reconcile, it clears progress UI, shows the step-complete outcome widget, sets status to **`next`**, notifies the user, sets **`preserveStepSurfaceAfterLoopExit`**, and **breaks** the loop. **`runUnitPhase`** sets **`gsd-auto`** to **`next`** (not **`auto`**) while step mode is active.
> 
> A **regression test** asserts a three-step custom workflow dispatches only one step under step mode and does not call **`stopAuto`** for workflow completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b82e8ee32ef3051841bbee98c059463aa5f3ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->