### PR TITLE
[codex] Forward project artifacts into worktrees

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Worktree State Projection Module — typed-Interface contract tests for projectRootToWorktree (ADR-016).
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { WorktreeStateProjection } from "../worktree-state-projection.js";
@@ -55,6 +55,43 @@ test("projectRootToWorktree is idempotent — repeated calls do not throw", () =
     projection.projectRootToWorktree(scope);
     projection.projectRootToWorktree(scope);
     assert.ok(true, "two calls did not throw");
+  } finally {
+    cleanup();
+  }
+});
+
+test("projectRootToWorktree forwards root PROJECT.md into isolated worktrees", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const worktree = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+    mkdirSync(join(worktree, ".gsd"), { recursive: true });
+
+    const projectContent = [
+      "# Project",
+      "",
+      "## Milestone Sequence",
+      "",
+      "- [ ] M001: Foundation — Establish the runnable slice.",
+      "",
+    ].join("\n");
+    writeFileSync(join(dir, ".gsd", "PROJECT.md"), projectContent);
+    writeFileSync(join(dir, ".gsd", "REQUIREMENTS.md"), "# Requirements\n");
+    writeFileSync(join(dir, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n");
+
+    const workspace = createWorkspace(worktree);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    projection.projectRootToWorktree(scope);
+
+    const projectedProject = join(worktree, ".gsd", "PROJECT.md");
+    assert.ok(existsSync(projectedProject), "PROJECT.md is available to worktree-bound units");
+    assert.equal(readFileSync(projectedProject, "utf-8"), projectContent);
+    assert.ok(
+      existsSync(join(worktree, ".gsd", "milestones", "M001", "M001-ROADMAP.md")),
+      "milestone artifacts still project into the worktree",
+    );
   } finally {
     cleanup();
   }

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -172,6 +172,35 @@ const ROOT_DIAGNOSTIC_FILES = [
   "metrics.json",
 ] as const;
 
+/**
+ * Root-level .gsd/ projections copied from project root into worktrees for
+ * compatibility reads. Project root remains authoritative; copy-back still
+ * excludes these markdown projections.
+ */
+const ROOT_FORWARD_PROJECTION_FILES = [
+  "DECISIONS.md",
+  "REQUIREMENTS.md",
+  "PROJECT.md",
+  "KNOWLEDGE.md",
+  "OVERRIDES.md",
+  "QUEUE.md",
+  "completed-units.json",
+  "metrics.json",
+  "mcp.json",
+] as const;
+
+function syncRootProjectionFilesToWorktree(prGsd: string, wtGsd: string): void {
+  mkdirSync(wtGsd, { recursive: true });
+
+  for (const file of ROOT_FORWARD_PROJECTION_FILES) {
+    const src = join(prGsd, file);
+    const dst = join(wtGsd, file);
+    if (!existsSync(src) || existsSync(dst)) continue;
+
+    safeCopy(src, dst, { force: false });
+  }
+}
+
 // ─── Implementation cores ────────────────────────────────────────────────
 //
 // The `_*Impl` exports take raw paths so the deprecated path-string
@@ -203,6 +232,10 @@ export function _projectRootToWorktreeImpl(
   // cpSync rejects the copy because source === destination (ERR_FS_CP_EINVAL).
   // Compare realpaths and skip when they resolve to the same physical path (#2184).
   if (isSamePath(prGsd, wtGsd)) return;
+
+  // Root PROJECT/REQUIREMENTS/DECISIONS projections must be readable from a
+  // worktree-bound unit; the project root remains authoritative.
+  syncRootProjectionFilesToWorktree(prGsd, wtGsd);
 
   // Copy milestone directory from project root to worktree — additive only.
   // force:false prevents cpSync from overwriting existing worktree files.


### PR DESCRIPTION
## What changed

- Forward root `.gsd` projection files such as `PROJECT.md`, `REQUIREMENTS.md`, and `DECISIONS.md` from the canonical project state into isolated milestone worktrees.
- Add a regression test proving `PROJECT.md` is available to worktree-bound units while milestone artifacts continue to project correctly.

## Why

Milestone closeout can run inside `.gsd/worktrees/<milestone>`. The newer `WorktreeStateProjection` path projected milestone directories, but not root project artifacts. As a result, a closeout unit could see no `.gsd/PROJECT.md`, synthesize a project artifact without `## Milestone Sequence`, and trigger the misleading zero-parseable-milestone error.

## Impact

Worktree-bound units can read the same root project context that the older sync path provided, while copy-back still keeps project-root and DB state authoritative.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-state-projection.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts`
- `git diff --check -- src/resources/extensions/gsd/worktree-state-projection.ts src/resources/extensions/gsd/tests/worktree-state-projection.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782838784&installation_id=134682257&pr_number=319&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F319&signature=a0cfd430ec922ea1b7eaaac2e8ee6a7e2bc0aef56fa61c03df8c691257a50e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worktree state sync used by milestone closeout and unit dispatch; behavior is additive and scoped, but incorrect file lists or overwrite rules could affect milestone parsing or stale worktree reads.
> 
> **Overview**
> **Root-to-worktree projection** now copies a fixed set of canonical `.gsd` files from the project root into isolated milestone worktrees before milestone directory sync. That includes markdown such as **`PROJECT.md`**, **`REQUIREMENTS.md`**, and **`DECISIONS.md`**, plus JSON/config like **`completed-units.json`**, **`metrics.json`**, and **`mcp.json`**. Copies are **additive only** (skip if the worktree already has the file; `force: false`).
> 
> **Copy-back is unchanged**: merge/finalize still only pulls diagnostic JSON from the worktree; root markdown stays project-root/DB authoritative.
> 
> A **regression test** asserts that `projectRootToWorktree` makes root **`PROJECT.md`** readable in an isolated worktree (with milestone artifacts still projected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af8f0d180c96c1c0e949e5c46060a363ada4194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->