### PR TITLE
[codex] fix safety evidence tool detection

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -68,7 +68,7 @@ import {
   runMilestoneCloseoutGitHub,
 } from "./milestone-closeout.js";
 import type { AutoSession, SidecarItem } from "./auto/session.js";
-import { getEvidence, clearEvidenceFromDisk } from "./safety/evidence-collector.js";
+import { getEvidence, clearEvidenceFromDisk, isExecutionToolName } from "./safety/evidence-collector.js";
 import { validateFileChanges } from "./safety/file-change-validator.js";
 import { crossReferenceEvidence, type ClaimedEvidence } from "./safety/evidence-cross-ref.js";
 import { validateContent } from "./safety/content-validator.js";
@@ -488,12 +488,6 @@ export function _shouldDispatchQuickTaskForTest(
     state.pendingQuickTasks.length > 0 &&
     !!state.currentUnit &&
     state.currentUnit.type !== "quick-task";
-}
-
-function isExecutionToolName(name: unknown): boolean {
-  if (typeof name !== "string") return false;
-  const normalized = name.trim().toLowerCase();
-  return normalized === "bash" || normalized === "gsd_exec";
 }
 
 export function _hasExecutionToolCallsInSessionForTest(entries: readonly unknown[]): boolean {
@@ -1470,11 +1464,11 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
                       suppressedWarning: "evidence-empty-but-session-has-exec-calls",
                     });
                   } else {
-                    logWarning("safety", `evidence mismatch: ${missingCommandMismatches.length} claimed command(s) not found in bash calls`);
-                  ctx.ui.notify(
-                    `Safety: task ${sTid} claimed ${missingCommandMismatches.length} command(s) not found in recorded bash calls`,
-                    "warning",
-                  );
+                    logWarning("safety", `evidence mismatch: ${missingCommandMismatches.length} claimed command(s) not found in recorded execution calls`);
+                    ctx.ui.notify(
+                      `Safety: task ${sTid} claimed ${missingCommandMismatches.length} command(s) not found in recorded execution calls`,
+                      "warning",
+                    );
                   }
                 }
 

--- a/src/resources/extensions/gsd/safety/evidence-collector.ts
+++ b/src/resources/extensions/gsd/safety/evidence-collector.ts
@@ -51,14 +51,15 @@ export interface FileEditEvidence {
 export type EvidenceEntry = BashEvidence | FileWriteEvidence | FileEditEvidence;
 
 const EXECUTION_TOOL_NAMES = new Set([
-  "bash",
-  "Bash",
-  "PowerShell",
   "async_bash",
+  "bash",
+  "exec_command",
+  "functions.exec_command",
   "gsd_exec",
   "gsd_exec_search",
   "mcp__gsd-workflow__gsd_exec",
   "mcp__gsd-workflow__gsd_exec_search",
+  "powershell",
 ]);
 
 // ─── Module State ───────────────────────────────────────────────────────────
@@ -87,6 +88,12 @@ export function getFilePaths(): string[] {
   return unitEvidence
     .filter((e): e is FileWriteEvidence | FileEditEvidence => e.kind === "write" || e.kind === "edit")
     .map(e => e.path);
+}
+
+/** True when a tool name represents a shell/command execution surface. */
+export function isExecutionToolName(name: unknown): boolean {
+  if (typeof name !== "string") return false;
+  return EXECUTION_TOOL_NAMES.has(name.trim().toLowerCase());
 }
 
 // ─── Persistence (Bug #4385 — evidence must survive session restarts) ────────
@@ -199,7 +206,7 @@ export function clearEvidenceFromDisk(
  * Exit codes and output are filled in by recordToolResult after execution.
  */
 export function recordToolCall(toolCallId: string, toolName: string, input: Record<string, unknown>): void {
-  if (EXECUTION_TOOL_NAMES.has(toolName)) {
+  if (isExecutionToolName(toolName)) {
     unitEvidence.push({
       kind: "bash",
       toolCallId,

--- a/src/resources/extensions/gsd/tests/auto-post-unit-evidence-crossref-4909.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-evidence-crossref-4909.test.ts
@@ -58,3 +58,33 @@ test("detects top-level bash tool call via toolName field", () => {
 
   assert.equal(_hasExecutionToolCallsInSessionForTest(entries), true);
 });
+
+test("detects session execution tools supported by the evidence collector", () => {
+  const entries = [
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            toolName: "async_bash",
+            arguments: { command: "npm test" },
+          },
+          {
+            type: "toolCall",
+            toolName: "PowerShell",
+            arguments: { command: "Get-ChildItem" },
+          },
+          {
+            type: "toolCall",
+            toolName: "functions.exec_command",
+            arguments: { cmd: "pnpm test" },
+          },
+        ],
+      },
+    },
+  ];
+
+  assert.equal(_hasExecutionToolCallsInSessionForTest(entries), true);
+});

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -95,4 +95,16 @@ describe("evidence-collector: toolCallId-based matching (A-3)", () => {
     assert.equal(entries[1].kind, "bash");
     assert.equal(entries[1].command, "npm run build");
   });
+
+  it("treats Codex exec_command tool names as execution evidence", () => {
+    recordToolCall("tc-exec", "exec_command", { cmd: "pnpm test" });
+    recordToolCall("tc-namespaced-exec", "functions.exec_command", { cmd: "pnpm lint" });
+
+    const entries = getEvidence() as readonly BashEvidence[];
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].kind, "bash");
+    assert.equal(entries[0].command, "pnpm test");
+    assert.equal(entries[1].kind, "bash");
+    assert.equal(entries[1].command, "pnpm lint");
+  });
 });


### PR DESCRIPTION
## Summary

- Share the safety harness execution-tool detector between evidence collection and post-unit fallback checks.
- Recognize additional execution surfaces, including `async_bash`, `PowerShell`, and Codex-style `exec_command` tool names.
- Update warning copy from bash-specific wording to execution-call wording.

## Why

The post-unit fallback only recognized `bash` and `gsd_exec`, while the evidence collector accepted more execution tools. That mismatch could surface false-positive warnings like “claimed command(s) not found in recorded bash calls” even when the session contained execution calls through another supported tool name.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-post-unit-evidence-crossref-4909.test.ts src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts`
- `pnpm run typecheck:extensions`

## Notes

Unrelated local changes to `.gitignore` and `packages/pi-ai/src/models.generated.ts` were intentionally left out of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782787447&installation_id=134682257&pr_number=303&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F303&signature=dff2cae2520c394344d0ed841725f960b0575f92cdac0741210a0e6d8a4aa626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted safety-harness alignment and wording changes with regression tests; no auth, data, or payment paths touched.
> 
> **Overview**
> Aligns **post-unit safety** with **evidence collection** by reusing a single `isExecutionToolName` helper from `evidence-collector` instead of a narrower local check that only treated `bash` and `gsd_exec` as execution tools.
> 
> The shared detector now normalizes tool names (case/whitespace) and covers additional execution surfaces—`async_bash`, `powershell`, Codex-style `exec_command` / `functions.exec_command`, and existing `gsd_exec` variants—so session fallback logic matches what gets recorded as bash evidence. User-facing mismatch warnings say **recorded execution calls** rather than **recorded bash calls**. Regression tests cover the expanded tool names for both session scanning and evidence recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cef0bc29c4ecc5cd3a1543b256c1cea78c52967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->