### PR TITLE
docs: keep release highlights user-facing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,13 @@ See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Rele
 
 ## Latest Release Highlights
 
-`v1.1.1` is the current `latest` npm release. It includes the `1.1.x` feature set plus a release-path patch that waits for npm tarballs to become installable before publishing Docker and GitHub release artifacts.
-
 - **Claude Opus 4.8 support** — Add the latest Claude model option to the generated model catalog.
 - **Better `/gsd` observability** — Add `/gsd usage` and `/gsd context` commands for inspecting session usage and context state.
 - **Sharper skill scoping** — Scope the skill catalog per unit, trim duplicate prompt surfaces, and apply unit-context manifest policy during auto-mode dispatch.
 - **Improved guided installs** — Redesign the `npx @opengsd/gsd-pi@latest` flow so first-time and scripted installs are clearer and more reliable.
 - **Smoother auto-mode progress** — Improve requirements backlog handling, completion summaries, quick branch inference, cleanup logic, and milestone closeout behavior.
 - **Cloud MCP gateway runtime** — Add the local cloud MCP gateway runtime with persisted auth state.
-- **More reliable packages** — Pin native engine packages to the release version and verify npm installability before release Docker images are built.
+- **More reliable installs** — Resolve native engine packages to the matching release version across npm installs and Docker images.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- remove internal npm tarball/Docker release-process copy from README highlights
- reword install reliability note from a user-facing perspective

## Verification
- git diff --check origin/main...HEAD -- README.md

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782856002&installation_id=134682257&pr_number=324&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F324&signature=3266708dcd46434abeefa5ca066cca89f4db47e8a89a22c221954baedd4571cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or security impact.
> 
> **Overview**
> The **Latest Release Highlights** section in `README.md` is trimmed so it reads for end users instead of maintainers.
> 
> The intro line that named `v1.1.1` as `latest` and described waiting for npm tarballs before Docker/GitHub release artifacts is **removed**. The reliability bullet is **renamed** from “More reliable packages” to **“More reliable installs”** and the text now describes matching native engine packages to the release version on **npm installs and Docker images**, without release-pipeline jargon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950107e0f419c89a3b990aaa6ac39345356a6ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->