### PR TITLE
[codex] fix mcp tool namespace leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
 
   docker-e2e:
     name: docker-e2e
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: [fast-gates, build]
     if: >-
       needs.fast-gates.outputs.heavy-code-changed == 'true' &&

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -653,7 +653,9 @@ async function prepareToolCall(
 		if (isToolSearchToolName(toolCall.name)) {
 			return {
 				kind: "immediate",
-				result: createToolSearchShimResult(toolCall.arguments),
+				result: createToolSearchShimResult(toolCall.arguments, {
+					activeToolNames: currentContext.tools?.map((tool) => tool.name),
+				}),
 				isError: false,
 			};
 		}

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -629,6 +629,7 @@ describe("agentLoop with AgentMessage", () => {
 		);
 		expect(toolResult?.isError).toBe(false);
 		expect(toolResult?.result.content[0]?.text).toContain("gsd_milestone_status");
+		expect(toolResult?.result.content[0]?.text).not.toContain("Call `mcp__gsd-workflow__gsd_milestone_status`");
 	});
 
 	it("returns Agent guidance when subagent is not in the active tool registry", async () => {

--- a/packages/pi-ai/src/utils/tests/tool-search-shim.test.ts
+++ b/packages/pi-ai/src/utils/tests/tool-search-shim.test.ts
@@ -14,12 +14,43 @@ describe("tool-search-shim", () => {
 		);
 	});
 
-	test("createToolSearchShimResult guides direct MCP call", () => {
+	test("createToolSearchShimResult guides direct MCP call when that exact tool is active", () => {
 		const result = createToolSearchShimResult({
 			query: "select:mcp__gsd-workflow__gsd_milestone_status",
+		}, {
+			activeToolNames: ["mcp__gsd-workflow__gsd_milestone_status"],
 		});
 		assert.ok(result.content[0]?.text.includes("mcp__gsd-workflow__gsd_milestone_status"));
 		assert.equal(result.details.resolvedTool, "mcp__gsd-workflow__gsd_milestone_status");
+	});
+
+	test("createToolSearchShimResult maps stale MCP aliases to the active scoped tool", () => {
+		const result = createToolSearchShimResult({
+			query: "select:mcp__gsd-workflow__gsd_milestone_status",
+		}, {
+			activeToolNames: ["mcp__custom-workflow__gsd_milestone_status"],
+		});
+		assert.ok(result.content[0]?.text.includes("mcp__custom-workflow__gsd_milestone_status"));
+		assert.ok(!result.content[0]?.text.includes("Call `mcp__gsd-workflow__gsd_milestone_status`"));
+		assert.equal(result.details.resolvedTool, "mcp__custom-workflow__gsd_milestone_status");
+	});
+
+	test("createToolSearchShimResult does not reinforce inactive MCP aliases", () => {
+		const result = createToolSearchShimResult({
+			query: "select:mcp__gsd-workflow__gsd_milestone_status",
+		});
+		assert.ok(result.content[0]?.text.includes("Do not call `mcp__gsd-workflow__gsd_milestone_status`"));
+		assert.ok(!result.content[0]?.text.includes("Call `mcp__gsd-workflow__gsd_milestone_status`"));
+		assert.equal(result.details.resolvedTool, "gsd_milestone_status");
+	});
+
+	test("createToolSearchShimResult avoids hard-coded workflow MCP aliases for canonical tools", () => {
+		const result = createToolSearchShimResult({
+			query: "select:gsd_milestone_status",
+		});
+		assert.ok(result.content[0]?.text.includes("Call `gsd_milestone_status` directly"));
+		assert.ok(!result.content[0]?.text.includes("mcp__gsd-workflow__gsd_milestone_status"));
+		assert.equal(result.details.resolvedTool, "gsd_milestone_status");
 	});
 
 	test("isToolSearchToolName is case insensitive", () => {

--- a/packages/pi-ai/src/utils/tool-search-shim.ts
+++ b/packages/pi-ai/src/utils/tool-search-shim.ts
@@ -4,6 +4,8 @@
  * of a hard "Tool ToolSearch not found" failure.
  */
 
+import { parseMcpToolName } from "./mcp-tool-name.js";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -36,30 +38,83 @@ export function extractToolSearchQuery(args: unknown): string {
 	return "";
 }
 
-function formatDirectCallHint(toolName: string): string {
-	if (toolName.startsWith("mcp__")) {
-		return `Call \`${toolName}\` directly in a tool-use block. ToolSearch is not available in GSD.`;
-	}
-	if (toolName.startsWith("gsd_") || toolName === "memory_query" || toolName === "capture_thought") {
-		return (
-			`Call \`${toolName}\` directly (or \`mcp__gsd-workflow__${toolName}\` when running inside Claude Code). ` +
-			"ToolSearch is not available in GSD."
-		);
-	}
-	return `Call \`${toolName}\` directly. ToolSearch is not available in GSD.`;
+export interface ToolSearchShimOptions {
+	activeToolNames?: readonly string[];
 }
 
-export function createToolSearchShimResult(args: unknown): {
+function activeEquivalentForSelectedTool(toolName: string, activeToolNames: readonly string[] | undefined): string | null {
+	if (!activeToolNames || activeToolNames.length === 0) return null;
+	const mcp = parseMcpToolName(toolName);
+	const canonicalToolName = mcp?.tool ?? toolName;
+
+	for (const activeName of activeToolNames) {
+		if (activeName === toolName || activeName === canonicalToolName) return activeName;
+		const activeMcp = parseMcpToolName(activeName);
+		if (activeMcp?.tool === canonicalToolName) return activeName;
+	}
+
+	const requestedLower = toolName.toLowerCase();
+	const canonicalLower = canonicalToolName.toLowerCase();
+	for (const activeName of activeToolNames) {
+		if (activeName.toLowerCase() === requestedLower || activeName.toLowerCase() === canonicalLower) return activeName;
+		const activeMcp = parseMcpToolName(activeName);
+		if (activeMcp?.tool.toLowerCase() === canonicalLower) return activeName;
+	}
+
+	return null;
+}
+
+function formatDirectCallHint(toolName: string, options: ToolSearchShimOptions = {}): { text: string; resolvedTool: string } {
+	const activeEquivalent = activeEquivalentForSelectedTool(toolName, options.activeToolNames);
+	if (activeEquivalent) {
+		return {
+			text: `Call \`${activeEquivalent}\` directly. ToolSearch is not available in GSD.`,
+			resolvedTool: activeEquivalent,
+		};
+	}
+
+	const mcpTool = parseMcpToolName(toolName);
+	if (mcpTool) {
+		return {
+			text:
+				`ToolSearch is not available in GSD. Do not call \`${toolName}\` unless it appears in the active tool list. ` +
+				`Call \`${mcpTool.tool}\` directly if listed, or use the exact active MCP-scoped name shown in your tool list.`,
+			resolvedTool: mcpTool.tool,
+		};
+	}
+
+	if (toolName.startsWith("mcp__")) {
+		return {
+			text:
+				`ToolSearch is not available in GSD. Do not call \`${toolName}\` unless it appears in the active tool list. ` +
+				"Use the exact active tool name shown in your tool list.",
+			resolvedTool: toolName,
+		};
+	}
+	if (toolName.startsWith("gsd_") || toolName === "memory_query" || toolName === "capture_thought") {
+		return {
+			text:
+				`Call \`${toolName}\` directly. In Claude Code, use that server's MCP-scoped name from the active tool list. ` +
+				"ToolSearch is not available in GSD.",
+			resolvedTool: toolName,
+		};
+	}
+	return {
+		text: `Call \`${toolName}\` directly. ToolSearch is not available in GSD.`,
+		resolvedTool: toolName,
+	};
+}
+
+export function createToolSearchShimResult(args: unknown, options: ToolSearchShimOptions = {}): {
 	content: Array<{ type: "text"; text: string }>;
 	details: { operation: "tool_search_shim"; query: string; resolvedTool: string | null };
 } {
 	const query = extractToolSearchQuery(args);
 	const selected = parseToolSearchSelectQuery(query);
-	const text = selected
-		? formatDirectCallHint(selected)
-		: "ToolSearch is not available in GSD. Call the workflow tool you need directly by name.";
+	const resolved = selected ? formatDirectCallHint(selected, options) : null;
+	const text = resolved?.text ?? "ToolSearch is not available in GSD. Call the workflow tool you need directly by name.";
 	return {
 		content: [{ type: "text", text }],
-		details: { operation: "tool_search_shim", query, resolvedTool: selected },
+		details: { operation: "tool_search_shim", query, resolvedTool: resolved?.resolvedTool ?? null },
 	};
 }

--- a/packages/pi-ai/src/utils/tool-shims.ts
+++ b/packages/pi-ai/src/utils/tool-shims.ts
@@ -25,6 +25,7 @@ export {
 	extractToolSearchQuery,
 	isToolSearchToolName,
 	parseToolSearchSelectQuery,
+	type ToolSearchShimOptions,
 } from "./tool-search-shim.js";
 
 /** Claude Code built-in names mapped to Pi built-in tool names. */

--- a/src/headless-answers.ts
+++ b/src/headless-answers.ts
@@ -8,6 +8,7 @@
 
 import { readFileSync } from 'node:fs'
 import { serializeJsonLine } from '@gsd/agent-modes'
+import { canonicalHeadlessToolName } from './headless-events.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -149,7 +150,7 @@ export class AnswerInjector {
    * Observe every event for question metadata (tool_execution_start of ask_user_questions).
    */
   observeEvent(event: Record<string, unknown>): void {
-    if (event.type !== 'tool_execution_start' || event.toolName !== 'ask_user_questions') return
+    if (event.type !== 'tool_execution_start' || canonicalHeadlessToolName(String(event.toolName ?? '')) !== 'ask_user_questions') return
 
     // Extract questions from event.input.questions or event.args?.questions
     const input = (event.input ?? event.args) as Record<string, unknown> | undefined

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -85,6 +85,13 @@ export const IDLE_TIMEOUT_MS = 15_000
 export const NEW_MILESTONE_IDLE_TIMEOUT_MS = 120_000
 const INTERACTIVE_HEADLESS_TOOLS = new Set(['ask_user_questions', 'secure_env_collect'])
 
+export function canonicalHeadlessToolName(toolName: string | undefined): string {
+  const name = String(toolName ?? '')
+  if (!name.startsWith('mcp__')) return name
+  const toolSeparator = name.indexOf('__', 'mcp__'.length)
+  return toolSeparator >= 0 ? name.slice(toolSeparator + 2) : name
+}
+
 function isManualResolutionNotification(message: string): boolean {
   return (
     message.includes('resolve manually and re-run /gsd auto') ||
@@ -154,7 +161,7 @@ export function isMilestoneReadyNotification(event: Record<string, unknown>): bo
 }
 
 export function isInteractiveHeadlessTool(toolName: string | undefined): boolean {
-  return INTERACTIVE_HEADLESS_TOOLS.has(String(toolName ?? ''))
+  return INTERACTIVE_HEADLESS_TOOLS.has(canonicalHeadlessToolName(toolName))
 }
 
 export function shouldArmHeadlessIdleTimeout(toolCallCount: number, interactiveToolCount: number): boolean {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -29,7 +29,7 @@ import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import { buildWorkflowMcpServers, resolveWorkflowMcpProjectRoot } from "../gsd/workflow-mcp.js";
 import { loadProjectGSDPreferences } from "../gsd/preferences.js";
-import { discoverMcpServerNames, computeMcpDisallowedTools } from "../gsd/mcp-filter.js";
+import { discoverMcpServerNames, discoverWorkflowMcpServerName, computeMcpDisallowedTools } from "../gsd/mcp-filter.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
 	SDKAssistantMessage,
@@ -58,6 +58,10 @@ export interface ExternalToolResultPayload {
 type ToolCallWithExternalResult = ToolCall & {
 	externalResult?: ExternalToolResultPayload;
 };
+
+interface PromptToolContextOptions {
+	workflowMcpServerName?: string | null;
+}
 
 /** `SimpleStreamOptions` extended with an optional extension UI context for elicitation dialogs. */
 interface ClaudeCodeStreamOptions extends SimpleStreamOptions {
@@ -331,7 +335,7 @@ function extractMessageText(msg: { role: string; content: unknown }): string {
  * user turns in its own output. XML tags read as document structure and
  * don't get mirrored in free text.
  */
-export function buildPromptFromContext(context: Context): string {
+export function buildPromptFromContext(context: Context, toolContext: PromptToolContextOptions = {}): string {
 	const hasContent = Boolean(context.systemPrompt) || context.messages.some((m) => extractMessageText(m));
 	if (!hasContent) return "";
 
@@ -339,6 +343,14 @@ export function buildPromptFromContext(context: Context): string {
 		"Respond only to the final user message below. " +
 			"Do not emit <user_message>, <assistant_message>, or <prior_system_context> tags in your response.",
 	];
+	const workflowToolLine = toolContext.workflowMcpServerName
+		? "- GSD workflow tools (gsd_exec, gsd_slice_complete, gsd_task_complete, gsd_plan_slice, gsd_save_gate_result, etc.) " +
+			`are MCP tools — call them as mcp__${toolContext.workflowMcpServerName}__<tool_name> ` +
+			`(e.g. mcp__${toolContext.workflowMcpServerName}__gsd_exec, mcp__${toolContext.workflowMcpServerName}__gsd_save_gate_result)\n`
+		: "- GSD workflow MCP tools are unavailable in this Claude Code run.\n";
+	const toolSearchLine = toolContext.workflowMcpServerName
+		? "- ToolSearch is NOT available — never use it to discover tools; invoke the MCP tool directly\n"
+		: "- ToolSearch is NOT available — never use it to discover tools\n";
 
 	// The prior system context lists pi-native tool names (lowercase: bash, read, gsd_exec, etc.)
 	// but this process runs inside Claude Code where tool names differ. Inject a remapping note
@@ -349,10 +361,8 @@ export function buildPromptFromContext(context: Context): string {
 			"You are running inside Claude Code. Use these exact tool names — do not use lowercase or pi-native names:\n" +
 			"- Shell commands: 'Bash' (not 'bash')\n" +
 			"- File operations: 'Read', 'Write', 'Edit', 'Glob', 'Grep' (PascalCase, not lowercase)\n" +
-			"- GSD workflow tools (gsd_exec, gsd_slice_complete, gsd_task_complete, gsd_plan_slice, gsd_save_gate_result, etc.) " +
-			"are MCP tools — call them as mcp__gsd-workflow__<tool_name> " +
-			"(e.g. mcp__gsd-workflow__gsd_exec, mcp__gsd-workflow__gsd_save_gate_result)\n" +
-			"- ToolSearch is NOT available — never use it to discover tools; invoke the MCP tool directly\n" +
+			workflowToolLine +
+			toolSearchLine +
 			"</tool_context>",
 	);
 
@@ -1441,6 +1451,16 @@ function mapThinkingLevelToAnthropicEffort(level: ThinkingLevel | undefined, mod
 	}
 }
 
+function workflowMcpServerNameFromAllowedTools(allowedTools: unknown): string | undefined {
+	if (!Array.isArray(allowedTools)) return undefined;
+	for (const toolName of allowedTools) {
+		if (typeof toolName !== "string") continue;
+		const match = /^mcp__(.+)__\*$/.exec(toolName);
+		if (match?.[1]) return match[1];
+	}
+	return undefined;
+}
+
 /**
  * Build the options object passed to the Claude Agent SDK's `query()` call.
  *
@@ -1468,16 +1488,19 @@ export function buildSdkOptions(
 
 	const preferences = loadProjectGSDPreferences(projectRoot);
 	const mcpConfig = preferences?.preferences.claude_code_mcp;
-	const workflowServerName = mcpServers ? Object.keys(mcpServers)[0] : undefined;
 
 	// Always discover project MCPs — needed for both duplicate detection and filtering.
 	const discovered = discoverMcpServerNames(projectRoot);
+	const injectedWorkflowServerName = mcpServers ? Object.keys(mcpServers)[0] : undefined;
+	const projectWorkflowServerName = discoverWorkflowMcpServerName(projectRoot);
+	const workflowServerName = projectWorkflowServerName ?? injectedWorkflowServerName;
 
 	// If the workflow MCP is already declared in the project's .mcp.json or
 	// .claude/settings.json, do not inject it again via mcpServers. Passing the
 	// same server name from two sources causes a duplicate registration conflict
 	// that prevents the MCP server from loading (tools become unavailable).
-	const workflowAlreadyInProject = workflowServerName !== undefined && discovered.includes(workflowServerName);
+	const workflowAlreadyInProject = projectWorkflowServerName !== undefined
+		|| (injectedWorkflowServerName !== undefined && discovered.includes(injectedWorkflowServerName));
 	let filteredMcpServers = workflowAlreadyInProject ? undefined : mcpServers;
 	let extraDisallowedTools: string[] = [];
 	let workflowExplicitlyBlocked = false;
@@ -1847,8 +1870,6 @@ async function pumpSdkMessages(
 			options.signal.addEventListener("abort", () => controller.abort(), { once: true });
 		}
 
-		const prompt = buildPromptFromContext(context);
-		const queryPrompt = buildSdkQueryPrompt(context, prompt);
 		const permissionMode = await resolveClaudePermissionMode();
 		const uiContext = (options as ClaudeCodeStreamOptions | undefined)?.extensionUIContext;
 		const onExternalToolCall = (options as ClaudeCodeStreamOptions | undefined)?.onExternalToolCall;
@@ -1862,7 +1883,7 @@ async function pumpSdkMessages(
 				({ behavior: "allow", toolUseID: opts.toolUseID }));
 		const sdkOpts = buildSdkOptions(
 			modelId,
-			prompt,
+			"",
 			{ permissionMode },
 			{
 				cwd,
@@ -1875,6 +1896,10 @@ async function pumpSdkMessages(
 					: {}),
 			},
 		);
+		const prompt = buildPromptFromContext(context, {
+			workflowMcpServerName: workflowMcpServerNameFromAllowedTools(sdkOpts.allowedTools),
+		});
+		const queryPrompt = buildSdkQueryPrompt(context, prompt);
 
 		const queryResult = sdk.query({
 			prompt: queryPrompt,

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -407,6 +407,30 @@ describe("stream-adapter — no transcript fabrication (#4102)", () => {
 		const prompt = buildPromptFromContext(context);
 		assert.equal(prompt, "", "empty context must not emit a bare directive");
 	});
+
+	test("buildPromptFromContext uses the active workflow MCP server name", () => {
+		const context: Context = {
+			messages: [{ role: "user", content: "Check status" } as Message],
+		};
+
+		const prompt = buildPromptFromContext(context, { workflowMcpServerName: "custom-workflow" });
+
+		assert.ok(prompt.includes("mcp__custom-workflow__<tool_name>"));
+		assert.ok(prompt.includes("mcp__custom-workflow__gsd_exec"));
+		assert.ok(!prompt.includes("mcp__gsd-workflow__<tool_name>"));
+	});
+
+	test("buildPromptFromContext does not advertise workflow MCP tools when unavailable", () => {
+		const context: Context = {
+			messages: [{ role: "user", content: "Check status" } as Message],
+		};
+
+		const prompt = buildPromptFromContext(context);
+
+		assert.ok(prompt.includes("GSD workflow MCP tools are unavailable"));
+		assert.ok(!prompt.includes("mcp__gsd-workflow__<tool_name>"));
+		assert.ok(!prompt.includes("mcp__gsd-workflow__gsd_exec"));
+	});
 });
 
 describe("stream-adapter — Claude Code external tool results", () => {
@@ -921,18 +945,21 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		}
 	});
 
-	test("buildSdkOptions prefers custom workflow MCP question tools over native AskUserQuestion", () => {
-		const restore = setWorkflowMcpEnv({
-			GSD_WORKFLOW_MCP_COMMAND: "node",
+		test("buildSdkOptions prefers custom workflow MCP question tools over native AskUserQuestion", () => {
+			const restore = setWorkflowMcpEnv({
+				GSD_WORKFLOW_MCP_COMMAND: "node",
 			GSD_WORKFLOW_MCP_NAME: "custom-workflow",
 			GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["packages/mcp-server/dist/cli.js"]),
-			GSD_WORKFLOW_MCP_ENV: JSON.stringify({ GSD_CLI_PATH: "/tmp/gsd" }),
-			GSD_WORKFLOW_MCP_CWD: "/tmp/project",
-		});
-		try {
+				GSD_WORKFLOW_MCP_ENV: JSON.stringify({ GSD_CLI_PATH: "/tmp/gsd" }),
+				GSD_WORKFLOW_MCP_CWD: "/tmp/project",
+			});
+			const originalCwd = process.cwd();
+			const emptyDir = mkdtempSync(join(tmpdir(), "claude-mcp-custom-inject-"));
+			try {
+				process.chdir(emptyDir);
 
-			const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
-			const mcpServers = options.mcpServers as Record<string, any>;
+				const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
+				const mcpServers = options.mcpServers as Record<string, any>;
 			assert.ok(mcpServers?.["custom-workflow"], "expected custom workflow server config");
 			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
 			assert.deepEqual(options.allowedTools, [
@@ -945,12 +972,14 @@ describe("stream-adapter — session persistence (#2859)", () => {
 				"Agent",
 				"WebFetch",
 				"WebSearch",
-				"mcp__custom-workflow__*",
-			]);
-		} finally {
-			restore();
-		}
-	});
+					"mcp__custom-workflow__*",
+				]);
+			} finally {
+				process.chdir(originalCwd);
+				rmSync(emptyDir, { recursive: true, force: true });
+				restore();
+			}
+		});
 
 	test("buildSdkOptions auto-discovers bundled MCP server even without env hints", () => {
 		// Use setWorkflowMcpEnv with no values to save current state;
@@ -1059,7 +1088,7 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		}
 	});
 
-	test("buildSdkOptions does not inject workflow MCP when already declared in project .mcp.json (avoids duplicate registration)", () => {
+		test("buildSdkOptions does not inject workflow MCP when already declared in project .mcp.json (avoids duplicate registration)", () => {
 		const restore = setWorkflowMcpEnv({
 			GSD_WORKFLOW_MCP_COMMAND: "node",
 			GSD_WORKFLOW_MCP_NAME: "gsd-workflow",
@@ -1089,10 +1118,48 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			process.chdir(originalCwd);
 			rmSync(projectDir, { recursive: true, force: true });
 			restore();
-		}
-	});
+			}
+		});
 
-	test("buildSdkOptions preserves runtime callbacks such as onElicitation", () => {
+		test("buildSdkOptions uses project-declared custom workflow MCP namespace", () => {
+			const restore = setWorkflowMcpEnv({
+				GSD_WORKFLOW_MCP_COMMAND: "node",
+				GSD_WORKFLOW_MCP_NAME: "gsd-workflow",
+				GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["packages/mcp-server/dist/cli.js"]),
+				GSD_WORKFLOW_MCP_ENV: JSON.stringify({ GSD_CLI_PATH: "/tmp/gsd" }),
+				GSD_WORKFLOW_MCP_CWD: "/tmp/project",
+			});
+			const originalCwd = process.cwd();
+			const projectDir = mkdtempSync(join(tmpdir(), "claude-mcp-custom-project-"));
+			try {
+				writeFileSync(
+					join(projectDir, ".mcp.json"),
+					JSON.stringify({
+						mcpServers: {
+							"custom-workflow": {
+								command: "node",
+								args: ["custom-cli.js"],
+								env: { GSD_WORKFLOW_PROJECT_ROOT: projectDir },
+							},
+						},
+					}),
+				);
+				process.chdir(projectDir);
+				const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
+				assert.equal(options.mcpServers, undefined, "should not inject default workflow MCP when project declares a workflow server");
+				const allowedTools = options.allowedTools as string[];
+				assert.ok(allowedTools.includes("mcp__custom-workflow__*"), "allowedTools must use the project workflow namespace");
+				assert.ok(!allowedTools.includes("mcp__gsd-workflow__*"), "allowedTools must not advertise the absent default namespace");
+				const disallowedTools = options.disallowedTools as string[];
+				assert.ok(disallowedTools.includes("AskUserQuestion"), "AskUserQuestion should be suppressed when workflow is available");
+			} finally {
+				process.chdir(originalCwd);
+				rmSync(projectDir, { recursive: true, force: true });
+				restore();
+			}
+		});
+
+		test("buildSdkOptions preserves runtime callbacks such as onElicitation", () => {
 		const restore = setWorkflowMcpEnv({});
 		const onElicitation = async () => ({ action: "decline" as const });
 		try {

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -4,6 +4,8 @@
  * can distinguish "waiting for tool completion" from "truly idle".
  */
 
+import { stripMcpToolPrefix } from "@gsd/pi-ai";
+
 interface InFlightTool {
   startedAt: number;
   toolName: string;
@@ -24,7 +26,7 @@ const INTERACTIVE_TOOLS = new Set(["ask_user_questions", "secure_env_collect"]);
  */
 export function markToolStart(toolCallId: string, isActive: boolean, toolName?: string): void {
   if (!isActive) return;
-  inFlightTools.set(toolCallId, { startedAt: Date.now(), toolName: toolName ?? "unknown" });
+  inFlightTools.set(toolCallId, { startedAt: Date.now(), toolName: stripMcpToolPrefix(toolName ?? "unknown") });
 }
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -262,7 +262,7 @@ function isGsdManagedTool(name: string): boolean {
  *
  * MCP-scoped names follow `mcp__<namespace>__<toolname>`.
  * Example: if `requestedToolNames` contains `gsd_exec` and `activeToolNames` contains
- * `mcp__gsd-workflow__gsd_exec`, the MCP-scoped active name is included in the result.
+ * `mcp__custom-workflow__gsd_exec`, the MCP-scoped active name is included in the result.
  *
  * Returns deduplicated active tool names that satisfy the requested base names.
  */

--- a/src/resources/extensions/gsd/bootstrap/tool-search-shim.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-search-shim.ts
@@ -1,5 +1,5 @@
 // GSD does not implement Anthropic deferred-tool ToolSearch. Models trained on
-// that API sometimes try `select:mcp__gsd-workflow__<tool>` and get a hard
+// that API sometimes try `select:mcp__<server>__<tool>` and get a hard
 // "Tool ToolSearch not found" failure. This shim returns explicit call guidance.
 
 import { createToolSearchShimResult, Type } from "@gsd/pi-ai";
@@ -12,14 +12,14 @@ export function registerToolSearchShim(pi: ExtensionAPI): void {
 		name: "ToolSearch",
 		label: "Tool Search (guidance)",
 		description:
-			"Not supported in GSD. Workflow tools are already in your tool list — invoke them by name " +
-			"(e.g. gsd_save_gate_result or mcp__gsd-workflow__gsd_save_gate_result). Do not use ToolSearch.",
+			"Not supported in GSD. If the needed workflow tool is active, invoke the exact listed tool name " +
+			"(e.g. gsd_save_gate_result, or the active MCP-scoped workflow name in Claude Code). Do not use ToolSearch.",
 		parameters: Type.Object({
 			query: Type.String({ description: "Ignored — use a direct tool call instead" }),
 			max_results: Type.Optional(Type.Number()),
 		}),
 		async execute(_toolCallId, params) {
-			return createToolSearchShimResult(params);
+			return createToolSearchShimResult(params, { activeToolNames: pi.getActiveTools() });
 		},
 		renderCall(args: any, theme: any) {
 			const q = args.query ?? "";

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -802,7 +802,7 @@ export function shouldBlockPlanningUnit(
   if (!policy) return { block: false };
   if (policy.mode === "all") return { block: false };
 
-  const tool = toolName;
+  const tool = canonicalToolName(toolName);
 
   // Read-only mode: only Read-class tools are permitted.
   if (policy.mode === "read-only") {

--- a/src/resources/extensions/gsd/mcp-filter.ts
+++ b/src/resources/extensions/gsd/mcp-filter.ts
@@ -6,37 +6,84 @@ import { resolveModelMcpConfig } from "./preferences-mcp.js";
 
 interface McpJsonFile {
   mcpServers?: Record<string, unknown>;
+  servers?: Record<string, unknown>;
 }
 
 interface ClaudeSettingsFile {
   mcpServers?: Record<string, unknown>;
 }
 
-export function discoverMcpServerNames(projectDir: string): string[] {
+interface DiscoveredMcpServer {
+  name: string;
+  config: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readJsonFile(path: string, ignoreParseErrors = false): unknown | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+  } catch (err) {
+    if (!ignoreParseErrors) throw err;
+    return undefined;
+  }
+}
+
+function collectServerEntries(servers: unknown): DiscoveredMcpServer[] {
+  if (!isRecord(servers)) return [];
+  return Object.entries(servers).map(([name, config]) => ({ name, config }));
+}
+
+export function discoverMcpServers(projectDir: string): DiscoveredMcpServer[] {
   const mcpJsonPath = resolve(projectDir, ".mcp.json");
   const settingsPath = resolve(projectDir, ".claude", "settings.json");
 
-  let mcpJsonServers: string[] = [];
-  if (existsSync(mcpJsonPath)) {
-    const raw = readFileSync(mcpJsonPath, "utf-8");
-    const parsed = JSON.parse(raw) as McpJsonFile;
-    mcpJsonServers = Object.keys(parsed.mcpServers ?? {});
-  }
+  const mcpJson = readJsonFile(mcpJsonPath) as McpJsonFile | undefined;
+  const settings = readJsonFile(settingsPath, true) as ClaudeSettingsFile | undefined;
 
-  let settingsServers: string[] = [];
-  if (existsSync(settingsPath)) {
-    try {
-      const raw = readFileSync(settingsPath, "utf-8");
-      const parsed = JSON.parse(raw) as ClaudeSettingsFile;
-      if (parsed.mcpServers) {
-        settingsServers = Object.keys(parsed.mcpServers);
-      }
-    } catch {
-      // settings.json parse errors are silently ignored
+  const seen = new Set<string>();
+  const discovered: DiscoveredMcpServer[] = [];
+  for (const entry of [
+    ...collectServerEntries(mcpJson?.mcpServers),
+    ...collectServerEntries(mcpJson?.servers),
+    ...collectServerEntries(settings?.mcpServers),
+  ]) {
+    if (seen.has(entry.name)) continue;
+    seen.add(entry.name);
+    discovered.push(entry);
+  }
+  return discovered;
+}
+
+function isWorkflowMcpServerConfig(config: unknown): boolean {
+  if (!isRecord(config)) return false;
+  const env = config.env;
+  if (isRecord(env)) {
+    if (
+      typeof env.GSD_WORKFLOW_PROJECT_ROOT === "string"
+      || typeof env.GSD_WORKFLOW_EXECUTORS_MODULE === "string"
+      || typeof env.GSD_WORKFLOW_WRITE_GATE_MODULE === "string"
+      || typeof env.GSD_PERSIST_WRITE_GATE_STATE === "string"
+    ) {
+      return true;
     }
   }
 
-  return [...new Set([...mcpJsonServers, ...settingsServers])];
+  const command = typeof config.command === "string" ? config.command : "";
+  if (command.includes("gsd-mcp-server")) return true;
+  const args = Array.isArray(config.args) ? config.args.filter((arg): arg is string => typeof arg === "string") : [];
+  return args.some((arg) => arg.includes("gsd-mcp-server") || arg.includes("packages/mcp-server"));
+}
+
+export function discoverWorkflowMcpServerName(projectDir: string): string | undefined {
+  return discoverMcpServers(projectDir).find((server) => isWorkflowMcpServerConfig(server.config))?.name;
+}
+
+export function discoverMcpServerNames(projectDir: string): string[] {
+  return discoverMcpServers(projectDir).map((server) => server.name);
 }
 
 export function computeMcpDisallowedTools(

--- a/src/resources/extensions/gsd/mcp-project-config.ts
+++ b/src/resources/extensions/gsd/mcp-project-config.ts
@@ -21,6 +21,11 @@ export interface EnsureProjectWorkflowMcpConfigResult {
   status: "created" | "updated" | "unchanged";
 }
 
+interface ProjectWorkflowMcpServerSpec {
+  serverName: string;
+  server: ProjectMcpServerConfig;
+}
+
 interface McpConfigFile {
   mcpServers?: Record<string, ProjectMcpServerConfig>;
   servers?: Record<string, ProjectMcpServerConfig>;
@@ -48,6 +53,13 @@ export function buildProjectWorkflowMcpServerConfig(
   projectRoot: string,
   env: NodeJS.ProcessEnv = process.env,
 ): ProjectMcpServerConfig {
+  return buildProjectWorkflowMcpServerSpec(projectRoot, env).server;
+}
+
+function buildProjectWorkflowMcpServerSpec(
+  projectRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ProjectWorkflowMcpServerSpec {
   const resolvedProjectRoot = resolve(projectRoot);
   const gsdCliPath = resolveBundledGsdCliPath(env);
   const launch = detectWorkflowMcpLaunchConfig(resolvedProjectRoot, {
@@ -62,10 +74,13 @@ export function buildProjectWorkflowMcpServerConfig(
   }
 
   return {
-    command: launch.command,
-    ...(launch.args && launch.args.length > 0 ? { args: launch.args } : {}),
-    ...(launch.cwd ? { cwd: launch.cwd } : {}),
-    ...(launch.env ? { env: launch.env } : {}),
+    serverName: launch.name || GSD_WORKFLOW_MCP_SERVER_NAME,
+    server: {
+      command: launch.command,
+      ...(launch.args && launch.args.length > 0 ? { args: launch.args } : {}),
+      ...(launch.cwd ? { cwd: launch.cwd } : {}),
+      ...(launch.env ? { env: launch.env } : {}),
+    },
   };
 }
 
@@ -92,23 +107,23 @@ export function ensureProjectWorkflowMcpConfig(
 
   const configPath = resolve(resolvedProjectRoot, ".mcp.json");
   const existing = readExistingConfig(configPath);
-  const desiredServer = buildProjectWorkflowMcpServerConfig(resolvedProjectRoot, env);
+  const { serverName, server: desiredServer } = buildProjectWorkflowMcpServerSpec(resolvedProjectRoot, env);
   const previousServers = existing.mcpServers ?? {};
   const nextServers = {
     ...previousServers,
-    [GSD_WORKFLOW_MCP_SERVER_NAME]: desiredServer,
+    [serverName]: desiredServer,
   };
 
   const alreadyPresent = existsSync(configPath);
   const unchanged =
-    JSON.stringify(previousServers[GSD_WORKFLOW_MCP_SERVER_NAME] ?? null)
+    JSON.stringify(previousServers[serverName] ?? null)
       === JSON.stringify(desiredServer)
     && existing.mcpServers !== undefined;
 
   if (unchanged) {
     return {
       configPath,
-      serverName: GSD_WORKFLOW_MCP_SERVER_NAME,
+      serverName,
       status: "unchanged",
     };
   }
@@ -122,7 +137,7 @@ export function ensureProjectWorkflowMcpConfig(
 
   return {
     configPath,
-    serverName: GSD_WORKFLOW_MCP_SERVER_NAME,
+    serverName,
     status: alreadyPresent ? "updated" : "created",
   };
 }

--- a/src/resources/extensions/gsd/prompts/gate-evaluate.md
+++ b/src/resources/extensions/gsd/prompts/gate-evaluate.md
@@ -35,7 +35,7 @@ You are evaluating **quality gates in parallel** for this slice. Each gate is an
 2. **Wait for all subagents** to complete.
 3. **Verify each gate wrote its result** by checking that `gsd_save_gate_result` was called for each gate ID.
    - Call it **directly** — do **not** use `ToolSearch` (it is not available in GSD).
-   - Inside Claude Code use `mcp__gsd-workflow__gsd_save_gate_result`; otherwise use `gsd_save_gate_result`.
+   - Inside Claude Code use the active MCP-scoped workflow name for `gsd_save_gate_result`; otherwise use `gsd_save_gate_result`.
    - Always pass all required fields (camelCase): `milestoneId`, `sliceId`, `gateId`, `verdict`, `rationale`. Never call with an empty `{}` object.
 4. **Report the batch outcome** — which gates passed, which flagged concerns, and which were omitted as not applicable.
 

--- a/src/resources/extensions/gsd/safety/evidence-collector.ts
+++ b/src/resources/extensions/gsd/safety/evidence-collector.ts
@@ -57,10 +57,9 @@ const EXECUTION_TOOL_NAMES = new Set([
   "functions.exec_command",
   "gsd_exec",
   "gsd_exec_search",
-  "mcp__gsd-workflow__gsd_exec",
-  "mcp__gsd-workflow__gsd_exec_search",
   "powershell",
 ]);
+const MCP_EXECUTION_TOOL_RE = /^mcp__.+__gsd_exec(?:_search)?$/;
 
 // ─── Module State ───────────────────────────────────────────────────────────
 
@@ -93,7 +92,8 @@ export function getFilePaths(): string[] {
 /** True when a tool name represents a shell/command execution surface. */
 export function isExecutionToolName(name: unknown): boolean {
   if (typeof name !== "string") return false;
-  return EXECUTION_TOOL_NAMES.has(name.trim().toLowerCase());
+  const normalized = name.trim().toLowerCase();
+  return EXECUTION_TOOL_NAMES.has(normalized) || MCP_EXECUTION_TOOL_RE.test(normalized);
 }
 
 // ─── Persistence (Bug #4385 — evidence must survive session restarts) ────────

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -107,4 +107,16 @@ describe("evidence-collector: toolCallId-based matching (A-3)", () => {
     assert.equal(entries[1].kind, "bash");
     assert.equal(entries[1].command, "pnpm lint");
   });
+
+  it("treats any workflow MCP gsd_exec server namespace as execution evidence", () => {
+    recordToolCall("tc-default", "mcp__gsd-workflow__gsd_exec", { command: "pnpm test" });
+    recordToolCall("tc-custom", "mcp__custom-workflow__gsd_exec_search", { query: "rg TODO" });
+
+    const entries = getEvidence() as readonly BashEvidence[];
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].kind, "bash");
+    assert.equal(entries[0].command, "pnpm test");
+    assert.equal(entries[1].kind, "bash");
+    assert.equal(entries[1].command, "rg TODO");
+  });
 });

--- a/src/resources/extensions/gsd/tests/headless-answers.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-answers.test.ts
@@ -92,10 +92,10 @@ test('loadAndValidateAnswerFile — wrong types (non-string secret value)', (t) 
 // AnswerInjector — observeEvent + tryHandle
 // ---------------------------------------------------------------------------
 
-function makeToolExecutionStart(questions: Record<string, unknown>[]) {
+function makeToolExecutionStart(questions: Record<string, unknown>[], toolName = 'ask_user_questions') {
   return {
     type: 'tool_execution_start',
-    toolName: 'ask_user_questions',
+    toolName,
     input: { questions },
   };
 }
@@ -138,6 +138,25 @@ test('observeEvent stores metadata', (t) => {
   assert.strictEqual(handled, false);
   // But questionsDefaulted should be incremented because processWithMeta was reached
   assert.strictEqual(injector.getStats().questionsDefaulted, 1);
+});
+
+test('observeEvent stores metadata for MCP-scoped ask_user_questions', (t) => {
+  const injector = new AnswerInjector({ questions: { deploy_target: 'GCP' } });
+
+  injector.observeEvent(makeToolExecutionStart([{
+    id: 'deploy_target',
+    header: 'Deploy',
+    question: 'Where to deploy?',
+    options: [{ label: 'AWS' }, { label: 'GCP' }],
+  }], 'mcp__custom-workflow__ask_user_questions'));
+
+  const captured: string[] = [];
+  const captureStdin = (data: string) => { captured.push(data); };
+  const event = makeSelectEvent('req-1', 'Deploy: Where to deploy?', ['AWS', 'GCP']);
+  const handled = injector.tryHandle(event, captureStdin);
+
+  assert.strictEqual(handled, true);
+  assert.strictEqual(captured.length, 1);
 });
 
 test('tryHandle matches by question ID — single select', (t) => {

--- a/src/resources/extensions/gsd/tests/headless-answers.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-answers.test.ts
@@ -331,7 +331,7 @@ test('tryHandle deferred resolution — observeEvent after tryHandle', async (t)
 // ---------------------------------------------------------------------------
 
 test('getSecretEnvVars returns secrets map', (t) => {
-  const secrets = { API_KEY: 'sk-123', DB_URL: 'postgres://localhost/db' };
+  const secrets = { API_KEY: 'sk-123', DB_URL: 'db-local-fixture' };
   const injector = new AnswerInjector({ secrets });
 
   assert.deepStrictEqual(injector.getSecretEnvVars(), secrets);

--- a/src/resources/extensions/gsd/tests/interactive-tool-idle-exemption.test.ts
+++ b/src/resources/extensions/gsd/tests/interactive-tool-idle-exemption.test.ts
@@ -43,6 +43,14 @@ describe("hasInteractiveToolInFlight", () => {
     assert.equal(hasInteractiveToolInFlight(), true);
   });
 
+  test("returns true when MCP-scoped interactive tools are in-flight", () => {
+    markToolStart("call-1", true, "mcp__custom-workflow__ask_user_questions");
+    assert.equal(hasInteractiveToolInFlight(), true);
+    clearInFlightTools();
+    markToolStart("call-2", true, "mcp__custom-workflow__secure_env_collect");
+    assert.equal(hasInteractiveToolInFlight(), true);
+  });
+
   test("returns false after interactive tool completes", () => {
     markToolStart("call-1", true, "ask_user_questions");
     assert.equal(hasInteractiveToolInFlight(), true);

--- a/src/resources/extensions/gsd/tests/mcp-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-filter.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { discoverMcpServerNames, computeMcpDisallowedTools } from "../mcp-filter.ts";
+import { discoverMcpServerNames, discoverWorkflowMcpServerName, computeMcpDisallowedTools } from "../mcp-filter.ts";
 import type { ClaudeCodeMcpConfig } from "../preferences-types.ts";
 
 // ─── discoverMcpServerNames ────────────────────────────────────────────────
@@ -56,6 +56,24 @@ describe("discoverMcpServerNames", () => {
     );
     const result = discoverMcpServerNames(dir);
     assert.deepEqual(result, ["only-server"]);
+  });
+
+  it("discovers workflow server names by config signature", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mcp-filter-test-"));
+    writeFileSync(
+      join(dir, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          "custom-workflow": {
+            command: "node",
+            args: ["custom-cli.js"],
+            env: { GSD_WORKFLOW_PROJECT_ROOT: dir },
+          },
+          unrelated: { command: "npx", args: ["other"] },
+        },
+      }),
+    );
+    assert.equal(discoverWorkflowMcpServerName(dir), "custom-workflow");
   });
 });
 

--- a/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
@@ -72,6 +72,30 @@ test("ensureProjectWorkflowMcpConfig preserves existing mcp servers", () => {
   }
 });
 
+test("ensureProjectWorkflowMcpConfig uses custom workflow server name from env", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-init-"));
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+
+  try {
+    const result = ensureProjectWorkflowMcpConfig(projectRoot, {
+      GSD_WORKFLOW_MCP_COMMAND: "node",
+      GSD_WORKFLOW_MCP_NAME: "custom-workflow",
+      GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["server.js"]),
+      GSD_WORKFLOW_MCP_CWD: projectRoot,
+    });
+    assert.equal(result.status, "created");
+    assert.equal(result.serverName, "custom-workflow");
+
+    const parsed = JSON.parse(readFileSync(result.configPath, "utf-8")) as {
+      mcpServers?: Record<string, { command?: string; args?: string[] }>;
+    };
+    assert.ok(parsed.mcpServers?.["custom-workflow"]);
+    assert.equal(parsed.mcpServers?.[GSD_WORKFLOW_MCP_SERVER_NAME], undefined);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
 test("ensureProjectWorkflowMcpConfig is idempotent when config is already current", () => {
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-init-"));
   mkdirSync(join(projectRoot, ".gsd"), { recursive: true });

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -296,6 +296,11 @@ test('complete-slice closeout policy allows gsd_exec verification surface', () =
   assert.strictEqual(r.block, false);
 });
 
+test('complete-slice closeout policy allows MCP-scoped gsd_exec verification surface', () => {
+  const r = shouldBlockPlanningUnit('mcp__custom-workflow__gsd_exec', '', BASE, 'complete-slice', PLANNING_DISPATCH_REVIEW);
+  assert.strictEqual(r.block, false);
+});
+
 test('planning-dispatch: still blocks writes to user source (write isolation preserved)', () => {
   const r = shouldBlockPlanningUnit('write', join(BASE, 'src', 'main.ts'), BASE, 'plan-slice', PLANNING_DISPATCH);
   assert.strictEqual(r.block, true);
@@ -326,6 +331,11 @@ test('planning-unit: allows ask_user_questions', () => {
 
 test('planning-unit: allows gsd_* MCP tools (own validation)', () => {
   const r = shouldBlockPlanningUnit('gsd_summary_save', '', BASE, 'discuss-milestone', PLANNING);
+  assert.strictEqual(r.block, false);
+});
+
+test('planning-unit: allows MCP-scoped gsd_* tools (own validation)', () => {
+  const r = shouldBlockPlanningUnit('mcp__custom-workflow__gsd_summary_save', '', BASE, 'discuss-milestone', PLANNING);
   assert.strictEqual(r.block, false);
 });
 

--- a/src/resources/skills/create-skill/workflows/verify-skill.md
+++ b/src/resources/skills/create-skill/workflows/verify-skill.md
@@ -82,11 +82,7 @@ which {tool-name}
 ```
 
 ### For API/Service Skills
-Use Context7 to fetch current documentation:
-```
-mcp__context7__resolve-library-id: {service-name}
-mcp__context7__get-library-docs: {library-id}, topic: {relevant-topic}
-```
+Use the active Context7 documentation tools to fetch current documentation if they are available. Resolve the library ID first, then fetch docs for `{library-id}` with `topic: {relevant-topic}`; use the exact tool names from the active tool list.
 
 Compare skill's documented patterns against current docs:
 - Are endpoints still valid?
@@ -94,11 +90,7 @@ Compare skill's documented patterns against current docs:
 - Are there deprecated methods being used?
 
 ### For Framework Skills
-Use Context7:
-```
-mcp__context7__resolve-library-id: {framework-name}
-mcp__context7__get-library-docs: {library-id}, topic: {specific-api}
-```
+Use the active Context7 documentation tools if they are available. Resolve the library ID first, then fetch docs for `{library-id}` with `topic: {specific-api}`; use the exact tool names from the active tool list.
 
 Check:
 - Are documented APIs still current?

--- a/src/resources/skills/debug-like-expert/references/when-to-research.md
+++ b/src/resources/skills/debug-like-expert/references/when-to-research.md
@@ -175,11 +175,7 @@ DO reason through it:
 - Learning correct usage patterns
 
 **How**:
-```
-Use mcp__context7__resolve-library-id with library name
-Then mcp__context7__get-library-docs with library ID
-Ask specific questions about the library
-```
+Use the active Context7 documentation tools if they are available: resolve the library ID with the library name, then fetch docs with the library ID. Ask specific questions about the library, and use exact tool names from the active tool list.
 
 **Good uses**:
 - "How do I use Prisma transactions?"

--- a/src/resources/skills/decompose-into-slices/SKILL.md
+++ b/src/resources/skills/decompose-into-slices/SKILL.md
@@ -31,7 +31,7 @@ Typical invocation points:
 1. Read `M###-CONTEXT.md` for the active milestone — the brief is the source of truth for scope.
 2. Read `M###-ROADMAP.md` if one exists — you may be refining rather than creating from scratch.
 3. Read `src/resources/extensions/gsd/templates/roadmap.md` for the exact slice format. The parser depends on it.
-4. If the plan came from a GitHub issue (user passed a URL or number), fetch it with `mcp__github__issue_read`.
+4. If the plan came from a GitHub issue (user passed a URL or number), fetch it with the active GitHub issue-read tool if one is available; use the exact tool name from the active tool list.
 
 ## Step 2: Explore the codebase briefly
 
@@ -84,7 +84,7 @@ Use `write` to the path `.gsd/milestones/<MID>/<MID>-ROADMAP.md`. Do not edit ch
 
 ## Step 6: Optionally file as GitHub issues
 
-If the user explicitly asks (and only if — outward actions need confirmation), create one GitHub issue per slice with `mcp__github__issue_write`. Create in dependency order so "Blocked by" references can cite real issue numbers.
+If the user explicitly asks (and only if — outward actions need confirmation), create one GitHub issue per slice with the active GitHub issue-write tool if one is available; use the exact tool name from the active tool list. Create in dependency order so "Blocked by" references can cite real issue numbers.
 
 ### Issue body template
 

--- a/src/resources/skills/forensics/SKILL.md
+++ b/src/resources/skills/forensics/SKILL.md
@@ -126,7 +126,7 @@ Format the output as a GitHub-issue-ready report:
 <high / medium / low> — <what would change this confidence>
 ```
 
-Offer to file this as a GitHub issue via `mcp__github__issue_write` — explicit confirmation required per the outward-action rule. Also save a copy to `.gsd/forensics/<slug>.md` for future reference.
+Offer to file this as a GitHub issue via the active GitHub issue-write tool if one is available, using its exact active tool name — explicit confirmation required per the outward-action rule. Also save a copy to `.gsd/forensics/<slug>.md` for future reference.
 
 </process>
 

--- a/src/resources/skills/grill-me/SKILL.md
+++ b/src/resources/skills/grill-me/SKILL.md
@@ -66,7 +66,7 @@ At the end, offer the user one of:
 
 1. Append resolved decisions to `.gsd/DECISIONS.md` (one line each, dated).
 2. Write or update `M###-CONTEXT.md` or `S##-CONTEXT.md` for the active milestone/slice.
-3. Draft a GitHub issue via `mcp__github__issue_write` (only with explicit confirmation per the outward-action rule).
+3. Draft a GitHub issue via the active GitHub issue-write tool if one is available, using its exact active tool name (only with explicit confirmation per the outward-action rule).
 4. Leave it as conversation context if the work is ephemeral.
 
 Default: ask which they want. Do not auto-write.

--- a/src/resources/skills/write-milestone-brief/SKILL.md
+++ b/src/resources/skills/write-milestone-brief/SKILL.md
@@ -78,7 +78,7 @@ Then append a one-line summary to `.gsd/DECISIONS.md` for any genuinely hard-to-
 After writing, offer the user (do not auto-execute):
 
 1. **Proceed to planning** — run `/gsd dispatch plan` to generate `M###-ROADMAP.md` from this brief.
-2. **File as GitHub issue** — use `mcp__github__issue_write` to create a tracking issue. Requires explicit "yes" per the outward-action rule. Use the PRD template below for the body.
+2. **File as GitHub issue** — use the active GitHub issue-write tool if one is available, using its exact active tool name. Requires explicit "yes" per the outward-action rule. Use the PRD template below for the body.
 3. **Iterate on the brief** — if something feels wrong, run `grill-me` to stress-test before moving on.
 
 ### GitHub issue body template (only if user chooses option 2)

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -285,6 +285,11 @@ test('isInteractiveHeadlessTool: secure_env_collect is interactive', () => {
   assert.equal(isInteractiveHeadlessTool('secure_env_collect'), true)
 })
 
+test('isInteractiveHeadlessTool: MCP-scoped interactive tools are interactive', () => {
+  assert.equal(isInteractiveHeadlessTool('mcp__custom-workflow__ask_user_questions'), true)
+  assert.equal(isInteractiveHeadlessTool('mcp__custom-workflow__secure_env_collect'), true)
+})
+
 test('isInteractiveHeadlessTool: non-interactive tools stay false', () => {
   assert.equal(isInteractiveHeadlessTool('bash'), false)
   assert.equal(isInteractiveHeadlessTool(undefined), false)

--- a/tests/e2e/docker/runtime.e2e.test.ts
+++ b/tests/e2e/docker/runtime.e2e.test.ts
@@ -19,6 +19,9 @@ import { join, resolve } from "node:path";
 
 import { stripAnsi } from "../_shared/index.ts";
 
+const DOCKER_BUILD_TIMEOUT_MS = 900_000;
+const RUNTIME_LOCAL_TEST_TIMEOUT_MS = DOCKER_BUILD_TIMEOUT_MS + 120_000;
+
 function dockerAvailable(): boolean {
 	const probe = spawnSync("docker", ["version", "--format", "{{.Server.Version}}"], {
 		stdio: "pipe",
@@ -81,7 +84,7 @@ function dockerBuildLocal(tarballName: string, tag: string): void {
 			cwd: root,
 			stdio: "pipe",
 			encoding: "utf8",
-			timeout: 600_000,
+			timeout: DOCKER_BUILD_TIMEOUT_MS,
 		},
 	);
 }
@@ -92,7 +95,7 @@ function dockerBuildBuilder(tag: string): void {
 		cwd: root,
 		stdio: "pipe",
 		encoding: "utf8",
-		timeout: 900_000,
+		timeout: DOCKER_BUILD_TIMEOUT_MS,
 	});
 }
 
@@ -126,7 +129,7 @@ describe("docker runtime e2e", () => {
 
 	test(
 		"CI builder image target builds for publish workflow bootstrap",
-		{ skip: skipReason ?? false, timeout: 900_000 },
+		{ skip: skipReason ?? false, timeout: RUNTIME_LOCAL_TEST_TIMEOUT_MS },
 		(t) => {
 			t.after(() => dockerRmImage(BUILDER_TAG));
 
@@ -136,7 +139,7 @@ describe("docker runtime e2e", () => {
 
 	test(
 		"`gsd --version` inside runtime-local container exits 0 with semver",
-		{ skip: skipReason ?? false, timeout: 900_000 },
+		{ skip: skipReason ?? false, timeout: RUNTIME_LOCAL_TEST_TIMEOUT_MS },
 		(t) => {
 			const packed = packToRoot();
 			t.after(packed.cleanup);


### PR DESCRIPTION
## Summary

- Make ToolSearch fallback guidance active-tool-aware so stale MCP-scoped selections are not echoed back as callable tools.
- Derive Claude Code workflow MCP guidance from the actual active/project workflow namespace instead of assuming `gsd-workflow`.
- Canonicalize MCP-scoped tool names before headless, auto idle, evidence, and planning/write-gate policy checks.
- Remove hard-coded third-party MCP namespace guidance from bundled model-facing skills.

## Root Cause

GSD was still leaking assumed MCP tool names into model-facing guidance and runtime fallbacks. The visible failure was `mcp__gsd-workflow__gsd_milestone_status` being suggested when that exact tool was not available. The deeper pattern was that several paths trusted raw MCP-scoped names instead of resolving against the active tool list or canonical `gsd_*` tool name.

## Impact

Models should now call the exact workflow tool exposed in the current runtime, including custom workflow server names. ToolSearch shims should steer away from unavailable namespaces instead of reinforcing them. Headless and auto-mode policy checks should correctly handle MCP-scoped interactive/workflow tools.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/utils/tests/tool-search-shim.test.ts src/resources/extensions/gsd/tests/mcp-filter.test.ts src/resources/extensions/gsd/tests/mcp-project-config.test.ts src/tests/headless-events.test.ts src/resources/extensions/gsd/tests/headless-answers.test.ts src/resources/extensions/gsd/tests/interactive-tool-idle-exemption.test.ts src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- `pnpm --filter @gsd/pi-agent-core exec vitest run test/agent-loop.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run test:compile`
- Source/root-dist/package-dist grep for non-test hard-coded `mcp__gsd-workflow__`, `mcp__github__`, and `mcp__context7__` guidance returned no hits.

## Notes

The local worktree still has unrelated unstaged changes in `packages/pi-ai/src/models.generated.ts`, `src/resources/extensions/gsd/migration-auto-check.ts`, and `src/resources/extensions/gsd/tests/migration-auto-check.test.ts`; they are intentionally excluded from this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782829567&installation_id=134682257&pr_number=312&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F312&signature=c1c94cb8dba789b695cbd8260dceadd6ef56617960d776fa774180c76fb86de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent tool shims, Claude Code SDK options/prompts, and safety/write-gate paths; behavior changes are well-tested but affect how models are steered to call workflow tools.
> 
> **Overview**
> This PR stops **assumed MCP tool names** from leaking into model guidance and runtime behavior when the active workflow server uses a different namespace (e.g. `custom-workflow` vs `gsd-workflow`).
> 
> **ToolSearch shims** now take the **active tool list**: stale `select:mcp__…` queries map to the matching scoped name when present, warn against calling inactive aliases, and no longer hard-code `mcp__gsd-workflow__*` for canonical `gsd_*` tools. The agent loop and GSD `ToolSearch` extension pass `activeToolNames` through.
> 
> **Claude Code** discovers the workflow MCP server from project config (signature-based), prefers that namespace for `allowedTools` / duplicate-injection logic, and builds prompts from the **actual** `mcp__<server>__*` pattern (or states workflow MCP is unavailable). Project `.mcp.json` init respects a custom `GSD_WORKFLOW_MCP_NAME`.
> 
> **Runtime policy** canonicalizes MCP-scoped names (strip `mcp__server__` prefix) for headless Q&A, idle timeouts, auto in-flight tracking, write-gate/planning checks, and execution evidence (regex for any `mcp__*__gsd_exec`). Bundled skills/prompts drop fixed `mcp__github__` / `mcp__context7__` strings in favor of “use the active tool list.”
> 
> CI/docker e2e timeouts were bumped slightly for slower builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ead4813e80b64ebd67a68c432b281b96acdf3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->