### PR TITLE
[codex] guard GSD drift recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -94,6 +94,7 @@ import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { probeGitConflictState } from "./git-conflict-state.js";
 import { runTurnGitAction } from "./git-service.js";
 import { parseUnitId } from "./unit-id.js";
+import { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -130,6 +131,15 @@ export interface DispatchContext {
   modelRegistry?: MinimalModelRegistry;
   /** Session model provider, used for provider-specific effective context windows. */
   sessionProvider?: string;
+}
+
+function resolveExistingExpectedArtifact(
+  unitType: string,
+  unitId: string,
+  basePath: string,
+): string | null {
+  const artifactPath = resolveExpectedArtifactPath(unitType, unitId, basePath);
+  return artifactPath && existsSync(artifactPath) ? artifactPath : null;
 }
 
 type ReassessmentChecker = typeof checkNeedsReassessment;
@@ -971,13 +981,17 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (await getMilestonePipelineVariant(mid) === "trivial") return null;
 
       // Load roadmap to find all slices
-      const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
+      const roadmapFile =
+        resolveExistingExpectedArtifact("plan-milestone", mid, basePath) ??
+        resolveMilestoneFile(basePath, mid, "ROADMAP");
       const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
       if (!roadmapContent) return null;
       const roadmap = parseRoadmap(roadmapContent);
 
       // Find slices that need research (no RESEARCH file, dependencies done)
-      const milestoneResearchFile = resolveMilestoneFile(basePath, mid, "RESEARCH");
+      const milestoneResearchFile =
+        resolveExistingExpectedArtifact("research-milestone", mid, basePath) ??
+        resolveMilestoneFile(basePath, mid, "RESEARCH");
       const researchReadySlices: Array<{ id: string; title: string }> = [];
 
       for (const slice of roadmap.slices) {
@@ -985,10 +999,10 @@ export const DISPATCH_RULES: DispatchRule[] = [
         // Skip S01 when milestone research exists
         if (milestoneResearchFile && slice.id === "S01") continue;
         // Skip if already has research
-        if (resolveSliceFile(basePath, mid, slice.id, "RESEARCH")) continue;
+        if (resolveExistingExpectedArtifact("research-slice", `${mid}/${slice.id}`, basePath)) continue;
         // Skip if dependencies aren't done (check for SUMMARY files)
         const depsComplete = (slice.depends ?? []).every((depId) =>
-          !!resolveSliceFile(basePath, mid, depId, "SUMMARY"),
+          !!resolveExistingExpectedArtifact("complete-slice", `${mid}/${depId}`, basePath),
         );
         if (!depsComplete) continue;
 
@@ -1001,7 +1015,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // #4414: If a previous parallel-research attempt escalated to a blocker
       // placeholder, skip this rule and fall through to per-slice research
       // (or other rules) rather than re-dispatching the same failing unit.
-      const parallelBlocker = resolveMilestoneFile(basePath, mid, "PARALLEL-BLOCKER");
+      const parallelBlocker =
+        resolveExistingExpectedArtifact("research-slice", `${mid}/parallel-research`, basePath) ??
+        resolveMilestoneFile(basePath, mid, "PARALLEL-BLOCKER");
       if (parallelBlocker) return null;
 
       return {
@@ -1030,15 +1046,19 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
       const sTitle = state.activeSlice!.title;
-      const researchFile = resolveSliceFile(basePath, mid, sid, "RESEARCH");
+      const researchFile =
+        resolveExistingExpectedArtifact("research-slice", `${mid}/${sid}`, basePath) ??
+        resolveSliceFile(basePath, mid, sid, "RESEARCH");
       if (researchFile) return null; // has research, fall through
       // Skip slice research for S01 when milestone research already exists —
       // the milestone research already covers the same ground for the first slice.
-      const milestoneResearchFile = resolveMilestoneFile(
-        basePath,
-        mid,
-        "RESEARCH",
-      );
+      const milestoneResearchFile =
+        resolveExistingExpectedArtifact("research-milestone", mid, basePath) ??
+        resolveMilestoneFile(
+          basePath,
+          mid,
+          "RESEARCH",
+        );
       if (milestoneResearchFile && sid === "S01") return null; // fall through to plan-slice
       return {
         action: "dispatch",

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -112,6 +112,27 @@ const MAX_VERIFICATION_RETRIES = 3;
 const MAX_NOTIFICATION_DETAILS = 3;
 const NOTIFICATION_BULLET = "•";
 
+function isParallelResearchUnit(unitType: string, unitId: string): boolean {
+  return unitType === "research-slice" && unitId.endsWith("/parallel-research");
+}
+
+export function maybeWriteParallelResearchCostSpikeBlocker(
+  unitType: string,
+  unitId: string,
+  basePath: string,
+  unitCostUsd: number,
+  rollingAvgUsd: number,
+): string | null {
+  if (!isParallelResearchUnit(unitType, unitId)) return null;
+  return writeBlockerPlaceholder(
+    unitType,
+    unitId,
+    basePath,
+    `Parallel slice research cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}). ` +
+      "Skipping the aggregate sentinel so dispatch can fall back to per-slice research.",
+  );
+}
+
 export function resolveCloseoutGitAction(
   uokFlags: ReturnType<typeof resolveUokFlags>,
 ): TurnGitActionMode | null {
@@ -1591,7 +1612,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       if (!triggerArtifactVerified) {
         try {
           const { milestone: mid, slice: sid } = parseUnitId(s.currentUnit.id);
-          if (mid && sid) {
+          if (mid && sid && !isParallelResearchUnit(s.currentUnit.type, s.currentUnit.id)) {
             // Phase C: write to the canonical project root (#5236 scope)
             // so non-symlinked worktrees no longer maintain a separate
             // local .gsd/ projection. copyPlanningArtifacts has been
@@ -1860,8 +1881,17 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
               );
               return "continue";
             }
+            const parallelBlocker = maybeWriteParallelResearchCostSpikeBlocker(
+              s.currentUnit.type,
+              s.currentUnit.id,
+              verificationBasePath,
+              unitCostUsd,
+              rollingAvgUsd,
+            );
             ctx.ui.notify(
-              `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — pausing auto-mode.`,
+              parallelBlocker
+                ? `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — wrote parallel blocker and pausing auto-mode.`
+                : `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — pausing auto-mode.`,
               "error",
             );
             await pauseAuto(ctx, pi);

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -413,17 +413,18 @@ export function verifyExpectedArtifact(
       return true;
     }
 
-    const roadmapFile = resolveMilestoneFile(base, mid, "ROADMAP");
+    const roadmapFile = resolveExpectedArtifactPath("plan-milestone", mid, base);
     if (!roadmapFile || !existsSync(roadmapFile)) {
       logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap missing`);
       return false;
     }
     try {
       const roadmap = parseLegacyRoadmap(readFileSync(roadmapFile, "utf-8"));
-      const milestoneResearchFile = resolveMilestoneFile(base, mid, "RESEARCH");
+      const milestoneResearchFile = resolveExpectedArtifactPath("research-milestone", mid, base);
+      const hasMilestoneResearch = !!milestoneResearchFile && existsSync(milestoneResearchFile);
       for (const slice of roadmap.slices) {
         if (slice.done) continue;
-        if (milestoneResearchFile && slice.id === "S01") continue;
+        if (hasMilestoneResearch && slice.id === "S01") continue;
         const depsComplete = (slice.depends ?? []).every((depId) => {
           const summaryPath = resolveExpectedArtifactPath("complete-slice", `${mid}/${depId}`, base);
           return !!summaryPath && existsSync(summaryPath);

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -424,11 +424,13 @@ export function verifyExpectedArtifact(
       for (const slice of roadmap.slices) {
         if (slice.done) continue;
         if (milestoneResearchFile && slice.id === "S01") continue;
-        const depsComplete = (slice.depends ?? []).every((depId) =>
-          !!resolveSliceFile(base, mid, depId, "SUMMARY"),
-        );
+        const depsComplete = (slice.depends ?? []).every((depId) => {
+          const summaryPath = resolveExpectedArtifactPath("complete-slice", `${mid}/${depId}`, base);
+          return !!summaryPath && existsSync(summaryPath);
+        });
         if (!depsComplete) continue;
-        if (!resolveSliceFile(base, mid, slice.id, "RESEARCH")) {
+        const researchPath = resolveExpectedArtifactPath("research-slice", `${mid}/${slice.id}`, base);
+        if (!researchPath || !existsSync(researchPath)) {
           logWarning("recovery", `verify-fail ${unitType} ${unitId}: slice ${slice.id} missing RESEARCH`);
           return false;
         }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -3,33 +3,11 @@ import { join } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
 import { isDbAvailable, _getAdapter } from "./gsd-db.js";
-import { gsdRoot, resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
+import { isAfter, latestExplicitReopenAt } from "./milestone-reopen-events.js";
+import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
 import { deriveState } from "./state.js";
 import { readEvents } from "./workflow-events.js";
 import { renderAllProjections } from "./workflow-projections.js";
-
-function latestExplicitReopenAt(basePath: string, milestoneId: string): string | null {
-  const root = gsdRoot(basePath);
-  const candidates = [
-    join(root, "event-log.jsonl"),
-    join(root, `event-log-${milestoneId}.jsonl.archived`),
-  ];
-  let latest: string | null = null;
-  for (const file of candidates) {
-    for (const event of readEvents(file)) {
-      const eventMilestoneId = (event.params as { milestoneId?: unknown }).milestoneId;
-      if (event.cmd !== "reopen-milestone" || eventMilestoneId !== milestoneId) continue;
-      if (!latest || event.ts > latest) latest = event.ts;
-    }
-  }
-  return latest;
-}
-
-function isAfter(value: string | null | undefined, cutoff: string | null): boolean {
-  if (!cutoff) return true;
-  if (!value) return true;
-  return Date.parse(value) > Date.parse(cutoff);
-}
 
 export async function checkEngineHealth(
   basePath: string,
@@ -186,14 +164,21 @@ export async function checkEngineHealth(
                AND ud.unit_type = 'complete-milestone'
                AND ud.unit_id = m.id
                AND ud.status = 'completed'
-             ORDER BY COALESCE(ud.ended_at, ud.started_at) DESC, ud.id DESC`,
+               AND ud.id = (
+                 SELECT latest.id
+                 FROM unit_dispatches latest
+                 WHERE latest.milestone_id = m.id
+                   AND latest.unit_type = 'complete-milestone'
+                   AND latest.unit_id = m.id
+                   AND latest.status = 'completed'
+                 ORDER BY COALESCE(latest.ended_at, latest.started_at) DESC, latest.id DESC
+                 LIMIT 1
+               )
+             ORDER BY m.id`,
           )
           .all() as Array<{ id: string; status: string; started_at: string | null; ended_at: string | null }>;
 
-        const seen = new Set<string>();
         for (const row of reopened) {
-          if (seen.has(row.id)) continue;
-          seen.add(row.id);
           const completedAt = row.ended_at ?? row.started_at ?? null;
           const reopenAt = latestExplicitReopenAt(basePath, row.id);
           if (reopenAt && completedAt && Date.parse(reopenAt) > Date.parse(completedAt)) continue;

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -3,15 +3,16 @@ import { join } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
 import { isDbAvailable, _getAdapter } from "./gsd-db.js";
-import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
+import { gsdRoot, resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
 import { deriveState } from "./state.js";
 import { readEvents } from "./workflow-events.js";
 import { renderAllProjections } from "./workflow-projections.js";
 
 function latestExplicitReopenAt(basePath: string, milestoneId: string): string | null {
+  const root = gsdRoot(basePath);
   const candidates = [
-    join(basePath, ".gsd", "event-log.jsonl"),
-    join(basePath, ".gsd", `event-log-${milestoneId}.jsonl.archived`),
+    join(root, "event-log.jsonl"),
+    join(root, `event-log-${milestoneId}.jsonl.archived`),
   ];
   let latest: string | null = null;
   for (const file of candidates) {

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -181,7 +181,7 @@ export async function checkEngineHealth(
         for (const row of reopened) {
           const completedAt = row.ended_at ?? row.started_at ?? null;
           const reopenAt = latestExplicitReopenAt(basePath, row.id);
-          if (reopenAt && completedAt && Date.parse(reopenAt) > Date.parse(completedAt)) continue;
+          if (reopenAt && (!completedAt || Date.parse(reopenAt) > Date.parse(completedAt))) continue;
           issues.push({
             severity: "error",
             code: "completed_milestone_reopened",

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -8,6 +8,28 @@ import { deriveState } from "./state.js";
 import { readEvents } from "./workflow-events.js";
 import { renderAllProjections } from "./workflow-projections.js";
 
+function latestExplicitReopenAt(basePath: string, milestoneId: string): string | null {
+  const candidates = [
+    join(basePath, ".gsd", "event-log.jsonl"),
+    join(basePath, ".gsd", `event-log-${milestoneId}.jsonl.archived`),
+  ];
+  let latest: string | null = null;
+  for (const file of candidates) {
+    for (const event of readEvents(file)) {
+      const eventMilestoneId = (event.params as { milestoneId?: unknown }).milestoneId;
+      if (event.cmd !== "reopen-milestone" || eventMilestoneId !== milestoneId) continue;
+      if (!latest || event.ts > latest) latest = event.ts;
+    }
+  }
+  return latest;
+}
+
+function isAfter(value: string | null | undefined, cutoff: string | null): boolean {
+  if (!cutoff) return true;
+  if (!value) return true;
+  return Date.parse(value) > Date.parse(cutoff);
+}
+
 export async function checkEngineHealth(
   basePath: string,
   issues: DoctorIssue[],
@@ -150,6 +172,97 @@ export async function checkEngineHealth(
         }
       } catch {
         // Non-fatal — duplicate ID check failed
+      }
+
+      // e. Completed milestone dispatch history but DB reopened without an explicit reopen event.
+      try {
+        const reopened = adapter
+          .prepare(
+            `SELECT m.id, m.status, ud.started_at, ud.ended_at
+             FROM milestones m
+             JOIN unit_dispatches ud ON ud.milestone_id = m.id
+             WHERE m.status NOT IN ('complete', 'done', 'skipped', 'closed')
+               AND ud.unit_type = 'complete-milestone'
+               AND ud.unit_id = m.id
+               AND ud.status = 'completed'
+             ORDER BY COALESCE(ud.ended_at, ud.started_at) DESC, ud.id DESC`,
+          )
+          .all() as Array<{ id: string; status: string; started_at: string | null; ended_at: string | null }>;
+
+        const seen = new Set<string>();
+        for (const row of reopened) {
+          if (seen.has(row.id)) continue;
+          seen.add(row.id);
+          const completedAt = row.ended_at ?? row.started_at ?? null;
+          const reopenAt = latestExplicitReopenAt(basePath, row.id);
+          if (reopenAt && completedAt && Date.parse(reopenAt) > Date.parse(completedAt)) continue;
+          issues.push({
+            severity: "error",
+            code: "completed_milestone_reopened",
+            scope: "milestone",
+            unitId: row.id,
+            message: `Milestone ${row.id} has completed complete-milestone dispatch history but DB status is ${row.status}. Explicitly reopen or recover before planning it again.`,
+            fixable: false,
+          });
+        }
+      } catch {
+        // Non-fatal — completed-milestone reopen check failed
+      }
+
+      // f. Completion artifacts disagree with open DB hierarchy rows.
+      try {
+        const rows = adapter
+          .prepare(
+            `SELECT a.path, a.artifact_type, a.milestone_id, a.slice_id, a.task_id, a.imported_at,
+                    m.status AS milestone_status,
+                    s.status AS slice_status,
+                    t.status AS task_status,
+                    (SELECT COUNT(*) FROM tasks tt WHERE tt.milestone_id = a.milestone_id AND tt.slice_id = a.slice_id) AS task_count
+             FROM artifacts a
+             JOIN milestones m ON m.id = a.milestone_id
+             LEFT JOIN slices s ON s.milestone_id = a.milestone_id AND s.id = a.slice_id
+             LEFT JOIN tasks t ON t.milestone_id = a.milestone_id AND t.slice_id = a.slice_id AND t.id = a.task_id
+             WHERE a.artifact_type = 'SUMMARY'
+               AND m.status NOT IN ('complete', 'done', 'skipped', 'closed')`,
+          )
+          .all() as Array<{
+            path: string;
+            milestone_id: string;
+            slice_id: string | null;
+            task_id: string | null;
+            imported_at: string | null;
+            slice_status: string | null;
+            task_status: string | null;
+            task_count: number;
+          }>;
+
+        const seen = new Set<string>();
+        for (const row of rows) {
+          const reopenAt = latestExplicitReopenAt(basePath, row.milestone_id);
+          if (!isAfter(row.imported_at, reopenAt)) continue;
+          const isSliceSummary = row.slice_id && !row.task_id && row.slice_status && !["complete", "done", "skipped", "closed"].includes(row.slice_status);
+          const isTaskSummary = row.slice_id && row.task_id && (!row.task_status || !["complete", "done", "skipped", "closed"].includes(row.task_status));
+          const isTaskArtifactWithoutDbTasks = row.slice_id && row.task_id && Number(row.task_count) === 0;
+          if (!isSliceSummary && !isTaskSummary && !isTaskArtifactWithoutDbTasks) continue;
+
+          const unitId = row.task_id
+            ? `${row.milestone_id}/${row.slice_id}/${row.task_id}`
+            : row.slice_id
+              ? `${row.milestone_id}/${row.slice_id}`
+              : row.milestone_id;
+          if (seen.has(unitId)) continue;
+          seen.add(unitId);
+          issues.push({
+            severity: "error",
+            code: "artifact_db_status_divergence",
+            scope: row.task_id ? "task" : row.slice_id ? "slice" : "milestone",
+            unitId,
+            message: `Completion artifact ${row.path} exists while DB state for ${unitId} is still open or missing. Runtime will not import it silently; run explicit recovery/repair after review.`,
+            fixable: false,
+          });
+        }
+      } catch {
+        // Non-fatal — artifact/DB status drift check failed
       }
     }
   } catch {

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -83,6 +83,8 @@ export type DoctorIssueCode =
   | "db_orphaned_task"
   | "db_orphaned_slice"
   | "db_done_task_no_summary"
+  | "artifact_db_status_divergence"
+  | "completed_milestone_reopened"
   | "db_duplicate_id"
   | "db_unavailable"
   | "projection_drift"

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -514,6 +514,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
           try {
             if (!lstatSync(join(slicesDir, entry)).isDirectory()) continue;
           } catch { continue; }
+          if (entry === "parallel-research") continue;
           if (!knownSliceIds.has(entry)) {
             issues.push({
               severity: "warning",

--- a/src/resources/extensions/gsd/milestone-reopen-events.ts
+++ b/src/resources/extensions/gsd/milestone-reopen-events.ts
@@ -1,0 +1,28 @@
+import { join } from "node:path";
+
+import { gsdRoot } from "./paths.js";
+import { readEvents } from "./workflow-events.js";
+
+export function latestExplicitReopenAt(basePath: string, milestoneId: string): string | null {
+  const root = gsdRoot(basePath);
+  const candidates = [
+    join(root, "event-log.jsonl"),
+    join(root, `event-log-${milestoneId}.jsonl.archived`),
+  ];
+
+  let latest: string | null = null;
+  for (const file of candidates) {
+    for (const event of readEvents(file)) {
+      const eventMilestoneId = (event.params as { milestoneId?: unknown }).milestoneId;
+      if (event.cmd !== "reopen-milestone" || eventMilestoneId !== milestoneId) continue;
+      if (!latest || event.ts > latest) latest = event.ts;
+    }
+  }
+  return latest;
+}
+
+export function isAfter(value: string | null | undefined, cutoff: string | null): boolean {
+  if (!cutoff) return true;
+  if (!value) return true;
+  return Date.parse(value) > Date.parse(cutoff);
+}

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -22,7 +22,6 @@ import { clearParseCache } from "../../files.js";
 import {
   clearPathCache,
   gsdProjectionRoot,
-  gsdRoot,
   resolveMilestonePath,
   resolveSliceFile,
   resolveTaskFile,
@@ -30,7 +29,7 @@ import {
 import { isClosedStatus } from "../../status-guards.js";
 import { invalidateStateCache } from "../../state.js";
 import type { GSDState } from "../../types.js";
-import { readEvents } from "../../workflow-events.js";
+import { isAfter, latestExplicitReopenAt } from "../../milestone-reopen-events.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
 type DiskSliceIdDivergenceDrift = Extract<
@@ -99,30 +98,6 @@ function latestCompletedMilestoneDispatch(
   } catch {
     return null;
   }
-}
-
-function latestExplicitReopenAt(basePath: string, milestoneId: string): string | null {
-  const root = gsdRoot(basePath);
-  const candidates = [
-    join(root, "event-log.jsonl"),
-    join(root, `event-log-${milestoneId}.jsonl.archived`),
-  ];
-
-  let latest: string | null = null;
-  for (const file of candidates) {
-    for (const event of readEvents(file)) {
-      const eventMilestoneId = (event.params as { milestoneId?: unknown }).milestoneId;
-      if (event.cmd !== "reopen-milestone" || eventMilestoneId !== milestoneId) continue;
-      if (!latest || event.ts > latest) latest = event.ts;
-    }
-  }
-  return latest;
-}
-
-function isAfter(value: string | null | undefined, cutoff: string | null): boolean {
-  if (!cutoff) return true;
-  if (!value) return true;
-  return Date.parse(value) > Date.parse(cutoff);
 }
 
 function hasExplicitReopenAfter(

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -183,7 +183,22 @@ function detectArtifactDbStatusDriftForMilestone(
 
     for (const row of summaryRows) {
       const task = row.task_id ? taskById.get(row.task_id) : null;
-      if (!task || isClosedStatus(task.status)) continue;
+      if (!task) {
+        if (tasks.length > 0) {
+          addUniqueDrift(drifts, seen, {
+            kind: "artifact-db-status-divergence",
+            milestoneId,
+            sliceId: slice.id,
+            taskId: row.task_id ?? undefined,
+            artifactType: "SUMMARY",
+            artifactPath: row.path,
+            dbStatus: "missing-db-task",
+            reason: `task ${slice.id}/${row.task_id} has SUMMARY artifact but no DB task`,
+          });
+        }
+        continue;
+      }
+      if (isClosedStatus(task.status)) continue;
       addUniqueDrift(drifts, seen, {
         kind: "artifact-db-status-divergence",
         milestoneId,

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -1,0 +1,470 @@
+// Project/App: gsd-pi
+// File Purpose: Fail-closed reconciliation guards for DB/artifact and slice-id drift.
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+
+import {
+  _getAdapter,
+  getAllMilestones,
+  getMilestoneSlices,
+  getSliceTasks,
+  isDbAvailable,
+} from "../../gsd-db.js";
+import { clearParseCache } from "../../files.js";
+import {
+  clearPathCache,
+  gsdProjectionRoot,
+  gsdRoot,
+  resolveMilestonePath,
+  resolveSliceFile,
+  resolveTaskFile,
+} from "../../paths.js";
+import { isClosedStatus } from "../../status-guards.js";
+import { invalidateStateCache } from "../../state.js";
+import type { GSDState } from "../../types.js";
+import { readEvents } from "../../workflow-events.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type DiskSliceIdDivergenceDrift = Extract<
+  DriftRecord,
+  { kind: "disk-slice-id-divergence" }
+>;
+type ArtifactDbStatusDivergenceDrift = Extract<
+  DriftRecord,
+  { kind: "artifact-db-status-divergence" }
+>;
+type CompletedMilestoneReopenedDrift = Extract<
+  DriftRecord,
+  { kind: "completed-milestone-reopened" }
+>;
+
+type ArtifactStatusRow = {
+  path: string;
+  artifact_type: string;
+  milestone_id: string | null;
+  slice_id: string | null;
+  task_id: string | null;
+  imported_at: string | null;
+};
+
+type CompletedDispatchRow = {
+  started_at: string | null;
+  ended_at: string | null;
+};
+
+function safeListArtifactRows(milestoneId: string): ArtifactStatusRow[] {
+  const adapter = _getAdapter();
+  if (!adapter) return [];
+  try {
+    return adapter
+      .prepare(
+        `SELECT path, artifact_type, milestone_id, slice_id, task_id, imported_at
+         FROM artifacts
+         WHERE milestone_id = :mid
+         ORDER BY imported_at, path`,
+      )
+      .all({ ":mid": milestoneId }) as ArtifactStatusRow[];
+  } catch {
+    return [];
+  }
+}
+
+function latestCompletedMilestoneDispatch(
+  milestoneId: string,
+): CompletedDispatchRow | null {
+  const adapter = _getAdapter();
+  if (!adapter) return null;
+  try {
+    const row = adapter
+      .prepare(
+        `SELECT started_at, ended_at
+         FROM unit_dispatches
+         WHERE milestone_id = :mid
+           AND unit_type = 'complete-milestone'
+           AND unit_id = :mid
+           AND status = 'completed'
+         ORDER BY COALESCE(ended_at, started_at) DESC, id DESC
+         LIMIT 1`,
+      )
+      .get({ ":mid": milestoneId }) as CompletedDispatchRow | undefined;
+    return row ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function latestExplicitReopenAt(basePath: string, milestoneId: string): string | null {
+  const root = gsdRoot(basePath);
+  const candidates = [
+    join(root, "event-log.jsonl"),
+    join(root, `event-log-${milestoneId}.jsonl.archived`),
+  ];
+
+  let latest: string | null = null;
+  for (const file of candidates) {
+    for (const event of readEvents(file)) {
+      const eventMilestoneId = (event.params as { milestoneId?: unknown }).milestoneId;
+      if (event.cmd !== "reopen-milestone" || eventMilestoneId !== milestoneId) continue;
+      if (!latest || event.ts > latest) latest = event.ts;
+    }
+  }
+  return latest;
+}
+
+function isAfter(value: string | null | undefined, cutoff: string | null): boolean {
+  if (!cutoff) return true;
+  if (!value) return true;
+  return Date.parse(value) > Date.parse(cutoff);
+}
+
+function hasExplicitReopenAfter(
+  basePath: string,
+  milestoneId: string,
+  completedDispatchAt: string | null | undefined,
+): boolean {
+  const reopenAt = latestExplicitReopenAt(basePath, milestoneId);
+  if (!reopenAt) return false;
+  if (!completedDispatchAt) return true;
+  return Date.parse(reopenAt) > Date.parse(completedDispatchAt);
+}
+
+function addUniqueDrift(
+  drifts: ArtifactDbStatusDivergenceDrift[],
+  seen: Set<string>,
+  drift: ArtifactDbStatusDivergenceDrift,
+): void {
+  const key = [
+    drift.milestoneId,
+    drift.sliceId ?? "",
+    drift.taskId ?? "",
+    drift.artifactType,
+    drift.artifactPath ?? "",
+    drift.reason,
+  ].join("|");
+  if (seen.has(key)) return;
+  seen.add(key);
+  drifts.push(drift);
+}
+
+function detectArtifactDbStatusDriftForMilestone(
+  basePath: string,
+  milestoneId: string,
+): ArtifactDbStatusDivergenceDrift[] {
+  const milestone = getAllMilestones().find((m) => m.id === milestoneId);
+  if (!milestone || isClosedStatus(milestone.status)) return [];
+
+  const latestReopen = latestExplicitReopenAt(basePath, milestoneId);
+  const artifacts = safeListArtifactRows(milestoneId).filter((row) =>
+    isAfter(row.imported_at, latestReopen),
+  );
+  const bySlice = new Map(getMilestoneSlices(milestoneId).map((slice) => [slice.id, slice]));
+  const drifts: ArtifactDbStatusDivergenceDrift[] = [];
+  const seen = new Set<string>();
+
+  for (const slice of bySlice.values()) {
+    if (!isClosedStatus(slice.status)) {
+      const diskSummary = resolveSliceFile(basePath, milestoneId, slice.id, "SUMMARY");
+      if (diskSummary && existsSync(diskSummary)) {
+        addUniqueDrift(drifts, seen, {
+          kind: "artifact-db-status-divergence",
+          milestoneId,
+          sliceId: slice.id,
+          artifactType: "SUMMARY",
+          artifactPath: diskSummary,
+          dbStatus: slice.status,
+          reason: `slice ${slice.id} has SUMMARY on disk while DB status is ${slice.status}`,
+        });
+      }
+    }
+
+    const tasks = getSliceTasks(milestoneId, slice.id);
+    const taskById = new Map(tasks.map((task) => [task.id, task]));
+    const summaryRows = artifacts.filter(
+      (row) =>
+        row.artifact_type === "SUMMARY" &&
+        row.slice_id === slice.id &&
+        row.task_id,
+    );
+
+    if (tasks.length === 0 && summaryRows.length > 0) {
+      addUniqueDrift(drifts, seen, {
+        kind: "artifact-db-status-divergence",
+        milestoneId,
+        sliceId: slice.id,
+        artifactType: "SUMMARY",
+        artifactPath: summaryRows[0]?.path,
+        dbStatus: "no-db-tasks",
+        reason: `slice ${slice.id} has task SUMMARY artifacts but no DB tasks`,
+      });
+    }
+
+    for (const row of summaryRows) {
+      const task = row.task_id ? taskById.get(row.task_id) : null;
+      if (!task || isClosedStatus(task.status)) continue;
+      addUniqueDrift(drifts, seen, {
+        kind: "artifact-db-status-divergence",
+        milestoneId,
+        sliceId: slice.id,
+        taskId: row.task_id ?? undefined,
+        artifactType: "SUMMARY",
+        artifactPath: row.path,
+        dbStatus: task.status,
+        reason: `task ${slice.id}/${row.task_id} has SUMMARY artifact while DB status is ${task.status}`,
+      });
+    }
+
+    for (const task of tasks) {
+      if (isClosedStatus(task.status)) continue;
+      const diskTaskSummary = resolveTaskFile(
+        basePath,
+        milestoneId,
+        slice.id,
+        task.id,
+        "SUMMARY",
+      );
+      if (!diskTaskSummary || !existsSync(diskTaskSummary)) continue;
+      addUniqueDrift(drifts, seen, {
+        kind: "artifact-db-status-divergence",
+        milestoneId,
+        sliceId: slice.id,
+        taskId: task.id,
+        artifactType: "SUMMARY",
+        artifactPath: diskTaskSummary,
+        dbStatus: task.status,
+        reason: `task ${slice.id}/${task.id} has SUMMARY on disk while DB status is ${task.status}`,
+      });
+    }
+  }
+
+  for (const row of artifacts) {
+    if (row.artifact_type !== "SUMMARY" || !row.slice_id || row.task_id) continue;
+    const slice = bySlice.get(row.slice_id);
+    if (!slice || isClosedStatus(slice.status)) continue;
+    addUniqueDrift(drifts, seen, {
+      kind: "artifact-db-status-divergence",
+      milestoneId,
+      sliceId: row.slice_id,
+      artifactType: "SUMMARY",
+      artifactPath: row.path,
+      dbStatus: slice.status,
+      reason: `slice ${row.slice_id} has SUMMARY artifact while DB status is ${slice.status}`,
+    });
+  }
+
+  return drifts;
+}
+
+function classifyDiskOnlySliceDir(
+  sliceDir: string,
+): DiskSliceIdDivergenceDrift["disposition"] {
+  let sawScaffold = false;
+  const stack = [sliceDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return "block-meaningful";
+    }
+    if (entries.length === 0 && dir !== sliceDir) {
+      sawScaffold = true;
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry === ".DS_Store") continue;
+      const full = join(dir, entry);
+      let stat;
+      try {
+        stat = lstatSync(full);
+      } catch {
+        return "block-meaningful";
+      }
+      if (stat.isDirectory()) {
+        sawScaffold = true;
+        stack.push(full);
+        continue;
+      }
+      if (stat.isFile() && stat.size === 0) {
+        sawScaffold = true;
+        continue;
+      }
+      return "block-meaningful";
+    }
+  }
+
+  return sawScaffold ? "quarantine-scaffold" : "delete-empty";
+}
+
+function detectDiskSliceIdDivergenceForMilestone(
+  basePath: string,
+  milestoneId: string,
+): DiskSliceIdDivergenceDrift[] {
+  const milestonePath = resolveMilestonePath(basePath, milestoneId);
+  if (!milestonePath) return [];
+
+  const slicesDir = join(milestonePath, "slices");
+  if (!existsSync(slicesDir)) return [];
+
+  const knownSliceIds = new Set(getMilestoneSlices(milestoneId).map((slice) => slice.id));
+  const drifts: DiskSliceIdDivergenceDrift[] = [];
+
+  for (const entry of readdirSync(slicesDir)) {
+    const sliceDir = join(slicesDir, entry);
+    try {
+      if (!lstatSync(sliceDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (entry === "parallel-research") continue;
+    if (knownSliceIds.has(entry)) continue;
+
+    const disposition = classifyDiskOnlySliceDir(sliceDir);
+    drifts.push({
+      kind: "disk-slice-id-divergence",
+      milestoneId,
+      sliceId: entry,
+      sliceDir,
+      disposition,
+      reason:
+        disposition === "block-meaningful"
+          ? `disk-only slice directory ${entry} contains meaningful files and is not in the DB`
+          : `disk-only slice directory ${entry} is not in the DB`,
+    });
+  }
+
+  return drifts;
+}
+
+export function detectArtifactDbDrift(
+  _state: GSDState,
+  ctx: DriftContext,
+): Array<
+  | DiskSliceIdDivergenceDrift
+  | ArtifactDbStatusDivergenceDrift
+  | CompletedMilestoneReopenedDrift
+> {
+  if (!isDbAvailable()) return [];
+
+  const drifts: Array<
+    | DiskSliceIdDivergenceDrift
+    | ArtifactDbStatusDivergenceDrift
+    | CompletedMilestoneReopenedDrift
+  > = [];
+
+  for (const milestone of getAllMilestones()) {
+    if (isClosedStatus(milestone.status)) continue;
+
+    const completedDispatch = latestCompletedMilestoneDispatch(milestone.id);
+    const completedAt = completedDispatch?.ended_at ?? completedDispatch?.started_at ?? null;
+    if (
+      completedDispatch &&
+      !hasExplicitReopenAfter(ctx.basePath, milestone.id, completedAt)
+    ) {
+      drifts.push({
+        kind: "completed-milestone-reopened",
+        milestoneId: milestone.id,
+        dbStatus: milestone.status,
+        completedDispatchAt: completedAt,
+      });
+    }
+
+    drifts.push(...detectArtifactDbStatusDriftForMilestone(ctx.basePath, milestone.id));
+    drifts.push(...detectDiskSliceIdDivergenceForMilestone(ctx.basePath, milestone.id));
+  }
+
+  return drifts;
+}
+
+function quarantineSliceDir(record: DiskSliceIdDivergenceDrift, basePath: string): void {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const quarantineDir = join(
+    gsdProjectionRoot(basePath),
+    "quarantine",
+    "milestones",
+    record.milestoneId,
+    "slices",
+  );
+  mkdirSync(quarantineDir, { recursive: true });
+  const target = join(quarantineDir, `${basename(record.sliceDir)}-${stamp}`);
+  renameSync(record.sliceDir, target);
+}
+
+export function repairArtifactDbDrift(
+  record:
+    | DiskSliceIdDivergenceDrift
+    | ArtifactDbStatusDivergenceDrift
+    | CompletedMilestoneReopenedDrift,
+  ctx: DriftContext,
+): void {
+  if (record.kind === "disk-slice-id-divergence") {
+    if (record.disposition === "delete-empty") {
+      rmSync(record.sliceDir, { recursive: true, force: true });
+    } else if (record.disposition === "quarantine-scaffold") {
+      quarantineSliceDir(record, ctx.basePath);
+    } else {
+      throw new Error(
+        `Slice ID drift in ${record.milestoneId}: ${record.reason}. ` +
+          "Runtime will not import disk-only slice IDs into the DB; run explicit recovery/repair after reviewing the directory.",
+      );
+    }
+    clearPathCache();
+    clearParseCache();
+    invalidateStateCache();
+    return;
+  }
+
+  if (record.kind === "completed-milestone-reopened") {
+    throw new Error(
+      `Milestone ${record.milestoneId} has completed complete-milestone dispatch history` +
+        ` (${record.completedDispatchAt ?? "time unknown"}) but the DB status is ${record.dbStatus}. ` +
+        "Refusing to plan it again without an explicit reopen or recovery.",
+    );
+  }
+
+  throw new Error(
+    `Artifact/DB status drift in ${record.milestoneId}` +
+      `${record.sliceId ? `/${record.sliceId}` : ""}` +
+      `${record.taskId ? `/${record.taskId}` : ""}: ${record.reason}. ` +
+      "Runtime will not silently import completion artifacts into DB state; run explicit recovery/repair after review.",
+  );
+}
+
+export const diskSliceIdDivergenceHandler: DriftHandler<DiskSliceIdDivergenceDrift> = {
+  kind: "disk-slice-id-divergence",
+  detect: (state, ctx) =>
+    detectArtifactDbDrift(state, ctx).filter(
+      (record): record is DiskSliceIdDivergenceDrift =>
+        record.kind === "disk-slice-id-divergence",
+    ),
+  repair: repairArtifactDbDrift,
+};
+
+export const artifactDbStatusDivergenceHandler: DriftHandler<ArtifactDbStatusDivergenceDrift> = {
+  kind: "artifact-db-status-divergence",
+  detect: (state, ctx) =>
+    detectArtifactDbDrift(state, ctx).filter(
+      (record): record is ArtifactDbStatusDivergenceDrift =>
+        record.kind === "artifact-db-status-divergence",
+    ),
+  repair: repairArtifactDbDrift,
+};
+
+export const completedMilestoneReopenedHandler: DriftHandler<CompletedMilestoneReopenedDrift> = {
+  kind: "completed-milestone-reopened",
+  detect: (state, ctx) =>
+    detectArtifactDbDrift(state, ctx).filter(
+      (record): record is CompletedMilestoneReopenedDrift =>
+        record.kind === "completed-milestone-reopened",
+    ),
+  repair: repairArtifactDbDrift,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -3,6 +3,11 @@
 // the catalog. Tests can override per-call via ReconciliationDeps.registry.
 
 import { completionTimestampHandler } from "./drift/completion.js";
+import {
+  artifactDbStatusDivergenceHandler,
+  completedMilestoneReopenedHandler,
+  diskSliceIdDivergenceHandler,
+} from "./drift/artifact-db.js";
 import { mergeStateHandler } from "./drift/merge-state.js";
 import { unregisteredMilestoneHandler } from "./drift/project-md.js";
 import { roadmapDivergenceHandler } from "./drift/roadmap.js";
@@ -22,6 +27,9 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   staleRenderHandler,
   staleWorkerHandler,
   unregisteredMilestoneHandler,
+  diskSliceIdDivergenceHandler,
   roadmapDivergenceHandler,
+  completedMilestoneReopenedHandler,
+  artifactDbStatusDivergenceHandler,
   completionTimestampHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -16,6 +16,30 @@ export type DriftRecord =
   | { kind: "unregistered-milestone"; milestoneId: string }
   | { kind: "roadmap-divergence"; milestoneId: string; sliceId?: string }
   | {
+      kind: "disk-slice-id-divergence";
+      milestoneId: string;
+      sliceId: string;
+      sliceDir: string;
+      disposition: "delete-empty" | "quarantine-scaffold" | "block-meaningful";
+      reason: string;
+    }
+  | {
+      kind: "artifact-db-status-divergence";
+      milestoneId: string;
+      sliceId?: string;
+      taskId?: string;
+      artifactType: string;
+      artifactPath?: string;
+      dbStatus?: string;
+      reason: string;
+    }
+  | {
+      kind: "completed-milestone-reopened";
+      milestoneId: string;
+      dbStatus: string;
+      completedDispatchAt?: string | null;
+    }
+  | {
       kind: "missing-completion-timestamp";
       entity: "task" | "slice" | "milestone";
       ids: string[];

--- a/src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts
@@ -1,9 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { _describeArtifactVerificationFailureForTest } from "../auto-post-unit.ts";
+import {
+  _describeArtifactVerificationFailureForTest,
+  maybeWriteParallelResearchCostSpikeBlocker,
+} from "../auto-post-unit.ts";
+import { resolveExpectedArtifactPath } from "../auto-recovery.ts";
 
 test("missing execute-task artifact includes completion contract and completion-tool hint", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-artifact-diag-"));
@@ -29,4 +33,26 @@ test("missing execute-task artifact skips completion-tool hint when completion t
   );
   assert.match(msg, /was not found on disk after unit execution/);
   assert.doesNotMatch(msg, /No completion tool call detected \(`gsd_task_complete`\/alias\)/);
+});
+
+test("parallel research cost spike writes durable PARALLEL-BLOCKER", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-parallel-cost-blocker-"));
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    const blocker = maybeWriteParallelResearchCostSpikeBlocker(
+      "research-slice",
+      "M001/parallel-research",
+      base,
+      3.73,
+      1.02,
+    );
+
+    const expected = resolveExpectedArtifactPath("research-slice", "M001/parallel-research", base);
+    assert.match(blocker ?? "", /M001-PARALLEL-BLOCKER\.md/);
+    assert.ok(expected);
+    assert.equal(existsSync(expected!), true);
+    assert.match(readFileSync(expected!, "utf-8"), /cost spike detected \(3\.73 vs avg 1\.02\)/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1837,3 +1837,44 @@ test("#4414: verifyExpectedArtifact parallel-research succeeds when all research
     cleanup(base);
   }
 });
+
+test("parallel-research verification accepts canonical project artifacts from a worktree base", () => {
+  const base = makeTmpBase();
+  try {
+    const milestoneDir = join(base, ".gsd", "milestones", "M001");
+    mkdirSync(join(milestoneDir, "slices", "S02", "tasks"), { recursive: true });
+    mkdirSync(join(milestoneDir, "slices", "S03", "tasks"), { recursive: true });
+
+    writeFileSync(
+      join(milestoneDir, "M001-ROADMAP.md"),
+      [
+        "# M001: Regression",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Alpha** `risk:low` `depends:[]`",
+        "- [ ] **S02: Beta** `risk:low` `depends:[]`",
+        "- [ ] **S03: Gamma** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(join(milestoneDir, "M001-RESEARCH.md"), "# milestone research\n", "utf-8");
+    writeFileSync(join(milestoneDir, "slices", "S02", "S02-RESEARCH.md"), "# research\n", "utf-8");
+    writeFileSync(join(milestoneDir, "slices", "S03", "S03-RESEARCH.md"), "# research\n", "utf-8");
+
+    const worktree = join(base, ".gsd", "worktrees", "M001");
+    mkdirSync(join(worktree, ".gsd", "milestones", "M001"), { recursive: true });
+    writeFileSync(join(worktree, ".git"), "gitdir: ../../../../.git/worktrees/M001\n", "utf-8");
+
+    clearParseCache();
+    invalidateAllCaches();
+    assert.equal(
+      verifyExpectedArtifact("research-slice", "M001/parallel-research", worktree),
+      true,
+      "worktree verification should use the same canonical artifacts as dispatch",
+    );
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, test } from "node:test";
 import assert from "node:assert/strict";
-import { closeDatabase } from "../gsd-db.ts";
+import { _getAdapter, closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { filterDoctorIssues } from "../doctor-format.ts";
 import { checkEngineHealth } from "../doctor-engine-checks.ts";
+import { appendEvent } from "../workflow-events.ts";
 
 afterEach(() => {
   closeDatabase();
@@ -40,4 +41,55 @@ test("checkEngineHealth reports db_unavailable when gsd.db exists but the DB is 
   assert.ok(dbIssue, "doctor should surface degraded DB mode when a DB file exists");
   assert.equal(dbIssue.unitId, "project");
   assert.equal(dbIssue.file, ".gsd/gsd.db");
+});
+
+test("checkEngineHealth reads canonical reopen events from worktree bases", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-reopen-worktree-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const worktree = join(gsdDir, "worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  writeFileSync(join(worktree, ".git"), "gitdir: ../../../../.git/worktrees/M001\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Reopened", status: "active" });
+  const db = _getAdapter()!;
+  db.prepare(
+    `INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status, project_root_realpath
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run("worker-1", "localhost", 1, "2026-01-01T00:00:00.000Z", "test", "2026-01-01T00:00:00.000Z", "stopped", base);
+  db.prepare(
+    `INSERT INTO unit_dispatches (
+      trace_id, worker_id, milestone_lease_token, milestone_id,
+      unit_type, unit_id, status, attempt_n, started_at, ended_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "trace-1",
+    "worker-1",
+    1,
+    "M001",
+    "complete-milestone",
+    "M001",
+    "completed",
+    1,
+    "2026-01-01T00:00:00.000Z",
+    "2026-01-01T00:00:01.000Z",
+  );
+  appendEvent(base, {
+    cmd: "reopen-milestone",
+    params: { milestoneId: "M001" },
+    ts: "2026-01-01T00:00:02.000Z",
+    actor: "agent",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(worktree, issues, []);
+
+  assert.equal(
+    issues.some((issue) => issue.code === "completed_milestone_reopened"),
+    false,
+    "canonical reopen event should exempt the reopened milestone from doctor drift errors",
+  );
 });

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -93,3 +93,51 @@ test("checkEngineHealth reads canonical reopen events from worktree bases", asyn
     "canonical reopen event should exempt the reopened milestone from doctor drift errors",
   );
 });
+
+test("checkEngineHealth treats explicit reopen as authoritative when dispatch timestamps are missing", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-reopen-no-dispatch-time-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Reopened", status: "active" });
+  const db = _getAdapter()!;
+  db.prepare(
+    `INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status, project_root_realpath
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run("worker-1", "localhost", 1, "2026-01-01T00:00:00.000Z", "test", "2026-01-01T00:00:00.000Z", "stopped", base);
+  db.exec("PRAGMA writable_schema = ON");
+  db.prepare(
+    `UPDATE sqlite_schema
+     SET sql = replace(sql, 'started_at TEXT NOT NULL', 'started_at TEXT')
+     WHERE type = 'table' AND name = 'unit_dispatches'`,
+  ).run();
+  db.exec("PRAGMA writable_schema = OFF");
+  closeDatabase();
+  openDatabase(join(gsdDir, "gsd.db"));
+  const reopenedDb = _getAdapter()!;
+  reopenedDb.prepare(
+    `INSERT INTO unit_dispatches (
+      trace_id, worker_id, milestone_lease_token, milestone_id,
+      unit_type, unit_id, status, attempt_n, started_at, ended_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run("trace-1", "worker-1", 1, "M001", "complete-milestone", "M001", "completed", 1, null, null);
+  appendEvent(base, {
+    cmd: "reopen-milestone",
+    params: { milestoneId: "M001" },
+    ts: "2026-01-01T00:00:02.000Z",
+    actor: "agent",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  assert.equal(
+    issues.some((issue) => issue.code === "completed_milestone_reopened"),
+    false,
+    "explicit reopen should exempt reopened milestone even when completion dispatch timestamps are absent",
+  );
+});

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -17,6 +17,7 @@ import { randomUUID } from "node:crypto";
 import {
   openDatabase,
   closeDatabase,
+  _getAdapter,
   insertMilestone,
   insertSlice,
   insertTask,
@@ -1050,6 +1051,94 @@ test("ADR-017 (#5706): repair is idempotent — re-running preserves the timesta
     "second pass: no drift detected after first repair",
   );
   assert.equal(getSlice("M001", "S01")?.completed_at, tsAfterFirst, "timestamp unchanged");
+});
+
+test("ADR-017: artifact/DB status divergence fails closed instead of importing completion artifacts", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-artifact-db-drift-"));
+  t.after(() => cleanup(base));
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "# S01 Summary\n\nAlready done on disk.\n",
+  );
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch(base, {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.match((err as Error).message, /artifact-db-status-divergence/);
+      assert.equal(getSlice("M001", "S01")?.status, "pending", "DB status remains authoritative");
+      return true;
+    },
+  );
+});
+
+test("ADR-017: completed milestone dispatch history blocks accidental re-planning", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-completed-reopened-drift-"));
+  t.after(() => cleanup(base));
+
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  adapter.prepare(
+    `INSERT OR REPLACE INTO workers
+      (worker_id, host, pid, started_at, version, last_heartbeat_at, status, project_root_realpath)
+     VALUES ('w1', 'local', 1, '2026-05-30T00:00:00.000Z', 'test', '2026-05-30T00:00:00.000Z', 'stopped', :root)`,
+  ).run({ ":root": base });
+  adapter.prepare(
+    `INSERT INTO unit_dispatches
+      (trace_id, worker_id, milestone_lease_token, milestone_id, unit_type, unit_id, status, attempt_n, started_at, ended_at)
+     VALUES
+      ('trace', 'w1', 1, 'M001', 'complete-milestone', 'M001', 'completed', 1, '2026-05-30T00:00:00.000Z', '2026-05-30T00:01:00.000Z')`,
+  ).run();
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch(base, {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.match((err as Error).message, /completed-milestone-reopened/);
+      return true;
+    },
+  );
+});
+
+test("ADR-017: synthetic parallel-research slice directory is ignored", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-parallel-sentinel-drift-"));
+  t.after(() => cleanup(base));
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "parallel-research", "tasks"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    existsSync(join(base, ".gsd", "milestones", "M001", "slices", "parallel-research")),
+    true,
+    "sentinel directory is left alone, not treated as a real disk-only slice",
+  );
+  assert.equal(result.repaired.some((record) => record.kind === "disk-slice-id-divergence"), false);
 });
 
 // ─── #5707: caller closure (reconcileBeforeSpawn) ────────────────────────────

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -18,6 +18,7 @@ import {
   openDatabase,
   closeDatabase,
   _getAdapter,
+  insertArtifact,
   insertMilestone,
   insertSlice,
   insertTask,
@@ -1076,6 +1077,38 @@ test("ADR-017: artifact/DB status divergence fails closed instead of importing c
       assert.ok(err instanceof ReconciliationFailedError);
       assert.match((err as Error).message, /artifact-db-status-divergence/);
       assert.equal(getSlice("M001", "S01")?.status, "pending", "DB status remains authoritative");
+      return true;
+    },
+  );
+});
+
+test("ADR-017: orphan task completion artifact fails closed", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orphan-task-artifact-drift-"));
+  t.after(() => cleanup(base));
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T99"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task", status: "pending" });
+  insertArtifact({
+    path: join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T99", "T99-SUMMARY.md"),
+    artifact_type: "SUMMARY",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T99",
+    full_content: "# T99 Summary\n\nStale artifact after replan.\n",
+  });
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch(base, {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.match((err as Error).message, /artifact-db-status-divergence/);
       return true;
     },
   );

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -108,6 +108,34 @@ test("executeSummarySave persists artifact and returns computed path", async () 
   }
 });
 
+test("executeSummarySave mirrors milestone artifacts into the active worktree projection", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  try {
+    mkdirSync(join(worktree, ".gsd"), { recursive: true });
+    writeFileSync(join(worktree, ".git"), "gitdir: ../../../.git/worktrees/M001\n");
+    openTestDb(base);
+
+    const result = await inProjectDir(worktree, () => executeSummarySave({
+      milestone_id: "M001",
+      slice_id: "S02",
+      artifact_type: "RESEARCH",
+      content: "# S02 Research\n\ncanonical and worktree",
+    }, worktree));
+
+    assert.equal(result.details.operation, "save_summary");
+    const relPath = "milestones/M001/slices/S02/S02-RESEARCH.md";
+    const projectPath = join(base, ".gsd", relPath);
+    const worktreePath = join(worktree, ".gsd", relPath);
+    assert.equal(existsSync(projectPath), true, "canonical artifact should be written");
+    assert.equal(existsSync(worktreePath), true, "active worktree projection should be mirrored");
+    assert.match(readFileSync(worktreePath, "utf-8"), /S02 Research/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeTaskComplete coerces string verificationEvidence entries", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -15,8 +15,10 @@ import {
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
-import { resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { clearPathCache, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { saveFile, clearParseCache } from "../files.js";
 import { unlinkSync } from "node:fs";
+import { join } from "node:path";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
 import { handleCompleteMilestone } from "./complete-milestone.js";
 import { handleCompleteTask } from "./complete-task.js";
@@ -94,6 +96,28 @@ function registerProjectMilestoneSequence(content: string): string[] {
     registered.push(milestone.id);
   }
   return registered;
+}
+
+async function mirrorArtifactToActiveWorktreeProjection(
+  basePath: string,
+  relativePath: string,
+  content: string,
+): Promise<void> {
+  const contract = resolveGsdPathContract(basePath);
+  if (!contract.worktreeGsd) return;
+  if (contract.worktreeGsd === contract.projectGsd) return;
+
+  const fullPath = join(contract.worktreeGsd, relativePath);
+  try {
+    await saveFile(fullPath, content);
+    clearPathCache();
+    clearParseCache();
+    invalidateStateCache();
+  } catch (err) {
+    logWarning("tool", `gsd_summary_save worktree projection mirror failed: ${(err as Error).message}`, {
+      path: relativePath,
+    });
+  }
 }
 
 export async function executeSummarySave(
@@ -197,6 +221,7 @@ export async function executeSummarySave(
       },
       basePath,
     );
+    await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, contentToSave);
 
     let registeredMilestones: string[] = [];
     if (params.artifact_type === "PROJECT") {


### PR DESCRIPTION
## Summary

This PR hardens GSD auto-mode against the drift pattern found in `/Users/jeremymcspadden/github/test-apps/123`:

- Adds fail-closed reconciliation for DB/artifact status drift and accidental re-planning of already completed milestones.
- Adds disk slice-ID divergence handling without silently importing disk-only slice IDs into the DB.
- Mirrors `gsd_summary_save` artifacts into the active worktree projection so verifier/dispatch do not split canonical and worktree views.
- Hardens `parallel-research` by ignoring its synthetic slice dir, skipping PLAN regeneration for it, and writing a durable `PARALLEL-BLOCKER` on cost spikes.
- Extends doctor diagnostics for artifact/DB status drift and completed milestone reopen drift.

## Root Cause

A completed milestone could be reopened/replanned with DB slices reset to pending while existing artifact history and worktree projections disagreed. Parallel research then verified against the active worktree projection, missed canonical research files, and retried/paused on the synthetic `parallel-research` unit.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782777891&installation_id=134682257&pr_number=284&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F284&signature=b7e4f9eed615714a068b2d1e4df220819746421fcec0707d093282b0bfb15990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes pre-dispatch reconciliation, milestone reopen semantics, and artifact/DB authority—core workflow paths where mistakes could block auto-mode or allow unsafe replanning without explicit recovery.
> 
> **Overview**
> This PR tightens **fail-closed** behavior when GSD auto-mode sees DB, filesystem, and worktree views diverge—especially after a milestone was completed and later reopened without a clear audit trail.
> 
> **Reconciliation & doctor** add drift kinds for completion artifacts vs open DB rows, milestones with completed `complete-milestone` dispatch history but non-closed DB status (unless an explicit `reopen-milestone` event), and disk-only slice directories (empty delete, scaffold quarantine, meaningful paths block). **`milestone-reopen-events`** supplies reopen timestamps from the workflow event log so those checks respect intentional reopens.
> 
> **Dispatch & verification** prefer **`resolveExpectedArtifactPath`** (canonical + worktree-aware) over legacy milestone/slice file helpers for parallel/single slice research, roadmap/deps, and blockers. **`gsd_summary_save`** mirrors saved artifacts into the active worktree projection so verifiers and dispatch see the same files.
> 
> **Parallel research** ignores the synthetic `parallel-research` slice dir in doctor orphan checks, skips PLAN regeneration for that unit, aligns recovery verification with expected paths, and on cost spikes writes a durable parallel blocker so dispatch can fall back to per-slice research instead of looping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad881f3001ee78085b184c06f01d67c3ee8e1f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->