### PR TITLE
test: cover bg-shell lifecycle/utilities and compaction file-ops

### DIFF
--- a/packages/gsd-agent-core/src/compaction/utils.test.ts
+++ b/packages/gsd-agent-core/src/compaction/utils.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AgentMessage } from "@gsd/pi-agent-core";
+
+import {
+	computeFileLists,
+	createFileOps,
+	extractFileOpsFromMessage,
+	formatFileOperations,
+} from "./utils.js";
+
+/** Build an assistant message carrying the given tool calls. */
+function assistantWithToolCalls(
+	calls: Array<{ name: string; arguments: Record<string, unknown> }>,
+): AgentMessage {
+	return {
+		role: "assistant",
+		content: calls.map((call, i) => ({
+			type: "toolCall",
+			id: `tool-${i}`,
+			name: call.name,
+			arguments: call.arguments,
+		})),
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: {
+			input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	} as unknown as AgentMessage;
+}
+
+test("createFileOps returns three empty sets", () => {
+	const ops = createFileOps();
+	assert.equal(ops.read.size, 0);
+	assert.equal(ops.written.size, 0);
+	assert.equal(ops.edited.size, 0);
+});
+
+test("extractFileOpsFromMessage buckets read/write/edit tool calls by path", () => {
+	const ops = createFileOps();
+	extractFileOpsFromMessage(
+		assistantWithToolCalls([
+			{ name: "read", arguments: { path: "src/a.ts" } },
+			{ name: "write", arguments: { path: "src/b.ts" } },
+			{ name: "edit", arguments: { path: "src/c.ts" } },
+		]),
+		ops,
+	);
+
+	assert.deepEqual([...ops.read], ["src/a.ts"]);
+	assert.deepEqual([...ops.written], ["src/b.ts"]);
+	assert.deepEqual([...ops.edited], ["src/c.ts"]);
+});
+
+test("extractFileOpsFromMessage ignores non-assistant messages", () => {
+	const ops = createFileOps();
+	const userMessage = { role: "user", content: "do a thing" } as unknown as AgentMessage;
+	extractFileOpsFromMessage(userMessage, ops);
+	assert.equal(ops.read.size + ops.written.size + ops.edited.size, 0);
+});
+
+test("extractFileOpsFromMessage skips tool calls without a string path and unknown tools", () => {
+	const ops = createFileOps();
+	extractFileOpsFromMessage(
+		assistantWithToolCalls([
+			{ name: "read", arguments: { notAPath: 123 } },
+			{ name: "bash", arguments: { path: "should-be-ignored" } },
+		]),
+		ops,
+	);
+	assert.equal(ops.read.size, 0);
+	assert.equal(ops.written.size, 0);
+	assert.equal(ops.edited.size, 0);
+});
+
+test("computeFileLists treats a file as modified (not read) when both read and written", () => {
+	const ops = createFileOps();
+	ops.read.add("shared.ts");
+	ops.read.add("only-read.ts");
+	ops.written.add("shared.ts");
+	ops.edited.add("edited.ts");
+
+	const { readFiles, modifiedFiles } = computeFileLists(ops);
+
+	assert.deepEqual(readFiles, ["only-read.ts"]);
+	assert.deepEqual(modifiedFiles, ["edited.ts", "shared.ts"]);
+});
+
+test("computeFileLists returns sorted lists", () => {
+	const ops = createFileOps();
+	ops.read.add("z.ts");
+	ops.read.add("a.ts");
+	ops.edited.add("m.ts");
+	ops.written.add("b.ts");
+
+	const { readFiles, modifiedFiles } = computeFileLists(ops);
+	assert.deepEqual(readFiles, ["a.ts", "z.ts"]);
+	assert.deepEqual(modifiedFiles, ["b.ts", "m.ts"]);
+});
+
+test("formatFileOperations emits both XML sections when present", () => {
+	const out = formatFileOperations(["r1.ts", "r2.ts"], ["m1.ts"]);
+	assert.match(out, /<read-files>\nr1\.ts\nr2\.ts\n<\/read-files>/);
+	assert.match(out, /<modified-files>\nm1\.ts\n<\/modified-files>/);
+});
+
+test("formatFileOperations returns an empty string when there are no files", () => {
+	assert.equal(formatFileOperations([], []), "");
+});
+
+test("formatFileOperations omits the read section when only modified files exist", () => {
+	const out = formatFileOperations([], ["m1.ts"]);
+	assert.ok(!out.includes("<read-files>"));
+	assert.match(out, /<modified-files>/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,21 @@ importers:
       '@mariozechner/clipboard':
         specifier: 0.3.6
         version: 0.3.6
+      '@opengsd/engine-darwin-arm64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-darwin-x64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-arm64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-x64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.1.1
+        version: 1.1.1
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1909,6 +1924,31 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-Z0lJq5f+WCQnox3ZJzaz0hZWp0iC9Pmzx1A9TGZ95b/UX+3woDJf3mZ3HX2KiiuhKkMVTGyvzwyKfuvylA+7xw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-Wi7xWysu6LsRH7ZBJszy+VtpZJETLeqAZ3/dG0CzjDK0VRAew+8nkZhpvDu1IipHZqsIHtCIhYKOk5apdRXK0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-8Asyr1Oj+0aszi2rMqRkbyFC+SHTFxqcB6fNnfo7zB+T0CGlH4EdrDfShz08OuZqfj1B3rOTp5EFsqVnUhYNgw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-bOQciYjimEbSzmuUKZPciTEJTWWUwKn1PoU3AVNb5EZq+C0Roj5FnsMgP5/pKV54ZoSPR0nSedH+DVKUHxc8dA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-56WdCcORvLj4FHAG5AJTDSdzeV7m7at6CcYjcGpf1fZtWz/0gGz9zTC10125gewQZiKgD0/sxXcxTtxTCC3Fpw==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -7711,6 +7751,21 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/resources/extensions/bg-shell/tests/lifecycle-and-utilities.test.ts
+++ b/src/resources/extensions/bg-shell/tests/lifecycle-and-utilities.test.ts
@@ -1,0 +1,206 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type { BgProcess } from "../types.ts";
+import { detectProcessType } from "../process-manager.ts";
+import { waitForReady } from "../readiness-detector.ts";
+import {
+  formatTimeAgo,
+  getBgShellLiveCwd,
+  resolveBgShellPersistenceCwd,
+} from "../utilities.ts";
+
+function makeBg(overrides: Partial<BgProcess> = {}): BgProcess {
+  return {
+    id: "bg-1",
+    label: "test",
+    command: "npm test",
+    cwd: "/tmp",
+    ownerSessionFile: null,
+    persistAcrossSessions: false,
+    startedAt: Date.now() - 1000,
+    proc: {} as BgProcess["proc"],
+    output: [],
+    exitCode: null,
+    signal: null,
+    alive: true,
+    lastReadIndex: 0,
+    processType: "server",
+    status: "starting",
+    ports: [],
+    urls: [],
+    recentErrors: [],
+    recentWarnings: [],
+    events: [],
+    lastErrorCount: 0,
+    lastWarningCount: 0,
+    readyPattern: null,
+    readyPort: null,
+    wasReady: false,
+    group: null,
+    stdoutLineCount: 0,
+    stderrLineCount: 0,
+    restartCount: 0,
+    startConfig: {
+      command: "npm test",
+      cwd: "/tmp",
+      label: "test",
+      processType: "server",
+      ownerSessionFile: null,
+      persistAcrossSessions: false,
+      readyPattern: null,
+      readyPort: null,
+      group: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("bg-shell detectProcessType", () => {
+  const cases: Array<[string, BgProcess["processType"]]> = [
+    ["npm run dev", "server"],
+    ["pnpm next start", "server"],
+    ["uvicorn main:app", "server"],
+    ["http-server ./public", "server"],
+    ["pnpm build", "build"],
+    ["tsc --noEmit", "build"],
+    ["tsc --watch", "watcher"],
+    ["webpack --watch", "watcher"],
+    ["npm test", "test"],
+    ["vitest run", "test"],
+    ["pytest tests/", "test"],
+    ["nodemon app.js", "watcher"],
+    ["fswatch src", "watcher"],
+    ["cat file.txt", "generic"],
+    ["echo hello", "generic"],
+  ];
+
+  for (const [command, expected] of cases) {
+    test(`classifies "${command}" as ${expected}`, () => {
+      assert.equal(detectProcessType(command), expected);
+    });
+  }
+
+  test("classification is case-insensitive", () => {
+    assert.equal(detectProcessType("NPM RUN DEV"), "server");
+  });
+});
+
+describe("bg-shell waitForReady", () => {
+  test("resolves ready immediately when status is already ready", async () => {
+    const bg = makeBg({
+      status: "ready",
+      events: [{ type: "ready", timestamp: Date.now(), detail: "listening on 3000" }],
+    });
+    const result = await waitForReady(bg, 1000);
+    assert.equal(result.ready, true);
+    assert.equal(result.detail, "listening on 3000");
+  });
+
+  test("reports failure with exit code when the process died before ready", async () => {
+    const bg = makeBg({
+      alive: false,
+      exitCode: 137,
+      output: [{ stream: "stderr", line: "killed", ts: Date.now() }],
+    });
+    const result = await waitForReady(bg, 1000);
+    assert.equal(result.ready, false);
+    assert.match(result.detail, /exited before becoming ready/);
+    assert.match(result.detail, /137/);
+  });
+
+  test("reports failure when the process entered an error state", async () => {
+    const bg = makeBg({ status: "error", readyPort: 5173 });
+    const result = await waitForReady(bg, 1000);
+    assert.equal(result.ready, false);
+    assert.match(result.detail, /error state/);
+  });
+
+  test("honors an already-aborted signal", async () => {
+    const bg = makeBg();
+    const result = await waitForReady(bg, 1000, AbortSignal.abort());
+    assert.equal(result.ready, false);
+    assert.equal(result.detail, "Cancelled");
+  });
+
+  test("times out while the process stays in starting", async () => {
+    const bg = makeBg({ status: "starting" });
+    const result = await waitForReady(bg, 10);
+    assert.equal(result.ready, false);
+    assert.match(result.detail, /Timed out after 10ms/);
+  });
+});
+
+describe("bg-shell formatTimeAgo", () => {
+  test("appends ' ago' to a formatted duration", () => {
+    const out = formatTimeAgo(Date.now() - 5000);
+    assert.equal(typeof out, "string");
+    assert.ok(out.endsWith(" ago"), `expected "${out}" to end with " ago"`);
+  });
+});
+
+describe("bg-shell getBgShellLiveCwd", () => {
+  test("returns process.cwd() when it is available", () => {
+    const result = getBgShellLiveCwd(
+      undefined,
+      () => true,
+      () => "/live/cwd",
+    );
+    assert.equal(result, "/live/cwd");
+  });
+
+  test("falls back to the project root derived from an auto-worktree path", () => {
+    const chdirCalls: string[] = [];
+    const result = getBgShellLiveCwd(
+      "/proj/.gsd/worktrees/abc/sub",
+      (p) => p === "/proj",
+      () => {
+        throw new Error("getcwd: no such file or directory");
+      },
+      (p) => chdirCalls.push(p),
+    );
+    assert.equal(result, "/proj");
+    assert.deepEqual(chdirCalls, ["/proj"]);
+  });
+
+  test("falls back to root when no candidate directory exists", () => {
+    const result = getBgShellLiveCwd(
+      undefined,
+      () => false,
+      () => {
+        throw new Error("getcwd failed");
+      },
+      () => {},
+    );
+    assert.equal(result, "/");
+  });
+});
+
+describe("bg-shell resolveBgShellPersistenceCwd", () => {
+  const exists = () => true;
+
+  test("keeps the cached cwd when it is not an auto-worktree", () => {
+    const result = resolveBgShellPersistenceCwd("/home/user/project", "/somewhere/else", exists);
+    assert.equal(result, "/home/user/project");
+  });
+
+  test("keeps the cached worktree when it matches the live cwd and still exists", () => {
+    const worktree = "/proj/.gsd/worktrees/feature-a";
+    const result = resolveBgShellPersistenceCwd(worktree, worktree, exists);
+    assert.equal(result, worktree);
+  });
+
+  test("falls back to the live cwd when the cached worktree no longer exists", () => {
+    const worktree = "/proj/.gsd/worktrees/feature-a";
+    const result = resolveBgShellPersistenceCwd(worktree, "/proj", (p) => p !== worktree);
+    assert.equal(result, "/proj");
+  });
+
+  test("prefers the live cwd when it diverges from an existing cached worktree", () => {
+    const result = resolveBgShellPersistenceCwd(
+      "/proj/.gsd/worktrees/feature-a",
+      "/proj/.gsd/worktrees/feature-b",
+      exists,
+    );
+    assert.equal(result, "/proj/.gsd/worktrees/feature-b");
+  });
+});


### PR DESCRIPTION
Adds unit tests for two previously-untested areas surfaced by the test
coverage audit (audit:test-matrix):

Command/shell execution & background processes (bg-shell):
- detectProcessType: table-driven classification across server/build/
  watcher/test/generic commands
- waitForReady: ready/exited/error/aborted/timeout transitions
- formatTimeAgo, getBgShellLiveCwd, resolveBgShellPersistenceCwd:
  cwd fallback and auto-worktree persistence logic (dependency-injected)

Session runtime & compaction (gsd-agent-core compaction/utils.ts):
- createFileOps / extractFileOpsFromMessage / computeFileLists /
  formatFileOperations: file-operation tracking used when building
  compaction summaries (read-vs-modified bucketing, sorting, XML framing)

https://claude.ai/code/session_01GetaEMZHsya6jeAeLMLzrq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782865923&installation_id=134682257&pr_number=325&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F325&signature=1a2386e4c633a81648cac3f792383b6b2cbe5e92f3394ca2a92fdd52c071a827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions and lockfile optional dependency metadata; no runtime logic changes in application code.
> 
> **Overview**
> Adds **unit test coverage** for two areas flagged by the test-matrix audit, without changing production behavior.
> 
> **Compaction (`gsd-agent-core`)** — New tests lock in file-operation tracking used in compaction summaries: empty ops, extracting `read`/`write`/`edit` paths from assistant tool calls (ignoring non-assistant messages, bad paths, and unrelated tools), read-vs-modified bucketing when a path is both read and written, sorted lists, and XML `<read-files>` / `<modified-files>` formatting (including empty and read-only-omitted cases).
> 
> **Background shell (`bg-shell`)** — New tests cover command classification (`detectProcessType`), readiness polling (`waitForReady` for ready, exit, error, abort, timeout), `formatTimeAgo`, and cwd helpers (`getBgShellLiveCwd` / `resolveBgShellPersistenceCwd`) with injected filesystem/process behavior for worktree fallbacks.
> 
> The **lockfile** also records optional per-platform `@opengsd/engine-*@1.1.1` optional dependencies; no application source changes beyond the new test files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c24aac114858262e38841a00f1b40f13f3850897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->