### PR TITLE
[codex] vary milestone vision openers

### DIFF
--- a/docs/dev/new-milestone-discuss-flow.md
+++ b/docs/dev/new-milestone-discuss-flow.md
@@ -108,7 +108,7 @@ Only when `findMilestoneIds(basePath).length === 0`:
 
 ```mermaid
 flowchart TD
-  V["What's the vision?"] --> W1[Wait]
+  V["Variable vision opener"] --> W1[Wait]
   W1 --> R["Reflection: Here's my read…"] --> W2[Wait]
   W2 --> VM["Vision mapping"]
   VM --> L1["Layer 1 Scope + gate"] --> L2["Layer 2 Architecture + gate"]
@@ -116,7 +116,7 @@ flowchart TD
   L4 --> ART["PROJECT, REQUIREMENTS, CONTEXT, ROADMAP, plan tools"]
 ```
 
-Prompt hardening in `discuss.md`: preamble is not vision input; end turn after reflection before Layer 1 questions.
+Prompt hardening in `discuss.md`: the first opener is selected from conversational variants, preamble is not vision input, and the turn ends after reflection before Layer 1 questions.
 
 ## Double-bubble failure mode (UI)
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1358,7 +1358,7 @@ function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, _basePa
  * Run preparation phase if enabled, then build the discuss prompt.
  * Preparation analyzes the codebase and prior context, injecting the results
  * as supplementary context into the standard discuss template. The discuss
- * template drives the conversation (asks "What's the vision?" first), while
+ * template drives the conversation with a variable vision opener, while
  * the preparation briefs give the agent grounding in the existing codebase.
  *
  * @param ctx - Extension command context with UI for progress notifications

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -22,6 +22,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { logWarning } from "./workflow-logger.js";
 import { gsdHome } from "./gsd-home.js";
+import { chooseVisionAskVariant } from "./vision-ask.js";
 
 type ExistsFn = (path: string) => boolean;
 
@@ -184,6 +185,7 @@ export function loadPrompt(name: string, vars: Record<string, string> = {}): str
     planTemplatePath: join(getTemplatesDir(), "plan.md"),
     taskPlanTemplatePath: join(getTemplatesDir(), "task-plan.md"),
     taskSummaryTemplatePath: join(getTemplatesDir(), "task-summary.md"),
+    visionAsk: chooseVisionAskVariant(),
     skillActivation: "If a `GSD Skill Preferences` block is present in system context, use it and the `<available_skills>` catalog in your system prompt to decide which skills to load and follow for this unit, without relaxing required verification or artifact rules.",
     ...vars,
   };

--- a/src/resources/extensions/gsd/prompts/discuss.md
+++ b/src/resources/extensions/gsd/prompts/discuss.md
@@ -1,8 +1,10 @@
 {{preamble}}
 
-Ask: "What's the vision?" once, then use the reply as vision input.
+Ask exactly this once: "{{visionAsk}}" Then use the user's reply as vision input.
 
-**Special handling:** If the **user's** message is status, branch state, clarification, or any other non-project-description, treat it as vision input and proceed instead of repeating "What's the vision?" Do **not** treat the system preamble above (e.g. "New milestone M00X.") as vision input — wait for the user.
+The opener is intentionally variable so GSD feels alive across project starts. Keep it natural, easy to answer, and assistant/developer shaped: plain language, light guidance, no corporate wording, no roleplay.
+
+**Special handling:** If the **user's** message is status, branch state, clarification, or any other non-project-description, treat it as vision input and proceed instead of repeating the opener. Do **not** treat the system preamble above (e.g. "New milestone M00X.") as vision input — wait for the user.
 
 ## Reflection Step
 

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -4,6 +4,8 @@ Discuss milestone {{milestoneId}} ("{{milestoneTitle}}"). Identify real gray are
 
 **Structured questions available: {{structuredQuestionsAvailable}}**
 
+**Conversation opener:** For the first user-facing question round, if you need a broad starting question, use: "{{visionAsk}}" Pair it with investigation-shaped follow-ups. Keep the tone natural and easy to answer, like an assistant/developer helping the user shape the next piece of work.
+
 {{inlinedTemplates}}
 
 ---

--- a/src/resources/extensions/gsd/tests/discuss-prompt.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-prompt.test.ts
@@ -9,7 +9,9 @@ const discussPrompt = readFileSync(promptPath, "utf-8");
 test("discuss prompt: resilient vision framing", () => {
   const hardenedPattern = /Say exactly:\s*"What's the vision\?"/;
   assert.ok(!hardenedPattern.test(discussPrompt), "prompt no longer uses exact-verbosity lock");
-  assert.ok(discussPrompt.includes('Ask: "What\'s the vision?" once'), "prompt asks for vision exactly once");
+  assert.ok(discussPrompt.includes('Ask exactly this once: "{{visionAsk}}"'), "prompt asks the injected vision opener exactly once");
+  assert.ok(discussPrompt.includes("The opener is intentionally variable"), "prompt documents variable opener voice");
   assert.ok(discussPrompt.includes("Special handling"), "prompt documents special handling");
-  assert.ok(discussPrompt.includes('instead of repeating "What\'s the vision?"'), "prompt forbids repeating");
+  assert.ok(discussPrompt.includes("instead of repeating the opener"), "prompt forbids repeating the opener");
+  assert.ok(!discussPrompt.includes('"What\'s the vision?"'), "prompt no longer freezes the old opener");
 });

--- a/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { VISION_ASK_VARIANTS } from "../vision-ask.ts";
 
 test("guided milestone prompt renders compact interview and context guidance", async (t) => {
   const previousGsdHome = process.env.GSD_HOME;
@@ -31,6 +32,11 @@ test("guided milestone prompt renders compact interview and context guidance", a
 
   assert.match(prompt, /M001 context written/);
   assert.match(prompt, /Project Shape/);
+  assert.ok(
+    VISION_ASK_VARIANTS.some((opener) => prompt.includes(opener)),
+    "prompt should render a conversational opener variant",
+  );
+  assert.doesNotMatch(prompt, /\{\{visionAsk\}\}/);
   assert.match(prompt, /default to `complex`/i);
   assert.match(prompt, /3 or 4 concrete, researched options/);
   assert.match(prompt, /"Other — let me discuss"/);

--- a/src/resources/extensions/gsd/tests/vision-ask.test.ts
+++ b/src/resources/extensions/gsd/tests/vision-ask.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chooseVisionAskVariant, VISION_ASK_VARIANTS } from "../vision-ask.ts";
+
+test("vision ask variants stay varied and conversational", () => {
+  assert.ok(VISION_ASK_VARIANTS.length >= 6, "keep enough openers to avoid repetition");
+  assert.equal(new Set(VISION_ASK_VARIANTS).size, VISION_ASK_VARIANTS.length, "openers should be unique");
+
+  for (const opener of VISION_ASK_VARIANTS) {
+    assert.ok(opener.length <= 72, `opener should stay short: ${opener}`);
+    assert.doesNotMatch(opener, /\n/, "opener should be a single line");
+    assert.doesNotMatch(opener, /\bstakeholders?|key success metrics?|business objectives?\b/i, "avoid corporate wording");
+    assert.notEqual(opener, "What's the vision?", "do not keep the old fixed opener in rotation");
+  }
+});
+
+test("chooseVisionAskVariant picks from the configured opener list", () => {
+  assert.equal(chooseVisionAskVariant(() => 0), VISION_ASK_VARIANTS[0]);
+  assert.equal(
+    chooseVisionAskVariant((exclusiveMax) => exclusiveMax - 1),
+    VISION_ASK_VARIANTS[VISION_ASK_VARIANTS.length - 1],
+  );
+});

--- a/src/resources/extensions/gsd/vision-ask.ts
+++ b/src/resources/extensions/gsd/vision-ask.ts
@@ -1,0 +1,28 @@
+/**
+ * Natural-language openers for milestone discussion.
+ *
+ * Keep these short and conversational. They are often the user's first prompt
+ * when GSD starts shaping a project or milestone, so they should feel like a
+ * collaborator starting a working session rather than a form field.
+ */
+import { randomInt } from "node:crypto";
+
+export const VISION_ASK_VARIANTS = [
+  "What are we building?",
+  "What do you want to make next?",
+  "What should this become?",
+  "What are you picturing?",
+  "Where should we take this?",
+  "What should this milestone unlock?",
+  "Tell me what you want to build.",
+  "What should GSD help you shape?",
+] as const;
+
+export type VisionAskVariant = typeof VISION_ASK_VARIANTS[number];
+
+export function chooseVisionAskVariant(
+  pickIndex: (exclusiveMax: number) => number = randomInt,
+): VisionAskVariant {
+  const index = pickIndex(VISION_ASK_VARIANTS.length);
+  return VISION_ASK_VARIANTS[index] ?? VISION_ASK_VARIANTS[0];
+}


### PR DESCRIPTION
## Summary

- Add a shared pool of short, conversational milestone opener variants.
- Render the selected opener through the prompt loader so greenfield and guided milestone discussion prompts can vary naturally.
- Update prompt contracts, rendering tests, and the new-milestone flow docs so the old fixed `What's the vision?` phrase does not get reintroduced.

## Why

GSD asked every new milestone the same question, which made the assistant feel static. This makes the first interaction feel more alive while preserving the existing discussion flow, reflection step, and write gates.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/discuss-prompt.test.ts src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts src/resources/extensions/gsd/tests/vision-ask.test.ts src/resources/extensions/gsd/tests/prompt-loader.test.ts`
- `pnpm run typecheck:extensions`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782772779&installation_id=134682257&pr_number=282&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F282&signature=1ed7c22cac34956f865df9fae4628a609f7dba8b2f88878240fd55f0f2efe3b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and copy-only change to first-turn wording; discussion gates, reflection, and artifact flows are unchanged.
> 
> **Overview**
> Replaces the fixed greenfield/milestone opener **"What's the vision?"** with a **randomly chosen short phrase** from a shared pool (`vision-ask.ts`), injected as `{{visionAsk}}` on every `loadPrompt` call.
> 
> **`discuss.md`** now instructs the agent to ask that injected line exactly once, documents variable tone (natural, non-corporate), and forbids repeating the opener instead of the old literal. **`guided-discuss-milestone.md`** adds an optional conversation opener using the same placeholder for broad first rounds.
> 
> **`prompt-loader.ts`** supplies `visionAsk` via `chooseVisionAskVariant()` alongside existing default template vars. Tests lock the contract (no old phrase, placeholder substituted, variant constraints); **`new-milestone-discuss-flow.md`** reflects the variable greenfield opener in the diagram and notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e7f523fad532abf0b0dd233e6c6cf4057bf562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->