### PR TITLE
fix(issue): [Bug]: Rate-limit / API-timeout responses treated as context exhaustion — zero-tool-calls guard triggers immediate retry loop (23× dispatches observed)

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -98,6 +98,20 @@ import { classifyError, isTransient } from "../error-classifier.js";
 
 export const STUCK_WINDOW_SIZE = 6;
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
+const ZERO_TOOL_PROVIDER_ERROR_PREFIX_RE =
+  /^(?:api error(?::|$|\s*\()|provider error(?::|$|\s*\()|request failed\b|(?:http\s*)?(?:429|500|502|503)\b|\b(?:econnreset|etimedout|econnrefused|epipe)\b|socket hang up\b|fetch failed\b|(?:network|connection|server) error(?::|$)|connection (?:reset|refused)(?::|$|\s+by\b)|dns\b.*(?:fail|error|timeout)|unexpected eof\b|stream idle timeout\b|partial response received\b|stream_exhausted\b|terminated(?::|$)|(?:connection|stream|request)\b.{0,40}\bterminated\b|other side closed\b|rate.?limit(?:ed| exceeded| reached| error)|too many requests\b|you(?:'ve| have) hit your limit\b|usage limit\b|out of extra usage\b|service.?unavailable\b|internal(?: server)? error(?::|$)|internal(?:[_-]server)?[_-]error\b|server[_-]error\b|(?:provider|server|api|model|codex|claude|openai|anthropic|gemini)\b.{0,80}\boverloaded\b|overloaded\b.{0,80}\b(?:provider|server|api|model)\b|context (?:window|length) exceed|context window exceed)/i;
+const ZERO_TOOL_PROVIDER_ERROR_SIGNAL_RE =
+  /(?:\b(?:http|status(?: code)?|code|error:)\s*(?:429|500|502|503)\b|\b(?:api|provider) error\s*[:(]?\s*(?:429|500|502|503)\b|\b(?:typeerror|error):\s*(?:fetch failed\b|socket hang up\b|terminated(?::|$)|connection (?:reset|refused)(?::|$|\s+by\b)|(?:network|connection|server) error(?::|$)|stream idle timeout\b|partial response received\b|unexpected eof\b)|\b(?:server_error|api_error|stream_exhausted(?:_without_result)?)\b|\b(?:econnreset|etimedout|econnrefused|epipe)\b|context (?:window|length) exceed|context window exceed)/i;
+
+function classifyZeroToolProviderMessage(message: string): ReturnType<typeof classifyError> | null {
+  const firstLine = message.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (
+    !firstLine ||
+    (!ZERO_TOOL_PROVIDER_ERROR_PREFIX_RE.test(firstLine) &&
+      !ZERO_TOOL_PROVIDER_ERROR_SIGNAL_RE.test(firstLine))
+  ) return null;
+  return classifyError(firstLine);
+}
 
 export function resolveDispatchRecoveryAttempts(
   unitRecoveryCount: Map<string, number>,
@@ -2640,8 +2654,8 @@ export async function runUnitPhase(
       );
       if (lastUnit && lastUnit.toolCalls === 0) {
         const lastAssistantMessage = lastAssistantText(s.lastUnitAgentEndMessages);
-        const providerMessageClass = classifyError(lastAssistantMessage);
-        if (lastAssistantMessage && isTransient(providerMessageClass)) {
+        const providerMessageClass = classifyZeroToolProviderMessage(lastAssistantMessage);
+        if (providerMessageClass && isTransient(providerMessageClass)) {
           const retryAfterMs = "retryAfterMs" in providerMessageClass ? providerMessageClass.retryAfterMs : 15_000;
           await pauseAutoForProviderError(
             ctx.ui,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -19,6 +19,7 @@ import {
   type PostUnitContext,
   type PreVerificationOpts,
 } from "../auto-post-unit.js";
+import { lastAssistantText } from "../user-input-boundary.js";
 import type { Phase } from "../types.js";
 import {
   MAX_RECOVERY_CHARS,
@@ -97,30 +98,6 @@ import { classifyError, isTransient } from "../error-classifier.js";
 
 export const STUCK_WINDOW_SIZE = 6;
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
-const TRANSIENT_PROVIDER_MESSAGE_KINDS = new Set(["rate-limit", "network", "stream", "connection", "server"]);
-
-function extractLastAssistantText(messages: unknown[] | null | undefined): string {
-  if (!Array.isArray(messages)) return "";
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (!msg || typeof msg !== "object") continue;
-    if ((msg as { role?: unknown }).role !== "assistant") continue;
-    const content = (msg as { content?: unknown }).content;
-    if (typeof content === "string" && content.trim()) return content.trim();
-    if (!Array.isArray(content)) continue;
-    const parts: string[] = [];
-    for (const block of content) {
-      if (!block || typeof block !== "object") continue;
-      const typed = block as { type?: unknown; text?: unknown };
-      if (typed.type === "text" && typeof typed.text === "string") {
-        parts.push(typed.text);
-      }
-    }
-    const text = parts.join("\n").trim();
-    if (text) return text;
-  }
-  return "";
-}
 
 export function resolveDispatchRecoveryAttempts(
   unitRecoveryCount: Map<string, number>,
@@ -2662,13 +2639,9 @@ export async function runUnitPhase(
         (u: { type: string; id: string; startedAt: number; toolCalls: number }) => u.type === unitType && u.id === unitId && u.startedAt === _resolveCurrentUnitStartedAtForTest(s.currentUnit),
       );
       if (lastUnit && lastUnit.toolCalls === 0) {
-        const lastAssistantMessage = extractLastAssistantText(s.lastUnitAgentEndMessages);
+        const lastAssistantMessage = lastAssistantText(s.lastUnitAgentEndMessages);
         const providerMessageClass = classifyError(lastAssistantMessage);
-        if (
-          lastAssistantMessage &&
-          isTransient(providerMessageClass) &&
-          TRANSIENT_PROVIDER_MESSAGE_KINDS.has(providerMessageClass.kind)
-        ) {
+        if (lastAssistantMessage && isTransient(providerMessageClass)) {
           const retryAfterMs = "retryAfterMs" in providerMessageClass ? providerMessageClass.retryAfterMs : 15_000;
           await pauseAutoForProviderError(
             ctx.ui,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -93,9 +93,34 @@ import {
   detectRootWriteLeak,
   formatRootWriteLeakMessage,
 } from "../root-write-leak-guard.js";
+import { classifyError, isTransient } from "../error-classifier.js";
 
 export const STUCK_WINDOW_SIZE = 6;
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
+const TRANSIENT_PROVIDER_MESSAGE_KINDS = new Set(["rate-limit", "network", "stream", "connection", "server"]);
+
+function extractLastAssistantText(messages: unknown[] | null | undefined): string {
+  if (!Array.isArray(messages)) return "";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") continue;
+    if ((msg as { role?: unknown }).role !== "assistant") continue;
+    const content = (msg as { content?: unknown }).content;
+    if (typeof content === "string" && content.trim()) return content.trim();
+    if (!Array.isArray(content)) continue;
+    const parts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const typed = block as { type?: unknown; text?: unknown };
+      if (typed.type === "text" && typeof typed.text === "string") {
+        parts.push(typed.text);
+      }
+    }
+    const text = parts.join("\n").trim();
+    if (text) return text;
+  }
+  return "";
+}
 
 export function resolveDispatchRecoveryAttempts(
   unitRecoveryCount: Map<string, number>,
@@ -2637,6 +2662,40 @@ export async function runUnitPhase(
         (u: { type: string; id: string; startedAt: number; toolCalls: number }) => u.type === unitType && u.id === unitId && u.startedAt === _resolveCurrentUnitStartedAtForTest(s.currentUnit),
       );
       if (lastUnit && lastUnit.toolCalls === 0) {
+        const lastAssistantMessage = extractLastAssistantText(s.lastUnitAgentEndMessages);
+        const providerMessageClass = classifyError(lastAssistantMessage);
+        if (
+          lastAssistantMessage &&
+          isTransient(providerMessageClass) &&
+          TRANSIENT_PROVIDER_MESSAGE_KINDS.has(providerMessageClass.kind)
+        ) {
+          const retryAfterMs = "retryAfterMs" in providerMessageClass ? providerMessageClass.retryAfterMs : 15_000;
+          await pauseAutoForProviderError(
+            ctx.ui,
+            ` for ${unitType} ${unitId}`,
+            () => deps.pauseAuto(ctx, pi),
+            {
+              isRateLimit: providerMessageClass.kind === "rate-limit",
+              isTransient: true,
+              retryAfterMs,
+              resume: () => {
+                void resumeAutoAfterProviderDelay(pi, ctx).catch((err) => {
+                  logWarning("engine", `Provider error auto-resume failed: ${err instanceof Error ? err.message : String(err)}`);
+                });
+              },
+            },
+          );
+          await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, {
+            message: lastAssistantMessage.slice(0, 200),
+            category: "provider",
+            isTransient: true,
+            retryAfterMs,
+          });
+          return {
+            action: "break",
+            reason: providerMessageClass.kind === "rate-limit" ? "rate-limit" : "api-timeout",
+          };
+        }
         if (USER_DRIVEN_DEEP_UNITS.has(unitType) && isAwaitingUserInput(s.lastUnitAgentEndMessages ?? undefined)) {
           debugLog("runUnitPhase", {
             phase: "zero-tool-calls-awaiting-user-input",

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4453,6 +4453,101 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
   );
 });
 
+test("runUnitPhase retries 0-tool units with ordinary network-related assistant text", async (t) => {
+  _resetPendingResolve();
+
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-zero-tool-network-text-"));
+  t.after(() => {
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = {
+    ...makeMockPi(),
+    sendMessage: () => {
+      queueMicrotask(() => resolveAgentEnd(makeEvent([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Error: I'll investigate the network error handling next." },
+          ],
+        },
+      ])));
+    },
+  } as any;
+  const s = makeLoopSession({
+    basePath,
+    canonicalProjectRoot: basePath,
+    originalBasePath: basePath,
+  });
+  const mockLedger = {
+    version: 1,
+    projectStartedAt: Date.now(),
+    units: [] as any[],
+  };
+  const deps = makeMockDeps({
+    closeoutUnit: async () => {
+      mockLedger.units.push({
+        type: "execute-task",
+        id: "M001/S01/T01",
+        startedAt: s.currentUnit?.startedAt ?? Date.now(),
+        toolCalls: 0,
+        assistantMessages: 1,
+        tokens: { input: 100, output: 20, total: 120, cacheRead: 0, cacheWrite: 0 },
+        cost: 0.01,
+      });
+    },
+    getLedger: () => mockLedger,
+  });
+  let seq = 0;
+
+  const result = await runUnitPhase(
+    { ctx, pi, s, deps, prefs: undefined, iteration: 1, flowId: "flow-zero-tool-network-text", nextSeq: () => ++seq },
+    {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "do work",
+      finalPrompt: "do work",
+      pauseAfterUatDispatch: false,
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Milestone" },
+        activeSlice: { id: "S01", title: "Slice" },
+        activeTask: { id: "T01", title: "Task" },
+        registry: [{ id: "M001", title: "Milestone", status: "active" }],
+        recentDecisions: [],
+        blockers: [],
+        nextAction: "",
+        progress: { milestones: { done: 0, total: 1 } },
+        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      } as any,
+      mid: "M001",
+      midTitle: "Milestone",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    { recentUnits: [{ key: "execute-task/M001/S01/T01" }], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 },
+  );
+
+  assert.equal(result.action, "retry");
+  assert.equal((result as any).reason, "zero-tool-calls");
+  assert.equal(deps.callLog.includes("pauseAuto"), false);
+});
+
 test("autoLoop pauses user-driven deep question instead of flagging 0 tool calls", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4696,7 +4696,7 @@ test("autoLoop pauses on zero-tool-call rate-limit assistant messages instead of
 
     const loopPromise = autoLoop(ctx as any, pi as any, s, deps);
 
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => originalSetTimeout(r, 50));
     resolveAgentEnd(makeEvent([
       {
         role: "assistant",

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4640,6 +4640,92 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
   );
 });
 
+test("autoLoop pauses on zero-tool-call rate-limit assistant messages instead of immediate retry", async (t) => {
+  _resetPendingResolve();
+
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-zero-tool-rate-limit-"));
+  t.after(() => {
+    _resetPendingResolve();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const originalSetTimeout = globalThis.setTimeout;
+  const timers: Array<{ fn: () => void; delay: number }> = [];
+  globalThis.setTimeout = ((fn: () => void, delay?: number) => {
+    timers.push({ fn, delay: delay ?? 0 });
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    const notifications: string[] = [];
+    ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+    ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+    ctx.modelRegistry = {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    };
+    const pi = makeMockPi();
+    const s = makeLoopSession({
+      basePath,
+      canonicalProjectRoot: basePath,
+      originalBasePath: basePath,
+    });
+
+    const mockLedger = {
+      version: 1,
+      projectStartedAt: Date.now(),
+      units: [] as any[],
+    };
+
+    const deps = makeMockDeps({
+      closeoutUnit: async () => {
+        mockLedger.units.push({
+          type: "execute-task",
+          id: "M001/S01/T01",
+          startedAt: s.currentUnit?.startedAt ?? Date.now(),
+          toolCalls: 0,
+          assistantMessages: 1,
+          tokens: { input: 100, output: 100, total: 200, cacheRead: 0, cacheWrite: 0 },
+          cost: 0.05,
+        });
+      },
+      getLedger: () => mockLedger,
+    });
+
+    const loopPromise = autoLoop(ctx as any, pi as any, s, deps);
+
+    await new Promise((r) => setTimeout(r, 50));
+    resolveAgentEnd(makeEvent([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "You've hit your limit · resets Jun 1 at 8am" }],
+      },
+    ]));
+
+    await loopPromise;
+
+    assert.equal(deps.callLog.includes("pauseAuto"), true);
+    assert.ok(
+      timers.some((timer) => timer.delay === 60_000),
+      "rate-limit message should schedule delayed auto-resume instead of immediate retry",
+    );
+    assert.ok(
+      notifications.some((msg) => msg.includes("Auto-resuming in 60s")),
+      "rate-limit pause should announce delayed resume",
+    );
+    assert.ok(
+      !notifications.some((msg) => msg.includes("context exhaustion")),
+      "rate-limit message should not be classified as context exhaustion",
+    );
+    const deriveCount = deps.callLog.filter((entry) => entry === "deriveState").length;
+    assert.equal(deriveCount, 1, "loop should pause after first iteration instead of redispatching");
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
 // ─── Worktree health check (#1833) ────────────────────────────────────────
 
 test("autoLoop stops when Worktree Safety finds no .git marker for execute-task (#1833)", async (t) => {

--- a/src/resources/extensions/gsd/tests/user-input-boundary.test.ts
+++ b/src/resources/extensions/gsd/tests/user-input-boundary.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import * as userInputBoundary from "../user-input-boundary.ts";
+
+test("lastAssistantText extracts the latest assistant text block content", () => {
+  const lastAssistantText = (userInputBoundary as {
+    lastAssistantText?: (messages: unknown[] | null | undefined) => string;
+  }).lastAssistantText;
+
+  assert.equal(typeof lastAssistantText, "function");
+  assert.equal(
+    lastAssistantText?.([
+      { role: "assistant", content: "Older message" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "First line" },
+          { type: "text", text: "Second line" },
+        ],
+      },
+    ]),
+    "First line\nSecond line",
+  );
+  assert.equal(lastAssistantText?.(null), "");
+});

--- a/src/resources/extensions/gsd/user-input-boundary.ts
+++ b/src/resources/extensions/gsd/user-input-boundary.ts
@@ -39,7 +39,7 @@ function extractTextFromMessage(msg: unknown): string {
   return parts.join("\n");
 }
 
-function lastAssistantText(messages: unknown[] | undefined): string {
+export function lastAssistantText(messages: unknown[] | null | undefined): string {
   if (!Array.isArray(messages)) return "";
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];


### PR DESCRIPTION
## Summary
- Routed zero-tool-call provider/rate-limit assistant-message completions to provider pause/resume flow and added regression coverage for the retry-loop case.

## Bugs Addressed
- [x] **Zero-tool-call retries spin on provider error messages**
- [ ] **Ghost completion detector is exported but never used** _(skipped: this branch already has `isSuspiciousGhostCompletion` imported and used in `runUnitPhase`, with existing behavioral coverage for ghost-completion pause.)_

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #208
- [#208 [Bug]: Rate-limit / API-timeout responses treated as context exhaustion — zero-tool-calls guard triggers immediate retry loop (23× dispatches observed)](https://github.com/open-gsd/gsd-pi/issues/208)

## User
- @michael0903

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/208-bug-rate-limit-api-timeout-responses-tre-1780185377`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782777557&installation_id=134682257&pr_number=283&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F283&signature=008c353833caef5b627e05b40038fe3a9fae7bd18844b95cf00556dc4b155db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-loop control flow for failed units (pause vs retry) in `runUnitPhase`, which is security- and reliability-sensitive, though scoped to message classification and existing provider-pause paths.
> 
> **Overview**
> When a unit finishes with **zero tool calls**, the auto loop now inspects the **last assistant message** before treating the outcome as context exhaustion. **Transient provider/API failures** (rate limits, timeouts, overloaded servers, and similar patterns) are classified with shared **`classifyError`** logic and routed through **`pauseAutoForProviderError`** with **delayed auto-resume**, instead of an immediate **`zero-tool-calls` retry** that could spin for many dispatches.
> 
> **`lastAssistantText`** is exported from **`user-input-boundary.ts`** for reuse in **`runUnitPhase`**. Regression tests cover ordinary network-flavored assistant text (still retries), rate-limit copy (pause + scheduled resume), and assistant text extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1202a526309f2cf2b3068124dedf786f225bb9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->