### PR TITLE
fix(issue): UOK orchestrator bypasses pre_dispatch_hooks — policy injection never fires

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -957,12 +957,12 @@ export async function autoLoop(
             if (preDispatchResult.unitType) {
               iterData.unitType = preDispatchResult.unitType;
             }
-            if (preDispatchResult.model) {
-              iterData.hookModelOverride = preDispatchResult.model;
-            }
           } else if (preDispatchResult.prompt) {
             iterData.prompt = preDispatchResult.prompt;
             iterData.finalPrompt = preDispatchResult.prompt;
+          }
+          if (preDispatchResult.model) {
+            iterData.hookModelOverride = preDispatchResult.model;
           }
           s.pendingOrchestrationDispatch = null;
           phaseReporter.report("dispatch", "next", {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -918,6 +918,52 @@ export async function autoLoop(
             isRetry: false,
             previousTier: undefined,
           };
+          const preDispatchResult = deps.runPreDispatchHooks(
+            iterData.unitType,
+            iterData.unitId,
+            iterData.prompt,
+            s.basePath,
+          );
+          if (preDispatchResult.firedHooks.length > 0) {
+            ctx.ui.notify(
+              `Pre-dispatch hook${preDispatchResult.firedHooks.length > 1 ? "s" : ""}: ${preDispatchResult.firedHooks.join(", ")}`,
+              "info",
+            );
+            deps.emitJournalEvent({
+              ts: new Date().toISOString(),
+              flowId: ic.flowId,
+              seq: ic.nextSeq(),
+              eventType: "pre-dispatch-hook",
+              data: {
+                firedHooks: preDispatchResult.firedHooks,
+                action: preDispatchResult.action,
+              },
+            });
+          }
+          if (preDispatchResult.action === "skip") {
+            ctx.ui.notify(
+              `Skipping ${iterData.unitType} ${iterData.unitId} (pre-dispatch hook).`,
+              "info",
+            );
+            s.pendingOrchestrationDispatch = null;
+            emitIterationEnd({ skipped: true });
+            completeIteration();
+            finishTurn("skipped");
+            continue;
+          }
+          if (preDispatchResult.action === "replace") {
+            iterData.prompt = preDispatchResult.prompt ?? iterData.prompt;
+            iterData.finalPrompt = iterData.prompt;
+            if (preDispatchResult.unitType) {
+              iterData.unitType = preDispatchResult.unitType;
+            }
+            if (preDispatchResult.model) {
+              iterData.hookModelOverride = preDispatchResult.model;
+            }
+          } else if (preDispatchResult.prompt) {
+            iterData.prompt = preDispatchResult.prompt;
+            iterData.finalPrompt = preDispatchResult.prompt;
+          }
           s.pendingOrchestrationDispatch = null;
           phaseReporter.report("dispatch", "next", {
             unitType: iterData.unitType,

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1773,6 +1773,11 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
   const ctx = makeMockCtx();
   ctx.ui.setStatus = () => {};
   ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  ctx.modelRegistry = {
+    getAvailable: () => [{ provider: "test", id: "hook-model" }],
+    getProviderAuthMode: () => undefined,
+    isProviderRequestReady: () => true,
+  };
   const pi = makeMockPi();
   const stateSnapshot = {
     phase: "executing",
@@ -1826,6 +1831,7 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
       firedHooks: ["complete-slice-policies"],
       action: "proceed",
       prompt: "hooked prompt",
+      model: "hook-model",
     }),
     emitJournalEvent: (entry: any) => {
       journalEvents.push(entry);
@@ -1852,6 +1858,14 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
     (pi.calls[0] as any[])[0].content,
     "hooked prompt",
     "runUnit should receive the dispatch prompt after pre-dispatch hooks",
+  );
+  assert.deepEqual(
+    pi.setModelCalls.map((call: any[]) => call[0]),
+    [
+      { provider: "test", id: "hook-model" },
+      { provider: "test", id: "hook-model" },
+    ],
+    "proceed hooks should apply model overrides before dispatch",
   );
   assert.deepEqual(finalizedUnits, ["execute-task:M002/S03/T05"]);
   assert.equal(s.pendingOrchestrationDispatch, null, "pending dispatch should be one-shot");

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1784,6 +1784,7 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
   } as any;
   let advanceCalls = 0;
   const finalizedUnits: string[] = [];
+  const journalEvents: any[] = [];
   let s: any;
   s = makeLoopSession({
     currentMilestoneId: "M002",
@@ -1821,6 +1822,14 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
       deps.callLog.push("resolveDispatch");
       throw new Error("legacy resolveDispatch must not run when orchestration is wired");
     },
+    runPreDispatchHooks: () => ({
+      firedHooks: ["complete-slice-policies"],
+      action: "proceed",
+      prompt: "hooked prompt",
+    }),
+    emitJournalEvent: (entry: any) => {
+      journalEvents.push(entry);
+    },
     postUnitPostVerification: async () => {
       deps.callLog.push("postUnitPostVerification");
       s.active = false;
@@ -1841,11 +1850,16 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
   );
   assert.equal(
     (pi.calls[0] as any[])[0].content,
-    "advance prompt",
-    "runUnit should receive the dispatch prompt captured by advance()",
+    "hooked prompt",
+    "runUnit should receive the dispatch prompt after pre-dispatch hooks",
   );
   assert.deepEqual(finalizedUnits, ["execute-task:M002/S03/T05"]);
   assert.equal(s.pendingOrchestrationDispatch, null, "pending dispatch should be one-shot");
+  assert.equal(
+    journalEvents.filter((entry) => entry.eventType === "pre-dispatch-hook").length,
+    1,
+    "hook dispatch should emit one pre-dispatch-hook journal event",
+  );
 });
 
 test("autoLoop consumes pending orchestration dispatch without advancing twice", async () => {


### PR DESCRIPTION
## Summary
- Added pre-dispatch hook execution to the orchestrator dispatch path and updated the orchestrator loop test to verify prompt injection and hook journaling.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #256
- [#256 UOK orchestrator bypasses pre_dispatch_hooks — policy injection never fires](https://github.com/open-gsd/gsd-pi/issues/256)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/256-uok-orchestrator-bypasses-pre-dispatch-h-1780186058`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782778168&installation_id=134682257&pr_number=289&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F289&signature=e0babc7a77e3d13ab0c951f8dbf866e144543202feae7730aade7934a58845db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode dispatch behavior for orchestrated runs (prompt, skip, model); limited scope but affects workflow execution and policy injection timing.
> 
> **Overview**
> The UOK orchestrator path in `autoLoop` now runs **`runPreDispatchHooks`** after `orchestration.advance()` builds dispatch data and before the unit is sent—matching the dev loop so policy hooks (e.g. slice completion policies) are not skipped.
> 
> Hook outcomes update **`iterData`**: **skip** ends the iteration without dispatch; **replace** / prompt tweaks change the prompt (and optionally unit type); **model** sets `hookModelOverride`. Fired hooks trigger UI notices and a **`pre-dispatch-hook`** journal event.
> 
> Tests for orchestration advance dispatch assert the hooked prompt, model override, and journal emission instead of the raw advance prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b122dd25bfe3c785765852228d1feacfd1de32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->