### PR TITLE
fix(issue): discardMilestone silently skips DB cleanup when MCP server holds WAL connection

### DIFF
--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -162,6 +162,8 @@ export function discardMilestone(basePath: string, milestoneId: string): boolean
     } catch (err) {
       logWarning("engine", `discardMilestone DB cleanup failed for ${milestoneId}: ${(err as Error).message}`);
     }
+  } else {
+    logWarning("engine", `discardMilestone DB cleanup skipped for ${milestoneId}: database unavailable`);
   }
 
   invalidateAllCaches();

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -19,6 +19,7 @@ import {
   openDatabase,
 } from "../gsd-db.ts";
 import { createWorktree } from "../worktree-manager.ts";
+import { _resetLogs, drainLogs, setStderrLoggingEnabled } from "../workflow-logger.ts";
 
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
 
@@ -190,7 +191,9 @@ test('getActiveMilestoneId skips parked', async () => {
   // ─── Test 10: discardMilestone removes directory ──────────────────────
 test('discardMilestone removes directory', async () => {
     const base = createFixtureBase();
+    const previousStderr = setStderrLoggingEnabled(false);
     try {
+      _resetLogs();
       createMilestone(base, 'M001', { withRoadmap: true });
       clearCaches();
 
@@ -200,7 +203,13 @@ test('discardMilestone removes directory', async () => {
       const success = discardMilestone(base, 'M001');
       assert.ok(success, 'discardMilestone returns true');
       assert.ok(!existsSync(mDir), 'milestone dir removed after discard');
+      const logs = drainLogs();
+      assert.ok(
+        logs.some((entry) => entry.message.includes('discardMilestone DB cleanup skipped for M001: database unavailable')),
+        'discardMilestone warns when DB cleanup is skipped',
+      );
     } finally {
+      setStderrLoggingEnabled(previousStderr);
       cleanup(base);
     }
 });


### PR DESCRIPTION
## Summary
- Added an explicit warning when discardMilestone skips DB deletion due unavailable DB and covered it with a focused discard regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #204
- [#204 discardMilestone silently skips DB cleanup when MCP server holds WAL connection](https://github.com/open-gsd/gsd-pi/issues/204)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/204-discardmilestone-silently-skips-db-clean-1780185879`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782777962&installation_id=134682257&pr_number=285&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F285&signature=50113ea7111371a4ba230324c9ef567c9076fef8c8fa3cfac4f5db56c14f3b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change; discard still succeeds on disk and behavior when the DB is available is unchanged.
> 
> **Overview**
> When **`discardMilestone`** cannot reach the GSD database, it now emits an **engine warning** that DB cleanup was skipped (same pattern as failed `deleteMilestone`), instead of doing nothing with no signal.
> 
> A **park-milestone** regression test was updated to capture logs and assert that warning when the fixture runs discard without an open DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f0178aad2ceee2adf8d6993390c435fb779138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->