### PR TITLE
[codex] Stabilize worktree recovery, MCP args, and closeout surfaces

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -690,6 +690,21 @@ describe('createMcpServer tool registration', () => {
     assert.equal(typeof session.startTime, 'number');
   });
 
+  it('gsd_status accepts omitted sessionId when exactly one session is tracked', async () => {
+    const sessionId = await sm.startSession('/tmp/tool-status-infer', { cliPath: '/usr/bin/gsd' });
+    const { server } = await createMcpServer(sm);
+    const statusTool = (server as any)._registeredTools?.gsd_status;
+
+    assert.ok(statusTool, 'gsd_status should be registered');
+    assert.equal(statusTool.inputSchema.safeParse({ sessionId: undefined }).success, true);
+
+    const result = await statusTool.handler({});
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.sessionId, sessionId);
+    assert.equal(payload.projectDir, resolve('/tmp/tool-status-infer'));
+    assert.equal(payload.status, 'running');
+  });
+
   it('gsd_resolve_blocker flow returns error when no blocker', async () => {
     const sessionId = await sm.startSession('/tmp/tool-resolve', { cliPath: '/usr/bin/gsd' });
     await assert.rejects(

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -18,6 +18,7 @@ import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 import type { SessionManager } from './session-manager.js';
+import type { ManagedSession } from './types.js';
 import { isRemoteConfigured, tryRemoteQuestions } from './remote-questions.js';
 import type { RemoteToolResult } from './remote-questions.js';
 import { readProgress } from './readers/state.js';
@@ -164,6 +165,67 @@ function errorContent(message: string): { isError: true; content: Array<{ type: 
 /** Return raw text content without JSON wrapping. */
 function textContent(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text' as const, text }] };
+}
+
+function getSessionStatusPayload(session: ManagedSession): Record<string, unknown> {
+  const durationMs = Date.now() - session.startTime;
+  const toolCallCount = session.events.filter(
+    (e) => (e as Record<string, unknown>).type === 'tool_use' ||
+           (e as Record<string, unknown>).type === 'tool_execution_start',
+  ).length;
+
+  return {
+    sessionId: session.sessionId || null,
+    projectDir: session.projectDir,
+    status: session.status,
+    progress: {
+      eventCount: session.events.length,
+      toolCalls: toolCallCount,
+    },
+    recentEvents: session.events.slice(-10),
+    pendingBlocker: session.pendingBlocker
+      ? {
+          id: session.pendingBlocker.id,
+          method: session.pendingBlocker.method,
+          message: session.pendingBlocker.message,
+        }
+      : null,
+    cost: session.cost,
+    durationMs,
+  };
+}
+
+function resolveStatusSession(
+  sessionManager: SessionManager,
+  input: { sessionId?: string; projectDir?: string },
+): { session?: ManagedSession; error?: string } {
+  const sessionId = typeof input.sessionId === 'string' ? input.sessionId.trim() : '';
+  const projectDir = typeof input.projectDir === 'string' ? input.projectDir.trim() : '';
+
+  if (sessionId) {
+    const session = sessionManager.getSession(sessionId);
+    return session ? { session } : { error: `Session not found: ${sessionId}` };
+  }
+
+  if (projectDir) {
+    const session = sessionManager.getSessionByDir(projectDir);
+    return session ? { session } : { error: `Session not found for projectDir: ${projectDir}` };
+  }
+
+  const only = sessionManager.getOnlySession();
+  if (only) return { session: only };
+
+  const sessions = sessionManager.listSessions();
+  if (sessions.length === 0) {
+    return {
+      error: 'No tracked GSD sessions. Call gsd_execute first, or pass projectDir for a session tracked by this server.',
+    };
+  }
+
+  const hints = sessions
+    .map((session) => `${session.sessionId || '(no sessionId)'} ${session.projectDir}`)
+    .join('; ');
+  return { error: `Multiple tracked GSD sessions; pass sessionId or projectDir. Tracked sessions: ${hints}` };
 }
 
 // ---------------------------------------------------------------------------
@@ -928,39 +990,17 @@ export async function createMcpServer(
   // -----------------------------------------------------------------------
   server.tool(
     'gsd_status',
-    'Get the current status of a GSD session including progress, recent events, and pending blockers.',
+    'Get the current status of a GSD session including progress, recent events, and pending blockers. Provide sessionId, projectDir, or omit both when this server tracks exactly one session.',
     {
-      sessionId: z.string().describe('Session ID returned from gsd_execute'),
+      sessionId: z.string().optional().describe('Session ID returned from gsd_execute. Optional when projectDir is provided or this server tracks exactly one session.'),
+      projectDir: z.string().optional().describe('Absolute path to the project directory (fallback when sessionId is unavailable)'),
     },
     async (args: Record<string, unknown>) => {
-      const { sessionId } = args as { sessionId: string };
+      const { sessionId, projectDir } = args as { sessionId?: string; projectDir?: string };
       try {
-        const session = sessionManager.getSession(sessionId);
-        if (!session) return errorContent(`Session not found: ${sessionId}`);
-
-        const durationMs = Date.now() - session.startTime;
-        const toolCallCount = session.events.filter(
-          (e) => (e as Record<string, unknown>).type === 'tool_use' ||
-                 (e as Record<string, unknown>).type === 'tool_execution_start'
-        ).length;
-
-        return jsonContent({
-          status: session.status,
-          progress: {
-            eventCount: session.events.length,
-            toolCalls: toolCallCount,
-          },
-          recentEvents: session.events.slice(-10),
-          pendingBlocker: session.pendingBlocker
-            ? {
-                id: session.pendingBlocker.id,
-                method: session.pendingBlocker.method,
-                message: session.pendingBlocker.message,
-              }
-            : null,
-          cost: session.cost,
-          durationMs,
-        });
+        const resolved = resolveStatusSession(sessionManager, { sessionId, projectDir });
+        if (!resolved.session) return errorContent(resolved.error ?? 'Session not found');
+        return jsonContent(getSessionStatusPayload(resolved.session));
       } catch (err) {
         return errorContent(err instanceof Error ? err.message : String(err));
       }

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -201,6 +201,29 @@ export class SessionManager {
   }
 
   /**
+   * Return the only tracked session, if there is exactly one.
+   *
+   * MCP clients occasionally lose the sessionId returned from gsd_execute while
+   * still talking to the same server process. A sole-session fallback lets
+   * read-only status polling recover without guessing across projects.
+   */
+  getOnlySession(): ManagedSession | undefined {
+    let only: ManagedSession | undefined;
+    for (const session of this.sessions.values()) {
+      if (only) return undefined;
+      only = session;
+    }
+    return only;
+  }
+
+  /**
+   * Snapshot tracked sessions for diagnostics and ambiguity errors.
+   */
+  listSessions(): ManagedSession[] {
+    return [...this.sessions.values()];
+  }
+
+  /**
    * Resolve a pending blocker by sending a UI response.
    */
   async resolveBlocker(sessionId: string, response: string): Promise<void> {

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 
 import { symlinkSync, realpathSync } from "node:fs";
 
@@ -2221,6 +2222,28 @@ export const executeTaskComplete = async (params, projectDir) => {
       assert.equal(gateRows.length, 1);
       assert.equal(gateRows[0]["status"], "complete");
       assert.equal(gateRows[0]["verdict"], "pass");
+
+      const gateInputSchema = z.object(gateTool!.params as any);
+      const inferredGateArgs = gateInputSchema.parse({
+        projectDir: base,
+        gateId: "Q4",
+        verdict: "omitted",
+        rationale: "No existing requirements are touched by this slice.",
+        findings: "",
+      });
+      assert.equal(
+        Object.prototype.hasOwnProperty.call(inferredGateArgs, "milestoneId"),
+        false,
+        "MCP input schema must allow gate result calls before milestoneId is inferred",
+      );
+      const inferredGateResult = await gateTool!.handler(inferredGateArgs);
+      assert.match((inferredGateResult as any).content[0].text as string, /Gate Q4 result saved/);
+      const inferredGateRows = _getAdapter()!.prepare(
+        "SELECT status, verdict, rationale FROM quality_gates WHERE milestone_id = ? AND slice_id = ? AND gate_id = ?",
+      ).all("M006", "S06", "Q4") as Array<Record<string, unknown>>;
+      assert.equal(inferredGateRows.length, 1);
+      assert.equal(inferredGateRows[0]["status"], "complete");
+      assert.equal(inferredGateRows[0]["verdict"], "omitted");
 
       await taskTool!.handler({
         projectDir: base,

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
 import {
@@ -1000,6 +1000,94 @@ async function handleReassessRoadmap(
   );
 }
 
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function inferMilestoneIdFromProjectDir(projectDir: string): string | undefined {
+  const name = basename(projectDir);
+  const match = /^M\d+(?:-[A-Za-z0-9]+)?$/.exec(name);
+  return match?.[0];
+}
+
+type GateDbModule = {
+  getAllMilestones?: () => Array<{ id?: unknown }>;
+  getMilestoneSlices?: (milestoneId: string) => Array<{ id?: unknown; sequence?: unknown; status?: unknown }>;
+  getPendingGates?: (milestoneId: string, sliceId: string) => Array<Record<string, unknown>>;
+  getGateResults?: (milestoneId: string, sliceId: string) => Array<Record<string, unknown>>;
+};
+
+async function inferSaveGateResultScope(
+  projectDir: string,
+  prepared: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const out = { ...prepared };
+  const gateId = stringValue(out.gateId)?.toUpperCase();
+  const taskId = stringValue(out.taskId);
+
+  if (!stringValue(out.milestoneId)) {
+    const inferredMilestoneId = inferMilestoneIdFromProjectDir(projectDir);
+    if (inferredMilestoneId) out.milestoneId = inferredMilestoneId;
+  }
+
+  if (stringValue(out.milestoneId) && stringValue(out.sliceId)) return out;
+  if (!gateId) return out;
+
+  const { ensureDbOpen } = await importLocalModule<WorkflowDbBootstrapModule>(
+    "../../../src/resources/extensions/gsd/bootstrap/dynamic-tools.js",
+  );
+  if (!(await ensureDbOpen(projectDir))) return out;
+
+  const db = await importLocalModule<GateDbModule>("../../../src/resources/extensions/gsd/gsd-db.js");
+  if (!db.getMilestoneSlices || !db.getPendingGates || !db.getGateResults) return out;
+
+  const milestoneFilter = stringValue(out.milestoneId);
+  const sliceFilter = stringValue(out.sliceId);
+  const milestones = milestoneFilter
+    ? [{ id: milestoneFilter }]
+    : (db.getAllMilestones?.() ?? []).filter((milestone) => stringValue(milestone.id));
+
+  const candidates: Array<{ milestoneId: string; sliceId: string; taskId?: string }> = [];
+  for (const milestone of milestones) {
+    const milestoneId = stringValue(milestone.id);
+    if (!milestoneId) continue;
+    const slices = db.getMilestoneSlices(milestoneId)
+      .filter((slice) => {
+        const sliceId = stringValue(slice.id);
+        return sliceId && (!sliceFilter || sliceId === sliceFilter);
+      });
+
+    for (const slice of slices) {
+      const sliceId = stringValue(slice.id);
+      if (!sliceId) continue;
+      const rows = [
+        ...db.getPendingGates(milestoneId, sliceId),
+        ...db.getGateResults(milestoneId, sliceId),
+      ];
+      for (const row of rows) {
+        if (stringValue(row.gate_id)?.toUpperCase() !== gateId) continue;
+        const rowTaskId = stringValue(row.task_id) ?? "";
+        if (taskId && rowTaskId !== taskId) continue;
+        candidates.push({ milestoneId, sliceId, taskId: rowTaskId || undefined });
+      }
+    }
+  }
+
+  const unique = new Map<string, { milestoneId: string; sliceId: string; taskId?: string }>();
+  for (const candidate of candidates) {
+    unique.set(`${candidate.milestoneId}/${candidate.sliceId}/${candidate.taskId ?? ""}`, candidate);
+  }
+
+  if (unique.size === 1) {
+    const only = [...unique.values()][0]!;
+    if (!stringValue(out.milestoneId)) out.milestoneId = only.milestoneId;
+    if (!stringValue(out.sliceId)) out.sliceId = only.sliceId;
+    if (!stringValue(out.taskId) && only.taskId) out.taskId = only.taskId;
+  }
+
+  return out;
+}
+
 async function handleSaveGateResult(
   projectDir: string,
   args: z.infer<typeof saveGateResultSchema>,
@@ -1103,6 +1191,8 @@ const projectDirParam = z
   .string()
   .optional()
   .describe("Optional. Omit this field — the server defaults to its current working directory, which is already the correct project or worktree root.");
+
+const unknownRecord = z.record(z.string(), z.unknown());
 
 const nonEmptyString = (field: string) =>
   z.string().trim().min(1, `${field} must be a non-empty string`);
@@ -1283,15 +1373,56 @@ const reassessRoadmapSchema = z.object(reassessRoadmapParams);
 
 const saveGateResultParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  sliceId: z.string().describe("Slice ID (e.g. S01)"),
-  gateId: z.string().describe("Gate ID (e.g. Q3, Q4, Q5, Q6, Q7, Q8, MV01, MV02, MV03, MV04). Accepts any string for forward-compatibility with new gates."),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  sliceId: nonEmptyString("sliceId").describe("Slice ID (e.g. S01)"),
+  gateId: nonEmptyString("gateId").describe("Gate ID (e.g. Q3, Q4, Q5, Q6, Q7, Q8, MV01, MV02, MV03, MV04). Accepts any string for forward-compatibility with new gates."),
   taskId: z.string().optional().describe("Task ID for task-scoped gates"),
   verdict: z.enum(["pass", "flag", "omitted"]).describe("Gate verdict"),
-  rationale: z.string().describe("One-sentence justification"),
+  rationale: nonEmptyString("rationale").describe("One-sentence justification"),
   findings: z.string().optional().describe("Detailed markdown findings"),
 };
 const saveGateResultSchema = z.object(saveGateResultParams);
+
+const saveGateResultIncomingParams = {
+  projectDir: projectDirParam,
+  milestoneId: z.string().optional().describe("Milestone ID (e.g. M001). Required unless it can be inferred from the active worktree or pending gate row."),
+  sliceId: z.string().optional().describe("Slice ID (e.g. S01). Required unless it can be inferred from the active pending gate row."),
+  gateId: z.string().optional().describe("Gate ID (e.g. Q3, Q4, Q5, Q6, Q7, Q8, MV01, MV02, MV03, MV04)"),
+  taskId: z.string().optional().describe("Task ID for task-scoped gates"),
+  verdict: z.string().optional().describe("Gate verdict: pass, flag, or omitted"),
+  rationale: z.string().optional().describe("One-sentence justification"),
+  findings: z.string().optional().describe("Detailed markdown findings"),
+  milestone_id: z.string().optional(),
+  mid: z.string().optional(),
+  milestone: z.string().optional(),
+  slice_id: z.string().optional(),
+  sid: z.string().optional(),
+  slice: z.string().optional(),
+  gate_id: z.string().optional(),
+  gate: z.string().optional(),
+  questionId: z.string().optional(),
+  question_id: z.string().optional(),
+  task_id: z.string().optional(),
+  tid: z.string().optional(),
+  task: z.string().optional(),
+  result: z.string().optional(),
+  status: z.string().optional(),
+  outcome: z.string().optional(),
+  reason: z.string().optional(),
+  summary: z.string().optional(),
+  justification: z.string().optional(),
+  explanation: z.string().optional(),
+  finding: z.string().optional(),
+  details: z.string().optional(),
+  analysis: z.string().optional(),
+  report: z.string().optional(),
+  arguments: unknownRecord.optional(),
+  args: unknownRecord.optional(),
+  params: unknownRecord.optional(),
+  input: unknownRecord.optional(),
+  payload: unknownRecord.optional(),
+};
+const saveGateResultIncomingSchema = z.object(saveGateResultIncomingParams);
 
 const replanSliceParams = {
   projectDir: projectDirParam,
@@ -1964,12 +2095,16 @@ export function registerWorkflowTools(
   server.tool(
     "gsd_save_gate_result",
     "Save a quality gate result to the GSD database.",
-    saveGateResultParams,
+    saveGateResultIncomingParams,
     async (args: Record<string, unknown>) => {
+      const incoming = parseWorkflowArgs(saveGateResultIncomingSchema, args);
       const { prepareSaveGateResultArguments } = await importLocalModule<{
         prepareSaveGateResultArguments: (raw: unknown) => unknown;
       }>("../../../src/resources/extensions/gsd/tools/save-gate-result-args.js");
-      const prepared = prepareSaveGateResultArguments(args);
+      const prepared = await inferSaveGateResultScope(
+        incoming.projectDir,
+        prepareSaveGateResultArguments(incoming) as Record<string, unknown>,
+      );
       const record =
         prepared !== null && typeof prepared === "object" && !Array.isArray(prepared)
           ? (prepared as Record<string, unknown>)

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1381,9 +1381,13 @@ export async function stopAuto(
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
   const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
   const displayReason = formatAutoStopDisplayReason(reason);
+  const isHeadlessStop = process.env.GSD_HEADLESS === "1";
   const completionStopRequested = Boolean(options.completionWidget);
-  const installCompletionWidget = completionStopRequested;
-  const preserveCompletionSurface = completionStopRequested;
+  const preserveCloseoutTranscript = !isHeadlessStop && (
+    options.preserveCloseoutTranscript ?? completionStopRequested
+  );
+  const installCompletionWidget = completionStopRequested && !preserveCloseoutTranscript;
+  const preserveCompletionSurface = completionStopRequested || preserveCloseoutTranscript;
   s.completionStopInProgress = preserveCompletionSurface;
 
   // #4764 — telemetry: record the exit reason, isolation mode, whether an auto
@@ -1808,8 +1812,9 @@ export async function stopAuto(
     if (installCompletionWidget) {
       // Completion stops keep the durable final closeout surface visible.
     } else if (preserveCompletionSurface) {
-      ctx?.ui.setWidget("gsd-progress", undefined);
-      ctx?.ui.setWidget("gsd-outcome", undefined);
+      // Foreground closeout-boundary stops preserve the transcript that the
+      // completing unit already printed. Avoid replacing it with a widget or
+      // clearing the progress slot, which can push the closeout into scrollback.
     } else {
       ctx?.ui.setWidget("gsd-progress", undefined);
       const status = isBlockedStopReason(reason) ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -33,6 +33,11 @@ export interface StopAutoOptions {
     milestoneTitle?: string | null;
     allMilestonesComplete?: boolean;
   };
+  /**
+   * Foreground closeout-boundary stops already have the useful final surface in
+   * the transcript. Preserve it instead of installing a replacement widget.
+   */
+  preserveCloseoutTranscript?: boolean;
   /** Preserve, rather than merge, a completed milestone during stop cleanup. */
   preserveCompletedMilestoneBranch?: boolean;
 }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -583,6 +583,7 @@ async function restorePreflightStashOrStop(
 export async function _runMilestoneMergeWithStashRestore(
   ic: IterationContext,
   milestoneId: string,
+  options: { preserveCloseoutTranscript?: boolean } = {},
 ): Promise<{ action: "break"; reason: string } | null> {
   const { ctx, pi, s, deps } = ic;
 
@@ -597,6 +598,7 @@ export async function _runMilestoneMergeWithStashRestore(
       : `Pre-merge dirty working tree overlaps milestone ${milestoneId}`;
     await deps.stopAuto(ctx, pi, reason, {
       preserveCompletedMilestoneBranch: true,
+      preserveCloseoutTranscript: options.preserveCloseoutTranscript,
     });
     return {
       action: "break",
@@ -677,6 +679,7 @@ export async function _runMilestoneMergeWithStashRestore(
 export async function _runMilestoneMergeOnceWithStashRestore(
   ic: IterationContext,
   milestoneId: string,
+  options: { preserveCloseoutTranscript?: boolean } = {},
 ): Promise<{ action: "break"; reason: string } | null> {
   if (ic.s.milestoneMergedInPhases) {
     debugLog("autoLoop", {
@@ -686,7 +689,7 @@ export async function _runMilestoneMergeOnceWithStashRestore(
     });
     return null;
   }
-  return _runMilestoneMergeWithStashRestore(ic, milestoneId);
+  return _runMilestoneMergeWithStashRestore(ic, milestoneId, options);
 }
 
 async function emitCancelledUnitEnd(
@@ -3063,7 +3066,9 @@ export async function runFinalize(
   }
 
   if (preUnitSnapshot?.type === "complete-milestone" && s.currentMilestoneId) {
-    const stop = await _runMilestoneMergeOnceWithStashRestore(ic, s.currentMilestoneId);
+    const stop = await _runMilestoneMergeOnceWithStashRestore(ic, s.currentMilestoneId, {
+      preserveCloseoutTranscript: true,
+    });
     if (stop) {
       clearFinalizingUnit();
       return stop;

--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -154,12 +154,13 @@ export async function mergeCompletedMilestone(
   // to read it from. Only use the worktree path when git actually knows
   // about it (`getAutoWorktreePath` returns non-null). When the directory
   // exists on disk but isn't a registered git worktree (e.g. a stale
-  // session-status marker dir), fall back to the project root and let the
-  // standalone's mode detection pick branch-mode or skipped — using the
-  // un-registered dir as `worktreeBasePath` would cause `getCurrentBranch`
-  // to fail with a "Worktree HEAD diverged" error.
+  // session-status marker dir), recover through branch mode from the project
+  // root. Letting worktree-mode run from the project root can auto-commit
+  // overlapping root files to the integration branch before the squash merge,
+  // creating a synthetic conflict.
   const registeredWtPath = getAutoWorktreePath(basePath, milestoneId);
   const worktreeBasePath = registeredWtPath ?? basePath;
+  const isolationModeOverride = registeredWtPath ? undefined : "branch";
 
   let result: MergeStandaloneResult;
   try {
@@ -167,6 +168,7 @@ export async function mergeCompletedMilestone(
       originalBasePath: basePath,
       worktreeBasePath,
       milestoneId,
+      isolationModeOverride,
       // Parallel context never runs with degraded isolation — workers only
       // exist when isolation succeeded. Pass `false` explicitly so the
       // standalone's degraded-skip branch is not reached.

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -84,7 +84,7 @@ Subagents report only; they do not write user source. Fold any findings into Dec
    - `deviations` (string) — Deviations from the original plan
 
 14. Do not commit manually — the system auto-commits your changes after this unit completes.
-- Say: "Milestone {{milestoneId}} complete."
+- After `gsd_complete_milestone` succeeds, emit only one closeout line: "Milestone {{milestoneId}} complete." Do not add a second final-status block, repeat the tool result, or restate the closeout summary.
 
 **Important:** Do NOT skip code-change, success-criteria, or definition-of-done verification (steps 4-6). The summary must reflect verified outcomes. Verification failures block completion; there is no override. If a verification tool fails, errors, or returns unexpected output, treat it as failure.
 

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -486,7 +486,7 @@ test("rerootCommandSession refreshes command workspace to project root", async (
   assert.deepEqual(calls, ["/project/root"]);
 });
 
-test("stopAuto foreground completion closeout reroots session and installs the durable roll-up surface", async (t) => {
+test("stopAuto foreground completion closeout reroots session and preserves the transcript surface", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -604,19 +604,11 @@ test("stopAuto foreground completion closeout reroots session and installs the d
     assert.deepEqual(newSessionWorkspaces, [base], "completion stop must reroot command session to original project root");
     assert.equal(restoreCalls, 1, "completion stop must restore project root through lifecycle");
     assert.equal(realpathSync(process.cwd()), realpathSync(base), "completion stop must chdir back to project root");
-    const lastProgressWidget = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
     assert.equal(
-      typeof lastProgressWidget?.[1],
-      "function",
-      "foreground completion stop must leave the durable roll-up widget visible",
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
+      false,
+      "foreground completion stop must not install a replacement roll-up widget over the transcript",
     );
-    const rollup = (lastProgressWidget?.[1] as any)(
-      { requestRender() {} },
-      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
-    ).render(140).join("\n");
-    assert.match(rollup, /Milestone M003 roll-up/);
-    assert.match(rollup, /Budget tracking/);
-    assert.match(rollup, /Users can see what shipped without opening a fresh session/);
     assert.ok(
       notifications.every(message => !message.includes("/gsd auto to resume")),
       "completion stop notification must not tell users to resume a finished auto run",
@@ -739,7 +731,66 @@ test("stopAuto completion closeout emits a headless terminal notification withou
   }
 });
 
-test("stopAuto foreground all-complete closeout leaves a durable roll-up as the final surface", async () => {
+test("stopAuto closeout-transcript preservation suppresses generic stop widgets", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-closeout-transcript-stop-"));
+  const previousCwd = process.cwd();
+  const widgetCalls: Array<[string, unknown]> = [];
+  const notifications: string[] = [];
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = false;
+  autoSession.basePath = base;
+  autoSession.originalBasePath = base;
+
+  try {
+    await stopAuto(
+      {
+        hasUI: true,
+        ui: {
+          setStatus: () => {},
+          setWidget: (key: string, value: unknown) => {
+            widgetCalls.push([key, value]);
+          },
+          setHeader: () => {},
+          notify: (message: string) => {
+            notifications.push(message);
+          },
+        },
+        modelRegistry: { find: () => null },
+      } as any,
+      { events: { emit: () => {} } } as any,
+      "Pre-merge dirty working tree overlaps milestone M003",
+      {
+        preserveCloseoutTranscript: true,
+        preserveCompletedMilestoneBranch: true,
+      },
+    );
+
+    assert.equal(
+      widgetCalls.some(([key]) => key === "gsd-outcome"),
+      false,
+      "closeout-preserving stop must not install a generic auto-stopped outcome",
+    );
+    assert.equal(
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
+      false,
+      "closeout-preserving stop must not clear the transcript/progress surface",
+    );
+    assert.equal(
+      notifications.some(message => message.includes("Auto-mode stopped")),
+      false,
+      "closeout-preserving stop must not append a duplicate terminal stop notification",
+    );
+  } finally {
+    try { closeDatabase(); } catch { /* noop */ }
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("stopAuto foreground all-complete closeout preserves the transcript surface", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-all-complete-closeout-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -789,17 +840,9 @@ test("stopAuto foreground all-complete closeout leaves a durable roll-up as the 
 
     assert.equal(
       widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
-      true,
-      "foreground all-complete closeout must install a durable roll-up widget",
+      false,
+      "foreground all-complete closeout must not replace the visible transcript with a roll-up widget",
     );
-    const finalProgress = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(typeof finalProgress?.[1], "function", "foreground all-complete closeout keeps the roll-up visible");
-    const rollup = (finalProgress?.[1] as any)(
-      { requestRender() {} },
-      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
-    ).render(140).join("\n");
-    assert.match(rollup, /All milestones complete/);
-    assert.match(rollup, /Review the roll-up/);
     const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1);
     assert.equal(finalOutcome?.[1], undefined, "foreground all-complete closeout must not add an outcome replacement");
   } finally {

--- a/src/resources/extensions/gsd/tests/complete-milestone-prompt-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-prompt-rendering.test.ts
@@ -43,5 +43,6 @@ test("complete milestone prompt renders compact verification and completion guid
   assert.match(prompt, /self-diff/i);
   assert.match(prompt, /GSD-(?:Task|Unit)/);
   assert.match(prompt, /Milestone M001 complete/);
+  assert.match(prompt, /Do not add a second final-status block/);
   assert.doesNotMatch(prompt, /\{\{[a-zA-Z][a-zA-Z0-9_]*\}\}/);
 });

--- a/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
@@ -370,6 +370,49 @@ test("mergeCompletedMilestone — synthesizes roadmap from DB when projection is
   }
 });
 
+test("mergeCompletedMilestone — stale worktree marker does not auto-commit dirty root overlap", async () => {
+  const savedCwd = process.cwd();
+  const repo = createTempRepo();
+
+  try {
+    setupWorktreeIsolation(repo);
+    setupRoadmap(repo, "M011", "Dirty Root Recovery", ["S01: App shell"]);
+
+    createMilestoneBranch(repo, "M011", [
+      { name: "index.html", content: "<h1>M011</h1>\n" },
+    ]);
+
+    // Stale marker without a registered git worktree. Recovery must not treat
+    // the project root as a worktree and auto-commit this overlapping file to
+    // main before attempting the milestone merge.
+    mkdirSync(join(repo, ".gsd", "worktrees", "M011", ".gsd"), { recursive: true });
+    writeFileSync(join(repo, "index.html"), "<h1>local root draft</h1>\n");
+
+    process.chdir(repo);
+    const result = await mergeCompletedMilestone(repo, "M011");
+
+    assert.equal(result.success, false, "dirty overlap should block branch-mode recovery");
+    assert.match(
+      result.error ?? "",
+      /checkout|overwritten|untracked|would be overwritten/i,
+      "error should explain that checkout/dirty root state blocked recovery",
+    );
+
+    const subjects = run("git log --format=%s", repo);
+    assert.ok(
+      !subjects.includes("chore: auto-commit before milestone merge"),
+      "recovery must not auto-commit project-root overlap to main",
+    );
+    assert.equal(run("git branch --show-current", repo), "main");
+    assert.equal(run("git branch --list milestone/M011", repo).trim(), "milestone/M011");
+    assert.equal(run("git status --short -- index.html", repo), "?? index.html");
+  } finally {
+    process.chdir(savedCwd);
+    try { run("git reset --hard HEAD", repo); } catch { /* */ }
+    cleanup(repo);
+  }
+});
+
 test("mergeCompletedMilestone — clean merge, session status cleaned up", async () => {
   const savedCwd = process.cwd();
   const repo = createTempRepo();

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -17,7 +17,7 @@ interface CallLog {
   mergeCalls: number;
   postflightCalls: number;
   stopAutoCalls: Array<string | undefined>;
-  stopAutoOptions: Array<{ preserveCompletedMilestoneBranch?: boolean } | undefined>;
+  stopAutoOptions: Array<{ preserveCompletedMilestoneBranch?: boolean; preserveCloseoutTranscript?: boolean } | undefined>;
   pauseAutoCalls: Array<string | undefined>;
   notifyCalls: Array<{ message: string; level: string }>;
   milestoneMergedInPhases: boolean;
@@ -104,7 +104,7 @@ function buildIc(opts: {
       _c?: unknown,
       _p?: unknown,
       reason?: string,
-      options?: { preserveCompletedMilestoneBranch?: boolean },
+      options?: { preserveCompletedMilestoneBranch?: boolean; preserveCloseoutTranscript?: boolean },
     ) => {
       log.stopAutoCalls.push(reason);
       log.stopAutoOptions.push(options);
@@ -290,6 +290,30 @@ test("dirty overlap: preflight stops before merge and postflight restore", async
     log.stopAutoOptions[0]?.preserveCompletedMilestoneBranch,
     true,
     "stopAuto cleanup must preserve the branch instead of merging after preflight blocks",
+  );
+});
+
+test("dirty overlap after closeout preserves the visible closeout transcript", async () => {
+  const { ic, log } = buildIc({
+    preflightResult: PREFLIGHT_BLOCKED,
+    mergeBehavior: "succeed",
+    postflightResult: POP_OK,
+  });
+
+  const result = await _runMilestoneMergeWithStashRestore(ic, "M002", {
+    preserveCloseoutTranscript: true,
+  });
+
+  assert.deepEqual(result, {
+    action: "break",
+    reason: "preflight-dirty-overlap",
+  });
+  assert.equal(log.mergeCalls, 0, "blocked preflight must not start milestone merge");
+  assert.equal(log.stopAutoOptions[0]?.preserveCompletedMilestoneBranch, true);
+  assert.equal(
+    log.stopAutoOptions[0]?.preserveCloseoutTranscript,
+    true,
+    "post-closeout merge blocks must not replace the closeout transcript with a stop widget",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Worktree State Projection Module — typed-Interface contract tests for projectRootToWorktree (ADR-016).
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { WorktreeStateProjection } from "../worktree-state-projection.js";
@@ -55,6 +55,43 @@ test("projectRootToWorktree is idempotent — repeated calls do not throw", () =
     projection.projectRootToWorktree(scope);
     projection.projectRootToWorktree(scope);
     assert.ok(true, "two calls did not throw");
+  } finally {
+    cleanup();
+  }
+});
+
+test("projectRootToWorktree forwards root PROJECT.md into isolated worktrees", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const worktree = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+    mkdirSync(join(worktree, ".gsd"), { recursive: true });
+
+    const projectContent = [
+      "# Project",
+      "",
+      "## Milestone Sequence",
+      "",
+      "- [ ] M001: Foundation — Establish the runnable slice.",
+      "",
+    ].join("\n");
+    writeFileSync(join(dir, ".gsd", "PROJECT.md"), projectContent);
+    writeFileSync(join(dir, ".gsd", "REQUIREMENTS.md"), "# Requirements\n");
+    writeFileSync(join(dir, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n");
+
+    const workspace = createWorkspace(worktree);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    projection.projectRootToWorktree(scope);
+
+    const projectedProject = join(worktree, ".gsd", "PROJECT.md");
+    assert.ok(existsSync(projectedProject), "PROJECT.md is available to worktree-bound units");
+    assert.equal(readFileSync(projectedProject, "utf-8"), projectContent);
+    assert.ok(
+      existsSync(join(worktree, ".gsd", "milestones", "M001", "M001-ROADMAP.md")),
+      "milestone artifacts still project into the worktree",
+    );
   } finally {
     cleanup();
   }

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -172,6 +172,35 @@ const ROOT_DIAGNOSTIC_FILES = [
   "metrics.json",
 ] as const;
 
+/**
+ * Root-level .gsd/ projections copied from project root into worktrees for
+ * compatibility reads. Project root remains authoritative; copy-back still
+ * excludes these markdown projections.
+ */
+const ROOT_FORWARD_PROJECTION_FILES = [
+  "DECISIONS.md",
+  "REQUIREMENTS.md",
+  "PROJECT.md",
+  "KNOWLEDGE.md",
+  "OVERRIDES.md",
+  "QUEUE.md",
+  "completed-units.json",
+  "metrics.json",
+  "mcp.json",
+] as const;
+
+function syncRootProjectionFilesToWorktree(prGsd: string, wtGsd: string): void {
+  mkdirSync(wtGsd, { recursive: true });
+
+  for (const file of ROOT_FORWARD_PROJECTION_FILES) {
+    const src = join(prGsd, file);
+    const dst = join(wtGsd, file);
+    if (!existsSync(src) || existsSync(dst)) continue;
+
+    safeCopy(src, dst, { force: false });
+  }
+}
+
 // ─── Implementation cores ────────────────────────────────────────────────
 //
 // The `_*Impl` exports take raw paths so the deprecated path-string
@@ -203,6 +232,10 @@ export function _projectRootToWorktreeImpl(
   // cpSync rejects the copy because source === destination (ERR_FS_CP_EINVAL).
   // Compare realpaths and skip when they resolve to the same physical path (#2184).
   if (isSamePath(prGsd, wtGsd)) return;
+
+  // Root PROJECT/REQUIREMENTS/DECISIONS projections must be readable from a
+  // worktree-bound unit; the project root remains authoritative.
+  syncRootProjectionFilesToWorktree(prGsd, wtGsd);
 
   // Copy milestone directory from project root to worktree — additive only.
   // force:false prevents cpSync from overwriting existing worktree files.

--- a/src/tests/integration/pack-install.test.ts
+++ b/src/tests/integration/pack-install.test.ts
@@ -13,7 +13,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createReadStream, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createGunzip } from "node:zlib";
 import { killChildProcess } from "./child-process-guard.ts";
@@ -62,24 +62,66 @@ function buildQuietNpmEnv(sandbox: NpmSandbox): NodeJS.ProcessEnv {
   };
 }
 
-function runNpmQuiet(args: string[], sandbox: NpmSandbox): void {
-  execFileSync("npm", args, {
+function formatCommand(args: string[]): string {
+  return `npm ${args.join(" ")}`;
+}
+
+function runNpmQuiet(args: string[], sandbox: NpmSandbox): string {
+  try {
+    return execFileSync("npm", args, {
+      cwd: projectRoot,
+      encoding: "utf-8",
+      env: buildQuietNpmEnv(sandbox),
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch (error) {
+    const err = error as {
+      signal?: NodeJS.Signals | null;
+      status?: number | null;
+      stderr?: string | Buffer;
+      stdout?: string | Buffer;
+    };
+    const stdout = Buffer.isBuffer(err.stdout) ? err.stdout.toString("utf-8") : (err.stdout ?? "");
+    const stderr = Buffer.isBuffer(err.stderr) ? err.stderr.toString("utf-8") : (err.stderr ?? "");
+    throw new Error(
+      [
+        `${formatCommand(args)} failed`,
+        `status=${err.status ?? "<none>"} signal=${err.signal ?? "<none>"}`,
+        stdout.trim() ? `stdout:\n${stdout.trim().slice(-4000)}` : "",
+        stderr.trim() ? `stderr:\n${stderr.trim().slice(-4000)}` : "",
+      ].filter(Boolean).join("\n\n"),
+    );
+  }
+}
+
+function runNodeScript(relativePath: string): void {
+  execFileSync(process.execPath, [join(projectRoot, relativePath)], {
     cwd: projectRoot,
-    env: buildQuietNpmEnv(sandbox),
-    stdio: "ignore",
+    stdio: "pipe",
     maxBuffer: 16 * 1024 * 1024,
   });
 }
 
 function packTarball(sandbox: NpmSandbox): string {
-  const pkg = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8"));
-  const safeName = pkg.name.replace(/^@/, "").replace(/\//g, "-");
-  const tarball = `${safeName}-${pkg.version}.tgz`;
   const packDestination = join(sandbox.rootDir, "pack-output");
 
   mkdirSync(packDestination, { recursive: true });
-  runNpmQuiet(["pack", "--pack-destination", packDestination], sandbox);
-  return join(packDestination, tarball);
+  runNodeScript("scripts/prepack-resolve-workspace.cjs");
+  try {
+    const packOutput = runNpmQuiet(
+      ["pack", "--json", "--ignore-scripts", "--pack-destination", packDestination],
+      sandbox,
+    );
+    const metadata = JSON.parse(packOutput);
+    const filename = Array.isArray(metadata) ? metadata[0]?.filename : undefined;
+    if (typeof filename !== "string" || filename.length === 0) {
+      throw new Error(`npm pack returned no filename metadata: ${packOutput.slice(0, 1000)}`);
+    }
+    return isAbsolute(filename) ? filename : join(packDestination, filename);
+  } finally {
+    runNodeScript("scripts/postpack-restore-workspace.cjs");
+  }
 }
 
 /** List file paths inside a .tgz using Node built-ins only (no tar CLI or npm package). */


### PR DESCRIPTION
## Summary

- Preserve project-root artifact projection and untracked content when auto-mode creates or syncs milestone worktrees.
- Harden milestone recovery so stale/dirty root overlap is not auto-committed during merge cleanup.
- Restore workflow MCP parity for status/gate arguments and tool namespace handling.
- Preserve the foreground milestone closeout transcript instead of replacing it with a duplicate stop/roll-up surface.

## Why

Auto/worktree recovery could lose or misplace state when project-root artifacts and untracked worktree content were involved. MCP callers could also invoke workflow tools with IDs the server was able to infer, but validation failed before the workflow layer could recover. At milestone boundaries, the foreground UI then installed a second stop surface after the useful closeout transcript, pushing the real result into scrollback.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/complete-milestone-prompt-rendering.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-worktree-untracked-content.test.ts src/resources/extensions/gsd/tests/worktree-state-projection.test.ts src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/mcp-server.test.ts packages/mcp-server/src/workflow-tools.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json`

## Notes

This PR intentionally excludes the current uncommitted local changes in the working tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch milestone merge paths, worktree state projection, and auto-mode stop UI—areas where regressions could affect shipped work or operator visibility—but behavior is mostly additive hardening with targeted tests.
> 
> **Overview**
> This PR hardens **worktree isolation and milestone merge recovery**, improves **MCP workflow ergonomics**, and fixes **foreground closeout UI** so users don’t lose the real completion transcript.
> 
> **Worktrees & merge:** Root-level `.gsd` artifacts (including `PROJECT.md`) are now **forward-projected** into milestone worktrees when syncing from the project root. **`mergeCompletedMilestone`** treats a **stale worktree marker without a registered git worktree** as **branch-mode recovery** instead of running worktree merge from the project root—avoiding **auto-commits of dirty root overlap** before squash merge (new integration test).
> 
> **MCP:** **`gsd_status`** accepts optional **`sessionId`** / **`projectDir`**, infers the session when exactly one is tracked, and returns a richer status payload (including **`sessionId`**). **`gsd_save_gate_result`** accepts a **permissive incoming schema** (aliases/snake_case) and **infers `milestoneId` / `sliceId` / `taskId`** from the worktree directory name and pending gate rows before strict validation.
> 
> **Auto UI:** Foreground milestone completion and post-closeout merge blocks use **`preserveCloseoutTranscript`** so **`stopAuto`** does not install roll-up/outcome widgets or generic stop notifications over the transcript already printed. Headless runs skip the completion widget path. The **complete-milestone** prompt asks for a **single** closeout line.
> 
> **Packaging test:** Integration **`pack-install`** uses prepack/postpack workspace scripts and clearer npm failure output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba1821bacb6141239633aa5924f1d512c25aa16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->