### PR TITLE
[codex] add claude code subscription guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Simplified Chinese translation: [`zh-CN/`](./zh-CN/).
 | [Cloud MCP Gateway](./user-docs/cloud-mcp-gateway.md) | Run a gateway, pair a local runtime, and connect remote MCP clients |
 | [Configuration](./user-docs/configuration.md) | Preferences, model selection, git settings, and token profiles |
 | [Provider Setup](./user-docs/providers.md) | Step-by-step setup for OpenRouter, Ollama, LM Studio, vLLM, and all supported providers |
+| [Claude Code Subscription Setup](./user-docs/claude-code-subscription.md) | Install Claude Code, sign in with `/login`, and use a Claude subscription with GSD |
 | [Custom Models](./user-docs/custom-models.md) | Advanced model configuration — models.json schema, compat flags, overrides |
 | [Token Optimization](./user-docs/token-optimization.md) | Token profiles, context compression, complexity routing, and adaptive learning (v2.17) |
 | [Dynamic Model Routing](./user-docs/dynamic-model-routing.md) | Complexity-based model selection, cost tables, escalation, and budget pressure (v2.19) |

--- a/docs/user-docs/claude-code-subscription.md
+++ b/docs/user-docs/claude-code-subscription.md
@@ -1,0 +1,292 @@
+# Use Claude Code With a Claude Subscription
+
+Last verified: 2026-05-30
+
+This guide is for users who have a Claude Pro, Max, Team, or Enterprise subscription and want to use that subscription with Claude Code and GSD.
+
+The short version:
+
+1. Install Anthropic's official Claude Code CLI.
+2. Run `claude`.
+3. Inside Claude Code, run `/login` and sign in with the Claude account that owns the subscription.
+4. Start GSD and choose the Claude Code CLI provider, or let GSD auto-detect the authenticated local CLI.
+
+GSD does not ask for, store, or replay Claude subscription OAuth credentials. Subscription login happens inside Anthropic's own `claude` CLI.
+
+## Prerequisites
+
+- A Claude subscription: Pro, Max, Team, or Enterprise.
+- A terminal or command prompt.
+- A project directory you want Claude Code or GSD to work in.
+- For the npm install path only: Node.js 18 or later.
+
+If you are using a work account, complete your organization's SSO or invitation flow first.
+
+## Step 1: Install Claude Code CLI
+
+Use one of the official install methods below.
+
+### macOS, Linux, or WSL
+
+Recommended native installer:
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Homebrew:
+
+```bash
+brew install --cask claude-code
+```
+
+npm:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Do not run the npm install with `sudo`. If npm reports permission errors, use the native installer or fix your npm global prefix instead of installing as root.
+
+### Windows PowerShell
+
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
+
+### Windows CMD
+
+```cmd
+curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+Git for Windows is recommended on native Windows so Claude Code can use a Bash-compatible shell. Without it, Claude Code falls back to PowerShell for shell commands.
+
+## Step 2: Verify the CLI
+
+Restart your terminal if the install changed your `PATH`, then run:
+
+```bash
+claude --version
+```
+
+On macOS, Linux, or WSL, you can also check where the binary is coming from:
+
+```bash
+command -v claude
+```
+
+On Windows:
+
+```powershell
+where.exe claude
+```
+
+If `claude` is not found, restart the terminal first. If it still fails, reinstall with the native installer for your platform.
+
+## Step 3: Log In With Your Subscription
+
+Start Claude Code:
+
+```bash
+claude
+```
+
+If this is your first run, Claude Code prompts you to authenticate in the browser. Sign in with the same Claude account that has your subscription.
+
+If you are already inside Claude Code, or need to switch accounts, type this at the start of a Claude Code message:
+
+```text
+/login
+```
+
+Follow the browser flow and approve the login. Team and Enterprise users may also see an SSO prompt.
+
+After login, Claude Code stores credentials locally so you do not need to log in every session.
+
+## Step 4: Confirm the Right Auth Method
+
+Inside Claude Code, run:
+
+```text
+/status
+```
+
+Use this to confirm the active account, model, version, and authentication state.
+
+If you expected subscription auth but Claude Code appears to be using another account or API billing instead, check whether an environment variable is overriding your `/login` credentials:
+
+```bash
+env | grep ANTHROPIC
+```
+
+For a clean interactive `/login` session, unset credential variables before starting Claude Code:
+
+```bash
+unset ANTHROPIC_API_KEY
+unset ANTHROPIC_AUTH_TOKEN
+unset CLAUDE_CODE_OAUTH_TOKEN
+claude
+```
+
+If those variables come back in new terminals, remove them from `~/.zshrc`, `~/.bashrc`, `~/.profile`, or your Windows PowerShell profile.
+
+## Step 5: Use Claude Code in a Project
+
+Open a project directory and start Claude Code there:
+
+```bash
+cd /path/to/your/project
+claude
+```
+
+Good first prompts:
+
+```text
+what does this project do?
+explain the folder structure
+where is the main entry point?
+find the tests for the CLI
+```
+
+Useful Claude Code commands:
+
+| Command | Use |
+| --- | --- |
+| `/help` | Show available commands. |
+| `/status` | Check account, model, version, and connectivity. |
+| `/login` | Log in, re-authenticate, or switch accounts. |
+| `/init` | Create a starter `CLAUDE.md` for project instructions. |
+| `/memory` | View and edit loaded memory files. |
+| `/permissions` | Review or change tool approval rules. |
+| `/resume` | Continue a previous conversation. |
+
+Before asking Claude Code to make changes, run:
+
+```bash
+git status --short
+```
+
+This makes it easier to tell which changes were already present and which changes Claude Code made during the session.
+
+## Step 6: Use Your Subscription Through GSD
+
+There are two supported ways to pair a Claude subscription with GSD.
+
+### Option A: Run GSD With the Local Claude Code Provider
+
+Install and log in to Claude Code first:
+
+```bash
+claude
+```
+
+Inside Claude Code:
+
+```text
+/login
+```
+
+Then start GSD:
+
+```bash
+gsd
+```
+
+During setup, choose the Claude Code CLI provider if prompted. If you already skipped setup, run `/login` inside GSD and choose Claude Code CLI.
+
+When this provider is active, GSD routes through the user's authenticated local Claude Code runtime. GSD does not perform Claude subscription OAuth itself.
+
+### Option B: Use GSD Tools From Inside Claude Code
+
+If you prefer to stay in Claude Code and call GSD's workflow tools from there, configure the GSD MCP server.
+
+Automatic setup:
+
+1. Start GSD once with the Claude Code provider selected.
+2. GSD writes or updates the project `.mcp.json`.
+3. Restart Claude Code in that project.
+4. In Claude Code, run `/mcp` to confirm the server is loaded.
+
+Manual setup from inside GSD:
+
+```text
+/gsd mcp init
+```
+
+Then restart Claude Code and ask it to use the GSD workflow tools for planning, milestones, auto-mode sessions, or project status.
+
+## Working Safely
+
+- Keep subscription login inside Claude Code. Do not paste Claude subscription tokens into GSD, shell profiles, scripts, or CI.
+- Use Claude Console API keys only when you want direct API-billed Anthropic access.
+- Review file edits before committing.
+- Let Claude Code run tests, but inspect failures yourself before accepting a fix.
+- Use `/permissions` if you want tighter approval prompts before edits or shell commands.
+- Use small, specific tasks when starting out. Example: "Add a failing test for X, then implement the smallest fix."
+
+## Troubleshooting
+
+### `claude: command not found`
+
+Restart the terminal, then run `claude --version` again. If it still fails, reinstall with the native installer or check that your package manager's global binary directory is on `PATH`.
+
+### npm permission errors
+
+Do not use `sudo npm install -g @anthropic-ai/claude-code`. Use the native installer, Homebrew, or fix your npm global prefix.
+
+### Browser login does not complete
+
+This can happen in WSL, SSH sessions, containers, and remote machines. Copy the login URL into a local browser if prompted, then paste the returned code back into the terminal.
+
+If pasting into the interactive prompt does not work, use:
+
+```bash
+claude auth login
+```
+
+### Wrong account or wrong billing method
+
+Inside Claude Code, run:
+
+```text
+/login
+/status
+```
+
+If Claude Code still uses the wrong credentials, unset `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_OAUTH_TOKEN`, then remove those exports from your shell profile.
+
+### Subscription is active but login is rejected
+
+Check the subscription on `claude.ai/settings`, confirm you are signing into the same account, and retry `/login`. For Team or Enterprise accounts, confirm that your organization invite or SSO access is active.
+
+### Upgrade Claude Code
+
+Native installs auto-update in the background.
+
+Homebrew:
+
+```bash
+brew upgrade claude-code
+```
+
+WinGet:
+
+```powershell
+winget upgrade Anthropic.ClaudeCode
+```
+
+npm:
+
+```bash
+npm install -g @anthropic-ai/claude-code@latest
+```
+
+## Official References
+
+- [Claude Code quickstart](https://code.claude.com/docs/en/quickstart)
+- [Claude Code setup](https://code.claude.com/docs/en/setup)
+- [Claude Code authentication](https://code.claude.com/docs/en/authentication)
+- [Claude Code commands](https://code.claude.com/docs/en/commands)
+- [Claude Code permissions](https://code.claude.com/docs/en/permissions)
+- [Claude Code troubleshooting](https://code.claude.com/docs/en/troubleshoot-install)

--- a/docs/user-docs/providers.md
+++ b/docs/user-docs/providers.md
@@ -67,16 +67,18 @@ Or run `gsd config` and paste your key when prompted.
 
 **Option B — Claude Code CLI:**
 
-If you have a Claude Pro or Max subscription, you can authenticate through Anthropic's official Claude Code CLI. Install it, sign in with `claude`, then GSD will detect and route through it automatically:
+If you have a Claude Pro, Max, Team, or Enterprise subscription, you can authenticate through Anthropic's official Claude Code CLI. Install it, sign in with `claude`, then GSD will detect and route through it automatically:
 
 ```bash
-# Install Claude Code CLI (see https://docs.anthropic.com/en/docs/claude-code)
+# Install Claude Code CLI first, then sign in inside Claude Code.
 claude
-# Sign in when prompted, then start GSD
+# Run /login if prompted or if you need to switch accounts, then start GSD.
 gsd
 ```
 
 GSD detects your local Claude Code installation and uses it as the authenticated Anthropic surface. This is the TOS-compliant path for subscription users — GSD never handles your subscription credentials directly.
+
+For the full walkthrough, including install commands, `/login`, verification, and troubleshooting, see [Use Claude Code With a Claude Subscription](./claude-code-subscription.md).
 
 > **Note:** GSD does not support browser-based OAuth sign-in for Anthropic. Use an API key or the Claude Code CLI instead.
 


### PR DESCRIPTION
## Summary

- Add a user guide for installing Claude Code and signing in with a Claude subscription via `/login`.
- Document verification, troubleshooting, upgrade paths, and the safe GSD integration pattern.
- Link the new guide from the docs index and Anthropic provider setup page.

## Validation

- `git diff --check -- docs/README.md docs/user-docs/providers.md docs/user-docs/claude-code-subscription.md`
- Docs-only change; full test suite not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782749601&installation_id=134682257&pr_number=274&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F274&signature=b4662159984773354990aa613071a43a4d0716bef188c1f67e82f706e64f807f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> Adds **`docs/user-docs/claude-code-subscription.md`**, a end-to-end guide for **Pro/Max/Team/Enterprise** users: install Claude Code (native, Homebrew, npm, Windows), verify the CLI, sign in with **`/login`**, confirm auth with **`/status`**, avoid **`ANTHROPIC_*`** env overrides, use GSD via the **local Claude Code provider** or **GSD MCP inside Claude Code**, plus safety notes and troubleshooting.
> 
> The docs index gains a **Claude Code Subscription Setup** row, and **`providers.md` Option B** now mentions Team/Enterprise, explicit **`/login`** steps, and links to the new guide instead of a stale docs URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf105be5ee29ae9cf4768574b5f24048330d8799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->