### PR TITLE
[codex] fix context report opener test

### DIFF
--- a/src/resources/extensions/gsd/tests/commands-context.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-context.test.ts
@@ -156,9 +156,11 @@ test("handleContext writes open reports under the command project root", async (
   process.chdir(processProject);
   try {
     const binDir = mkdtempSync(join(tmpdir(), "gsd-context-bin-"));
-    const xdgOpen = join(binDir, "xdg-open");
-    writeFileSync(xdgOpen, "#!/bin/sh\nexit 0\n");
-    chmodSync(xdgOpen, 0o755);
+    for (const opener of ["open", "xdg-open"]) {
+      const openerPath = join(binDir, opener);
+      writeFileSync(openerPath, "#!/bin/sh\nexit 0\n");
+      chmodSync(openerPath, 0o755);
+    }
     process.env.PATH = `${binDir}:${originalPath ?? ""}`;
 
     const notifications: string[] = [];


### PR DESCRIPTION
## Summary

Fixes the `/gsd context --open` unit test so it stubs the platform opener used on macOS as well as Linux.

## Root Cause

The test created a fake `xdg-open`, but `openInBrowser()` calls `open` on Darwin. That allowed the real macOS opener to run during tests and open temporary `context-*.html` reports in the default browser.

## Impact

Running the context command tests should no longer produce random browser popups from temp `.gsd/reports/context-*.html` files on macOS.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-context.test.ts`
- `git diff --check -- src/resources/extensions/gsd/tests/commands-context.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782761581&installation_id=134682257&pr_number=277&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F277&signature=bc279af83957633cd25381f6dc0726c0650e7496f0ad6dbad5a3751f2d261df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only PATH stubbing; no production code or runtime behavior changes.
> 
> **Overview**
> The **`handleContext --open`** integration test now stubs **both** `open` and `xdg-open` in a fake `PATH` bin directory, instead of only `xdg-open`.
> 
> That matches production behavior on macOS (`openInBrowser` invokes `open` on Darwin), so the test no longer falls through to the real system opener and accidentally launches temp `context-*.html` reports in a browser during CI/local runs on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e987f0bde066d328854c9b3dde2a6a7c68f769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->