### PR TITLE
fix(issue): Post-execution checks falsely block SvelteKit $types imports and pause auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -601,6 +601,7 @@ export async function runPostUnitVerification(
     // ── Post-execution checks (run after main verification passes for execute-task units) ──
     let postExecChecks: PostExecutionCheckJSON[] | undefined;
     let postExecBlockingFailure = false;
+    let postExecFailureSummary: string | undefined;
 
     if (result.passed && mid && sid && tid) {
       // Check preferences — respect enhanced_verification and enhanced_verification_post
@@ -694,9 +695,13 @@ export async function runPostUnitVerification(
             // Check for blocking failures
             if (postExecResult.status === "fail") {
               postExecBlockingFailure = true;
-              const blockingCount = postExecResult.checks.filter(
-                (c) => !c.passed && c.blocking
-              ).length;
+              const failedChecks = postExecResult.checks.filter((c) => !c.passed);
+              const blockingCount = failedChecks.filter((c) => c.blocking).length;
+              const primaryFailure =
+                failedChecks.find((c) => c.blocking) ?? failedChecks[0];
+              if (primaryFailure) {
+                postExecFailureSummary = `[${primaryFailure.category}] ${primaryFailure.target}: ${primaryFailure.message}`;
+              }
               ctx.ui.notify(
                 `Post-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
                 "error"
@@ -709,6 +714,10 @@ export async function runPostUnitVerification(
               // Strict mode: treat warnings as blocking
               if (prefs?.enhanced_verification_strict === true) {
                 postExecBlockingFailure = true;
+                const warningCheck = postExecResult.checks.find((c) => !c.passed);
+                if (warningCheck) {
+                  postExecFailureSummary = `[${warningCheck.category}] ${warningCheck.target}: ${warningCheck.message}`;
+                }
               }
             }
           }
@@ -811,12 +820,13 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
+      const postExecFailureDetail = postExecFailureSummary ?? "specific failing check unavailable";
       ctx.ui.notify(
-        `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
+        `Post-execution checks failed — ${postExecFailureDetail}; pausing for human review`,
         "error",
       );
       await pauseAuto(ctx, pi, {
-        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        message: `Post-execution checks failed: ${postExecFailureDetail}.`,
         category: "unknown",
       });
       return "pause";

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -321,7 +321,11 @@ export function checkImportResolution(
       // React Router generated +types modules may not exist on disk during
       // post-exec checks (generated during framework build). Don't block task
       // completion on these imports.
-      if (/^\.{1,2}\/\+types\//.test(importPath)) {
+      // SvelteKit-generated $types modules are also generated artifacts.
+      if (
+        /^\.{1,2}\/\+types(?:\/|$)/.test(importPath) ||
+        /^\.{1,2}\/\$types(?:\/|$)/.test(importPath)
+      ) {
         continue;
       }
 

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -359,13 +359,8 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
-  test("post-exec failure notification mentions cross-task consistency", async () => {
-    // This test verifies that the notification for post-exec failures includes
-    // the appropriate message about cross-task consistency issues.
-    // The actual post-exec failure would require specific file/output state
-    // that's harder to set up in a unit test, but we can verify the code path exists.
-    
-    createBasicTask();
+  test("post-exec failure pause message includes specific failing check", async () => {
+    createPostExecFailureTask();
     writePreferences({
       enhanced_verification: true,
       enhanced_verification_post: true,
@@ -381,9 +376,12 @@ describe("Post-execution blocking failure retry bypass", () => {
     const vctx: VerificationContext = { s, ctx, pi };
     const result = await runPostUnitVerification(vctx, pauseAutoMock);
 
-    // The verification should pass with our simple "echo pass" task
-    // This test mainly confirms the wiring is correct
-    assert.equal(result, "continue");
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+    const pauseArgs = pauseAutoMock.mock.calls[0].arguments;
+    const pauseContext = pauseArgs[2] as { message?: string } | undefined;
+    assert.ok(pauseContext?.message?.includes("[import] src/broken.ts:1"));
+    assert.ok(!pauseContext?.message?.includes("cross-task consistency issue"));
   });
 
   test("uok gate runner persists post-execution gate failures when enabled", async () => {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -451,6 +451,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores generated SvelteKit $types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src", "routes"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "routes", "+page.ts"),
+      "import type { PageLoad } from './$types';\nexport const load: PageLoad = async () => ({});"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["src/routes/+page.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Fixed false SvelteKit `$types` post-exec blocking and made verification pauses report the specific failing post-exec check, with targeted tests updated and run where environment allowed.

## Bugs Addressed
- [x] **SvelteKit './$types' imports falsely fail post-exec checks**
- [x] **Verification pause message hides actual failing check**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #217
- [#217 Post-execution checks falsely block SvelteKit $types imports and pause auto-mode](https://github.com/open-gsd/gsd-pi/issues/217)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/217-post-execution-checks-falsely-block-svel-1780192557`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted verification/post-exec heuristics and messaging only; no auth or data-path changes.
> 
> **Overview**
> Post-execution import checks now **skip SvelteKit-generated** `./$types` paths (alongside React Router `+types`), so tasks are not blocked when those modules are not on disk yet.
> 
> When post-exec checks force a pause, **auto-mode notifications and pause messages** include the primary failing check (`[category] target: message`) instead of a generic cross-task consistency note; strict-mode warnings get the same detail.
> 
> Tests cover `$types` ignore behavior and the updated pause copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64f7a0e457f323355f3a60c51380bf65978f987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782785382&installation_id=134682257&pr_number=300&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F300&signature=1ec04707406c7b59272b7074f0eab03a3e49cd039955589cba37395dc6b48001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->