### PR TITLE
docs: add v1.1.1 release highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ GSD runs as a terminal-first TUI with optional browser dashboard controls.
 
 See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Release History](./docs/archive/legacy-release-history.md) for archived history before the `open-gsd/gsd-pi` baseline.
 
+## Latest Release Highlights
+
+`v1.1.1` is the current `latest` npm release. It includes the `1.1.x` feature set plus a release-path patch that waits for npm tarballs to become installable before publishing Docker and GitHub release artifacts.
+
+- **Claude Opus 4.8 support** — Add the latest Claude model option to the generated model catalog.
+- **Better `/gsd` observability** — Add `/gsd usage` and `/gsd context` commands for inspecting session usage and context state.
+- **Sharper skill scoping** — Scope the skill catalog per unit, trim duplicate prompt surfaces, and apply unit-context manifest policy during auto-mode dispatch.
+- **Improved guided installs** — Redesign the `npx @opengsd/gsd-pi@latest` flow so first-time and scripted installs are clearer and more reliable.
+- **Smoother auto-mode progress** — Improve requirements backlog handling, completion summaries, quick branch inference, cleanup logic, and milestone closeout behavior.
+- **Cloud MCP gateway runtime** — Add the local cloud MCP gateway runtime with persisted auth state.
+- **More reliable packages** — Pin native engine packages to the release version and verify npm installability before release Docker images are built.
+
 ## Status
 
 This repository is starting a new development baseline at version `1.0.0` under the `open-gsd/gsd-pi` project.


### PR DESCRIPTION
## Summary
- add a Latest Release Highlights section for v1.1.1
- summarize the 1.1.x user-facing additions and the npm/Docker release reliability fix

## Verification
- git diff --check -- README.md

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782854433&installation_id=134682257&pr_number=323&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F323&signature=d9583ffa804ad8c26980c57cae9bfba04351f4a4125fd0f58b81ea32c7dd393a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or security impact.
> 
> **Overview**
> Adds a **Latest Release Highlights** section to `README.md` immediately after the feature roll-up, so readers see what `v1.1.1` ships without opening the changelog.
> 
> The section states that `v1.1.1` is the current npm `latest` release and summarizes the `1.1.x` user-facing additions (Claude Opus 4.8, `/gsd usage` and `/gsd context`, skill scoping, guided `npx` installs, auto-mode improvements, cloud MCP gateway) plus the release reliability fix that waits for npm tarballs before Docker/GitHub artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 248d59177ebaade7cb685531280a84ffd9fa1760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->