### PR TITLE
fix(issue): Post-execution checks falsely block SvelteKit $types imports and pause auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -601,6 +601,7 @@ export async function runPostUnitVerification(
     // ── Post-execution checks (run after main verification passes for execute-task units) ──
     let postExecChecks: PostExecutionCheckJSON[] | undefined;
     let postExecBlockingFailure = false;
+    let postExecFailureSummary: string | null = null;
 
     if (result.passed && mid && sid && tid) {
       // Check preferences — respect enhanced_verification and enhanced_verification_post
@@ -697,6 +698,13 @@ export async function runPostUnitVerification(
               const blockingCount = postExecResult.checks.filter(
                 (c) => !c.passed && c.blocking
               ).length;
+              const firstBlockingFailure = postExecResult.checks.find(
+                (c) => !c.passed && c.blocking
+              );
+              if (firstBlockingFailure) {
+                postExecFailureSummary =
+                  `[${firstBlockingFailure.category}] ${firstBlockingFailure.target}: ${firstBlockingFailure.message}`;
+              }
               ctx.ui.notify(
                 `Post-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
                 "error"
@@ -811,12 +819,13 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
+      const failureDetail = postExecFailureSummary ?? "unknown post-execution check failure";
       ctx.ui.notify(
-        `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
+        `Post-execution checks failed (${failureDetail}) — pausing for human review`,
         "error",
       );
       await pauseAuto(ctx, pi, {
-        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        message: `Post-execution checks failed: ${failureDetail}.`,
         category: "unknown",
       });
       return "pause";

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -717,6 +717,13 @@ export async function runPostUnitVerification(
               // Strict mode: treat warnings as blocking
               if (prefs?.enhanced_verification_strict === true) {
                 postExecBlockingFailure = true;
+                const firstWarning = postExecResult.checks.find(
+                  (c) => (!c.passed && !c.blocking) || (c.passed && c.category === "pattern")
+                );
+                if (firstWarning) {
+                  postExecFailureSummary =
+                    `[${firstWarning.category}] ${firstWarning.target}: ${firstWarning.message}`;
+                }
               }
             }
           }

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -318,10 +318,13 @@ export function checkImportResolution(
     const imports = extractRelativeImports(source);
 
     for (const { importPath, lineNum } of imports) {
-      // React Router generated +types modules may not exist on disk during
-      // post-exec checks (generated during framework build). Don't block task
-      // completion on these imports.
-      if (/^\.{1,2}\/\+types\//.test(importPath)) {
+      // Framework-generated type modules may not exist on disk during post-exec
+      // checks (typically generated during framework builds/typegen). Don't
+      // block task completion on these imports.
+      if (
+        /^\.{1,2}\/\+types\//.test(importPath) ||
+        /^\.{1,2}\/\$types(?:$|\/)/.test(importPath)
+      ) {
         continue;
       }
 

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -323,7 +323,7 @@ export function checkImportResolution(
       // block task completion on these imports.
       if (
         /^\.{1,2}\/\+types\//.test(importPath) ||
-        /^\.{1,2}\/\$types(?:$|\/)/.test(importPath)
+        /^(?:\.{1,2}\/)+(?:[^/]+\/)*\$types(?:$|\/)/.test(importPath)
       ) {
         continue;
       }

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -359,13 +359,8 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
-  test("post-exec failure notification mentions cross-task consistency", async () => {
-    // This test verifies that the notification for post-exec failures includes
-    // the appropriate message about cross-task consistency issues.
-    // The actual post-exec failure would require specific file/output state
-    // that's harder to set up in a unit test, but we can verify the code path exists.
-    
-    createBasicTask();
+  test("post-exec failure notification includes failing check details", async () => {
+    createPostExecFailureTask();
     writePreferences({
       enhanced_verification: true,
       enhanced_verification_post: true,
@@ -381,9 +376,27 @@ describe("Post-execution blocking failure retry bypass", () => {
     const vctx: VerificationContext = { s, ctx, pi };
     const result = await runPostUnitVerification(vctx, pauseAutoMock);
 
-    // The verification should pass with our simple "echo pass" task
-    // This test mainly confirms the wiring is correct
-    assert.equal(result, "continue");
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+    const notifyMessages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) =>
+      String(c.arguments[0])
+    );
+    assert.ok(
+      notifyMessages.some(
+        (m: string) =>
+          m.includes("Post-execution checks failed ([import] src/broken.ts:1") &&
+          m.includes("pausing for human review")
+      )
+    );
+
+    const pauseCallArgs = pauseAutoMock.mock.calls[0]?.arguments?.[2] as
+      | { message?: string }
+      | undefined;
+    assert.ok(
+      pauseCallArgs?.message?.includes(
+        "Post-execution checks failed: [import] src/broken.ts:1"
+      )
+    );
   });
 
   test("uok gate runner persists post-execution gate failures when enabled", async () => {

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -238,6 +238,67 @@ function createPostExecFailureTask(): void {
   });
 }
 
+function createPostExecWarningTask(): void {
+  insertMilestone({ id: "M001" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Test Slice",
+    risk: "low",
+  });
+
+  const srcDir = join(tempDir, "src");
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(
+    join(srcDir, "prior.ts"),
+    "export function formatName(name: string): string { return name; }\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(srcDir, "current.ts"),
+    "export function formatName(first: string, last: string): string { return `${first} ${last}`; }\n",
+    "utf-8",
+  );
+
+  insertTask({
+    id: "T00",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Prior task",
+    status: "complete",
+    keyFiles: ["src/prior.ts"],
+    planning: {
+      description: "Prior task with original signature",
+      estimate: "1h",
+      files: ["src/prior.ts"],
+      verify: "echo pass",
+      inputs: [],
+      expectedOutput: [],
+      observabilityImpact: "",
+    },
+    sequence: 0,
+  });
+
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task with signature warning",
+    status: "pending",
+    keyFiles: ["src/current.ts"],
+    planning: {
+      description: "Task that changes a prior function signature",
+      estimate: "1h",
+      files: ["src/current.ts"],
+      verify: "echo pass",
+      inputs: [],
+      expectedOutput: [],
+      observabilityImpact: "",
+    },
+    sequence: 1,
+  });
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("Post-execution blocking failure retry bypass", () => {
@@ -389,7 +450,8 @@ describe("Post-execution blocking failure retry bypass", () => {
       )
     );
 
-    const pauseCallArgs = pauseAutoMock.mock.calls[0]?.arguments?.[2] as
+    const pauseCalls = pauseAutoMock.mock.calls as Array<{ arguments: unknown[] }>;
+    const pauseCallArgs = pauseCalls[0]?.arguments[2] as
       | { message?: string }
       | undefined;
     assert.ok(
@@ -397,6 +459,48 @@ describe("Post-execution blocking failure retry bypass", () => {
         "Post-execution checks failed: [import] src/broken.ts:1"
       )
     );
+  });
+
+  test("strict post-exec warning pause includes warning details", async () => {
+    createPostExecWarningTask();
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: true,
+      enhanced_verification_strict: true,
+      verification_auto_fix: true,
+      verification_max_retries: 3,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+    const notifyMessages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) =>
+      String(c.arguments[0])
+    );
+    assert.ok(
+      notifyMessages.some(
+        (m: string) =>
+          m.includes("Post-execution checks failed ([signature] formatName:") &&
+          m.includes("pausing for human review")
+      )
+    );
+
+    const pauseCalls = pauseAutoMock.mock.calls as Array<{ arguments: unknown[] }>;
+    const pauseCallArgs = pauseCalls[0]?.arguments[2] as
+      | { message?: string }
+      | undefined;
+    assert.ok(
+      pauseCallArgs?.message?.includes(
+        "Post-execution checks failed: [signature] formatName:"
+      )
+    );
+    assert.ok(!pauseCallArgs?.message?.includes("unknown post-execution check failure"));
   });
 
   test("uok gate runner persists post-execution gate failures when enabled", async () => {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -451,6 +451,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores generated SvelteKit $types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src", "routes"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "routes", "+page.ts"),
+      "import type { PageLoad } from './$types';\nexport const load: PageLoad = async () => ({})"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["src/routes/+page.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -473,6 +473,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores nested generated SvelteKit $types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src", "lib", "components"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "lib", "components", "RouteCard.ts"),
+      "import type { PageData } from '../../routes/blog/$types';\nexport const data = {} as PageData;"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["src/lib/components/RouteCard.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Fixed false blocking on SvelteKit `$types` imports and made post-exec pause errors report specific failing check details, with targeted tests updated and run where environment allowed.

## Bugs Addressed
- [x] **SvelteKit './$types' imports falsely fail post-exec checks**
- [x] **Verification pause message hides actual failing check**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #217
- [#217 Post-execution checks falsely block SvelteKit $types imports and pause auto-mode](https://github.com/open-gsd/gsd-pi/issues/217)

## User
- @chan95821

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/217-post-execution-checks-falsely-block-svel-1780192940`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782785471&installation_id=134682257&pr_number=302&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F302&signature=ce9df54ee0939326547a1e26f0e0b63589243658332b87c26d145642c3fc86c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted changes to post-execution import heuristics and auto-mode pause messaging in the GSD extension, with added unit/integration tests and no auth or data-path impact.
> 
> **Overview**
> Post-execution **import resolution** no longer treats missing **SvelteKit `$types`** modules (including nested paths like `../../routes/blog/$types`) as blocking failures, alongside the existing React Router `+types` exemption.
> 
> When post-exec checks force a **pause** (blocking failures or **strict** mode on warnings), **auto-verification** now surfaces the **first failing check** (`[category] target: message`) in UI notifications and `pauseAuto` messages instead of a generic cross-task consistency note.
> 
> Tests cover **`$types` skip behavior** and **detailed pause messaging** for import failures and strict signature warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bef491d72a0dadb9bb553b756b1b6db5e4dd339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->