### PR TITLE
[codex] fix shared resource sync

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -587,6 +587,7 @@ function pruneRemovedBundledExtensions(
  * Syncs all bundled resources to agentDir (~/.gsd/agent/) on every launch.
  *
  * - extensions/ → ~/.gsd/agent/extensions/   (overwrite when version changes)
+ * - shared/     → ~/.gsd/agent/shared/       (overwrite when version changes)
  * - agents/     → ~/.gsd/agent/agents/        (overwrite when version changes)
  * - skills/     → ~/.gsd/agent/skills/        (overwrite when version changes)
  * - GSD-WORKFLOW.md → ~/.gsd/agent/GSD-WORKFLOW.md (fallback for env var miss)
@@ -632,7 +633,16 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
     // Version matches — check content fingerprint for same-version staleness.
     const currentHash = getCurrentResourceFingerprint()
     const hasStaleExtensionFiles = hasStaleCompiledExtensionSiblings(extensionsDir, bundledExtensionsDir)
-    if (manifest.contentHash && manifest.contentHash === currentHash && !hasStaleExtensionFiles) {
+    const hasMissingSharedFiles = hasMissingBundledResourceFiles(
+      join(agentDir, 'shared'),
+      join(resourcesDir, 'shared'),
+    )
+    if (
+      manifest.contentHash &&
+      manifest.contentHash === currentHash &&
+      !hasStaleExtensionFiles &&
+      !hasMissingSharedFiles
+    ) {
       return
     }
   }
@@ -640,6 +650,7 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
   // Sync bundled resources — overwrite so updates land on next launch.
 
   syncResourceDir(bundledExtensionsDir, join(agentDir, 'extensions'))
+  syncResourceDir(join(resourcesDir, 'shared'), join(agentDir, 'shared'))
   syncResourceDir(join(resourcesDir, 'agents'), join(agentDir, 'agents'))
   syncResourceDir(join(resourcesDir, 'skills'), skillsDir)
 
@@ -722,6 +733,17 @@ export function hasStaleCompiledExtensionSiblings(extensionsDir: string, sourceD
     if (sourceFiles.has(bundledSibling)) return true
   }
 
+  return false
+}
+
+export function hasMissingBundledResourceFiles(destDir: string, sourceDir: string): boolean {
+  const sourceFiles = collectRelativeFiles(sourceDir)
+  if (sourceFiles.size === 0) return false
+
+  const installedFiles = collectRelativeFiles(destDir)
+  for (const relPath of sourceFiles) {
+    if (!installedFiles.has(relPath)) return true
+  }
   return false
 }
 

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -31,6 +31,17 @@ function overrideHomeEnv(homeDir: string): () => void {
   };
 }
 
+function hasSyncedResourceFile(rootDir: string, relativePathWithoutExtension: string): boolean {
+  return existsSync(join(rootDir, `${relativePathWithoutExtension}.js`)) ||
+    existsSync(join(rootDir, `${relativePathWithoutExtension}.ts`));
+}
+
+function bundledSharedDir(): string {
+  return existsSync(join(process.cwd(), "dist", "resources", "shared"))
+    ? join(process.cwd(), "dist", "resources", "shared")
+    : join(process.cwd(), "src", "resources", "shared");
+}
+
 test("getExtensionKey normalizes top-level .ts and .js entry names to the same key", async () => {
   const { getExtensionKey } = await import("../resource-loader.ts");
   const extensionsDir = "/tmp/extensions";
@@ -214,6 +225,77 @@ test("initResources syncs bundled skills to the GSD agent dir by default", async
     existsSync(join(tmp, ".agents", "skills", "lint", "SKILL.md")),
     false,
     "initResources should not write bundled skills to ~/.agents/skills by default",
+  );
+});
+
+test("initResources syncs top-level shared resources used by extension imports", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-shared-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir, join(tmp, "skills"));
+
+  assert.equal(
+    hasSyncedResourceFile(join(fakeAgentDir, "shared"), "gsd-pi-logo"),
+    true,
+    "top-level resources/shared files must sync under ~/.gsd/agent/shared",
+  );
+  assert.equal(
+    hasSyncedResourceFile(join(fakeAgentDir, "shared"), "package-manager-detection"),
+    true,
+    "extension imports like ../../shared/package-manager-detection.js must resolve after fresh install",
+  );
+});
+
+test("initResources resyncs when current manifest is missing top-level shared resources", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-shared-stale-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const {
+    computeResourceFingerprint,
+    hasMissingBundledResourceFiles,
+    initResources,
+  } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir, join(tmp, "skills"));
+
+  rmSync(join(fakeAgentDir, "shared"), { recursive: true, force: true });
+  const packageVersion = JSON.parse(
+    readFileSync(join(process.cwd(), "package.json"), "utf-8"),
+  ).version;
+  writeFileSync(
+    join(fakeAgentDir, "managed-resources.json"),
+    JSON.stringify({
+      gsdVersion: process.env.GSD_VERSION && process.env.GSD_VERSION !== "0.0.0"
+        ? process.env.GSD_VERSION
+        : packageVersion,
+      packageName: "@opengsd/gsd-pi",
+      contentHash: computeResourceFingerprint(),
+    }),
+  );
+
+  assert.equal(
+    hasMissingBundledResourceFiles(
+      join(fakeAgentDir, "shared"),
+      bundledSharedDir(),
+    ),
+    true,
+    "test setup should simulate a current manifest with missing shared files",
+  );
+
+  initResources(fakeAgentDir, join(tmp, "skills"));
+
+  assert.equal(
+    hasSyncedResourceFile(join(fakeAgentDir, "shared"), "package-manager-detection"),
+    true,
+    "current managed-resource manifests must not skip missing top-level shared files",
   );
 });
 


### PR DESCRIPTION
## Summary

- Sync top-level `resources/shared` into `~/.gsd/agent/shared` during managed resource initialization.
- Treat missing shared resource files as a stale managed-resource install even when version and content hash match.
- Add regression coverage for fresh installs and current manifests missing `shared/package-manager-detection`.

## Root Cause

The GSD extension now imports shared package-manager detection from `../../shared/package-manager-detection.js`, which resolves to `~/.gsd/agent/shared/package-manager-detection.js` after resources are installed. `initResources()` only copied `extensions`, `agents`, and `skills`, so a fresh `npx` install could ship the compiled module but never install it into the agent tree.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `pnpm run copy-resources`
- `pnpm exec tsc --noEmit --pretty false`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/resource-loader.test.ts src/tests/update-cmd-diagnostics.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782714778&installation_id=134682257&pr_number=267&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F267&signature=5d69853efde858d680e96bcc2bcbe2f9db89f222a42efc5ec03e8e3dd7f1b996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup resource sync and skip logic only; no auth or data paths, with regression tests for fresh and stale installs.
> 
> **Overview**
> **Fixes agent installs that never copied bundled `shared/` modules**, so extension imports like `../../shared/package-manager-detection.js` resolve under `~/.gsd/agent/shared`.
> 
> `initResources` now **syncs `resources/shared` → `~/.gsd/agent/shared`** alongside extensions, agents, and skills. The managed-resource **fast path** no longer skips when the manifest version and content hash match but **`shared/` is incomplete**—a new `hasMissingBundledResourceFiles` check forces a resync (same idea as stale compiled extension siblings). **Tests** cover a fresh sync and a “current” manifest with `shared/` deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5568c34debf64b5a560aad4eeac1157423a1d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->