### PR TITLE
[codex] recover stranded milestone work

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -918,6 +918,44 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_task_complete accepts step-mode evidence when verification summary is omitted", async () => {
+    const base = makeTmpBase();
+    try {
+      mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+      writeFileSync(
+        join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+        "# S01\n\n- [ ] **T01: Demo** `est:5m`\n",
+      );
+
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const taskTool = server.tools.find((t) => t.name === "gsd_task_complete");
+      assert.ok(taskTool, "task tool should be registered");
+
+      const taskResult = await taskTool!.handler({
+        projectDir: base,
+        taskId: "T01",
+        sliceId: "S01",
+        milestoneId: "M001",
+        oneLiner: "Completed task",
+        narrative: "Did the work",
+        verificationEvidence: [
+          { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+        ],
+      });
+
+      assert.match((taskResult as any).content[0].text as string, /Completed task T01/);
+      const db = _getAdapter();
+      assert.ok(db, "DB should be open after tool completion");
+      const row = db!.prepare(
+        "SELECT verification_result FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?",
+      ).get("M001", "S01", "T01") as Record<string, unknown> | undefined;
+      assert.match(String(row?.verification_result), /`npm test` exited 0 \(pass\)/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("#4477 gsd_task_complete forwards every schema field to the executor (regression for destructure-rebuild bug class)", async () => {
     // Locks in the class-fix from PR #4477 review: handleTaskComplete previously
     // destructured args into a hand-listed set of fields and rebuilt the call

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -212,7 +212,7 @@ type WorkflowToolExecutors = {
       milestoneId: string;
       oneLiner: string;
       narrative: string;
-      verification: string;
+      verification?: string;
       deviations?: string;
       knownIssues?: string;
       keyFiles?: string[];
@@ -1449,7 +1449,7 @@ const taskCompleteParams = {
   milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
   oneLiner: z.string().describe("One-line summary of what was accomplished"),
   narrative: z.string().describe("Detailed narrative of what happened during the task"),
-  verification: z.string().describe("What was verified and how"),
+  verification: z.string().optional().describe("What was verified and how. If omitted, the executor derives this from verificationEvidence when possible."),
   deviations: z.string().optional().describe("Deviations from the task plan"),
   knownIssues: z.string().optional().describe("Known issues discovered but not fixed"),
   keyFiles: z.array(z.string()).optional().describe("List of key files created or modified"),

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -272,6 +272,10 @@ export interface OrphanAuditResult {
   blockingStrandedWork: OrphanAuditAction | null;
 }
 
+function isBlockingStrandedWorkAction(action: OrphanAuditAction): boolean {
+  return action.kind === "in-progress-stranded-work" && action.blocksAuto;
+}
+
 function detectWorktreeEvidence(
   basePath: string,
   milestoneId: string,
@@ -667,8 +671,7 @@ export function auditOrphanedMilestoneBranches(
     recovered,
     warnings,
     actions,
-    blockingStrandedWork:
-      actions.find((action) => action.kind === "in-progress-stranded-work" && action.blocksAuto) ?? null,
+    blockingStrandedWork: actions.find(isBlockingStrandedWorkAction) ?? null,
   };
 }
 
@@ -1091,10 +1094,12 @@ export async function bootstrapAutoSession(
     // was lost due to session ending between completion and teardown.
     // Must run after DB open and before worktree entry.
     let orphanAuditRecovered = false;
+    let strandedRecoveryActions: OrphanAuditAction[] = [];
     let strandedRecoveryAction: OrphanAuditAction | null = null;
     try {
       const auditResult = auditOrphanedMilestoneBranches(base, getIsolationMode(base));
-      strandedRecoveryAction = auditResult.blockingStrandedWork;
+      strandedRecoveryActions = auditResult.actions.filter(isBlockingStrandedWorkAction);
+      strandedRecoveryAction = strandedRecoveryActions[0] ?? null;
       for (const msg of auditResult.recovered) {
         ctx.ui.notify(`Orphan audit: ${msg}`, "info");
       }
@@ -1108,6 +1113,7 @@ export async function bootstrapAutoSession(
           recovered: auditResult.recovered,
           warnings: auditResult.warnings,
           strandedRecoveryAction,
+          strandedRecoveryActions,
         });
       }
     } catch (err) {
@@ -1162,21 +1168,28 @@ export async function bootstrapAutoSession(
       }
     }
 
-    if (strandedRecoveryAction) {
+    const blockingStrandedRecoveryAction = state.activeMilestone
+      ? strandedRecoveryActions.find(
+        (action) => action.milestoneId !== state.activeMilestone?.id,
+      ) ?? strandedRecoveryAction
+      : strandedRecoveryAction;
+
+    if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {
         ctx.ui.notify(
-          `Stranded work for ${strandedRecoveryAction.milestoneId} blocks auto-mode, but that milestone is not active in project state. Park or discard it explicitly before continuing.`,
+          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode, but that milestone is not active in project state. Park or discard it explicitly before continuing.`,
           "error",
         );
         return releaseLockAndReturn();
       }
-      if (state.activeMilestone.id !== strandedRecoveryAction.milestoneId) {
+      if (state.activeMilestone.id !== blockingStrandedRecoveryAction.milestoneId) {
         ctx.ui.notify(
-          `Stranded work for ${strandedRecoveryAction.milestoneId} blocks auto-mode before ${state.activeMilestone.id}. Recover, park, or discard ${strandedRecoveryAction.milestoneId} explicitly before continuing.`,
+          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode before ${state.activeMilestone.id}. Recover, park, or discard ${blockingStrandedRecoveryAction.milestoneId} explicitly before continuing.`,
           "error",
         );
         return releaseLockAndReturn();
       }
+      strandedRecoveryAction = blockingStrandedRecoveryAction;
       ctx.ui.notify(
         `Recovering stranded work for ${strandedRecoveryAction.milestoneId} before dispatching new units.`,
         "info",

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1150,19 +1150,6 @@ export async function bootstrapAutoSession(
 
     let state = await deriveState(base);
 
-    if (
-      process.env.GSD_HEADLESS === "1" &&
-      orphanAuditRecovered &&
-      !state.activeMilestone &&
-      state.phase === "complete"
-    ) {
-      ctx.ui.notify(
-        "Auto-mode stopped (Recovered completed milestone cleanup; all milestones complete).",
-        "info",
-      );
-      return releaseLockAndReturn();
-    }
-
     // Stale worktree state recovery (#654)
     if (
       state.activeMilestone &&
@@ -1194,6 +1181,19 @@ export async function bootstrapAutoSession(
         `Recovering stranded work for ${strandedRecoveryAction.milestoneId} before dispatching new units.`,
         "info",
       );
+    }
+
+    if (
+      process.env.GSD_HEADLESS === "1" &&
+      orphanAuditRecovered &&
+      !state.activeMilestone &&
+      state.phase === "complete"
+    ) {
+      ctx.ui.notify(
+        "Auto-mode stopped (Recovered completed milestone cleanup; all milestones complete).",
+        "info",
+      );
+      return releaseLockAndReturn();
     }
 
     // Milestone branch recovery (#601, #2358)
@@ -1329,7 +1329,7 @@ export async function bootstrapAutoSession(
       { hasSurvivorBranch },
     );
 
-    if (deepProjectStagePending) {
+    if (deepProjectStagePending && !strandedRecoveryAction) {
       // Deep project-level setup runs before the first milestone exists. Let
       // the auto loop dispatch workflow-preferences / project / requirements
       // units instead of recursing back through showSmartEntry while this
@@ -1451,9 +1451,8 @@ export async function bootstrapAutoSession(
     s.pendingQuickTasks = [];
     s.currentUnit = null;
     s.currentMilestoneId ??=
-      deepProjectStagePending
-        ? null
-        : strandedRecoveryAction?.milestoneId ?? state.activeMilestone?.id ?? null;
+      strandedRecoveryAction?.milestoneId ??
+      (deepProjectStagePending ? null : state.activeMilestone?.id ?? null);
     s.originalModelId = startModelSnapshot?.id ?? ctx.model?.id ?? null;
     s.originalModelProvider = startModelSnapshot?.provider ?? ctx.model?.provider ?? null;
     s.originalThinkingLevel = startThinkingSnapshot ?? null;

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -48,6 +48,7 @@ import {
   nativeBranchDelete,
   nativeWorktreeRemove,
   nativeCommitCountBetween,
+  nativeHasChanges,
 } from "./native-git-bridge.js";
 import { GitServiceImpl } from "./git-service.js";
 import {
@@ -242,24 +243,122 @@ export function resolveSurvivorRecoveryIsolationMode(
   return isolationMode;
 }
 
+export type StrandedWorkRecoveryMode = "worktree" | "branch";
+
+export type OrphanAuditActionKind =
+  | "in-progress-stranded-work"
+  | "complete-merged-branch"
+  | "complete-merged-worktree"
+  | "complete-unmerged-branch"
+  | "complete-branchless-worktree";
+
+export interface OrphanAuditAction {
+  kind: OrphanAuditActionKind;
+  milestoneId: string;
+  message: string;
+  severity: "info" | "warning";
+  branch?: string;
+  commitsAhead?: number;
+  dirtyWorktree?: boolean;
+  worktreeDirExists?: boolean;
+  recoveryMode?: StrandedWorkRecoveryMode;
+  blocksAuto: boolean;
+}
+
+export interface OrphanAuditResult {
+  recovered: string[];
+  warnings: string[];
+  actions: OrphanAuditAction[];
+  blockingStrandedWork: OrphanAuditAction | null;
+}
+
+function detectWorktreeEvidence(
+  basePath: string,
+  milestoneId: string,
+  hasChanges: typeof nativeHasChanges,
+): { path: string | null; dirExists: boolean; dirty: boolean } {
+  const wtDir = getWorktreeDir(basePath, milestoneId);
+  const wtPath = getAutoWorktreePath(basePath, milestoneId);
+  let dirty = false;
+  if (wtPath) {
+    try {
+      dirty = hasChanges(wtPath);
+    } catch {
+      dirty = false;
+    }
+  }
+  return {
+    path: wtPath,
+    dirExists: existsSync(wtDir),
+    dirty,
+  };
+}
+
+function strandedWorkMessage(args: {
+  milestoneId: string;
+  branch?: string;
+  commitsAhead: number;
+  mainBranch: string;
+  dirtyWorktree: boolean;
+  worktreeDirExists: boolean;
+  recoveryMode: StrandedWorkRecoveryMode;
+}): string {
+  const evidence: string[] = [];
+  if (args.branch && args.commitsAhead > 0) {
+    evidence.push(
+      `branch ${args.branch} has ${args.commitsAhead} commit(s) ahead of ${args.mainBranch}`,
+    );
+  }
+  if (args.dirtyWorktree) {
+    evidence.push("the worktree has uncommitted changes");
+  }
+  if (evidence.length === 0) {
+    evidence.push("physical git evidence exists");
+  }
+
+  const wtSuffix = args.worktreeDirExists
+    ? ` Worktree directory at .gsd/worktrees/${args.milestoneId}/ holds live work.`
+    : "";
+  const recovery = args.recoveryMode === "worktree"
+    ? "Recovering will adopt the existing worktree."
+    : "Recovering will adopt the milestone branch.";
+
+  return (
+    `Stranded work for in-progress milestone ${args.milestoneId}: ${evidence.join("; ")}.` +
+    wtSuffix +
+    ` ${recovery} Park or discard explicitly if abandoning.`
+  );
+}
+
 export function auditOrphanedMilestoneBranches(
   basePath: string,
-  isolationMode: "worktree" | "branch" | "none",
+  _isolationMode: "worktree" | "branch" | "none",
   gitDeps: {
     branchList?: typeof nativeBranchList;
     branchExists?: typeof nativeBranchExists;
+    hasChanges?: typeof nativeHasChanges;
   } = {},
-): { recovered: string[]; warnings: string[] } {
+): OrphanAuditResult {
   const recovered: string[] = [];
   const warnings: string[] = [];
+  const actions: OrphanAuditAction[] = [];
   const branchList = gitDeps.branchList ?? nativeBranchList;
   const branchExists = gitDeps.branchExists ?? nativeBranchExists;
+  const hasChanges = gitDeps.hasChanges ?? nativeHasChanges;
 
-  // Skip in none mode — no milestone branches are created
-  if (isolationMode === "none") return { recovered, warnings };
+  const pushAction = (action: OrphanAuditAction): void => {
+    actions.push(action);
+    if (action.severity === "info") {
+      recovered.push(action.message);
+    } else {
+      warnings.push(action.message);
+    }
+  };
 
   // Skip if DB not available — can't determine completion status
-  if (!isDbAvailable()) return { recovered, warnings };
+  if (!isDbAvailable()) {
+    return { recovered, warnings, actions, blockingStrandedWork: null };
+  }
 
   let milestoneBranches: string[];
   let milestoneBranchListAvailable = true;
@@ -295,6 +394,7 @@ export function auditOrphanedMilestoneBranches(
     if (!milestone) continue;
 
     const isMerged = mergedBranches.has(branch);
+    const worktreeEvidence = detectWorktreeEvidence(basePath, milestoneId, hasChanges);
 
     // #4762 — in-progress milestone branch with unmerged commits ahead of
     // main. This is the pre-completion orphan case: auto-mode exited without
@@ -307,33 +407,45 @@ export function auditOrphanedMilestoneBranches(
     // Parked/other closed statuses go through the legacy complete/unmerged
     // path below where appropriate.
     if (!isClosedStatus(milestone.status)) {
-      if (isMerged) continue; // nothing to recover
       let commitsAhead = 0;
       try {
         commitsAhead = nativeCommitCountBetween(basePath, mainBranch, branch);
       } catch {
-        // Rev-walk failure — skip rather than noise
-        continue;
+        commitsAhead = 0;
       }
-      if (commitsAhead === 0) continue;
+      if ((isMerged || commitsAhead === 0) && !worktreeEvidence.dirty) continue;
 
-      const wtDir = getWorktreeDir(basePath, milestoneId);
-      const wtDirExists = existsSync(wtDir);
-      const wtSuffix = wtDirExists
-        ? ` Worktree directory at .gsd/worktrees/${milestoneId}/ holds the live work.`
-        : "";
-      warnings.push(
-        `Branch ${branch} has ${commitsAhead} commit(s) ahead of ${mainBranch} for in-progress milestone ${milestoneId}.` +
-        wtSuffix +
-        ` Run \`/gsd auto\` to resume, or merge manually if abandoning.`,
-      );
+      const recoveryMode: StrandedWorkRecoveryMode = worktreeEvidence.path
+        ? "worktree"
+        : "branch";
+      const message = strandedWorkMessage({
+        milestoneId,
+        branch,
+        commitsAhead,
+        mainBranch,
+        dirtyWorktree: worktreeEvidence.dirty,
+        worktreeDirExists: worktreeEvidence.dirExists,
+        recoveryMode,
+      });
+      pushAction({
+        kind: "in-progress-stranded-work",
+        milestoneId,
+        branch,
+        commitsAhead,
+        dirtyWorktree: worktreeEvidence.dirty,
+        worktreeDirExists: worktreeEvidence.dirExists,
+        recoveryMode,
+        message,
+        severity: "warning",
+        blocksAuto: true,
+      });
 
       // #4764 telemetry
       try {
         emitWorktreeOrphaned(basePath, milestoneId, {
           reason: "in-progress-unmerged",
           commitsAhead,
-          worktreeDirExists: wtDirExists,
+          worktreeDirExists: worktreeEvidence.dirExists,
         });
       } catch (err) {
         logWarning("engine", `worktree-orphaned telemetry failed for ${milestoneId}: ${err instanceof Error ? err.message : String(err)}`);
@@ -351,7 +463,14 @@ export function auditOrphanedMilestoneBranches(
       // Branch is merged — safe to delete branch and clean up worktree dir
       try {
         nativeBranchDelete(basePath, branch, true);
-        recovered.push(`Deleted merged branch ${branch} for completed milestone ${milestoneId}.`);
+        pushAction({
+          kind: "complete-merged-branch",
+          milestoneId,
+          branch,
+          message: `Deleted merged branch ${branch} for completed milestone ${milestoneId}.`,
+          severity: "info",
+          blocksAuto: false,
+        });
       } catch (err) {
         warnings.push(`Failed to delete merged branch ${branch}: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -374,7 +493,15 @@ export function auditOrphanedMilestoneBranches(
           if (isInsideWorktreesDir(basePath, wtDir)) {
             try {
               rmSync(wtDir, { recursive: true, force: true });
-              recovered.push(`Removed orphaned worktree directory for ${milestoneId}.`);
+              pushAction({
+                kind: "complete-merged-worktree",
+                milestoneId,
+                branch,
+                worktreeDirExists: true,
+                message: `Removed orphaned worktree directory for ${milestoneId}.`,
+                severity: "info",
+                blocksAuto: false,
+              });
             } catch (err2) {
               warnings.push(`Failed to remove worktree directory for ${milestoneId}: ${err2 instanceof Error ? err2.message : String(err2)}`);
             }
@@ -382,15 +509,30 @@ export function auditOrphanedMilestoneBranches(
             warnings.push(`Orphaned worktree directory for ${milestoneId} is outside .gsd/worktrees/ — skipping removal for safety.`);
           }
         } else {
-          recovered.push(`Removed orphaned worktree directory for ${milestoneId}.`);
+          pushAction({
+            kind: "complete-merged-worktree",
+            milestoneId,
+            branch,
+            worktreeDirExists: true,
+            message: `Removed orphaned worktree directory for ${milestoneId}.`,
+            severity: "info",
+            blocksAuto: false,
+          });
         }
       }
     } else {
       // Branch is NOT merged — preserve for safety, warn the user
-      warnings.push(
-        `Branch ${branch} exists for completed milestone ${milestoneId} but is NOT merged into ${mainBranch}. ` +
-        `This may contain unmerged work. Merge manually or run \`/gsd doctor fix\` to resolve.`,
-      );
+      pushAction({
+        kind: "complete-unmerged-branch",
+        milestoneId,
+        branch,
+        worktreeDirExists: worktreeEvidence.dirExists,
+        message:
+          `Branch ${branch} exists for completed milestone ${milestoneId} but is NOT merged into ${mainBranch}. ` +
+          `This may contain unmerged work. Merge manually or run \`/gsd doctor fix\` to resolve.`,
+        severity: "warning",
+        blocksAuto: false,
+      });
 
       // #4764 telemetry
       try {
@@ -428,6 +570,41 @@ export function auditOrphanedMilestoneBranches(
     completedMilestones = [];
   }
   for (const m of completedMilestones) {
+    if (!isClosedStatus(m.status)) {
+      if (seenMilestoneIds.has(m.id)) continue;
+      const worktreeEvidence = detectWorktreeEvidence(basePath, m.id, hasChanges);
+      if (!worktreeEvidence.dirty) continue;
+      const message = strandedWorkMessage({
+        milestoneId: m.id,
+        commitsAhead: 0,
+        mainBranch,
+        dirtyWorktree: true,
+        worktreeDirExists: worktreeEvidence.dirExists,
+        recoveryMode: "worktree",
+      });
+      pushAction({
+        kind: "in-progress-stranded-work",
+        milestoneId: m.id,
+        commitsAhead: 0,
+        dirtyWorktree: true,
+        worktreeDirExists: worktreeEvidence.dirExists,
+        recoveryMode: "worktree",
+        message,
+        severity: "warning",
+        blocksAuto: true,
+      });
+      try {
+        emitWorktreeOrphaned(basePath, m.id, {
+          reason: "in-progress-unmerged",
+          commitsAhead: 0,
+          worktreeDirExists: worktreeEvidence.dirExists,
+        });
+      } catch (err) {
+        logWarning("engine", `worktree-orphaned telemetry failed for ${m.id}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      continue;
+    }
+
     if (m.status !== "complete") continue;
     if (seenMilestoneIds.has(m.id)) continue; // already processed in the branch loop
     if (!milestoneBranchListAvailable) {
@@ -461,18 +638,38 @@ export function auditOrphanedMilestoneBranches(
     if (existsSync(wtDir)) {
       try {
         rmSync(wtDir, { recursive: true, force: true });
-        recovered.push(`Removed orphaned worktree directory for ${m.id} (branch already deleted).`);
+        pushAction({
+          kind: "complete-branchless-worktree",
+          milestoneId: m.id,
+          worktreeDirExists: true,
+          message: `Removed orphaned worktree directory for ${m.id} (branch already deleted).`,
+          severity: "info",
+          blocksAuto: false,
+        });
       } catch (err) {
         warnings.push(
           `Failed to remove orphaned worktree directory for ${m.id}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     } else {
-      recovered.push(`Removed orphaned worktree directory for ${m.id} (branch already deleted).`);
+      pushAction({
+        kind: "complete-branchless-worktree",
+        milestoneId: m.id,
+        worktreeDirExists: true,
+        message: `Removed orphaned worktree directory for ${m.id} (branch already deleted).`,
+        severity: "info",
+        blocksAuto: false,
+      });
     }
   }
 
-  return { recovered, warnings };
+  return {
+    recovered,
+    warnings,
+    actions,
+    blockingStrandedWork:
+      actions.find((action) => action.kind === "in-progress-stranded-work" && action.blocksAuto) ?? null,
+  };
 }
 
 /**
@@ -894,17 +1091,24 @@ export async function bootstrapAutoSession(
     // was lost due to session ending between completion and teardown.
     // Must run after DB open and before worktree entry.
     let orphanAuditRecovered = false;
+    let strandedRecoveryAction: OrphanAuditAction | null = null;
     try {
       const auditResult = auditOrphanedMilestoneBranches(base, getIsolationMode(base));
+      strandedRecoveryAction = auditResult.blockingStrandedWork;
       for (const msg of auditResult.recovered) {
         ctx.ui.notify(`Orphan audit: ${msg}`, "info");
       }
       for (const msg of auditResult.warnings) {
-        ctx.ui.notify(`Orphan audit: ${msg}`, "warning");
+        const prefix = msg.startsWith("Stranded work") ? "" : "Orphan audit: ";
+        ctx.ui.notify(`${prefix}${msg}`, "warning");
       }
       if (auditResult.recovered.length > 0) {
         orphanAuditRecovered = true;
-        debugLog("orphan-audit", { recovered: auditResult.recovered, warnings: auditResult.warnings });
+        debugLog("orphan-audit", {
+          recovered: auditResult.recovered,
+          warnings: auditResult.warnings,
+          strandedRecoveryAction,
+        });
       }
     } catch (err) {
       // Non-fatal — the audit is defensive, never block bootstrap
@@ -971,6 +1175,27 @@ export async function bootstrapAutoSession(
       }
     }
 
+    if (strandedRecoveryAction) {
+      if (!state.activeMilestone) {
+        ctx.ui.notify(
+          `Stranded work for ${strandedRecoveryAction.milestoneId} blocks auto-mode, but that milestone is not active in project state. Park or discard it explicitly before continuing.`,
+          "error",
+        );
+        return releaseLockAndReturn();
+      }
+      if (state.activeMilestone.id !== strandedRecoveryAction.milestoneId) {
+        ctx.ui.notify(
+          `Stranded work for ${strandedRecoveryAction.milestoneId} blocks auto-mode before ${state.activeMilestone.id}. Recover, park, or discard ${strandedRecoveryAction.milestoneId} explicitly before continuing.`,
+          "error",
+        );
+        return releaseLockAndReturn();
+      }
+      ctx.ui.notify(
+        `Recovering stranded work for ${strandedRecoveryAction.milestoneId} before dispatching new units.`,
+        "info",
+      );
+    }
+
     // Milestone branch recovery (#601, #2358)
     // Detect survivor milestone branches in both pre-planning and complete phases.
     // In phase=complete, the milestone artifacts exist but finalization (merge,
@@ -1005,7 +1230,10 @@ export async function bootstrapAutoSession(
     // The worktree/branch was created but the milestone only has CONTEXT-DRAFT.md.
     // Route to the interactive discussion handler instead of falling through to
     // auto-mode, which would immediately stop with "needs discussion".
-    if (decideSurvivorAction(hasSurvivorBranch, state.phase) === "discuss") {
+    if (
+      !strandedRecoveryAction &&
+      decideSurvivorAction(hasSurvivorBranch, state.phase) === "discuss"
+    ) {
       const { showSmartEntry } = await import("./guided-flow.js");
       await showSmartEntry(ctx, pi, base, { step: requestedStepMode });
 
@@ -1109,7 +1337,7 @@ export async function bootstrapAutoSession(
       s.currentMilestoneId = null;
     }
 
-    if (!hasSurvivorBranch && !deepProjectStagePending) {
+    if (!hasSurvivorBranch && !deepProjectStagePending && !strandedRecoveryAction) {
       // No active work — start a new milestone via discuss flow
       if (!state.activeMilestone || state.phase === "complete") {
         // Guard against recursive dialog loop (#1348):
@@ -1185,7 +1413,7 @@ export async function bootstrapAutoSession(
     }
 
     // Unreachable safety check
-    if (!state.activeMilestone && !deepProjectStagePending) {
+    if (!state.activeMilestone && !deepProjectStagePending && !strandedRecoveryAction) {
       const { showSmartEntry } = await import("./guided-flow.js");
       await showSmartEntry(ctx, pi, base, { step: requestedStepMode });
       return releaseLockAndReturn();
@@ -1222,7 +1450,10 @@ export async function bootstrapAutoSession(
     s.resourceVersionOnStart = readResourceVersion();
     s.pendingQuickTasks = [];
     s.currentUnit = null;
-    s.currentMilestoneId ??= deepProjectStagePending ? null : state.activeMilestone?.id ?? null;
+    s.currentMilestoneId ??=
+      deepProjectStagePending
+        ? null
+        : strandedRecoveryAction?.milestoneId ?? state.activeMilestone?.id ?? null;
     s.originalModelId = startModelSnapshot?.id ?? ctx.model?.id ?? null;
     s.originalModelProvider = startModelSnapshot?.provider ?? ctx.model?.provider ?? null;
     s.originalThinkingLevel = startThinkingSnapshot ?? null;
@@ -1232,7 +1463,7 @@ export async function bootstrapAutoSession(
 
     // Capture integration branch
     if (s.currentMilestoneId) {
-      if (getIsolationMode(base) !== "none") {
+      if (getIsolationMode(base) !== "none" || strandedRecoveryAction) {
         captureIntegrationBranch(base, s.currentMilestoneId);
       }
       setActiveMilestoneId(base, s.currentMilestoneId);
@@ -1243,7 +1474,7 @@ export async function bootstrapAutoSession(
     // milestone/<MID>. Auto-checkout back to the integration branch.
     const isolationMode = getIsolationMode(base);
     const isRepo = nativeIsRepo(base);
-    if (isolationMode === "none" && isRepo) {
+    if (isolationMode === "none" && isRepo && !strandedRecoveryAction) {
       try {
         const currentBranch = nativeGetCurrentBranch(base);
         const integrationBranch = nativeDetectMainBranch(base);
@@ -1282,13 +1513,21 @@ export async function bootstrapAutoSession(
 
     if (
       s.currentMilestoneId &&
-      getIsolationMode(base) !== "none" &&
+      (getIsolationMode(base) !== "none" || strandedRecoveryAction?.recoveryMode) &&
       !detectWorktreeName(base) &&
       !isUnderGsdWorktrees(base)
     ) {
-      const enterResult = buildLifecycle().enterMilestone(s.currentMilestoneId, {
-        notify: ctx.ui.notify.bind(ctx.ui),
-      });
+      const lifecycle = buildLifecycle();
+      const enterResult = strandedRecoveryAction?.recoveryMode
+        ? lifecycle.adoptStrandedMilestone(
+          s.currentMilestoneId,
+          base,
+          { notify: ctx.ui.notify.bind(ctx.ui) },
+          { mode: strandedRecoveryAction.recoveryMode },
+        )
+        : lifecycle.enterMilestone(s.currentMilestoneId, {
+          notify: ctx.ui.notify.bind(ctx.ui),
+        });
       if (!enterResult.ok) {
         s.active = false;
         if (enterResult.reason === "lease-conflict") {

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -218,6 +218,8 @@ export class AutoSession {
   // ── Isolation degradation ────────────────────────────────────────────
   /** Set to true when worktree creation fails; prevents merge of nonexistent branch. */
   isolationDegraded = false;
+  /** Temporary recovery mode for stranded work adopted from physical git evidence. */
+  strandedRecoveryIsolationMode: "worktree" | "branch" | null = null;
   /** Project-root dirty snapshot captured before an isolated worktree unit runs. */
   rootWriteBaseline: RootDirtySnapshot | null = null;
 
@@ -382,6 +384,7 @@ export class AutoSession {
     this.lastGitActionFailure = null;
     this.lastGitActionStatus = null;
     this.isolationDegraded = false;
+    this.strandedRecoveryIsolationMode = null;
     this.rootWriteBaseline = null;
     this.milestoneMergedInPhases = false;
     this.milestoneStartShas = new Map();

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -715,8 +715,9 @@ export function registerDbTools(pi: ExtensionAPI): void {
     promptSnippet: "Complete a GSD task (DB write + summary render + checkbox toggle)",
     promptGuidelines: [
       "Use gsd_task_complete (or gsd_complete_task) when a task is finished and needs to be recorded.",
-      "All string fields are required. verificationEvidence is an array of objects with command, exitCode, verdict, durationMs.",
-      "The tool validates required fields and returns an error message if any are missing.",
+      "Include verification whenever possible. If verification is omitted, the executor derives it from verificationEvidence when possible.",
+      "verificationEvidence is an array of objects with command, exitCode, verdict, durationMs.",
+      "The tool validates required fields and returns an error message if verification cannot be derived.",
       "On success, returns the summaryPath where the SUMMARY.md was written.",
       "Idempotent — calling with the same params twice will upsert (INSERT OR REPLACE) without error.",
     ],
@@ -727,7 +728,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       milestoneId: Type.String({ description: "Milestone ID (e.g. M001)" }),
       oneLiner: Type.String({ description: "One-line summary of what was accomplished" }),
       narrative: Type.String({ description: "Detailed narrative of what happened during the task" }),
-      verification: Type.String({ description: "What was verified and how — commands run, tests passed, behavior confirmed" }),
+      verification: Type.Optional(Type.String({ description: "What was verified and how — commands run, tests passed, behavior confirmed. If omitted, derived from verificationEvidence when possible." })),
       // ── Enrichment metadata (optional — defaults to empty) ────────────
       deviations: Type.Optional(Type.String({ description: "Deviations from the task plan, or 'None.'" })),
       knownIssues: Type.Optional(Type.String({ description: "Known issues discovered but not fixed, or 'None.'" })),

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -82,6 +82,42 @@ function makeRepoWithStrandedActiveMilestone(options: { deepPlanning?: boolean }
   return base;
 }
 
+function makeRepoWithMultipleStrandedMilestones(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-multiple-stranded-bootstrap-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M002"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: \"none\"\n---\n",
+  );
+  runGit(base, ["init"]);
+  runGit(base, ["config", "user.email", "test@test.com"]);
+  runGit(base, ["config", "user.name", "Test"]);
+  writeFileSync(join(base, "README.md"), "# test\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "init"]);
+  runGit(base, ["branch", "-M", "main"]);
+
+  runGit(base, ["checkout", "-b", "milestone/M001"]);
+  writeFileSync(join(base, "m001.txt"), "active stranded work\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M001 in progress"]);
+  runGit(base, ["checkout", "main"]);
+
+  runGit(base, ["checkout", "-b", "milestone/M002"]);
+  writeFileSync(join(base, "m002.txt"), "additional stranded work\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M002 in progress"]);
+  runGit(base, ["checkout", "main"]);
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Active milestone", status: "active" });
+  insertMilestone({ id: "M002", title: "Pending milestone", status: "pending" });
+  closeDatabase();
+
+  return base;
+}
+
 function makeRepoWithRecoveredCleanupAndStrandedMismatch(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-headless-stranded-bootstrap-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
@@ -302,6 +338,78 @@ test("headless bootstrap checks stranded work before recovered-complete shortcut
     } else {
       process.env.GSD_MILESTONE_LOCK = previousMilestoneLock;
     }
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap blocks active stranded recovery when another open milestone also has stranded work", async () => {
+  const base = makeRepoWithMultipleStrandedMilestones();
+  const previousCwd = process.cwd();
+  const s = new AutoSession();
+  const adoptCalls: string[] = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: () => ({ ok: true, mode: "none", path: base }),
+          adoptStrandedMilestone: (milestoneId: string) => {
+            adoptCalls.push(milestoneId);
+            return { ok: true, mode: "branch", path: base };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    const messages = notifications.map((entry) => entry.message).join("\n");
+    assert.equal(ready, false);
+    assert.deepEqual(adoptCalls, []);
+    assert.match(messages, /Stranded work for M002 blocks auto-mode before M001/);
+  } finally {
     try {
       closeDatabase();
     } catch {}

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -52,6 +52,34 @@ function makeRepoWithUnmergedCompletedMilestone(): string {
   return base;
 }
 
+function makeRepoWithStrandedActiveMilestone(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-stranded-bootstrap-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: \"none\"\n---\n",
+  );
+  runGit(base, ["init"]);
+  runGit(base, ["config", "user.email", "test@test.com"]);
+  runGit(base, ["config", "user.name", "Test"]);
+  writeFileSync(join(base, "README.md"), "# test\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "init"]);
+  runGit(base, ["branch", "-M", "main"]);
+
+  runGit(base, ["checkout", "-b", "milestone/M001"]);
+  writeFileSync(join(base, "m001.txt"), "in-progress stranded work\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M001 in progress"]);
+  runGit(base, ["checkout", "main"]);
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Active milestone", status: "active" });
+  closeDatabase();
+
+  return base;
+}
+
 function makeCtx(notifications: Array<{ message: string; level?: string }>) {
   const model = { provider: "claude-code", id: "claude-sonnet-4-6", contextWindow: 128000 };
   return {
@@ -150,6 +178,95 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
     assert.match(
       notifications.map((entry) => entry.message).join("\n"),
       /Could not merge orphan milestone M002: synthetic merge failure/,
+    );
+  } finally {
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap adopts stranded active branch even when isolation is none", async () => {
+  const base = makeRepoWithStrandedActiveMilestone();
+  const previousCwd = process.cwd();
+  const s = new AutoSession();
+  const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];
+  const enterCalls: string[] = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: (milestoneId: string) => {
+            enterCalls.push(milestoneId);
+            return { ok: true, mode: "none", path: base };
+          },
+          adoptStrandedMilestone: (
+            milestoneId: string,
+            sessionBase: string,
+            _ctx: unknown,
+            opts: { mode: "worktree" | "branch" },
+          ) => {
+            adoptCalls.push({ milestoneId, mode: opts.mode });
+            s.basePath = sessionBase;
+            s.originalBasePath = sessionBase;
+            s.strandedRecoveryIsolationMode = opts.mode;
+            return { ok: true, mode: opts.mode, path: sessionBase };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    assert.equal(ready, true);
+    assert.deepEqual(adoptCalls, [{ milestoneId: "M001", mode: "branch" }]);
+    assert.deepEqual(enterCalls, []);
+    assert.equal(s.currentMilestoneId, "M001");
+    assert.equal(s.strandedRecoveryIsolationMode, "branch");
+    assert.match(
+      notifications.map((entry) => entry.message).join("\n"),
+      /Recovering stranded work for M001/,
     );
   } finally {
     try {

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -52,12 +52,14 @@ function makeRepoWithUnmergedCompletedMilestone(): string {
   return base;
 }
 
-function makeRepoWithStrandedActiveMilestone(): string {
+function makeRepoWithStrandedActiveMilestone(options: { deepPlanning?: boolean } = {}): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-stranded-bootstrap-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
   writeFileSync(
     join(base, ".gsd", "PREFERENCES.md"),
-    "---\ngit:\n  isolation: \"none\"\n---\n",
+    options.deepPlanning
+      ? "---\nplanning_depth: deep\ngit:\n  isolation: \"none\"\n---\n"
+      : "---\ngit:\n  isolation: \"none\"\n---\n",
   );
   runGit(base, ["init"]);
   runGit(base, ["config", "user.email", "test@test.com"]);
@@ -75,6 +77,37 @@ function makeRepoWithStrandedActiveMilestone(): string {
 
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Active milestone", status: "active" });
+  closeDatabase();
+
+  return base;
+}
+
+function makeRepoWithRecoveredCleanupAndStrandedMismatch(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-headless-stranded-bootstrap-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M002"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: \"none\"\n---\n",
+  );
+  runGit(base, ["init"]);
+  runGit(base, ["config", "user.email", "test@test.com"]);
+  runGit(base, ["config", "user.name", "Test"]);
+  writeFileSync(join(base, "README.md"), "# test\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "init"]);
+  runGit(base, ["branch", "-M", "main"]);
+
+  runGit(base, ["branch", "milestone/M001"]);
+  runGit(base, ["checkout", "-b", "milestone/M002"]);
+  writeFileSync(join(base, "m002.txt"), "in-progress stranded work\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M002 in progress"]);
+  runGit(base, ["checkout", "main"]);
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Completed milestone", status: "complete" });
+  insertMilestone({ id: "M002", title: "Stranded milestone", status: "active" });
   closeDatabase();
 
   return base;
@@ -188,8 +221,186 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
   }
 });
 
+test("headless bootstrap checks stranded work before recovered-complete shortcut", async () => {
+  const base = makeRepoWithRecoveredCleanupAndStrandedMismatch();
+  const previousCwd = process.cwd();
+  const previousHeadless = process.env.GSD_HEADLESS;
+  const previousParallelWorker = process.env.GSD_PARALLEL_WORKER;
+  const previousMilestoneLock = process.env.GSD_MILESTONE_LOCK;
+  const s = new AutoSession();
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    process.env.GSD_HEADLESS = "1";
+    process.env.GSD_PARALLEL_WORKER = "1";
+    process.env.GSD_MILESTONE_LOCK = "M001";
+
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: () => ({ ok: true, mode: "none", path: base }),
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    const messages = notifications.map((entry) => entry.message).join("\n");
+    assert.equal(ready, false);
+    assert.match(messages, /Stranded work for M002 blocks auto-mode/);
+    assert.doesNotMatch(messages, /all milestones complete/);
+  } finally {
+    if (previousHeadless === undefined) {
+      delete process.env.GSD_HEADLESS;
+    } else {
+      process.env.GSD_HEADLESS = previousHeadless;
+    }
+    if (previousParallelWorker === undefined) {
+      delete process.env.GSD_PARALLEL_WORKER;
+    } else {
+      process.env.GSD_PARALLEL_WORKER = previousParallelWorker;
+    }
+    if (previousMilestoneLock === undefined) {
+      delete process.env.GSD_MILESTONE_LOCK;
+    } else {
+      process.env.GSD_MILESTONE_LOCK = previousMilestoneLock;
+    }
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("bootstrap adopts stranded active branch even when isolation is none", async () => {
   const base = makeRepoWithStrandedActiveMilestone();
+  const previousCwd = process.cwd();
+  const s = new AutoSession();
+  const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];
+  const enterCalls: string[] = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: (milestoneId: string) => {
+            enterCalls.push(milestoneId);
+            return { ok: true, mode: "none", path: base };
+          },
+          adoptStrandedMilestone: (
+            milestoneId: string,
+            sessionBase: string,
+            _ctx: unknown,
+            opts: { mode: "worktree" | "branch" },
+          ) => {
+            adoptCalls.push({ milestoneId, mode: opts.mode });
+            s.basePath = sessionBase;
+            s.originalBasePath = sessionBase;
+            s.strandedRecoveryIsolationMode = opts.mode;
+            return { ok: true, mode: opts.mode, path: sessionBase };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    assert.equal(ready, true);
+    assert.deepEqual(adoptCalls, [{ milestoneId: "M001", mode: "branch" }]);
+    assert.deepEqual(enterCalls, []);
+    assert.equal(s.currentMilestoneId, "M001");
+    assert.equal(s.strandedRecoveryIsolationMode, "branch");
+    assert.match(
+      notifications.map((entry) => entry.message).join("\n"),
+      /Recovering stranded work for M001/,
+    );
+  } finally {
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap adopts stranded active branch before deep project setup", async () => {
+  const base = makeRepoWithStrandedActiveMilestone({ deepPlanning: true });
   const previousCwd = process.cwd();
   const s = new AutoSession();
   const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -48,20 +48,27 @@ describe("auditOrphanedMilestoneBranches", () => {
     const result = auditOrphanedMilestoneBranches(dir, "worktree");
     assert.deepStrictEqual(result.recovered, []);
     assert.deepStrictEqual(result.warnings, []);
+    assert.deepStrictEqual(result.actions, []);
+    assert.equal(result.blockingStrandedWork, null);
   });
 
-  test("skips in none isolation mode", () => {
-    // Create a milestone branch that would otherwise be detected
+  test("runs in none isolation mode and cleans safe completed residue", () => {
     run("git branch milestone/M001", dir);
     insertMilestone({ id: "M001", title: "Test", status: "complete" });
 
     const result = auditOrphanedMilestoneBranches(dir, "none");
-    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(
+      result.recovered.some((r) => r.includes("Deleted merged branch milestone/M001")),
+      `should clean merged completed residue even in none mode; got: ${JSON.stringify(result.recovered)}`,
+    );
     assert.deepStrictEqual(result.warnings, []);
+    assert.ok(
+      result.actions.some((action) => action.kind === "complete-merged-branch"),
+      "should record structured cleanup action",
+    );
 
-    // Branch should still exist
     const branches = run("git branch --list milestone/M001", dir);
-    assert.ok(branches.includes("milestone/M001"), "branch should be preserved in none mode");
+    assert.equal(branches, "", "safe completed branch should be cleaned in none mode");
   });
 
   test("deletes merged branch for completed milestone", () => {
@@ -149,9 +156,12 @@ describe("auditOrphanedMilestoneBranches", () => {
     // Must surface a warning so the user knows the worktree holds uncollapsed work
     assert.ok(result.warnings.length > 0, "should warn about in-progress orphan");
     assert.ok(
-      result.warnings.some(w => w.includes("milestone/M001") && w.includes("in-progress")),
-      `warning should mention milestone/M001 and in-progress state; got: ${JSON.stringify(result.warnings)}`,
+      result.warnings.some(w => w.includes("Stranded work") && w.includes("milestone/M001") && w.includes("in-progress")),
+      `warning should mention stranded milestone/M001 and in-progress state; got: ${JSON.stringify(result.warnings)}`,
     );
+    assert.equal(result.blockingStrandedWork?.milestoneId, "M001");
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "branch");
+    assert.equal(result.blockingStrandedWork?.commitsAhead, 1);
 
     // Branch must still exist
     const branches = run("git branch --list milestone/M001", dir);
@@ -184,6 +194,53 @@ describe("auditOrphanedMilestoneBranches", () => {
       result.warnings.some(w => w.includes(".gsd/worktrees/M001") || w.includes("worktree")),
       `warning should reference the worktree location; got: ${JSON.stringify(result.warnings)}`,
     );
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "worktree");
+  });
+
+  test("detects dirty in-progress worktree even when branch has no commits ahead", () => {
+    run("git branch milestone/M001", dir);
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, ".git"), `gitdir: ${join(dir, ".git", "worktrees", "M001")}\n`);
+    writeFileSync(join(wtDir, "dirty.txt"), "uncommitted work\n");
+
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree", {
+      hasChanges: (basePath) => basePath === wtDir,
+    });
+
+    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(
+      result.warnings.some((w) => w.includes("uncommitted changes")),
+      `dirty worktree should be treated as stranded work; got: ${JSON.stringify(result.warnings)}`,
+    );
+    assert.equal(result.blockingStrandedWork?.milestoneId, "M001");
+    assert.equal(result.blockingStrandedWork?.dirtyWorktree, true);
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "worktree");
+  });
+
+  test("detects dirty in-progress worktree even when milestone branch is absent", () => {
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, ".git"), `gitdir: ${join(dir, ".git", "worktrees", "M001")}\n`);
+    writeFileSync(join(wtDir, "dirty.txt"), "branchless work\n");
+
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const result = auditOrphanedMilestoneBranches(dir, "none", {
+      hasChanges: (basePath) => basePath === wtDir,
+    });
+
+    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(
+      result.warnings.some((w) => w.includes("Stranded work") && w.includes("M001")),
+      `branchless dirty worktree should block; got: ${JSON.stringify(result.warnings)}`,
+    );
+    assert.equal(result.blockingStrandedWork?.branch, undefined);
+    assert.equal(result.blockingStrandedWork?.dirtyWorktree, true);
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "worktree");
   });
 
   test("cleans up orphaned worktree directory for merged milestone", () => {
@@ -359,7 +416,7 @@ describe("auditOrphanedMilestoneBranches", () => {
     assert.ok(existsSync(wtDir), "active milestone worktree dir must be preserved");
   });
 
-  test("#5879 — skips branch-less orphan in 'none' isolation mode", () => {
+  test("#5879 — cleans branch-less complete orphan in 'none' isolation mode", () => {
     insertMilestone({ id: "M001", title: "Test", status: "complete" });
 
     const wtDir = join(dir, ".gsd", "worktrees", "M001");
@@ -368,7 +425,10 @@ describe("auditOrphanedMilestoneBranches", () => {
 
     const result = auditOrphanedMilestoneBranches(dir, "none");
 
-    assert.deepStrictEqual(result.recovered, []);
-    assert.ok(existsSync(wtDir), "'none' mode must not touch worktree dirs");
+    assert.ok(
+      result.recovered.some((r) => r.includes("M001") && r.includes("branch already deleted")),
+      `none mode should still clean safe completed residue; got: ${JSON.stringify(result.recovered)}`,
+    );
+    assert.ok(!existsSync(wtDir), "completed orphan worktree dir should be cleaned in none mode");
   });
 });

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -15,6 +15,13 @@ function readGsdFile(relativePath: string): string {
   return readFileSync(resolve(gsdDir, relativePath), "utf-8");
 }
 
+function firstIndexOfAny(source: string, needles: string[]): number {
+  const indexes = needles
+    .map((needle) => source.indexOf(needle))
+    .filter((index) => index > -1);
+  return indexes.length > 0 ? Math.min(...indexes) : -1;
+}
+
 test("command entrypoints use startAutoDetached instead of awaiting startAuto (#3733)", () => {
   const autoHandlerSrc = readGsdFile("commands/handlers/auto.ts");
   const workflowHandlerSrc = readGsdFile("commands/handlers/workflow.ts");
@@ -145,7 +152,11 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
   const resumeEnterMilestoneIdx = resumeBody.indexOf("buildLifecycle().enterMilestone");
   const dbOpenIdx = bootstrapBody.indexOf("await openProjectDbIfPresent(base);");
   const bootstrapRegisterIdx = bootstrapBody.indexOf("registerAutoWorkerForSession(base);");
-  const enterMilestoneIdx = bootstrapBody.indexOf("buildLifecycle().enterMilestone");
+  const enterMilestoneIdx = firstIndexOfAny(bootstrapBody, [
+    "buildLifecycle().enterMilestone",
+    "lifecycle.enterMilestone",
+    "lifecycle.adoptStrandedMilestone",
+  ]);
 
   assert.ok(startAutoIdx > -1, "startAuto should exist");
   assert.ok(preBootstrapRegisterIdx > -1, "startAuto should register worker before bootstrap");
@@ -158,7 +169,7 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
   assert.ok(bootstrapIdx > -1, "bootstrapAutoSession should exist");
   assert.ok(dbOpenIdx > -1, "bootstrap should open the project DB");
   assert.ok(bootstrapRegisterIdx > -1, "bootstrap should register worker after DB open");
-  assert.ok(enterMilestoneIdx > -1, "bootstrap should enter milestones through lifecycle");
+  assert.ok(enterMilestoneIdx > -1, "bootstrap should enter or adopt milestones through lifecycle");
   assert.ok(
     preBootstrapRegisterIdx < bootstrapCallIdx,
     "worker registration must happen before bootstrap so enterMilestone can claim milestone leases on first entry",

--- a/src/resources/extensions/gsd/tests/tool-param-optionality.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-param-optionality.test.ts
@@ -235,11 +235,15 @@ test("gsd_task_complete — enrichment arrays are optional", () => {
     "milestoneId",
     "oneLiner",
     "narrative",
-    "verification",
   ];
   for (const field of coreRequired) {
     assert.ok(required.has(field), `core field "${field}" must be required`);
   }
+
+  assert.ok(
+    !required.has("verification"),
+    "verification must be optional at the schema layer so step-mode can recover when verificationEvidence is present",
+  );
 
   // Enrichment fields must be optional
   const enrichmentFields = [
@@ -270,6 +274,25 @@ test("gsd_task_complete — validates with only core params", () => {
 
   const errors = validateSchema(tool, minimalParams);
   assert.strictEqual(errors.length, 0, `Minimal params should validate but got errors: ${errors.join(", ")}`);
+});
+
+test("gsd_task_complete — accepts evidence-only verification at schema layer", () => {
+  const tool = getTool("gsd_task_complete");
+  assert.ok(tool, "gsd_task_complete must be registered");
+
+  const params = {
+    taskId: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    oneLiner: "Implemented the feature",
+    narrative: "Created the module and wired it up.",
+    verificationEvidence: [
+      { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+    ],
+  };
+
+  const errors = validateSchema(tool, params);
+  assert.strictEqual(errors.length, 0, `Evidence-only params should validate but got errors: ${errors.join(", ")}`);
 });
 
 // ─── gsd_complete_milestone: enrichment arrays must be optional ──────────────

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -148,6 +148,60 @@ test("executeTaskComplete coerces string verificationEvidence entries", async ()
   }
 });
 
+test("executeTaskComplete derives missing verification from evidence", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    const planDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "S01-PLAN.md"), "# S01\n\n- [ ] **T01: Demo** `est:5m`\n");
+
+    const result = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work",
+      verificationEvidence: [
+        { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+      ],
+    }, base));
+
+    assert.equal(result.details.operation, "complete_task");
+    const db = _getAdapter();
+    assert.ok(db, "DB should be open");
+    const row = db!.prepare(
+      "SELECT verification_result FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?",
+    ).get("M001", "S01", "T01") as Record<string, unknown> | undefined;
+
+    assert.match(String(row?.verification_result), /Verification evidence recorded/);
+    assert.match(String(row?.verification_result), /`npm test` exited 0 \(pass\)/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeTaskComplete returns a tool error when verification cannot be derived", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    const result = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work",
+    }, base));
+
+    assert.equal(result.isError, true);
+    assert.match(String(result.content[0]?.text), /verification is required/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeSliceComplete preserves omitted optional requirement arrays", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -212,6 +212,34 @@ test("enterMilestone returns ok:true mode:none when isolation disabled", () => {
   assert.equal(s.basePath, "/project");
 });
 
+test("adoptStrandedMilestone forces branch recovery even when normal preferences differ", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "worktree" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+
+  const s = makeSession({ basePath: base, originalBasePath: base });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.adoptStrandedMilestone("M001", base, ctx, {
+    mode: "branch",
+  });
+
+  assert.equal(result.ok, true, `expected ok:true, got: ${JSON.stringify(result)}`);
+  if (result.ok) {
+    assert.equal(result.mode, "branch");
+    assert.equal(result.path, base);
+  }
+  assert.equal(s.basePath, base);
+  assert.equal(s.strandedRecoveryIsolationMode, "branch");
+  const currentBranch = execFileSync("git", ["branch", "--show-current"], {
+    cwd: base,
+    encoding: "utf-8",
+  }).trim();
+  assert.equal(currentBranch, "milestone/M001");
+});
+
 test("enterMilestone returns ok:false reason:isolation-degraded when session degraded", () => {
   const s = makeSession({ isolationDegraded: true });
   const deps = makeDeps({ getIsolationMode: () => "branch" });

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -173,6 +173,15 @@ export async function handleCompleteTask(
   if (!params.milestoneId || typeof params.milestoneId !== "string" || params.milestoneId.trim() === "") {
     return { error: "milestoneId is required and must be a non-empty string" };
   }
+  if (!params.oneLiner || typeof params.oneLiner !== "string" || params.oneLiner.trim() === "") {
+    return { error: "oneLiner is required and must be a non-empty string" };
+  }
+  if (!params.narrative || typeof params.narrative !== "string" || params.narrative.trim() === "") {
+    return { error: "narrative is required and must be a non-empty string" };
+  }
+  if (!params.verification || typeof params.verification !== "string" || params.verification.trim() === "") {
+    return { error: "verification is required and must be a non-empty string" };
+  }
 
   const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, params.milestoneId);
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -306,13 +306,47 @@ export interface TaskCompleteParams {
   milestoneId: string;
   oneLiner: string;
   narrative: string;
-  verification: string;
+  verification?: string;
   deviations?: string;
   knownIssues?: string;
   keyFiles?: string[];
   keyDecisions?: string[];
   blockerDiscovered?: boolean;
   verificationEvidence?: VerificationEvidenceInput[];
+}
+
+type NormalizedVerificationEvidence = {
+  command: string;
+  exitCode: number;
+  verdict: string;
+  durationMs: number;
+};
+
+function normalizeVerificationEvidence(
+  evidence: VerificationEvidenceInput[] | undefined,
+): NormalizedVerificationEvidence[] {
+  return (evidence ?? []).map((entry) =>
+    typeof entry === "string"
+      ? { command: entry, exitCode: -1, verdict: "unknown (coerced from string)", durationMs: 0 }
+      : entry,
+  );
+}
+
+function deriveVerificationSummary(
+  evidence: NormalizedVerificationEvidence[],
+): string | null {
+  if (evidence.length === 0) return null;
+
+  const rendered = evidence.slice(0, 3).map((entry) => {
+    const command = entry.command.trim() || "(unspecified command)";
+    const verdict = entry.verdict.trim() || "recorded";
+    return `\`${command}\` exited ${entry.exitCode} (${verdict})`;
+  });
+  const suffix = evidence.length > rendered.length
+    ? `; ${evidence.length - rendered.length} more check(s) recorded`
+    : "";
+
+  return `Verification evidence recorded: ${rendered.join("; ")}${suffix}.`;
 }
 
 export type CompleteMilestoneExecutorParams = Partial<CompleteMilestoneParams> & Record<string, unknown>;
@@ -350,9 +384,27 @@ export async function executeTaskComplete(
   }
   try {
     const coerced = { ...params };
-    coerced.verificationEvidence = (params.verificationEvidence ?? []).map((v) =>
-      typeof v === "string" ? { command: v, exitCode: -1, verdict: "unknown (coerced from string)", durationMs: 0 } : v,
-    );
+    const verificationEvidence = normalizeVerificationEvidence(params.verificationEvidence);
+    coerced.verificationEvidence = verificationEvidence;
+
+    const verification = typeof params.verification === "string" ? params.verification.trim() : "";
+    if (verification.length === 0) {
+      const derived = deriveVerificationSummary(verificationEvidence);
+      if (derived) {
+        coerced.verification = derived;
+      } else if (params.blockerDiscovered === true) {
+        coerced.verification = "Not run: blocker discovered before verification.";
+      } else {
+        return {
+          content: [{
+            type: "text",
+            text: "Error completing task: verification is required unless verificationEvidence is provided or blockerDiscovered is true.",
+          }],
+          details: { operation: "complete_task", error: "verification_required" },
+          isError: true,
+        };
+      }
+    }
 
     const result = await handleCompleteTask(coerced as any, basePath);
     if ("error" in result) {

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -216,6 +216,10 @@ export type EnterResult =
       cause?: unknown;
     };
 
+export interface StrandedMilestoneAdoptionOptions {
+  mode: "worktree" | "branch";
+}
+
 export type ExitResult =
   | { ok: true; merged: boolean; codeFilesChanged: boolean }
   | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
@@ -237,6 +241,8 @@ export interface MergeContext {
    */
   worktreeBasePath: string;
   milestoneId: string;
+  /** Temporary override used while recovering stranded work. */
+  isolationModeOverride?: "worktree" | "branch" | "none";
   /**
    * When true, `mergeMilestoneStandalone` returns `{ merged: false,
    * mode: "skipped" }` immediately (mirrors the single-loop guard). Default
@@ -533,6 +539,7 @@ export function _enterMilestoneCore(
   deps: WorktreeLifecycleDeps,
   milestoneId: string,
   ctx: NotifyCtx,
+  opts: { modeOverride?: "worktree" | "branch" } = {},
 ): EnterResult {
   if (!isValidMilestoneId(milestoneId)) {
     debugLog("WorktreeLifecycle", {
@@ -653,7 +660,7 @@ export function _enterMilestoneCore(
   // Handles the case where originalBasePath is falsy and basePath is itself
   // a worktree path — prevents double-nested worktree paths (#3729).
   const basePath = resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
-  const mode = getIsolationMode(basePath);
+  const mode = opts.modeOverride ?? getIsolationMode(basePath);
 
   if (s.isolationDegraded) {
     if (mode === "worktree") {
@@ -1298,7 +1305,9 @@ export function mergeMilestoneStandalone(
     };
   }
 
-  const mode = getIsolationMode(originalBasePath || worktreeBasePath);
+  const mode =
+    mctx.isolationModeOverride ??
+    getIsolationMode(originalBasePath || worktreeBasePath);
   debugLog("WorktreeLifecycle", {
     action: "mergeAndExit",
     milestoneId,
@@ -1637,6 +1646,7 @@ export class WorktreeLifecycle {
         originalBasePath: this.s.originalBasePath,
         worktreeBasePath: this.s.basePath,
         milestoneId,
+        isolationModeOverride: this.s.strandedRecoveryIsolationMode ?? undefined,
         isolationDegraded: this.s.isolationDegraded,
         notify: ctx.notify,
       });
@@ -1740,6 +1750,7 @@ export class WorktreeLifecycle {
       // Rebuild GitService after merge (branch HEAD changed)
       rebuildGitService(this.s, this.deps);
     }
+    this.s.strandedRecoveryIsolationMode = null;
     return result;
   }
 
@@ -1874,6 +1885,30 @@ export class WorktreeLifecycle {
     persistedWorktreePath: string | null,
   ): void {
     this.s.basePath = resolvePausedResumeBasePath(base, persistedWorktreePath);
+  }
+
+  /**
+   * Adopt in-progress stranded work during bootstrap.
+   *
+   * Unlike completed-orphan recovery, this does not merge, delete, or commit.
+   * It only moves the live session onto the branch/worktree proven by the
+   * audit evidence, while preserving that mode for the eventual merge.
+   */
+  adoptStrandedMilestone(
+    milestoneId: string,
+    base: string,
+    ctx: NotifyCtx,
+    opts: StrandedMilestoneAdoptionOptions,
+  ): EnterResult {
+    this.adoptSessionRoot(base);
+    this.s.strandedRecoveryIsolationMode = opts.mode;
+    const result = _enterMilestoneCore(this.s, this.deps, milestoneId, ctx, {
+      modeOverride: opts.mode,
+    });
+    if (!result.ok) {
+      this.s.strandedRecoveryIsolationMode = null;
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Rename the orphaned in-progress path into structured stranded-work detection.
- Run stranded-work detection on every `/gsd auto`, including `isolation: none`.
- Treat branch commits ahead of main and dirty milestone worktrees as live in-progress work.
- Add a bootstrap recovery gate that adopts the evidence-backed branch or worktree before dispatching new units.
- Preserve the temporary recovery isolation mode through lifecycle merge so recovered branch-mode work does not get skipped by normal preferences.

## Why

Interrupted auto sessions could leave active milestone work on `milestone/*` branches or `.gsd/worktrees/*`. The old audit surfaced some of this as an orphan warning, skipped entirely in `isolation: none`, and did not give bootstrap a structured recovery path.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts`
- `pnpm run test:compile`
- `pnpm run typecheck:extensions`

Note: this fresh worktree needed `pnpm install --frozen-lockfile --ignore-scripts`, `pnpm run build:pi`, `pnpm run build:rpc-client`, and `pnpm run build:mcp-server` so generated workspace package dist/types were present for local verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782744821&installation_id=134682257&pr_number=272&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F272&signature=801e164389becc56b969b9bd0966326ca77d4d2d303615679b21c746646e0254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto bootstrap, git orphan audit, and lifecycle merge/isolation paths where incorrect detection could block auto or mishandle live work; mitigated by data-preserving warnings, explicit blocking, and broad tests.
> 
> **Overview**
> This PR adds **structured stranded-work recovery** for `/gsd auto` and relaxes **task completion verification** for step-style callers.
> 
> **Stranded work:** The orphan milestone audit now returns structured `actions` (including `blockingStrandedWork`) instead of only loose warnings. In-progress milestones are flagged when there are commits ahead of `main` and/or a **dirty milestone worktree**, including under `isolation: none` and when the branch is missing. Bootstrap **blocks or adopts** that work via `adoptStrandedMilestone`, sets `strandedRecoveryIsolationMode` on the session, and uses it through merge so recovered branch-mode work is not skipped by normal preferences. Multiple stranded milestones can block auto until the user resolves them.
> 
> **Task complete:** `verification` is optional on `gsd_task_complete` (MCP, DB tools, executors). When omitted, the executor **derives** a summary from `verificationEvidence` (or a blocker path); schemas and tests lock this in.
> 
> Completed-milestone cleanup (merged branches/worktrees) still runs, with clearer messaging for stranded vs cleanup cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0848b5cd397c06532468daaa09253c42573bb3f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->