### PR TITLE
[codex] restore missing bundled skills during resource sync

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -637,11 +637,16 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
       join(agentDir, 'shared'),
       join(resourcesDir, 'shared'),
     )
+    const hasMissingSkillFiles = hasMissingBundledResourceFiles(
+      skillsDir,
+      join(resourcesDir, 'skills'),
+    )
     if (
       manifest.contentHash &&
       manifest.contentHash === currentHash &&
       !hasStaleExtensionFiles &&
-      !hasMissingSharedFiles
+      !hasMissingSharedFiles &&
+      !hasMissingSkillFiles
     ) {
       return
     }

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -42,6 +42,12 @@ function bundledSharedDir(): string {
     : join(process.cwd(), "src", "resources", "shared");
 }
 
+function bundledSkillsDir(): string {
+  return existsSync(join(process.cwd(), "dist", "resources", "skills"))
+    ? join(process.cwd(), "dist", "resources", "skills")
+    : join(process.cwd(), "src", "resources", "skills");
+}
+
 test("getExtensionKey normalizes top-level .ts and .js entry names to the same key", async () => {
   const { getExtensionKey } = await import("../resource-loader.ts");
   const extensionsDir = "/tmp/extensions";
@@ -296,6 +302,56 @@ test("initResources resyncs when current manifest is missing top-level shared re
     hasSyncedResourceFile(join(fakeAgentDir, "shared"), "package-manager-detection"),
     true,
     "current managed-resource manifests must not skip missing top-level shared files",
+  );
+});
+
+test("initResources resyncs when current manifest is missing bundled skills", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-skill-stale-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const restoreHome = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHome();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const {
+    computeResourceFingerprint,
+    hasMissingBundledResourceFiles,
+    initResources,
+  } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  rmSync(join(fakeAgentDir, "skills", "tdd"), { recursive: true, force: true });
+  const packageVersion = JSON.parse(
+    readFileSync(join(process.cwd(), "package.json"), "utf-8"),
+  ).version;
+  writeFileSync(
+    join(fakeAgentDir, "managed-resources.json"),
+    JSON.stringify({
+      gsdVersion: process.env.GSD_VERSION && process.env.GSD_VERSION !== "0.0.0"
+        ? process.env.GSD_VERSION
+        : packageVersion,
+      packageName: "@opengsd/gsd-pi",
+      contentHash: computeResourceFingerprint(),
+    }),
+  );
+
+  assert.equal(
+    hasMissingBundledResourceFiles(
+      join(fakeAgentDir, "skills"),
+      bundledSkillsDir(),
+    ),
+    true,
+    "test setup should simulate a current manifest with missing bundled skills",
+  );
+
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(join(fakeAgentDir, "skills", "tdd", "SKILL.md")),
+    true,
+    "current managed-resource manifests must not skip missing bundled skills",
   );
 });
 


### PR DESCRIPTION
## Summary

This fixes a managed-resource sync edge case where `initResources()` could skip a full resync when `managed-resources.json` was current even though bundled skill files were missing from `~/.gsd/agent/skills`.

## Root Cause

The current-manifest fast path checked for stale extension siblings and missing shared files, but it did not check for missing bundled skill files. A fresh or repaired install could therefore keep reporting a skill like `tdd` as unavailable if the manifest hash/version looked current while the skill directory was absent.

## Changes

- Include bundled skill files in the missing-resource check before skipping sync.
- Add a regression test that removes `skills/tdd`, writes a current manifest, and verifies `initResources()` restores the skill.

## Validation

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/resource-loader.test.ts
```

Result: 14 passing tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782790234&installation_id=134682257&pr_number=307&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F307&signature=85d9273ef3f353bb93b371ae02ff743b29c3c8cea6ad33bc69127e58afca5ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only resource sync logic with a focused regression test; no auth, network, or data-path changes.
> 
> **Overview**
> Fixes a gap in **`initResources()`**’s managed-resource fast path: when `managed-resources.json` already matched the current version and content hash, startup could **skip a full resync** even if bundled **skill** files were missing under `~/.gsd/agent/skills` (extensions and shared were already guarded).
> 
> The fast-path skip now also runs **`hasMissingBundledResourceFiles`** against the skills install dir vs bundled `resources/skills`, mirroring the existing shared check. A regression test removes **`skills/tdd`**, keeps a “current” manifest, and asserts **`initResources()`** restores **`SKILL.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9810fd65ba2b02bf99b026f3bda003b93dfa3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->