### PR TITLE
[codex] auto prepare Claude Code workflow MCP

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -507,6 +507,21 @@ function initSessionNotifications(ctx: ExtensionContext): void {
   initNotificationWidget(ctx);
 }
 
+async function prepareWorkflowMcpForHookContext(
+  ctx: ExtensionContext,
+  basePath: string,
+): Promise<void> {
+  // Skip MCP auto-prep when running inside an auto-worktree. The worktree
+  // already has .mcp.json from createAutoWorktree, and re-running the writer
+  // post-chdir rewrites the file mid-run (non-idempotent due to cwd-relative
+  // CLI path resolution), dirtying the tree and breaking the milestone merge.
+  const { isInAutoWorktree } = await import("../auto-worktree.js");
+  if (isInAutoWorktree(basePath)) return;
+
+  const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
+  prepareWorkflowMcpForProject(ctx, basePath);
+}
+
 export function registerHooks(
   pi: ExtensionAPI,
   ecosystemHandlers: GSDEcosystemBeforeAgentStartHandler[],
@@ -532,12 +547,7 @@ export function registerHooks(
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);
-    // Skip MCP auto-prep when running inside an auto-worktree (see session_switch below).
-    const { isInAutoWorktree } = await import("../auto-worktree.js");
-    if (!isInAutoWorktree(basePath)) {
-      const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
-      prepareWorkflowMcpForProject(ctx, basePath);
-    }
+    await prepareWorkflowMcpForHookContext(ctx, basePath);
 
     // Apply show_token_cost preference (#1515)
     try {
@@ -563,15 +573,7 @@ export function registerHooks(
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);
-    // Skip MCP auto-prep when running inside an auto-worktree. The worktree
-    // already has .mcp.json from createAutoWorktree, and re-running the writer
-    // post-chdir rewrites the file mid-run (non-idempotent due to cwd-relative
-    // CLI path resolution), dirtying the tree and breaking the milestone merge.
-    const { isInAutoWorktree } = await import("../auto-worktree.js");
-    if (!isInAutoWorktree(basePath)) {
-      const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
-      prepareWorkflowMcpForProject(ctx, basePath);
-    }
+    await prepareWorkflowMcpForHookContext(ctx, basePath);
     await loadToolApiKeysForSession();
     if (!isAutoActive()) {
       ctx.ui.setWidget("gsd-progress", undefined);
@@ -607,6 +609,11 @@ export function registerHooks(
       }
     }
     clearDeferredApprovalGate(beforeAgentBasePath);
+
+    // session_start can fire before the active provider has settled. By
+    // before_agent_start, Claude Code CLI sessions should get the same
+    // project MCP config that /gsd mcp init would write.
+    await prepareWorkflowMcpForHookContext(ctx, beforeAgentBasePath);
 
     // GSD's own context injection (existing behavior — unchanged).
     const { buildBeforeAgentStartResult } = await import("./system-context.js");

--- a/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { GSD_WORKFLOW_MCP_SERVER_NAME } from "../mcp-project-config.ts";
 import { prepareWorkflowMcpForProject, shouldAutoPrepareWorkflowMcp } from "../workflow-mcp-auto-prep.ts";
 
 test("shouldAutoPrepareWorkflowMcp enables prep for externalCli local transport", () => {
@@ -73,4 +78,59 @@ test("prepareWorkflowMcpForProject warns with /gsd mcp init guidance when prep f
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0].level, "warning");
   assert.match(notifications[0].message, /Please run \/gsd mcp init \./);
+});
+
+test("before_agent_start auto-prepares project workflow MCP for Claude Code CLI", async (t) => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-before-agent-"));
+  const originalCwd = process.cwd();
+  const notifications: string[] = [];
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+    getActiveTools: () => [],
+    getAllTools: () => [],
+    setActiveTools() {},
+  };
+
+  t.after(() => {
+    process.chdir(originalCwd);
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  process.chdir(projectRoot);
+  registerHooks(pi as any, []);
+
+  const beforeAgentStart = handlers.get("before_agent_start")?.[0];
+  assert.ok(beforeAgentStart, "before_agent_start hook should be registered");
+
+  await beforeAgentStart(
+    { prompt: "hello", systemPrompt: "base" },
+    {
+      cwd: projectRoot,
+      model: { provider: "claude-code", baseUrl: "local://claude-code" },
+      modelRegistry: {
+        getProviderAuthMode: () => "externalCli",
+        isProviderRequestReady: () => true,
+      },
+      ui: {
+        notify(message: string) {
+          notifications.push(message);
+        },
+        setWidget() {},
+      },
+    },
+  );
+
+  const configPath = join(projectRoot, ".mcp.json");
+  assert.equal(existsSync(configPath), true, "Claude Code CLI turns should create project MCP config");
+
+  const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as {
+    mcpServers?: Record<string, unknown>;
+  };
+  assert.ok(parsed.mcpServers?.[GSD_WORKFLOW_MCP_SERVER_NAME]);
+  assert.match(notifications.join("\n"), /Claude Code MCP prepared/);
 });


### PR DESCRIPTION
## Summary

- Reuses the existing workflow MCP auto-prep logic across session start, session switch, and agent start.
- Adds a `before_agent_start` safety net so Claude Code CLI sessions write the same project `.mcp.json` config that `/gsd mcp init` would create once the active provider is known.
- Covers the Claude Code path with a regression test that exercises the registered hook and verifies the `gsd-workflow` MCP server is written.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts`
- `pnpm run typecheck:extensions`

Note: in the clean worktree I first ran `pnpm install --frozen-lockfile --ignore-scripts`, `pnpm run build:pi`, `pnpm run build:rpc-client`, and `pnpm run build:mcp-server` to generate local workspace package dist outputs required by the checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782698344&installation_id=134682257&pr_number=265&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F265&signature=092aa353ca078e2585e0c66cd41251888155a9af0b33d2e149030936396817ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hook-layer refactor with auto-worktree guard preserved; adds MCP config writes only for eligible Claude Code CLI sessions, covered by a new test.
> 
> **Overview**
> Centralizes workflow MCP auto-prep in **`prepareWorkflowMcpForHookContext`**, which still skips auto-worktrees so `.mcp.json` is not rewritten mid-run and milestone merges stay clean.
> 
> **`session_start`** and **`session_switch`** now call that helper instead of inlined logic. **`before_agent_start`** also runs it so Claude Code CLI sessions get project `.mcp.json` (same as `/gsd mcp init`) once the active provider is known—covering cases where **`session_start`** fires too early.
> 
> A regression test exercises the registered **`before_agent_start`** hook and asserts **`gsd-workflow`** is written under **`mcpServers`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75adba6ad4c5fa6e54e0db31d48ccf8079f9b2fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->