### PR TITLE
[codex] fix mcp-server package test compile scope

### DIFF
--- a/packages/mcp-server/tsconfig.test.json
+++ b/packages/mcp-server/tsconfig.test.json
@@ -14,6 +14,7 @@
     "dist",
     "**/*.d.ts",
     "src/**/*.d.ts",
-    "src/workflow-tools.test.ts"
+    "src/workflow-tools.test.ts",
+    "src/workflow-tools-parity.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- Exclude `workflow-tools-parity.test.ts` from the package-local `tsconfig.test.json` build.
- Keep `pnpm --filter @opengsd/mcp-server test` focused on the two compiled smoke tests it actually runs.

## Root Cause

The package-local test build compiled every `packages/mcp-server/src/**/*.ts` file, while the package `test` script only runs `dist/mcp-server.test.js` and `dist/remote-questions.test.js`. `workflow-tools-parity.test.ts` imports root GSD source files by `.ts` extension outside the package root, which is valid for repo-level test execution but invalid for this package-local TypeScript build.

## Validation

- `pnpm --filter @opengsd/mcp-server test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782792125&installation_id=134682257&pr_number=309&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F309&signature=f8631ecf0ab70b6034a904879184f092e5ea5f2d5360fd1ee076d572d5ecd816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test build configuration only; no runtime or production code paths change.
> 
> **Overview**
> Excludes `workflow-tools-parity.test.ts` from the `@opengsd/mcp-server` package-local `tsconfig.test.json` compile, alongside the existing exclusion for `workflow-tools.test.ts`.
> 
> That aligns the **build:test** graph with what `pnpm --filter @opengsd/mcp-server test` actually runs (`dist/mcp-server.test.js` and `dist/remote-questions.test.js`). The parity test is meant for repo-level runs and pulls in root GSD `.ts` sources outside the package, which breaks the scoped TypeScript build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67bdd34cd3e1ef0a147688855930ef91f6846414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->