### PR TITLE
[codex] report terminal GSD drift as blockers

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -881,10 +881,31 @@ export async function autoLoop(
                 message: orchestrationResult.reason,
                 category: "unknown",
               });
+              finishTurn("paused", "manual-attention", "orchestration-blocked");
             } else {
               await deps.stopAuto(ctx, pi, orchestrationResult.reason);
+              finishTurn("stopped", "manual-attention", "orchestration-blocked");
             }
-            finishTurn("stopped", "manual-attention", "orchestration-blocked");
+            finishIncompleteIteration({
+              status: orchestrationResult.action === "pause" ? "paused" : "stopped",
+              reason: orchestrationResult.reason,
+              failureClass: "manual-attention",
+            });
+            break;
+          }
+
+          if (orchestrationResult.kind === "paused" || orchestrationResult.kind === "error") {
+            s.pendingOrchestrationDispatch = null;
+            await deps.pauseAuto(ctx, pi, {
+              message: orchestrationResult.reason,
+              category: "unknown",
+            });
+            finishTurn("paused", "manual-attention", `orchestration-${orchestrationResult.kind}`);
+            finishIncompleteIteration({
+              status: "paused",
+              reason: orchestrationResult.reason,
+              failureClass: "manual-attention",
+            });
             break;
           }
 

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -894,7 +894,13 @@ export async function autoLoop(
             break;
           }
 
-          if (orchestrationResult.kind === "paused" || orchestrationResult.kind === "error") {
+          if (orchestrationResult.kind === "paused") {
+            s.pendingOrchestrationDispatch = null;
+            finishTurn("skipped");
+            continue;
+          }
+
+          if (orchestrationResult.kind === "error") {
             s.pendingOrchestrationDispatch = null;
             await deps.pauseAuto(ctx, pi, {
               message: orchestrationResult.reason,

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -516,12 +516,16 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
           } catch { continue; }
           if (entry === "parallel-research") continue;
           if (!knownSliceIds.has(entry)) {
+            const quarantineExample = `.gsd/quarantine/milestones/${milestoneId}/slices/${entry}-manual-review`;
             issues.push({
               severity: "warning",
               code: "orphaned_slice_directory",
               scope: "milestone",
               unitId: milestoneId,
-              message: `Directory "${entry}" exists in ${milestoneId}/slices/ but is not referenced in the roadmap`,
+              message:
+                `Directory "${entry}" exists in ${milestoneId}/slices/ but is not referenced in the roadmap or DB. ` +
+                `Review it; if stale, move or delete it. To preserve it, move it under ${quarantineExample}. ` +
+                "If it contains work to keep, copy or merge that content into a DB-backed slice before resuming.",
               file: `${relMilestonePath(basePath, milestoneId)}/slices/${entry}`,
               fixable: false,
             });

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -389,6 +389,18 @@ function quarantineSliceDir(record: DiskSliceIdDivergenceDrift, basePath: string
   renameSync(record.sliceDir, target);
 }
 
+function diskSliceIdDivergenceGuidance(record: DiskSliceIdDivergenceDrift): string {
+  const quarantineExample = `.gsd/quarantine/milestones/${record.milestoneId}/slices/${record.sliceId}-manual-review`;
+  return (
+    `Slice ID drift in ${record.milestoneId}: ${record.reason}. ` +
+    "Runtime will not import disk-only slice IDs into the DB. " +
+    `Review ${record.sliceDir}. ` +
+    `If ${record.sliceId} is stale, move or delete that directory; to preserve it, move it under ${quarantineExample}. ` +
+    "If it contains work to keep, copy or merge that content into a DB-backed slice, or explicitly recreate the slice through GSD planning, then remove the disk-only directory. " +
+    `After repair, run /gsd doctor ${record.milestoneId}, then resume with /gsd next or /gsd auto.`
+  );
+}
+
 export function repairArtifactDbDrift(
   record:
     | DiskSliceIdDivergenceDrift
@@ -402,10 +414,7 @@ export function repairArtifactDbDrift(
     } else if (record.disposition === "quarantine-scaffold") {
       quarantineSliceDir(record, ctx.basePath);
     } else {
-      throw new Error(
-        `Slice ID drift in ${record.milestoneId}: ${record.reason}. ` +
-          "Runtime will not import disk-only slice IDs into the DB; run explicit recovery/repair after reviewing the directory.",
-      );
+      throw new Error(diskSliceIdDivergenceGuidance(record));
     }
     clearPathCache();
     clearParseCache();
@@ -437,10 +446,7 @@ export function describeArtifactDbDriftBlocker(
 ): string | null {
   if (record.kind === "disk-slice-id-divergence") {
     if (record.disposition !== "block-meaningful") return null;
-    return (
-      `Slice ID drift in ${record.milestoneId}: ${record.reason}. ` +
-      "Runtime will not import disk-only slice IDs into the DB; run explicit recovery/repair after reviewing the directory."
-    );
+    return diskSliceIdDivergenceGuidance(record);
   }
 
   if (record.kind === "completed-milestone-reopened") {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -429,6 +429,36 @@ export function repairArtifactDbDrift(
   );
 }
 
+export function describeArtifactDbDriftBlocker(
+  record:
+    | DiskSliceIdDivergenceDrift
+    | ArtifactDbStatusDivergenceDrift
+    | CompletedMilestoneReopenedDrift,
+): string | null {
+  if (record.kind === "disk-slice-id-divergence") {
+    if (record.disposition !== "block-meaningful") return null;
+    return (
+      `Slice ID drift in ${record.milestoneId}: ${record.reason}. ` +
+      "Runtime will not import disk-only slice IDs into the DB; run explicit recovery/repair after reviewing the directory."
+    );
+  }
+
+  if (record.kind === "completed-milestone-reopened") {
+    return (
+      `Milestone ${record.milestoneId} has completed complete-milestone dispatch history` +
+      ` (${record.completedDispatchAt ?? "time unknown"}) but the DB status is ${record.dbStatus}. ` +
+      "Refusing to plan it again without an explicit reopen or recovery."
+    );
+  }
+
+  return (
+    `Artifact/DB status drift in ${record.milestoneId}` +
+    `${record.sliceId ? `/${record.sliceId}` : ""}` +
+    `${record.taskId ? `/${record.taskId}` : ""}: ${record.reason}. ` +
+    "Runtime will not silently import completion artifacts into DB state; run explicit recovery/repair after review."
+  );
+}
+
 export const diskSliceIdDivergenceHandler: DriftHandler<DiskSliceIdDivergenceDrift> = {
   kind: "disk-slice-id-divergence",
   detect: (state, ctx) =>
@@ -436,6 +466,7 @@ export const diskSliceIdDivergenceHandler: DriftHandler<DiskSliceIdDivergenceDri
       (record): record is DiskSliceIdDivergenceDrift =>
         record.kind === "disk-slice-id-divergence",
     ),
+  blocker: describeArtifactDbDriftBlocker,
   repair: repairArtifactDbDrift,
 };
 
@@ -446,6 +477,7 @@ export const artifactDbStatusDivergenceHandler: DriftHandler<ArtifactDbStatusDiv
       (record): record is ArtifactDbStatusDivergenceDrift =>
         record.kind === "artifact-db-status-divergence",
     ),
+  blocker: describeArtifactDbDriftBlocker,
   repair: repairArtifactDbDrift,
 };
 
@@ -456,5 +488,6 @@ export const completedMilestoneReopenedHandler: DriftHandler<CompletedMilestoneR
       (record): record is CompletedMilestoneReopenedDrift =>
         record.kind === "completed-milestone-reopened",
     ),
+  blocker: describeArtifactDbDriftBlocker,
   repair: repairArtifactDbDrift,
 };

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -123,12 +123,17 @@ export async function reconcileBeforeDispatch(
 
   if (persistent.length > 0) {
     const blockers: string[] = [];
+    const unblockedPersistent: DriftRecord[] = [];
     for (const record of persistent) {
       const handler = registry.find((h) => h.kind === record.kind);
       const blocker = handler?.blocker ? await handler.blocker(record, finalCtx) : null;
-      if (blocker) blockers.push(blocker);
+      if (blocker) {
+        blockers.push(blocker);
+      } else {
+        unblockedPersistent.push(record);
+      }
     }
-    if (blockers.length > 0) {
+    if (blockers.length > 0 && unblockedPersistent.length === 0) {
       return {
         ok: true,
         stateSnapshot: finalState,

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -76,6 +76,7 @@ export async function reconcileBeforeDispatch(
     }
 
     const failures: ReconciliationFailureDetail[] = [];
+    const blockers: string[] = [];
     for (const record of drift) {
       const handler = registry.find((h) => h.kind === record.kind);
       if (!handler) {
@@ -85,6 +86,11 @@ export async function reconcileBeforeDispatch(
             `No drift handler registered for kind "${record.kind}"`,
           ),
         });
+        continue;
+      }
+      const blocker = handler.blocker ? await handler.blocker(record, ctx) : null;
+      if (blocker) {
+        blockers.push(blocker);
         continue;
       }
       try {
@@ -97,6 +103,14 @@ export async function reconcileBeforeDispatch(
 
     if (failures.length > 0) {
       throw new ReconciliationFailedError({ failures, pass });
+    }
+    if (blockers.length > 0) {
+      return {
+        ok: true,
+        stateSnapshot,
+        repaired,
+        blockers: [...new Set([...(stateSnapshot.blockers ?? []), ...blockers])],
+      };
     }
     // Pass fully succeeded; loop runs again to detect cascading drift.
   }

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -77,6 +77,7 @@ export async function reconcileBeforeDispatch(
 
     const failures: ReconciliationFailureDetail[] = [];
     const blockers: string[] = [];
+    let repairedThisPass = false;
     for (const record of drift) {
       const handler = registry.find((h) => h.kind === record.kind);
       if (!handler) {
@@ -96,17 +97,23 @@ export async function reconcileBeforeDispatch(
       try {
         await handler.repair(record, ctx);
         repaired.push(record);
+        repairedThisPass = true;
       } catch (cause) {
         failures.push({ drift: record, cause });
       }
     }
 
     if (blockers.length > 0) {
+      let blockerState = stateSnapshot;
+      if (repairedThisPass) {
+        deps.invalidateStateCache();
+        blockerState = await deps.deriveState(basePath, deps.deriveStateOptions);
+      }
       return {
         ok: true,
-        stateSnapshot,
+        stateSnapshot: blockerState,
         repaired,
-        blockers: [...new Set([...(stateSnapshot.blockers ?? []), ...blockers])],
+        blockers: [...new Set([...(blockerState.blockers ?? []), ...blockers])],
       };
     }
     if (failures.length > 0) {

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -122,6 +122,20 @@ export async function reconcileBeforeDispatch(
   const persistent = await detectAllDrift(finalState, finalCtx, registry);
 
   if (persistent.length > 0) {
+    const blockers: string[] = [];
+    for (const record of persistent) {
+      const handler = registry.find((h) => h.kind === record.kind);
+      const blocker = handler?.blocker ? await handler.blocker(record, finalCtx) : null;
+      if (blocker) blockers.push(blocker);
+    }
+    if (blockers.length > 0) {
+      return {
+        ok: true,
+        stateSnapshot: finalState,
+        repaired,
+        blockers: [...new Set([...(finalState.blockers ?? []), ...blockers])],
+      };
+    }
     throw new ReconciliationFailedError({ persistentDrift: persistent });
   }
 

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -101,9 +101,6 @@ export async function reconcileBeforeDispatch(
       }
     }
 
-    if (failures.length > 0) {
-      throw new ReconciliationFailedError({ failures, pass });
-    }
     if (blockers.length > 0) {
       return {
         ok: true,
@@ -111,6 +108,9 @@ export async function reconcileBeforeDispatch(
         repaired,
         blockers: [...new Set([...(stateSnapshot.blockers ?? []), ...blockers])],
       };
+    }
+    if (failures.length > 0) {
+      throw new ReconciliationFailedError({ failures, pass });
     }
     // Pass fully succeeded; loop runs again to detect cascading drift.
   }

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -64,6 +64,12 @@ export interface DriftContext {
 export interface DriftHandler<T extends DriftRecord = DriftRecord> {
   kind: T["kind"];
   detect: (state: GSDState, ctx: DriftContext) => T[] | Promise<T[]>;
+  /**
+   * Return a terminal blocker message for drift that is intentionally
+   * non-repairable in runtime. This lets callers stop cleanly without
+   * classifying the condition as a repair exception.
+   */
+  blocker?: (record: T, ctx: DriftContext) => string | null | Promise<string | null>;
   repair: (record: T, ctx: DriftContext) => Promise<void> | void;
 }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1848,6 +1848,52 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
   assert.equal(s.pendingOrchestrationDispatch, null, "pending dispatch should be one-shot");
 });
 
+test("autoLoop pauses once when orchestration reports reconciliation drift error", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  let advanceCalls = 0;
+  const s = makeLoopSession({
+    currentMilestoneId: "M002",
+    orchestration: {
+      start: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      advance: async () => {
+        advanceCalls++;
+        return {
+          kind: "error" as const,
+          reason: "Reconciliation drift: Reconciliation repair failed in pass 0",
+        };
+      },
+      completeActiveUnit: async () => {},
+      retryActiveUnit: async () => {},
+      resume: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      stop: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      getStatus: () => ({ phase: "error" as const, transitionCount: 1 }),
+    },
+  });
+
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      throw new Error("legacy resolveDispatch must not run after orchestration error");
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.equal(advanceCalls, 1, "orchestration error must not be retried in the same loop");
+  assert.ok(deps.callLog.includes("pauseAuto"), "orchestration error should pause auto-mode");
+  assert.equal(
+    deps.callLog.includes("resolveDispatch"),
+    false,
+    "orchestration error must not fall back to legacy dispatch",
+  );
+  assert.equal(s.pendingOrchestrationDispatch, null, "no orchestration dispatch should remain pending");
+});
+
 test("autoLoop consumes pending orchestration dispatch without advancing twice", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1894,6 +1894,51 @@ test("autoLoop pauses once when orchestration reports reconciliation drift error
   assert.equal(s.pendingOrchestrationDispatch, null, "no orchestration dispatch should remain pending");
 });
 
+test("autoLoop retries next iteration when orchestration reports paused", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  let advanceCalls = 0;
+  const s = makeLoopSession({
+    currentMilestoneId: "M002",
+    orchestration: {
+      start: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      advance: async () => {
+        advanceCalls++;
+        return advanceCalls === 1
+          ? { kind: "paused" as const, reason: "provider transient; retry" }
+          : { kind: "stopped" as const, reason: "done retrying" };
+      },
+      completeActiveUnit: async () => {},
+      retryActiveUnit: async () => {},
+      resume: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      stop: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      getStatus: () => ({ phase: "running" as const, transitionCount: advanceCalls }),
+    },
+  });
+
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      throw new Error("legacy resolveDispatch must not run after orchestration paused");
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.equal(advanceCalls, 2, "orchestration paused should retry on the next loop iteration");
+  assert.equal(deps.callLog.includes("pauseAuto"), false, "orchestration paused should not pause auto-mode");
+  assert.equal(
+    deps.callLog.includes("resolveDispatch"),
+    false,
+    "orchestration paused must not fall back to legacy dispatch",
+  );
+  assert.equal(s.pendingOrchestrationDispatch, null, "no orchestration dispatch should remain pending");
+});
+
 test("autoLoop consumes pending orchestration dispatch without advancing twice", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1132,6 +1132,33 @@ test("ADR-017: artifact/DB status divergence fails closed instead of importing c
   assert.equal(getSlice("M001", "S01")?.status, "pending", "DB status remains authoritative");
 });
 
+test("ADR-017: meaningful disk-only slice drift blocker includes repair guidance", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-disk-slice-guidance-"));
+  const diskOnlySliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S99");
+  t.after(() => cleanup(base));
+
+  mkdirSync(diskOnlySliceDir, { recursive: true });
+  writeFileSync(join(diskOnlySliceDir, "S99-PLAN.md"), "# Disk-only plan\n\nWork to review.\n");
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Known Slice", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  const message = result.blockers.join("\n");
+  assert.match(message, /Slice ID drift in M001/);
+  assert.match(message, /Review .*S99/);
+  assert.match(message, /move or delete/);
+  assert.match(message, /\.gsd\/quarantine\/milestones\/M001\/slices\/S99-manual-review/);
+  assert.match(message, /copy or merge/);
+  assert.match(message, /\/gsd doctor M001/);
+  assert.match(message, /\/gsd next or \/gsd auto/);
+});
+
 test("ADR-017: orphan task completion artifact fails closed", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-orphan-task-artifact-drift-"));
   t.after(() => cleanup(base));

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -321,6 +321,48 @@ test("ADR-017: terminal drift found after repair cap returns blockers", async ()
   assert.deepEqual(result.blockers, ["manual completed-milestone review required"]);
 });
 
+test("ADR-017: final persistent drift mixed with blockers still fails closed", async () => {
+  const repairDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const terminalDrift: DriftRecord = {
+    kind: "completed-milestone-reopened",
+    milestoneId: "M001",
+    dbStatus: "active",
+  };
+  let repairCount = 0;
+  const repairHandler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [repairDrift],
+    repair: () => {
+      repairCount++;
+    },
+  };
+  const terminalHandler: DriftHandler = {
+    kind: "completed-milestone-reopened",
+    detect: () => (repairCount >= 2 ? [terminalDrift] : []),
+    blocker: () => "manual completed-milestone review required",
+    repair: () => {
+      throw new Error("repair should not run for terminal blockers");
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch("/project", {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState(),
+        registry: [repairHandler, terminalHandler],
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.deepEqual(err.persistentDrift.map((d) => d.kind).sort(), [
+        "completed-milestone-reopened",
+        "stale-sketch-flag",
+      ]);
+      return true;
+    },
+  );
+});
+
 // ─── #5701: merge-state drift ────────────────────────────────────────────────
 
 function makeGitBase(): string {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -231,6 +231,28 @@ test("ADR-017 (#5700): classifyFailure recognizes ReconciliationFailedError", ()
   assert.match(result.remediation, /persistent or repair-failed drift kinds/);
 });
 
+test("ADR-017: terminal drift blockers return blockers instead of repair exceptions", async () => {
+  const record: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [record],
+    blocker: () => "manual drift review required",
+    repair: () => {
+      throw new Error("repair should not run for terminal blockers");
+    },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [handler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.blockers, ["manual drift review required"]);
+  assert.equal(result.repaired.length, 0);
+});
+
 // ─── #5701: merge-state drift ────────────────────────────────────────────────
 
 function makeGitBase(): string {
@@ -1067,19 +1089,14 @@ test("ADR-017: artifact/DB status divergence fails closed instead of importing c
     "# S01 Summary\n\nAlready done on disk.\n",
   );
 
-  await assert.rejects(
-    () =>
-      reconcileBeforeDispatch(base, {
-        invalidateStateCache: () => {},
-        deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
-      }),
-    (err: unknown) => {
-      assert.ok(err instanceof ReconciliationFailedError);
-      assert.match((err as Error).message, /artifact-db-status-divergence/);
-      assert.equal(getSlice("M001", "S01")?.status, "pending", "DB status remains authoritative");
-      return true;
-    },
-  );
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.match(result.blockers.join("\n"), /Artifact\/DB status drift/);
+  assert.equal(getSlice("M001", "S01")?.status, "pending", "DB status remains authoritative");
 });
 
 test("ADR-017: orphan task completion artifact fails closed", async (t) => {
@@ -1100,18 +1117,13 @@ test("ADR-017: orphan task completion artifact fails closed", async (t) => {
     full_content: "# T99 Summary\n\nStale artifact after replan.\n",
   });
 
-  await assert.rejects(
-    () =>
-      reconcileBeforeDispatch(base, {
-        invalidateStateCache: () => {},
-        deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
-      }),
-    (err: unknown) => {
-      assert.ok(err instanceof ReconciliationFailedError);
-      assert.match((err as Error).message, /artifact-db-status-divergence/);
-      return true;
-    },
-  );
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.match(result.blockers.join("\n"), /Artifact\/DB status drift/);
 });
 
 test("ADR-017: completed milestone dispatch history blocks accidental re-planning", async (t) => {
@@ -1136,18 +1148,13 @@ test("ADR-017: completed milestone dispatch history blocks accidental re-plannin
       ('trace', 'w1', 1, 'M001', 'complete-milestone', 'M001', 'completed', 1, '2026-05-30T00:00:00.000Z', '2026-05-30T00:01:00.000Z')`,
   ).run();
 
-  await assert.rejects(
-    () =>
-      reconcileBeforeDispatch(base, {
-        invalidateStateCache: () => {},
-        deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
-      }),
-    (err: unknown) => {
-      assert.ok(err instanceof ReconciliationFailedError);
-      assert.match((err as Error).message, /completed-milestone-reopened/);
-      return true;
-    },
-  );
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.match(result.blockers.join("\n"), /completed complete-milestone dispatch history/);
 });
 
 test("ADR-017: synthetic parallel-research slice directory is ignored", async (t) => {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -253,6 +253,39 @@ test("ADR-017: terminal drift blockers return blockers instead of repair excepti
   assert.equal(result.repaired.length, 0);
 });
 
+test("ADR-017: terminal drift blockers take precedence over co-occurring repair failures", async () => {
+  const terminalDrift: DriftRecord = {
+    kind: "completed-milestone-reopened",
+    milestoneId: "M001",
+    dbStatus: "active",
+  };
+  const repairDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const terminalHandler: DriftHandler = {
+    kind: "completed-milestone-reopened",
+    detect: () => [terminalDrift],
+    blocker: () => "manual completed-milestone review required",
+    repair: () => {
+      throw new Error("repair should not run for terminal blockers");
+    },
+  };
+  const repairHandler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [repairDrift],
+    repair: () => {
+      throw new Error("simulated repair failure");
+    },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [repairHandler, terminalHandler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.blockers, ["manual completed-milestone review required"]);
+});
+
 // ─── #5701: merge-state drift ────────────────────────────────────────────────
 
 function makeGitBase(): string {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -286,6 +286,41 @@ test("ADR-017: terminal drift blockers take precedence over co-occurring repair 
   assert.deepEqual(result.blockers, ["manual completed-milestone review required"]);
 });
 
+test("ADR-017: terminal drift found after repair cap returns blockers", async () => {
+  const repairDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const terminalDrift: DriftRecord = {
+    kind: "completed-milestone-reopened",
+    milestoneId: "M001",
+    dbStatus: "active",
+  };
+  let repairCount = 0;
+  const repairHandler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => (repairCount < 2 ? [repairDrift] : []),
+    repair: () => {
+      repairCount++;
+    },
+  };
+  const terminalHandler: DriftHandler = {
+    kind: "completed-milestone-reopened",
+    detect: () => (repairCount >= 2 ? [terminalDrift] : []),
+    blocker: () => "manual completed-milestone review required",
+    repair: () => {
+      throw new Error("repair should not run for terminal blockers");
+    },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [repairHandler, terminalHandler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.repaired.length, 2);
+  assert.deepEqual(result.blockers, ["manual completed-milestone review required"]);
+});
+
 // ─── #5701: merge-state drift ────────────────────────────────────────────────
 
 function makeGitBase(): string {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -253,6 +253,43 @@ test("ADR-017: terminal drift blockers return blockers instead of repair excepti
   assert.equal(result.repaired.length, 0);
 });
 
+test("ADR-017: terminal blockers return a state snapshot refreshed after co-occurring repairs", async () => {
+  const repairDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const terminalDrift: DriftRecord = {
+    kind: "completed-milestone-reopened",
+    milestoneId: "M001",
+    dbStatus: "active",
+  };
+  let repaired = false;
+  const repairHandler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: (state) => (state.nextAction === "before repair" ? [repairDrift] : []),
+    repair: () => {
+      repaired = true;
+    },
+  };
+  const terminalHandler: DriftHandler = {
+    kind: "completed-milestone-reopened",
+    detect: (state) => (state.nextAction === "before repair" ? [terminalDrift] : []),
+    blocker: () => "manual completed-milestone review required",
+    repair: () => {
+      throw new Error("repair should not run for terminal blockers");
+    },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () =>
+      makeState({ nextAction: repaired ? "after repair" : "before repair" }),
+    registry: [repairHandler, terminalHandler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stateSnapshot.nextAction, "after repair");
+  assert.equal(result.repaired.length, 1);
+  assert.deepEqual(result.blockers, ["manual completed-milestone review required"]);
+});
+
 test("ADR-017: terminal drift blockers take precedence over co-occurring repair failures", async () => {
   const terminalDrift: DriftRecord = {
     kind: "completed-milestone-reopened",


### PR DESCRIPTION
## Summary

This follow-up fixes the control flow from #284. The new drift guards were correctly detecting completed-milestone and artifact/DB divergence, but they surfaced intentional fail-closed conditions by throwing `ReconciliationFailedError`. That made auto-mode repeatedly print repair-failed reconciliation errors.

This PR:

- adds optional terminal `blocker` support to drift handlers
- returns manual-review drift through `ReconciliationResult.blockers` instead of repair exceptions
- keeps actual repair failures throwing as before
- updates artifact/DB drift and completed-milestone-reopened drift to use blockers
- adds regression coverage proving terminal drift blockers do not invoke repair or throw

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782781019&installation_id=134682257&pr_number=295&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F295&signature=1b860b4406ce680f416e472ee4e46824f7d80c6c1d1efd5894aa0a4e46ef321f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-dispatch reconciliation and auto-mode orchestration exit paths; mis-handling could pause/stop incorrectly or mask real repair failures, but behavior is covered by new regression tests.
> 
> **Overview**
> Fixes follow-up control flow from drift guards that were surfacing **intentional fail-closed** conditions as `ReconciliationFailedError`, which made auto-mode loop on “repair failed” messages.
> 
> **Reconciliation** adds optional **`blocker`** hooks on drift handlers. Terminal, manual-review drift (artifact/DB divergence, completed-milestone reopened, meaningful disk-only slice IDs) is returned in **`ReconciliationResult.blockers`** with **`ok: true`** instead of going through repair and throwing. Co-occurring repairs still run; state is re-derived when needed. **Repair failures** still throw as before.
> 
> **Artifact/DB drift** centralizes user-facing repair guidance (quarantine paths, `/gsd doctor`, resume commands). **Doctor** orphaned-slice warnings align with that guidance.
> 
> **Auto loop** handles orchestration **`paused`** (retry next iteration) and **`error`** (pause once, no legacy dispatch fallback), and distinguishes **pause vs stop** for blocked orchestration when finishing turns/iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746d2d023fe1947448195a1fc79ef1474b5dd1f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->