### PR TITLE
fix(issue): complete-slice retries forever when gsd_replan_slice is the correct outcome

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -202,13 +202,38 @@ function completeSliceReopenReplanHandoffDetected(
     agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_task_reopen") ||
     agentEndMessagesMentionTool(agentEndMessages, "gsd_task_reopen") ||
     unitActivityMentionsTool(s.basePath, unitType, unitId, "gsd_task_reopen") ||
-    unitActivityMentionsTool(s.canonicalProjectRoot, unitType, unitId, "gsd_task_reopen") ||
+    unitActivityMentionsTool(s.canonicalProjectRoot, unitType, unitId, "gsd_task_reopen")
+  );
+}
+
+function completeSliceValidReplanOutcomeDetected(
+  s: AutoSession,
+  agentEndMessages: unknown[] | undefined,
+): boolean {
+  if (s.currentUnit?.type !== "complete-slice") return false;
+  const { milestone: mid, slice: sid } = parseUnitId(s.currentUnit.id);
+  if (!mid || !sid) return false;
+
+  const hasReplanSignal = (
     agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_replan_slice") ||
     agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_replan_slice") ||
     agentEndMessagesMentionTool(agentEndMessages, "gsd_replan_slice") ||
-    unitActivityMentionsTool(s.basePath, unitType, unitId, "gsd_replan_slice") ||
-    unitActivityMentionsTool(s.canonicalProjectRoot, unitType, unitId, "gsd_replan_slice")
+    unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice") ||
+    unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice")
   );
+  if (!hasReplanSignal) return false;
+
+  const replanPath = resolveSliceFile(s.basePath, mid, sid, "REPLAN");
+  const canonicalReplanPath = resolveSliceFile(s.canonicalProjectRoot, mid, sid, "REPLAN");
+  const hasReplanArtifact = (
+    Boolean(replanPath && existsSync(replanPath)) ||
+    Boolean(canonicalReplanPath && existsSync(canonicalReplanPath))
+  );
+  if (!hasReplanArtifact) return false;
+
+  if (!isDbAvailable()) return true;
+  const slice = getSlice(mid, sid);
+  return Boolean(slice && !isClosedStatus(slice.status));
 }
 
 function formatPreExecutionCheckDetail(check: PreExecutionCheckJSON): string {
@@ -1774,6 +1799,24 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         });
         ctx.ui.notify(
           `complete-slice ${s.currentUnit.id} intentionally handed off via reopen/replan; continuing orchestration instead of retrying closeout.`,
+          "warning",
+        );
+        return "continue";
+      } else if (
+        !triggerArtifactVerified &&
+        completeSliceValidReplanOutcomeDetected(s, opts?.agentEndMessages)
+      ) {
+        const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+        s.pendingVerificationRetry = null;
+        s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
+        debugLog("postUnit", {
+          phase: "artifact-verify-complete-slice-replan-outcome",
+          unitType: s.currentUnit.type,
+          unitId: s.currentUnit.id,
+        });
+        ctx.ui.notify(
+          `complete-slice ${s.currentUnit.id} produced a valid replan outcome; continuing orchestration instead of retrying closeout.`,
           "warning",
         );
         return "continue";

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -206,6 +206,20 @@ function completeSliceReopenReplanHandoffDetected(
   );
 }
 
+function completeSliceReplanSignalDetected(
+  s: AutoSession,
+  agentEndMessages: unknown[] | undefined,
+): boolean {
+  if (s.currentUnit?.type !== "complete-slice") return false;
+  return (
+    agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_replan_slice") ||
+    agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_replan_slice") ||
+    agentEndMessagesMentionTool(agentEndMessages, "gsd_replan_slice") ||
+    unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice") ||
+    unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice")
+  );
+}
+
 function completeSliceValidReplanOutcomeDetected(
   s: AutoSession,
   agentEndMessages: unknown[] | undefined,
@@ -214,14 +228,7 @@ function completeSliceValidReplanOutcomeDetected(
   const { milestone: mid, slice: sid } = parseUnitId(s.currentUnit.id);
   if (!mid || !sid) return false;
 
-  const hasReplanSignal = (
-    agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_replan_slice") ||
-    agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_replan_slice") ||
-    agentEndMessagesMentionTool(agentEndMessages, "gsd_replan_slice") ||
-    unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice") ||
-    unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice")
-  );
-  if (!hasReplanSignal) return false;
+  if (!completeSliceReplanSignalDetected(s, agentEndMessages)) return false;
 
   const replanPath = resolveSliceFile(s.basePath, mid, sid, "REPLAN");
   const canonicalReplanPath = resolveSliceFile(s.canonicalProjectRoot, mid, sid, "REPLAN");
@@ -1820,7 +1827,11 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           "warning",
         );
         return "continue";
-      } else if (!triggerArtifactVerified && !isDbAvailable()) {
+      } else if (
+        !triggerArtifactVerified &&
+        !isDbAvailable() &&
+        !completeSliceReplanSignalDetected(s, opts?.agentEndMessages)
+      ) {
         debugLog("postUnit", { phase: "artifact-verify-skip-db-unavailable", unitType: s.currentUnit.type, unitId: s.currentUnit.id });
         const dbSkipDiag = diagnoseExpectedArtifact(s.currentUnit.type, s.currentUnit.id, verificationBasePath);
         ctx.ui.notify(

--- a/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
@@ -2,7 +2,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { postUnitPreVerification } from "../auto-post-unit.ts";
@@ -70,7 +70,9 @@ test("complete-slice with gsd_task_reopen handoff continues instead of artifact-
 test("complete-slice with gsd_replan_slice tool result continues instead of artifact-retrying", async () => {
   const base = makeTempRepo("gsd-complete-slice-replan-");
   try {
-    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(sliceDir, { recursive: true });
+    writeFileSync(join(sliceDir, "S01-REPLAN.md"), "# Replan\n");
 
     const s = new AutoSession();
     s.active = true;
@@ -101,9 +103,44 @@ test("complete-slice with gsd_replan_slice tool result continues instead of arti
     assert.equal(s.pendingVerificationRetry, null);
     assert.equal(s.verificationRetryCount.has(retryKey), false);
     assert.ok(
-      notifications.some((message) => message.includes("handed off via reopen/replan")),
+      notifications.some((message) => message.includes("valid replan outcome")),
       `expected handoff notification, got: ${notifications.join("\n")}`,
     );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("complete-slice with gsd_replan_slice but no REPLAN artifact retries", async () => {
+  const base = makeTempRepo("gsd-complete-slice-replan-missing-artifact-");
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+    const notifications: string[] = [];
+    const result = await postUnitPreVerification(
+      makePostUnitContext(base, s, notifications),
+      {
+        skipSettleDelay: true,
+        skipWorktreeSync: true,
+        agentEndMessages: [
+          {
+            role: "toolResult",
+            toolName: "gsd_replan_slice",
+            isError: false,
+            content: "Slice replanned with reopened task T02.",
+          },
+        ],
+      },
+    );
+
+    assert.equal(result, "retry");
+    assert.ok(s.pendingVerificationRetry);
+    assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01");
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Added a guarded complete-slice replan terminal-outcome path (requires REPLAN artifact and open slice) and regression tests for continue vs retry behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #243
- [#243 complete-slice retries forever when gsd_replan_slice is the correct outcome](https://github.com/open-gsd/gsd-pi/issues/243)

## User
- @rangardt

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/243-complete-slice-retries-forever-when-gsd--1780187750`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782779858&installation_id=134682257&pr_number=293&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F293&signature=b2d8272ae1af44bd2ccbadb64be0e77259a65fb464b5ff3be05c5e37cff4f955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-loop closeout and retry behavior for complete-slice units; incorrect guards could skip needed retries or advance with incomplete replans.
> 
> **Overview**
> **complete-slice** post-unit artifact verification no longer treats every `gsd_replan_slice` signal like a full reopen/replan handoff. Replan detection is split into a **signal** helper and a **valid replan outcome** path that only continues orchestration when a **REPLAN** artifact exists on the worktree or canonical root and (when the DB is available) the slice is still open.
> 
> When that outcome is recognized, verification retries are cleared and the loop returns **continue** with a dedicated notification instead of re-dispatching closeout. If replan was signaled but the REPLAN file is missing, behavior falls through to the normal artifact **retry** path. The DB-unavailable “skip retry” branch is tightened so it does not run when a replan signal is present.
> 
> Regression tests cover continue-with-REPLAN, reopen handoff messaging, and retry when replan ran without a REPLAN artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4619cd42d9e1b382eede8e561043119d408c054b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->