### PR TITLE
[codex] Avoid root auto-commit during milestone recovery

### DIFF
--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -154,12 +154,13 @@ export async function mergeCompletedMilestone(
   // to read it from. Only use the worktree path when git actually knows
   // about it (`getAutoWorktreePath` returns non-null). When the directory
   // exists on disk but isn't a registered git worktree (e.g. a stale
-  // session-status marker dir), fall back to the project root and let the
-  // standalone's mode detection pick branch-mode or skipped — using the
-  // un-registered dir as `worktreeBasePath` would cause `getCurrentBranch`
-  // to fail with a "Worktree HEAD diverged" error.
+  // session-status marker dir), recover through branch mode from the project
+  // root. Letting worktree-mode run from the project root can auto-commit
+  // overlapping root files to the integration branch before the squash merge,
+  // creating a synthetic conflict.
   const registeredWtPath = getAutoWorktreePath(basePath, milestoneId);
   const worktreeBasePath = registeredWtPath ?? basePath;
+  const isolationModeOverride = registeredWtPath ? undefined : "branch";
 
   let result: MergeStandaloneResult;
   try {
@@ -167,6 +168,7 @@ export async function mergeCompletedMilestone(
       originalBasePath: basePath,
       worktreeBasePath,
       milestoneId,
+      isolationModeOverride,
       // Parallel context never runs with degraded isolation — workers only
       // exist when isolation succeeded. Pass `false` explicitly so the
       // standalone's degraded-skip branch is not reached.

--- a/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
@@ -370,6 +370,49 @@ test("mergeCompletedMilestone — synthesizes roadmap from DB when projection is
   }
 });
 
+test("mergeCompletedMilestone — stale worktree marker does not auto-commit dirty root overlap", async () => {
+  const savedCwd = process.cwd();
+  const repo = createTempRepo();
+
+  try {
+    setupWorktreeIsolation(repo);
+    setupRoadmap(repo, "M011", "Dirty Root Recovery", ["S01: App shell"]);
+
+    createMilestoneBranch(repo, "M011", [
+      { name: "index.html", content: "<h1>M011</h1>\n" },
+    ]);
+
+    // Stale marker without a registered git worktree. Recovery must not treat
+    // the project root as a worktree and auto-commit this overlapping file to
+    // main before attempting the milestone merge.
+    mkdirSync(join(repo, ".gsd", "worktrees", "M011", ".gsd"), { recursive: true });
+    writeFileSync(join(repo, "index.html"), "<h1>local root draft</h1>\n");
+
+    process.chdir(repo);
+    const result = await mergeCompletedMilestone(repo, "M011");
+
+    assert.equal(result.success, false, "dirty overlap should block branch-mode recovery");
+    assert.match(
+      result.error ?? "",
+      /checkout|overwritten|untracked|would be overwritten/i,
+      "error should explain that checkout/dirty root state blocked recovery",
+    );
+
+    const subjects = run("git log --format=%s", repo);
+    assert.ok(
+      !subjects.includes("chore: auto-commit before milestone merge"),
+      "recovery must not auto-commit project-root overlap to main",
+    );
+    assert.equal(run("git branch --show-current", repo), "main");
+    assert.equal(run("git branch --list milestone/M011", repo).trim(), "milestone/M011");
+    assert.equal(run("git status --short -- index.html", repo), "?? index.html");
+  } finally {
+    process.chdir(savedCwd);
+    try { run("git reset --hard HEAD", repo); } catch { /* */ }
+    cleanup(repo);
+  }
+});
+
 test("mergeCompletedMilestone — clean merge, session status cleaned up", async () => {
   const savedCwd = process.cwd();
   const repo = createTempRepo();


### PR DESCRIPTION
## Summary

Fix preserved milestone merge recovery when the original registered worktree is gone but a stale `.gsd/worktrees/<MID>` marker still exists.

Recovery now explicitly routes through branch mode in that case instead of treating the project root as a worktree. That prevents the merge primitive from auto-committing overlapping project-root files to the integration branch with `chore: auto-commit before milestone merge`, which could create a synthetic conflict on retry.

## Root Cause

`mergeCompletedMilestone` fell back to `worktreeBasePath = basePath` when `getAutoWorktreePath()` returned null. With worktree isolation preferences still enabled, the standalone merge path could run worktree-mode logic from the project root and commit dirty root overlap before attempting the milestone squash merge.

## Changes

- Force branch-mode recovery when no registered git worktree exists for the milestone.
- Add a regression test with a stale worktree marker and dirty overlapping `index.html` in the project root.
- Assert recovery does not create the protective auto-commit and preserves the milestone branch for retry.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts`
- 23/23 passing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782838770&installation_id=134682257&pr_number=318&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F318&signature=362f64fe5f33d9e30af430ae34fc89208388687b4e22546e9e4b7472da9e44f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git merge/recovery behavior for parallel milestones with stale worktree markers; incorrect mode selection could still affect integration-branch state, but scope is narrow and covered by a new integration test.
> 
> **Overview**
> Fixes **parallel milestone merge recovery** when a milestone’s git worktree is gone but a stale `.gsd/worktrees/<MID>` marker remains.
> 
> `mergeCompletedMilestone` now passes **`isolationModeOverride: "branch"`** whenever `getAutoWorktreePath` returns null, so recovery does not run **worktree-mode** logic from the project root. That path could **`chore: auto-commit before milestone merge`** overlapping dirty root files onto the integration branch and cause **synthetic conflicts** on retry.
> 
> Adds an integration test: stale marker, dirty overlapping `index.html` at root — merge fails without the auto-commit, **`milestone/M011`** stays, and the dirty file remains untracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494e759f3248ff756438823e00ddc9c9b074d905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->