### PR TITLE
[codex] fix OpenAI web search tool leak

### DIFF
--- a/src/resources/extensions/context7/index.ts
+++ b/src/resources/extensions/context7/index.ts
@@ -132,6 +132,19 @@ function formatLibraryList(libs: C7Library[], query: string): string {
 	return lines.join("\n");
 }
 
+function getFirstTextContent(result: { content?: unknown }): string | undefined {
+	const content = result.content;
+	if (!Array.isArray(content)) return undefined;
+	const textBlock = content.find(
+		(block: unknown) =>
+			typeof block === "object" &&
+			block !== null &&
+			(block as { type?: unknown }).type === "text" &&
+			typeof (block as { text?: unknown }).text === "string",
+	) as { text: string } | undefined;
+	return textBlock?.text.trim() || undefined;
+}
+
 // ─── Tool details types ───────────────────────────────────────────────────────
 
 interface ResolveDetails {
@@ -234,7 +247,7 @@ export default function (pi: ExtensionAPI) {
 			const d = result.details as ResolveDetails | undefined;
 			if (isPartial) return new Text(theme.fg("warning", "Searching Context7..."), 0, 0);
 			if ((result as any).isError || d?.error) {
-				return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+				return new Text(theme.fg("error", `Error: ${d?.error ?? getFirstTextContent(result) ?? "unknown"}`), 0, 0);
 			}
 			let text = theme.fg("success", `${d?.resultCount ?? 0} ${d?.resultCount === 1 ? "library" : "libraries"} found`);
 			if (d?.cached) text += theme.fg("dim", " (cached)");
@@ -389,7 +402,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (isPartial) return new Text(theme.fg("warning", "Fetching documentation..."), 0, 0);
 			if ((result as any).isError || d?.error) {
-				return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+				return new Text(theme.fg("error", `Error: ${d?.error ?? getFirstTextContent(result) ?? "unknown"}`), 0, 0);
 			}
 
 			let text = theme.fg("success", `${(d?.charCount ?? 0).toLocaleString()} chars`);

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -36,6 +36,11 @@ const NATIVE_WEB_SEARCH_PROVIDERS = new Set([
   "vercel-ai-gateway",
 ]);
 
+function looksLikeAnthropicModelName(modelName: string): boolean {
+  const normalized = modelName.trim().toLowerCase();
+  return normalized.startsWith("claude-") || normalized.startsWith("anthropic/claude-");
+}
+
 /**
  * True when the model is an Anthropic-shaped transport AND the provider is
  * known to accept the native `web_search_20250305` tool. Gate both on api
@@ -180,6 +185,8 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     // The model name heuristic is needed for session restores where
     // modelsAreEqual suppresses model_select AND the SDK doesn't pass model.
     const eventModel = event.model as { provider?: string; api?: string } | undefined;
+    const payloadModelName = typeof payload.model === "string" ? payload.model : "";
+    const payloadLooksAnthropic = payloadModelName ? looksLikeAnthropicModelName(payloadModelName) : undefined;
     let isAnthropic: boolean;
     if (eventModel?.api || eventModel?.provider) {
       // Preferred path: gate on api shape + provider allowlist. Both fields
@@ -188,12 +195,14 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
       // (#444 regression) or minimax-served Claude-compat as Anthropic (#4492).
       isAnthropic = supportsNativeWebSearch(eventModel);
     } else if (modelSelectFired) {
-      isAnthropic = isAnthropicProvider;
+      // The model_select flag can be stale if the next request omits event.model
+      // after a provider switch. A concrete non-Claude payload must win so an
+      // Anthropic-only tool never leaks into OpenAI Responses requests.
+      isAnthropic = isAnthropicProvider && payloadLooksAnthropic !== false;
     } else {
       // Last resort: session-restore paths where the SDK doesn't pass model.
       // The model-name prefix is best-effort and assumes direct Anthropic.
-      const modelName = typeof payload.model === "string" ? payload.model : "";
-      isAnthropic = modelName.startsWith("claude-");
+      isAnthropic = payloadLooksAnthropic === true;
     }
     if (!isAnthropic) return;
 

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -148,6 +148,36 @@ test("before_provider_request does NOT inject for non-claude models", async () =
   assert.equal(tools.length, 1, "Should not add tools to non-claude payload");
 });
 
+test("before_provider_request does NOT inject stale Anthropic state into OpenAI payloads", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const payload: Record<string, unknown> = {
+    model: "gpt-5.4",
+    tools: [{ name: "bash", type: "function" }],
+  };
+
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+  });
+
+  assert.equal(result, undefined, "Should not modify OpenAI payload with stale Anthropic state");
+  const tools = payload.tools as any[];
+  assert.equal(tools.length, 1, "Should not inject web_search for OpenAI payload");
+  assert.ok(
+    !tools.some((t: any) => t.type === "web_search_20250305"),
+    "web_search_20250305 must NOT be present in OpenAI Responses requests"
+  );
+});
+
 test("before_provider_request does NOT inject for claude model on non-Anthropic provider", async () => {
   const pi = createMockPI();
   registerNativeSearchHooks(pi);


### PR DESCRIPTION
## Summary

- Prevent Anthropic native `web_search_20250305` injection from leaking into OpenAI Responses payloads when `model_select` state is stale.
- Add a regression test for an OpenAI `gpt-5.4` payload following an Anthropic model selection.
- Improve Context7 tool error rendering so failures show returned text instead of falling back to `Error: unknown`.

## Root Cause

The native search hook trusted the last Anthropic `model_select` state when `before_provider_request` arrived without `event.model`. If the actual payload model had switched to an OpenAI model, the hook could still inject Anthropic-only server search into an OpenAI Responses request, producing a 400 for unsupported tool type.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/native-search.test.ts`
- `pnpm run typecheck:extensions`

Note: this PR was prepared from a clean worktree off `origin/main`; unrelated dirty files in the original checkout were intentionally excluded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782738804&installation_id=134682257&pr_number=268&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F268&signature=64d96ee2d4a205b7635e2155b41047a817a46fd36211e168cb8a35f5e5d6edd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider-request tool injection logic on the critical path for LLM API calls; scope is small and covered by a new regression test, but misclassification could still break search or requests.
> 
> **Overview**
> Fixes a regression where **native Anthropic `web_search_20250305`** could be injected into **OpenAI Responses** requests after switching models, when `before_provider_request` had no `event.model` but still trusted stale `model_select` state. Injection now requires the payload model name to look Anthropic (`claude-*` / `anthropic/claude-*`) whenever that heuristic path is used; a concrete non-Claude name (e.g. `gpt-5.4`) blocks injection. A regression test covers Anthropic `model_select` followed by an OpenAI payload.
> 
> **Context7** tool error UI now falls back to the first text block in the tool result when `details.error` is missing, instead of showing `Error: unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8988fbe0a8299abe50b1384b5423cb4359b37055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->