### PR TITLE
[codex] fix login auth provider routing

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
@@ -59,12 +59,13 @@ export class LoginDialogComponent extends Container implements Focusable {
 		tui: TUI,
 		providerId: string,
 		private onComplete: (success: boolean, message?: string) => void,
+		providerDisplayName?: string,
 	) {
 		super();
 		this.tui = tui;
 
 		const providerInfo = getOAuthProviders().find((p) => p.id === providerId);
-		const providerName = providerInfo?.name || providerId;
+		const providerName = providerDisplayName || providerInfo?.name || providerId;
 
 		// Top border
 		this.addChild(new DynamicBorder());

--- a/packages/gsd-agent-modes/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/oauth-selector.ts
@@ -10,12 +10,17 @@ import { DynamicBorder } from "./dynamic-border.js";
 import { selectorFooter } from "./keybinding-hints.js";
 import { renderCursor } from "./tree-render-utils.js";
 
+export type AuthSelectorProvider = Pick<OAuthProviderInterface, "id" | "name" | "usesCallbackServer"> & {
+	authType?: "oauth" | "api_key" | "external_cli";
+	statusLabel?: string;
+};
+
 /**
  * Component that renders an OAuth provider selector
  */
 export class OAuthSelectorComponent extends Container {
 	private listContainer: Container;
-	private allProviders: OAuthProviderInterface[] = [];
+	private allProviders: AuthSelectorProvider[] = [];
 	private selectedIndex: number = 0;
 	private mode: "login" | "logout";
 	private authStorage: AuthStorage;
@@ -27,6 +32,7 @@ export class OAuthSelectorComponent extends Container {
 		authStorage: AuthStorage,
 		onSelect: (providerId: string) => void,
 		onCancel: () => void,
+		providers?: AuthSelectorProvider[],
 	) {
 		super();
 
@@ -36,7 +42,7 @@ export class OAuthSelectorComponent extends Container {
 		this.onCancelCallback = onCancel;
 
 		// Load all OAuth providers
-		this.loadProviders();
+		this.loadProviders(providers);
 
 		// Add top border
 		this.addChild(new DynamicBorder());
@@ -62,8 +68,8 @@ export class OAuthSelectorComponent extends Container {
 		this.updateList();
 	}
 
-	private loadProviders(): void {
-		this.allProviders = getOAuthProviders();
+	private loadProviders(providers?: AuthSelectorProvider[]): void {
+		this.allProviders = providers ?? getOAuthProviders();
 	}
 
 	private updateList(): void {
@@ -75,10 +81,13 @@ export class OAuthSelectorComponent extends Container {
 
 			const isSelected = i === this.selectedIndex;
 
-			// Check if user is logged in for this provider
 			const credentials = this.authStorage.get(provider.id);
 			const isLoggedIn = credentials?.type === "oauth";
-			const statusIndicator = isLoggedIn ? theme.fg("success", " ✓ logged in") : "";
+			const statusIndicator = provider.statusLabel
+				? theme.fg("success", ` ${provider.statusLabel}`)
+				: isLoggedIn
+					? theme.fg("success", " ✓ logged in")
+					: "";
 
 			let line = "";
 			if (isSelected) {

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts
@@ -5,10 +5,80 @@
 import type { OAuthProviderId } from "@gsd/pi-ai";
 import { getAuthPath } from "@gsd/pi-coding-agent/config.js";
 import { LoginDialogComponent } from "./components/login-dialog.js";
-import { OAuthSelectorComponent } from "./components/oauth-selector.js";
+import { type AuthSelectorProvider, OAuthSelectorComponent } from "./components/oauth-selector.js";
 import type { InteractiveModeDelegateHost } from "./interactive-mode-delegate-host.js";
 
+const BLOCKED_BROWSER_OAUTH_PROVIDERS = new Set(["anthropic"]);
+
+function isBrowserOAuthProviderAllowed(providerId: string): boolean {
+	return !BLOCKED_BROWSER_OAUTH_PROVIDERS.has(providerId);
+}
+
+function uniqueProviders(providers: AuthSelectorProvider[]): AuthSelectorProvider[] {
+	const seen = new Set<string>();
+	const unique: AuthSelectorProvider[] = [];
+	for (const provider of providers) {
+		if (seen.has(provider.id)) continue;
+		seen.add(provider.id);
+		unique.push(provider);
+	}
+	return unique;
+}
+
+function formatAuthStatus(status: { source?: string; label?: string } | undefined): string | undefined {
+	if (!status?.source) return undefined;
+	if (status.source === "stored") return "✓ configured";
+	if (status.source === "environment" && status.label) return `✓ env: ${status.label}`;
+	if (status.source === "runtime" && status.label) return `✓ ${status.label}`;
+	if (status.source === "models_json_command") return "✓ command in models.json";
+	if (status.source === "models_json_key") return "✓ key in models.json";
+	if (status.source === "fallback") return "✓ configured";
+	return undefined;
+}
+
+export function buildLoginProviderOptions(host: InteractiveModeDelegateHost): AuthSelectorProvider[] {
+	const modelRegistry = host.session.modelRegistry;
+	const oauthProviders = modelRegistry.authStorage
+		.getOAuthProviders()
+		.filter((provider) => isBrowserOAuthProviderAllowed(provider.id));
+	const oauthProviderIds = new Set(oauthProviders.map((provider) => provider.id));
+	const modelProviderIds = Array.from(new Set(modelRegistry.getAll().map((model) => model.provider))).sort();
+
+	const externalCliProviders = modelProviderIds
+		.filter((providerId) => modelRegistry.getProviderAuthMode(providerId) === "externalCli")
+		.map((providerId) => ({
+			id: providerId,
+			name: modelRegistry.getProviderDisplayName(providerId),
+			authType: "external_cli" as const,
+			statusLabel: modelRegistry.isProviderRequestReady(providerId) ? "✓ ready" : undefined,
+		}));
+
+	const apiKeyProviders = modelProviderIds
+		.filter((providerId) => modelRegistry.getProviderAuthMode(providerId) === "apiKey")
+		.filter((providerId) => !oauthProviderIds.has(providerId))
+		.map((providerId) => ({
+			id: providerId,
+			name: modelRegistry.getProviderDisplayName(providerId),
+			authType: "api_key" as const,
+			statusLabel: formatAuthStatus(modelRegistry.getProviderAuthStatus(providerId)),
+		}));
+
+	const browserOAuthProviders = oauthProviders.map((provider) => ({
+		...provider,
+		authType: "oauth" as const,
+		statusLabel: formatAuthStatus(modelRegistry.getProviderAuthStatus(provider.id)),
+	}));
+
+	return uniqueProviders([
+		...externalCliProviders,
+		...apiKeyProviders,
+		...browserOAuthProviders,
+	]);
+}
+
 export async function showOAuthSelector(host: InteractiveModeDelegateHost, mode: "login" | "logout"): Promise<void> {
+	const loginProviders = mode === "login" ? buildLoginProviderOptions(host) : undefined;
+
 	if (mode === "logout") {
 		const providers = host.session.modelRegistry.authStorage.list();
 		const loggedInProviders = providers.filter(
@@ -29,7 +99,7 @@ export async function showOAuthSelector(host: InteractiveModeDelegateHost, mode:
 
 				const handleAsync = async () => {
 					if (mode === "login") {
-						await host.showLoginDialog(providerId);
+						await handleLoginProviderSelection(host, providerId);
 					} else {
 						const providerInfo = host.session.modelRegistry.authStorage
 							.getOAuthProviders()
@@ -68,12 +138,101 @@ export async function showOAuthSelector(host: InteractiveModeDelegateHost, mode:
 				done();
 				host.ui.requestRender();
 			},
+			loginProviders,
 		);
 		return { component: selector, focus: selector };
 	});
 }
 
+export async function handleLoginProviderSelection(host: InteractiveModeDelegateHost, providerId: string): Promise<void> {
+	const modelRegistry = host.session.modelRegistry;
+	const authMode = modelRegistry.getProviderAuthMode(providerId);
+
+	if (authMode === "externalCli") {
+		await activateExternalCliProvider(host, providerId);
+		return;
+	}
+
+	const oauthProvider = modelRegistry.authStorage.getOAuthProviders().find((provider) => provider.id === providerId);
+	if (oauthProvider && isBrowserOAuthProviderAllowed(providerId)) {
+		await host.showLoginDialog(providerId);
+		return;
+	}
+
+	await showApiKeyLoginDialog(host, providerId);
+}
+
+async function activateExternalCliProvider(host: InteractiveModeDelegateHost, providerId: string): Promise<void> {
+	const modelRegistry = host.session.modelRegistry;
+	const providerName = modelRegistry.getProviderDisplayName(providerId);
+
+	if (!modelRegistry.isProviderRequestReady(providerId)) {
+		host.showError(`${providerName} is not ready. Run the provider's own login command, then try /login again.`);
+		return;
+	}
+
+	modelRegistry.authStorage.set(providerId, { type: "api_key", key: "cli" });
+	modelRegistry.refresh();
+	await host.updateAvailableProviderCount();
+
+	const targetModel = modelRegistry.getAvailable().find((model) => model.provider === providerId);
+	if (targetModel) {
+		await host.session.setModel(targetModel);
+		host.showStatus(`Using ${providerName}: ${providerId}/${targetModel.id}`);
+	} else {
+		host.showStatus(`${providerName} is ready. Use /model to choose a model.`);
+	}
+}
+
+async function showApiKeyLoginDialog(host: InteractiveModeDelegateHost, providerId: string): Promise<void> {
+	const providerName = host.session.modelRegistry.getProviderDisplayName(providerId);
+	const dialog = new LoginDialogComponent(host.ui, providerId, (_success, _message) => {}, providerName);
+
+	host.editorContainer.clear();
+	host.editorContainer.addChild(dialog);
+	host.ui.setFocus(dialog);
+	host.ui.requestRender();
+
+	const restoreEditor = () => {
+		dialog.dispose();
+		host.editorContainer.clear();
+		host.editorContainer.addChild(host.editor);
+		host.ui.setFocus(host.editor);
+		host.ui.requestRender();
+	};
+
+	try {
+		const apiKey = (await dialog.showPrompt(`Paste your ${providerName} API key:`)).trim();
+		if (!apiKey) {
+			throw new Error("API key is required");
+		}
+
+		host.session.modelRegistry.authStorage.set(providerId, { type: "api_key", key: apiKey });
+		restoreEditor();
+		host.session.modelRegistry.refresh();
+		await host.updateAvailableProviderCount();
+
+		const targetModel = host.session.modelRegistry.getAvailable().find((model) => model.provider === providerId);
+		if (targetModel) {
+			await host.session.setModel(targetModel);
+		}
+
+		host.showStatus(`Saved ${providerName} API key to ${getAuthPath()}`);
+	} catch (error: unknown) {
+		restoreEditor();
+		const errorMsg = error instanceof Error ? error.message : String(error);
+		if (errorMsg !== "Login cancelled" && !errorMsg.includes("Superseded") && !errorMsg.includes("disposed")) {
+			host.showError(`Failed to save ${providerName} API key: ${errorMsg}`);
+		}
+	}
+}
+
 export async function showLoginDialog(host: InteractiveModeDelegateHost, providerId: string): Promise<void> {
+	if (!isBrowserOAuthProviderAllowed(providerId)) {
+		await showApiKeyLoginDialog(host, providerId);
+		return;
+	}
+
 	const providerInfo = host.session.modelRegistry.authStorage.getOAuthProviders().find((p) => p.id === providerId);
 	const providerName = providerInfo?.name || providerId;
 	const usesCallbackServer = providerInfo?.usesCallbackServer ?? false;

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-session.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-session.ts
@@ -24,6 +24,7 @@ import {
   handleModelCommand as handleModelCommandController,
   updateAvailableProviderCount as updateAvailableProviderCountController,
 } from "./controllers/model-controller.js";
+import { handleLoginProviderSelection } from "./interactive-selectors-auth.js";
 import type { InteractiveModeDelegateHost } from "./interactive-mode-delegate-host.js";
 
 export function showUserMessageSelector(host: InteractiveModeDelegateHost): void {
@@ -281,21 +282,8 @@ export function showProviderManager(host: InteractiveModeDelegateHost): void {
 					host.ui.requestRender();
 				},
 				async (provider: string) => {
-					// Enter key → auth setup for selected provider (#3579).
-					// Only OAuth providers support the login dialog flow.
-					// externalCli providers (e.g. claude-code) authenticate through
-					// their own CLI — sending them to the OAuth dialog produces
-					// "Unknown OAuth provider: claude-code" (#4548).
-					const isOAuthProvider = host.session.modelRegistry.authStorage
-						.getOAuthProviders()
-						.some((p) => p.id === provider);
-					if (!isOAuthProvider) {
-						done();
-						host.showStatus(`${provider} uses external CLI auth — use /model to select a model or run the provider's own auth command.`);
-						return;
-					}
 					done();
-					await host.showLoginDialog(provider);
+					await handleLoginProviderSelection(host, provider);
 				},
 			);
 			return { component, focus: component };

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -17,6 +17,7 @@ import type { AuthStorage } from '@gsd/pi-coding-agent'
 import { renderGsdPiLogo, GSD_PI_BRAND, GSD_WEBSITE } from './logo.js'
 import { agentDir } from './app-paths.js'
 import { isClaudeCliReady } from './claude-cli-check.js'
+import { isAntigravityCliReady, isGeminiCliReady } from './resources/extensions/google-cli/readiness.js'
 import {
   markOnboardingComplete,
   markStepCompleted,
@@ -409,8 +410,20 @@ export async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: Au
     )
   }
 
+  if (isGeminiCliReady()) {
+    authOptions.push(
+      { value: 'gemini-cli', label: 'Use Google Gemini CLI', hint: 'uses your existing Gemini CLI session' },
+    )
+  }
+
+  if (isAntigravityCliReady()) {
+    authOptions.push(
+      { value: 'antigravity-cli', label: 'Use Antigravity CLI', hint: 'uses your existing Antigravity session' },
+    )
+  }
+
   authOptions.push(
-    { value: 'browser', label: 'Sign in with your browser', hint: 'GitHub Copilot, ChatGPT, Google, etc.' },
+    { value: 'browser', label: 'Sign in with your browser', hint: 'GitHub Copilot or ChatGPT/Codex' },
     { value: 'api-key', label: 'Paste an API key', hint: 'from your provider dashboard' },
     { value: 'skip', label: 'Skip for now', hint: 'use /login inside GSD later' },
   )
@@ -434,6 +447,22 @@ export async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: Au
     return true
   }
 
+  if (method === 'gemini-cli') {
+    p.log.success('Google Gemini CLI detected — routing through local CLI')
+    p.log.info('Your Gemini CLI session will be used for inference. No API key needed.')
+    authStorage.set('google-gemini-cli', { type: 'api_key', key: 'cli' })
+    persistDefaultProvider('google-gemini-cli')
+    return true
+  }
+
+  if (method === 'antigravity-cli') {
+    p.log.success('Antigravity CLI detected — routing through local CLI')
+    p.log.info('Your Antigravity session will be used for inference. No API key needed.')
+    authStorage.set('google-antigravity', { type: 'api_key', key: 'cli' })
+    persistDefaultProvider('google-antigravity')
+    return true
+  }
+
   // ── Step 2: Which provider? ──────────────────────────────────────────────
   if (method === 'browser') {
     // Anthropic OAuth is removed from browser auth — it violates Anthropic TOS for
@@ -442,12 +471,10 @@ export async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: Au
     const provider = await p.select({
       message: 'Choose provider',
       options: [
-        { value: 'github-copilot', label: 'GitHub Copilot' },
-        { value: 'openai-codex', label: 'ChatGPT Plus/Pro (Codex)' },
-        { value: 'google-gemini-cli', label: 'Google Gemini CLI' },
-        { value: 'google-antigravity', label: 'Antigravity (Gemini 3, Claude, GPT-OSS)' },
-      ],
-    })
+	        { value: 'github-copilot', label: 'GitHub Copilot' },
+	        { value: 'openai-codex', label: 'ChatGPT Plus/Pro (Codex)' },
+	      ],
+	    })
     if (p.isCancel(provider)) return false
     return await runOAuthFlow(p, pc, authStorage, provider as string, oauthMap)
   }

--- a/src/resources/extensions/google-cli/index.ts
+++ b/src/resources/extensions/google-cli/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Google local CLI providers.
+ *
+ * These deliberately use authMode "externalCli": GSD never owns the browser
+ * OAuth flow or cached tokens. Users authenticate with the official CLI, then
+ * /login activates the provider once the local binary is available.
+ */
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import { GOOGLE_ANTIGRAVITY_MODELS, GOOGLE_GEMINI_CLI_MODELS } from "./models.js";
+import { isAntigravityCliReady, isGeminiCliReady } from "./readiness.js";
+import { streamViaGoogleCli } from "./stream-adapter.js";
+
+export default function googleCli(pi: ExtensionAPI) {
+	pi.registerProvider("google-gemini-cli", {
+		name: "Google Gemini CLI",
+		authMode: "externalCli",
+		api: "google-gemini-cli",
+		baseUrl: "local://google-gemini-cli",
+		isReady: isGeminiCliReady,
+		streamSimple: streamViaGoogleCli,
+		models: GOOGLE_GEMINI_CLI_MODELS,
+	});
+
+	pi.registerProvider("google-antigravity", {
+		name: "Google Antigravity",
+		authMode: "externalCli",
+		api: "google-antigravity",
+		baseUrl: "local://google-antigravity",
+		isReady: isAntigravityCliReady,
+		streamSimple: streamViaGoogleCli,
+		models: GOOGLE_ANTIGRAVITY_MODELS,
+	});
+}

--- a/src/resources/extensions/google-cli/models.ts
+++ b/src/resources/extensions/google-cli/models.ts
@@ -1,0 +1,57 @@
+const ZERO_COST = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+};
+
+export const GOOGLE_GEMINI_CLI_MODELS = [
+	{
+		id: "gemini-2.5-flash",
+		name: "Gemini 2.5 Flash",
+		reasoning: true,
+		input: ["text" as const],
+		cost: ZERO_COST,
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	},
+	{
+		id: "gemini-2.5-pro",
+		name: "Gemini 2.5 Pro",
+		reasoning: true,
+		input: ["text" as const],
+		cost: ZERO_COST,
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	},
+	{
+		id: "gemini-3-flash-preview",
+		name: "Gemini 3 Flash Preview",
+		reasoning: true,
+		input: ["text" as const],
+		cost: ZERO_COST,
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	},
+	{
+		id: "gemini-3.1-pro-preview",
+		name: "Gemini 3.1 Pro Preview",
+		reasoning: true,
+		input: ["text" as const],
+		cost: ZERO_COST,
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	},
+];
+
+export const GOOGLE_ANTIGRAVITY_MODELS = [
+	{
+		id: "default",
+		name: "Antigravity Default",
+		reasoning: true,
+		input: ["text" as const],
+		cost: ZERO_COST,
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	},
+];

--- a/src/resources/extensions/google-cli/package.json
+++ b/src/resources/extensions/google-cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gsd/google-cli",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/src/resources/extensions/google-cli/readiness.ts
+++ b/src/resources/extensions/google-cli/readiness.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from "node:child_process";
+
+function isCommandInPath(command: string): boolean {
+	const resolver = process.platform === "win32" ? "where" : "which";
+	const result = spawnSync(resolver, [command], { stdio: "ignore" });
+	return result.status === 0;
+}
+
+export function isGeminiCliReady(): boolean {
+	return isCommandInPath("gemini");
+}
+
+export function isAntigravityCliReady(): boolean {
+	return isCommandInPath("agy");
+}

--- a/src/resources/extensions/google-cli/stream-adapter.ts
+++ b/src/resources/extensions/google-cli/stream-adapter.ts
@@ -132,9 +132,21 @@ function argsForProvider(provider: GoogleCliProviderId, model: Model<Api>, promp
 	return args;
 }
 
+export function buildGoogleCliSpawnInvocation(
+	command: string,
+	args: string[],
+	platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
+	if (platform === "win32") {
+		return { command: "cmd", args: ["/c", command, ...args] };
+	}
+	return { command, args };
+}
+
 function runCli(command: string, args: string[], options?: SimpleStreamOptions): Promise<CliRunResult> {
 	return new Promise((resolve, reject) => {
-		const child = spawn(command, args, {
+		const invocation = buildGoogleCliSpawnInvocation(command, args);
+		const child = spawn(invocation.command, invocation.args, {
 			cwd: options?.cwd || process.cwd(),
 			env: process.env,
 			stdio: ["ignore", "pipe", "pipe"],

--- a/src/resources/extensions/google-cli/stream-adapter.ts
+++ b/src/resources/extensions/google-cli/stream-adapter.ts
@@ -1,0 +1,233 @@
+import { spawn } from "node:child_process";
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEventStream,
+	Context,
+	Message,
+	Model,
+	SimpleStreamOptions,
+	TextContent,
+} from "@gsd/pi-ai";
+import { createAssistantMessageEventStream } from "@gsd/pi-ai";
+
+const ZERO_USAGE = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+type GoogleCliProviderId = "google-gemini-cli" | "google-antigravity";
+
+interface CliRunResult {
+	stdout: string;
+	stderr: string;
+	code: number | null;
+	signal: NodeJS.Signals | null;
+}
+
+function textBlocks(content: (TextContent | { type: string })[]): string {
+	return content
+		.map((block) => block.type === "text" ? (block as TextContent).text : `[${block.type} omitted]`)
+		.join("\n");
+}
+
+function messageToText(message: Message): string {
+	if (message.role === "user") {
+		const content = typeof message.content === "string" ? message.content : textBlocks(message.content);
+		return `User:\n${content}`;
+	}
+
+	if (message.role === "assistant") {
+		const text = message.content
+			.map((block) => {
+				if (block.type === "text") return block.text;
+				if (block.type === "thinking") return `[thinking omitted]`;
+				if (block.type === "toolCall") return `[tool call: ${block.name}]`;
+				if (block.type === "serverToolUse") return `[server tool: ${block.name}]`;
+				if (block.type === "webSearchResult") return `[web search result omitted]`;
+				return `[${(block as { type: string }).type} omitted]`;
+			})
+			.join("\n");
+		return `Assistant:\n${text}`;
+	}
+
+	return `Tool result (${message.toolName}):\n${textBlocks(message.content)}`;
+}
+
+export function buildGoogleCliPrompt(context: Context): string {
+	const parts: string[] = [];
+
+	if (context.systemPrompt?.trim()) {
+		parts.push(`System instructions:\n${context.systemPrompt.trim()}`);
+	}
+
+	if (context.messages.length > 0) {
+		parts.push(context.messages.map(messageToText).join("\n\n"));
+	}
+
+	if (context.tools?.length) {
+		const names = context.tools.map((tool) => tool.name).join(", ");
+		parts.push(
+			`Available local GSD tools were not forwarded to this external CLI bridge. ` +
+			`If you need to act, use the CLI's own tools or ask the user to switch to a provider with native tool-call support. ` +
+			`Requested GSD tools: ${names}`,
+		);
+	}
+
+	return parts.join("\n\n").trim();
+}
+
+function buildAssistantMessage(
+	model: Model<Api>,
+	text: string,
+	stopReason: AssistantMessage["stopReason"] = "stop",
+	errorMessage?: string,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: text ? [{ type: "text", text }] : [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: { ...ZERO_USAGE, cost: { ...ZERO_USAGE.cost } },
+		stopReason,
+		...(errorMessage ? { errorMessage } : {}),
+		timestamp: Date.now(),
+	};
+}
+
+function extractGeminiJsonResponse(raw: string): string {
+	const trimmed = raw.trim();
+	if (!trimmed) return "";
+
+	try {
+		const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+		for (const key of ["response", "text", "content", "message"]) {
+			const value = parsed[key];
+			if (typeof value === "string") return value;
+		}
+		return JSON.stringify(parsed, null, 2);
+	} catch {
+		return trimmed;
+	}
+}
+
+function commandForProvider(provider: GoogleCliProviderId): string {
+	return provider === "google-gemini-cli" ? "gemini" : "agy";
+}
+
+function argsForProvider(provider: GoogleCliProviderId, model: Model<Api>, prompt: string): string[] {
+	if (provider === "google-gemini-cli") {
+		const args = ["-p", prompt, "--output-format", "json"];
+		if (model.id !== "default") args.unshift("-m", model.id);
+		return args;
+	}
+
+	const args = ["-p", prompt];
+	if (model.id !== "default") args.unshift("-m", model.id);
+	return args;
+}
+
+function runCli(command: string, args: string[], options?: SimpleStreamOptions): Promise<CliRunResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options?.cwd || process.cwd(),
+			env: process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+
+		const settle = (fn: () => void) => {
+			if (settled) return;
+			settled = true;
+			options?.signal?.removeEventListener("abort", onAbort);
+			fn();
+		};
+
+		const onAbort = () => {
+			child.kill("SIGTERM");
+			settle(() => reject(new Error("Request was aborted")));
+		};
+
+		if (options?.signal?.aborted) {
+			onAbort();
+			return;
+		}
+		options?.signal?.addEventListener("abort", onAbort);
+
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+
+		child.on("error", (error) => {
+			settle(() => reject(error));
+		});
+
+		child.on("close", (code, signal) => {
+			settle(() => resolve({ stdout, stderr, code, signal }));
+		});
+	});
+}
+
+function emitText(stream: AssistantMessageEventStream, message: AssistantMessage, text: string): void {
+	stream.push({ type: "start", partial: { ...message, content: [] } });
+	if (text) {
+		stream.push({ type: "text_start", contentIndex: 0, partial: message });
+		stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: message });
+		stream.push({ type: "text_end", contentIndex: 0, content: text, partial: message });
+	}
+	stream.push({ type: "done", reason: "stop", message });
+	stream.end(message);
+}
+
+function emitError(stream: AssistantMessageEventStream, model: Model<Api>, error: unknown): void {
+	const message = error instanceof Error ? error.message : String(error);
+	const output = buildAssistantMessage(model, "", "error", message);
+	stream.push({ type: "error", reason: "error", error: output });
+	stream.end(output);
+}
+
+export function streamViaGoogleCli(
+	model: Model<Api>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	const stream = createAssistantMessageEventStream();
+	const provider = model.provider as GoogleCliProviderId;
+
+	queueMicrotask(async () => {
+		try {
+			const prompt = buildGoogleCliPrompt(context);
+			const command = commandForProvider(provider);
+			const args = argsForProvider(provider, model, prompt);
+			const result = await runCli(command, args, options);
+
+			if (result.code !== 0) {
+				const detail = (result.stderr || result.stdout || `CLI exited with code ${result.code}`).trim();
+				throw new Error(detail);
+			}
+
+			const text = provider === "google-gemini-cli"
+				? extractGeminiJsonResponse(result.stdout)
+				: result.stdout.trim();
+			const message = buildAssistantMessage(model, text);
+			emitText(stream, message, text);
+		} catch (error) {
+			emitError(stream, model, error);
+		}
+	});
+
+	return stream;
+}

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -241,9 +241,15 @@ function resolveKey(providerId: string): KeyLookup {
       const creds = auth.getCredentialsForProvider(providerId);
       if (creds.length > 0) {
         // Filter out empty placeholder keys (from skipped onboarding)
-        const hasRealKey = creds.some(c =>
-          c.type === "oauth" || (c.type === "api_key" && (c as { key?: string }).key)
-        );
+        const hasRealKey = creds.some(c => {
+          if (c.type === "oauth") return true;
+          if (c.type !== "api_key") return false;
+
+          const key = (c as { key?: string }).key?.trim();
+          if (!key) return false;
+
+          return !(CLI_AUTH_PROVIDERS.has(providerId) && key === "cli");
+        });
         if (hasRealKey) {
           return {
             found: true,

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -161,6 +161,11 @@ const CLI_BINARY_MAP: Record<string, string[]> = {
   "google-antigravity": ["agy"],
 };
 
+const CLI_AUTH_PATH_CHECK_PROVIDERS = new Set([
+  "google-gemini-cli",
+  "google-antigravity",
+]);
+
 /**
  * Check if a CLI provider's binary exists anywhere in PATH.
  * Fast filesystem scan — no subprocess, no network, sub-1ms.
@@ -286,15 +291,31 @@ function checkLlmProviders(): ProviderCheckResult[] {
 
   for (const providerId of required) {
     // CLI-authenticated providers don't need API keys. The provider's own
-    // request path validates the installed CLI/session when it is used.
+    // request path validates CLI sessions when it is used.
     if (CLI_AUTH_PROVIDERS.has(providerId)) {
       const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
+      const label = info?.label ?? providerId;
+      if (CLI_AUTH_PATH_CHECK_PROVIDERS.has(providerId) && !isCliBinaryInPath(providerId)) {
+        const binaries = CLI_BINARY_MAP[providerId]?.map(binary => `\`${binary}\``).join(" or ");
+        results.push({
+          name: providerId,
+          label,
+          category: "llm",
+          status: "error",
+          message: `${label} — CLI not found`,
+          detail: binaries
+            ? `Install ${label} and ensure ${binaries} is on PATH`
+            : `Install ${label} and ensure its CLI is on PATH`,
+          required: true,
+        });
+        continue;
+      }
       results.push({
         name: providerId,
-        label: info?.label ?? providerId,
+        label,
         category: "llm",
         status: "ok",
-        message: `${info?.label ?? providerId} — CLI auth (no key needed)`,
+        message: `${label} — CLI auth (no key needed)`,
         required: true,
       });
       continue;

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -16,7 +16,7 @@ import { delimiter, join } from "node:path";
 import { AuthStorage } from "@gsd/pi-coding-agent";
 import { getEnvApiKey } from "@gsd/pi-ai";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
-import { getAuthPath, PROVIDER_REGISTRY, type ProviderCategory } from "./key-manager.js";
+import { getAuthPath, PROVIDER_REGISTRY, supportsBrowserOAuth, type ProviderCategory } from "./key-manager.js";
 import { homedir } from "node:os";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -42,11 +42,10 @@ export interface ProviderCheckResult {
 
 /**
  * Providers that use external CLI authentication (not API keys).
- * These are always considered "found" — the host CLI handles auth.
+ * These are configured only when their official CLI binary is on PATH.
  */
 const CLI_AUTH_PROVIDERS = new Set([
   "claude-code",
-  "openai-codex",
   "google-gemini-cli",
   "google-antigravity",
 ]);
@@ -156,11 +155,10 @@ interface KeyLookup {
  * Map of CLI provider IDs to their binary names on disk.
  * Used for lightweight binary-presence checks (PATH scan, no subprocess).
  */
-const CLI_BINARY_MAP: Record<string, string> = {
-  "claude-code": "claude",
-  "openai-codex": "codex",
-  "google-gemini-cli": "gemini",
-  "google-antigravity": "antigravity",
+const CLI_BINARY_MAP: Record<string, string[]> = {
+  "claude-code": ["claude", "claude-code"],
+  "google-gemini-cli": ["gemini"],
+  "google-antigravity": ["agy"],
 };
 
 /**
@@ -168,14 +166,14 @@ const CLI_BINARY_MAP: Record<string, string> = {
  * Fast filesystem scan — no subprocess, no network, sub-1ms.
  */
 function isCliBinaryInPath(providerId: string): boolean {
-  const binary = CLI_BINARY_MAP[providerId];
-  if (!binary) return false;
+  const binaries = CLI_BINARY_MAP[providerId];
+  if (!binaries) return false;
 
   const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
 
   // On Windows, command shims are commonly installed as .cmd/.exe/.bat/.com.
   // Scan PATHEXT candidates in addition to the bare binary name.
-  const executableNames: string[] = [binary];
+  const executableNames: string[] = [...binaries];
   if (process.platform === "win32") {
     const rawPathExt = process.env.PATHEXT
       ?.split(";")
@@ -185,9 +183,11 @@ function isCliBinaryInPath(providerId: string): boolean {
       ext.startsWith(".") ? ext.toLowerCase() : `.${ext.toLowerCase()}`,
     );
     const defaultExt = [".exe", ".cmd", ".bat", ".com"];
-    for (const ext of [...normalizedPathExt, ...defaultExt]) {
-      const candidate = `${binary}${ext}`;
-      if (!executableNames.includes(candidate)) executableNames.push(candidate);
+    for (const binary of binaries) {
+      for (const ext of [...normalizedPathExt, ...defaultExt]) {
+        const candidate = `${binary}${ext}`;
+        if (!executableNames.includes(candidate)) executableNames.push(candidate);
+      }
     }
   }
 
@@ -224,10 +224,12 @@ function hasModelsJsonApiKey(providerId: string): boolean {
 function resolveKey(providerId: string): KeyLookup {
   const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
 
-  // claude-code never stores credentials in auth.json — GSD delegates entirely to
-  // the local CLI binary. Presence of the binary in PATH is the only signal.
-  if (providerId === "claude-code") {
-    return { found: isCliBinaryInPath("claude-code"), source: "env", backedOff: false };
+  // External CLI providers never store usable provider credentials in GSD.
+  // Presence of the official binary in PATH is the setup signal; the CLI owns
+  // its own login/session validation.
+  if (CLI_AUTH_PROVIDERS.has(providerId)) {
+    const found = isCliBinaryInPath(providerId);
+    return { found, source: found ? "env" : "none", backedOff: false };
   }
 
   if (providerId === "anthropic-vertex" && process.env.ANTHROPIC_VERTEX_PROJECT_ID) {
@@ -285,15 +287,19 @@ function checkLlmProviders(): ProviderCheckResult[] {
   const results: ProviderCheckResult[] = [];
 
   for (const providerId of required) {
-    // CLI-authenticated providers don't need API keys — skip key check
+    // CLI-authenticated providers don't need API keys, but the binary must exist.
     if (CLI_AUTH_PROVIDERS.has(providerId)) {
       const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
+      const found = isCliBinaryInPath(providerId);
       results.push({
         name: providerId,
         label: info?.label ?? providerId,
         category: "llm",
-        status: "ok",
-        message: `${info?.label ?? providerId} — CLI auth (no key needed)`,
+        status: found ? "ok" : "error",
+        message: found
+          ? `${info?.label ?? providerId} — external CLI ready`
+          : `${info?.label ?? providerId} — CLI not found`,
+        detail: found ? undefined : "Install and sign in with the provider CLI, then run /login",
         required: true,
       });
       continue;
@@ -333,7 +339,7 @@ function checkLlmProviders(): ProviderCheckResult[] {
         message: `${label} — not configured`,
         detail: providerId === "anthropic-vertex"
           ? "Set ANTHROPIC_VERTEX_PROJECT_ID and authenticate with Google ADC"
-          : info?.hasOAuth
+          : info && supportsBrowserOAuth(info)
           ? `Run /gsd keys to authenticate`
           : `Set ${envVar} or run /gsd keys`,
         required: true,

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -42,7 +42,7 @@ export interface ProviderCheckResult {
 
 /**
  * Providers that use external CLI authentication (not API keys).
- * These are configured only when their official CLI binary is on PATH.
+ * When explicitly selected, the provider's own CLI/session owns auth.
  */
 const CLI_AUTH_PROVIDERS = new Set([
   "claude-code",
@@ -224,14 +224,6 @@ function hasModelsJsonApiKey(providerId: string): boolean {
 function resolveKey(providerId: string): KeyLookup {
   const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
 
-  // External CLI providers never store usable provider credentials in GSD.
-  // Presence of the official binary in PATH is the setup signal; the CLI owns
-  // its own login/session validation.
-  if (CLI_AUTH_PROVIDERS.has(providerId)) {
-    const found = isCliBinaryInPath(providerId);
-    return { found, source: found ? "env" : "none", backedOff: false };
-  }
-
   if (providerId === "anthropic-vertex" && process.env.ANTHROPIC_VERTEX_PROJECT_ID) {
     return { found: true, source: "env", backedOff: false };
   }
@@ -277,6 +269,12 @@ function resolveKey(providerId: string): KeyLookup {
     return { found: true, source: "models.json", backedOff: false };
   }
 
+  // Cross-provider routes can use a local CLI when it is installed. Explicit
+  // external CLI provider selections are handled in checkLlmProviders() below.
+  if (CLI_AUTH_PROVIDERS.has(providerId) && isCliBinaryInPath(providerId)) {
+    return { found: true, source: "env", backedOff: false };
+  }
+
   return { found: false, source: "none", backedOff: false };
 }
 
@@ -287,19 +285,16 @@ function checkLlmProviders(): ProviderCheckResult[] {
   const results: ProviderCheckResult[] = [];
 
   for (const providerId of required) {
-    // CLI-authenticated providers don't need API keys, but the binary must exist.
+    // CLI-authenticated providers don't need API keys. The provider's own
+    // request path validates the installed CLI/session when it is used.
     if (CLI_AUTH_PROVIDERS.has(providerId)) {
       const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
-      const found = isCliBinaryInPath(providerId);
       results.push({
         name: providerId,
         label: info?.label ?? providerId,
         category: "llm",
-        status: found ? "ok" : "error",
-        message: found
-          ? `${info?.label ?? providerId} — external CLI ready`
-          : `${info?.label ?? providerId} — CLI not found`,
-        detail: found ? undefined : "Install and sign in with the provider CLI, then run /login",
+        status: "ok",
+        message: `${info?.label ?? providerId} — CLI auth (no key needed)`,
         required: true,
       });
       continue;

--- a/src/resources/extensions/gsd/key-manager.ts
+++ b/src/resources/extensions/gsd/key-manager.ts
@@ -22,6 +22,7 @@ import { gsdHome } from "./gsd-home.js";
 // ─── Provider Registry ─────────────────────────────────────────────────────────
 
 export type ProviderCategory = "llm" | "tool" | "search" | "remote";
+export type ProviderAuthMode = "apiKey" | "browserOAuth" | "externalCli" | "cloudIdentity" | "none";
 
 export interface ProviderInfo {
   id: string;
@@ -29,24 +30,24 @@ export interface ProviderInfo {
   category: ProviderCategory;
   envVar?: string;
   prefixes?: string[];
-  hasOAuth?: boolean;
+  authMode?: ProviderAuthMode;
   dashboardUrl?: string;
 }
 
 export const PROVIDER_REGISTRY: ProviderInfo[] = [
   // LLM Providers
-  { id: "anthropic",        label: "Anthropic (Claude)",      category: "llm", envVar: "ANTHROPIC_API_KEY",      prefixes: ["sk-ant-"], hasOAuth: true, dashboardUrl: "console.anthropic.com" },
+  { id: "anthropic",        label: "Anthropic (Claude)",      category: "llm", envVar: "ANTHROPIC_API_KEY",      prefixes: ["sk-ant-"], authMode: "apiKey", dashboardUrl: "console.anthropic.com" },
   // Claude Code CLI: routes through the local `claude` binary — no API key,
   // authentication is handled by the CLI's own OAuth flow.
   // Referenced by doctor-providers.ts, auto-model-selection.ts, and others;
   // must be in the canonical registry so all consumers see the same catalog.
   // See: https://github.com/open-gsd/gsd-pi/issues/4541
-  { id: "claude-code",      label: "Claude Code CLI",         category: "llm",                                   hasOAuth: true },
+  { id: "claude-code",      label: "Claude Code CLI",         category: "llm",                                   authMode: "externalCli" },
   { id: "openai",           label: "OpenAI",                  category: "llm", envVar: "OPENAI_API_KEY",         prefixes: ["sk-"],     dashboardUrl: "platform.openai.com/api-keys" },
-  { id: "github-copilot",   label: "GitHub Copilot",          category: "llm", envVar: "GITHUB_TOKEN",           hasOAuth: true },
-  { id: "openai-codex",     label: "ChatGPT Plus/Pro (Codex)",category: "llm",                                   hasOAuth: true },
-  { id: "google-gemini-cli",label: "Google Gemini CLI",       category: "llm",                                   hasOAuth: true },
-  { id: "google-antigravity",label: "Antigravity",            category: "llm",                                   hasOAuth: true },
+  { id: "github-copilot",   label: "GitHub Copilot",          category: "llm", envVar: "GITHUB_TOKEN",           authMode: "browserOAuth" },
+  { id: "openai-codex",     label: "ChatGPT Plus/Pro (Codex)",category: "llm",                                   authMode: "browserOAuth" },
+  { id: "google-gemini-cli",label: "Google Gemini CLI",       category: "llm",                                   authMode: "externalCli" },
+  { id: "google-antigravity",label: "Antigravity",            category: "llm",                                   authMode: "externalCli" },
   { id: "google",           label: "Google (Gemini)",         category: "llm", envVar: "GEMINI_API_KEY",         dashboardUrl: "aistudio.google.com/apikey" },
   { id: "groq",             label: "Groq",                    category: "llm", envVar: "GROQ_API_KEY",           dashboardUrl: "console.groq.com" },
   { id: "xai",              label: "xAI (Grok)",              category: "llm", envVar: "XAI_API_KEY",            dashboardUrl: "console.x.ai" },
@@ -77,6 +78,21 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
 
 // ─── Utilities ──────────────────────────────────────────────────────────────────
 
+export function getProviderAuthMode(provider: ProviderInfo): ProviderAuthMode {
+  return provider.authMode ?? "apiKey";
+}
+
+export function supportsBrowserOAuth(provider: ProviderInfo): boolean {
+  return getProviderAuthMode(provider) === "browserOAuth";
+}
+
+export function supportsStoredApiKey(provider: ProviderInfo): boolean {
+  const mode = getProviderAuthMode(provider);
+  if (mode === "externalCli" || mode === "cloudIdentity" || mode === "none") return false;
+  if (mode === "browserOAuth") return Boolean(provider.envVar || provider.prefixes?.length);
+  return true;
+}
+
 /**
  * Mask an API key for display: show first 4 + last 4 chars.
  * Keys shorter than 12 chars show only first 2 + last 2.
@@ -104,10 +120,13 @@ export function formatDuration(ms: number): string {
 /**
  * Describe a credential's type and status.
  */
-export function describeCredential(cred: AuthCredential): string {
+export function describeCredential(cred: AuthCredential, provider?: ProviderInfo): string {
   if (cred.type === "api_key") {
     const apiCred = cred as ApiKeyCredential;
     if (!apiCred.key) return "empty key";
+    if (apiCred.key === "cli" && provider && getProviderAuthMode(provider) === "externalCli") {
+      return "external CLI";
+    }
     return `API key (${maskKey(apiCred.key)})`;
   }
   if (cred.type === "oauth") {
@@ -171,7 +190,7 @@ export function getAllKeyStatuses(auth: AuthStorage): KeyStatus[] {
       const desc =
         creds.length > 1
           ? `${creds.length} keys (round-robin)`
-          : describeCredential(firstCred);
+          : describeCredential(firstCred, provider);
       return {
         provider,
         configured: true,
@@ -289,9 +308,28 @@ export async function handleAddKey(
     provider = PROVIDER_REGISTRY[idx];
   }
 
-  // If OAuth is available, offer choice
-  if (provider.hasOAuth) {
-    const methods = ["API key", "Browser login (OAuth)"];
+  const authMode = getProviderAuthMode(provider);
+  if (authMode === "externalCli") {
+    ctx.ui.notify(
+      `${provider.label} is authenticated by its own local CLI. ` +
+      `Sign in with that CLI first, then run /login to activate it in GSD.`,
+      "info",
+    );
+    return false;
+  }
+
+  if (authMode === "cloudIdentity") {
+    ctx.ui.notify(
+      `${provider.label} uses cloud identity credentials. Configure the provider's cloud CLI or environment, then restart GSD.`,
+      "info",
+    );
+    return false;
+  }
+
+  if (supportsBrowserOAuth(provider)) {
+    const methods = supportsStoredApiKey(provider)
+      ? ["API token/key", "Browser login (OAuth)"]
+      : ["Browser login (OAuth)"];
     const method = await ctx.ui.select(
       `${provider.label} — how do you want to authenticate?`,
       methods,
@@ -306,6 +344,11 @@ export async function handleAddKey(
       );
       return false;
     }
+  }
+
+  if (!supportsStoredApiKey(provider)) {
+    ctx.ui.notify(`${provider.label} does not accept a GSD-stored API key. Use /login.`, "info");
+    return false;
   }
 
   // API key input
@@ -387,7 +430,7 @@ export async function handleRemoveKey(
 
   // Multi-key handling
   if (creds.length > 1) {
-    const options = creds.map((c, i) => `[${i + 1}] ${describeCredential(c)}`);
+    const options = creds.map((c, i) => `[${i + 1}] ${describeCredential(c, provider)}`);
     options.push("Remove all");
 
     const choice = await ctx.ui.select(
@@ -411,7 +454,7 @@ export async function handleRemoveKey(
   } else {
     const confirmed = await ctx.ui.confirm(
       "Remove key?",
-      `Remove ${describeCredential(creds[0])} for ${provider.label}?`,
+      `Remove ${describeCredential(creds[0], provider)} for ${provider.label}?`,
     );
     if (!confirmed) return false;
     auth.remove(provider.id);

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -778,6 +778,69 @@ test("runProviderChecks reports ok for Anthropic via claude-code binary in PATH"
   });
 });
 
+test("runProviderChecks ignores external CLI auth sentinels when the CLI is missing", () => {
+  const scenarios = [
+    {
+      requiredProvider: "anthropic",
+      routeProvider: "claude-code",
+      model: "claude-sonnet-4-6",
+      env: {
+        ANTHROPIC_API_KEY: undefined,
+        ANTHROPIC_OAUTH_TOKEN: undefined,
+        COPILOT_GITHUB_TOKEN: undefined,
+        GH_TOKEN: undefined,
+        GITHUB_TOKEN: undefined,
+      },
+    },
+    {
+      requiredProvider: "google",
+      routeProvider: "google-gemini-cli",
+      model: "gemini-2.5-pro",
+      env: {
+        GEMINI_API_KEY: undefined,
+        GOOGLE_API_KEY: undefined,
+      },
+    },
+  ];
+
+  for (const { requiredProvider, routeProvider, model, env } of scenarios) {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), `gsd-providers-${routeProvider}-sentinel-repo-`)));
+    const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), `gsd-providers-${routeProvider}-sentinel-home-`)));
+    const agentDir = join(tmpHome, ".gsd", "agent");
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(repo, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "models:",
+        `  execution: ${model}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(agentDir, "auth.json"), JSON.stringify({
+      [routeProvider]: { type: "api_key", key: "cli" },
+    }));
+
+    withEnv({
+      ...env,
+      HOME: tmpHome,
+      PATH: tmpHome,
+    }, () => {
+      withCwd(repo, () => {
+        const results = runProviderChecks();
+        const provider = results.find(r => r.name === requiredProvider);
+        assert.ok(provider, `${requiredProvider} result should exist`);
+        assert.equal(provider!.status, "error", `${routeProvider} sentinel should not satisfy ${requiredProvider}`);
+      });
+    });
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
 test("runProviderChecks detects claude.cmd in PATH on Windows (#4503)", { skip: process.platform !== "win32" }, () => {
   const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-cc-win-route-home-")));
   const binDir = join(tmpHome, "bin");

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -702,6 +702,48 @@ test("runProviderChecks reports ok for claude-code without any API key", () => {
   rmSync(tmpHome, { recursive: true, force: true });
 });
 
+test("runProviderChecks reports errors for required Google CLI providers missing from PATH", () => {
+  const scenarios = [
+    { provider: "google-gemini-cli", label: "Google Gemini CLI", model: "gemini-2.5-pro" },
+    { provider: "google-antigravity", label: "Antigravity", model: "default" },
+  ];
+
+  for (const { provider, label, model } of scenarios) {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), `gsd-providers-${provider}-repo-`)));
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(repo, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "models:",
+        "  execution:",
+        `    model: ${model}`,
+        `    provider: ${provider}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+
+    const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), `gsd-providers-${provider}-home-`)));
+
+    withEnv({
+      HOME: tmpHome,
+      PATH: tmpHome,
+    }, () => {
+      withCwd(repo, () => {
+        const results = runProviderChecks();
+        const cli = results.find(r => r.name === provider);
+        assert.ok(cli, `${provider} result should exist`);
+        assert.equal(cli!.status, "error", `${provider} should error when the CLI binary is missing`);
+        assert.ok(cli!.detail?.includes(label), "should explain which CLI must be installed");
+      });
+    });
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
 test("runProviderChecks reports ok for Anthropic via claude-code binary in PATH", () => {
   // Simulate a user who has no Anthropic API key but has the claude CLI installed.
   // Their PREFERENCES use a claude model without an explicit provider, so the doctor

--- a/src/resources/extensions/gsd/tests/key-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/key-manager.test.ts
@@ -10,9 +10,10 @@ import {
   formatKeyDashboard,
   formatTestResults,
   runKeyDoctor,
-  formatDoctorFindings,
-  PROVIDER_REGISTRY,
-} from "../key-manager.ts";
+	  formatDoctorFindings,
+	  PROVIDER_REGISTRY,
+	  getProviderAuthMode,
+	} from "../key-manager.ts";
 
 function makeAuth(data: Record<string, any> = {}): AuthStorage {
   return AuthStorage.inMemory(data);
@@ -74,6 +75,12 @@ test("describeCredential describes an API key with masked value", () => {
 
 test("describeCredential describes an empty API key", () => {
   assert.equal(describeCredential({ type: "api_key", key: "" }), "empty key");
+});
+
+test("describeCredential describes external CLI sentinels without calling them API keys", () => {
+  const provider = PROVIDER_REGISTRY.find((p) => p.id === "claude-code");
+  assert.ok(provider);
+  assert.equal(describeCredential({ type: "api_key", key: "cli" }, provider), "external CLI");
 });
 
 test("describeCredential describes an OAuth token with expiry", () => {
@@ -149,7 +156,19 @@ test("PROVIDER_REGISTRY includes claude-code as a first-class LLM provider (#454
   const entry = PROVIDER_REGISTRY.find((p) => p.id === "claude-code");
   assert.ok(entry, "claude-code must be in PROVIDER_REGISTRY");
   assert.equal(entry!.category, "llm");
-  assert.ok(entry!.hasOAuth, "claude-code uses OAuth (CLI auth)");
+  assert.equal(getProviderAuthMode(entry!), "externalCli");
+});
+
+test("PROVIDER_REGISTRY classifies only Copilot and Codex as browser OAuth LLM providers", () => {
+  const modes = Object.fromEntries(
+    PROVIDER_REGISTRY.filter((p) => p.category === "llm").map((p) => [p.id, getProviderAuthMode(p)]),
+  );
+  assert.equal(modes.anthropic, "apiKey");
+  assert.equal(modes["github-copilot"], "browserOAuth");
+  assert.equal(modes["openai-codex"], "browserOAuth");
+  assert.equal(modes["claude-code"], "externalCli");
+  assert.equal(modes["google-gemini-cli"], "externalCli");
+  assert.equal(modes["google-antigravity"], "externalCli");
 });
 
 test("PROVIDER_REGISTRY includes all tool/search providers", () => {

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -357,9 +357,15 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
     "alibaba-dashscope",
     "claude-code",
   ]);
-  const anthropicProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "anthropic");
-  assert.equal(anthropicProvider.supports.apiKey, true);
-  assert.equal(anthropicProvider.supports.oauthAvailable, false);
+	  const anthropicProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "anthropic");
+	  assert.equal(anthropicProvider.supports.apiKey, true);
+	  assert.equal(anthropicProvider.supports.oauthAvailable, false);
+	  const geminiCliProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "google-gemini-cli");
+	  assert.equal(geminiCliProvider.supports.oauth, false);
+	  assert.equal(geminiCliProvider.supports.externalCli, true);
+	  const antigravityProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "google-antigravity");
+	  assert.equal(antigravityProvider.supports.oauth, false);
+	  assert.equal(antigravityProvider.supports.externalCli, true);
 
   const onboardingResponse = await onboardingRoute.GET(projectRequest(fixture.projectCwd, "/api/onboarding"));
   assert.equal(onboardingResponse.status, 200);
@@ -709,10 +715,11 @@ test("claude-code ExternalCli provider is recognized as configured and unlocks o
   clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   configureBridgeFixture(fixture, "sess-claude-code-extcli");
-  onboarding.configureOnboardingServiceForTests({
-    authStorage,
-    getEnvApiKey: noEnvApiKey,
-  });
+	  onboarding.configureOnboardingServiceForTests({
+	    authStorage,
+	    getEnvApiKey: noEnvApiKey,
+	    isExternalCliProvider: (id) => id === "claude-code",
+	  });
 
   t.after(async () => {
     onboarding.resetOnboardingServiceForTests();

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -757,6 +757,45 @@ test("claude-code ExternalCli provider is recognized as configured and unlocks o
   assert.equal(claudeCodeProvider.recommended, true);
 });
 
+test("ExternalCli auth sentinels do not unlock onboarding when CLI is missing", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({
+    "google-gemini-cli": { type: "api_key", key: "cli" },
+    "google-antigravity": { type: "api_key", key: "cli" },
+    "claude-code": { type: "api_key", key: "cli" },
+  } as any);
+  configureBridgeFixture(fixture, "sess-extcli-sentinel-missing");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+    isExternalCliProvider: () => false,
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    fixture.cleanup();
+  });
+
+  const bootResponse = await bootRoute.GET(projectRequest(fixture.projectCwd, "/api/boot"));
+  assert.equal(bootResponse.status, 200);
+  const bootPayload = (await bootResponse.json()) as any;
+
+  assert.equal(bootPayload.onboardingNeeded, true);
+  assert.equal(bootPayload.onboarding.locked, true);
+  assert.equal(bootPayload.onboarding.required.satisfied, false);
+  assert.equal(bootPayload.onboarding.required.satisfiedBy, null);
+
+  for (const providerId of ["google-gemini-cli", "google-antigravity", "claude-code"]) {
+    const provider = bootPayload.onboarding.required.providers.find((candidate: any) => candidate.id === providerId);
+    assert.ok(provider, `${providerId} must appear in the providers list`);
+    assert.equal(provider.configured, false);
+    assert.equal(provider.configuredVia, null);
+  }
+});
+
 test("validateAndSaveApiKey throws for claude-code because supportsApiKey is false", async (t) => {
   const fixture = makeWorkspaceFixture();
   clearOnboardingEnv();

--- a/src/tests/provider-manager-externalcli-routing.test.ts
+++ b/src/tests/provider-manager-externalcli-routing.test.ts
@@ -5,9 +5,9 @@
  *
  *   "Failed to login to claude-code: Unknown OAuth provider: claude-code"
  *
- * The fix adds a guard in the onSetupAuth callback inside showProviderManager:
- * if the provider is not in the OAuth provider registry, show a "ready" status
- * message instead of opening the login dialog.
+ * The fix routes selected providers through the shared /login auth dispatcher:
+ * externalCli providers are activated and selected instead of being sent to
+ * the OAuth dialog.
  *
  * This test verifies the guard through the provider manager callback behavior.
  */
@@ -18,31 +18,47 @@ import assert from "node:assert/strict";
 import { initTheme } from "../../packages/pi-coding-agent/src/theme/theme.ts";
 
 const { InteractiveMode } = await import("../../packages/gsd-agent-modes/src/modes/interactive/interactive-mode.ts");
+const { buildLoginProviderOptions } = await import("../../packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts");
 
 initTheme("dark", false);
 
 function createProviderManagerHarness(oauthProviderIds: string[]) {
   const statusMessages: string[] = [];
   const loginProviders: string[] = [];
+  const storedAuth: Array<{ provider: string; value: unknown }> = [];
+  const setModels: Array<{ provider: string; id: string }> = [];
   let doneCount = 0;
   let component: any;
   const authStorage = {
     getOAuthProviders: () => oauthProviderIds.map((id) => ({ id })),
     hasAuth: () => false,
+    set: (provider: string, value: unknown) => {
+      storedAuth.push({ provider, value });
+    },
   };
   const mode = Object.create(InteractiveMode.prototype) as any;
   mode.ui = { requestRender() {} };
+  const models = [
+    { provider: "claude-code", id: "claude-sonnet-4-6", name: "Claude Code", api: "anthropic-messages" },
+    { provider: "openai-codex", id: "gpt-test", name: "GPT Test", api: "openai" },
+  ];
   mode.session = {
     modelRegistry: {
       authStorage,
       modelsJsonPath: "/tmp/models.json",
-      getAll: () => [
-        { provider: "claude-code", id: "claude-code", name: "Claude Code", api: "externalCli" },
-        { provider: "openai-codex", id: "gpt-test", name: "GPT Test", api: "openai" },
-      ],
+      getAll: () => models,
+      getAvailable: () => models,
+      getProviderAuthMode: (provider: string) => provider === "claude-code" ? "externalCli" : "oauth",
+      getProviderDisplayName: (provider: string) => provider === "claude-code" ? "Claude Code CLI" : provider,
+      isProviderRequestReady: (provider: string) => provider === "claude-code",
+      refresh() {},
       discoverModels: async () => [],
     },
+    setModel: async (model: { provider: string; id: string }) => {
+      setModels.push(model);
+    },
   };
+  mode.updateAvailableProviderCount = async () => {};
   mode.showStatus = (message: string) => {
     statusMessages.push(message);
   };
@@ -57,25 +73,75 @@ function createProviderManagerHarness(oauthProviderIds: string[]) {
   };
 
   mode.showProviderManager();
-  return { component, statusMessages, loginProviders, get doneCount() { return doneCount; } };
+  return { component, statusMessages, loginProviders, storedAuth, setModels, get doneCount() { return doneCount; } };
 }
 
 describe("interactive-mode.ts — provider Enter-key routing guard (#4548)", () => {
-  test("externalCli providers show informational status instead of login dialog", () => {
+  test("/login offers Claude Code CLI and Anthropic API key, not Anthropic browser OAuth", () => {
+    const host = {
+      session: {
+        modelRegistry: {
+          authStorage: {
+            getOAuthProviders: () => [
+              { id: "anthropic", name: "Anthropic OAuth" },
+              { id: "openai-codex", name: "ChatGPT Plus/Pro (Codex)" },
+            ],
+          },
+	          getAll: () => [
+	            { provider: "anthropic", id: "claude-sonnet-4-6" },
+	            { provider: "claude-code", id: "claude-sonnet-4-6" },
+	            { provider: "google-gemini-cli", id: "gemini-2.5-flash" },
+	            { provider: "google-antigravity", id: "default" },
+	            { provider: "openai-codex", id: "gpt-test" },
+	          ],
+	          getProviderAuthMode: (provider: string) => ["claude-code", "google-gemini-cli", "google-antigravity"].includes(provider)
+	            ? "externalCli"
+	            : provider === "openai-codex"
+	              ? "oauth"
+	              : "apiKey",
+          getProviderDisplayName: (provider: string) => provider === "anthropic"
+            ? "Anthropic"
+	            : provider === "claude-code"
+	              ? "Claude Code CLI"
+	              : provider === "google-gemini-cli"
+	                ? "Google Gemini CLI"
+	                : provider === "google-antigravity"
+	                  ? "Google Antigravity"
+	                  : provider,
+	          isProviderRequestReady: (provider: string) => provider === "claude-code",
+          getProviderAuthStatus: () => ({ configured: false }),
+        },
+      },
+    };
+
+    const options = buildLoginProviderOptions(host);
+    const byIdAndType = options.map((option: any) => `${option.id}:${option.authType}`);
+
+	    assert.ok(byIdAndType.includes("claude-code:external_cli"));
+	    assert.ok(byIdAndType.includes("google-gemini-cli:external_cli"));
+	    assert.ok(byIdAndType.includes("google-antigravity:external_cli"));
+	    assert.ok(byIdAndType.includes("anthropic:api_key"));
+    assert.ok(byIdAndType.includes("openai-codex:oauth"));
+    assert.ok(!byIdAndType.includes("anthropic:oauth"));
+  });
+
+  test("externalCli providers activate and select the CLI provider instead of opening OAuth", async () => {
     const harness = createProviderManagerHarness(["openai-codex"]);
 
-    harness.component.onSetupAuth("claude-code");
+    await harness.component.onSetupAuth("claude-code");
 
     assert.equal(harness.doneCount, 1);
     assert.deepEqual(harness.loginProviders, []);
+    assert.deepEqual(harness.storedAuth, [{ provider: "claude-code", value: { type: "api_key", key: "cli" } }]);
+    assert.deepEqual(harness.setModels, [{ provider: "claude-code", id: "claude-sonnet-4-6", name: "Claude Code", api: "anthropic-messages" }]);
     assert.equal(harness.statusMessages.length, 1);
-    assert.match(harness.statusMessages[0], /external CLI auth/i);
+    assert.match(harness.statusMessages[0], /Using Claude Code CLI/i);
   });
 
-  test("OAuth providers still route to showLoginDialog", () => {
+  test("OAuth providers still route to showLoginDialog", async () => {
     const harness = createProviderManagerHarness(["openai-codex"]);
 
-    harness.component.onSetupAuth("openai-codex");
+    await harness.component.onSetupAuth("openai-codex");
 
     assert.equal(harness.doneCount, 1);
     assert.deepEqual(harness.loginProviders, ["openai-codex"]);

--- a/src/tests/windows-portability.test.ts
+++ b/src/tests/windows-portability.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { encodeCwd } from "../resources/extensions/subagent/isolation.ts";
+import { buildGoogleCliSpawnInvocation } from "../resources/extensions/google-cli/stream-adapter.ts";
 import { buildGsdClientSpawnPlan } from "../../vscode-extension/src/gsd-client-spawn.ts";
 
 test("encodeCwd produces a filesystem-safe token for Windows paths", () => {
@@ -18,4 +19,16 @@ test("VS Code RPC launch plan uses shell mode for Windows command shims", () => 
 	assert.equal(plan.options.cwd, "C:\\repo");
 	assert.equal(plan.options.shell, true);
 	assert.equal(plan.options.env.PATH, "C:\\Windows\\System32");
+});
+
+test("Google CLI spawn plan uses cmd.exe on Windows command shims", () => {
+	const plan = buildGoogleCliSpawnInvocation("gemini", ["-p", "hello"], "win32");
+	assert.equal(plan.command, "cmd");
+	assert.deepEqual(plan.args, ["/c", "gemini", "-p", "hello"]);
+});
+
+test("Google CLI spawn plan keeps direct execution on non-Windows platforms", () => {
+	const plan = buildGoogleCliSpawnInvocation("agy", ["-p", "hello"], "linux");
+	assert.equal(plan.command, "agy");
+	assert.deepEqual(plan.args, ["-p", "hello"]);
 });

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -314,10 +314,13 @@ function resolveCredentialSource(
   getEnvApiKeyFn: GetEnvApiKeyFn,
   isExternalCliProviderFn: (id: string) => boolean,
 ): OnboardingCredentialSource | null {
-  // ExternalCli providers authenticate through a local CLI — no credentials
-  // are stored in GSD. Treat them as always configured.
   if (isExternalCliProviderFn(providerId)) {
     return "external_cli";
+  }
+  // ExternalCli providers authenticate through a local CLI. Stored "cli"
+  // sentinels only remember selection and must not bypass PATH readiness.
+  if (CLI_AUTH_PROVIDERS.has(providerId)) {
+    return null;
   }
   if (hasStoredCredentialValue(authStorage, providerId)) {
     return "auth_file";

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 
 import { getEnvApiKey } from "../../packages/pi-ai/src/env-api-keys.ts";
 import type { OAuthAuthInfo, OAuthPrompt, OAuthProviderInterface } from "../../packages/pi-ai/dist/oauth.js";
@@ -169,17 +170,16 @@ type ProviderFlowRuntime = {
  * provider in this list. Reordering entries changes which provider wins when
  * multiple are configured simultaneously — do so intentionally.
  *
- * ExternalCli providers (those with `supportsExternalCli: true`) are always
- * treated as configured by the onboarding service regardless of auth-file
- * contents, so placing them higher in the list gives them higher precedence.
+ * ExternalCli providers (those with `supportsExternalCli: true`) are treated
+ * as configured only when their official CLI command is present on PATH.
  */
 const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "anthropic", label: "Anthropic (Claude)", supportsApiKey: true, supportsOAuth: false, recommended: true },
   { id: "openai", label: "OpenAI", supportsApiKey: true, supportsOAuth: false },
   { id: "github-copilot", label: "GitHub Copilot", supportsApiKey: false, supportsOAuth: true },
   { id: "openai-codex", label: "ChatGPT Plus/Pro (Codex Subscription)", supportsApiKey: false, supportsOAuth: true },
-  { id: "google-gemini-cli", label: "Google Cloud Code Assist (Gemini CLI)", supportsApiKey: false, supportsOAuth: true },
-  { id: "google-antigravity", label: "Antigravity (Gemini 3, Claude, GPT-OSS)", supportsApiKey: false, supportsOAuth: true },
+  { id: "google-gemini-cli", label: "Google Gemini CLI", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true },
+  { id: "google-antigravity", label: "Antigravity (Gemini 3, Claude, GPT-OSS)", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true },
   { id: "google", label: "Google (Gemini API)", supportsApiKey: true, supportsOAuth: false },
   { id: "groq", label: "Groq", supportsApiKey: true, supportsOAuth: false },
   { id: "xai", label: "xAI (Grok)", supportsApiKey: true, supportsOAuth: false },
@@ -228,21 +228,29 @@ const OPTIONAL_SECTION_CATALOG: OptionalSectionCatalogEntry[] = [
 
 /**
  * ExternalCli providers authenticate through a local CLI tool rather than
- * storing credentials in GSD. They are always treated as "configured" by the
- * onboarding service — if the binary is missing, inference will fail at
- * runtime (the correct place to surface that error).
+ * storing credentials in GSD. They are configured only when their official CLI
+ * command is on PATH; provider-specific login state is validated at request time.
  *
- * **Sync requirement:** This set must stay in sync with `CLI_AUTH_PROVIDERS`
+ * **Sync requirement:** This map must stay in sync with `CLI_AUTH_PROVIDERS`
  * in `src/resources/extensions/gsd/doctor-providers.ts`. If a new ExternalCli
  * provider is added to one set but not the other, onboarding will silently
  * mis-classify it (treating it as unconfigured or vice-versa).
  */
-const CLI_AUTH_PROVIDER_IDS = new Set([
-  "claude-code",
+const CLI_AUTH_PROVIDERS = new Map<string, string[]>([
+  ["claude-code", ["claude", "claude-code"]],
+  ["google-gemini-cli", ["gemini"]],
+  ["google-antigravity", ["agy"]],
 ]);
 
+function isCommandInPath(command: string): boolean {
+  const resolver = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(resolver, [command], { stdio: "ignore" });
+  return result.status === 0;
+}
+
 function defaultIsExternalCliProvider(id: string): boolean {
-  return CLI_AUTH_PROVIDER_IDS.has(id);
+  const commands = CLI_AUTH_PROVIDERS.get(id);
+  return Boolean(commands?.some(isCommandInPath));
 }
 
 let onboardingServiceOverrides: Partial<OnboardingServiceDeps> | null = null;


### PR DESCRIPTION
## Summary

- Route `/login` through an auth-mode-aware provider dispatcher instead of treating every provider as browser OAuth.
- Keep browser OAuth limited to GitHub Copilot and OpenAI Codex, while Anthropic direct auth uses API keys and Claude subscription usage goes through the Claude Code external CLI path.
- Add Google Gemini CLI and Google Antigravity as external CLI providers, with explicit readiness checks and local CLI stream bridging.
- Replace loose `hasOAuth` setup metadata with explicit auth modes in the GSD provider registry, doctor checks, CLI onboarding, web onboarding, and tests.

## Root Cause

The Pi seam split left GSD interactive login using the global OAuth provider list directly. That exposed Anthropic browser OAuth and sent external CLI providers such as `claude-code` into OAuth login instead of activating the local CLI-backed provider.

## Validation

- `pnpm -s exec tsc --noEmit --pretty false`
- `pnpm run typecheck:extensions`
- `pnpm --filter @gsd/agent-modes run build`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/provider-manager-externalcli-routing.test.ts src/resources/extensions/gsd/tests/key-manager.test.ts src/tests/integration/web-onboarding-contract.test.ts`
- `node scripts/dev-cli.js --list-models claude-code`
- `node scripts/dev-cli.js --print --no-session --model claude-code/claude-haiku-4-5 "Reply with exactly: ok"`

## Notes

Gemini CLI and Antigravity register as external CLI providers, but this local machine does not currently have `gemini` or `agy` on PATH, so they correctly show as not ready until the official CLIs are installed and signed in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782759618&installation_id=134682257&pr_number=275&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F275&signature=67d474eaeba9b5aa22b44e3247407dbee18faddc37da397535f7aaaf13ae430f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication flows, credential storage, and onboarding unlock semantics across CLI, TUI, doctor, and web surfaces; mis-routing could block login or incorrectly mark providers configured.
> 
> **Overview**
> This PR fixes **login and provider auth routing** so GSD no longer treats every provider as browser OAuth.
> 
> **Interactive `/login` and provider manager** now build a unified provider list (external CLI, API key, and allowed browser OAuth) and dispatch through `handleLoginProviderSelection`: **external CLI** providers activate when the local binary is ready (storing a `cli` sentinel and optionally switching models), **Copilot/Codex** still use the OAuth dialog, **Anthropic browser OAuth is blocked** in favor of API-key paste, and **Google CLI providers** follow the external-CLI path instead of OAuth.
> 
> A new **`google-cli` extension** registers `google-gemini-cli` and `google-antigravity` with `authMode: externalCli`, PATH readiness (`gemini` / `agy`), and a **local CLI stream bridge** (prompt flattening, subprocess spawn, Windows `cmd /c` shims).
> 
> **Registry and health surfaces** replace loose `hasOAuth` with explicit **`ProviderAuthMode`** (`apiKey`, `browserOAuth`, `externalCli`, …) in `key-manager`, doctor checks, CLI onboarding (Gemini/Antigravity CLI options; browser flow limited to Copilot/Codex), and **web onboarding** (external CLI only counts as configured when the official binary is on PATH—not from `cli` sentinels alone). Doctor/key resolution ignores external-CLI `cli` placeholders when the binary is missing and errors when required Google CLIs are absent from PATH.
> 
> Tests cover provider-manager routing, key-manager auth modes, doctor PATH behavior, web onboarding contracts, and Windows spawn plans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f444bfbc57adf7e9902aaa9a37b197748c9ba4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->