### PR TITLE
fix(issue): stuck-loop: verification gate re-dispatches already-complete execute-task when pytest runs from wrong cwd (compound: missing taskAlreadyComplete guard + subproject cwd mismatch)

### DIFF
--- a/src/resources/extensions/gsd/repository-registry.ts
+++ b/src/resources/extensions/gsd/repository-registry.ts
@@ -1,8 +1,10 @@
 // Project/App: gsd-pi
 // File Purpose: Repository registry seam for parent workspace multi-repo resolution.
 
+import { execFileSync } from "node:child_process";
 import { isAbsolute, relative, resolve } from "node:path";
 import type { GSDPreferences, WorkspacePreferences, WorkspaceRepositoryPreference } from "./preferences-types.js";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { resolveGsdPathContract } from "./paths.js";
 
 export interface RegisteredRepository {
@@ -52,6 +54,20 @@ function resolveRepositoryRoot(
   };
 }
 
+function resolveGitWorkingTreeRoot(basePath: string): string | null {
+  try {
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+    }).trim();
+    return root ? resolve(root) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Build a repository registry with an implicit reserved "project" repository
  * rooted at projectRoot. User-defined workspace repositories may not use id "project".
@@ -61,7 +77,9 @@ export function createRepositoryRegistry(
   workspacePrefs?: WorkspacePreferences,
 ): RepositoryRegistry {
   const contract = resolveGsdPathContract(basePath);
-  const projectRoot = contract.projectRoot;
+  const projectRoot = contract.isWorktree
+    ? resolveGitWorkingTreeRoot(contract.workRoot) ?? contract.projectRoot
+    : contract.projectRoot;
   const mode = workspacePrefs?.mode ?? "project";
   const repoMap = new Map<string, RegisteredRepository>();
 

--- a/src/resources/extensions/gsd/repository-registry.ts
+++ b/src/resources/extensions/gsd/repository-registry.ts
@@ -1,10 +1,8 @@
 // Project/App: gsd-pi
 // File Purpose: Repository registry seam for parent workspace multi-repo resolution.
 
-import { execFileSync } from "node:child_process";
 import { isAbsolute, relative, resolve } from "node:path";
 import type { GSDPreferences, WorkspacePreferences, WorkspaceRepositoryPreference } from "./preferences-types.js";
-import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { resolveGsdPathContract } from "./paths.js";
 
 export interface RegisteredRepository {
@@ -54,20 +52,6 @@ function resolveRepositoryRoot(
   };
 }
 
-function resolveGitWorkingTreeRoot(basePath: string): string | null {
-  try {
-    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-      cwd: basePath,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-      env: GIT_NO_PROMPT_ENV,
-    }).trim();
-    return root ? resolve(root) : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Build a repository registry with an implicit reserved "project" repository
  * rooted at projectRoot. User-defined workspace repositories may not use id "project".
@@ -77,7 +61,7 @@ export function createRepositoryRegistry(
   workspacePrefs?: WorkspacePreferences,
 ): RepositoryRegistry {
   const contract = resolveGsdPathContract(basePath);
-  const projectRoot = resolveGitWorkingTreeRoot(contract.workRoot) ?? contract.projectRoot;
+  const projectRoot = contract.projectRoot;
   const mode = workspacePrefs?.mode ?? "project";
   const repoMap = new Map<string, RegisteredRepository>();
 

--- a/src/resources/extensions/gsd/tests/repository-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/repository-registry.test.ts
@@ -115,3 +115,16 @@ test("repository registry keeps project root anchored to .gsd project in monorep
   assert.equal(registry.projectRoot, subproject);
   assert.equal(registry.byId.get("project")?.root, subproject);
 });
+
+test("repository registry uses external-state worktree checkout as project root", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-repo-registry-external-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const worktree = join(base, ".gsd", "projects", "abc123", "worktrees", "M001");
+  mkdirSync(worktree, { recursive: true });
+  execFileSync("git", ["init"], { cwd: worktree, stdio: "ignore" });
+
+  const registry = createRepositoryRegistryFromPreferences(worktree, undefined);
+
+  assert.equal(registry.projectRoot, worktree);
+  assert.equal(registry.byId.get("project")?.root, worktree);
+});

--- a/src/resources/extensions/gsd/tests/repository-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/repository-registry.test.ts
@@ -2,9 +2,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import { createRepositoryRegistryFromPreferences, defaultRepositoryTargets } from "../repository-registry.ts";
 
 test("repository registry includes implicit project root and declared child repos", (t) => {
@@ -98,4 +99,19 @@ test("defaultRepositoryTargets returns [project] for a parent-mode registry", (t
   });
 
   assert.deepEqual(defaultRepositoryTargets(registry), ["project"]);
+});
+
+test("repository registry keeps project root anchored to .gsd project in monorepo subdirectory", (t) => {
+  const monorepo = mkdtempSync(join(tmpdir(), "gsd-repo-registry-mono-"));
+  t.after(() => rmSync(monorepo, { recursive: true, force: true }));
+  execFileSync("git", ["init"], { cwd: monorepo, stdio: "ignore" });
+
+  const subproject = join(monorepo, "fieldkit-tools");
+  mkdirSync(join(subproject, ".gsd"), { recursive: true });
+  writeFileSync(join(subproject, ".gsd", "PREFERENCES.md"), "---\nversion: 1\n---\n");
+
+  const registry = createRepositoryRegistryFromPreferences(subproject, undefined);
+
+  assert.equal(registry.projectRoot, subproject);
+  assert.equal(registry.byId.get("project")?.root, subproject);
 });


### PR DESCRIPTION
## Summary
- Fixed subproject verification cwd resolution and added a regression test, while confirming the complete-status redispatch guard was already present.

## Bugs Addressed
- [ ] **Missing complete-status guard causes redundant unit redispatch** _(skipped: already fixed in current branch code; verified guard logic exists with no additional patch required.)_
- [x] **Pytest command runs from wrong cwd in monorepo subproject setup**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #266
- [#266 stuck-loop: verification gate re-dispatches already-complete execute-task when pytest runs from wrong cwd (compound: missing taskAlreadyComplete guard + subproject cwd mismatch)](https://github.com/open-gsd/gsd-pi/issues/266)

## User
- @mpeter

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/266-stuck-loop-verification-gate-re-dispatch-1780188352`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782780460&installation_id=134682257&pr_number=294&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F294&signature=ad40a3c58b235bb919bc76012d8e6faae96f3cd4fb774cfde121708f7288fe94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how default verification/repo cwd is chosen for all non-worktree registries; scoped logic and tests reduce blast radius but this path affects task verification behavior.
> 
> **Overview**
> **Repository registry** no longer always resolves the implicit `project` repo root via `git rev-parse --show-toplevel`. For normal (non-worktree) GSD projects it now uses the path contract’s `projectRoot`, so a `.gsd` project nested inside a larger git repo (monorepo subfolder) stays anchored on that subproject instead of the monorepo root—fixing verification commands (e.g. pytest) running from the wrong cwd.
> 
> Worktree execution still prefers the git working tree root when `contract.isWorktree` is true, preserving external-state worktree checkouts as the project root.
> 
> Regression tests cover monorepo subdirectory anchoring and GSD worktree layout roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d3fc9cbfb084c9f4e45332ce74dbdb6a136762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->