### PR TITLE
fix(issue): Project with configured remote falls into first-time-init: getRemoteUrl() swallows transient git failures, flipping the identity hash

### DIFF
--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -323,7 +323,10 @@ export function repoIdentity(basePath: string): string {
     // Unknown remote status (transient git failure): prefer persisted identity.
     const markerRoot = resolveGitRoot(basePath);
     const markerId = readGsdIdMarker(markerRoot);
-    if (markerId) return markerId;
+    if (markerId) {
+      const markerPath = join(process.env.GSD_STATE_DIR || gsdHome(), "projects", markerId);
+      if (hasProjectState(markerPath)) return markerId;
+    }
   }
   // Local-only repo: include git root since there's no remote to anchor identity.
   const root = resolveGitRoot(basePath);

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -202,6 +202,17 @@ function getRemoteUrl(basePath: string): string | null {
       timeout: 5_000,
     }).trim();
   } catch (error) {
+    const status = typeof error === "object" && error !== null && "status" in error
+      ? (error as { status?: number }).status
+      : undefined;
+    if (status === 1) {
+      try {
+        if (existsSync(join(resolveGitCommonDir(basePath), "config"))) return "";
+      } catch {
+        // Fall through to report unknown git/config failures.
+      }
+    }
+
     // Keep transient git failures distinct from "no remote configured".
     console.warn(`[GSD] repo-identity: failed to resolve remote.origin.url for ${basePath}:`, error);
     return null;

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -188,10 +188,12 @@ function isProjectGsd(gsdPath: string): boolean {
 // ─── Repo Identity ──────────────────────────────────────────────────────────
 
 /**
- * Get the git remote URL for "origin", or "" if no remote is configured.
+ * Get the git remote URL for "origin", or:
+ * - "" when git cleanly reports no remote
+ * - null when git command failed (transient/unknown)
  * Uses `git config` rather than `git remote get-url` for broader compat.
  */
-function getRemoteUrl(basePath: string): string {
+function getRemoteUrl(basePath: string): string | null {
   try {
     return execFileSync("git", ["config", "--get", "remote.origin.url"], {
       cwd: basePath,
@@ -199,8 +201,10 @@ function getRemoteUrl(basePath: string): string {
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
     }).trim();
-  } catch {
-    return "";
+  } catch (error) {
+    // Keep transient git failures distinct from "no remote configured".
+    console.warn(`[GSD] repo-identity: failed to resolve remote.origin.url for ${basePath}:`, error);
+    return null;
   }
 }
 
@@ -300,6 +304,12 @@ export function repoIdentity(basePath: string): string {
     // This makes moves transparent for repos with remotes (#2750).
     return createHash("sha256").update(remoteUrl).digest("hex").slice(0, 12);
   }
+  if (remoteUrl === null) {
+    // Unknown remote status (transient git failure): prefer persisted identity.
+    const markerRoot = resolveGitRoot(basePath);
+    const markerId = readGsdIdMarker(markerRoot);
+    if (markerId) return markerId;
+  }
   // Local-only repo: include git root since there's no remote to anchor identity.
   const root = resolveGitRoot(basePath);
   const input = `\n${root}`;
@@ -315,8 +325,7 @@ export function repoIdentity(basePath: string): string {
  * otherwise `~/.gsd/projects/<hash>`.
  */
 export function externalGsdRoot(basePath: string): string {
-  const base = process.env.GSD_STATE_DIR || gsdHome();
-  return join(base, "projects", repoIdentity(basePath));
+  return resolveExternalPathWithRecovery(basePath).path;
 }
 
 /**
@@ -596,7 +605,7 @@ function ensureGsdSymlinkCore(projectPath: string): { path: string; identity: st
   // Write repo metadata once so cleanup commands can identify this directory later.
   // Skip refresh for external-state worktrees — parent store already has metadata.
   if (!(isGsdWorktreePath(projectPath) && resolveExternalStateProjectGsdFromWorktreePath(projectPath))) {
-    writeRepoMeta(externalPath, getRemoteUrl(projectPath), resolveGitRoot(projectPath));
+    writeRepoMeta(externalPath, getRemoteUrl(projectPath) ?? "", resolveGitRoot(projectPath));
   }
 
   const replaceWithSymlink = (): { path: string; identity: string } => {

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -325,7 +325,7 @@ export function repoIdentity(basePath: string): string {
     const markerId = readGsdIdMarker(markerRoot);
     if (markerId) {
       const markerPath = join(process.env.GSD_STATE_DIR || gsdHome(), "projects", markerId);
-      if (hasProjectState(markerPath)) return markerId;
+      if (hasProjectState(markerPath) || readRepoMeta(markerPath)) return markerId;
     }
   }
   // Local-only repo: include git root since there's no remote to anchor identity.

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -16,6 +16,7 @@ import {
   resolveExternalStateProjectGsdFromWorktreePath,
   resolveExternalStateProjectIdentityFromWorktreePath,
 } from "./worktree-root.js";
+import { logWarning } from "./workflow-logger.js";
 
 
 // ─── Repo Metadata ───────────────────────────────────────────────────────────
@@ -214,7 +215,10 @@ function getRemoteUrl(basePath: string): string | null {
     }
 
     // Keep transient git failures distinct from "no remote configured".
-    console.warn(`[GSD] repo-identity: failed to resolve remote.origin.url for ${basePath}:`, error);
+    logWarning("state", "repo-identity: failed to resolve remote.origin.url", {
+      basePath,
+      error: String(error),
+    });
     return null;
   }
 }

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -522,6 +522,7 @@ function resolveExternalPathWithRecovery(projectPath: string): { path: string; i
         }
         // Clean up old directory after successful migration.
         try { rmSync(markerPath, { recursive: true, force: true }); } catch { /* non-fatal */ }
+        writeGsdIdMarker(projectPath, computedId);
       } catch {
         // If migration fails, just point at the old directory.
         return { path: markerPath, identity: markerId };

--- a/src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts
@@ -271,6 +271,46 @@ describe("project-relocation-recovery (#2750)", () => {
     rmSync(repoB, { recursive: true, force: true });
   });
 
+  test("repoIdentity ignores stale .gsd-id after relocation migration when git remote lookup fails", () => {
+    const repoA = realpathSync(mkdtempSync(join(tmpdir(), "gsd-reloc-stale-marker-a-")));
+    initRepo(repoA);
+
+    const externalA = ensureGsdSymlink(repoA);
+    mkdirSync(join(externalA, "milestones"), { recursive: true });
+    writeFileSync(join(externalA, "milestones", "M001.md"), "# Local Milestone\n", "utf-8");
+
+    const repoB = join(
+      tmpdir(),
+      `gsd-reloc-stale-marker-b-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    renameSync(repoA, repoB);
+
+    const migratedExternal = externalGsdRoot(repoB);
+    const expectedIdentity = repoIdentity(repoB);
+    rmSync(join(repoB, ".git", "config"), { force: true });
+
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      assert.strictEqual(
+        repoIdentity(repoB),
+        expectedIdentity,
+        "transient git failures must not pin identity to a stale marker",
+      );
+      assert.ok(
+        existsSync(join(migratedExternal, "milestones", "M001.md")),
+        "migrated state remains under the recovered identity",
+      );
+    } finally {
+      console.warn = originalWarn;
+      rmSync(repoB, { recursive: true, force: true });
+    }
+  });
+
   // ── Edge cases ────────────────────────────────────────────────────────
 
   test("identity remains different for repos with different remotes", () => {

--- a/src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts
@@ -204,6 +204,32 @@ describe("project-relocation-recovery (#2750)", () => {
     rmSync(repo, { recursive: true, force: true });
   });
 
+  test("local-only repo does not warn when origin remote is missing", () => {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-reloc-no-origin-")));
+    initRepo(repo);
+
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      repoIdentity(repo);
+      externalGsdRoot(repo);
+      ensureGsdSymlink(repo);
+    } finally {
+      console.warn = originalWarn;
+      rmSync(repo, { recursive: true, force: true });
+    }
+
+    assert.deepStrictEqual(
+      warnings,
+      [],
+      "missing origin must be treated as local-only repo, not a git failure",
+    );
+  });
+
   test("local-only repo recovers state via .gsd-id marker after move", () => {
     const repoA = realpathSync(mkdtempSync(join(tmpdir(), "gsd-reloc-local-a-")));
     initRepo(repoA);

--- a/src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts
@@ -311,6 +311,41 @@ describe("project-relocation-recovery (#2750)", () => {
     }
   });
 
+  test("externalGsdRoot syncs .gsd-id after recovering remote-backed state", () => {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-reloc-remote-marker-")));
+    initRepo(repo, "https://github.com/example/remote-marker.git");
+
+    const expectedIdentity = repoIdentity(repo);
+    const staleMarkerId = "stale-marker-id";
+    const staleExternal = join(stateDir, "projects", staleMarkerId);
+    mkdirSync(join(staleExternal, "milestones"), { recursive: true });
+    writeFileSync(join(staleExternal, "milestones", "M001.md"), "# Remote Milestone\n", "utf-8");
+    writeFileSync(join(repo, ".gsd-id"), `${staleMarkerId}\n`, "utf-8");
+
+    const recoveredExternal = externalGsdRoot(repo);
+    assert.strictEqual(
+      readFileSync(join(repo, ".gsd-id"), "utf-8").trim(),
+      expectedIdentity,
+      "recovery must update .gsd-id to the identity that now owns migrated state",
+    );
+
+    rmSync(join(repo, ".git", "config"), { force: true });
+
+    try {
+      assert.strictEqual(
+        repoIdentity(repo),
+        expectedIdentity,
+        "transient git failures must keep using the recovered remote-backed identity",
+      );
+      assert.ok(
+        existsSync(join(recoveredExternal, "milestones", "M001.md")),
+        "migrated state remains under the recovered remote-backed identity",
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   // ── Edge cases ────────────────────────────────────────────────────────
 
   test("identity remains different for repos with different remotes", () => {

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -255,4 +255,31 @@ test('ensureGsdSymlink prefers marker directory when marker/computed identities 
     rmSync(repo, { recursive: true, force: true });
 });
 
+test('repoIdentity/externalGsdRoot stay marker-stable when git remote read transiently fails (#276)', () => {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-remote-transient-")));
+    run("git init -b main", repo);
+    run('git config user.name "Pi Test"', repo);
+    run('git config user.email "pi@example.com"', repo);
+    run('git remote add origin git@github.com:example/transient.git', repo);
+    writeFileSync(join(repo, "README.md"), "# Transient Remote Test\n", "utf-8");
+    run("git add README.md", repo);
+    run('git commit -m "init"', repo);
+
+    const stableExternal = ensureGsdSymlink(repo);
+    const stableIdentity = repoIdentity(repo);
+    assert.deepStrictEqual(externalGsdRoot(repo), stableExternal, "externalGsdRoot initially resolves canonical state directory");
+
+    const gitConfigPath = join(repo, ".git", "config");
+    const gitConfigBakPath = join(repo, ".git", "config.bak");
+    renameSync(gitConfigPath, gitConfigBakPath);
+
+    try {
+      assert.deepStrictEqual(repoIdentity(repo), stableIdentity, "repoIdentity remains anchored to .gsd-id marker during transient git remote read failure");
+      assert.deepStrictEqual(externalGsdRoot(repo), stableExternal, "externalGsdRoot remains marker-resolved during transient git remote read failure");
+    } finally {
+      renameSync(gitConfigBakPath, gitConfigPath);
+      rmSync(repo, { recursive: true, force: true });
+    }
+});
+
 });


### PR DESCRIPTION
## Summary
- Fixed repo identity resolution to preserve marker-based identity during transient git remote lookup failures and unified external path recovery, with a focused regression test for #276.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #276
- [#276 Project with configured remote falls into first-time-init: getRemoteUrl() swallows transient git failures, flipping the identity hash](https://github.com/open-gsd/gsd-pi/issues/276)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/276-project-with-configured-remote-falls-int-1780186035`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782778127&installation_id=134682257&pr_number=287&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F287&signature=93afe5c2aed0603d7ef62bc9c73a10e6626ff9edb3503efd646a7363e22a3bf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core project identity and external state path resolution; incorrect behavior could attach the wrong state directory, but scope is narrow and well-covered by new tests.
> 
> **Overview**
> Fixes **repo identity** when `git config` for `remote.origin.url` fails transiently (e.g. broken `.git/config`), which previously looked like “no remote” and could re-hash the project into empty first-time state (#276).
> 
> **`getRemoteUrl`** now returns `""` only when git cleanly reports no origin (exit 1 with a readable git config), **`null`** on other failures (with a warning), and **`repoIdentity`** uses the **`.gsd-id` marker** and existing external state when `remoteUrl === null` instead of falling back to path-only hashing. **`externalGsdRoot`** already goes through recovery; **`writeGsdIdMarker`** runs after successful relocation migration, and **`writeRepoMeta`** treats unknown remote as `""`.
> 
> Regression tests cover missing origin (no warn), stale markers during git failure, remote recovery + marker sync, and stable identity/`externalGsdRoot` when config is temporarily unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aaf7fad9f603cf5543e6367272646f859e975c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->