### PR TITLE
fix(issue): fix(pi-ai): ensure unique OpenAI Responses message ids after cross-model thinking downgrade

### DIFF
--- a/packages/pi-ai/src/providers/openai-responses-shared.ts
+++ b/packages/pi-ai/src/providers/openai-responses-shared.ts
@@ -132,6 +132,29 @@ export function convertResponsesMessages<TApi extends Api>(
 	}
 
 	let msgIndex = 0;
+	const emittedResponseItemIds = new Set<string>();
+	const uniqueResponseItemId = (baseId: string): string => {
+		const normalizeTo64 = (value: string): string => {
+			if (value.length <= 64) return value;
+			return `msg_${shortHash(value)}`;
+		};
+		let candidate = normalizeTo64(baseId);
+		if (!emittedResponseItemIds.has(candidate)) {
+			emittedResponseItemIds.add(candidate);
+			return candidate;
+		}
+		let suffix = 1;
+		while (true) {
+			const suffixPart = `_${suffix}`;
+			const head = candidate.slice(0, Math.max(0, 64 - suffixPart.length));
+			const deduped = `${head}${suffixPart}`;
+			if (!emittedResponseItemIds.has(deduped)) {
+				emittedResponseItemIds.add(deduped);
+				return deduped;
+			}
+			suffix += 1;
+		}
+	};
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
@@ -162,6 +185,7 @@ export function convertResponsesMessages<TApi extends Api>(
 		} else if (msg.role === "assistant") {
 			const output: ResponseInput = [];
 			const assistantMsg = msg as AssistantMessage;
+			let textItemIndex = 0;
 			const isDifferentModel =
 				assistantMsg.model !== model.id &&
 				assistantMsg.provider === model.provider &&
@@ -179,10 +203,12 @@ export function convertResponsesMessages<TApi extends Api>(
 					// OpenAI requires id to be max 64 characters
 					let msgId = parsedSignature?.id;
 					if (!msgId) {
-						msgId = `msg_${msgIndex}`;
+						msgId = `msg_${msgIndex}_${textItemIndex}`;
 					} else if (msgId.length > 64) {
 						msgId = `msg_${shortHash(msgId)}`;
 					}
+					msgId = uniqueResponseItemId(msgId);
+					textItemIndex += 1;
 					output.push({
 						type: "message",
 						role: "assistant",

--- a/packages/pi-ai/src/providers/openai-responses-shared.ts
+++ b/packages/pi-ai/src/providers/openai-responses-shared.ts
@@ -204,8 +204,6 @@ export function convertResponsesMessages<TApi extends Api>(
 					let msgId = parsedSignature?.id;
 					if (!msgId) {
 						msgId = `msg_${msgIndex}_${textItemIndex}`;
-					} else if (msgId.length > 64) {
-						msgId = `msg_${shortHash(msgId)}`;
 					}
 					msgId = uniqueResponseItemId(msgId);
 					textItemIndex += 1;

--- a/packages/pi-ai/test/openai-responses-foreign-toolcall-id.test.ts
+++ b/packages/pi-ai/test/openai-responses-foreign-toolcall-id.test.ts
@@ -63,4 +63,39 @@ describe("OpenAI Responses foreign tool call ID normalization", () => {
 		expect(functionCall.id?.length ?? 0).toBeLessThanOrEqual(64);
 		expect(functionCall.id).toMatch(/^fc_[A-Za-z0-9]+$/);
 	});
+
+	it("ensures unique Responses message ids after cross-model thinking-to-text downgrade", () => {
+		const model = getModel("openai-codex", "gpt-5.5");
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "internal plan" },
+				{ type: "text", text: "visible answer" },
+				{
+					type: "toolCall",
+					id: "call_1|fc_1",
+					name: "edit",
+					arguments: { path: "src/index.ts" },
+				},
+			],
+			api: "openai-responses",
+			provider: "openai-codex",
+			model: "gpt-5.4-mini",
+			usage,
+			stopReason: "toolUse",
+			timestamp: Date.now() - 2000,
+		};
+		const context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Use the tool.", timestamp: Date.now() - 3000 }, assistant],
+		};
+
+		const input = convertResponsesMessages(model, context, new Set(["openai", "openai-codex", "opencode"]));
+		const ids = input
+			.filter((item): item is { id: string } => typeof item === "object" && item !== null && "id" in item && typeof item.id === "string")
+			.map((item) => item.id);
+
+		expect(ids.length).toBeGreaterThan(1);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
 });


### PR DESCRIPTION
## Summary
- Fixed `convertResponsesMessages` to generate and dedupe per-output-item message IDs and added a regression test for cross-model thinking-to-text replay collisions.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #246
- [#246 fix(pi-ai): ensure unique OpenAI Responses message ids after cross-model thinking downgrade](https://github.com/open-gsd/gsd-pi/issues/246)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/246-fix-pi-ai-ensure-unique-openai-responses-1780187147`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782779228&installation_id=134682257&pr_number=292&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F292&signature=7d25c903fbc57678fa8869e378c4afa22f576bcb96da41c3aa1665b83cfdf3c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to outbound message id generation in pi-ai with a focused unit test; no auth or data-path changes.
> 
> **Overview**
> Fixes **duplicate `id` values** on assistant `message` items when `convertResponsesMessages` rebuilds history for the OpenAI Responses API—especially when **cross-model replay** drops unsigned thinking blocks and leaves multiple output items (text, tool calls) that used to share the same generated id.
> 
> **`openai-responses-shared.ts`** now assigns per-text-block bases (`msg_${msgIndex}_${textItemIndex}`) and runs every assistant message id through **`uniqueResponseItemId`**, which enforces the 64-character limit and **suffix-dedupes** collisions within a single conversion. A **regression test** asserts all emitted item ids are unique in a thinking-to-text downgrade scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491ace391543b17ee0e9bed00268a03650ab3b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->