### PR TITLE
[codex] fix doctor empty worktree repair

### DIFF
--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -1,7 +1,7 @@
 // gsd-pi doctor git health checks
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, realpathSync, rmSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { cpSync, existsSync, mkdirSync, readdirSync, realpathSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { loadFile } from "./files.js";
@@ -56,17 +56,74 @@ function isSameOrNestedPath(candidate: string, container: string): boolean {
     normalizedCandidate.startsWith(`${normalizedContainer}/`);
 }
 
-function hasProjectContentOnDisk(dirPath: string): boolean {
+function normalizeGitPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function isProjectContentPath(path: string): boolean {
+  const normalized = normalizeGitPath(path);
+  if (!normalized || normalized.endsWith("/")) return false;
+  if (normalized === ".gitignore" || normalized === ".gitattributes") return false;
+  if (normalized.endsWith(".DS_Store")) return false;
+  const parts = normalized.split("/");
+  return !parts.some(part => part === ".git" || part === ".gsd");
+}
+
+function gitLines(basePath: string, args: string[]): string[] {
+  const result = spawnSync("git", args, {
+    cwd: basePath,
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) return [];
+  return result.stdout
+    .split("\n")
+    .map(line => normalizeGitPath(line.trim()))
+    .filter(isProjectContentPath);
+}
+
+function listProjectContentFiles(basePath: string): string[] {
+  return [...new Set([
+    ...gitLines(basePath, ["ls-files"]),
+    ...gitLines(basePath, ["ls-files", "--others", "--exclude-standard"]),
+  ])];
+}
+
+function hasMaterializedProjectContentFallback(dirPath: string): boolean {
   try {
     for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
-      if (entry.name === ".git" || entry.name === ".gsd") continue;
+      if (!isProjectContentPath(entry.name)) continue;
       if (entry.name === ".DS_Store") continue;
+      if (entry.isDirectory()) {
+        if (hasMaterializedProjectContentFallback(join(dirPath, entry.name))) return true;
+        continue;
+      }
       return true;
     }
   } catch {
     return false;
   }
   return false;
+}
+
+function hasProjectContentOnDisk(dirPath: string): boolean {
+  const gitProjectFiles = listProjectContentFiles(dirPath);
+  if (gitProjectFiles.length > 0) {
+    return gitProjectFiles.some(file => existsSync(join(dirPath, file)));
+  }
+  return hasMaterializedProjectContentFallback(dirPath);
+}
+
+function copyProjectRootContentIntoWorktree(projectRoot: string, worktreeRoot: string): number {
+  let copied = 0;
+  for (const relPath of listProjectContentFiles(projectRoot)) {
+    const src = join(projectRoot, relPath);
+    if (!existsSync(src)) continue;
+    const dst = join(worktreeRoot, relPath);
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(src, dst, { recursive: true, force: true });
+    copied++;
+  }
+  return copied;
 }
 
 function getSnapshotDiffCheckFailure(basePath: string): string | null {
@@ -176,7 +233,17 @@ export async function checkGitHealth(
             if (reset.status !== 0) {
               throw new Error(reset.stderr || reset.error?.message || "git reset --hard failed");
             }
-            fixesApplied.push(`recreated empty worktree ${wt.path}`);
+            const copied = !hasProjectContentOnDisk(recreated.path) && hasProjectContentOnDisk(basePath)
+              ? copyProjectRootContentIntoWorktree(basePath, recreated.path)
+              : 0;
+            if (!hasProjectContentOnDisk(recreated.path) && hasProjectContentOnDisk(basePath)) {
+              throw new Error("recreated worktree still has no project content");
+            }
+            fixesApplied.push(
+              copied > 0
+                ? `recreated empty worktree ${wt.path} and copied ${copied} project file${copied === 1 ? "" : "s"} from project root`
+                : `recreated empty worktree ${wt.path}`,
+            );
           } catch {
             fixesApplied.push(`failed to recreate empty worktree ${wt.path}`);
           }

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -332,7 +332,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
     return true;
   };
 
-  const prefs = loadEffectiveGSDPreferences();
+  const prefs = loadEffectiveGSDPreferences(basePath);
   if (prefs) {
     const prefIssues = validatePreferenceShape(prefs.preferences);
     for (const issue of prefIssues) {

--- a/src/resources/extensions/gsd/tests/doctor-empty-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-empty-worktree.test.ts
@@ -4,7 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,6 +27,17 @@ function makeRepo(): string {
   writeFileSync(join(base, "package.json"), "{\"scripts\":{}}\n", "utf-8");
   runGit(["add", "."], base);
   runGit(["commit", "-m", "chore: init"], base);
+  return base;
+}
+
+function makeRepoWithOnlyGitignoreCommitted(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-empty-worktree-"));
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+  writeFileSync(join(base, ".gitignore"), "node_modules\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "chore: init gitignore"], base);
   return base;
 }
 
@@ -62,4 +73,63 @@ test("doctor fix recreates an empty registered milestone worktree", async (t) =>
   );
   assert.ok(existsSync(join(wtPath, "package.json")), "worktree content is restored");
   assert.ok(existsSync(join(wtPath, "milestone-note.txt")), "branch content is restored");
+});
+
+test("doctor fix recreates an empty worktree when cwd is inside that worktree", async (t) => {
+  const base = makeRepo();
+  const originalCwd = process.cwd();
+  t.after(() => {
+    try {
+      process.chdir(originalCwd);
+    } catch { /* ignore deleted cwd during cleanup */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  createWorktree(base, "M001", { branch: "milestone/M001" });
+  const wtPath = worktreePath(base, "M001");
+  for (const entry of readdirSync(wtPath)) {
+    if (entry === ".git") continue;
+    rmSync(join(wtPath, entry), { recursive: true, force: true });
+  }
+  process.chdir(wtPath);
+
+  const report = await runGSDDoctor(base, {
+    fix: true,
+    fixLevel: "all",
+    isolationMode: "worktree",
+  });
+
+  assert.ok(
+    report.fixesApplied.some((fix) => fix.includes("recreated empty worktree")),
+    "doctor applies the repair while cwd is in the worktree",
+  );
+  assert.ok(existsSync(join(wtPath, "package.json")), "worktree content is restored");
+});
+
+test("doctor fix imports untracked project-root content when the worktree only has git metadata", async (t) => {
+  const base = makeRepoWithOnlyGitignoreCommitted();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "---\ngit:\n  isolation: worktree\n---\n", "utf-8");
+  writeFileSync(join(base, "package.json"), "{\"scripts\":{}}\n", "utf-8");
+  createWorktree(base, "M001", { branch: "milestone/M001" });
+  const wtPath = worktreePath(base, "M001");
+  assert.ok(existsSync(join(wtPath, ".gitignore")), "test setup keeps committed non-content metadata");
+  assert.equal(existsSync(join(wtPath, "package.json")), false, "test setup leaves project content only at the root");
+
+  const report = await runGSDDoctor(base, {
+    fix: true,
+    fixLevel: "all",
+  });
+
+  assert.ok(
+    report.issues.some((issue) => issue.code === "worktree_empty_with_project_content"),
+    "doctor reports the empty worktree even when .gitignore exists",
+  );
+  assert.ok(
+    report.fixesApplied.some((fix) => fix.includes("copied") && fix.includes("project file")),
+    "doctor copies the root project content into the recreated worktree",
+  );
+  assert.ok(existsSync(join(wtPath, "package.json")), "untracked project content is restored into the worktree");
 });


### PR DESCRIPTION
## Summary

Fixes the `/gsd doctor fix` recovery path for `empty-worktree-with-project-content` failures.

## Root Cause

`runGSDDoctor(basePath)` loaded preferences from `process.cwd()` instead of the project path being diagnosed, so doctor could miss `git.isolation: worktree` and skip worktree repair entirely. The git-health empty-worktree detector also counted metadata-only files like `.gitignore` as project content, which hid broken milestone worktrees. Finally, when the project root content was untracked, recreating the worktree could still leave it without source content.

## Changes

- Load doctor preferences from the explicit diagnosed `basePath`.
- Make doctor worktree content detection ignore git/GSD metadata and use tracked plus non-ignored untracked project files.
- Copy non-ignored project-root content into the recreated worktree when the branch itself still materializes empty.
- Add regression coverage for cwd-in-worktree repair and metadata-only worktrees with untracked project-root content.

## Validation

- `pnpm run test:compile`
- focused `doctor-empty-worktree.test.js`
- focused `worktree-safety.test.js`
- focused `preferences.test.js`
- `pnpm run typecheck:extensions`

Note: the clean PR worktree needed dependencies installed with `--ignore-scripts` after the normal postinstall hung in optional setup; package dist prerequisites were built before running the checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782831934&installation_id=134682257&pr_number=313&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F313&signature=a26bc91b14dbc979fb8ef490324e2933f9063e60dbae98219096433ebdd0f3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git worktree auto-repair and file copy behavior in doctor; mistakes could affect milestone isolation workflows, but scope is limited to fix paths and regression tests.
> 
> **Overview**
> Fixes **`/gsd doctor --fix`** when milestone worktrees look empty but the project root still has real source files.
> 
> **`runGSDDoctor`** now loads GSD preferences from the diagnosed **`basePath`** instead of **`process.cwd()`**, so **`git.isolation: worktree`** is honored even when the shell is inside a milestone worktree.
> 
> Empty-worktree detection no longer treats **`.gitignore`** (and similar metadata) as project content. It uses tracked plus non-ignored untracked paths (excluding **`.git`** / **`.gsd`**). After recreating a broken worktree, doctor **copies** missing project-root files into the worktree when the branch checkout still materializes empty.
> 
> Regression tests cover repair with **cwd inside the worktree** and roots where only metadata is committed but **`package.json`** lives untracked at the project root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f761d6e15a31ea5ef7b0edefc74cfaa704f9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->