### PR TITLE
fix(issue): [Bug]: retry_on post-unit hook stops auto-mode when same execute-task is re-dispatched

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2031,6 +2031,11 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
           "info",
         );
 
+        await s.orchestration?.retryActiveUnit({
+          unitType: trigger.unitType,
+          unitId: trigger.unitId,
+        });
+
         // ── State reset: undo the completion so deriveState re-derives the unit ──
         try {
           const { milestone: mid, slice: sid, task: tid } = parseUnitId(trigger.unitId);

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -396,9 +396,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     const activeUnitKey = this.status.activeUnit
       ? `${this.status.activeUnit.unitType}:${this.status.activeUnit.unitId}`
       : null;
-    if (activeUnitKey !== unitKey) return;
+    if (activeUnitKey !== unitKey && this.lastFinalizedUnitKey !== unitKey) return;
 
-    this.status.activeUnit = undefined;
+    if (activeUnitKey === unitKey) {
+      this.status.activeUnit = undefined;
+    }
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
     this.bumpTransition();

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -592,6 +592,27 @@ test("retryActiveUnit clears in-flight idempotency without marking the unit fina
   assert.equal(prepareCalls, 2, "retry should intentionally redispatch the same unit");
 });
 
+test("retryActiveUnit clears finalized same-unit guard for post-hook retries", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const first = await orchestrator.advance();
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+
+  await orchestrator.completeActiveUnit(first.unit);
+  await orchestrator.retryActiveUnit(first.unit);
+  const second = await orchestrator.advance();
+
+  assert.equal(second.kind, "advanced");
+  if (second.kind !== "advanced") throw new Error("expected retry advance");
+  assert.deepEqual(second.unit, first.unit);
+  assert.ok(calls.includes("journal:unit-finalized"));
+  assert.ok(calls.includes("journal:unit-retry"));
+  const prepareCalls = calls.filter((c) => c === "worktree.prepare").length;
+  assert.equal(prepareCalls, 2, "post-hook retry should redispatch the finalized unit");
+});
+
 test("resume() re-enters running phase", async () => {
   const { deps } = makeDeps();
   const orchestrator = createAutoOrchestrator(deps);

--- a/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
@@ -17,6 +17,7 @@ post_unit_hooks:
   - name: review-arbiter
     after:
       - execute-task
+    prompt: Review {taskId}
     agent: arbiter
     artifact: REVIEW-DEBATE.md
     retry_on: NEEDS-REWORK.md
@@ -46,7 +47,7 @@ test("post-unit retry_on marks trigger unit as retry in orchestrator before redi
     const retryPath = resolveHookArtifactPath(base, "M001/S01/T01", "NEEDS-REWORK.md");
     writeFileSync(retryPath, "rework requested", "utf-8");
 
-    const retryActiveUnit = mock.fn(async () => {});
+    const retryActiveUnit = mock.fn(async (_unit: { unitType: string; unitId: string }) => {});
     const s = new AutoSession();
     s.basePath = base;
     s.active = true;

--- a/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mock } from "node:test";
+
+import { postUnitPostVerification, type PostUnitContext } from "../auto-post-unit.ts";
+import { AutoSession } from "../auto/session.ts";
+import { checkPostUnitHooks, resetHookState, resolveHookArtifactPath } from "../post-unit-hooks.ts";
+import { _clearGsdRootCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+function writePreferences(basePath: string): void {
+  const content = `---
+post_unit_hooks:
+  - name: review-arbiter
+    after:
+      - execute-task
+    agent: arbiter
+    artifact: REVIEW-DEBATE.md
+    retry_on: NEEDS-REWORK.md
+    max_cycles: 3
+    enabled: true
+---
+`;
+  writeFileSync(join(basePath, ".gsd", "PREFERENCES.md"), content, "utf-8");
+}
+
+test("post-unit retry_on marks trigger unit as retry in orchestrator before redispatch", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-retry-"));
+  const taskDir = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+  mkdirSync(taskDir, { recursive: true });
+
+  try {
+    process.chdir(base);
+    _clearGsdRootCache();
+    invalidateAllCaches();
+    resetHookState();
+    writePreferences(base);
+
+    const hookDispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(hookDispatch, "hook should dispatch for execute-task");
+
+    const retryPath = resolveHookArtifactPath(base, "M001/S01/T01", "NEEDS-REWORK.md");
+    writeFileSync(retryPath, "rework requested", "utf-8");
+
+    const retryActiveUnit = mock.fn(async () => {});
+    const s = new AutoSession();
+    s.basePath = base;
+    s.active = true;
+    s.currentUnit = { type: "hook/review-arbiter", id: "M001/S01/T01", startedAt: Date.now() };
+    s.orchestration = {
+      start: async () => ({ kind: "started" }),
+      advance: async () => ({ kind: "stopped", reason: "unused" }),
+      completeActiveUnit: async () => {},
+      retryActiveUnit,
+      resume: async () => ({ kind: "resumed" }),
+      stop: async (reason: string) => ({ kind: "stopped", reason }),
+      getStatus: () => ({ phase: "running", transitionCount: 0 }),
+    };
+
+    const pctx: PostUnitContext = {
+      s,
+      ctx: {
+        ui: { notify: () => {}, setStatus: () => {}, setWidget: () => {}, setFooter: () => {} },
+        model: { id: "test-model" },
+      } as any,
+      pi: { sendMessage: async () => {}, setModel: async () => true } as any,
+      buildSnapshotOpts: () => ({}),
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => {},
+      updateProgressWidget: () => {},
+    };
+
+    const result = await postUnitPostVerification(pctx);
+    assert.equal(result, "continue");
+    assert.equal(retryActiveUnit.mock.callCount(), 1);
+    assert.deepEqual(retryActiveUnit.mock.calls[0]?.arguments[0], {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+  } finally {
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Added an orchestrator retry bridge for post-unit `retry_on` so intentional same-task redispatch no longer hits the finalized-unit stop guard, with a targeted regression test added.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #273
- [#273 [Bug]: retry_on post-unit hook stops auto-mode when same execute-task is re-dispatched](https://github.com/open-gsd/gsd-pi/issues/273)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/273-bug-retry-on-post-unit-hook-stops-auto-m-1780186552`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782778705&installation_id=134682257&pr_number=291&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F291&signature=a87edc39bb486b8bb9d14e7ea19864baef28fbc7049433ed01de35859ba5decc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-orchestrator finalize/retry guards and post-unit hook flow; behavior is narrow but affects when the same unit can advance again in auto-mode.
> 
> **Overview**
> Fixes auto-mode stopping when a post-unit hook’s **`retry_on`** (e.g. `NEEDS-REWORK.md`) asks to rerun the same **`execute-task`** after that task was already finalized.
> 
> **`postUnitPostVerification`** now calls **`orchestration.retryActiveUnit`** for the trigger unit **before** DB/markdown cleanup, so the orchestrator clears guards that blocked redispatch.
> 
> **`retryActiveUnit`** no longer requires the unit to still be “active”; it also runs when **`lastFinalizedUnitKey`** matches (typical post-hook path) and only clears **`activeUnit`** when it is still that unit.
> 
> Regression coverage: orchestrator test for finalize-then-retry, plus an integration test that **`retry_on`** invokes **`retryActiveUnit`** with the original **`execute-task`** id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8848f8d0e4c145c8e8ab4c858797477f54428f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->