### PR TITLE
[codex] Fix auto worktree untracked content import

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -20,7 +20,7 @@ import {
   unlinkSync,
   lstatSync as lstatSyncFn,
 } from "node:fs";
-import { isAbsolute, join, relative, resolve, sep as pathSep } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep as pathSep } from "node:path";
 import { GSDError, GSD_IO_ERROR, GSD_GIT_ERROR } from "./errors.js";
 import {
   reconcileWorktreeDb,
@@ -60,6 +60,7 @@ import { logWarning, logError } from "./workflow-logger.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import { runWorktreePostCreateHook } from "./worktree-post-create-hook.js";
+import { classifyProject } from "./detection.js";
 import {
   nativeGetCurrentBranch,
   nativeDetectMainBranch,
@@ -257,6 +258,47 @@ export function _resolveAutoWorktreeStartPoint(
     branchExists(gitMainBranch)
     ? gitMainBranch
     : undefined;
+}
+
+function importUntrackedProjectRootContentIntoEmptyWorktree(
+  projectRoot: string,
+  worktreeRoot: string,
+  milestoneId: string,
+): number {
+  const worktreeClassification = classifyProject(worktreeRoot);
+  if (worktreeClassification.kind !== "greenfield") return 0;
+
+  const projectRootClassification = classifyProject(projectRoot);
+  if (
+    projectRootClassification.kind === "greenfield" ||
+    projectRootClassification.kind === "invalid-repo" ||
+    projectRootClassification.untrackedFiles.length === 0
+  ) {
+    return 0;
+  }
+
+  let copied = 0;
+  for (const relPath of projectRootClassification.untrackedFiles) {
+    const src = join(projectRoot, relPath);
+    if (!existsSync(src)) continue;
+
+    const dst = join(worktreeRoot, relPath);
+    if (existsSync(dst)) continue;
+
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(src, dst, { recursive: true, force: false });
+    copied++;
+  }
+
+  if (copied > 0) {
+    debugLog("createAutoWorktree", {
+      phase: "import-untracked-project-content",
+      milestoneId,
+      copied,
+    });
+  }
+
+  return copied;
 }
 
 export function _shouldReconcileWorktreeDb(
@@ -1332,6 +1374,8 @@ export function createAutoWorktree(
   // .gsd/ — both reads and writes converge on the project-root .gsd/.
   // The original concerns (#759, #778) no longer apply because there is
   // no second copy to drift.
+
+  importUntrackedProjectRootContentIntoEmptyWorktree(basePath, info.path, milestoneId);
 
   // Run user-configured post-create hook (#597) — e.g. copy .env, symlink assets
   const hookError = runWorktreePostCreateHook(basePath, info.path);

--- a/src/resources/extensions/gsd/tests/auto-worktree-untracked-content.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-untracked-content.test.ts
@@ -1,0 +1,53 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for auto-worktree import of untracked root content.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createAutoWorktree, teardownAutoWorktree, _resetAutoWorktreeOriginalBaseForTests } from "../auto-worktree.ts";
+import { classifyProject } from "../detection.ts";
+
+function runGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function makeRepoWithUntrackedSource(): string {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-auto-wt-untracked-")));
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+  writeFileSync(join(base, ".gitignore"), ".gsd\n.DS_Store\n", "utf-8");
+  runGit(["add", ".gitignore"], base);
+  runGit(["commit", "-m", "chore: init gitignore"], base);
+  writeFileSync(join(base, "index.html"), "<h1>Todo</h1>\n", "utf-8");
+  return base;
+}
+
+test("createAutoWorktree imports untracked project-root content into empty milestone worktrees", (t) => {
+  const originalCwd = process.cwd();
+  const base = makeRepoWithUntrackedSource();
+  t.after(() => {
+    _resetAutoWorktreeOriginalBaseForTests();
+    try {
+      process.chdir(originalCwd);
+    } catch { /* ignore deleted cwd during cleanup */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  assert.equal(classifyProject(base).kind, "untyped-existing", "root has untracked project content");
+
+  const wtPath = createAutoWorktree(base, "M001");
+
+  assert.ok(existsSync(join(wtPath, "index.html")), "untracked source file is copied into the worktree");
+  assert.equal(classifyProject(wtPath).kind, "untyped-existing", "worktree is no longer classified as greenfield");
+
+  teardownAutoWorktree(base, "M001");
+});


### PR DESCRIPTION
## Summary

- Import non-ignored untracked project-root content into a newly created milestone worktree when the worktree would otherwise classify as greenfield.
- Add a regression test for a repo with only `.gitignore` committed and `index.html` left untracked at the project root.

## Root Cause

Auto-mode creates milestone worktrees from Git-tracked content. When a project has real source files only as untracked root content, the milestone worktree starts empty, Worktree Safety blocks source-writing units, and doctor cleanup can recreate the same empty checkout on the next auto run.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-worktree-untracked-content.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/doctor-empty-worktree.test.ts src/resources/extensions/gsd/tests/worktree-project-root-degrade.test.ts src/resources/extensions/gsd/tests/worktree-safety.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-worktree-registry.test.ts`
- `pnpm run typecheck:extensions`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782835175&installation_id=134682257&pr_number=316&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F316&signature=105ad87de02f4e232995503b40a4047e2000a33e830c3ae4de10448dbc9b47bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, additive filesystem copy during worktree creation with existing-path skips; does not alter git refs or tracked files on the project root.
> 
> **Overview**
> **Auto worktrees** now seed milestone checkouts with **untracked, non-ignored project-root files** when the new worktree would otherwise look **greenfield** (only tracked git content), so auto mode can run source-writing units instead of staying empty and tripping Worktree Safety / doctor re-create loops.
> 
> After `createWorktree`, `importUntrackedProjectRootContentIntoEmptyWorktree` uses `classifyProject` on both roots: it copies each listed untracked path from the project root into the worktree (recursive `cpSync`, skip if the destination already exists), then logs via `debugLog`. The post-create hook still runs afterward.
> 
> A regression test builds a repo with only `.gitignore` committed and `index.html` untracked, asserts the file appears in the worktree and classification moves off greenfield.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343011e0205ee5aea5ba13173aa67c88974350fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->