### PR TITLE
[codex] Fix Claude Code ToolSearch browser remap

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -351,6 +351,9 @@ export function buildPromptFromContext(context: Context, toolContext: PromptTool
 	const toolSearchLine = toolContext.workflowMcpServerName
 		? "- ToolSearch is NOT available — never use it to discover tools; invoke the MCP tool directly\n"
 		: "- ToolSearch is NOT available — never use it to discover tools\n";
+	const browserToolLine =
+		"- Pi/GSD browser_* tools from prior context (for example browser_navigate, browser_find, browser_evaluate, browser_close) are not Claude Code tools. " +
+		"Never use ToolSearch to select browser_* tools; for browser verification, use Bash to run a local Playwright/Node check unless an explicit browser MCP tool is already listed.\n";
 
 	// The prior system context lists pi-native tool names (lowercase: bash, read, gsd_exec, etc.)
 	// but this process runs inside Claude Code where tool names differ. Inject a remapping note
@@ -362,6 +365,7 @@ export function buildPromptFromContext(context: Context, toolContext: PromptTool
 			"- Shell commands: 'Bash' (not 'bash')\n" +
 			"- File operations: 'Read', 'Write', 'Edit', 'Glob', 'Grep' (PascalCase, not lowercase)\n" +
 			workflowToolLine +
+			browserToolLine +
 			toolSearchLine +
 			"</tool_context>",
 	);
@@ -1523,7 +1527,11 @@ export function buildSdkOptions(
 	const workflowMcpTools = filteredMcpServers
 		? Object.keys(filteredMcpServers).map((serverName) => `mcp__${serverName}__*`)
 		: (!workflowExplicitlyBlocked && workflowServerName ? [`mcp__${workflowServerName}__*`] : []);
-	const disallowedTools: string[] = [...(workflowMcpTools.length > 0 ? ["AskUserQuestion"] : []), ...extraDisallowedTools];
+	const disallowedTools: string[] = [...new Set([
+		"ToolSearch",
+		...(workflowMcpTools.length > 0 ? ["AskUserQuestion"] : []),
+		...extraDisallowedTools,
+	])];
 	const allowedTools = [
 		"Read",
 		"Write",

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -431,6 +431,20 @@ describe("stream-adapter — no transcript fabrication (#4102)", () => {
 		assert.ok(!prompt.includes("mcp__gsd-workflow__<tool_name>"));
 		assert.ok(!prompt.includes("mcp__gsd-workflow__gsd_exec"));
 	});
+
+	test("buildPromptFromContext remaps pi-native browser tools for Claude Code", () => {
+		const context: Context = {
+			systemPrompt: "Browser verification: use browser_find and browser_navigate.",
+			messages: [{ role: "user", content: "Verify the app" } as Message],
+		};
+
+		const prompt = buildPromptFromContext(context, { workflowMcpServerName: "gsd-workflow" });
+
+		assert.ok(prompt.includes("browser_navigate"), "remap should name stale browser tool examples");
+		assert.ok(prompt.includes("not Claude Code tools"), "remap should explain browser_* is unavailable in Claude Code");
+		assert.ok(prompt.includes("Never use ToolSearch to select browser_* tools"));
+		assert.ok(prompt.includes("Bash to run a local Playwright/Node check"));
+	});
 });
 
 describe("stream-adapter — Claude Code external tool results", () => {
@@ -925,7 +939,7 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			assert.equal(srv.env.GSD_CLI_PATH, "/tmp/gsd");
 			assert.equal(srv.env.GSD_PERSIST_WRITE_GATE_STATE, "1");
 			assert.equal(srv.env.GSD_WORKFLOW_PROJECT_ROOT, "/tmp/project");
-			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
+			assert.deepEqual(options.disallowedTools, ["ToolSearch", "AskUserQuestion"]);
 			assert.deepEqual(options.allowedTools, [
 				"Read",
 				"Write",
@@ -961,7 +975,7 @@ describe("stream-adapter — session persistence (#2859)", () => {
 				const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
 				const mcpServers = options.mcpServers as Record<string, any>;
 			assert.ok(mcpServers?.["custom-workflow"], "expected custom workflow server config");
-			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
+			assert.deepEqual(options.disallowedTools, ["ToolSearch", "AskUserQuestion"]);
 			assert.deepEqual(options.allowedTools, [
 				"Read",
 				"Write",
@@ -1005,9 +1019,9 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			const mcpServers = (options as any).mcpServers;
 			if (mcpServers) {
 				assert.ok(mcpServers["gsd-workflow"], "if present, must be gsd-workflow");
-				assert.deepEqual((options as any).disallowedTools, ["AskUserQuestion"]);
+				assert.deepEqual((options as any).disallowedTools, ["ToolSearch", "AskUserQuestion"]);
 			} else {
-				assert.deepEqual((options as any).disallowedTools, []);
+				assert.deepEqual((options as any).disallowedTools, ["ToolSearch"]);
 			}
 			rmSync(emptyDir, { recursive: true, force: true });
 		} finally {
@@ -1046,7 +1060,7 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			assert.equal(srv.env.GSD_CLI_PATH, "/tmp/gsd");
 			assert.equal(srv.env.GSD_PERSIST_WRITE_GATE_STATE, "1");
 			assert.equal(srv.env.GSD_WORKFLOW_PROJECT_ROOT, resolvedRepoDir);
-			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
+			assert.deepEqual(options.disallowedTools, ["ToolSearch", "AskUserQuestion"]);
 		} finally {
 			process.chdir(originalCwd);
 			rmSync(repoDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes the Claude Code provider path that let GSD-native `browser_*` tool names leak into Claude Code and trigger a failed `ToolSearch` lookup such as `select:browser_navigate,browser_evaluate,browser_find,browser_close`.

## What changed

- Add a Claude Code prompt remap explaining that pi-native `browser_*` tools are not Claude Code tools, and that browser verification should use `Bash` with a local Playwright/Node check unless an explicit browser MCP tool is listed.
- Always disallow `ToolSearch` in Claude Code SDK options so the model does not attempt deferred-tool discovery in this provider path.
- Update stream adapter tests to cover the remap and the new disallowed tool contract.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts --prefer-offline`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` (147/147 pass)

## Notes

The original checkout had unrelated dirty files, so this PR was prepared from a clean worktree based on `origin/main` and includes only the two intended Claude Code provider files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782845559&installation_id=134682257&pr_number=321&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F321&signature=fb167e69a98399bd80794b58341e416c693b763e1182a0d40a8290f21b515ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and SDK allowlist changes only; no auth, data, or payment paths touched.
> 
> **Overview**
> Stops **pi/GSD `browser_*` tool names** from leaking into the Claude Code provider path, where they previously triggered failed **`ToolSearch`** lookups (e.g. selecting `browser_navigate`, `browser_find`).
> 
> The Claude Code prompt’s **`<tool_context>`** block now states that **`browser_*` tools are not Claude Code tools**, that **`ToolSearch` must not be used** to pick them, and that **browser checks should use `Bash`** with a local Playwright/Node script unless an explicit browser MCP tool is already available.
> 
> **`buildSdkOptions`** always adds **`ToolSearch`** to **`disallowedTools`** (deduped with existing entries such as **`AskUserQuestion`** when workflow MCP is active). Tests cover the remap text and the updated disallowed-tool contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00143b4476fadb1abf9206eeb86277d7f25bdee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->