### PR TITLE
[codex] expose checkpoint DB over workflow MCP

### DIFF
--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -65,6 +65,7 @@ test("workflow tool contracts expose canonical names and aliases", () => {
 	assert.ok(WORKFLOW_TOOL_NAMES.includes("gsd_task_reopen"));
 	assert.ok(WORKFLOW_TOOL_NAMES.includes("gsd_reopen_task"));
 	assert.ok(WORKFLOW_TOOL_NAMES.includes("gsd_plan_milestone"));
+	assert.ok(WORKFLOW_TOOL_NAMES.includes("gsd_checkpoint_db"));
 
 	const taskComplete = WORKFLOW_TOOL_CONTRACTS.find((tool) => tool.canonicalName === "gsd_task_complete");
 	assert.ok(taskComplete);
@@ -77,4 +78,9 @@ test("workflow tool contracts expose canonical names and aliases", () => {
 	assert.deepEqual([...taskReopen.aliases], ["gsd_reopen_task"]);
 	assert.equal(taskReopen.writePolicy, "write");
 	assert.equal(taskReopen.schemaId, "workflow.task.reopen");
+
+	const checkpointDb = WORKFLOW_TOOL_CONTRACTS.find((tool) => tool.canonicalName === "gsd_checkpoint_db");
+	assert.ok(checkpointDb);
+	assert.equal(checkpointDb.writePolicy, "read");
+	assert.equal(checkpointDb.schemaId, "workflow.database.checkpoint");
 });

--- a/packages/contracts/src/workflow.test.ts
+++ b/packages/contracts/src/workflow.test.ts
@@ -20,5 +20,6 @@ test("workflow aliases map back to known canonical tools", () => {
 test("read-only workflow tools are classified correctly", () => {
   const readOnly = WORKFLOW_TOOL_CONTRACTS.filter((tool) => tool.writePolicy === "read");
   assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_milestone_status"));
+  assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_checkpoint_db"));
   assert.ok(readOnly.every((tool) => tool.writePolicy === "read"));
 });

--- a/packages/contracts/src/workflow.ts
+++ b/packages/contracts/src/workflow.ts
@@ -174,6 +174,14 @@ export const WORKFLOW_TOOL_CONTRACTS = [
 		auditEvent: "workflow.milestone.status",
 	},
 	{
+		canonicalName: "gsd_checkpoint_db",
+		aliases: [],
+		schemaId: "workflow.database.checkpoint",
+		executorId: "executeCheckpointDb",
+		writePolicy: "read",
+		auditEvent: "workflow.database.checkpoint",
+	},
+	{
 		canonicalName: "gsd_journal_query",
 		aliases: [],
 		schemaId: "workflow.journal.query",

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -15,6 +15,7 @@ import {
   _getAdapter,
   closeDatabase,
   getSliceTasks,
+  insertDecision,
   insertMilestone,
   insertSlice,
   openDatabase,
@@ -187,6 +188,45 @@ describe("workflow MCP tools", () => {
     assert.ok("sliceId" in taskReopen.params);
     assert.ok("taskId" in taskReopen.params);
     assert.ok("reason" in taskReopen.params);
+  });
+
+  it("registers gsd_checkpoint_db and flushes the open WAL", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_checkpoint_db");
+      assert.ok(tool, "gsd_checkpoint_db must be registered");
+      assert.ok("projectDir" in tool.params);
+
+      const dbPath = join(base, ".gsd", "gsd.db");
+      openDatabase(dbPath);
+      insertDecision({
+        id: "D001",
+        when_context: "test",
+        scope: "global",
+        decision: "Expose checkpoint tool over MCP",
+        choice: "register gsd_checkpoint_db",
+        rationale: "MCP clients need to flush WAL before staging gsd.db",
+        revisable: "yes",
+        made_by: "agent",
+        superseded_by: null,
+      });
+
+      const walPath = `${dbPath}-wal`;
+      assert.ok(existsSync(walPath), "WAL file should exist after a write");
+      assert.ok(statSync(walPath).size > 0, "WAL file should be non-empty after a write");
+
+      const result = await tool.handler({ projectDir: base });
+      const record = result as { content?: Array<{ text?: string }>; structuredContent?: Record<string, unknown> };
+      assert.equal(record.content?.[0]?.text, "WAL checkpoint complete. gsd.db is now up to date and safe to stage with git add.");
+      assert.deepEqual(record.structuredContent, { operation: "checkpoint_db", status: "ok" });
+
+      const walSizeAfter = existsSync(walPath) ? statSync(walPath).size : 0;
+      assert.equal(walSizeAfter, 0, "WAL file should be truncated to 0 after MCP checkpoint");
+    } finally {
+      cleanup(base);
+    }
   });
 
   it("prefers source TypeScript for generic local module imports", () => {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1517,6 +1517,11 @@ const milestoneStatusParams = {
 };
 const milestoneStatusSchema = z.object(milestoneStatusParams);
 
+const checkpointDbParams = {
+  projectDir: projectDirParam,
+};
+const checkpointDbSchema = z.object(checkpointDbParams);
+
 const journalQueryParams = {
   projectDir: projectDirParam,
   flowId: z.string().optional().describe("Filter by flow ID"),
@@ -2068,6 +2073,28 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
       return adaptExecutorResult(
         await runSerializedWorkflowOperation(() => executeMilestoneStatus({ milestoneId }, projectDir)),
       );
+    },
+  );
+
+  server.tool(
+    "gsd_checkpoint_db",
+    "Flush the SQLite WAL into gsd.db so git add stages the current GSD database state.",
+    checkpointDbParams,
+    async (args: Record<string, unknown>) => {
+      const { projectDir } = parseWorkflowArgs(checkpointDbSchema, args);
+      await runSerializedWorkflowDbOperation(projectDir, async () => {
+        const { checkpointDatabase } = await importLocalModule<any>(
+          "../../../src/resources/extensions/gsd/gsd-db.js",
+        );
+        checkpointDatabase();
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: "WAL checkpoint complete. gsd.db is now up to date and safe to stage with git add.",
+        }],
+        structuredContent: { operation: "checkpoint_db", status: "ok" },
+      };
     },
   );
 


### PR DESCRIPTION
## Summary

- Add `gsd_checkpoint_db` to the canonical workflow tool contracts so deferred/MCP discovery advertises it.
- Register the packaged workflow MCP handler and route it through the serialized workflow DB operation path.
- Add regression coverage proving the MCP tool is registered and truncates the SQLite WAL.

## Root Cause

`gsd_checkpoint_db` existed in the in-process GSD extension tool surface, but the packaged workflow MCP surface is driven by `@opengsd/contracts`. The contract list did not include the checkpoint tool, so deferred schema lookup could not discover it.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/contracts/src/workflow.test.ts packages/contracts/src/rpc.test.ts packages/mcp-server/src/workflow-tools.test.ts`
- `pnpm --filter @opengsd/contracts run build`
- `pnpm --filter @opengsd/mcp-server run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782791279&installation_id=134682257&pr_number=308&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F308&signature=e0ba3bdda52b06f26111c89255ddbbfb47ae1a96bf35a6eef7d6633bd0b5ecbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-classified DB maintenance on an existing checkpoint path; scope is contracts, MCP registration, and tests with no auth or schema migration changes.
> 
> **Overview**
> Exposes **`gsd_checkpoint_db`** on the packaged workflow MCP surface so external clients can flush the SQLite WAL into **`gsd.db`** before staging it with git—matching behavior that already existed in-process but was missing from **`@opengsd/contracts`**-driven discovery.
> 
> Adds the tool to **`WORKFLOW_TOOL_CONTRACTS`** as a **read** policy entry (`workflow.database.checkpoint` / `executeCheckpointDb`), registers the MCP handler in **`workflow-tools.ts`** via **`runSerializedWorkflowDbOperation`** and **`checkpointDatabase()`**, and adds tests that the tool is advertised and that a write leaves a non-empty **`-wal`** file that is truncated after the call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b84179dc50f1fefc366a94c70083446b5122dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->