### PR TITLE
[codex] fix external tool result handling

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -633,6 +633,21 @@ async function prepareToolCall(
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
+	const externalResult = toolCall.externalResult;
+	if (externalResult) {
+		return {
+			kind: "immediate",
+			result: {
+				content:
+					externalResult.content && externalResult.content.length > 0
+						? (externalResult.content as AgentToolResult<any>["content"])
+						: [{ type: "text", text: "" }],
+				details: externalResult.details ?? {},
+			},
+			isError: externalResult.isError ?? false,
+		};
+	}
+
 	const tool = resolveAgentTool(currentContext.tools, toolCall.name);
 	if (!tool) {
 		if (isToolSearchToolName(toolCall.name)) {
@@ -653,21 +668,6 @@ async function prepareToolCall(
 			kind: "immediate",
 			result: createErrorToolResult(`Tool ${toolCall.name} not found`),
 			isError: true,
-		};
-	}
-
-	const externalResult = toolCall.externalResult;
-	if (externalResult) {
-		return {
-			kind: "immediate",
-			result: {
-				content:
-					externalResult.content && externalResult.content.length > 0
-						? (externalResult.content as AgentToolResult<any>["content"])
-						: [{ type: "text", text: "" }],
-				details: externalResult.details ?? {},
-			},
-			isError: externalResult.isError ?? false,
 		};
 	}
 

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -511,6 +511,75 @@ describe("agentLoop with AgentMessage", () => {
 		expect(executed).toEqual(["bash:pwd", "find:*.ts"]);
 	});
 
+	it("uses external tool results before requiring local tool registration", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let callIndex = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					const message = createAssistantMessage(
+						[
+							{
+								type: "toolCall",
+								id: "tool-glob",
+								name: "Glob",
+								arguments: { pattern: "*.ts" },
+								externalResult: {
+									content: [{ type: "text", text: "src/index.ts" }],
+									details: { source: "claude-code" },
+									isError: false,
+								},
+							} as any,
+							{
+								type: "toolCall",
+								id: "tool-gsd",
+								name: "mcp__gsd-workflow__gsd_progress",
+								arguments: { projectDir: "/tmp/project" },
+								externalResult: {
+									content: [{ type: "text", text: "{\"status\":\"ok\"}" }],
+									details: { source: "gsd-workflow" },
+									isError: false,
+								},
+							} as any,
+						],
+						"toolUse",
+					);
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage([{ type: "text", text: "done" }]) });
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("inspect tools")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const toolResults = events.filter(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end",
+		);
+		expect(toolResults.map((event) => [event.toolCallId, event.isError, event.result.content[0]?.text])).toEqual([
+			["tool-glob", false, "src/index.ts"],
+			["tool-gsd", false, "{\"status\":\"ok\"}"],
+		]);
+		expect(toolResults.map((event) => event.result.content[0]?.text).join("\n")).not.toContain("not found");
+	});
+
 	it("returns ToolSearch guidance when the shim is not in the active tool registry", async () => {
 		const context: AgentContext = {
 			systemPrompt: "",


### PR DESCRIPTION
## Summary

Fixes the Agent Core tool preparation path so tool calls that already carry an externally executed result are accepted before checking the local tool registry.

## Why

Claude Code executes native tools such as `Glob` and workflow MCP tools such as `mcp__gsd-workflow__gsd_progress` outside the local Agent Core registry, then passes the result back on the tool-call block. Agent Core previously checked local registration first, so valid external results were converted into `Tool ... not found` errors.

## Changes

- Handle `toolCall.externalResult` before local registry lookup in `prepareToolCall`.
- Add a regression test covering externally executed `Glob` and `mcp__gsd-workflow__gsd_progress` tool calls with no local tools registered.

## Validation

- `pnpm --filter @gsd/pi-agent-core exec vitest run test/agent-loop.test.ts`
- `pnpm --filter @gsd/pi-agent-core run build`
- `node --experimental-strip-types --test --test-concurrency=1 tests/e2e/mcp-server.e2e.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782698159&installation_id=134682257&pr_number=264&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F264&signature=0a5d9b752baf02f08835d0c3cfc9355a709f45c956af301c13b23648b32c0331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering change in tool preparation with a focused regression test; no auth, security, or broad API surface changes.
> 
> **Overview**
> **Agent Core** now honors `toolCall.externalResult` at the start of `prepareToolCall`, before resolving tools in the local registry. Tool calls that were already executed elsewhere (e.g. Claude Code `Glob` or workflow MCP tools) no longer fail with `Tool ... not found` when those tools are not registered locally.
> 
> A regression test asserts that externally supplied results are emitted as successful `tool_execution_end` events even with an empty `tools` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 009ac498f3e43e2d0bb228bbf32c6aa3e0d93dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->