### PR TITLE
fix(issue): [Bug]: Discord invite expired in readme and via bot

### DIFF
--- a/packages/pi-coding-agent/README.md
+++ b/packages/pi-coding-agent/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://discord.com/invite/3cU7Bz4UPx"><img alt="Discord" src="https://img.shields.io/badge/discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
+  <a href="https://discord.gg/8NnkKuepmQ"><img alt="Discord" src="https://img.shields.io/badge/discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
   <a href="https://www.npmjs.com/package/@earendil-works/pi-coding-agent"><img alt="npm" src="https://img.shields.io/npm/v/@earendil-works/pi-coding-agent?style=flat-square" /></a>
 </p>
 <p align="center">

--- a/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
+++ b/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
@@ -19,6 +19,7 @@ const VALID_INVITE = "https://discord.gg/8NnkKuepmQ";
 const FILES_WITH_INVITE_LINKS: string[] = [
   "README.md",
   "docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md",
+  "packages/pi-coding-agent/README.md",
 ];
 
 describe("Discord invite links (#2699)", () => {


### PR DESCRIPTION
## Summary
- Replaced the stale Discord invite in the app README and expanded the invite-link regression test, then verified the targeted test suite passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #233
- [#233 [Bug]: Discord invite expired in readme and via bot](https://github.com/open-gsd/gsd-pi/issues/233)

## User
- @IntegerMan

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/233-bug-discord-invite-expired-in-readme-and-1780188948`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782781034&installation_id=134682257&pr_number=296&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F296&signature=2b7e2156fb39bd705ab0e8907dcb2241611f59384bbccc2ff7c09869dfc37099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Updates the **Discord community badge** in `packages/pi-coding-agent/README.md` from the expired `discord.com/invite/3cU7Bz4UPx` URL to the canonical `https://discord.gg/8NnkKuepmQ` used elsewhere in the repo.
> 
> Adds **`packages/pi-coding-agent/README.md`** to the Discord invite regression test so future README edits cannot reintroduce a stale invite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36aab234ba1c1c3c8aa51e5125e613c972e3cf22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->