### PR TITLE
fix(issue): Post-execution checks falsely block SvelteKit $types imports and pause auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -601,6 +601,7 @@ export async function runPostUnitVerification(
     // ── Post-execution checks (run after main verification passes for execute-task units) ──
     let postExecChecks: PostExecutionCheckJSON[] | undefined;
     let postExecBlockingFailure = false;
+    let postExecFailureDetail: string | null = null;
 
     if (result.passed && mid && sid && tid) {
       // Check preferences — respect enhanced_verification and enhanced_verification_post
@@ -697,6 +698,12 @@ export async function runPostUnitVerification(
               const blockingCount = postExecResult.checks.filter(
                 (c) => !c.passed && c.blocking
               ).length;
+              const firstBlockingCheck = postExecResult.checks.find(
+                (c) => !c.passed && c.blocking
+              );
+              postExecFailureDetail = firstBlockingCheck
+                ? `[${firstBlockingCheck.category}] ${firstBlockingCheck.target}`
+                : "unknown post-execution check";
               ctx.ui.notify(
                 `Post-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
                 "error"
@@ -709,6 +716,10 @@ export async function runPostUnitVerification(
               // Strict mode: treat warnings as blocking
               if (prefs?.enhanced_verification_strict === true) {
                 postExecBlockingFailure = true;
+                const firstWarningCheck = postExecResult.checks.find((c) => !c.passed);
+                postExecFailureDetail = firstWarningCheck
+                  ? `[${firstWarningCheck.category}] ${firstWarningCheck.target}`
+                  : "unknown post-execution warning";
               }
             }
           }
@@ -811,12 +822,13 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
+      const detail = postExecFailureDetail ?? "unknown post-execution check";
       ctx.ui.notify(
-        `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
+        `Post-execution checks failed — ${detail}; pausing for human review`,
         "error",
       );
       await pauseAuto(ctx, pi, {
-        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        message: `Post-execution checks failed: ${detail}.`,
         category: "unknown",
       });
       return "pause";

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -318,10 +318,15 @@ export function checkImportResolution(
     const imports = extractRelativeImports(source);
 
     for (const { importPath, lineNum } of imports) {
-      // React Router generated +types modules may not exist on disk during
+      // Framework-generated types modules may not exist on disk during
       // post-exec checks (generated during framework build). Don't block task
       // completion on these imports.
-      if (/^\.{1,2}\/\+types\//.test(importPath)) {
+      // - React Router: ./+types/<route>
+      // - SvelteKit: ./$types or ./$types/<route>
+      if (
+        /^\.{1,2}\/\+types\//.test(importPath) ||
+        /^\.{1,2}\/\$types(?:$|\/)/.test(importPath)
+      ) {
         continue;
       }
 

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -359,13 +359,8 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
-  test("post-exec failure notification mentions cross-task consistency", async () => {
-    // This test verifies that the notification for post-exec failures includes
-    // the appropriate message about cross-task consistency issues.
-    // The actual post-exec failure would require specific file/output state
-    // that's harder to set up in a unit test, but we can verify the code path exists.
-    
-    createBasicTask();
+  test("post-exec failure pause surfaces the failing check detail", async () => {
+    createPostExecFailureTask();
     writePreferences({
       enhanced_verification: true,
       enhanced_verification_post: true,
@@ -381,9 +376,22 @@ describe("Post-execution blocking failure retry bypass", () => {
     const vctx: VerificationContext = { s, ctx, pi };
     const result = await runPostUnitVerification(vctx, pauseAutoMock);
 
-    // The verification should pass with our simple "echo pass" task
-    // This test mainly confirms the wiring is correct
-    assert.equal(result, "continue");
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+
+    const pauseArgs = pauseAutoMock.mock.calls[0]?.arguments;
+    assert.ok(pauseArgs, "pauseAuto should be called with pause context");
+    const pauseContext = pauseArgs?.[2] as { message?: string } | undefined;
+    assert.ok(
+      pauseContext?.message?.includes("[import] src/broken.ts:1"),
+      "pause message should include failing post-exec category and target",
+    );
+
+    const messages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) => String(c.arguments[0]));
+    assert.ok(
+      messages.some((m: string) => m.includes("Post-execution checks failed — [import] src/broken.ts:1")),
+      "notification should include failing post-exec category and target",
+    );
   });
 
   test("uok gate runner persists post-execution gate failures when enabled", async () => {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -451,6 +451,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores generated SvelteKit $types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src", "routes"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "routes", "+page.ts"),
+      "import type { PageLoad } from './$types';\nexport const load: PageLoad = async () => ({});"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["src/routes/+page.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Fixed false blocking on SvelteKit `./$types` imports and made post-exec pause messages identify the actual failing check, with targeted tests updated.

## Bugs Addressed
- [x] **SvelteKit './$types' imports falsely fail post-exec checks**
- [x] **Verification pause message hides actual failing check**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #217
- [#217 Post-execution checks falsely block SvelteKit $types imports and pause auto-mode](https://github.com/open-gsd/gsd-pi/issues/217)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/217-post-execution-checks-falsely-block-svel-1780192831`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted heuristics and messaging in GSD verification; behavior change reduces false pauses and improves debuggability without touching auth or data paths.
> 
> **Overview**
> Post-execution **import resolution** no longer treats SvelteKit framework type imports as missing files: relative `./$types` and `./$types/...` paths are skipped the same way React Router `./+types/...` imports already were, so auto-mode should not pause on generated types that only exist at build time.
> 
> When post-execution checks block completion, **auto verification** now records the first blocking (or strict-mode warning) check as `[category] target` and uses that in the pause notification and `pauseAuto` message instead of a generic cross-task consistency note.
> 
> Tests cover the SvelteKit exemption and assert that a real post-exec import failure surfaces `[import] src/broken.ts:1` in pause and UI text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af4dd08b2fd66dd866866d20ded0b69f483a7344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782785430&installation_id=134682257&pr_number=301&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F301&signature=44ac42e00a97a25236b5ee728f59876ff2372a99a2ccc19f29fee8448deaaed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->