### PR TITLE
fix(issue): Post-execution checks falsely block SvelteKit $types imports and pause auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -712,6 +712,9 @@ export async function runPostUnitVerification(
               // Strict mode: treat warnings as blocking
               if (prefs?.enhanced_verification_strict === true) {
                 postExecBlockingFailure = true;
+                firstPostExecBlockingCheck = postExecResult.checks.find(
+                  (c) => (!c.passed && !c.blocking) || (c.passed && c.category === "pattern")
+                );
               }
             }
           }

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -601,6 +601,7 @@ export async function runPostUnitVerification(
     // ── Post-execution checks (run after main verification passes for execute-task units) ──
     let postExecChecks: PostExecutionCheckJSON[] | undefined;
     let postExecBlockingFailure = false;
+    let firstPostExecBlockingCheck: PostExecutionCheckJSON | undefined;
 
     if (result.passed && mid && sid && tid) {
       // Check preferences — respect enhanced_verification and enhanced_verification_post
@@ -694,9 +695,11 @@ export async function runPostUnitVerification(
             // Check for blocking failures
             if (postExecResult.status === "fail") {
               postExecBlockingFailure = true;
-              const blockingCount = postExecResult.checks.filter(
+              const blockingChecks = postExecResult.checks.filter(
                 (c) => !c.passed && c.blocking
-              ).length;
+              );
+              firstPostExecBlockingCheck = blockingChecks[0];
+              const blockingCount = blockingChecks.length;
               ctx.ui.notify(
                 `Post-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
                 "error"
@@ -811,12 +814,15 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
+      const postExecFailureDetail = firstPostExecBlockingCheck
+        ? `[${firstPostExecBlockingCheck.category}] ${firstPostExecBlockingCheck.target}: ${firstPostExecBlockingCheck.message}`
+        : "unknown post-execution blocking failure";
       ctx.ui.notify(
-        `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
+        `Post-execution checks failed — ${postExecFailureDetail}. Pausing for human review.`,
         "error",
       );
       await pauseAuto(ctx, pi, {
-        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        message: `Post-execution checks failed: ${postExecFailureDetail}.`,
         category: "unknown",
       });
       return "pause";

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -318,10 +318,13 @@ export function checkImportResolution(
     const imports = extractRelativeImports(source);
 
     for (const { importPath, lineNum } of imports) {
-      // React Router generated +types modules may not exist on disk during
+      // Framework-generated type modules may not exist on disk during
       // post-exec checks (generated during framework build). Don't block task
       // completion on these imports.
-      if (/^\.{1,2}\/\+types\//.test(importPath)) {
+      if (
+        /^\.{1,2}\/\+types\//.test(importPath) || // React Router
+        /^\.{1,2}\/\$types(?:$|\/)/.test(importPath) // SvelteKit
+      ) {
         continue;
       }
 

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -238,6 +238,43 @@ function createPostExecFailureTask(): void {
   });
 }
 
+function createPostExecWarningTask(): void {
+  insertMilestone({ id: "M001" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Test Slice",
+    risk: "low",
+  });
+
+  const srcDir = join(tempDir, "src");
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(
+    join(srcDir, "style.ts"),
+    "export async function loadUser() {\n  await Promise.resolve();\n  return fetch('/user').then((response) => response.json());\n}\n",
+    "utf-8",
+  );
+
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task with style warning",
+    status: "pending",
+    keyFiles: ["src/style.ts"],
+    planning: {
+      description: "Task that introduces a post-execution warning in key files",
+      estimate: "1h",
+      files: ["src/style.ts"],
+      verify: "echo pass",
+      inputs: [],
+      expectedOutput: [],
+      observabilityImpact: "",
+    },
+    sequence: 0,
+  });
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("Post-execution blocking failure retry bypass", () => {
@@ -379,7 +416,7 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(result, "pause");
     assert.equal(pauseAutoMock.mock.callCount(), 1);
 
-    const pauseCall = pauseAutoMock.mock.calls[0];
+    const pauseCall = pauseAutoMock.mock.calls[0] as { arguments: unknown[] };
     const pauseContext = pauseCall.arguments[2] as { message?: string } | undefined;
     assert.ok(pauseContext?.message?.includes("[import] src/broken.ts:1"));
     assert.ok(pauseContext?.message?.includes("does not resolve to an existing file"));
@@ -390,6 +427,43 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(
       notifyMessages.some((message: string) =>
         message.includes("Post-execution checks failed — [import] src/broken.ts:1")
+      )
+    );
+  });
+
+  test("strict post-exec warning pause message includes warning check details", async () => {
+    createPostExecWarningTask();
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: true,
+      enhanced_verification_strict: true,
+      verification_auto_fix: true,
+      verification_max_retries: 3,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const vctx: VerificationContext = { s, ctx, pi };
+    const result = await runPostUnitVerification(vctx, pauseAutoMock);
+
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+
+    const pauseCall = pauseAutoMock.mock.calls[0] as { arguments: unknown[] };
+    const pauseContext = pauseCall.arguments[2] as { message?: string } | undefined;
+    assert.ok(pauseContext?.message?.includes("[pattern] src/style.ts"));
+    assert.ok(pauseContext?.message?.includes("mixes async/await with .then()"));
+    assert.ok(!pauseContext?.message?.includes("unknown post-execution blocking failure"));
+
+    const notifyMessages = ctx.ui.notify.mock.calls.map(
+      (c: { arguments: unknown[] }) => String(c.arguments[0])
+    );
+    assert.ok(
+      notifyMessages.some((message: string) =>
+        message.includes("Post-execution checks failed — [pattern] src/style.ts")
       )
     );
   });

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -359,13 +359,8 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
-  test("post-exec failure notification mentions cross-task consistency", async () => {
-    // This test verifies that the notification for post-exec failures includes
-    // the appropriate message about cross-task consistency issues.
-    // The actual post-exec failure would require specific file/output state
-    // that's harder to set up in a unit test, but we can verify the code path exists.
-    
-    createBasicTask();
+  test("post-exec failure pause message includes failing check details", async () => {
+    createPostExecFailureTask();
     writePreferences({
       enhanced_verification: true,
       enhanced_verification_post: true,
@@ -381,9 +376,22 @@ describe("Post-execution blocking failure retry bypass", () => {
     const vctx: VerificationContext = { s, ctx, pi };
     const result = await runPostUnitVerification(vctx, pauseAutoMock);
 
-    // The verification should pass with our simple "echo pass" task
-    // This test mainly confirms the wiring is correct
-    assert.equal(result, "continue");
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+
+    const pauseCall = pauseAutoMock.mock.calls[0];
+    const pauseContext = pauseCall.arguments[2] as { message?: string } | undefined;
+    assert.ok(pauseContext?.message?.includes("[import] src/broken.ts:1"));
+    assert.ok(pauseContext?.message?.includes("does not resolve to an existing file"));
+
+    const notifyMessages = ctx.ui.notify.mock.calls.map(
+      (c: { arguments: unknown[] }) => String(c.arguments[0])
+    );
+    assert.ok(
+      notifyMessages.some((message: string) =>
+        message.includes("Post-execution checks failed — [import] src/broken.ts:1")
+      )
+    );
   });
 
   test("uok gate runner persists post-execution gate failures when enabled", async () => {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -451,6 +451,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores generated SvelteKit $types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src", "routes"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "routes", "+page.svelte.ts"),
+      "import type { PageLoad } from './$types';\nexport const load: PageLoad = async () => ({})"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["src/routes/+page.svelte.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Exempted SvelteKit `$types` generated imports from blocking post-exec resolution and made post-exec pause messages include the exact failing check detail, with regressions tests updated.

## Bugs Addressed
- [x] **SvelteKit './$types' imports falsely fail post-exec checks**
- [x] **Verification pause message hides actual failing check**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #217
- [#217 Post-execution checks falsely block SvelteKit $types imports and pause auto-mode](https://github.com/open-gsd/gsd-pi/issues/217)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/217-post-execution-checks-falsely-block-svel-1780192522`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782785353&installation_id=134682257&pr_number=299&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F299&signature=7e4c0e24a5d6373f786045ba9500fca369680b724b53a2bbfeacd19051f6c42c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changes to post-execution import heuristics and verification messaging; no auth, data, or payment paths affected.
> 
> **Overview**
> Post-execution import resolution now skips **SvelteKit** generated `./$types` modules (alongside existing React Router `+types` skips), so auto-mode no longer pauses on imports that only exist after a framework build.
> 
> When post-execution checks block completion, **pause and UI notifications** include the first failing check’s category, target, and message (including strict-mode pattern warnings), instead of a generic cross-task consistency note. Tests cover SvelteKit imports and the detailed pause paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f829c50f13b506f037f123453ccd1799e484709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->