### PR TITLE
[codex] unify GSD slash dialog borders

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/dialog-container.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/dialog-container.ts
@@ -1,0 +1,55 @@
+import { Container, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { theme } from "@gsd/pi-coding-agent/theme/theme.js";
+
+function padVisible(text: string, width: number): string {
+	const clipped = truncateToWidth(text, width, "");
+	return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+function renderTopBorder(title: string, width: number, border: (text: string) => string): string {
+	const trimmedTitle = title.trim();
+	if (!trimmedTitle || width < 10) {
+		return border("╭" + "─".repeat(width - 2) + "╮");
+	}
+
+	const safeTitle = truncateToWidth(trimmedTitle, Math.max(0, width - 7), "");
+	const fill = Math.max(0, width - visibleWidth(safeTitle) - 5);
+	return border("╭─ ") + theme.bold(theme.fg("accent", safeTitle)) + border(" " + "─".repeat(fill) + "╮");
+}
+
+export class DialogContainer extends Container {
+	private dialogTitle: string;
+
+	constructor(title: string) {
+		super();
+		this.dialogTitle = title;
+	}
+
+	setDialogTitle(title: string): void {
+		this.dialogTitle = title;
+	}
+
+	render(width: number): string[] {
+		const outerWidth = Math.max(1, width);
+		if (outerWidth < 4) return super.render(outerWidth).map((line) => truncateToWidth(line, outerWidth, ""));
+
+		const contentWidth = Math.max(1, outerWidth - 4);
+		const border = (text: string) => theme.fg("borderAccent", text);
+		const lines = [renderTopBorder(this.dialogTitle, outerWidth, border)];
+
+		for (const line of super.render(contentWidth)) {
+			lines.push(border("│") + " " + padVisible(line, contentWidth) + " " + border("│"));
+		}
+
+		lines.push(border("╰" + "─".repeat(outerWidth - 2) + "╯"));
+		return lines;
+	}
+}
+
+export function splitDialogTitle(title: string): { title: string; detailLines: string[] } {
+	const lines = title.split(/\r?\n/);
+	return {
+		title: lines[0] ?? "",
+		detailLines: lines.slice(1).filter((line) => line.trim().length > 0),
+	};
+}

--- a/packages/gsd-agent-modes/src/modes/interactive/components/extension-editor.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/extension-editor.ts
@@ -8,7 +8,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
-	Container,
 	Editor,
 	type EditorOptions,
 	type Focusable,
@@ -19,10 +18,10 @@ import {
 } from "@gsd/pi-tui";
 import type { KeybindingsManager } from "@gsd/agent-core";
 import { getEditorTheme, theme } from "@gsd/pi-coding-agent/theme/theme.js";
-import { DynamicBorder } from "./dynamic-border.js";
+import { DialogContainer, splitDialogTitle } from "./dialog-container.js";
 import { appKeyHint, keyHint } from "./keybinding-hints.js";
 
-export class ExtensionEditorComponent extends Container implements Focusable {
+export class ExtensionEditorComponent extends DialogContainer implements Focusable {
 	private editor: Editor;
 	private onSubmitCallback: (value: string) => void;
 	private onCancelCallback: () => void;
@@ -47,20 +46,21 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		onCancel: () => void,
 		options?: EditorOptions,
 	) {
-		super();
+		const dialogTitle = splitDialogTitle(title);
+		super(dialogTitle.title);
 
 		this.tui = tui;
 		this.keybindings = keybindings;
 		this.onSubmitCallback = onSubmit;
 		this.onCancelCallback = onCancel;
 
-		// Add top border
-		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
-
-		// Add title
-		this.addChild(new Text(theme.fg("accent", title), 1, 0));
-		this.addChild(new Spacer(1));
+		for (const detail of dialogTitle.detailLines) {
+			this.addChild(new Text(theme.fg("text", detail), 1, 0));
+		}
+		if (dialogTitle.detailLines.length > 0) {
+			this.addChild(new Spacer(1));
+		}
 
 		// Create editor
 		this.editor = new Editor(tui, getEditorTheme(), options);
@@ -87,9 +87,6 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		this.addChild(new Text(hint, 1, 0));
 
 		this.addChild(new Spacer(1));
-
-		// Add bottom border
-		this.addChild(new DynamicBorder());
 	}
 
 	handleInput(keyData: string): void {

--- a/packages/gsd-agent-modes/src/modes/interactive/components/extension-input.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/extension-input.ts
@@ -3,10 +3,10 @@
  * Simple text input component for extensions.
  */
 
-import { Container, type Focusable, getEditorKeybindings, Input, Spacer, Text, type TUI } from "@gsd/pi-tui";
+import { type Focusable, getEditorKeybindings, Input, Spacer, Text, type TUI } from "@gsd/pi-tui";
 import { theme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { CountdownTimer } from "./countdown-timer.js";
-import { DynamicBorder } from "./dynamic-border.js";
+import { DialogContainer, splitDialogTitle } from "./dialog-container.js";
 import { keyHint } from "./keybinding-hints.js";
 
 export interface ExtensionInputOptions {
@@ -15,11 +15,10 @@ export interface ExtensionInputOptions {
 	secure?: boolean;
 }
 
-export class ExtensionInputComponent extends Container implements Focusable {
+export class ExtensionInputComponent extends DialogContainer implements Focusable {
 	private input: Input;
 	private onSubmitCallback: (value: string) => void;
 	private onCancelCallback: () => void;
-	private titleText: Text;
 	private baseTitle: string;
 	private countdown: CountdownTimer | undefined;
 
@@ -40,24 +39,26 @@ export class ExtensionInputComponent extends Container implements Focusable {
 		onCancel: () => void,
 		opts?: ExtensionInputOptions,
 	) {
-		super();
+		const dialogTitle = splitDialogTitle(title);
+		super(dialogTitle.title);
 
 		this.onSubmitCallback = onSubmit;
 		this.onCancelCallback = onCancel;
-		this.baseTitle = title;
+		this.baseTitle = dialogTitle.title;
 
-		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
-
-		this.titleText = new Text(theme.fg("accent", title), 1, 0);
-		this.addChild(this.titleText);
-		this.addChild(new Spacer(1));
+		for (const detail of dialogTitle.detailLines) {
+			this.addChild(new Text(theme.fg("text", detail), 1, 0));
+		}
+		if (dialogTitle.detailLines.length > 0) {
+			this.addChild(new Spacer(1));
+		}
 
 		if (opts?.timeout && opts.timeout > 0 && opts.tui) {
 			this.countdown = new CountdownTimer(
 				opts.timeout,
 				opts.tui,
-				(s) => this.titleText.setText(theme.fg("accent", `${this.baseTitle} (${s}s)`)),
+				(s) => this.setDialogTitle(`${this.baseTitle} (${s}s)`),
 				() => this.onCancelCallback(),
 			);
 		}
@@ -71,7 +72,6 @@ export class ExtensionInputComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(`${keyHint("selectConfirm", "submit")}  ${keyHint("selectCancel", "cancel")}`, 1, 0));
 		this.addChild(new Spacer(1));
-		this.addChild(new DynamicBorder());
 	}
 
 	handleInput(keyData: string): void {

--- a/packages/gsd-agent-modes/src/modes/interactive/components/extension-selector.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/extension-selector.ts
@@ -8,7 +8,7 @@
 import { Container, getEditorKeybindings, matchesKey, Spacer, Text, type TUI } from "@gsd/pi-tui";
 import { theme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { CountdownTimer } from "./countdown-timer.js";
-import { DynamicBorder } from "./dynamic-border.js";
+import { DialogContainer, splitDialogTitle } from "./dialog-container.js";
 import { selectorFooter } from "./keybinding-hints.js";
 
 /** Prefix that marks an option as a non-selectable group header. */
@@ -19,13 +19,12 @@ export interface ExtensionSelectorOptions {
 	timeout?: number;
 }
 
-export class ExtensionSelectorComponent extends Container {
+export class ExtensionSelectorComponent extends DialogContainer {
 	private options: string[];
 	private selectedIndex = 0;
 	private listContainer: Container;
 	private onSelectCallback: (option: string) => void;
 	private onCancelCallback: () => void;
-	private titleText: Text;
 	private baseTitle: string;
 	private countdown: CountdownTimer | undefined;
 
@@ -36,25 +35,27 @@ export class ExtensionSelectorComponent extends Container {
 		onCancel: () => void,
 		opts?: ExtensionSelectorOptions,
 	) {
-		super();
+		const dialogTitle = splitDialogTitle(title);
+		super(dialogTitle.title);
 
 		this.options = options;
 		this.onSelectCallback = onSelect;
 		this.onCancelCallback = onCancel;
-		this.baseTitle = title;
+		this.baseTitle = dialogTitle.title;
 
-		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
-
-		this.titleText = new Text(theme.fg("accent", title), 1, 0);
-		this.addChild(this.titleText);
-		this.addChild(new Spacer(1));
+		for (const detail of dialogTitle.detailLines) {
+			this.addChild(new Text(theme.fg("text", detail), 1, 0));
+		}
+		if (dialogTitle.detailLines.length > 0) {
+			this.addChild(new Spacer(1));
+		}
 
 		if (opts?.timeout && opts.timeout > 0 && opts.tui) {
 			this.countdown = new CountdownTimer(
 				opts.timeout,
 				opts.tui,
-				(s) => this.titleText.setText(theme.fg("accent", `${this.baseTitle} (${s}s)`)),
+				(s) => this.setDialogTitle(`${this.baseTitle} (${s}s)`),
 				() => this.onCancelCallback(),
 			);
 		}
@@ -70,7 +71,6 @@ export class ExtensionSelectorComponent extends Container {
 			),
 		);
 		this.addChild(new Spacer(1));
-		this.addChild(new DynamicBorder());
 
 		// Start on the first selectable (non-separator) item
 		this.selectedIndex = this.nextSelectable(0, 1);

--- a/packages/gsd-agent-modes/src/modes/interactive/components/index.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/index.ts
@@ -8,6 +8,7 @@ export { CompactionSummaryMessageComponent } from "./compaction-summary-message.
 export { CustomEditor } from "./custom-editor.js";
 export { CustomMessageComponent } from "./custom-message.js";
 export { DaxnutsComponent } from "./daxnuts.js";
+export { DialogContainer } from "./dialog-container.js";
 export { type RenderDiffOptions, renderDiff } from "./diff.js";
 export { DynamicBorder } from "./dynamic-border.js";
 export { ExtensionEditorComponent } from "./extension-editor.js";

--- a/packages/gsd-agent-modes/src/modes/interactive/components/interactive-key-handling.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/interactive-key-handling.test.ts
@@ -1,18 +1,21 @@
 // gsd-pi + packages/pi-coding-agent/src/modes/interactive/components/interactive-key-handling.test.ts - Interactive component key handling regressions.
 
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	EditorKeybindingsManager,
 	setEditorKeybindings,
 	setKittyProtocolActive,
 	TUI,
+	visibleWidth,
 	type EditorTheme,
 	type Terminal,
 } from "@gsd/pi-tui";
 import { KeybindingsManager } from "@gsd/agent-core";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { CustomEditor } from "./custom-editor.js";
+import { ExtensionEditorComponent } from "./extension-editor.js";
 import { ExtensionInputComponent } from "./extension-input.js";
 import { ExtensionSelectorComponent } from "./extension-selector.js";
 
@@ -46,6 +49,22 @@ const editorTheme: EditorTheme = {
 		noMatch: (text) => text,
 	},
 };
+
+function assertFullOuterBorder(lines: string[], width: number): void {
+	assert.ok(lines.length >= 2, "dialog must include top and bottom borders");
+	for (const [index, line] of lines.entries()) {
+		assert.equal(visibleWidth(line), width, `line ${index} must fill dialog width`);
+	}
+	const top = stripVTControlCharacters(lines[0] ?? "");
+	const bottom = stripVTControlCharacters(lines.at(-1) ?? "");
+	assert.match(top, /^[╭┌].*[╮┐]$/);
+	assert.match(bottom, /^[╰└].*[╯┘]$/);
+	for (let index = 1; index < lines.length - 1; index++) {
+		const line = stripVTControlCharacters(lines[index] ?? "");
+		assert.match(line, /^[│┃├]/, `line ${index} missing left border: ${line}`);
+		assert.match(line, /[│┃┤]$/, `line ${index} missing right border: ${line}`);
+	}
+}
 
 describe("interactive component key handling", () => {
 	beforeEach(() => {
@@ -105,6 +124,20 @@ describe("interactive component key handling", () => {
 		selector.handleInput("\r");
 
 		assert.equal(selected, "beta");
+	});
+
+	it("extension selector, input, and editor render full dialog borders", () => {
+		const width = 80;
+		const tui = new TUI(makeTerminal());
+		const components = [
+			new ExtensionSelectorComponent("Pick\nChoose one", ["alpha", "beta"], () => {}, () => {}),
+			new ExtensionInputComponent("Input\nType a value", "placeholder", () => {}, () => {}),
+			new ExtensionEditorComponent(tui, KeybindingsManager.inMemory(), "Editor\nWrite details", "", () => {}, () => {}),
+		];
+
+		for (const component of components) {
+			assertFullOuterBorder(component.render(width), width);
+		}
 	});
 
 	it("custom editor treats the legacy alt-enter sequence as newline outside kitty mode", () => {

--- a/src/resources/extensions/get-secrets-from-user.ts
+++ b/src/resources/extensions/get-secrets-from-user.ts
@@ -13,6 +13,7 @@ import { resolve } from "node:path";
 import type { ExtensionAPI, Theme } from "@gsd/pi-coding-agent";
 import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth, wrapTextWithAnsi } from "@gsd/pi-tui";
 import { Type } from "@sinclair/typebox";
+import { renderSharedDialogFrame } from "./shared/dialog-frame.js";
 import { makeUI } from "./shared/tui.js";
 import { maskEditorLine, type ProgressStatus } from "./shared/mod.js";
 import { parseSecretsManifest, formatSecretsManifest } from "./gsd/files.js";
@@ -41,6 +42,10 @@ function maskPreview(value: string): string {
 	if (!value) return "";
 	if (value.length <= 8) return "*".repeat(value.length);
 	return `${value.slice(0, 4)}${"*".repeat(Math.max(4, value.length - 8))}${value.slice(-4)}`;
+}
+
+function dialogContentWidth(width: number): number {
+	return width < 4 ? Math.max(1, width) : Math.max(1, width - 4);
 }
 
 function shellEscapeSingle(value: string): string {
@@ -168,10 +173,10 @@ async function collectOneSecret(
 
 		function render(width: number): string[] {
 			if (cachedLines) return cachedLines;
+			const contentWidth = dialogContentWidth(width);
 			const lines: string[] = [];
-			const add = (s: string) => lines.push(truncateToWidth(s, width));
+			const add = (s: string) => lines.push(truncateToWidth(s, contentWidth));
 
-			add(theme.fg("accent", "─".repeat(width)));
 			add(theme.fg("dim", ` Page ${pageIndex + 1}/${totalPages} · Secure Env Setup`));
 			lines.push("");
 
@@ -187,7 +192,7 @@ async function collectOneSecret(
 				for (let g = 0; g < guidance.length; g++) {
 					const prefix = `  ${g + 1}. `;
 					const step = guidance[g] as string;
-					const wrappedLines = wrapTextWithAnsi(step, width - 4);
+					const wrappedLines = wrapTextWithAnsi(step, Math.max(1, contentWidth - 4));
 					for (let w = 0; w < wrappedLines.length; w++) {
 						const indent = w === 0 ? prefix : " ".repeat(prefix.length);
 						lines.push(theme.fg("dim", `${indent}${wrappedLines[w]}`));
@@ -205,16 +210,15 @@ async function collectOneSecret(
 
 			// Editor
 			add(theme.fg("muted", " Enter value:"));
-			for (const line of editor.render(width - 2)) {
+			for (const line of editor.render(Math.max(1, contentWidth - 2))) {
 				add(theme.fg("text", maskEditorLine(line)));
 			}
 
 			lines.push("");
-			add(theme.fg("dim", ` enter to confirm  |  ctrl+s or esc to skip  |  esc cancels`));
-			add(theme.fg("accent", "─".repeat(width)));
+			const footer = theme.fg("dim", " enter to confirm  |  ctrl+s or esc to skip  |  esc cancels");
 
-			cachedLines = lines;
-			return lines;
+			cachedLines = renderSharedDialogFrame(theme, "Secure Env Setup", lines, width, { footer });
+			return cachedLines;
 		}
 
 		return {
@@ -286,13 +290,11 @@ export async function showSecretsSummary(
 		function render(width: number): string[] {
 			if (cachedLines) return cachedLines;
 
-			const ui = makeUI(theme, width);
+			const contentWidth = dialogContentWidth(width);
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
-			push(ui.bar());
-			push(ui.blank());
-			push(ui.header("  Secrets Summary"));
 			push(ui.blank());
 
 			for (const entry of entries) {
@@ -314,11 +316,10 @@ export async function showSecretsSummary(
 			}
 
 			push(ui.blank());
-			push(ui.hints(["any key to continue"]));
-			push(ui.bar());
+			const footer = ui.hints(["any key to continue"])[0] ?? "";
 
-			cachedLines = lines;
-			return lines;
+			cachedLines = renderSharedDialogFrame(theme, "Secrets Summary", lines, width, { footer });
+			return cachedLines;
 		}
 
 		return {

--- a/src/resources/extensions/gsd/commands-usage.ts
+++ b/src/resources/extensions/gsd/commands-usage.ts
@@ -4,10 +4,11 @@
  * Shows current LLM context window usage and session token totals.
  */
 
-import type { ExtensionCommandContext, ContextUsage, SessionEntry } from "@gsd/pi-coding-agent";
+import type { ExtensionCommandContext, ContextUsage, SessionEntry, Theme } from "@gsd/pi-coding-agent";
 
 import { formatCost, formatPercent, formatTokenCount } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { renderDialogFrame, renderKeyHints } from "./tui/render-kit.js";
 
 export interface SessionTokenTotals {
   input: number;
@@ -160,6 +161,48 @@ export function formatUsageReport(options: {
   return lines.join("\n");
 }
 
+async function showUsageDialog(
+  ctx: ExtensionCommandContext,
+  reportText: string,
+): Promise<boolean | undefined> {
+  return ctx.ui.custom<boolean>((_tui, theme: Theme, _kb, done) => {
+    let cachedLines: string[] | undefined;
+    let cachedWidth: number | undefined;
+
+    function render(width: number): string[] {
+      if (cachedLines && cachedWidth === width) return cachedLines;
+
+      const contentWidth = Math.max(1, width - 4);
+      const body = reportText.split("\n");
+      if (body[0] === "Context Usage") body.shift();
+      while (body[0] === "") body.shift();
+
+      cachedLines = renderDialogFrame(theme, "Context Usage", body, width, {
+        footer: renderKeyHints(theme, ["any key close"], contentWidth),
+      });
+      cachedWidth = width;
+      return cachedLines;
+    }
+
+    return {
+      render,
+      invalidate: () => {
+        cachedLines = undefined;
+        cachedWidth = undefined;
+      },
+      handleInput: () => done(true),
+    };
+  }, {
+    overlay: true,
+    overlayOptions: {
+      width: "70%",
+      minWidth: 64,
+      maxHeight: "80%",
+      anchor: "center",
+    },
+  });
+}
+
 export async function handleUsage(args: string, ctx: ExtensionCommandContext): Promise<void> {
   const contextUsage = ctx.getContextUsage?.();
   const sessionTotals = scanSessionTokenTotals(ctx.sessionManager.getEntries());
@@ -187,8 +230,16 @@ export async function handleUsage(args: string, ctx: ExtensionCommandContext): P
     return;
   }
 
-  ctx.ui.notify(
-    formatUsageReport({ modelLabel, contextUsage, sessionTotals }),
-    "info",
-  );
+  const reportText = formatUsageReport({ modelLabel, contextUsage, sessionTotals });
+
+  if (ctx.hasUI) {
+    try {
+      const result = await showUsageDialog(ctx, reportText);
+      if (result !== undefined) return;
+    } catch {
+      // Fall back to text notify below when custom overlays are unavailable.
+    }
+  }
+
+  ctx.ui.notify(reportText, "info");
 }

--- a/src/resources/extensions/gsd/commands-usage.ts
+++ b/src/resources/extensions/gsd/commands-usage.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ExtensionCommandContext, ContextUsage, SessionEntry, Theme } from "@gsd/pi-coding-agent";
+import { Key, matchesKey } from "@gsd/pi-tui";
 
 import { formatCost, formatPercent, formatTokenCount } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -165,23 +166,51 @@ async function showUsageDialog(
   ctx: ExtensionCommandContext,
   reportText: string,
 ): Promise<boolean | undefined> {
-  return ctx.ui.custom<boolean>((_tui, theme: Theme, _kb, done) => {
+  return ctx.ui.custom<boolean>((tui, theme: Theme, _kb, done) => {
     let cachedLines: string[] | undefined;
     let cachedWidth: number | undefined;
+    let cachedScrollOffset: number | undefined;
+    let scrollOffset = 0;
+    let lastMaxScroll = 0;
+    let lastVisibleRows = 1;
 
     function render(width: number): string[] {
-      if (cachedLines && cachedWidth === width) return cachedLines;
+      if (cachedLines && cachedWidth === width && cachedScrollOffset === scrollOffset) return cachedLines;
 
       const contentWidth = Math.max(1, width - 4);
       const body = reportText.split("\n");
       if (body[0] === "Context Usage") body.shift();
       while (body[0] === "") body.shift();
+      const terminalRows = process.stdout.rows || 0;
+      const maxOverlayRows = terminalRows > 0 ? Math.max(5, Math.floor(terminalRows * 0.8)) : 24;
+      const frameRows = 4;
+      const visibleRows = Math.max(1, maxOverlayRows - frameRows);
+      const maxScroll = Math.max(0, body.length - visibleRows);
+      scrollOffset = Math.min(Math.max(scrollOffset, 0), maxScroll);
+      lastMaxScroll = maxScroll;
+      lastVisibleRows = visibleRows;
+      const visible = body.slice(scrollOffset, scrollOffset + visibleRows);
+      const scrollable = body.length > visibleRows;
 
-      cachedLines = renderDialogFrame(theme, "Context Usage", body, width, {
-        footer: renderKeyHints(theme, ["any key close"], contentWidth),
+      cachedLines = renderDialogFrame(theme, "Context Usage", visible, width, {
+        footer: renderKeyHints(theme, scrollable ? ["↑↓ scroll", "any key close"] : ["any key close"], contentWidth),
+        scroll: { offset: scrollOffset, visibleRows, totalRows: body.length },
       });
       cachedWidth = width;
+      cachedScrollOffset = scrollOffset;
       return cachedLines;
+    }
+
+    function scrollBy(delta: number): boolean {
+      if (lastMaxScroll <= 0) return false;
+      const nextOffset = Math.min(Math.max(scrollOffset + delta, 0), lastMaxScroll);
+      if (nextOffset !== scrollOffset) {
+        scrollOffset = nextOffset;
+        cachedLines = undefined;
+        cachedScrollOffset = undefined;
+        tui.requestRender();
+      }
+      return true;
     }
 
     return {
@@ -189,8 +218,23 @@ async function showUsageDialog(
       invalidate: () => {
         cachedLines = undefined;
         cachedWidth = undefined;
+        cachedScrollOffset = undefined;
       },
-      handleInput: () => done(true),
+      handleInput: (data: string) => {
+        if (matchesKey(data, Key.down) || matchesKey(data, "j")) {
+          if (scrollBy(1)) return;
+        }
+        if (matchesKey(data, Key.up) || matchesKey(data, "k")) {
+          if (scrollBy(-1)) return;
+        }
+        if (matchesKey(data, Key.pageDown)) {
+          if (scrollBy(lastVisibleRows)) return;
+        }
+        if (matchesKey(data, Key.pageUp)) {
+          if (scrollBy(-lastVisibleRows)) return;
+        }
+        done(true);
+      },
     };
   }, {
     overlay: true,

--- a/src/resources/extensions/gsd/commands-usage.ts
+++ b/src/resources/extensions/gsd/commands-usage.ts
@@ -169,19 +169,27 @@ async function showUsageDialog(
   return ctx.ui.custom<boolean>((tui, theme: Theme, _kb, done) => {
     let cachedLines: string[] | undefined;
     let cachedWidth: number | undefined;
+    let cachedRows: number | undefined;
     let cachedScrollOffset: number | undefined;
     let scrollOffset = 0;
     let lastMaxScroll = 0;
     let lastVisibleRows = 1;
 
     function render(width: number): string[] {
-      if (cachedLines && cachedWidth === width && cachedScrollOffset === scrollOffset) return cachedLines;
+      const terminalRows = process.stdout.rows || 0;
+      if (
+        cachedLines &&
+        cachedWidth === width &&
+        cachedRows === terminalRows &&
+        cachedScrollOffset === scrollOffset
+      ) {
+        return cachedLines;
+      }
 
       const contentWidth = Math.max(1, width - 4);
       const body = reportText.split("\n");
       if (body[0] === "Context Usage") body.shift();
       while (body[0] === "") body.shift();
-      const terminalRows = process.stdout.rows || 0;
       const maxOverlayRows = terminalRows > 0 ? Math.max(5, Math.floor(terminalRows * 0.8)) : 24;
       const frameRows = 4;
       const visibleRows = Math.max(1, maxOverlayRows - frameRows);
@@ -197,6 +205,7 @@ async function showUsageDialog(
         scroll: { offset: scrollOffset, visibleRows, totalRows: body.length },
       });
       cachedWidth = width;
+      cachedRows = terminalRows;
       cachedScrollOffset = scrollOffset;
       return cachedLines;
     }
@@ -218,6 +227,7 @@ async function showUsageDialog(
       invalidate: () => {
         cachedLines = undefined;
         cachedWidth = undefined;
+        cachedRows = undefined;
         cachedScrollOffset = undefined;
       },
       handleInput: (data: string) => {

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -318,7 +318,7 @@ export class GSDConfigOverlay {
 
     // Apply scroll
     const terminalRows = process.stdout.rows || 32;
-    const maxBodyRows = Math.max(8, Math.min(allLines.length, terminalRows - 8));
+    const maxBodyRows = Math.max(1, Math.min(allLines.length, terminalRows - 12));
     const maxScroll = Math.max(0, allLines.length - maxBodyRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
     const visible = allLines.slice(this.scrollOffset, this.scrollOffset + maxBodyRows);

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -10,6 +10,7 @@
 import type { Theme } from "@gsd/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth } from "@gsd/pi-tui";
 
+import { renderDialogFrame, renderKeyHints } from "./tui/render-kit.js";
 import {
   loadEffectiveGSDPreferences,
   loadGlobalGSDPreferences,
@@ -231,6 +232,7 @@ export class GSDConfigOverlay {
   private onClose: () => void;
   private sections: ConfigSection[];
   private cachedLines?: string[];
+  private cachedWidth?: number;
   private scrollOffset = 0;
   private disposed = false;
 
@@ -247,6 +249,7 @@ export class GSDConfigOverlay {
 
   invalidate(): void {
     this.cachedLines = undefined;
+    this.cachedWidth = undefined;
   }
 
   dispose(): void {
@@ -286,15 +289,12 @@ export class GSDConfigOverlay {
   }
 
   render(width: number): string[] {
-    if (this.cachedLines) return this.cachedLines;
+    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
 
     const t = this.theme;
-    const w = Math.max(width, 50);
+    const w = Math.max(1, width);
+    const contentWidth = Math.max(1, w - 4);
     const allLines: string[] = [];
-
-    // Header
-    allLines.push(t.bold(t.fg("accent", " GSD Configuration ")));
-    allLines.push(t.fg("muted", "\u2500".repeat(w)));
 
     // Find max label width for alignment
     let maxLabel = 0;
@@ -306,26 +306,29 @@ export class GSDConfigOverlay {
     const labelPad = Math.min(maxLabel + 2, 24);
 
     for (const section of this.sections) {
-      allLines.push("");
+      if (allLines.length > 0) allLines.push("");
       allLines.push(t.bold(t.fg("accent", `  ${section.title}`)));
 
       for (const row of section.rows) {
         const label = t.fg("muted", `    ${row.label.padEnd(labelPad)}`);
         const value = row.accent ? t.bold(row.value) : row.value;
-        allLines.push(truncateToWidth(`${label}${value}`, w));
+        allLines.push(truncateToWidth(`${label}${value}`, contentWidth));
       }
     }
 
-    allLines.push("");
-    allLines.push(t.fg("muted", `  ${"\u2500".repeat(w - 4)}`));
-    allLines.push(t.fg("muted", "  esc/q close  \u2502  \u2191\u2193/jk scroll  \u2502  /gsd prefs to edit"));
-
     // Apply scroll
-    const maxScroll = Math.max(0, allLines.length - 20);
+    const terminalRows = process.stdout.rows || 32;
+    const maxBodyRows = Math.max(8, Math.min(allLines.length, terminalRows - 8));
+    const maxScroll = Math.max(0, allLines.length - maxBodyRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
-    const visible = allLines.slice(this.scrollOffset);
+    const visible = allLines.slice(this.scrollOffset, this.scrollOffset + maxBodyRows);
+    const footer = renderKeyHints(t, ["esc/q close", "\u2191\u2193/jk scroll", "/gsd prefs to edit"], contentWidth);
 
-    this.cachedLines = visible;
-    return visible;
+    this.cachedLines = renderDialogFrame(t, "GSD Configuration", visible, w, {
+      footer,
+      scroll: { offset: this.scrollOffset, visibleRows: maxBodyRows, totalRows: allLines.length },
+    });
+    this.cachedWidth = width;
+    return this.cachedLines;
   }
 }

--- a/src/resources/extensions/gsd/context-overlay.ts
+++ b/src/resources/extensions/gsd/context-overlay.ts
@@ -188,7 +188,7 @@ export class GSDContextOverlay {
     lines.push(`    ${theme.fg("muted", "Subagent spawns")} ${theme.fg("text", String(this.report.subagentSpawns))}`);
 
     const terminalRows = process.stdout.rows || 32;
-    const maxBodyRows = Math.max(8, Math.min(lines.length, terminalRows - 8));
+    const maxBodyRows = Math.max(1, Math.min(lines.length, terminalRows - 12));
     const maxScroll = Math.max(0, lines.length - maxBodyRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
     const visible = lines.slice(this.scrollOffset, this.scrollOffset + maxBodyRows);

--- a/src/resources/extensions/gsd/context-overlay.ts
+++ b/src/resources/extensions/gsd/context-overlay.ts
@@ -3,11 +3,11 @@
  */
 
 import type { Theme, ThemeColor } from "@gsd/pi-coding-agent";
-import { matchesKey, Key, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { matchesKey, Key, truncateToWidth } from "@gsd/pi-tui";
 
 import type { ContextBreakdownReport, ContextSectionBreakdown } from "./commands-context.js";
 import { formatTokenCount } from "./metrics.js";
-import { renderProgressBar, rightAlign } from "./tui/render-kit.js";
+import { renderDialogFrame, renderKeyHints, renderProgressBar, rightAlign } from "./tui/render-kit.js";
 
 const SECTION_COLORS: ThemeColor[] = ["accent", "success", "warning", "borderAccent", "text"];
 
@@ -70,6 +70,7 @@ export class GSDContextOverlay {
   private onClose: () => void;
   private report: ContextBreakdownReport;
   private cachedLines?: string[];
+  private cachedWidth?: number;
   private scrollOffset = 0;
   private disposed = false;
 
@@ -87,6 +88,7 @@ export class GSDContextOverlay {
 
   invalidate(): void {
     this.cachedLines = undefined;
+    this.cachedWidth = undefined;
   }
 
   dispose(): void {
@@ -125,24 +127,22 @@ export class GSDContextOverlay {
   }
 
   render(width: number): string[] {
-    if (this.cachedLines) return this.cachedLines;
+    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
 
     const theme = this.theme;
-    const w = Math.max(width, 60);
+    const w = Math.max(1, width);
+    const contentWidth = Math.max(1, w - 4);
     const totals = getContextChartTotals(this.report);
     const chartTotal = Math.max(totals.inContext, totals.estimated, 1);
     const lines: string[] = [];
 
-    lines.push(theme.bold(theme.fg("accent", " Context Breakdown ")));
-    lines.push(theme.fg("muted", "─".repeat(w)));
-
     if (this.report.modelLabel) {
-      lines.push(rightAlign(theme.fg("muted", "Model"), theme.fg("text", this.report.modelLabel), w));
+      lines.push(rightAlign(theme.fg("muted", "Model"), theme.fg("text", this.report.modelLabel), contentWidth));
     }
 
     lines.push("");
     if (totals.window != null) {
-      const usageBarWidth = Math.max(20, w - 28);
+      const usageBarWidth = Math.max(8, contentWidth - 28);
       const usageBar = renderProgressBar(theme, totals.inContext, totals.window, usageBarWidth, {
         filledColor: totals.inContext / totals.window > 0.85 ? "warning" : "accent",
       });
@@ -151,7 +151,7 @@ export class GSDContextOverlay {
       lines.push(`  ${theme.fg("muted", "Estimated")} ${theme.fg("text", formatTokenCount(chartTotal))}`);
     }
 
-    const splitWidth = Math.max(16, Math.floor((w - 8) / 2));
+    const splitWidth = Math.max(8, Math.floor((contentWidth - 8) / 2));
     const systemBar = renderProgressBar(theme, totals.systemTokens, chartTotal, splitWidth, { filledColor: "accent" });
     const convBar = renderProgressBar(theme, totals.conversationTokens, chartTotal, splitWidth, { filledColor: "success" });
     lines.push("");
@@ -160,11 +160,11 @@ export class GSDContextOverlay {
 
     lines.push("");
     lines.push(theme.bold(theme.fg("accent", "  System prompt")));
-    lines.push(...renderSectionBars(theme, this.report.systemSections, chartTotal, w, 22));
+    lines.push(...renderSectionBars(theme, this.report.systemSections, chartTotal, contentWidth, 22));
 
     lines.push("");
     lines.push(theme.bold(theme.fg("accent", "  Conversation")));
-    lines.push(...renderSectionBars(theme, this.report.conversationSections, chartTotal, w, 22));
+    lines.push(...renderSectionBars(theme, this.report.conversationSections, chartTotal, contentWidth, 22));
 
     lines.push("");
     lines.push(theme.bold(theme.fg("accent", "  Skills")));
@@ -172,7 +172,7 @@ export class GSDContextOverlay {
     if (skills.available.length > 0) {
       lines.push(`    ${theme.fg("muted", "Available")} ${theme.fg("text", `${skills.available.length}`)}`);
       const preview = skills.available.slice(0, 8).join(", ");
-      lines.push(truncateToWidth(`      ${preview}${skills.available.length > 8 ? "…" : ""}`, w));
+      lines.push(truncateToWidth(`      ${preview}${skills.available.length > 8 ? "…" : ""}`, contentWidth));
     } else {
       lines.push(theme.fg("dim", "    none in prompt"));
     }
@@ -187,13 +187,18 @@ export class GSDContextOverlay {
     lines.push(theme.bold(theme.fg("accent", "  Agents")));
     lines.push(`    ${theme.fg("muted", "Subagent spawns")} ${theme.fg("text", String(this.report.subagentSpawns))}`);
 
-    lines.push("");
-    lines.push(theme.fg("muted", `  ${"─".repeat(Math.max(0, w - 4))}`));
-    lines.push(theme.fg("muted", "  esc/q close  │  ↑↓ scroll  │  /gsd context --open for browser chart"));
-
-    const maxScroll = Math.max(0, lines.length - 24);
+    const terminalRows = process.stdout.rows || 32;
+    const maxBodyRows = Math.max(8, Math.min(lines.length, terminalRows - 8));
+    const maxScroll = Math.max(0, lines.length - maxBodyRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
-    this.cachedLines = lines.slice(this.scrollOffset);
+    const visible = lines.slice(this.scrollOffset, this.scrollOffset + maxBodyRows);
+    const footer = renderKeyHints(theme, ["esc/q close", "↑↓ scroll", "/gsd context --open"], contentWidth);
+
+    this.cachedLines = renderDialogFrame(theme, "Context Breakdown", visible, w, {
+      footer,
+      scroll: { offset: this.scrollOffset, visibleRows: maxBodyRows, totalRows: lines.length },
+    });
+    this.cachedWidth = width;
     return this.cachedLines;
   }
 }

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Theme } from "@gsd/pi-coding-agent";
-import { truncateToWidth, visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
+import { truncateToWidth, matchesKey, Key } from "@gsd/pi-tui";
 import { deriveState } from "./state.js";
 import { loadFile } from "./files.js";
 import { isDbAvailable, getMilestoneSlices, getSliceTasks } from "./gsd-db.js";
@@ -29,6 +29,7 @@ import { estimateTimeRemaining } from "./auto-dashboard.js";
 import { computeProgressScore, formatProgressLine } from "./progress-score.js";
 import { runEnvironmentChecks, type EnvironmentCheckResult } from "./doctor-environment.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
+import { renderDialogFrame, renderKeyHints } from "./tui/render-kit.js";
 
 export function unitLabel(type: string): string {
   switch (type) {
@@ -258,32 +259,23 @@ export class GSDDashboardOverlay {
 
     const content = this.buildContentLines(width);
     const viewportHeight = Math.max(5, process.stdout.rows ? process.stdout.rows - 8 : 24);
-    const chromeHeight = 2;
-    const visibleContentRows = Math.max(1, viewportHeight - chromeHeight);
+    const visibleContentRows = Math.max(1, viewportHeight - 4);
     const maxScroll = Math.max(0, content.length - visibleContentRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
     const visibleContent = content.slice(this.scrollOffset, this.scrollOffset + visibleContentRows);
-
-    const lines = this.wrapInBox(visibleContent, width);
+    const contentWidth = Math.max(1, width - 4);
+    const footer = renderKeyHints(
+      this.theme,
+      ["↑↓ scroll", "g/G top/end", `Esc/${formattedShortcutPair("dashboard")} close`],
+      contentWidth,
+    );
+    const lines = renderDialogFrame(this.theme, "GSD Dashboard", visibleContent, width, {
+      footer,
+      scroll: { offset: this.scrollOffset, visibleRows: visibleContentRows, totalRows: content.length },
+    });
 
     this.cachedWidth = width;
     this.cachedLines = lines;
-    return lines;
-  }
-
-  private wrapInBox(inner: string[], width: number): string[] {
-    const th = this.theme;
-    const border = (s: string) => th.fg("borderAccent", s);
-    const innerWidth = width - 4;
-    const lines: string[] = [];
-
-    lines.push(border("╭" + "─".repeat(width - 2) + "╮"));
-    for (const line of inner) {
-      const truncated = truncateToWidth(line, innerWidth);
-      const padWidth = Math.max(0, innerWidth - visibleWidth(truncated));
-      lines.push(border("│") + " " + truncated + " ".repeat(padWidth) + " " + border("│"));
-    }
-    lines.push(border("╰" + "─".repeat(width - 2) + "╯"));
     return lines;
   }
 
@@ -303,7 +295,6 @@ export class GSDDashboardOverlay {
     const hr = () => row(th.fg("dim", "─".repeat(contentWidth)));
     const centered = (content: string) => row(centerLine(content, contentWidth));
 
-    const title = th.fg("accent", th.bold("GSD Dashboard"));
     const isRemote = !!this.dashData.remoteSession;
     const status = this.dashData.active
       ? `${Date.now() % 2000 < 1000 ? th.fg("success", "●") : th.fg("dim", "○")} ${th.fg("success", "AUTO")}`
@@ -328,7 +319,7 @@ export class GSDDashboardOverlay {
     } else if (isRemote) {
       elapsedParts = th.fg("dim", `since ${this.dashData.remoteSession!.startedAt.replace("T", " ").slice(0, 19)}`);
     }
-    lines.push(row(joinColumns(`${title}  ${status}${worktreeTag}`, elapsedParts, contentWidth)));
+    lines.push(row(joinColumns(`${status}${worktreeTag}`, elapsedParts, contentWidth)));
 
     // Progress score — traffic light indicator (#1221)
     if (this.dashData.active || this.dashData.paused) {
@@ -609,10 +600,6 @@ export class GSDDashboardOverlay {
         }
       }
     }
-
-    lines.push(blank());
-    lines.push(hr());
-    lines.push(centered(th.fg("dim", `↑↓ scroll · g/G top/end · Esc/${formattedShortcutPair("dashboard")} close`)));
 
     return lines;
   }

--- a/src/resources/extensions/gsd/notification-overlay.ts
+++ b/src/resources/extensions/gsd/notification-overlay.ts
@@ -15,7 +15,7 @@ import {
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import {
   padRightVisible,
-  renderFrame,
+  renderDialogFrame,
   renderKeyHints,
   rightAlign,
   wrapVisibleText,
@@ -200,13 +200,20 @@ export class GSDNotificationOverlay {
       availableRows,
       Math.max(1, Math.floor((terminalRows * OVERLAY_MAX_HEIGHT_PERCENT) / 100)),
     );
-    const maxVisibleRows = Math.max(5, overlayRows - 2);
+    const maxVisibleRows = Math.max(5, overlayRows - 4);
     const visibleContentRows = Math.min(content.length, maxVisibleRows);
     const maxScroll = Math.max(0, content.length - visibleContentRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
     const visibleContent = content.slice(this.scrollOffset, this.scrollOffset + visibleContentRows);
-
-    const lines = renderFrame(this.theme, visibleContent, width);
+    const footer = renderKeyHints(
+      this.theme,
+      ["↑/↓ scroll", "f filter", "c clear", `Esc/${formattedShortcutPair("notifications")} close`],
+      Math.max(1, width - 4),
+    );
+    const lines = renderDialogFrame(this.theme, "Notifications", visibleContent, width, {
+      footer,
+      scroll: { offset: this.scrollOffset, visibleRows: visibleContentRows, totalRows: content.length },
+    });
 
     this.cachedWidth = width;
     this.cachedLines = lines;
@@ -256,8 +263,6 @@ export class GSDNotificationOverlay {
     const blank = () => row("");
     const hr = () => row(th.fg("dim", "─".repeat(contentWidth)));
 
-    // Header
-    const title = th.fg("accent", th.bold("Notifications"));
     const filterLabel = this.filter === "all"
       ? th.fg("dim", "all")
       : th.fg(
@@ -269,15 +274,11 @@ export class GSDNotificationOverlay {
       );
     const count = `${this.filteredEntries.length} entries`;
     lines.push(row(rightAlign(
-      `${title}  ${th.fg("dim", "filter:")} ${filterLabel}`,
+      `${th.fg("dim", "filter:")} ${filterLabel}`,
       th.fg("dim", count),
       contentWidth,
     )));
     lines.push(hr());
-
-    // Controls
-    const closeShortcut = formattedShortcutPair("notifications");
-    lines.push(row(renderKeyHints(th, ["↑/↓ scroll", "f filter", "c clear", `Esc/${closeShortcut} close`], contentWidth)));
     lines.push(blank());
 
     // Entries

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -493,7 +493,7 @@ export class ParallelMonitorOverlay {
 
     // Apply scroll — use terminal rows as height estimate
     const termHeight = process.stdout.rows || 40;
-    const maxBodyRows = Math.max(6, Math.min(lines.length, termHeight - 8));
+    const maxBodyRows = Math.max(1, Math.min(lines.length, termHeight - 12));
     const maxScroll = Math.max(0, lines.length - maxBodyRows);
     this.scrollOffset = Math.min(Math.max(this.scrollOffset, 0), maxScroll);
     const visible = lines

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -13,6 +13,7 @@ import { formattedShortcutPair } from "./shortcut-defs.js";
 import { resolveGsdPathContract } from "./paths.js";
 import {
   renderBar,
+  renderDialogFrame,
   renderKeyHints,
   renderProgressBar,
   safeLine,
@@ -378,19 +379,18 @@ export class ParallelMonitorOverlay {
     const t = this.theme;
     const lines: string[] = [];
     const w = Math.max(1, width);
+    const contentWidth = Math.max(1, w - 4);
 
-    // Header
     const totalCost = this.workers.reduce((s, wk) => s + wk.cost, 0);
     const aliveCount = this.workers.filter((wk) => wk.alive).length;
     const now = new Date().toLocaleTimeString();
 
-    lines.push(t.bold(t.fg("accent", " GSD Parallel Monitor ")));
     lines.push(
       t.fg("muted", `  ${now}  │  ${aliveCount}/${this.workers.length} alive  │  Total: `) +
       t.bold(`$${totalCost.toFixed(2)}`) +
       t.fg("muted", "  │  5s refresh"),
     );
-    lines.push(renderBar(t, w));
+    lines.push(renderBar(t, contentWidth));
 
     if (this.workers.length === 0) {
       lines.push("");
@@ -444,7 +444,7 @@ export class ParallelMonitorOverlay {
           lines.push(`     ${t.fg("muted", "slices")}  ${chips.join("  ")}`);
 
           // Task progress bar
-          const barWidth = Math.max(6, Math.min(25, w - 32));
+          const barWidth = Math.max(6, Math.min(25, contentWidth - 32));
           const bar = renderProgressBar(t, wk.doneTasks, wk.totalTasks, barWidth, {
             filledChar: "█",
             emptyChar: "░",
@@ -466,7 +466,7 @@ export class ParallelMonitorOverlay {
 
     // Event feed
     lines.push("");
-    lines.push(renderBar(t, w));
+    lines.push(renderBar(t, contentWidth));
     lines.push(`  ${t.bold("Recent Events")}`);
 
     if (this.events.length === 0) {
@@ -478,7 +478,6 @@ export class ParallelMonitorOverlay {
       }
     }
 
-    // Footer
     lines.push("");
     const allDone = this.workers.length > 0 && this.workers.every((wk) => !wk.alive);
     if (allDone) {
@@ -491,17 +490,22 @@ export class ParallelMonitorOverlay {
       }
       lines.push(`  ${t.bold("Total: $" + this.workers.reduce((s, wk) => s + wk.cost, 0).toFixed(2))}`);
     }
-    lines.push(renderKeyHints(t, [`ESC/q/${formattedShortcutPair("parallel")} close`, "↑↓ scroll"], w));
 
     // Apply scroll — use terminal rows as height estimate
     const termHeight = process.stdout.rows || 40;
-    const maxScroll = Math.max(0, lines.length - termHeight);
+    const maxBodyRows = Math.max(6, Math.min(lines.length, termHeight - 8));
+    const maxScroll = Math.max(0, lines.length - maxBodyRows);
     this.scrollOffset = Math.min(Math.max(this.scrollOffset, 0), maxScroll);
     const visible = lines
-      .slice(this.scrollOffset, this.scrollOffset + termHeight)
-      .map((line) => safeLine(line, w));
-    this.cachedLines = visible;
+      .slice(this.scrollOffset, this.scrollOffset + maxBodyRows)
+      .map((line) => safeLine(line, contentWidth));
+    const footer = renderKeyHints(t, [`ESC/q/${formattedShortcutPair("parallel")} close`, "↑↓ scroll"], contentWidth);
+
+    this.cachedLines = renderDialogFrame(t, "GSD Parallel Monitor", visible, w, {
+      footer,
+      scroll: { offset: this.scrollOffset, visibleRows: maxBodyRows, totalRows: lines.length },
+    });
     this.cachedWidth = width;
-    return visible;
+    return this.cachedLines;
   }
 }

--- a/src/resources/extensions/gsd/queue-reorder-ui.ts
+++ b/src/resources/extensions/gsd/queue-reorder-ui.ts
@@ -11,9 +11,9 @@
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { type Theme } from "@gsd/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, type TUI } from "@gsd/pi-tui";
-import { makeUI } from "../shared/tui.js";
 import { GLYPH } from "../shared/mod.js";
 import { validateQueueOrder, type DependencyValidation } from "./queue-order.js";
+import { renderDialogFrame, renderKeyHints } from "./tui/render-kit.js";
 
 export interface ReorderItem {
   id: string;
@@ -45,6 +45,7 @@ export async function showQueueReorder(
     let grabbed = false;
     let scrollOffset = 0;
     let cachedLines: string[] | undefined;
+    let cachedWidth: number | undefined;
     let validation: DependencyValidation;
 
     // Mutable deps map — tracks removals during this session
@@ -66,6 +67,7 @@ export async function showQueueReorder(
 
     function refresh() {
       cachedLines = undefined;
+      cachedWidth = undefined;
       tui.requestRender();
     }
 
@@ -151,17 +153,15 @@ export async function showQueueReorder(
     }
 
     function render(width: number): string[] {
-      if (cachedLines) return cachedLines;
+      if (cachedLines && cachedWidth === width) return cachedLines;
 
-      const ui = makeUI(theme, width);
+      const contentWidth = Math.max(1, width - 4);
       const lines: string[] = [];
       const queueRows: string[] = [];
-      const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
-      const add = (s: string) => truncateToWidth(s, width);
+      const add = (s: string) => truncateToWidth(s, contentWidth);
       let cursorQueueRow = 0;
 
-      const headerText = grabbed ? "  Queue Reorder — Moving Item" : "  Queue Reorder";
-      push(ui.bar(), ui.blank(), ui.header(headerText), ui.blank());
+      const headerText = grabbed ? "Queue Reorder - Moving Item" : "Queue Reorder";
 
       // Completed milestones (dimmed)
       if (completed.length > 0) {
@@ -170,7 +170,7 @@ export async function showQueueReorder(
           const label = m.title && m.title !== m.id ? `${m.id}  ${m.title}` : m.id;
           lines.push(add(`    ${theme.fg("dim", `${GLYPH.statusDone} ${label}`)}`));
         }
-        push(ui.blank());
+        lines.push("");
       }
 
       // Pending milestones
@@ -223,7 +223,7 @@ export async function showQueueReorder(
       // Removed deps feedback
       const trailingLines: string[] = [];
       if (removedDeps.length > 0) {
-        trailingLines.push(...ui.blank());
+        trailingLines.push("");
         for (const r of removedDeps) {
           trailingLines.push(add(`  ${theme.fg("success", `${GLYPH.statusDone} Removed: ${r.milestone} depends_on ${r.dep}`)}`));
         }
@@ -232,11 +232,9 @@ export async function showQueueReorder(
       // Circular warning
       const circ = validation.violations.find(v => v.type === 'circular');
       if (circ) {
-        trailingLines.push(...ui.blank());
+        trailingLines.push("");
         trailingLines.push(add(`  ${theme.fg("error", `${GLYPH.statusWarning} ${circ.message}`)}`));
       }
-
-      trailingLines.push(...ui.blank());
 
       // Hints — context-sensitive based on grab state
       const hints: string[] = [];
@@ -256,10 +254,9 @@ export async function showQueueReorder(
       }
       hints.push("esc");
 
-      trailingLines.push(...ui.hints(hints), ...ui.bar());
-
       const maxOverlayRows = Math.max(10, process.stdout.rows ? Math.floor(process.stdout.rows * 0.8) : 24);
-      const availableQueueRows = Math.max(1, maxOverlayRows - lines.length - trailingLines.length);
+      const frameRows = 4;
+      const availableQueueRows = Math.max(1, maxOverlayRows - frameRows - lines.length - trailingLines.length);
       const maxScroll = Math.max(0, queueRows.length - availableQueueRows);
       if (cursorQueueRow < scrollOffset) {
         scrollOffset = cursorQueueRow;
@@ -270,11 +267,15 @@ export async function showQueueReorder(
 
       lines.push(...queueRows.slice(scrollOffset, scrollOffset + availableQueueRows), ...trailingLines);
 
-      cachedLines = lines;
-      return lines;
+      cachedLines = renderDialogFrame(theme, headerText, lines, width, {
+        footer: renderKeyHints(theme, hints, contentWidth),
+        scroll: { offset: scrollOffset, visibleRows: availableQueueRows, totalRows: queueRows.length },
+      });
+      cachedWidth = width;
+      return cachedLines;
     }
 
-    return { render, invalidate: () => { cachedLines = undefined; }, handleInput };
+    return { render, invalidate: () => { cachedLines = undefined; cachedWidth = undefined; }, handleInput };
   }, {
     overlay: true,
     overlayOptions: { width: "70%", minWidth: 50, maxHeight: "80%", anchor: "center" },

--- a/src/resources/extensions/gsd/queue-reorder-ui.ts
+++ b/src/resources/extensions/gsd/queue-reorder-ui.ts
@@ -265,11 +265,19 @@ export async function showQueueReorder(
       }
       scrollOffset = Math.min(Math.max(scrollOffset, 0), maxScroll);
 
-      lines.push(...queueRows.slice(scrollOffset, scrollOffset + availableQueueRows), ...trailingLines);
+      const queueStartRow = lines.length;
+      const visibleQueueRows = queueRows.slice(scrollOffset, scrollOffset + availableQueueRows);
+      lines.push(...visibleQueueRows, ...trailingLines);
 
       cachedLines = renderDialogFrame(theme, headerText, lines, width, {
         footer: renderKeyHints(theme, hints, contentWidth),
-        scroll: { offset: scrollOffset, visibleRows: availableQueueRows, totalRows: queueRows.length },
+        scroll: {
+          offset: scrollOffset,
+          visibleRows: availableQueueRows,
+          totalRows: queueRows.length,
+          trackOffset: queueStartRow,
+          trackRows: visibleQueueRows.length,
+        },
       });
       cachedWidth = width;
       return cachedLines;

--- a/src/resources/extensions/gsd/tests/collect-from-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/collect-from-manifest.test.ts
@@ -16,7 +16,33 @@ import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { visibleWidth } from "@gsd/pi-tui";
 import type { SecretsManifest, SecretsManifestEntry } from "../types.ts";
+
+const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_PATTERN, "");
+}
+
+function assertFullOuterBorder(lines: string[], width: number): void {
+	assert.ok(lines.length >= 2, "dialog must include top and bottom borders");
+
+	for (const [index, line] of lines.entries()) {
+		assert.equal(visibleWidth(line), width, `line ${index} must fill dialog width`);
+	}
+
+	const top = stripAnsi(lines[0] ?? "");
+	const bottom = stripAnsi(lines.at(-1) ?? "");
+	assert.match(top, /^╭.*╮$/, `top border missing full corners: ${top}`);
+	assert.match(bottom, /^╰.*╯$/, `bottom border missing full corners: ${bottom}`);
+
+	for (let index = 1; index < lines.length - 1; index++) {
+		const line = stripAnsi(lines[index] ?? "");
+		assert.match(line, /^[│├]/, `line ${index} missing left border: ${line}`);
+		assert.match(line, /[│┤]$/, `line ${index} missing right border: ${line}`);
+	}
+}
 
 // Dynamic imports for files.ts functions to avoid cascading failure
 // when paths.js isn't available (files.ts statically imports paths.js)
@@ -300,6 +326,7 @@ test("showSecretsSummary: produces lines with correct status glyphs for each ent
 
 	assert.ok(renderFn, "render function should have been captured from factory");
 	const lines = renderFn!(80);
+	assertFullOuterBorder(lines, 80);
 
 	// Verify each key appears in the output
 	const output = lines.join("\n");
@@ -341,6 +368,7 @@ test("showSecretsSummary: existing keys shown with distinct status indicator", a
 
 	assert.ok(renderFn, "render function should have been captured");
 	const lines = renderFn!(80);
+	assertFullOuterBorder(lines, 80);
 	const output = lines.join("\n");
 
 	assert.ok(output.includes("NEW_KEY"), "should include NEW_KEY");
@@ -380,6 +408,7 @@ test("collectOneSecret: guidance lines appear in render output when guidance is 
 
 	assert.ok(renderFn, "render function should have been captured");
 	const lines = renderFn!(80);
+	assertFullOuterBorder(lines, 80);
 	const output = lines.join("\n");
 
 	// Verify guidance steps appear in the output
@@ -417,6 +446,7 @@ test("collectOneSecret: guidance lines wrap long URLs instead of truncating", as
 	assert.ok(renderFn, "render function should have been captured");
 	// Render at narrow width to force wrapping
 	const lines = renderFn!(50);
+	assertFullOuterBorder(lines, 50);
 	const output = lines.join("\n");
 
 	// The full URL should be present (wrapped, not truncated)
@@ -449,6 +479,7 @@ test("collectOneSecret: no guidance provided — render output has no guidance s
 
 	assert.ok(renderFn, "render function should have been captured");
 	const lines = renderFn!(80);
+	assertFullOuterBorder(lines, 80);
 	const output = lines.join("\n");
 
 	// Should include the key name and hint but no numbered guidance steps

--- a/src/resources/extensions/gsd/tests/commands-usage.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-usage.test.ts
@@ -8,6 +8,7 @@ import {
   scanSessionTokenTotals,
   handleUsage,
 } from "../commands-usage.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 const TS = 1;
 
@@ -107,4 +108,37 @@ test("handleUsage emits JSON when --json is passed", async () => {
   assert.equal(parsed.model, "claude-code/claude-sonnet-4-6");
   assert.equal(parsed.contextUsage.tokens, 10_000);
   assert.equal(parsed.sessionTotals.input, 0);
+});
+
+test("handleUsage renders interactive usage output inside a full border", async () => {
+  let renderFn: ((width: number) => string[]) | undefined;
+  const messages: string[] = [];
+  const ctx = {
+    hasUI: true,
+    model: { provider: "claude-code", id: "claude-sonnet-4-6", contextWindow: 200_000 },
+    getContextUsage: () => ({ tokens: 10_000, contextWindow: 200_000, percent: 5 }),
+    sessionManager: { getEntries: () => [] },
+    ui: {
+      custom: async (factory: any) => {
+        const theme = {
+          fg: (_color: string, text: string) => text,
+          bold: (text: string) => text,
+        };
+        const component = factory({ requestRender: () => {} }, theme, {}, () => {});
+        renderFn = component.render;
+        return true;
+      },
+      notify(message: string) {
+        messages.push(message);
+      },
+    },
+  };
+
+  await handleUsage("", ctx as any);
+
+  assert.equal(messages.length, 0, "interactive usage should use the dialog instead of notify");
+  assert.ok(renderFn, "render function should have been captured");
+  const lines = renderFn!(80);
+  assertFullOuterBorder(lines, 80);
+  assert.match(lines.join("\n"), /claude-code\/claude-sonnet-4-6/);
 });

--- a/src/resources/extensions/gsd/tests/commands-usage.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-usage.test.ts
@@ -142,3 +142,66 @@ test("handleUsage renders interactive usage output inside a full border", async 
   assertFullOuterBorder(lines, 80);
   assert.match(lines.join("\n"), /claude-code\/claude-sonnet-4-6/);
 });
+
+test("handleUsage keeps short-terminal usage dialog scrollable", async () => {
+  const originalRowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+  Object.defineProperty(process.stdout, "rows", { value: 10, configurable: true });
+
+  try {
+    let component: { render(width: number): string[]; handleInput(data: string): void } | undefined;
+    let closed = false;
+    const ctx = {
+      hasUI: true,
+      model: { provider: "claude-code", id: "claude-sonnet-4-6", contextWindow: 200_000 },
+      getContextUsage: () => ({ tokens: 10_000, contextWindow: 200_000, percent: 5 }),
+      sessionManager: {
+        getEntries: () => sessionEntries({
+          role: "assistant",
+          usage: {
+            input: 1000,
+            output: 200,
+            cacheRead: 500,
+            cacheWrite: 100,
+            totalTokens: 1800,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.05 },
+          },
+          content: [{ type: "toolCall", id: "tc-1", name: "read", arguments: {} }],
+          timestamp: TS,
+        }),
+      },
+      ui: {
+        custom: async (factory: any) => {
+          const theme = {
+            fg: (_color: string, text: string) => text,
+            bold: (text: string) => text,
+          };
+          component = factory({ requestRender: () => {} }, theme, {}, () => {
+            closed = true;
+          });
+          return true;
+        },
+        notify() {},
+      },
+    };
+
+    await handleUsage("", ctx as any);
+
+    assert.ok(component, "usage dialog should render via custom UI");
+    const initialLines = component.render(80);
+    assert.ok(initialLines.length <= 8, `usage dialog should fit 80% terminal height, got ${initialLines.length}`);
+
+    for (let i = 0; i < 10; i++) component.handleInput("\u001b[B");
+
+    assert.equal(closed, false, "scroll keys should not close a scrollable usage dialog");
+    assert.match(component.render(80).join("\n"), /Tool calls: 1/);
+
+    component.handleInput("x");
+    assert.equal(closed, true, "non-scroll keys should close the usage dialog");
+  } finally {
+    if (originalRowsDescriptor) {
+      Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);
+    } else {
+      delete (process.stdout as { rows?: number }).rows;
+    }
+  }
+});

--- a/src/resources/extensions/gsd/tests/context-chart.test.ts
+++ b/src/resources/extensions/gsd/tests/context-chart.test.ts
@@ -10,6 +10,7 @@ import type { ContextBreakdownReport } from "../commands-context.ts";
 import { buildContextChartHtml, writeContextChartHtml } from "../context-chart-html.ts";
 import { formatContextChartText, getContextChartTotals } from "../context-overlay.ts";
 import { buildContextBreakdown } from "../commands-context.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 const TS = 1;
 
@@ -102,4 +103,12 @@ test("formatContextChartText includes chart sections", () => {
   assert.match(text, /System prompt/);
   assert.match(text, /Conversation/);
   assert.match(text, /█/);
+});
+
+test("formatContextChartText renders the context dialog inside a full border", () => {
+  const lines = formatContextChartText(SAMPLE_REPORT, 80).split("\n");
+  assertFullOuterBorder(lines, 80);
+  assert.match(lines[0] ?? "", /^╭─ Context Breakdown /);
+  assert.ok(lines.some((line) => line.startsWith("│")), "body rows should have side borders");
+  assert.match(lines.at(-1) ?? "", /^╰─+╯$/);
 });

--- a/src/resources/extensions/gsd/tests/dashboard-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/dashboard-overlay.test.ts
@@ -1,0 +1,25 @@
+/**
+ * GSD dashboard overlay dialog chrome tests.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GSDDashboardOverlay } from "../dashboard-overlay.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
+
+const fakeTheme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+test("GSDDashboardOverlay renders inside the shared full border", (t) => {
+  const overlay = new GSDDashboardOverlay({ requestRender() {} }, fakeTheme as any, () => {});
+  t.after(() => overlay.dispose());
+
+  const lines = overlay.render(100);
+  assertFullOuterBorder(lines, 100);
+  assert.match(lines[0] ?? "", /^╭─ GSD Dashboard /);
+  assert.ok(lines.some((line) => line.startsWith("│")), "body rows should have side borders");
+  assert.match(lines.at(-1) ?? "", /^╰─+╯$/);
+});

--- a/src/resources/extensions/gsd/tests/notification-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-overlay.test.ts
@@ -11,6 +11,7 @@ import { visibleWidth } from "@gsd/pi-tui";
 import { appendNotification, initNotificationStore, _resetNotificationStore } from "../notification-store.ts";
 import { GSDNotificationOverlay, notificationOverlayOptions } from "../notification-overlay.ts";
 import { wrapVisibleText } from "../tui/render-kit.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 const fakeTheme = {
   fg: (_color: string, text: string) => text,
@@ -92,7 +93,11 @@ describe("notification overlay — wrapText", () => {
     t.after(() => overlay.dispose());
 
     for (const width of [40, 80, 120]) {
-      assertLinesFit(overlay.render(width), width);
+      const rendered = overlay.render(width);
+      assertLinesFit(rendered, width);
+      assertFullOuterBorder(rendered, width);
+      assert.match(rendered[0] ?? "", /^╭─ Notifications /);
+      assert.match(rendered.at(-1) ?? "", /^╰─+╯$/);
       overlay.invalidate();
     }
   });

--- a/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { visibleWidth } from "@gsd/pi-tui";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 function assertLinesFit(lines: string[], width: number): void {
   for (const line of lines) {
@@ -51,6 +52,9 @@ describe("parallel-monitor-overlay", () => {
     const joined = lines.join("\n");
     assert.ok(joined.includes("Parallel Monitor"), "should include title");
     assert.ok(joined.includes("No parallel workers found"), "should show empty state");
+    assertFullOuterBorder(lines, 80);
+    assert.match(lines[0] ?? "", /^╭─ GSD Parallel Monitor /);
+    assert.match(lines.at(-1) ?? "", /^╰─+╯$/);
 
     // Dispose should not throw
     overlay.dispose();
@@ -105,7 +109,9 @@ describe("parallel-monitor-overlay", () => {
     );
 
     for (const width of [40, 80, 120]) {
-      assertLinesFit(overlay.render(width), width);
+      const lines = overlay.render(width);
+      assertLinesFit(lines, width);
+      assertFullOuterBorder(lines, width);
       overlay.invalidate();
     }
 

--- a/src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts
+++ b/src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
 import { showQueueReorder } from "../queue-reorder-ui.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 const fakeTheme = {
   fg: (_color: string, text: string) => text,
@@ -43,6 +44,9 @@ describe("queue-reorder-ui", () => {
       const joined = lastRender.join("\n");
       assert.ok(joined.includes("M016"), "selected item should stay visible after scrolling");
       assert.ok(lastRender.length <= 16, `overlay should fit terminal max-height, got ${lastRender.length}`);
+      assertFullOuterBorder(lastRender, 100);
+      assert.match(lastRender[0] ?? "", /^╭─ Queue Reorder /);
+      assert.match(lastRender.at(-1) ?? "", /^╰─+╯$/);
     } finally {
       if (originalRowsDescriptor) {
         Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);

--- a/src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts
+++ b/src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts
@@ -55,4 +55,46 @@ describe("queue-reorder-ui", () => {
       }
     }
   });
+
+  test("draws queue scroll thumb beside queue rows when completed rows are shown", async () => {
+    const originalRowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+    Object.defineProperty(process.stdout, "rows", { value: 12, configurable: true });
+
+    try {
+      const completed = [
+        { id: "M000", title: "Already done" },
+      ];
+      const pending = Array.from({ length: 8 }, (_, idx) => ({
+        id: `M${String(idx + 1).padStart(3, "0")}`,
+        title: `Milestone ${idx + 1}`,
+      }));
+      let rendered: string[] = [];
+
+      const ctx = {
+        hasUI: true,
+        ui: {
+          custom: async (factory: any) => {
+            const component = factory({ requestRender() {} }, fakeTheme, null, () => {});
+            rendered = component.render(80);
+            return null;
+          },
+        },
+      } as any;
+
+      await showQueueReorder(ctx, completed, pending);
+
+      const completedHeader = rendered.find(line => line.includes("Completed:"));
+      const firstQueueRow = rendered.find(line => line.includes("M001"));
+      assert.ok(completedHeader, "completed header should be rendered before queue rows");
+      assert.ok(firstQueueRow, "first queue row should be rendered");
+      assert.match(completedHeader, /│$/);
+      assert.match(firstQueueRow, /┃$/);
+    } finally {
+      if (originalRowsDescriptor) {
+        Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);
+      } else {
+        delete (process.stdout as { rows?: number }).rows;
+      }
+    }
+  });
 });

--- a/src/resources/extensions/gsd/tests/show-config-command.test.ts
+++ b/src/resources/extensions/gsd/tests/show-config-command.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 
 import { GSDConfigOverlay, formatConfigText } from "../config-overlay.ts";
 import { handleCoreCommand } from "../commands/handlers/core.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 const theme = {
   bold: (s: string) => s,
@@ -24,6 +25,9 @@ test("GSDConfigOverlay renders and responds to input", () => {
 
   const lines = overlay.render(60);
   assert.ok(lines.some((line) => line.includes("GSD Configuration")));
+  assertFullOuterBorder(lines, 60);
+  assert.match(lines[0] ?? "", /^╭─ GSD Configuration /);
+  assert.match(lines.at(-1) ?? "", /^╰─+╯$/);
 
   overlay.handleInput("j");
   assert.equal(renderRequests, 1);

--- a/src/resources/extensions/gsd/tests/tui-border-assertions.ts
+++ b/src/resources/extensions/gsd/tests/tui-border-assertions.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+
+import { visibleWidth } from "@gsd/pi-tui";
+
+const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+export function assertFullOuterBorder(lines: string[], width: number): void {
+  assert.ok(lines.length >= 2, "dialog must include top and bottom borders");
+
+  for (const [index, line] of lines.entries()) {
+    assert.equal(visibleWidth(line), width, `line ${index} must fill dialog width`);
+  }
+
+  const top = stripAnsi(lines[0] ?? "");
+  const bottom = stripAnsi(lines.at(-1) ?? "");
+  assert.match(top, /^[╭┌].*[╮┐]$/, `top border missing full corners: ${top}`);
+  assert.match(bottom, /^[╰└].*[╯┘]$/, `bottom border missing full corners: ${bottom}`);
+
+  for (let index = 1; index < lines.length - 1; index++) {
+    const line = stripAnsi(lines[index] ?? "");
+    assert.match(line, /^[│┃├]/, `line ${index} missing left border: ${line}`);
+    assert.match(line, /[│┃┤]$/, `line ${index} missing right border: ${line}`);
+  }
+}

--- a/src/resources/extensions/gsd/tests/tui-render-kit.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-render-kit.test.ts
@@ -5,8 +5,10 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
 import { visibleWidth } from "@gsd/pi-tui";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 import {
   padRightVisible,
+  renderDialogFrame,
   renderFrame,
   renderKeyHints,
   renderPanel,
@@ -58,6 +60,18 @@ describe("tui render kit", () => {
     for (const width of [3, 40, 80]) {
       assertWidth(renderFrame(theme, ["row", "long ".repeat(40)], width), width);
     }
+  });
+
+  test("renderDialogFrame draws a full titled modal border with footer", () => {
+    const lines = renderDialogFrame(theme, "Dialog", ["row", "long ".repeat(40)], 40, {
+      footer: renderKeyHints(theme, ["esc close"], 36),
+    });
+    assertWidth(lines, 40);
+    assertFullOuterBorder(lines, 40);
+    assert.match(lines[0] ?? "", /^╭─ Dialog ─+╮$/);
+    assert.ok(lines.some((line) => line.startsWith("│") && line.endsWith("│")));
+    assert.ok(lines.some((line) => line.startsWith("├") && line.endsWith("┤")));
+    assert.match(lines.at(-1) ?? "", /^╰─+╯$/);
   });
 
   test("renderPanel stays within width and draws no vertical borders", () => {

--- a/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
@@ -14,6 +14,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { GSDVisualizerOverlay, TAB_COUNT } from "../visualizer-overlay.ts";
+import { assertFullOuterBorder } from "./tui-border-assertions.ts";
 
 function makeTui() {
   const renders: number[] = [];
@@ -50,7 +51,11 @@ test("overlay renders 10 tabs (Progress, Timeline, Deps, Metrics, Health, Agent,
   overlay.loading = true; // body shows loading text, but tab bar renders regardless
 
   // Use a very wide terminal so the tab bar is not truncated.
-  const lines = overlay.render(200).map(stripAnsi);
+  const rawLines = overlay.render(200);
+  assertFullOuterBorder(rawLines, 200);
+  const lines = rawLines.map(stripAnsi);
+  assert.match(lines[0] ?? "", /^╭─ GSD Visualizer /);
+  assert.match(lines.at(-1) ?? "", /^╰─+╯$/);
   const tabBar = lines.find((l) => l.includes("Progress") && l.includes("Export"));
   assert.ok(tabBar, `expected a tab-bar line containing all labels, got:\n${lines.slice(0, 5).join("\n")}`);
   for (const label of ["Progress", "Timeline", "Deps", "Metrics", "Health", "Agent", "Changes", "Knowledge", "Captures", "Export"]) {

--- a/src/resources/extensions/gsd/tui/render-kit.ts
+++ b/src/resources/extensions/gsd/tui/render-kit.ts
@@ -151,3 +151,81 @@ export function renderFrame(
   lines.push(border("╰" + "─".repeat(width - 2) + "╯"));
   return lines.map((line) => safeLine(line, width, ""));
 }
+
+export interface DialogFrameOptions {
+  borderColor?: string;
+  paddingX?: number;
+  footer?: string | string[];
+  scroll?: {
+    offset: number;
+    visibleRows: number;
+    totalRows: number;
+  };
+}
+
+function renderTitledTopBorder(
+  theme: ThemeLike,
+  title: string,
+  width: number,
+  border: (text: string) => string,
+): string {
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle || width < 10) {
+    return border("╭" + "─".repeat(width - 2) + "╮");
+  }
+
+  const maxTitleWidth = Math.max(0, width - 7);
+  const safeTitle = safeLine(trimmedTitle, maxTitleWidth);
+  const fill = Math.max(0, width - visibleWidth(safeTitle) - 5);
+  return border("╭─ ") + theme.bold(theme.fg("accent", safeTitle)) + border(" " + "─".repeat(fill) + "╮");
+}
+
+export function renderDialogFrame(
+  theme: ThemeLike,
+  title: string,
+  inner: string[],
+  width: number,
+  options: DialogFrameOptions = {},
+): string[] {
+  if (width < 4) return inner.map((line) => safeLine(line, width));
+
+  const borderColor = options.borderColor ?? "borderAccent";
+  const paddingX = Math.max(0, options.paddingX ?? 1);
+  const contentWidth = Math.max(0, width - 2 - paddingX * 2);
+  const border = (text: string) => theme.fg(borderColor, text);
+  const pad = " ".repeat(paddingX);
+  const lines = [renderTitledTopBorder(theme, title, width, border)];
+
+  const scroll = options.scroll;
+  const bodyRows = inner.length;
+  const scrollable = !!scroll && scroll.totalRows > scroll.visibleRows && bodyRows > 0;
+  const thumbLen = scrollable
+    ? Math.max(1, Math.round((scroll.visibleRows / scroll.totalRows) * bodyRows))
+    : 0;
+  const maxThumbStart = Math.max(0, bodyRows - thumbLen);
+  const maxScrollOffset = scrollable ? Math.max(1, scroll.totalRows - scroll.visibleRows) : 1;
+  const thumbStart = scrollable
+    ? Math.min(maxThumbStart, Math.round((scroll.offset / maxScrollOffset) * maxThumbStart))
+    : -1;
+
+  for (let i = 0; i < inner.length; i++) {
+    const line = inner[i] ?? "";
+    const rightBorder = scrollable && i >= thumbStart && i < thumbStart + thumbLen ? "┃" : "│";
+    lines.push(border("│") + pad + padRightVisible(line, contentWidth) + pad + border(rightBorder));
+  }
+
+  const footer = Array.isArray(options.footer)
+    ? options.footer
+    : options.footer
+      ? [options.footer]
+      : [];
+  if (footer.length > 0) {
+    lines.push(border("├" + "─".repeat(width - 2) + "┤"));
+    for (const line of footer) {
+      lines.push(border("│") + pad + padRightVisible(line, contentWidth) + pad + border("│"));
+    }
+  }
+
+  lines.push(border("╰" + "─".repeat(width - 2) + "╯"));
+  return lines.map((line) => safeLine(line, width, ""));
+}

--- a/src/resources/extensions/gsd/tui/render-kit.ts
+++ b/src/resources/extensions/gsd/tui/render-kit.ts
@@ -160,6 +160,8 @@ export interface DialogFrameOptions {
     offset: number;
     visibleRows: number;
     totalRows: number;
+    trackOffset?: number;
+    trackRows?: number;
   };
 }
 
@@ -198,14 +200,16 @@ export function renderDialogFrame(
 
   const scroll = options.scroll;
   const bodyRows = inner.length;
-  const scrollable = !!scroll && scroll.totalRows > scroll.visibleRows && bodyRows > 0;
+  const trackOffset = Math.max(0, Math.min(scroll?.trackOffset ?? 0, bodyRows));
+  const trackRows = Math.max(0, Math.min(scroll?.trackRows ?? bodyRows, bodyRows - trackOffset));
+  const scrollable = !!scroll && scroll.totalRows > scroll.visibleRows && trackRows > 0;
   const thumbLen = scrollable
-    ? Math.max(1, Math.round((scroll.visibleRows / scroll.totalRows) * bodyRows))
+    ? Math.max(1, Math.round((scroll.visibleRows / scroll.totalRows) * trackRows))
     : 0;
-  const maxThumbStart = Math.max(0, bodyRows - thumbLen);
+  const maxThumbStart = Math.max(0, trackRows - thumbLen);
   const maxScrollOffset = scrollable ? Math.max(1, scroll.totalRows - scroll.visibleRows) : 1;
   const thumbStart = scrollable
-    ? Math.min(maxThumbStart, Math.round((scroll.offset / maxScrollOffset) * maxThumbStart))
+    ? trackOffset + Math.min(maxThumbStart, Math.round((scroll.offset / maxScrollOffset) * maxThumbStart))
     : -1;
 
   for (let i = 0; i < inner.length; i++) {

--- a/src/resources/extensions/gsd/visualizer-overlay.ts
+++ b/src/resources/extensions/gsd/visualizer-overlay.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@gsd/pi-coding-agent";
-import { truncateToWidth, visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
+import { visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
 import { loadVisualizerData, type VisualizerData } from "./visualizer-data.js";
 import {
   renderProgressView,
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { writeExportFile } from "./export.js";
 import { gsdRoot } from "./paths.js";
 import { stripAnsi } from "../shared/mod.js";
+import { renderDialogFrame, renderKeyHints } from "./tui/render-kit.js";
 
 export const TAB_COUNT = 10;
 const TAB_LABELS = [
@@ -500,8 +501,7 @@ export class GSDVisualizerOverlay {
 
     // Apply scroll
     const viewportHeight = Math.max(5, process.stdout.rows ? process.stdout.rows - 8 : 24);
-    const chromeHeight = 2;
-    const visibleContentRows = Math.max(1, viewportHeight - chromeHeight);
+    const visibleContentRows = Math.max(1, viewportHeight - 4);
     this.lastVisibleRows = visibleContentRows;
     const totalLines = content.length;
     const maxScroll = Math.max(0, content.length - visibleContentRows);
@@ -509,46 +509,18 @@ export class GSDVisualizerOverlay {
     const offset = this.scrollOffsets[this.activeTab];
     const visibleContent = content.slice(offset, offset + visibleContentRows);
 
-    const lines = this.wrapInBox(visibleContent, width, offset, visibleContentRows, totalLines);
-
-    // Footer hint
-    const hint = th.fg("dim", "Tab/Shift+Tab/1-9,0 switch \u00b7 / filter \u00b7 PgUp/PgDn scroll \u00b7 ? help \u00b7 esc close");
-    const hintVis = visibleWidth(hint);
-    const hintPad = Math.max(0, Math.floor((width - hintVis) / 2));
-    lines.push(" ".repeat(hintPad) + hint);
+    const footer = renderKeyHints(
+      th,
+      ["Tab/Shift+Tab/1-9,0 switch", "/ filter", "PgUp/PgDn scroll", "? help", "esc close"],
+      Math.max(1, width - 4),
+    );
+    const lines = renderDialogFrame(th, "GSD Visualizer", visibleContent, width, {
+      footer,
+      scroll: { offset, visibleRows: visibleContentRows, totalRows: totalLines },
+    });
 
     this.cachedWidth = width;
     this.cachedLines = lines;
-    return lines;
-  }
-
-  private wrapInBox(inner: string[], width: number, offset?: number, visibleRows?: number, totalLines?: number): string[] {
-    const th = this.theme;
-    const border = (s: string) => th.fg("borderAccent", s);
-    const innerWidth = width - 4;
-    const lines: string[] = [];
-    lines.push(border("\u256d" + "\u2500".repeat(width - 2) + "\u256e"));
-
-    // Compute scroll indicator positions
-    const scrollable = totalLines !== undefined && visibleRows !== undefined && totalLines > visibleRows;
-    let thumbStart = -1;
-    let thumbLen = 0;
-    const innerRows = inner.length;
-    if (scrollable && innerRows > 0 && totalLines! > 0) {
-      thumbStart = Math.round(((offset ?? 0) / totalLines!) * innerRows);
-      thumbLen = Math.max(1, Math.round((visibleRows! / totalLines!) * innerRows));
-    }
-
-    for (let i = 0; i < inner.length; i++) {
-      const line = inner[i];
-      const truncated = truncateToWidth(line, innerWidth);
-      const padWidth = Math.max(0, innerWidth - visibleWidth(truncated));
-      const rightBorder = scrollable && i >= thumbStart && i < thumbStart + thumbLen
-        ? border("\u2503")
-        : border("\u2502");
-      lines.push(border("\u2502") + " " + truncated + " ".repeat(padWidth) + " " + rightBorder);
-    }
-    lines.push(border("\u2570" + "\u2500".repeat(width - 2) + "\u256f"));
     return lines;
   }
 

--- a/src/resources/extensions/shared/confirm-ui.ts
+++ b/src/resources/extensions/shared/confirm-ui.ts
@@ -18,6 +18,7 @@
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { type Theme } from "@gsd/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, type TUI } from "@gsd/pi-tui";
+import { renderSharedDialogFrame } from "./dialog-frame.js";
 import { makeUI, GLYPH } from "./ui.js";
 
 export interface ConfirmOptions {
@@ -83,20 +84,18 @@ export async function showConfirm(
 		function render(width: number): string[] {
 			if (cachedLines) return cachedLines;
 
-			const ui = makeUI(theme, width);
+			const contentWidth = Math.max(1, width - 4);
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
 			push(
-				ui.bar(),
-				ui.blank(),
-				ui.header(`  ${opts.title}`),
 				ui.blank(),
 				ui.subtitle(`  ${opts.message}`),
 				ui.blank(),
 			);
 
-			const add = (s: string) => truncateToWidth(s, width);
+			const add = (s: string) => truncateToWidth(s, contentWidth);
 			const option = (num: number, label: string, selected: boolean) => {
 				if (selected) {
 					return add(`  ${theme.fg("accent", GLYPH.cursor)} ${theme.fg("accent", `${num}. ${label}`)}`);
@@ -107,14 +106,11 @@ export async function showConfirm(
 			lines.push(option(1, yesLabel, cursor === 0));
 			lines.push(option(2, noLabel, cursor === 1));
 
-			push(
-				ui.blank(),
-				ui.hints(["↑/↓ to choose", "y/n to quick-select", "enter to confirm"]),
-				ui.bar(),
-			);
+			push(ui.blank());
+			const footer = ui.hints(["↑/↓ to choose", "y/n to quick-select", "enter to confirm"])[0] ?? "";
 
-			cachedLines = lines;
-			return lines;
+			cachedLines = renderSharedDialogFrame(theme, opts.title, lines, width, { footer });
+			return cachedLines;
 		}
 
 		return {

--- a/src/resources/extensions/shared/dialog-frame.ts
+++ b/src/resources/extensions/shared/dialog-frame.ts
@@ -1,0 +1,71 @@
+import { type Theme } from "@gsd/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+
+type ThemeColor = Parameters<Theme["fg"]>[0];
+
+export interface SharedDialogFrameOptions {
+	borderColor?: ThemeColor;
+	footer?: string | string[];
+	paddingX?: number;
+}
+
+function safeLine(text: string, width: number): string {
+	return truncateToWidth(text, width, "");
+}
+
+function padVisible(text: string, width: number): string {
+	const clipped = safeLine(text, width);
+	return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+function renderTopBorder(
+	theme: Theme,
+	title: string,
+	width: number,
+	border: (text: string) => string,
+): string {
+	const trimmedTitle = title.trim();
+	if (!trimmedTitle || width < 10) {
+		return border("╭" + "─".repeat(width - 2) + "╮");
+	}
+
+	const safeTitle = safeLine(trimmedTitle, Math.max(0, width - 7));
+	const fill = Math.max(0, width - visibleWidth(safeTitle) - 5);
+	return border("╭─ ") + theme.bold(theme.fg("accent", safeTitle)) + border(" " + "─".repeat(fill) + "╮");
+}
+
+export function renderSharedDialogFrame(
+	theme: Theme,
+	title: string,
+	inner: string[],
+	width: number,
+	options: SharedDialogFrameOptions = {},
+): string[] {
+	if (width < 4) return inner.map((line) => safeLine(line, width));
+
+	const paddingX = Math.max(0, options.paddingX ?? 1);
+	const contentWidth = Math.max(0, width - 2 - paddingX * 2);
+	const border = (text: string) => theme.fg(options.borderColor ?? "borderAccent", text);
+	const pad = " ".repeat(paddingX);
+	const lines = [renderTopBorder(theme, title, width, border)];
+
+	for (const line of inner) {
+		lines.push(border("│") + pad + padVisible(line, contentWidth) + pad + border("│"));
+	}
+
+	const footer = Array.isArray(options.footer)
+		? options.footer
+		: options.footer
+			? [options.footer]
+			: [];
+	if (footer.length > 0) {
+		lines.push(border("├" + "─".repeat(width - 2) + "┤"));
+		for (const line of footer) {
+			lines.push(border("│") + pad + padVisible(line, contentWidth) + pad + border("│"));
+		}
+	}
+
+	lines.push(border("╰" + "─".repeat(width - 2) + "╯"));
+	return lines;
+}
+

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -36,6 +36,7 @@ import {
 	truncateToWidth,
 	type TUI,
 } from "@gsd/pi-tui";
+import { renderSharedDialogFrame } from "./dialog-frame.js";
 import { mergeSideBySide } from "./layout-utils.js";
 import { makeUI, INDENT } from "./ui.js";
 
@@ -126,6 +127,10 @@ const DIVIDER_CHARS = " │ ";
 const DIVIDER_WIDTH = 3;
 const PREVIEW_MAX_LINES = 20;     // hard cap — keeps total ≤ 24 rows for single-question
 
+function dialogContentWidth(width: number): number {
+	return width < 4 ? Math.max(1, width) : Math.max(1, width - 4);
+}
+
 // ─── Wrap-up screen ───────────────────────────────────────────────────────────
 
 export async function showWrapUpScreen(
@@ -157,11 +162,12 @@ export async function showWrapUpScreen(
 
 		function render(width: number): string[] {
 			if (cachedLines) return cachedLines;
-			const ui = makeUI(theme, width);
+			const contentWidth = dialogContentWidth(width);
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
-			push(ui.bar(), ui.blank(), ui.header(`  ${opts.headline}`), ui.blank());
+			push(ui.blank());
 			if (opts.progress) push(ui.meta(`  ${opts.progress}`), ui.blank());
 
 			if (cursorIdx === 1) {
@@ -175,14 +181,11 @@ export async function showWrapUpScreen(
 			} else {
 				push(ui.actionUnselected(2, opts.keepGoingLabel, "Continue with another batch of questions."));
 			}
-			push(
-				ui.blank(),
-				ui.hints(["↑/↓ to choose", "1/2 to quick-select", "enter to confirm"]),
-				ui.bar(),
-			);
+			push(ui.blank());
 
-			cachedLines = lines;
-			return lines;
+			const footer = ui.hints(["↑/↓ to choose", "1/2 to quick-select", "enter to confirm"])[0] ?? "";
+			cachedLines = renderSharedDialogFrame(theme, opts.headline, lines, width, { footer });
+			return cachedLines;
 		}
 
 		return {
@@ -469,11 +472,13 @@ export async function showInterviewRound(
 		// ── Review screen ────────────────────────────────────────────────
 
 		function renderReviewScreen(width: number): string[] {
-			const ui = makeUI(theme, width);
+			const contentWidth = dialogContentWidth(width);
+			const title = opts.reviewHeadline ?? "Review your answers";
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
-			push(ui.bar(), ui.blank(), ui.header(`  ${opts.reviewHeadline ?? "Review your answers"}`), ui.blank());
+			push(ui.blank());
 
 			for (let i = 0; i < questions.length; i++) {
 				const q = questions[i];
@@ -500,24 +505,22 @@ export async function showInterviewRound(
 			push(
 				ui.actionSelected(0, "Submit answers"),
 				ui.blank(),
-				ui.hints(["← to go back and edit", "enter to submit", `esc to ${opts.exitLabel ?? "end interview"}`]),
-				ui.bar(),
 			);
 
-			return lines;
+			const footer = ui.hints(["← to go back and edit", "enter to submit", `esc to ${opts.exitLabel ?? "end interview"}`])[0] ?? "";
+			return renderSharedDialogFrame(theme, title, lines, width, { footer });
 		}
 
 		// ── Exit confirm screen ──────────────────────────────────────────
 
 		function renderExitConfirm(width: number): string[] {
-			const ui = makeUI(theme, width);
+			const contentWidth = dialogContentWidth(width);
+			const title = opts.exitHeadline ?? "End interview?";
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
 			push(
-				ui.bar(),
-				ui.blank(),
-				ui.header(`  ${opts.exitHeadline ?? "End interview?"}`),
 				ui.blank(),
 				ui.subtitle("  Answers from this batch won't be saved."),
 				ui.blank(),
@@ -538,13 +541,10 @@ export async function showInterviewRound(
 			} else {
 				push(ui.actionUnselected(2, exitActionLabel, "Exit and discard this batch of answers."));
 			}
-			push(
-				ui.blank(),
-				ui.hints(["↑/↓ to choose", "1/2 to quick-select", "enter to confirm"]),
-				ui.bar(),
-			);
+			push(ui.blank());
 
-			return lines;
+			const footer = ui.hints(["↑/↓ to choose", "1/2 to quick-select", "enter to confirm"])[0] ?? "";
+			return renderSharedDialogFrame(theme, title, lines, width, { footer });
 		}
 
 		// ── Preview helpers ──────────────────────────────────────────────
@@ -648,16 +648,16 @@ export async function showInterviewRound(
 			if (showingExitConfirm) { cachedLines = renderExitConfirm(width); return cachedLines; }
 			if (showingReview) { cachedLines = renderReviewScreen(width); return cachedLines; }
 
+			const contentWidth = dialogContentWidth(width);
+			const title = questions[currentIdx]?.header || "GSD Interview";
 			const useSideBySide = questionHasAnyPreview()
-				&& width >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
+				&& contentWidth >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
 
 			if (useSideBySide) {
 				// ── Preview path ──────────────────────────────────────
-				const ui = makeUI(theme, width);
+				const ui = makeUI(theme, contentWidth);
 				const lines: string[] = [];
 				const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
-
-				push(ui.bar());
 
 				if (isMultiQuestion) {
 					const unanswered = questions.filter((_, i) => !isQuestionAnswered(i)).length;
@@ -680,12 +680,15 @@ export async function showInterviewRound(
 				// component: spinner/loader (1-2), status line (1), tool header (1),
 				// plus a safety margin for future additions.
 				const termRows = (typeof process !== "undefined" && process.stdout?.rows) || 24;
-				const footerLines = 3; // blank + hints + bar
+				const footerLines = 5; // body spacer + frame top/footer/bottom chrome
 				const tuiChrome = 5;
 				const maxBody = Math.min(PREVIEW_MAX_LINES, Math.max(6, termRows - lines.length - footerLines - tuiChrome));
 
-				const previewWidth = Math.max(MIN_PREVIEW_WIDTH, Math.floor(width * PREVIEW_RATIO));
-				const leftWidth = Math.max(MIN_OPTIONS_WIDTH, width - previewWidth - DIVIDER_WIDTH);
+				const previewWidth = Math.max(
+					MIN_PREVIEW_WIDTH,
+					Math.min(contentWidth - MIN_OPTIONS_WIDTH - DIVIDER_WIDTH, Math.floor(contentWidth * PREVIEW_RATIO)),
+				);
+				const leftWidth = Math.max(MIN_OPTIONS_WIDTH, contentWidth - previewWidth - DIVIDER_WIDTH);
 
 				const fullLeft = renderOptionsColumn(leftWidth);
 				const leftLines = fullLeft.slice(0, maxBody);
@@ -709,7 +712,7 @@ export async function showInterviewRound(
 				while (leftLines.length < maxBody) leftLines.push("");
 				while (rightLines.length < maxBody) rightLines.push("");
 				const divider = theme.fg("dim", DIVIDER_CHARS);
-				lines.push(...mergeSideBySide(leftLines, rightLines, leftWidth, divider, width));
+				lines.push(...mergeSideBySide(leftLines, rightLines, leftWidth, divider, contentWidth));
 
 				// Footer
 				push(ui.blank());
@@ -729,23 +732,21 @@ export async function showInterviewRound(
 					hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
 				}
 				hints.push("esc to exit");
-				push(ui.hints(hints), ui.bar());
+				const footer = ui.hints(hints)[0] ?? "";
 
-				cachedLines = lines;
-				return lines;
+				cachedLines = renderSharedDialogFrame(theme, title, lines, width, { footer });
+				return cachedLines;
 			}
 
 			// ── Original path — no preview, untouched ────────────────
 
-			const ui = makeUI(theme, width);
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
 			const q = questions[currentIdx];
 			const st = states[currentIdx];
 			const multiSel = isMultiSelect(currentIdx);
-
-			push(ui.bar());
 
 			// ── Progress header ────────────────────────────────────────────
 			if (isMultiQuestion) {
@@ -809,7 +810,7 @@ export async function showInterviewRound(
 			if (st.notesVisible || focusNotes) {
 				push(ui.blank(), ui.notesLabel(focusNotes));
 				if (focusNotes) {
-					for (const line of getEditor().render(width - 2)) lines.push(truncateToWidth(` ${line}`, width));
+					for (const line of getEditor().render(contentWidth - 2)) lines.push(truncateToWidth(` ${line}`, contentWidth));
 				} else if (st.notes) {
 					push(ui.notesText(st.notes));
 				}
@@ -833,10 +834,10 @@ export async function showInterviewRound(
 				hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
 			}
 			hints.push("esc to exit");
-			push(ui.hints(hints), ui.bar());
+			const footer = ui.hints(hints)[0] ?? "";
 
-			cachedLines = lines;
-			return lines;
+			cachedLines = renderSharedDialogFrame(theme, title, lines, width, { footer });
+			return cachedLines;
 		}
 
 		return {

--- a/src/resources/extensions/shared/next-action-ui.ts
+++ b/src/resources/extensions/shared/next-action-ui.ts
@@ -44,6 +44,7 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { type Theme } from "@gsd/pi-coding-agent";
 import { Key, matchesKey, type TUI } from "@gsd/pi-tui";
+import { renderSharedDialogFrame } from "./dialog-frame.js";
 import { makeUI } from "./ui.js";
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -142,14 +143,14 @@ export async function showNextAction(
 
 		function render(width: number): string[] {
 			if (cachedLines) return cachedLines;
-			const ui = makeUI(theme, width);
+			const contentWidth = Math.max(1, width - 4);
+			const ui = makeUI(theme, contentWidth);
 			const lines: string[] = [];
 			const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
 
 			// ── Header — uses success colour to signal completion ────────────
 			// Note: next-action intentionally uses "success" for its bar/title
 			// to distinguish it from regular accent-coloured screens.
-			push(ui.bar());
 			push(ui.blank());
 			push(ui.header(`  ✓  ${opts.title}`));
 
@@ -192,11 +193,10 @@ export async function showNextAction(
 
 			// ── Footer ────────────────────────────────────────────────────────
 			const numHint = allActions.map((_, i) => `${i + 1}`).join("/");
-			push(ui.hints([`↑/↓ to choose`, `${numHint} to quick-select`, `enter to confirm`]));
-			push(ui.bar());
+			const footer = ui.hints([`↑/↓ to choose`, `${numHint} to quick-select`, `enter to confirm`])[0] ?? "";
 
-			cachedLines = lines;
-			return lines;
+			cachedLines = renderSharedDialogFrame(theme, "GSD Next Action", lines, width, { footer });
+			return cachedLines;
 		}
 
 		return { render, invalidate: () => { cachedLines = undefined; }, handleInput };

--- a/src/resources/extensions/shared/tests/confirm-ui.test.ts
+++ b/src/resources/extensions/shared/tests/confirm-ui.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+
+import { visibleWidth } from "@gsd/pi-tui";
+
+import { showConfirm } from "../confirm-ui.js";
+
+function assertFullOuterBorder(lines: string[], width: number): void {
+  assert.ok(lines.length >= 2, "dialog must include top and bottom borders");
+  for (const [index, line] of lines.entries()) {
+    assert.equal(visibleWidth(line), width, `line ${index} must fill dialog width`);
+  }
+  const top = stripVTControlCharacters(lines[0] ?? "");
+  const bottom = stripVTControlCharacters(lines.at(-1) ?? "");
+  assert.match(top, /^[╭┌].*[╮┐]$/);
+  assert.match(bottom, /^[╰└].*[╯┘]$/);
+  for (let index = 1; index < lines.length - 1; index++) {
+    const line = stripVTControlCharacters(lines[index] ?? "");
+    assert.match(line, /^[│┃├]/, `line ${index} missing left border: ${line}`);
+    assert.match(line, /[│┃┤]$/, `line ${index} missing right border: ${line}`);
+  }
+}
+
+describe("showConfirm", () => {
+  it("renders the confirmation prompt inside a full border", async () => {
+    let rendered: string[] = [];
+    const theme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    };
+
+    const ctx = {
+      hasUI: true,
+      ui: {
+        custom: async (factory: any) => {
+          let resolved: boolean | undefined;
+          const component = factory({ requestRender() {} }, theme, null, (value: boolean) => {
+            resolved = value;
+          });
+          rendered = component.render(80);
+          component.handleInput("\r");
+          return resolved as never;
+        },
+      },
+    };
+
+    const result = await showConfirm(ctx as any, {
+      title: "Confirm action",
+      message: "Proceed with the change?",
+    });
+
+    assert.equal(result, true);
+    assertFullOuterBorder(rendered, 80);
+    assert.match(stripVTControlCharacters(rendered[0] ?? ""), /Confirm action/);
+  });
+});

--- a/src/resources/extensions/shared/tests/interview-ui-border.test.ts
+++ b/src/resources/extensions/shared/tests/interview-ui-border.test.ts
@@ -1,0 +1,163 @@
+// gsd-pi — Shared interview UI dialog border contract
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import { visibleWidth } from "@gsd/pi-tui";
+import { initTheme } from "@gsd/pi-coding-agent";
+import {
+	showInterviewRound,
+	showWrapUpScreen,
+	type Question,
+	type RoundResult,
+	type WrapUpResult,
+} from "../interview-ui.js";
+
+const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const ENTER = "\r";
+const ESC = "\x1b";
+
+before(() => { initTheme(); });
+
+type RenderWidget = {
+	render(width: number): string[];
+	handleInput(input: string): void;
+};
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_PATTERN, "");
+}
+
+function assertFullOuterBorder(lines: string[], width: number): void {
+	assert.ok(lines.length >= 2, "dialog must include top and bottom borders");
+
+	for (const [index, line] of lines.entries()) {
+		assert.equal(visibleWidth(line), width, `line ${index} must fill dialog width`);
+	}
+
+	const top = stripAnsi(lines[0] ?? "");
+	const bottom = stripAnsi(lines.at(-1) ?? "");
+	assert.match(top, /^╭.*╮$/, `top border missing full corners: ${top}`);
+	assert.match(bottom, /^╰.*╯$/, `bottom border missing full corners: ${bottom}`);
+
+	for (let index = 1; index < lines.length - 1; index++) {
+		const line = stripAnsi(lines[index] ?? "");
+		assert.match(line, /^[│├]/, `line ${index} missing left border: ${line}`);
+		assert.match(line, /[│┤]$/, `line ${index} missing right border: ${line}`);
+	}
+}
+
+function mockTheme() {
+	return {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+		dim: (text: string) => text,
+		italic: (text: string) => text,
+		strikethrough: (text: string) => text,
+		accent: (text: string) => text,
+		success: (text: string) => text,
+		warning: (text: string) => text,
+		error: (text: string) => text,
+		info: (text: string) => text,
+		muted: (text: string) => text,
+		dimmed: (text: string) => text,
+	};
+}
+
+async function captureInterviewWidget(
+	questions: Question[],
+): Promise<RenderWidget> {
+	let widget: RenderWidget | undefined;
+
+	await showInterviewRound(questions, {}, {
+		ui: {
+			custom: (factory: any) => {
+				widget = factory(
+					{ requestRender: () => {} },
+					mockTheme(),
+					{},
+					(_result: RoundResult) => {},
+				);
+				return Promise.resolve({ endInterview: false, answers: {} });
+			},
+		},
+	} as any);
+
+	assert.ok(widget, "interview widget should be created");
+	return widget;
+}
+
+async function captureWrapUpWidget(): Promise<RenderWidget> {
+	let widget: RenderWidget | undefined;
+
+	await showWrapUpScreen({
+		headline: "Ready to wrap up?",
+		progress: "4 questions answered",
+		keepGoingLabel: "Keep going",
+		satisfiedLabel: "I'm satisfied",
+	}, {
+		ui: {
+			custom: (factory: any) => {
+				widget = factory(
+					{ requestRender: () => {} },
+					mockTheme(),
+					{},
+					(_result: WrapUpResult) => {},
+				);
+				return Promise.resolve({ satisfied: false });
+			},
+		},
+	} as any);
+
+	assert.ok(widget, "wrap-up widget should be created");
+	return widget;
+}
+
+describe("interview-ui dialog borders", () => {
+	const questions: Question[] = [
+		{
+			id: "project_type",
+			header: "Project Type",
+			question: "What type of project?",
+			options: [
+				{ label: "Web App", description: "Frontend or full-stack" },
+				{ label: "CLI Tool", description: "Command-line utility" },
+			],
+		},
+	];
+
+	it("renders the main question screen with a full border", async () => {
+		const widget = await captureInterviewWidget(questions);
+		assertFullOuterBorder(widget.render(80), 80);
+	});
+
+	it("renders the preview split screen with a full border", async () => {
+		const widget = await captureInterviewWidget([{
+			...questions[0],
+			options: [
+				{
+					label: "Web App",
+					description: "Frontend or full-stack",
+					preview: "### Stack\n\nUse React with a typed API boundary.",
+				},
+			],
+		}]);
+		assertFullOuterBorder(widget.render(100), 100);
+	});
+
+	it("renders review and exit confirmation screens with full borders", async () => {
+		const widget = await captureInterviewWidget(questions);
+
+		widget.handleInput(ENTER);
+		assertFullOuterBorder(widget.render(80), 80);
+
+		const exitWidget = await captureInterviewWidget(questions);
+		exitWidget.handleInput(ESC);
+		assertFullOuterBorder(exitWidget.render(80), 80);
+	});
+
+	it("renders the wrap-up screen with a full border", async () => {
+		const widget = await captureWrapUpWidget();
+		assertFullOuterBorder(widget.render(80), 80);
+	});
+});

--- a/src/resources/extensions/shared/tests/next-action-ui-hasui.test.ts
+++ b/src/resources/extensions/shared/tests/next-action-ui-hasui.test.ts
@@ -15,8 +15,26 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { visibleWidth } from "@gsd/pi-tui";
 
 import { showNextAction } from "../next-action-ui.js";
+
+function assertFullOuterBorder(lines: string[], width: number): void {
+  assert.ok(lines.length >= 2, "dialog must include top and bottom borders");
+  for (const [index, line] of lines.entries()) {
+    assert.equal(visibleWidth(line), width, `line ${index} must fill dialog width`);
+  }
+  const top = stripVTControlCharacters(lines[0] ?? "");
+  const bottom = stripVTControlCharacters(lines.at(-1) ?? "");
+  assert.match(top, /^[╭┌].*[╮┐]$/);
+  assert.match(bottom, /^[╰└].*[╯┘]$/);
+  for (let index = 1; index < lines.length - 1; index++) {
+    const line = stripVTControlCharacters(lines[index] ?? "");
+    assert.match(line, /^[│┃├]/, `line ${index} missing left border: ${line}`);
+    assert.match(line, /[│┃┤]$/, `line ${index} missing right border: ${line}`);
+  }
+}
 
 describe("showNextAction ctx.hasUI guard (#5125 lockup root protection)", () => {
   it("returns 'not_yet' immediately when ctx.hasUI is false (no UI calls)", async () => {
@@ -151,5 +169,42 @@ describe("showNextAction ctx.hasUI guard (#5125 lockup root protection)", () => 
 
     assert.equal(result, "beta", "TUI selection should be returned verbatim");
     assert.equal(selectCalled, 0, "ctx.ui.select fallback must NOT fire when custom returns a value");
+  });
+
+  it("renders the interactive next-action menu inside a full border", async () => {
+    let rendered: string[] = [];
+    const theme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    };
+
+    const ctx = {
+      hasUI: true,
+      ui: {
+        custom: async (factory: any) => {
+          let resolved: string | undefined;
+          const component = factory({ requestRender() {} }, theme, null, (value: string) => {
+            resolved = value;
+          });
+          rendered = component.render(80);
+          component.handleInput("\r");
+          return resolved as never;
+        },
+        select: async () => undefined,
+      },
+    };
+
+    const result = await showNextAction(ctx as any, {
+      title: "GSD — test",
+      summary: ["summary"],
+      actions: [
+        { id: "alpha", label: "Alpha", description: "first", recommended: true },
+        { id: "beta", label: "Beta", description: "second" },
+      ],
+    });
+
+    assert.equal(result, "alpha");
+    assertFullOuterBorder(rendered, 80);
+    assert.match(stripVTControlCharacters(rendered[0] ?? ""), /GSD Next Action/);
   });
 });


### PR DESCRIPTION
## Summary

Unifies the bordered dialog treatment across GSD slash-command surfaces. This adds shared dialog frame helpers for extension/custom TUI output, migrates the GSD overlay family to use full outer borders, and converts `/gsd usage` from a plain notify surface into a bordered interactive dialog.

## What Changed

- Added reusable full-border dialog framing for GSD overlays and shared extension dialogs.
- Updated `/gsd context`, `/gsd usage`, show-config, dashboard/status, visualizer, notifications, parallel monitor, queue reorder, next-action, confirm, interview/wrap-up, and secure env collection surfaces to render consistent outer borders.
- Reworked extension selector/input/editor components to share a full bordered container.
- Added regression tests that assert full-width top/bottom borders and left/right borders on dialog body/footer lines.

## Why

Some `/gsd` slash-command outputs, especially newly added context/usage surfaces, rendered as horizontal-rule panels without a complete border. That made GSD dialogs feel inconsistent and caused the new context dialog to visually drift from the rest of the slash-command UI.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/tui-render-kit.test.ts src/resources/extensions/gsd/tests/context-chart.test.ts src/resources/extensions/gsd/tests/commands-usage.test.ts src/resources/extensions/gsd/tests/show-config-command.test.ts src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts src/resources/extensions/gsd/tests/notification-overlay.test.ts src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts src/resources/extensions/gsd/tests/visualizer-overlay.test.ts src/resources/extensions/gsd/tests/dashboard-overlay.test.ts src/resources/extensions/gsd/tests/collect-from-manifest.test.ts src/resources/extensions/gsd/tests/secure-env-collect.test.ts src/resources/extensions/shared/tests/next-action-ui-hasui.test.ts src/resources/extensions/shared/tests/confirm-ui.test.ts src/resources/extensions/shared/tests/interview-notes-loop.test.ts src/resources/extensions/shared/tests/interview-ui-border.test.ts packages/gsd-agent-modes/src/modes/interactive/components/interactive-key-handling.test.ts` - 107 tests passed
- `pnpm --filter @gsd/agent-modes run build`
- `pnpm run typecheck:extensions`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782771902&installation_id=134682257&pr_number=281&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F281&signature=7fa0935db890043ddd0853d892903fc24830b23f993e987f742e04834d162c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only TUI rendering across many overlays; behavior is largely unchanged aside from /gsd usage switching from notify to a bordered dialog when UI is available.
> 
> **Overview**
> This PR **standardizes GSD and extension TUI surfaces** on a shared **full outer border** with a **titled top edge**, optional **footer band**, and (where needed) **scroll indicators**—replacing ad‑hoc horizontal rules and partial `DynamicBorder` chrome.
> 
> **Agent modes:** New `DialogContainer` (and `splitDialogTitle`) wraps extension **selector, input, and editor** dialogs; countdown titles update via `setDialogTitle`.
> 
> **GSD extensions:** `renderDialogFrame` in `tui/render-kit.ts` drives overlays for **config, context, dashboard, notifications, parallel monitor, visualizer, and queue reorder**. **`/gsd usage`** becomes a **scrollable centered overlay** (with notify fallback) instead of a plain notification.
> 
> **Shared extension UIs** (`renderSharedDialogFrame`, secure env collection, confirm, interview, next-action) use the same framing. **Regression tests** assert full-width borders on these dialogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6fe6a6ea320ca77e9fd26feb9bb4c282a851265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->