### PR TITLE
[codex] fix task completion verification fallback

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -918,6 +918,44 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_task_complete accepts step-mode evidence when verification summary is omitted", async () => {
+    const base = makeTmpBase();
+    try {
+      mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+      writeFileSync(
+        join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+        "# S01\n\n- [ ] **T01: Demo** `est:5m`\n",
+      );
+
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const taskTool = server.tools.find((t) => t.name === "gsd_task_complete");
+      assert.ok(taskTool, "task tool should be registered");
+
+      const taskResult = await taskTool!.handler({
+        projectDir: base,
+        taskId: "T01",
+        sliceId: "S01",
+        milestoneId: "M001",
+        oneLiner: "Completed task",
+        narrative: "Did the work",
+        verificationEvidence: [
+          { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+        ],
+      });
+
+      assert.match((taskResult as any).content[0].text as string, /Completed task T01/);
+      const db = _getAdapter();
+      assert.ok(db, "DB should be open after tool completion");
+      const row = db!.prepare(
+        "SELECT verification_result FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?",
+      ).get("M001", "S01", "T01") as Record<string, unknown> | undefined;
+      assert.match(String(row?.verification_result), /`npm test` exited 0 \(pass\)/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("#4477 gsd_task_complete forwards every schema field to the executor (regression for destructure-rebuild bug class)", async () => {
     // Locks in the class-fix from PR #4477 review: handleTaskComplete previously
     // destructured args into a hand-listed set of fields and rebuilt the call

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -212,7 +212,7 @@ type WorkflowToolExecutors = {
       milestoneId: string;
       oneLiner: string;
       narrative: string;
-      verification: string;
+      verification?: string;
       deviations?: string;
       knownIssues?: string;
       keyFiles?: string[];
@@ -1449,7 +1449,7 @@ const taskCompleteParams = {
   milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
   oneLiner: z.string().describe("One-line summary of what was accomplished"),
   narrative: z.string().describe("Detailed narrative of what happened during the task"),
-  verification: z.string().describe("What was verified and how"),
+  verification: z.string().optional().describe("What was verified and how. If omitted, the executor derives this from verificationEvidence when possible."),
   deviations: z.string().optional().describe("Deviations from the task plan"),
   knownIssues: z.string().optional().describe("Known issues discovered but not fixed"),
   keyFiles: z.array(z.string()).optional().describe("List of key files created or modified"),

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -715,8 +715,9 @@ export function registerDbTools(pi: ExtensionAPI): void {
     promptSnippet: "Complete a GSD task (DB write + summary render + checkbox toggle)",
     promptGuidelines: [
       "Use gsd_task_complete (or gsd_complete_task) when a task is finished and needs to be recorded.",
-      "All string fields are required. verificationEvidence is an array of objects with command, exitCode, verdict, durationMs.",
-      "The tool validates required fields and returns an error message if any are missing.",
+      "Include verification whenever possible. If verification is omitted, the executor derives it from verificationEvidence when possible.",
+      "verificationEvidence is an array of objects with command, exitCode, verdict, durationMs.",
+      "The tool validates required fields and returns an error message if verification cannot be derived.",
       "On success, returns the summaryPath where the SUMMARY.md was written.",
       "Idempotent — calling with the same params twice will upsert (INSERT OR REPLACE) without error.",
     ],
@@ -727,7 +728,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       milestoneId: Type.String({ description: "Milestone ID (e.g. M001)" }),
       oneLiner: Type.String({ description: "One-line summary of what was accomplished" }),
       narrative: Type.String({ description: "Detailed narrative of what happened during the task" }),
-      verification: Type.String({ description: "What was verified and how — commands run, tests passed, behavior confirmed" }),
+      verification: Type.Optional(Type.String({ description: "What was verified and how — commands run, tests passed, behavior confirmed. If omitted, derived from verificationEvidence when possible." })),
       // ── Enrichment metadata (optional — defaults to empty) ────────────
       deviations: Type.Optional(Type.String({ description: "Deviations from the task plan, or 'None.'" })),
       knownIssues: Type.Optional(Type.String({ description: "Known issues discovered but not fixed, or 'None.'" })),

--- a/src/resources/extensions/gsd/tests/tool-param-optionality.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-param-optionality.test.ts
@@ -235,11 +235,15 @@ test("gsd_task_complete — enrichment arrays are optional", () => {
     "milestoneId",
     "oneLiner",
     "narrative",
-    "verification",
   ];
   for (const field of coreRequired) {
     assert.ok(required.has(field), `core field "${field}" must be required`);
   }
+
+  assert.ok(
+    !required.has("verification"),
+    "verification must be optional at the schema layer so step-mode can recover when verificationEvidence is present",
+  );
 
   // Enrichment fields must be optional
   const enrichmentFields = [
@@ -270,6 +274,25 @@ test("gsd_task_complete — validates with only core params", () => {
 
   const errors = validateSchema(tool, minimalParams);
   assert.strictEqual(errors.length, 0, `Minimal params should validate but got errors: ${errors.join(", ")}`);
+});
+
+test("gsd_task_complete — accepts evidence-only verification at schema layer", () => {
+  const tool = getTool("gsd_task_complete");
+  assert.ok(tool, "gsd_task_complete must be registered");
+
+  const params = {
+    taskId: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    oneLiner: "Implemented the feature",
+    narrative: "Created the module and wired it up.",
+    verificationEvidence: [
+      { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+    ],
+  };
+
+  const errors = validateSchema(tool, params);
+  assert.strictEqual(errors.length, 0, `Evidence-only params should validate but got errors: ${errors.join(", ")}`);
 });
 
 // ─── gsd_complete_milestone: enrichment arrays must be optional ──────────────

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -148,6 +148,60 @@ test("executeTaskComplete coerces string verificationEvidence entries", async ()
   }
 });
 
+test("executeTaskComplete derives missing verification from evidence", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    const planDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "S01-PLAN.md"), "# S01\n\n- [ ] **T01: Demo** `est:5m`\n");
+
+    const result = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work",
+      verificationEvidence: [
+        { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+      ],
+    }, base));
+
+    assert.equal(result.details.operation, "complete_task");
+    const db = _getAdapter();
+    assert.ok(db, "DB should be open");
+    const row = db!.prepare(
+      "SELECT verification_result FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?",
+    ).get("M001", "S01", "T01") as Record<string, unknown> | undefined;
+
+    assert.match(String(row?.verification_result), /Verification evidence recorded/);
+    assert.match(String(row?.verification_result), /`npm test` exited 0 \(pass\)/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeTaskComplete returns a tool error when verification cannot be derived", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    const result = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work",
+    }, base));
+
+    assert.equal(result.isError, true);
+    assert.match(String(result.content[0]?.text), /verification is required/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeSliceComplete preserves omitted optional requirement arrays", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -173,6 +173,15 @@ export async function handleCompleteTask(
   if (!params.milestoneId || typeof params.milestoneId !== "string" || params.milestoneId.trim() === "") {
     return { error: "milestoneId is required and must be a non-empty string" };
   }
+  if (!params.oneLiner || typeof params.oneLiner !== "string" || params.oneLiner.trim() === "") {
+    return { error: "oneLiner is required and must be a non-empty string" };
+  }
+  if (!params.narrative || typeof params.narrative !== "string" || params.narrative.trim() === "") {
+    return { error: "narrative is required and must be a non-empty string" };
+  }
+  if (!params.verification || typeof params.verification !== "string" || params.verification.trim() === "") {
+    return { error: "verification is required and must be a non-empty string" };
+  }
 
   const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, params.milestoneId);
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -306,13 +306,47 @@ export interface TaskCompleteParams {
   milestoneId: string;
   oneLiner: string;
   narrative: string;
-  verification: string;
+  verification?: string;
   deviations?: string;
   knownIssues?: string;
   keyFiles?: string[];
   keyDecisions?: string[];
   blockerDiscovered?: boolean;
   verificationEvidence?: VerificationEvidenceInput[];
+}
+
+type NormalizedVerificationEvidence = {
+  command: string;
+  exitCode: number;
+  verdict: string;
+  durationMs: number;
+};
+
+function normalizeVerificationEvidence(
+  evidence: VerificationEvidenceInput[] | undefined,
+): NormalizedVerificationEvidence[] {
+  return (evidence ?? []).map((entry) =>
+    typeof entry === "string"
+      ? { command: entry, exitCode: -1, verdict: "unknown (coerced from string)", durationMs: 0 }
+      : entry,
+  );
+}
+
+function deriveVerificationSummary(
+  evidence: NormalizedVerificationEvidence[],
+): string | null {
+  if (evidence.length === 0) return null;
+
+  const rendered = evidence.slice(0, 3).map((entry) => {
+    const command = entry.command.trim() || "(unspecified command)";
+    const verdict = entry.verdict.trim() || "recorded";
+    return `\`${command}\` exited ${entry.exitCode} (${verdict})`;
+  });
+  const suffix = evidence.length > rendered.length
+    ? `; ${evidence.length - rendered.length} more check(s) recorded`
+    : "";
+
+  return `Verification evidence recorded: ${rendered.join("; ")}${suffix}.`;
 }
 
 export type CompleteMilestoneExecutorParams = Partial<CompleteMilestoneParams> & Record<string, unknown>;
@@ -350,9 +384,27 @@ export async function executeTaskComplete(
   }
   try {
     const coerced = { ...params };
-    coerced.verificationEvidence = (params.verificationEvidence ?? []).map((v) =>
-      typeof v === "string" ? { command: v, exitCode: -1, verdict: "unknown (coerced from string)", durationMs: 0 } : v,
-    );
+    const verificationEvidence = normalizeVerificationEvidence(params.verificationEvidence);
+    coerced.verificationEvidence = verificationEvidence;
+
+    const verification = typeof params.verification === "string" ? params.verification.trim() : "";
+    if (verification.length === 0) {
+      const derived = deriveVerificationSummary(verificationEvidence);
+      if (derived) {
+        coerced.verification = derived;
+      } else if (params.blockerDiscovered === true) {
+        coerced.verification = "Not run: blocker discovered before verification.";
+      } else {
+        return {
+          content: [{
+            type: "text",
+            text: "Error completing task: verification is required unless verificationEvidence is provided or blockerDiscovered is true.",
+          }],
+          details: { operation: "complete_task", error: "verification_required" },
+          isError: true,
+        };
+      }
+    }
 
     const result = await handleCompleteTask(coerced as any, basePath);
     if ("error" in result) {


### PR DESCRIPTION
## Summary

Fixes the step-mode/MCP task completion path so `gsd_task_complete` no longer fails with an MCP `-32602` validation error when the model supplies structured `verificationEvidence` but omits the short `verification` summary.

## Root Cause

The MCP and native tool schemas required `verification`, so invalid evidence-only completion payloads were rejected before the shared GSD executor could normalize or return a recoverable tool error.

## Changes

- Makes `verification` optional at the MCP/native schema boundary for task completion.
- Derives a readable verification summary from `verificationEvidence` in the shared executor.
- Fails closed with a normal tool error when neither `verification` nor derivable evidence is present.
- Adds handler-level validation before summary/state writes.
- Adds regression coverage for evidence-only step-mode payloads and fail-closed behavior.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/tool-param-optionality.test.ts packages/mcp-server/src/workflow-tools.test.ts` — 91 passing
- `pnpm run typecheck:extensions` — passing
- `pnpm --filter @opengsd/mcp-server run build` — passing

Note: `pnpm --filter @opengsd/mcp-server run build:test` still fails due existing package test tsconfig/rootDir issues around tests importing `../../../src/...*.ts`; this is unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782743756&installation_id=134682257&pr_number=271&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F271&signature=2ecfbc47e5de3a9a4d7a57967b946ba0641201085ebab8d5e98e85e6c6cc56be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow task-completion contract change with fail-closed errors and tests; no auth or security surface, and explicit `verification` still works unchanged.
> 
> **Overview**
> **`gsd_task_complete` now accepts evidence-only completions** when step-mode agents send `verificationEvidence` but omit the short `verification` string, fixing MCP `-32602` schema rejections before the shared executor could run.
> 
> At the **MCP and native tool boundaries**, `verification` is optional; prompts/schemas say it may be derived from evidence. The **shared executor** normalizes evidence, builds a readable summary (up to three commands), uses a blocker placeholder when `blockerDiscovered` is true, and otherwise returns a normal tool error if nothing can be derived. **`handleCompleteTask`** still requires a non-empty `verification` after that coercion, with added checks for `oneLiner` and `narrative`.
> 
> Regression tests cover MCP end-to-end evidence-only completion, schema optionality, derived summaries in the DB, and fail-closed behavior when verification is missing entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073a9eb5ca7fb53f92187b7aabfd5dd421a80a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->