### PR TITLE
fix(issue): Post-execution checks falsely block SvelteKit $types imports and pause auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -601,6 +601,7 @@ export async function runPostUnitVerification(
     // ── Post-execution checks (run after main verification passes for execute-task units) ──
     let postExecChecks: PostExecutionCheckJSON[] | undefined;
     let postExecBlockingFailure = false;
+    let postExecPauseDetail: string | null = null;
 
     if (result.passed && mid && sid && tid) {
       // Check preferences — respect enhanced_verification and enhanced_verification_post
@@ -697,6 +698,10 @@ export async function runPostUnitVerification(
               const blockingCount = postExecResult.checks.filter(
                 (c) => !c.passed && c.blocking
               ).length;
+              const firstBlocking = postExecResult.checks.find((c) => !c.passed && c.blocking);
+              if (firstBlocking) {
+                postExecPauseDetail = `[${firstBlocking.category}] ${firstBlocking.target}: ${firstBlocking.message}`;
+              }
               ctx.ui.notify(
                 `Post-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
                 "error"
@@ -811,12 +816,13 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
+      const pauseDetail = postExecPauseDetail ?? "post-execution blocking check failed";
       ctx.ui.notify(
-        `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
+        `Post-execution checks failed — ${pauseDetail}. Pausing for human review.`,
         "error",
       );
       await pauseAuto(ctx, pi, {
-        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        message: `Post-execution checks failed: ${pauseDetail}.`,
         category: "unknown",
       });
       return "pause";

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -318,10 +318,9 @@ export function checkImportResolution(
     const imports = extractRelativeImports(source);
 
     for (const { importPath, lineNum } of imports) {
-      // React Router generated +types modules may not exist on disk during
-      // post-exec checks (generated during framework build). Don't block task
-      // completion on these imports.
-      if (/^\.{1,2}\/\+types\//.test(importPath)) {
+      // Framework-generated type modules may not exist on disk during
+      // post-exec checks. Don't block task completion on these imports.
+      if (isGeneratedTypeImport(importPath)) {
         continue;
       }
 
@@ -340,6 +339,20 @@ export function checkImportResolution(
   }
 
   return results;
+}
+
+function isGeneratedTypeImport(importPath: string): boolean {
+  // React Router generated route types.
+  if (/^\.{1,2}\/\+types(?:\/|$)/.test(importPath)) {
+    return true;
+  }
+
+  // SvelteKit generated route types imported as "./$types" (or with extension).
+  if (/^\.{1,2}\/\$types(?:$|\.[^/]+$)/.test(importPath)) {
+    return true;
+  }
+
+  return false;
 }
 
 // ─── Cross-Task Signature Check ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -5,7 +5,7 @@
  *
  * Verifies that when post-execution checks fail (postExecBlockingFailure is true),
  * the retry system is bypassed and auto-mode pauses immediately. Post-execution
- * failures are cross-task consistency issues — retrying the same task won't fix them.
+ * failures should pause immediately with specific failure details.
  */
 
 import { describe, test, mock, beforeEach, afterEach } from "node:test";
@@ -359,13 +359,8 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
-  test("post-exec failure notification mentions cross-task consistency", async () => {
-    // This test verifies that the notification for post-exec failures includes
-    // the appropriate message about cross-task consistency issues.
-    // The actual post-exec failure would require specific file/output state
-    // that's harder to set up in a unit test, but we can verify the code path exists.
-    
-    createBasicTask();
+  test("post-exec failure pause message includes concrete failing check", async () => {
+    createPostExecFailureTask();
     writePreferences({
       enhanced_verification: true,
       enhanced_verification_post: true,
@@ -381,9 +376,22 @@ describe("Post-execution blocking failure retry bypass", () => {
     const vctx: VerificationContext = { s, ctx, pi };
     const result = await runPostUnitVerification(vctx, pauseAutoMock);
 
-    // The verification should pass with our simple "echo pass" task
-    // This test mainly confirms the wiring is correct
-    assert.equal(result, "continue");
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+
+    const notifyMessages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) => String(c.arguments[0]));
+    assert.ok(
+      notifyMessages.some(
+        (m: string) =>
+          m.includes("Post-execution checks failed") &&
+          m.includes("[import]") &&
+          m.includes("src/broken.ts:1")
+      )
+    );
+
+    const pauseArgs = pauseAutoMock.mock.calls[0].arguments[2] as { message?: string };
+    assert.ok(pauseArgs.message?.includes("[import]"));
+    assert.ok(pauseArgs.message?.includes("src/broken.ts:1"));
   });
 
   test("uok gate runner persists post-execution gate failures when enabled", async () => {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -451,6 +451,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores generated SvelteKit $types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src", "routes"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "routes", "+page.ts"),
+      "import type { PageLoad } from './$types';\nexport const load: PageLoad = async () => ({ });"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["src/routes/+page.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Added SvelteKit `$types` import exemptions and surfaced specific post-exec failure details in pause messaging, with targeted regression test updates and one focused suite verified passing.

## Bugs Addressed
- [x] **SvelteKit './$types' imports wrongly treated as blocking failures**
- [x] **Pause message hides actual post-execution failure reason**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #217
- [#217 Post-execution checks falsely block SvelteKit $types imports and pause auto-mode](https://github.com/open-gsd/gsd-pi/issues/217)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/217-post-execution-checks-falsely-block-svel-1780190150`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782782713&installation_id=134682257&pr_number=298&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F298&signature=372f1c3228b012c788ea0a8b2f0fa5339cd1f7266f6d584519fee82f75218838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted changes to post-execution import heuristics and user-facing pause strings in the GSD auto verification path, with added unit tests.
> 
> **Overview**
> Post-execution import checks no longer treat **SvelteKit** `./$types` (and optional extension) as missing files, alongside the existing **React Router** `+types` exemption via a shared `isGeneratedTypeImport` helper.
> 
> When post-exec checks block auto-mode, **notifications and pause messages** now include the first blocking check (`[category] target: message`) instead of a generic cross-task consistency note.
> 
> Tests cover SvelteKit import skipping and concrete pause messaging on real post-exec failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700b09f3485d4a8a962e880548317963c895a5ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->