### PR TITLE
[codex] Fix PROD publishing workflow

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -15,7 +15,7 @@ on:
           - "false"
           - "true"
       publish_auth:
-        description: "npm auth: token creates packages not on npm yet; trusted after first publish"
+        description: "npm auth: token creates/bootstrap-publishes packages; trusted only works if npm trusts build-native.yml"
         required: false
         default: "trusted"
         type: choice

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: ""
       publish_auth:
-        description: "npm auth: token uses NPM_TOKEN; trusted uses OIDC (default)"
+        description: "npm auth fallback: token uses NPM_TOKEN for prerelease/native publishes; trusted uses OIDC (default)"
         required: false
         default: "trusted"
         type: choice
@@ -221,9 +221,126 @@ jobs:
           echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate @opengsd/gsd-pi@${PUBLISH_VERSION} \"broken ${CHANNEL} build; see Actions run\"', (3) cut a fix and re-run NPM Publish."
           exit 1
 
+  prod-release-plan:
+    name: Plan Production Release
+    if: ${{ github.event.inputs.channel == 'latest' }}
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.release.outputs.source_sha }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Generate changelog and determine version
+        id: release
+        run: |
+          OUTPUT=$(node scripts/generate-changelog.mjs)
+          echo "$OUTPUT" | jq .
+          mkdir -p release-metadata
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$(echo "$OUTPUT" | jq -r '.newVersion')" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" | jq -r '.changelogEntry' > release-metadata/changelog-entry.md
+          echo "$OUTPUT" | jq -r '.releaseNotes' > release-metadata/release-notes.md
+
+      - name: Upload release metadata
+        uses: actions/upload-artifact@v5
+        with:
+          name: prod-release-metadata
+          path: release-metadata/
+          if-no-files-found: error
+
+  prod-native-build:
+    name: Build native ${{ matrix.platform }}
+    if: ${{ github.event.inputs.channel == 'latest' }}
+    needs: prod-release-plan
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            platform: darwin-arm64
+          - os: macos-14
+            target: x86_64-apple-darwin
+            platform: darwin-x64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            platform: linux-x64-gnu
+          - os: blacksmith-4vcpu-ubuntu-2404-arm
+            target: aarch64-unknown-linux-gnu
+            platform: linux-arm64-gnu
+            cross: true
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: win32-x64-msvc
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prod-release-plan.outputs.source_sha }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust compilation target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: native-${{ matrix.platform }}
+          workspaces: |
+            native -> target
+
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Build native addon
+        working-directory: native/crates/engine
+        env:
+          # CARGO_ENCODED_RUSTFLAGS overrides target-specific rustflags in
+          # .cargo/config.toml, which sets -C target-cpu=native for dev builds.
+          # CI must produce portable binaries.
+          CARGO_ENCODED_RUSTFLAGS: ""
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.cross && 'aarch64-linux-gnu-gcc' || '' }}
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Prepare artifact (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p artifacts
+          cp native/target/${{ matrix.target }}/release/libgsd_engine.dylib artifacts/gsd_engine.node 2>/dev/null || \
+          cp native/target/${{ matrix.target }}/release/libgsd_engine.so artifacts/gsd_engine.node 2>/dev/null || \
+          { echo "::error::No library found for ${{ matrix.platform }}"; exit 1; }
+          ls -la artifacts/
+
+      - name: Prepare artifact (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir artifacts
+          copy native\target\${{ matrix.target }}\release\gsd_engine.dll artifacts\gsd_engine.node
+
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: native-${{ matrix.platform }}
+          path: artifacts/gsd_engine.node
+          if-no-files-found: error
+
   prod-release:
     name: Production Release
     if: ${{ github.event.inputs.channel == 'latest' }}
+    needs:
+      - prod-release-plan
+      - prod-native-build
     # npm trusted publishing + provenance require GitHub-hosted runners (not Blacksmith).
     runs-on: ubuntu-latest
     environment: prod
@@ -233,6 +350,19 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Verify release source is still current
+        env:
+          RELEASE_SOURCE_SHA: ${{ needs.prod-release-plan.outputs.source_sha }}
+        run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "${CURRENT_SHA}" != "${RELEASE_SOURCE_SHA}" ]; then
+            echo "::error::main moved after the production release was planned."
+            echo "::error::planned=${RELEASE_SOURCE_SHA}"
+            echo "::error::current=${CURRENT_SHA}"
+            echo "::error::Re-run NPM Publish so native binaries, changelog, and package version are computed from the same commit."
+            exit 1
+          fi
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -263,18 +393,15 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GSD_LIVE_TESTS: "1"
 
-      - name: Generate changelog and determine version
-        id: release
-        run: |
-          OUTPUT=$(node scripts/generate-changelog.mjs)
-          echo "$OUTPUT" | jq .
-          echo "version=$(echo "$OUTPUT" | jq -r '.newVersion')" >> "$GITHUB_OUTPUT"
-          echo "$OUTPUT" | jq -r '.changelogEntry' > /tmp/changelog-entry.md
-          echo "$OUTPUT" | jq -r '.releaseNotes' > /tmp/release-notes.md
+      - name: Download release metadata
+        uses: actions/download-artifact@v5
+        with:
+          name: prod-release-metadata
+          path: release-metadata
 
       - name: Bump version and sync packages
         env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: node scripts/bump-version.mjs "$RELEASE_VERSION"
 
       - name: Validate package files after version bump
@@ -286,17 +413,26 @@ jobs:
           echo "All package.json files are valid"
 
       - name: Update CHANGELOG.md
-        run: node scripts/update-changelog.mjs /tmp/changelog-entry.md
+        run: node scripts/update-changelog.mjs release-metadata/changelog-entry.md
 
       - name: Commit and tag release
         env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_SOURCE_SHA: ${{ needs.prod-release-plan.outputs.source_sha }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          REMOTE_MAIN_SHA=$(git rev-parse origin/main)
+          if [ "${REMOTE_MAIN_SHA}" != "${RELEASE_SOURCE_SHA}" ]; then
+            echo "::error::main moved before the release commit could be created."
+            echo "::error::planned=${RELEASE_SOURCE_SHA}"
+            echo "::error::origin/main=${REMOTE_MAIN_SHA}"
+            echo "::error::Re-run NPM Publish so the release includes the latest main."
+            exit 1
+          fi
           git add package.json pnpm-lock.yaml CHANGELOG.md native/Cargo.toml native/Cargo.lock native/npm/*/package.json pkg/package.json packages/*/package.json extensions/google-search/package.json
           git commit -m "release: v${RELEASE_VERSION}"
-          git pull --rebase origin main
           git tag "v${RELEASE_VERSION}"
 
       - name: Build release
@@ -309,6 +445,105 @@ jobs:
           export GSD_SMOKE_BINARY
           pnpm run test:live-regression
 
+      - name: Download native artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: native-*
+          path: artifacts
+          merge-multiple: false
+
+      - name: Copy native binaries to platform packages
+        run: |
+          for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
+            cp "artifacts/native-${platform}/gsd_engine.node" "native/npm/${platform}/gsd_engine.node"
+            echo "Copied binary for ${platform}"
+            ls -la "native/npm/${platform}/"
+          done
+
+      - name: Select native npm publish auth
+        run: |
+          if [ "${{ github.event.inputs.publish_auth || 'trusted' }}" = "token" ]; then
+            echo "Using NPM_TOKEN for native package publish."
+          else
+            echo "Using npm trusted publishing for native package publish."
+          fi
+
+      - name: Require token auth for native packages not on npm yet
+        if: github.event.inputs.publish_auth != 'token'
+        run: |
+          MISSING=()
+          for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
+            PKG="@opengsd/engine-${platform}"
+            if ! npm view "${PKG}" name >/dev/null 2>&1; then
+              MISSING+=("${PKG}")
+            fi
+          done
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::These npm packages do not exist on npm yet:"
+            for pkg in "${MISSING[@]}"; do
+              echo "::error::  - ${pkg}"
+            done
+            echo "::error::Trusted publishing is configured after first publish. Re-run with publish_auth=token and NPM_TOKEN set."
+            exit 1
+          fi
+
+      - name: Verify NPM_TOKEN is configured for native token publish
+        if: github.event.inputs.publish_auth == 'token'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::error::publish_auth=token requires the NPM_TOKEN repository secret."
+            exit 1
+          fi
+          npm whoami
+
+      - name: Publish native platform packages for release version
+        env:
+          ENGINE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
+          TAG_FLAG: --tag latest
+        run: bash scripts/publish-engine-packages.sh
+
+      - name: Verify native platform packages are published
+        env:
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
+        run: |
+          echo "Verifying native platform packages at version ${RELEASE_VERSION}..."
+          DELAY=5
+          for attempt in $(seq 1 5); do
+            FAILED=0
+            for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
+              PKG="@opengsd/engine-${platform}"
+              PUBLISHED=$(npm view "${PKG}@${RELEASE_VERSION}" version 2>/dev/null || echo "")
+              if [ "${PUBLISHED}" != "${RELEASE_VERSION}" ]; then
+                FAILED=1
+                break
+              fi
+            done
+            if [ "${FAILED}" = "0" ]; then
+              echo "All native platform packages verified (attempt ${attempt})."
+              exit 0
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "::error::One or more native platform packages were not visible after 5 attempts."
+              for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
+                PKG="@opengsd/engine-${platform}"
+                PUBLISHED=$(npm view "${PKG}@${RELEASE_VERSION}" version 2>/dev/null || echo "")
+                if [ "${PUBLISHED}" = "${RELEASE_VERSION}" ]; then
+                  echo "  ✓ ${PKG}@${RELEASE_VERSION}"
+                else
+                  echo "  ✗ ${PKG}@${RELEASE_VERSION} (got: '${PUBLISHED}')"
+                fi
+              done
+              exit 1
+            fi
+            echo "  Attempt ${attempt}: not all packages visible yet, retrying in ${DELAY}s..."
+            sleep "${DELAY}"
+            DELAY=$((DELAY * 2))
+            if [ "${DELAY}" -gt 30 ]; then DELAY=30; fi
+          done
+
       - name: Verify native platform packages for release version
         run: pnpm run verify:native-platform-packages
 
@@ -317,7 +552,7 @@ jobs:
 
       - name: Publish release to npm @latest
         env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           trap 'node scripts/postpack-restore-workspace.cjs' EXIT
           node scripts/prepack-resolve-workspace.cjs
@@ -344,7 +579,7 @@ jobs:
 
       - name: Push release commit and tag
         env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           git push origin main
           git push origin "v${RELEASE_VERSION}"
@@ -352,20 +587,20 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           gh release create "v${RELEASE_VERSION}" \
             --title "v${RELEASE_VERSION}" \
-            --notes-file /tmp/release-notes.md \
+            --notes-file release-metadata/release-notes.md \
             --latest
 
       - name: Post to Discord
         if: ${{ env.DISCORD_WEBHOOK != '' }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
-          NOTES=$(cat /tmp/release-notes.md)
+          NOTES=$(cat release-metadata/release-notes.md)
           curl -s -X POST "$DISCORD_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg c "**GSD v${RELEASE_VERSION} Released**\n\n${NOTES}\n\n\`npm i @opengsd/gsd-pi@${RELEASE_VERSION}\`" '{content:$c}')"
@@ -379,7 +614,7 @@ jobs:
 
       - name: Build and push release Docker image
         env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           docker build --target runtime \
             -t ghcr.io/open-gsd/gsd-pi:latest \
@@ -391,7 +626,7 @@ jobs:
       - name: Open back-merge PR main to next if behind
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           if ! git ls-remote --exit-code --heads origin next >/dev/null 2>&1; then
             echo "next branch does not exist yet; skipping back-merge"

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -136,9 +136,9 @@ The pipeline only triggers after `ci.yml` passes. Key gating tests include:
 ### Approving a Prod Release
 
 1. A version reaches the Test stage automatically
-2. In GitHub Actions, run **NPM Publish** with `channel=latest`; the `prod-release` job will show "Waiting for review"
+2. In GitHub Actions, run **NPM Publish** with `channel=latest`; the workflow plans the release, builds all five native binaries, then the `prod-release` job will show "Waiting for review"
 3. Click **Review deployments** → select `prod` → **Approve**
-4. The version is promoted to `@latest` and a GitHub Release is created
+4. The workflow publishes the matching `@opengsd/engine-*` packages, verifies they are visible on npm, publishes `@opengsd/gsd-pi@latest`, pushes the release commit/tag, and creates a GitHub Release
 
 To enable live LLM tests during Prod promotion:
 - Set the `RUN_LIVE_TESTS` environment variable to `true` on the `prod` environment
@@ -167,7 +167,7 @@ For `@dev` or `@next` rollbacks, the next successful merge will overwrite the ta
 | Environment: `dev` | No protection rules |
 | Environment: `test` | No protection rules |
 | Environment: `prod` | Required reviewers: maintainers |
-| Secret: `NPM_TOKEN` | Not required for trusted publishing; set for token-fallback bootstrap (`build-native.yml` → `publish_auth=token`) |
+| Secret: `NPM_TOKEN` | Not required for trusted publishing; set for token-fallback bootstrap/manual native publishes (`publish_auth=token`) |
 | Secret: `ANTHROPIC_API_KEY` | Prod environment only |
 | Secret: `OPENAI_API_KEY` | Prod environment only |
 | Variable: `RUN_LIVE_TESTS` | `false` (set to `true` to enable live LLM tests) |
@@ -200,15 +200,15 @@ Configure **every** package on [npm package settings](https://www.npmjs.com/sett
 | npm package | Trusted Publisher workflow |
 |-------------|---------------------------|
 | `@opengsd/gsd-pi` | `npm-publish.yml` |
-| `@opengsd/engine-darwin-arm64` | `build-native.yml` |
-| `@opengsd/engine-darwin-x64` | `build-native.yml` |
-| `@opengsd/engine-linux-x64-gnu` | `build-native.yml` |
-| `@opengsd/engine-linux-arm64-gnu` | `build-native.yml` |
-| `@opengsd/engine-win32-x64-msvc` | `build-native.yml` |
+| `@opengsd/engine-darwin-arm64` | `npm-publish.yml` |
+| `@opengsd/engine-darwin-x64` | `npm-publish.yml` |
+| `@opengsd/engine-linux-x64-gnu` | `npm-publish.yml` |
+| `@opengsd/engine-linux-arm64-gnu` | `npm-publish.yml` |
+| `@opengsd/engine-win32-x64-msvc` | `npm-publish.yml` |
 
 For all packages: repository **`open-gsd/gsd-pi`**, environment **(none)**.
 
-After trusted publishing is configured, use `publish_auth=trusted` (default) for routine native publishes.
+After trusted publishing is configured, use **NPM Publish** with `channel=latest` and `publish_auth=trusted` (default) for routine production publishes. The standalone **Build Native Binaries** workflow remains useful for manual binary builds and token-based bootstrap publishes, but trusted production native package publishing belongs to `npm-publish.yml` so the prod workflow can publish a single coherent version end to end.
 
 ### Docker Images
 

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -30,6 +30,10 @@ test("production publish keeps the prod approval gate", () => {
     workflow.jobs["prod-release"].if,
     "${{ github.event.inputs.channel == 'latest' }}",
   );
+  assert.deepEqual(workflow.jobs["prod-release"].needs, [
+    "prod-release-plan",
+    "prod-native-build",
+  ]);
   assert.equal(workflow.jobs["prod-release"].environment, "prod");
 });
 
@@ -65,6 +69,37 @@ test("publish jobs use GitHub-hosted runners for npm provenance", () => {
   assert.equal(workflow.jobs["prod-release"]["runs-on"], "ubuntu-latest");
 });
 
+test("production publish plans the release and builds native artifacts in the same workflow", () => {
+  const plan = workflow.jobs["prod-release-plan"];
+  const nativeBuild = workflow.jobs["prod-native-build"];
+
+  assert.ok(plan, "production publish must plan the release version");
+  assert.equal(plan.if, "${{ github.event.inputs.channel == 'latest' }}");
+  assert.equal(plan.outputs.version, "${{ steps.release.outputs.version }}");
+  assert.equal(plan.outputs.source_sha, "${{ steps.release.outputs.source_sha }}");
+  assert.ok(
+    plan.steps.some((step) => step.uses === "actions/upload-artifact@v5"),
+    "release metadata must be passed to the gated publish job",
+  );
+
+  assert.ok(nativeBuild, "production publish must build native binaries");
+  assert.equal(nativeBuild.needs, "prod-release-plan");
+  assert.deepEqual(
+    nativeBuild.strategy.matrix.include.map((entry) => entry.platform).sort(),
+    [
+      "darwin-arm64",
+      "darwin-x64",
+      "linux-arm64-gnu",
+      "linux-x64-gnu",
+      "win32-x64-msvc",
+    ],
+  );
+  assert.ok(
+    nativeBuild.steps.some((step) => step.uses === "actions/upload-artifact@v5"),
+    "native artifacts must be uploaded for the production release job",
+  );
+});
+
 test("npm publish opts into Node 24 actions runtime and quiet npm install noise", () => {
   assert.equal(workflow.env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, "true");
   assert.equal(workflow.env.NPM_CONFIG_AUDIT, "false");
@@ -88,16 +123,29 @@ test("main package publish verifies native engine packages first", () => {
   assert.ok(prereleaseVerifyIndex > -1 && prereleaseVerifyIndex < prereleasePublishIndex);
 
   const prodSteps = workflow.jobs["prod-release"].steps;
+  const prodNativePublish = prodSteps.find(
+    (step) => step.name === "Publish native platform packages for release version",
+  );
   const prodVerify = prodSteps.find(
     (step) => step.name === "Verify native platform packages for release version",
   );
   const prodPublishIndex = prodSteps.findIndex(
     (step) => step.name === "Publish release to npm @latest",
   );
+  const prodNativePublishIndex = prodSteps.indexOf(prodNativePublish);
   const prodVerifyIndex = prodSteps.indexOf(prodVerify);
 
+  assert.ok(prodNativePublish, "production publish must publish native packages");
+  assert.match(prodNativePublish.run, /publish-engine-packages\.sh/);
+  assert.equal(
+    prodNativePublish.env.ENGINE_VERSION,
+    "${{ needs.prod-release-plan.outputs.version }}",
+  );
   assert.ok(prodVerify, "production publish must verify native packages");
   assert.match(prodVerify.run, /npm run verify:native-platform-packages/);
+  assert.ok(
+    prodNativePublishIndex > -1 && prodNativePublishIndex < prodVerifyIndex,
+  );
   assert.ok(prodVerifyIndex > -1 && prodVerifyIndex < prodPublishIndex);
 });
 

--- a/scripts/verify-native-platform-packages.mjs
+++ b/scripts/verify-native-platform-packages.mjs
@@ -45,6 +45,6 @@ for (const spec of missing) {
 process.stderr.write(
   allowAnyVersion
     ? "Publish the missing @opengsd/engine-* packages before publishing @opengsd/gsd-pi.\nRun Build Native Binaries (build-native.yml) with publish=true, platform_packages_only=true, publish_auth=token.\nPackages must exist on npm before trusted publishing can be configured — see docs/dev/ci-cd-pipeline.md.\n"
-    : "Run the native binary publish workflow for this version before publishing @opengsd/gsd-pi.\n",
+    : "Publish the native platform packages for this version before publishing @opengsd/gsd-pi. The production NPM Publish workflow does this automatically before the main package publish.\n",
 );
 process.exit(1);


### PR DESCRIPTION
## Summary

- Make `npm-publish.yml` own the full `channel=latest` release path: plan the release, build all five native binaries, publish matching `@opengsd/engine-*` packages, verify them, then publish `@opengsd/gsd-pi@latest`.
- Keep the existing `prod` environment approval gate before any production publishing.
- Update workflow regression tests, release docs, and native verification messaging for the single-workflow PROD path.

## Root Cause

The previous PROD workflow bumped and tagged the release locally, then checked npm for `@opengsd/engine-*` packages at the new version before the separate native workflow had any chance to publish those packages.

## Validation

- `node --test scripts/__tests__/npm-publish-workflow.test.mjs scripts/__tests__/build-native-workflow.test.mjs scripts/__tests__/sync-platform-versions.test.mjs`
- `git diff --check`
- `node --check scripts/verify-native-platform-packages.mjs`
- `bash -n scripts/publish-engine-packages.sh`

## Notes

For trusted npm publishing, the five `@opengsd/engine-*` packages need their trusted publisher workflow set to `npm-publish.yml` so the single PROD workflow can publish them with OIDC.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782844461&installation_id=134682257&pr_number=320&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F320&signature=84adfdd8adca690a183afbbf1f2702ea8f95d650a3470d89dac2e577f7ea053d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production npm release and tagging path (version coherence, native publish order, trusted-publisher workflow binding); mitigated by existing prod approval gate and expanded workflow regression tests.
> 
> **Overview**
> **Production `channel=latest` publishing is consolidated into `npm-publish.yml`** so version planning, native builds, engine package publish, and `@opengsd/gsd-pi@latest` happen in one workflow instead of expecting a separate native run after the main package is already bumped.
> 
> For `latest`, the workflow now adds **`prod-release-plan`** (changelog/version + `source_sha`, metadata artifact) and **`prod-native-build`** (five-platform matrix at the planned commit). **`prod-release`** still waits on the `prod` environment, but only after those jobs finish; it checks that `main` has not moved, bumps from the artifact, commits/tags without rebasing mid-release, copies downloaded native artifacts, publishes and retries verification for `@opengsd/engine-*`, then publishes the main package.
> 
> Docs and workflow tests are updated so trusted publishers for engine packages point at **`npm-publish.yml`**, and `build-native.yml` input descriptions clarify token vs trusted bootstrap. The native verify script error text now tells operators that prod NPM Publish publishes engines automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138c1042560bfd8ff38376914d1319b79c6a98de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->