### PR TITLE
[codex] Preserve Anthropic native search replay blocks

### DIFF
--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -17,6 +17,7 @@ import type {
 	ImageContent,
 	Message,
 	Model,
+	ServerToolUse,
 	SimpleStreamOptions,
 	StopReason,
 	StreamFunction,
@@ -26,6 +27,7 @@ import type {
 	Tool,
 	ToolCall,
 	ToolResultMessage,
+	WebSearchResult,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
@@ -518,7 +520,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
-			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
+			type Block = (ThinkingContent | TextContent | ServerToolUse | WebSearchResult | (ToolCall & { partialJson: string })) & {
+				index: number;
+			};
 			const blocks = output.content as Block[];
 
 			for await (const event of iterateAnthropicEvents(response, options?.signal)) {
@@ -575,6 +579,26 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						};
 						output.content.push(block);
 						stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+					} else if (event.content_block.type === "server_tool_use") {
+						const block: Block = {
+							type: "serverToolUse",
+							id: event.content_block.id,
+							name: event.content_block.name,
+							input: event.content_block.input,
+							caller: event.content_block.caller,
+							index: event.index,
+						};
+						output.content.push(block);
+						stream.push({ type: "server_tool_use", contentIndex: output.content.length - 1, partial: output });
+					} else if (event.content_block.type === "web_search_tool_result") {
+						const block: Block = {
+							type: "webSearchResult",
+							toolUseId: event.content_block.tool_use_id,
+							content: event.content_block.content,
+							caller: event.content_block.caller,
+							index: event.index,
+						};
+						output.content.push(block);
 					}
 				} else if (event.type === "content_block_delta") {
 					if (event.delta.type === "text_delta") {
@@ -1090,6 +1114,21 @@ function convertMessages(
 						name: isOAuthToken ? toClaudeCodeName(block.name) : block.name,
 						input: block.arguments ?? {},
 					});
+				} else if (block.type === "serverToolUse") {
+					blocks.push({
+						type: "server_tool_use",
+						id: block.id,
+						name: block.name,
+						input: block.input,
+						...(block.caller ? { caller: block.caller } : {}),
+					} as ContentBlockParam);
+				} else if (block.type === "webSearchResult") {
+					blocks.push({
+						type: "web_search_tool_result",
+						tool_use_id: block.toolUseId,
+						content: block.content,
+						...(block.caller ? { caller: block.caller } : {}),
+					} as ContentBlockParam);
 				}
 			}
 			if (blocks.length === 0) continue;

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -520,7 +520,13 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
-			type Block = (ThinkingContent | TextContent | ServerToolUse | WebSearchResult | (ToolCall & { partialJson: string })) & {
+			type Block = (
+				| ThinkingContent
+				| TextContent
+				| (ServerToolUse & { partialJson?: string })
+				| WebSearchResult
+				| (ToolCall & { partialJson: string })
+			) & {
 				index: number;
 			};
 			const blocks = output.content as Block[];
@@ -586,6 +592,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 							name: event.content_block.name,
 							input: event.content_block.input,
 							caller: event.content_block.caller,
+							partialJson: "",
 							index: event.index,
 						};
 						output.content.push(block);
@@ -637,6 +644,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								delta: event.delta.partial_json,
 								partial: output,
 							});
+						} else if (block && block.type === "serverToolUse") {
+							block.partialJson = (block.partialJson ?? "") + event.delta.partial_json;
+							block.input = parseStreamingJson<unknown>(block.partialJson);
 						}
 					} else if (event.delta.type === "signature_delta") {
 						const index = blocks.findIndex((b) => b.index === event.index);
@@ -676,6 +686,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								toolCall: block,
 								partial: output,
 							});
+						} else if (block.type === "serverToolUse") {
+							if (block.partialJson) {
+								block.input = parseStreamingJson<unknown>(block.partialJson);
+							}
+							delete (block as { partialJson?: string }).partialJson;
 						}
 					}
 				} else if (event.type === "message_delta") {

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -265,6 +265,7 @@ export interface ServerToolUse {
 	id: string;
 	name: string;
 	input: unknown;
+	caller?: unknown;
 	externalResult?: {
 		content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
 		details?: Record<string, unknown>;
@@ -277,6 +278,7 @@ export interface WebSearchResult {
 	type: "webSearchResult";
 	toolUseId: string;
 	content: unknown;
+	caller?: unknown;
 }
 
 /** GSD compat alias for {@link ServerToolUse}. */

--- a/packages/pi-ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/pi-ai/test/anthropic-sse-parsing.test.ts
@@ -3,7 +3,7 @@ import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { getModel } from "../src/models.ts";
 import { streamAnthropic } from "../src/providers/anthropic.ts";
-import type { Context, ToolCall } from "../src/types.ts";
+import type { Context, ServerToolUse, ToolCall, WebSearchResult } from "../src/types.ts";
 
 function createSseResponse(events: Array<{ event: string; data: string }>): Response {
 	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
@@ -78,9 +78,22 @@ function createFakeAnthropicClient(response: Response): Anthropic {
 	} as unknown as Anthropic;
 }
 
+function createCapturingAnthropicClient(response: Response, capture: { params?: unknown }): Anthropic {
+	return {
+		messages: {
+			create: (params: unknown) => {
+				capture.params = params;
+				return {
+					asResponse: async () => response,
+				};
+			},
+		},
+	} as unknown as Anthropic;
+}
+
 describe("Anthropic raw SSE parsing", () => {
 	it("repairs malformed SSE JSON and malformed streamed tool JSON", async () => {
-		const model = getModel("anthropic", "claude-haiku-4-5");
+		const model = getModel("anthropic", "claude-opus-4-8");
 		const context: Context = {
 			messages: [{ role: "user", content: "Use the edit tool.", timestamp: Date.now() }],
 			tools: [
@@ -167,7 +180,7 @@ describe("Anthropic raw SSE parsing", () => {
 	});
 
 	it("ignores unknown SSE events after message_stop", async () => {
-		const model = getModel("anthropic", "claude-haiku-4-5");
+		const model = getModel("anthropic", "claude-opus-4-8");
 		const context: Context = {
 			messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }],
 		};
@@ -185,5 +198,170 @@ describe("Anthropic raw SSE parsing", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.errorMessage).toBeUndefined();
 		expect(result.content).toEqual([{ type: "text", text: "Hello" }]);
+	});
+
+	it("preserves native web search blocks from Anthropic streams", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "Search the web.", timestamp: Date.now() }],
+		};
+		const webSearchContent = [
+			{
+				type: "web_search_result",
+				title: "Example",
+				url: "https://example.com",
+				encrypted_content: "encrypted-result",
+				page_age: null,
+			},
+		];
+		const caller = { type: "direct" };
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_test",
+						usage: {
+							input_tokens: 12,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "server_tool_use", id: "srv_1", name: "web_search", input: { query: "gsd" }, caller },
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 1,
+					content_block: { type: "web_search_tool_result", tool_use_id: "srv_1", content: webSearchContent, caller },
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 1 }) },
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: {
+						input_tokens: 12,
+						output_tokens: 5,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				}),
+			},
+			{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+		]);
+
+		const stream = streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(response),
+		});
+		const result = await stream.result();
+
+		const serverToolUse = result.content.find((block): block is ServerToolUse => block.type === "serverToolUse");
+		const webSearchResult = result.content.find((block): block is WebSearchResult => block.type === "webSearchResult");
+		expect(serverToolUse).toMatchObject({
+			id: "srv_1",
+			name: "web_search",
+			input: { query: "gsd" },
+			caller,
+		});
+		expect(webSearchResult).toMatchObject({
+			toolUseId: "srv_1",
+			content: webSearchContent,
+			caller,
+		});
+	});
+
+	it("replays preserved native web search blocks in assistant history", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const caller = { type: "direct" };
+		const webSearchContent = [
+			{
+				type: "web_search_result",
+				title: "Example",
+				url: "https://example.com",
+				encrypted_content: "encrypted-result",
+			},
+		];
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: "Search the web.",
+					timestamp: Date.now(),
+				},
+				{
+					role: "assistant",
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					content: [
+						{ type: "thinking", thinking: "Need a current result.", thinkingSignature: "sig_1" },
+						{ type: "serverToolUse", id: "srv_1", name: "web_search", input: { query: "gsd" }, caller },
+						{ type: "webSearchResult", toolUseId: "srv_1", content: webSearchContent, caller },
+						{ type: "text", text: "Found one result." },
+					],
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				},
+				{
+					role: "user",
+					content: "Continue.",
+					timestamp: Date.now(),
+				},
+			],
+		};
+		const capture: { params?: any } = {};
+		const stream = streamAnthropic(model, context, {
+			client: createCapturingAnthropicClient(createSseResponse(minimalAnthropicEvents), capture),
+		});
+
+		await stream.result();
+
+		expect(capture.params.messages[1]).toEqual({
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Need a current result.",
+					signature: "sig_1",
+				},
+				{
+					type: "server_tool_use",
+					id: "srv_1",
+					name: "web_search",
+					input: { query: "gsd" },
+					caller,
+				},
+				{
+					type: "web_search_tool_result",
+					tool_use_id: "srv_1",
+					content: webSearchContent,
+					caller,
+				},
+				{ type: "text", text: "Found one result." },
+			],
+		});
 	});
 });

--- a/packages/pi-ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/pi-ai/test/anthropic-sse-parsing.test.ts
@@ -285,6 +285,82 @@ describe("Anthropic raw SSE parsing", () => {
 		});
 	});
 
+	it("accumulates native web search input JSON deltas", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "Search the web.", timestamp: Date.now() }],
+		};
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_test",
+						usage: {
+							input_tokens: 12,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "server_tool_use", id: "srv_1", name: "web_search", input: {} },
+				}),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: '{"query":' },
+				}),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: '"gsd","max_uses":2}' },
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: {
+						input_tokens: 12,
+						output_tokens: 5,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				}),
+			},
+			{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+		]);
+
+		const stream = streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(response),
+		});
+		const result = await stream.result();
+
+		const serverToolUse = result.content.find((block): block is ServerToolUse => block.type === "serverToolUse");
+		expect(serverToolUse).toMatchObject({
+			id: "srv_1",
+			name: "web_search",
+			input: { query: "gsd", max_uses: 2 },
+		});
+		expect(serverToolUse).not.toHaveProperty("partialJson");
+	});
+
 	it("replays preserved native web search blocks in assistant history", async () => {
 		const model = getModel("anthropic", "claude-haiku-4-5");
 		const caller = { type: "direct" };

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -16,6 +16,12 @@ export const CUSTOM_SEARCH_TOOL_NAMES = ["search-the-web", "search_and_read", "g
 
 /** Thinking block types that require signature validation by the API */
 const THINKING_TYPES = new Set(["thinking", "redacted_thinking"]);
+const NATIVE_SERVER_TOOL_TYPES = new Set([
+  "server_tool_use",
+  "web_search_tool_result",
+  "serverToolUse",
+  "webSearchResult",
+]);
 
 /**
  * Providers whose Anthropic-Messages endpoint is known to accept the native
@@ -89,11 +95,10 @@ export interface NativeSearchPI {
  * those blocks. The Anthropic API detects the modification and rejects the
  * request with "thinking blocks cannot be modified."
  *
- * Fix: Remove thinking blocks from all assistant messages in the history.
- * In Anthropic's Messages API, the messages array always ends with a user
- * message, so every assistant message is from a previous turn that has been
- * through a store/replay cycle. The model generates fresh thinking for the
- * current turn regardless.
+ * Fix: Remove thinking blocks only from assistant messages that do not carry
+ * native server-tool blocks. Complete native server-tool histories can be
+ * replayed as-is; stripping thinking from those messages is itself a latest
+ * assistant message modification.
  */
 export function stripThinkingFromHistory(
   messages: Array<Record<string, unknown>>
@@ -103,6 +108,9 @@ export function stripThinkingFromHistory(
 
     const content = msg.content;
     if (!Array.isArray(content)) continue;
+    if (content.some((block: any) => NATIVE_SERVER_TOOL_TYPES.has(block?.type))) {
+      continue;
+    }
 
     msg.content = content.filter(
       (block: any) => !THINKING_TYPES.has(block?.type)

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -16,12 +16,47 @@ export const CUSTOM_SEARCH_TOOL_NAMES = ["search-the-web", "search_and_read", "g
 
 /** Thinking block types that require signature validation by the API */
 const THINKING_TYPES = new Set(["thinking", "redacted_thinking"]);
-const NATIVE_SERVER_TOOL_TYPES = new Set([
+const NATIVE_SERVER_TOOL_USE_TYPES = new Set([
   "server_tool_use",
-  "web_search_tool_result",
   "serverToolUse",
+]);
+const NATIVE_WEB_SEARCH_RESULT_TYPES = new Set([
+  "web_search_tool_result",
   "webSearchResult",
 ]);
+
+function nativeServerToolId(block: any): string | undefined {
+  if (!NATIVE_SERVER_TOOL_USE_TYPES.has(block?.type)) return undefined;
+  return typeof block.id === "string" ? block.id : undefined;
+}
+
+function nativeWebSearchResultId(block: any): string | undefined {
+  if (!NATIVE_WEB_SEARCH_RESULT_TYPES.has(block?.type)) return undefined;
+  const id = block.type === "webSearchResult" ? block.toolUseId : block.tool_use_id;
+  return typeof id === "string" ? id : undefined;
+}
+
+function hasCompleteNativeServerToolReplay(content: any[]): boolean {
+  const pendingToolUseIds = new Set<string>();
+  let sawNativeServerToolUse = false;
+
+  for (const block of content) {
+    const toolUseId = nativeServerToolId(block);
+    if (toolUseId !== undefined) {
+      if (pendingToolUseIds.has(toolUseId)) return false;
+      sawNativeServerToolUse = true;
+      pendingToolUseIds.add(toolUseId);
+      continue;
+    }
+
+    const resultId = nativeWebSearchResultId(block);
+    if (resultId !== undefined) {
+      if (!pendingToolUseIds.delete(resultId)) return false;
+    }
+  }
+
+  return sawNativeServerToolUse && pendingToolUseIds.size === 0;
+}
 
 /**
  * Providers whose Anthropic-Messages endpoint is known to accept the native
@@ -108,7 +143,7 @@ export function stripThinkingFromHistory(
 
     const content = msg.content;
     if (!Array.isArray(content)) continue;
-    if (content.some((block: any) => NATIVE_SERVER_TOOL_TYPES.has(block?.type))) {
+    if (hasCompleteNativeServerToolReplay(content)) {
       continue;
     }
 

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -107,7 +107,7 @@ test("before_provider_request injects web_search for claude models even without 
 
   // NO model_select fired — simulates session restore where modelsAreEqual suppresses the event
   const payload: Record<string, unknown> = {
-    model: "claude-opus-4-6",
+    model: "claude-opus-4-8",
     tools: [
       { name: "bash", type: "custom" },
       { name: "search-the-web", type: "function" },
@@ -319,13 +319,13 @@ test("before_provider_request does not double-inject", async () => {
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-opus-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-opus-4-8" },
     previousModel: undefined,
     source: "set",
   });
 
   const payload: Record<string, unknown> = {
-    model: "claude-opus-4-6-20250514",
+    model: "claude-opus-4-8",
     tools: [{ type: "web_search_20250305", name: "web_search" }],
   };
 
@@ -1053,6 +1053,29 @@ test("stripThinkingFromHistory removes redacted_thinking too", () => {
 
   assert.equal(messages[1].content.length, 1);
   assert.equal(messages[1].content[0].type, "text");
+});
+
+test("stripThinkingFromHistory preserves complete native search assistant blocks", () => {
+  const messages: any[] = [
+    { role: "user", content: "search" },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "need search", signature: "sig1" },
+        { type: "server_tool_use", id: "srv1", name: "web_search", input: { query: "gsd" } },
+        { type: "web_search_tool_result", tool_use_id: "srv1", content: [] },
+        { type: "text", text: "response" },
+      ],
+    },
+    { role: "user", content: "next" },
+  ];
+
+  stripThinkingFromHistory(messages);
+
+  assert.equal(messages[1].content.length, 4);
+  assert.equal(messages[1].content[0].type, "thinking");
+  assert.equal(messages[1].content[1].type, "server_tool_use");
+  assert.equal(messages[1].content[2].type, "web_search_tool_result");
 });
 
 test("stripThinkingFromHistory strips even single assistant message", () => {

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -1078,6 +1078,27 @@ test("stripThinkingFromHistory preserves complete native search assistant blocks
   assert.equal(messages[1].content[2].type, "web_search_tool_result");
 });
 
+test("stripThinkingFromHistory strips thinking from partial native search blocks", () => {
+  const messages: any[] = [
+    { role: "user", content: "search" },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "need search", signature: "sig1" },
+        { type: "server_tool_use", id: "srv1", name: "web_search", input: { query: "gsd" } },
+        { type: "text", text: "interrupted" },
+      ],
+    },
+    { role: "user", content: "next" },
+  ];
+
+  stripThinkingFromHistory(messages);
+
+  assert.equal(messages[1].content.length, 2);
+  assert.equal(messages[1].content[0].type, "server_tool_use");
+  assert.equal(messages[1].content[1].type, "text");
+});
+
 test("stripThinkingFromHistory strips even single assistant message", () => {
   const messages: any[] = [
     { role: "user", content: "hello" },


### PR DESCRIPTION
## Summary

Preserves Anthropic native `server_tool_use` and `web_search_tool_result` blocks in assistant messages so Opus 4.8 native-search turns can be replayed without modifying signed thinking blocks.

## Root Cause

The Anthropic stream parser kept text, thinking, and client tool-use blocks, but dropped native server-tool blocks. On replay, the assistant message no longer matched the original Anthropic response structure, and later thinking stripping could modify a message that Anthropic expects to remain byte-for-byte compatible with its signed/redacted thinking blocks.

## Changes

- Capture `server_tool_use` and `web_search_tool_result` blocks from Anthropic SSE streams into the shared assistant message content model.
- Replay preserved native search blocks back into Anthropic request history.
- Avoid stripping thinking blocks when an assistant message already contains complete native server-tool history.
- Add Opus 4.8 regression coverage for parsing, replay, and native-search hook behavior.

## Validation

- `pnpm --filter @gsd/pi-ai exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm --filter @gsd/pi-ai exec vitest run test/anthropic-sse-parsing.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/native-search.test.ts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782740159&installation_id=134682257&pr_number=269&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F269&signature=d1481302642c3ac78ac92c499844d8dbd4e631b2be0009e54aea287f63d9a29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Anthropic message parsing, history replay, and thinking-block stripping—mistakes can break multi-turn native search or trigger API “thinking blocks cannot be modified” errors.
> 
> **Overview**
> Fixes **Opus 4.8 native web search** multi-turn replay by teaching the Anthropic stream path to **retain** `server_tool_use` and `web_search_tool_result` blocks end-to-end instead of dropping them on parse.
> 
> The **`@gsd/pi-ai` Anthropic provider** now maps those SSE blocks into `serverToolUse` / `webSearchResult` assistant content (including streamed `input_json_delta` for server tools), emits `server_tool_use` stream events, and **re-serializes** them when building the next Messages API request. Shared types gain optional **`caller`** on those blocks.
> 
> **Native search hooks** change **`stripThinkingFromHistory`**: thinking/redacted blocks are removed only when an assistant turn does **not** have a complete paired native server-tool + result history; complete native-search turns are left intact so Anthropic does not treat signed thinking as modified.
> 
> Regression tests cover SSE parsing, history replay, and the new strip-vs-preserve behavior (plus minor **claude-opus-4-8** fixture updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697c5a24915e9d598e9a64ef5bf5d55ae4856d4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->