### PR TITLE
[codex] fix gsd_exec argument normalization

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -275,6 +275,28 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_exec accepts command alias without an explicit runtime", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_exec");
+      assert.ok(tool, "exec tool should be registered");
+
+      const result = await tool!.handler({
+        projectDir: base,
+        command: "echo mcp-command-alias-defaults-to-bash",
+      });
+
+      const record = result as any;
+      assert.equal(record.isError, false);
+      assert.equal(record.structuredContent.runtime, "bash");
+      assert.match(record.content[0].text as string, /mcp-command-alias-defaults-to-bash/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_exec returns an MCP error when context mode is disabled", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1529,11 +1529,16 @@ const journalQueryParams = {
 };
 const journalQuerySchema = z.object(journalQueryParams);
 
-const execRuntimeSchema = z.enum(["bash", "node", "python"]);
+const execRuntimeSchema = z.string();
 const execParams = {
   projectDir: projectDirParam,
-  runtime: execRuntimeSchema.describe("Interpreter: bash (-c), node (-e), or python3 (-c)."),
-  script: nonEmptyString("script").describe("Script body. Keep output small; capped stdout/stderr are persisted under .gsd/exec."),
+  runtime: execRuntimeSchema
+    .optional()
+    .describe("Optional interpreter. Defaults to bash. Supported: bash, node, python; sh/shell, js/nodejs, and py/python3 aliases are accepted."),
+  script: z.string().optional().describe("Script body. Keep output small; capped stdout/stderr are persisted under .gsd/exec."),
+  command: z.string().optional().describe("Alias for script; defaults to bash when runtime is omitted."),
+  cmd: z.string().optional().describe("Short alias for script."),
+  code: z.string().optional().describe("Alias for script, useful for node/python snippets."),
   purpose: z.string().optional().describe("Short label recorded in meta.json for later review."),
   timeout_ms: z.number().int().min(1_000).max(600_000).optional().describe("Per-invocation timeout in milliseconds."),
 };
@@ -1542,7 +1547,7 @@ const execSchema = z.object(execParams);
 const execSearchParams = {
   projectDir: projectDirParam,
   query: z.string().optional().describe("Substring matched against id and purpose, case-insensitive."),
-  runtime: execRuntimeSchema.optional().describe("Restrict to one runtime."),
+  runtime: z.enum(["bash", "node", "python"]).optional().describe("Restrict to one runtime."),
   failing_only: z.boolean().optional().describe("Only non-zero exit codes and timeouts."),
   limit: z.number().int().min(1).max(200).optional().describe("Max results (default 20, cap 200)."),
 };

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -43,11 +43,16 @@ export function registerExecTools(pi: ExtensionAPI): void {
       "Need persisted output? Read the stdout_path returned in details (file on local disk).",
     ],
     parameters: Type.Object({
-      runtime: Type.Union(
-        [Type.Literal("bash"), Type.Literal("node"), Type.Literal("python")],
-        { description: "Interpreter: bash (-c), node (-e), or python3 (-c)." },
+      runtime: Type.Optional(
+        Type.String({
+          description:
+            "Optional interpreter. Defaults to bash. Supported: bash, node, python; sh/shell, js/nodejs, and py/python3 aliases are accepted.",
+        }),
       ),
-      script: Type.String({ description: "Script body. Keep output small (log the finding, not the data)." }),
+      script: Type.Optional(Type.String({ description: "Script body. Keep output small (log the finding, not the data)." })),
+      command: Type.Optional(Type.String({ description: "Alias for script; defaults to bash when runtime is omitted." })),
+      cmd: Type.Optional(Type.String({ description: "Short alias for script." })),
+      code: Type.Optional(Type.String({ description: "Alias for script, useful for node/python snippets." })),
       purpose: Type.Optional(Type.String({ description: "Short label recorded in meta.json for later review." })),
       timeout_ms: Type.Optional(
         Type.Number({

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -241,6 +241,36 @@ test('executeGsdExec: enforces per-call timeout override end-to-end', async () =
   }
 });
 
+test('executeGsdExec: defaults to bash and accepts command alias', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { command: 'echo command-alias-defaults-to-bash' },
+      { baseDir: base, preferences: { context_mode: { enabled: true } } },
+    );
+    assert.equal(result.isError, false);
+    assert.equal(result.details.runtime, 'bash');
+    assert.ok(result.content[0].text.includes('command-alias-defaults-to-bash'));
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeGsdExec: accepts common runtime aliases', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'js', code: 'console.log("runtime-alias-node")' },
+      { baseDir: base, preferences: { context_mode: { enabled: true } } },
+    );
+    assert.equal(result.isError, false);
+    assert.equal(result.details.runtime, 'node');
+    assert.ok(result.content[0].text.includes('runtime-alias-node'));
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('executeGsdExec: rejects empty script', async () => {
   const base = freshBase();
   try {

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -14,8 +14,11 @@ import { isContextModeEnabled, type ContextModeConfig } from "../preferences-typ
 import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
 
 export interface ExecToolParams {
-  runtime: ExecSandboxRequest["runtime"];
-  script: string;
+  runtime?: unknown;
+  script?: unknown;
+  command?: unknown;
+  cmd?: unknown;
+  code?: unknown;
   purpose?: string;
   timeout_ms?: number;
 }
@@ -78,6 +81,39 @@ function paramError(message: string): ToolExecutionResult {
     details: { operation: "gsd_exec", error: "invalid_params", detail: message },
     isError: true,
   };
+}
+
+function normalizeRuntime(value: unknown): ExecSandboxRequest["runtime"] | ToolExecutionResult {
+  if (value === undefined || value === null || value === "") return "bash";
+  if (typeof value !== "string") {
+    return paramError(`invalid runtime "${String(value)}" — must be bash | node | python`);
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "" || normalized === "bash" || normalized === "sh" || normalized === "shell") return "bash";
+  if (normalized === "node" || normalized === "nodejs" || normalized === "js" || normalized === "javascript") return "node";
+  if (normalized === "python" || normalized === "python3" || normalized === "py") return "python";
+  return paramError(`invalid runtime "${value}" — must be bash | node | python`);
+}
+
+function normalizeScript(params: ExecToolParams): string | ToolExecutionResult {
+  const candidates = [params.script, params.command, params.cmd, params.code];
+  let sawNonString = false;
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === null) continue;
+    if (typeof candidate !== "string") {
+      sawNonString = true;
+      continue;
+    }
+    if (candidate.trim().length > 0) return candidate;
+  }
+  if (sawNonString) {
+    return paramError("script/command must be a non-empty string");
+  }
+  return paramError("script is required and must be a non-empty string");
+}
+
+function isToolExecutionResult(value: unknown): value is ToolExecutionResult {
+  return typeof value === "object" && value !== null && Array.isArray((value as { content?: unknown }).content);
 }
 
 function escapeRegExp(value: string): string {
@@ -201,14 +237,10 @@ export async function executeGsdExec(
 ): Promise<ToolExecutionResult> {
   if (!isEnabled(deps.preferences)) return contextModeDisabledResult("gsd_exec");
 
-  const runtime = params.runtime;
-  if (runtime !== "bash" && runtime !== "node" && runtime !== "python") {
-    return paramError(`invalid runtime "${String(runtime)}" — must be bash | node | python`);
-  }
-  const script = typeof params.script === "string" ? params.script : "";
-  if (script.trim().length === 0) {
-    return paramError("script is required and must be a non-empty string");
-  }
+  const runtime = normalizeRuntime(params.runtime);
+  if (isToolExecutionResult(runtime)) return runtime;
+  const script = normalizeScript(params);
+  if (isToolExecutionResult(script)) return script;
   if (Buffer.byteLength(script, "utf8") > 200_000) {
     return paramError("script exceeds the 200 KB length limit");
   }


### PR DESCRIPTION
## Summary

Fixes `gsd_exec` calls that currently fail at MCP input validation when an agent supplies a shell-style `command` without an explicit `runtime`/`script` pair.

## Root Cause

The public `gsd_exec` schemas required `runtime` to be exactly `bash | node | python` and required `script`, so recoverable calls never reached the executor's structured parameter handling.

## Changes

- Default omitted `runtime` to `bash` in the executor.
- Accept `script`, `command`, `cmd`, and `code` as script-body aliases.
- Normalize common runtime aliases like `shell`, `js`, `nodejs`, `py`, and `python3`.
- Relax the in-process extension and packaged MCP schemas so recoverable input reaches the executor.
- Add regression coverage for command-alias/default-runtime calls.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/exec-sandbox.test.ts packages/mcp-server/src/workflow-tools.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/claude-tool-schema-golden.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm --filter @opengsd/mcp-server exec tsc --noEmit -p tsconfig.json`

## Note

`pnpm --filter @opengsd/mcp-server run build:test` still fails on existing package test tsconfig/rootDir issues involving `workflow-tools-parity.test.ts` importing repo-level `.ts` files outside the package root; that failure is unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782788733&installation_id=134682257&pr_number=306&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F306&signature=837da9bc015b7356b668d7278981b823eaa2c193a369b3e36d0024e105dd3b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands accepted gsd_exec inputs but execution still uses the existing sandbox, timeouts, and worktree path guards; main risk is mis-normalized runtime or script content reaching subprocess execution.
> 
> **Overview**
> Fixes **`gsd_exec`** failing at **MCP/schema validation** when agents send a shell-style **`command`** (or omit **`runtime`**) instead of the strict **`runtime` + `script`** pair.
> 
> **Executor (`executeGsdExec`)** now normalizes input before the sandbox runs: omitted **`runtime`** defaults to **`bash`**; **`script`**, **`command`**, **`cmd`**, and **`code`** are treated as the script body (first non-empty string wins); common runtime aliases map to **`bash` / `node` / `python`** (e.g. **`sh`**, **`js`**, **`py`**).
> 
> **Public tool contracts** are aligned so recoverable calls get through: packaged MCP Zod in **`workflow-tools`**, in-process TypeBox in **`exec-tools`**, with regression tests on both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531d233abc6529a58323636d494d992a9f589bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->