### PR TITLE
[codex] remove TUI assistant background

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -25,7 +25,8 @@ describe("AssistantMessageComponent open surface", () => {
 		} as unknown as AssistantMessage;
 
 		const component = new AssistantMessageComponent(message, true);
-		const plain = component.render(80).map((line) => stripAnsi(line));
+		const raw = component.render(80);
+		const plain = raw.map((line) => stripAnsi(line));
 		const joined = plain.join("\n");
 
 		assert.match(joined, /GSD/);
@@ -49,7 +50,8 @@ describe("AssistantMessageComponent open surface", () => {
 			/^ {10,}/,
 			`assistant content should not preserve the old outer rail indent:\n${joined}`,
 		);
-		assert.equal(plain[contentIndex].length, 80, `assistant content row should fill the bubble background:\n${joined}`);
+		assert.doesNotMatch(raw[contentIndex] ?? "", /\x1b\[48[;:]/, "assistant content rows should not paint a background");
+		assert.equal(plain[contentIndex].length, 80, `assistant content row should fill the card interior:\n${joined}`);
 		assert.doesNotMatch(plain[contentIndex], /[│┃╭╮╰╯]/, `content line must stay copy-clean:\n${joined}`);
 	});
 

--- a/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
@@ -288,7 +288,6 @@ export function renderAssistantRail(
 		indent: 0,
 		titleRight,
 		railColor,
-		bodyBg: "customMessageBg",
 		closeBottom: !opts.continuesToUser,
 	});
 	let result = card;


### PR DESCRIPTION
## Summary

- Remove the painted `customMessageBg` body background from the GSD assistant rail in the TUI.
- Keep the assistant rail/header, spacing, copy-clean content rows, and metadata behavior intact.
- Add regression coverage that asserts assistant content rows do not emit ANSI background color codes.

## Why

The assistant message surface was still applying the custom message background while the desired TUI treatment is a transparent assistant content area.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts`
- Earlier local checks also passed for the package test script and user-message design surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782766408&installation_id=134682257&pr_number=279&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F279&signature=3e50b0026cf0f098133e650b683a5995d7e24f01d85015e52a99cc23d975989e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-only change in transcript rendering with a targeted regression test; no auth, data, or business-logic impact.
> 
> **Overview**
> Removes the **`customMessageBg`** fill from assistant transcript cards in the interactive TUI so GSD message body lines render on a transparent background while keeping the connected rail, header/metadata, bridges, and copy-clean layout unchanged.
> 
> Adds a visual contract assertion that assistant content rows do not emit ANSI background (`\x1b[48…`) sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d01b984deca845561e5934e707442c24b0f8dcc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->