### PR TITLE
fix(mcp-server): add CLI shebang

### DIFF
--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @opengsd/mcp-server CLI — stdio transport entry point.
  *


### PR DESCRIPTION
## Summary

- Add a Node shebang to the MCP server CLI source (`packages/mcp-server/src/cli.ts`).
- This makes the package `bin` target executable when launched directly as `gsd-mcp-server`.

## Why

While testing the native Hermes integration from PR #185 on macOS, the installed `gsd-mcp-server` binary failed with:

```text
OSError: [Errno 8] Exec format error
```

The package `bin` entry points at the built JS file, but the source CLI did not include a shebang, so the generated executable could not be launched directly by subprocess callers.

## Verification

Ran locally from a fresh PR #185 checkout:

- `npm run build:mcp-server`
- `gsd-mcp-server </dev/null`
  - observed: `[gsd-mcp-server] MCP server started on stdio`
  - observed: `[gsd-mcp-server] Shutting down...`
- `bash integrations/hermes/scripts/preflight.sh`
  - observed: `6 passed, 0 failed`
- Hermes integration Python tests:
  - observed: `35 passed`

## Notes

`npm test -w @opengsd/mcp-server` currently fails before executing tests because the package test tsconfig pulls cross-root `.ts` imports outside `packages/mcp-server/src`; that appears unrelated to this one-line executable fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807036&installation_id=134682257&pr_number=310&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F310&signature=de9317255b5bfa3b31405208fcc7a4383ad4f43462fad3472c8b43475baf0b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->