### PR TITLE
fix(issue): Auto-mode stuck-loop re-dispatches already-completed execute-task units

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2139,6 +2139,7 @@ export function createWiredDispatchAdapter(
         );
         if (alreadyClosedReason) {
           session.pendingOrchestrationDispatch = null;
+          session.pendingVerificationRetry = null;
           return { kind: "skipped", reason: alreadyClosedReason };
         }
         session.pendingOrchestrationDispatch = pendingRetry;
@@ -2180,7 +2181,10 @@ export function createWiredDispatchAdapter(
       }
       const alreadyClosedReason = getAlreadyClosedDispatchReason(action.unitType, action.unitId);
       if (alreadyClosedReason) {
-        if (session) session.pendingOrchestrationDispatch = null;
+        if (session) {
+          session.pendingOrchestrationDispatch = null;
+          session.pendingVerificationRetry = null;
+        }
         return { kind: "skipped", reason: alreadyClosedReason };
       }
       if (session) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -216,7 +216,14 @@ import {
   deregisterSigtermHandler as _deregisterSigtermHandler,
   detectWorkingTreeActivity,
 } from "./auto-supervisor.js";
-import { isDbAvailable, getMilestone, getMilestoneSlices } from "./gsd-db.js";
+import {
+  isDbAvailable,
+  getMilestone,
+  getMilestoneSlices,
+  getSlice,
+  getTask,
+  refreshOpenDatabaseFromDisk,
+} from "./gsd-db.js";
 import { markLatestActiveForWorkerCanceled } from "./db/unit-dispatches.js";
 import { writeUnitRuntimeRecord } from "./unit-runtime.js";
 import { countPendingCaptures } from "./captures.js";
@@ -2068,6 +2075,25 @@ export function createWiredDispatchAdapter(
   dispatchBasePath: string,
   session?: AutoSession,
 ): DispatchAdapter {
+  function getAlreadyClosedDispatchReason(unitType: string, unitId: string): string | null {
+    if (!isDbAvailable()) return null;
+    refreshOpenDatabaseFromDisk();
+    const { milestone, slice, task } = parseUnitId(unitId);
+    if (unitType === "execute-task" && milestone && slice && task) {
+      const row = getTask(milestone, slice, task);
+      return row && isClosedStatus(row.status)
+        ? `execute-task ${unitId} is already ${row.status}`
+        : null;
+    }
+    if (unitType === "complete-slice" && milestone && slice) {
+      const row = getSlice(milestone, slice);
+      return row && isClosedStatus(row.status)
+        ? `complete-slice ${unitId} is already ${row.status}`
+        : null;
+    }
+    return null;
+  }
+
   return {
     async decideNextUnit(input) {
       const state = input.stateSnapshot;
@@ -2107,6 +2133,14 @@ export function createWiredDispatchAdapter(
       const pendingRetry = session?.pendingVerificationRetryDispatch;
       if (session && pendingRetry) {
         session.pendingVerificationRetryDispatch = null;
+        const alreadyClosedReason = getAlreadyClosedDispatchReason(
+          pendingRetry.unitType,
+          pendingRetry.unitId,
+        );
+        if (alreadyClosedReason) {
+          session.pendingOrchestrationDispatch = null;
+          return { kind: "skipped", reason: alreadyClosedReason };
+        }
         session.pendingOrchestrationDispatch = pendingRetry;
         return {
           unitType: pendingRetry.unitType,
@@ -2143,6 +2177,11 @@ export function createWiredDispatchAdapter(
           kind: "skipped",
           reason: action.matchedRule ?? "dispatch-skip",
         };
+      }
+      const alreadyClosedReason = getAlreadyClosedDispatchReason(action.unitType, action.unitId);
+      if (alreadyClosedReason) {
+        if (session) session.pendingOrchestrationDispatch = null;
+        return { kind: "skipped", reason: alreadyClosedReason };
       }
       if (session) {
         const pending: PendingOrchestrationDispatch = {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -15,6 +15,7 @@ import { resolveDispatch, type DispatchContext } from "../auto-dispatch.js";
 import { RuleRegistry, setRegistry, resetRegistry } from "../rule-registry.js";
 import type { UnifiedRule } from "../rule-types.js";
 import { supportsStructuredQuestions } from "../workflow-mcp.js";
+import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.js";
 
 function assertBlockedResult(
   result: Awaited<ReturnType<ReturnType<typeof createAutoOrchestrator>["advance"]>>,
@@ -1253,6 +1254,59 @@ test("wired DispatchAdapter replays pending verification retry dispatch", async 
   assert.equal(session.pendingVerificationRetryDispatch, null);
   assert.equal(session.pendingOrchestrationDispatch?.prompt, "repair slice closeout");
   assert.equal(session.pendingOrchestrationDispatch?.state, stateSnapshot);
+});
+
+test("wired DispatchAdapter clears verification retry state when skipping an already closed retry dispatch", async () => {
+  const stateSnapshot = makeState();
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-closed-retry-"));
+
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Slice", status: "active" });
+    insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Task", status: "complete" });
+
+    const retryRule: UnifiedRule = {
+      name: "test-closed-verification-retry",
+      when: "dispatch",
+      evaluation: "first-match",
+      where: async () => ({
+        action: "dispatch" as const,
+        unitType: "execute-task",
+        unitId: "M001/S01/T01",
+        prompt: "retry closed task",
+      }),
+      then: (r: unknown) => r,
+    };
+    setRegistry(new RuleRegistry([retryRule]));
+
+    const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;
+    const pi = { getActiveTools: () => [] } as any;
+    const session = {
+      basePath: base,
+      pendingOrchestrationDispatch: { stale: true },
+      pendingVerificationRetry: {
+        unitId: "M001/S01/T01",
+        failureContext: "artifact missing",
+        attempt: 1,
+      },
+    } as any;
+    const adapter = createWiredDispatchAdapter(ctx, pi, base, session);
+
+    const result = await adapter.decideNextUnit({ stateSnapshot });
+
+    assert.deepEqual(result, {
+      kind: "skipped",
+      reason: "execute-task M001/S01/T01 is already complete",
+    });
+    assert.equal(session.pendingVerificationRetry, null);
+    assert.equal(session.pendingOrchestrationDispatch, null);
+  } finally {
+    resetRegistry();
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("wired DispatchAdapter preserves stop reason as a blocked decision", async () => {


### PR DESCRIPTION
## Summary
- Added a DB-backed already-closed dispatch guard in `createWiredDispatchAdapter` for both retry and normal dispatch paths, and verified syntax with `node --experimental-strip-types --check`.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #223
- [#223 Auto-mode stuck-loop re-dispatches already-completed execute-task units](https://github.com/open-gsd/gsd-pi/issues/223)

## User
- @Miltonian66

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/223-auto-mode-stuck-loop-re-dispatches-alrea-1780189547`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782781870&installation_id=134682257&pr_number=297&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F297&signature=a37107a5012590cb3fc0796c8ee2572d57e3c448ee9d33a505ede0ee69948f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto orchestration dispatch decisions and session retry clearing; scope is narrow but affects when units run in production auto-mode.
> 
> **Overview**
> **Auto-mode** no longer re-dispatches units that the database already marks closed. `createWiredDispatchAdapter` refreshes the open DB, checks `execute-task` and `complete-slice` targets via `getTask` / `getSlice` and `isClosedStatus`, and returns a **skipped** decision with a clear reason instead of enqueueing work.
> 
> The guard runs on both the **verification-retry** path and normal `resolveDispatch` dispatch decisions, and it clears `pendingOrchestrationDispatch` and verification-retry session state so a completed task cannot spin a stuck loop. A new orchestrator test seeds a completed task and asserts retry state is cleared when the adapter skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3af228f4e0db0d76611e33cce0b9ebdecf34f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->