### PR TITLE
fix(memory): plug long-running service leaks and bound unbounded growth

### DIFF
--- a/packages/cloud-mcp-gateway/src/runtime-registry.ts
+++ b/packages/cloud-mcp-gateway/src/runtime-registry.ts
@@ -23,6 +23,8 @@ interface PendingCall {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  /** Detaches the abort listener from the caller's signal on resolution. */
+  removeAbortListener: () => void;
 }
 
 export interface GatewayToolCall {
@@ -153,11 +155,16 @@ export class RuntimeRegistry {
     };
 
     return new Promise((resolve, reject) => {
+      // Removes the abort listener so a long-lived signal reused across many
+      // calls doesn't retain a listener per resolved call.
+      const removeAbortListener = () => {
+        call.signal?.removeEventListener("abort", abort);
+      };
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        removeAbortListener();
         reject(new Error(`Timed out waiting for Local GSD Runtime response to ${call.toolName}`));
       }, 10 * 60 * 1000);
-      this.pending.set(requestId, { runtimeId: runtime.runtimeId, toolName: call.toolName, resolve, reject, timer });
 
       const abort = () => {
         this.send(runtime, { type: "cancel", requestId });
@@ -165,13 +172,22 @@ export class RuntimeRegistry {
         clearTimeout(timer);
         reject(new Error(`${call.toolName} cancelled by client`));
       };
+      this.pending.set(requestId, {
+        runtimeId: runtime.runtimeId,
+        toolName: call.toolName,
+        resolve,
+        reject,
+        timer,
+        removeAbortListener,
+      });
+
       if (call.signal?.aborted) return abort();
       call.signal?.addEventListener("abort", abort, { once: true });
 
       try {
         this.send(runtime, payload);
       } catch (err) {
-        call.signal?.removeEventListener("abort", abort);
+        removeAbortListener();
         this.pending.delete(requestId);
         clearTimeout(timer);
         reject(err instanceof Error ? err : new Error(String(err)));
@@ -206,6 +222,7 @@ export class RuntimeRegistry {
       if (!pending) return;
       this.pending.delete(message.requestId);
       clearTimeout(pending.timer);
+      pending.removeAbortListener();
       if (message.error) pending.reject(new Error(message.error));
       else pending.resolve(message.result);
     }
@@ -223,6 +240,7 @@ export class RuntimeRegistry {
       if (pending.runtimeId !== runtimeId) continue;
       this.pending.delete(requestId);
       clearTimeout(pending.timer);
+      pending.removeAbortListener();
       pending.reject(new Error(`${message} while waiting for ${pending.toolName}`));
     }
   }

--- a/packages/daemon/src/cloud-runtime.ts
+++ b/packages/daemon/src/cloud-runtime.ts
@@ -66,8 +66,14 @@ export class CloudRuntime {
     });
     const previousSocket = this.socket;
     this.socket = socket;
-    if (previousSocket && previousSocket.readyState !== WebSocket.CLOSING && previousSocket.readyState !== WebSocket.CLOSED) {
-      previousSocket.close();
+    if (previousSocket) {
+      // Detach the old socket's handlers before closing so its listeners don't
+      // linger on a socket we've already replaced (handlers also guard on
+      // identity, but this releases them eagerly for GC).
+      previousSocket.removeAllListeners();
+      if (previousSocket.readyState !== WebSocket.CLOSING && previousSocket.readyState !== WebSocket.CLOSED) {
+        previousSocket.close();
+      }
     }
 
     socket.on("open", () => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,5 +1,6 @@
 import type { DaemonConfig, ProjectInfo } from './types.js';
 import type { Logger } from './logger.js';
+import type { DiscordMessageLike } from './orchestrator.js';
 import { SessionManager } from './session-manager.js';
 import { scanForProjects } from './project-scanner.js';
 import { DiscordBot, validateDiscordConfig } from './discord-bot.js';
@@ -22,6 +23,7 @@ export class Daemon {
   private discordBot: DiscordBot | undefined;
   private eventBridge: EventBridge | undefined;
   private orchestrator: Orchestrator | undefined;
+  private removeOrchestratorListener: (() => void) | undefined;
   private cloudRuntime: CloudRuntime | undefined;
 
   constructor(
@@ -93,9 +95,18 @@ export class Daemon {
               logger: this.logger,
               ownerId: this.config.discord.owner_id,
             });
-            client.on('messageCreate', (message) => {
-              void this.orchestrator!.handleMessage(message);
-            });
+            // Named handler so it can be removed on shutdown. Guard against a
+            // null orchestrator: shutdown nulls `this.orchestrator` before the
+            // Discord client is destroyed, so a late message must be a no-op
+            // rather than throw on `this.orchestrator!`.
+            const orchestratorMessageHandler = (message: DiscordMessageLike): void => {
+              if (!this.orchestrator) return;
+              void this.orchestrator.handleMessage(message);
+            };
+            client.on('messageCreate', orchestratorMessageHandler);
+            this.removeOrchestratorListener = () => {
+              client.off('messageCreate', orchestratorMessageHandler);
+            };
             this.logger.info('orchestrator wired', {
               control_channel_id: this.config.discord.control_channel_id,
             });
@@ -184,7 +195,11 @@ export class Daemon {
       this.keepaliveTimer = undefined;
     }
 
-    // Stop Orchestrator first
+    // Stop Orchestrator first — detach its Discord listener before nulling it.
+    if (this.removeOrchestratorListener) {
+      this.removeOrchestratorListener();
+      this.removeOrchestratorListener = undefined;
+    }
     if (this.orchestrator) {
       this.orchestrator.stop();
       this.orchestrator = undefined;

--- a/packages/daemon/src/event-bridge.ts
+++ b/packages/daemon/src/event-bridge.ts
@@ -75,6 +75,8 @@ export class EventBridge {
   private readonly batchers = new Map<string, MessageBatcher>();
   /** sessionId → TextChannel (cached for send operations) */
   private readonly channels = new Map<string, TextChannel>();
+  /** sessionId → active blocker button collectors (stopped on cleanup) */
+  private readonly collectors = new Map<string, Set<{ stop: (reason?: string) => void }>>();
 
   private readonly verbosity = new VerbosityManager();
 
@@ -84,6 +86,7 @@ export class EventBridge {
     event: (...args: unknown[]) => void;
     blocked: (...args: unknown[]) => void;
     completed: (...args: unknown[]) => void;
+    cancelled: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
     messageCreate: (msg: Message) => void;
   } | null = null;
@@ -118,6 +121,9 @@ export class EventBridge {
       completed: (data: unknown) => {
         void this.onSessionCompleted(data as SessionCompletedPayload);
       },
+      cancelled: (data: unknown) => {
+        void this.onSessionCancelled(data as SessionCancelledPayload);
+      },
       error: (data: unknown) => {
         void this.onSessionError(data as SessionErrorPayload);
       },
@@ -130,6 +136,7 @@ export class EventBridge {
     this.sessionManager.on('session:event', this.boundHandlers.event);
     this.sessionManager.on('session:blocked', this.boundHandlers.blocked);
     this.sessionManager.on('session:completed', this.boundHandlers.completed);
+    this.sessionManager.on('session:cancelled', this.boundHandlers.cancelled);
     this.sessionManager.on('session:error', this.boundHandlers.error);
     this.client.on('messageCreate', this.boundHandlers.messageCreate);
 
@@ -143,10 +150,17 @@ export class EventBridge {
       this.sessionManager.off('session:event', this.boundHandlers.event);
       this.sessionManager.off('session:blocked', this.boundHandlers.blocked);
       this.sessionManager.off('session:completed', this.boundHandlers.completed);
+      this.sessionManager.off('session:cancelled', this.boundHandlers.cancelled);
       this.sessionManager.off('session:error', this.boundHandlers.error);
       this.client.off('messageCreate', this.boundHandlers.messageCreate);
       this.boundHandlers = null;
     }
+
+    // Stop any still-active blocker collectors so their 24h timers don't linger.
+    for (const set of this.collectors.values()) {
+      for (const collector of set) collector.stop('shutdown');
+    }
+    this.collectors.clear();
 
     // Destroy all batchers
     const destroyPromises: Promise<void>[] = [];
@@ -269,6 +283,14 @@ export class EventBridge {
     this.logger.info('bridge: session completed', { sessionId, projectName });
   }
 
+  private async onSessionCancelled(data: SessionCancelledPayload): Promise<void> {
+    const { sessionId, projectName } = data;
+    // Cancellation has no completion embed to flush — just tear down the
+    // batcher, channel mappings, and any active blocker collectors.
+    await this.cleanupSession(sessionId);
+    this.logger.info('bridge: session cancelled', { sessionId, projectName });
+  }
+
   private async onSessionError(data: SessionErrorPayload): Promise<void> {
     const { sessionId, projectName, error } = data;
     const batcher = this.batchers.get(sessionId);
@@ -300,6 +322,16 @@ export class EventBridge {
           return interaction.customId.startsWith(`blocker:${blocker.id}:`);
         },
       });
+
+      // Track the collector so a session that completes/cancels/errors before
+      // the blocker is answered doesn't leave the 24h timer (and its closures)
+      // alive. Untrack on 'end'.
+      let collectorSet = this.collectors.get(sessionId);
+      if (!collectorSet) {
+        collectorSet = new Set();
+        this.collectors.set(sessionId, collectorSet);
+      }
+      collectorSet.add(collector);
 
       collector.on('collect', async (interaction: MessageComponentInteraction) => {
         // Auth guard
@@ -333,6 +365,12 @@ export class EventBridge {
       });
 
       collector.on('end', (_collected, reason) => {
+        // Untrack — the collector is no longer active regardless of reason.
+        const set = this.collectors.get(sessionId);
+        if (set) {
+          set.delete(collector);
+          if (set.size === 0) this.collectors.delete(sessionId);
+        }
         if (reason === 'time') {
           // Timeout: edit to show expired
           this.logger.info('bridge: blocker collector timed out', { sessionId, blockerId: blocker.id });
@@ -442,6 +480,13 @@ export class EventBridge {
   // -----------------------------------------------------------------------
 
   private async cleanupSession(sessionId: string): Promise<void> {
+    // Stop any active blocker collectors (each holds a 24h timer + closures).
+    const collectorSet = this.collectors.get(sessionId);
+    if (collectorSet) {
+      for (const collector of collectorSet) collector.stop('session-ended');
+      this.collectors.delete(sessionId);
+    }
+
     const batcher = this.batchers.get(sessionId);
     if (batcher) {
       await batcher.destroy();
@@ -451,6 +496,7 @@ export class EventBridge {
     const channelId = this.sessionToChannel.get(sessionId);
     if (channelId) {
       this.channelToSession.delete(channelId);
+      this.verbosity.clearLevel(channelId);
     }
     this.sessionToChannel.delete(sessionId);
     this.channels.delete(sessionId);
@@ -481,6 +527,12 @@ interface SessionBlockedPayload {
 }
 
 interface SessionCompletedPayload {
+  sessionId: string;
+  projectDir: string;
+  projectName: string;
+}
+
+interface SessionCancelledPayload {
   sessionId: string;
   projectDir: string;
   projectName: string;

--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -819,4 +819,86 @@ describe('SessionManager', () => {
     assert.ok(session);
     assert.equal(session.projectName, 'dir-lookup');
   });
+
+  // ---- Bounded terminal-session retention (memory) ----
+
+  /** Drive a session to the 'completed' terminal state via a stop notification. */
+  function completeViaNotify(client: MockRpcClient): void {
+    client.emitEvent({
+      type: 'extension_ui_request',
+      id: 'done',
+      method: 'notify',
+      message: 'Auto-mode stopped: complete',
+    });
+  }
+
+  // MAX_TERMINAL_SESSIONS in session-manager.ts.
+  const TERMINAL_RETENTION_CAP = 50;
+
+  it('retains completed sessions for inspection up to the retention cap', async () => {
+    const { manager } = createManager();
+
+    for (let i = 0; i < TERMINAL_RETENTION_CAP; i++) {
+      const id = await manager.startSession({ projectDir: `/tmp/retain-${i}` });
+      completeViaNotify(manager.lastClient!);
+      // Still inspectable after completion (status preserved).
+      assert.equal(manager.getSession(id)!.status, 'completed');
+    }
+
+    assert.equal(manager.getAllSessions().length, TERMINAL_RETENTION_CAP);
+  });
+
+  it('evicts the oldest terminal session beyond the cap and reclaims its process', async () => {
+    const { manager } = createManager();
+
+    const dirs: string[] = [];
+    let oldestClient: MockRpcClient | null = null;
+
+    for (let i = 0; i <= TERMINAL_RETENTION_CAP; i++) {
+      const dir = `/tmp/evict-${i}`;
+      dirs.push(dir);
+      await manager.startSession({ projectDir: dir });
+      if (i === 0) oldestClient = manager.lastClient!;
+      completeViaNotify(manager.lastClient!);
+    }
+
+    // One past the cap → exactly cap retained, oldest evicted.
+    assert.equal(manager.getAllSessions().length, TERMINAL_RETENTION_CAP);
+    assert.equal(manager.getSessionByDir(dirs[0]), undefined);
+    // Evicted session's child process is reclaimed.
+    assert.ok(oldestClient!.stopped);
+    // Newest session is still retained for inspection.
+    assert.ok(manager.getSessionByDir(dirs[TERMINAL_RETENTION_CAP]));
+  });
+
+  // ---- Cancel path emits session:cancelled (symmetric teardown) ----
+
+  it('cancelSession emits session:cancelled with the session payload', async () => {
+    const { manager } = createManager();
+
+    let cancelled: Record<string, unknown> | undefined;
+    manager.on('session:cancelled', (data: Record<string, unknown>) => { cancelled = data; });
+
+    const sessionId = await manager.startSession({ projectDir: '/tmp/cancel-emit' });
+    await manager.cancelSession(sessionId);
+
+    assert.ok(cancelled, 'session:cancelled should be emitted so EventBridge can tear down');
+    assert.equal(cancelled.sessionId, sessionId);
+    assert.ok(String(cancelled.projectDir).endsWith('cancel-emit'));
+    assert.equal(cancelled.projectName, 'cancel-emit');
+  });
+
+  // ---- cleanup empties the sessions map (no retained references) ----
+
+  it('cleanup clears the sessions map', async () => {
+    const { manager } = createManager();
+
+    await manager.startSession({ projectDir: '/tmp/clear-a' });
+    await manager.startSession({ projectDir: '/tmp/clear-b' });
+    assert.equal(manager.getAllSessions().length, 2);
+
+    await manager.cleanup();
+
+    assert.equal(manager.getAllSessions().length, 0);
+  });
 });

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -64,9 +64,23 @@ function isBlockingUIRequest(event: Record<string, unknown>): boolean {
 // SessionManager
 // ---------------------------------------------------------------------------
 
+/** Terminal lifecycle states — work is finished, process may be reclaimed. */
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['completed', 'error', 'cancelled']);
+
+/**
+ * How many terminal (completed/cancelled/errored) sessions to retain for
+ * inspection before evicting the oldest. Bounds heap growth on a daemon that
+ * services many distinct project dirs over its lifetime — without this, every
+ * session ever run stays resident forever (events buffer + RpcClient ref).
+ */
+const MAX_TERMINAL_SESSIONS = 50;
+
 export class SessionManager extends EventEmitter {
   /** Sessions keyed by resolved projectDir for duplicate-start prevention */
   private sessions = new Map<string, ManagedSession>();
+
+  /** Resolved dirs of terminal sessions, oldest-first — for bounded retention. */
+  private terminalOrder: string[] = [];
 
   constructor(private readonly logger: Logger) {
     super();
@@ -91,9 +105,16 @@ export class SessionManager extends EventEmitter {
 
     const existing = this.sessions.get(resolvedDir);
     if (existing) {
-      throw new Error(
-        `Session already active for ${resolvedDir} (sessionId: ${existing.sessionId}, status: ${existing.status})`
-      );
+      // A terminal session (completed/cancelled/error) is retained only for
+      // inspection — it must not block a fresh start for the same dir. Evict it
+      // and reclaim its process before starting anew.
+      if (TERMINAL_STATUSES.has(existing.status)) {
+        this.evictSession(resolvedDir);
+      } else {
+        throw new Error(
+          `Session already active for ${resolvedDir} (sessionId: ${existing.sessionId}, status: ${existing.status})`
+        );
+      }
     }
 
     const cliPath = options.cliPath ?? SessionManager.resolveCLIPath();
@@ -163,7 +184,9 @@ export class SessionManager extends EventEmitter {
       this.logger.error('session error', { sessionId: session.sessionId, projectDir: resolvedDir, error: session.error });
       this.emit('session:error', { sessionId: session.sessionId, projectDir: resolvedDir, projectName, error: session.error });
 
-      // Keep session in map so callers can inspect the error
+      // Keep session in map so callers can inspect the error, but under the
+      // bounded terminal-retention policy so it is eventually reclaimed.
+      this.markTerminal(resolvedDir);
       throw new Error(`Failed to start session for ${resolvedDir}: ${session.error}`);
     }
   }
@@ -233,8 +256,20 @@ export class SessionManager extends EventEmitter {
 
     session.status = 'cancelled';
     session.unsubscribe?.();
+    session.unsubscribe = undefined;
 
     this.logger.info('session cancelled', { sessionId, projectDir: session.projectDir });
+
+    // Symmetric teardown: notify listeners (EventBridge) so they can dispose the
+    // session's batcher, channel mappings, and any blocker collectors — the
+    // start path emits 'session:started', so cancel must emit too.
+    this.emit('session:cancelled', {
+      sessionId,
+      projectDir: session.projectDir,
+      projectName: session.projectName,
+    });
+
+    this.markTerminal(session.projectDir);
   }
 
   async cancelSessionByDir(projectDir: string): Promise<void> {
@@ -284,6 +319,48 @@ export class SessionManager extends EventEmitter {
     }
 
     await Promise.allSettled(stopPromises);
+
+    this.sessions.clear();
+    this.terminalOrder = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: Terminal-session retention (bounded)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Record a session (by resolved dir) as terminal and evict the oldest
+   * terminal sessions once the retention cap is exceeded. Retains recent
+   * terminal sessions for inspection while bounding heap growth.
+   */
+  private markTerminal(resolvedDir: string): void {
+    // Move to most-recent position (dedupe if it was already terminal).
+    const existingIdx = this.terminalOrder.indexOf(resolvedDir);
+    if (existingIdx !== -1) this.terminalOrder.splice(existingIdx, 1);
+    this.terminalOrder.push(resolvedDir);
+
+    while (this.terminalOrder.length > MAX_TERMINAL_SESSIONS) {
+      const oldest = this.terminalOrder.shift();
+      if (oldest) this.evictSession(oldest);
+    }
+  }
+
+  /**
+   * Remove a session from tracking and best-effort reclaim its agent process.
+   */
+  private evictSession(resolvedDir: string): void {
+    const session = this.sessions.get(resolvedDir);
+    this.sessions.delete(resolvedDir);
+    const orderIdx = this.terminalOrder.indexOf(resolvedDir);
+    if (orderIdx !== -1) this.terminalOrder.splice(orderIdx, 1);
+
+    if (session) {
+      session.unsubscribe?.();
+      session.unsubscribe = undefined;
+      // The agent child process may still be alive (e.g. a completed session
+      // kept for follow-up relay) — reclaim it on eviction.
+      void session.client.stop().catch(() => { /* swallow */ });
+    }
   }
 
   /**
@@ -355,12 +432,14 @@ export class SessionManager extends EventEmitter {
       } else {
         session.status = 'completed';
         session.unsubscribe?.();
+        session.unsubscribe = undefined;
         this.logger.info('session completed', { sessionId: session.sessionId, projectDir: session.projectDir });
         this.emit('session:completed', {
           sessionId: session.sessionId,
           projectDir: session.projectDir,
           projectName: session.projectName,
         });
+        this.markTerminal(session.projectDir);
       }
       return;
     }

--- a/packages/daemon/src/verbosity.test.ts
+++ b/packages/daemon/src/verbosity.test.ts
@@ -37,6 +37,21 @@ describe('VerbosityManager', () => {
     assert.equal(vm.shouldShow('chan-q', 'tool_execution_start'), false);
     assert.equal(vm.shouldShow('chan-q', 'extension_ui_request'), true);
   });
+
+  it('clearLevel drops a channel back to the default (prevents unbounded growth)', () => {
+    vm.setLevel('chan-x', 'verbose');
+    assert.equal(vm.getLevel('chan-x'), 'verbose');
+
+    vm.clearLevel('chan-x');
+    assert.equal(vm.getLevel('chan-x'), 'default');
+  });
+
+  it('clearLevel is a no-op for an unknown channel', () => {
+    // Must not throw and must not affect other channels.
+    vm.setLevel('chan-keep', 'quiet');
+    vm.clearLevel('chan-never-set');
+    assert.equal(vm.getLevel('chan-keep'), 'quiet');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/verbosity.ts
+++ b/packages/daemon/src/verbosity.ts
@@ -60,6 +60,13 @@ export class VerbosityManager {
     this.levels.set(channelId, level);
   }
 
+  /** Drop a channel's stored level — call on session/channel teardown so the
+   * map doesn't accumulate one entry per distinct channel over the daemon's
+   * lifetime. */
+  clearLevel(channelId: string): void {
+    this.levels.delete(channelId);
+  }
+
   /**
    * Determine whether an event of the given type should be shown
    * in the specified channel.

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-client.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-client.ts
@@ -47,6 +47,9 @@ export interface ModelInfo {
 
 export type RpcEventListener = (event: AgentEvent) => void;
 
+/** Cap on retained stderr tail (bytes) to bound heap for long-lived agents. */
+const MAX_STDERR_BYTES = 64 * 1024;
+
 // ============================================================================
 // RPC Client
 // ============================================================================
@@ -90,9 +93,14 @@ export class RpcClient {
 			stdio: ["pipe", "pipe", "pipe"],
 		});
 
-		// Collect stderr for debugging
+		// Collect stderr for debugging. The agent process can run for hours/days,
+		// so cap the retained tail to avoid unbounded heap growth — only the most
+		// recent output is useful for error messages.
 		this._stderrHandler = (data: Buffer) => {
 			this.stderr += data.toString();
+			if (this.stderr.length > MAX_STDERR_BYTES) {
+				this.stderr = this.stderr.slice(-MAX_STDERR_BYTES);
+			}
 		};
 		this.process.stderr?.on("data", this._stderrHandler);
 

--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -823,6 +823,8 @@ function scheduleSessionWebSocketExpiry(sessionId: string, entry: CachedWebSocke
 		closeWebSocketSilently(entry.socket, 1000, "idle_timeout");
 		websocketSessionCache.delete(sessionId);
 	}, SESSION_WEBSOCKET_CACHE_TTL_MS);
+	// Don't let a cached idle socket keep the process alive up to the TTL.
+	entry.idleTimer.unref?.();
 }
 
 async function connectWebSocket(url: string, headers: Headers, signal?: AbortSignal): Promise<WebSocketLike> {

--- a/packages/pi-coding-agent/src/utils/sleep.ts
+++ b/packages/pi-coding-agent/src/utils/sleep.ts
@@ -8,11 +8,18 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 			return;
 		}
 
-		const timeout = setTimeout(resolve, ms);
-
-		signal?.addEventListener("abort", () => {
+		// Remove the abort listener on normal resolution so a long-lived signal
+		// reused across repeated sleeps (retry/backoff loops) doesn't accumulate
+		// listeners until it's finally aborted.
+		const onAbort = () => {
 			clearTimeout(timeout);
 			reject(new Error("Aborted"));
-		});
+		};
+		const timeout = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+
+		signal?.addEventListener("abort", onAbort, { once: true });
 	});
 }

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -97,6 +97,24 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	start(onInput: (data: string) => void, onResize: () => void): void {
+		// Idempotency guard: if start() is called again without an intervening
+		// stop() (e.g. a mis-paired suspend/resume cycle), detach any stale
+		// listeners first so they don't accumulate on the long-lived
+		// process.stdin/stdout and trip MaxListenersExceededWarning. No-op on a
+		// fresh start since all handles are undefined.
+		if (this.stdinDataHandler) {
+			process.stdin.removeListener("data", this.stdinDataHandler);
+			this.stdinDataHandler = undefined;
+		}
+		if (this.resizeHandler) {
+			process.stdout.removeListener("resize", this.resizeHandler);
+			this.resizeHandler = undefined;
+		}
+		if (this.stdinBuffer) {
+			this.stdinBuffer.destroy();
+			this.stdinBuffer = undefined;
+		}
+
 		if (!this.isTTY) {
 			this.inputHandler = onInput;
 			this.resizeHandler = onResize;

--- a/packages/rpc-client/src/rpc-client.ts
+++ b/packages/rpc-client/src/rpc-client.ts
@@ -52,6 +52,9 @@ export interface RpcClientOptions {
 
 export type RpcEventListener = (event: SdkAgentEvent) => void;
 
+/** Cap on retained stderr tail (bytes) to bound heap for long-lived agents. */
+const MAX_STDERR_BYTES = 64 * 1024;
+
 // ============================================================================
 // RPC Client
 // ============================================================================
@@ -98,9 +101,14 @@ export class RpcClient {
 			stdio: ["pipe", "pipe", "pipe"],
 		});
 
-		// Collect stderr for debugging
+		// Collect stderr for debugging. The agent process can run for hours/days,
+		// so cap the retained tail to avoid unbounded heap growth — only the most
+		// recent output is useful for error messages.
 		this._stderrHandler = (data: Buffer) => {
 			this.stderr += data.toString();
+			if (this.stderr.length > MAX_STDERR_BYTES) {
+				this.stderr = this.stderr.slice(-MAX_STDERR_BYTES);
+			}
 		};
 		this.process.stderr?.on("data", this._stderrHandler);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,21 @@ importers:
       '@mariozechner/clipboard':
         specifier: 0.3.6
         version: 0.3.6
+      '@opengsd/engine-darwin-arm64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-darwin-x64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-arm64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-x64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.1.1
+        version: 1.1.1
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1909,6 +1924,31 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-Z0lJq5f+WCQnox3ZJzaz0hZWp0iC9Pmzx1A9TGZ95b/UX+3woDJf3mZ3HX2KiiuhKkMVTGyvzwyKfuvylA+7xw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-Wi7xWysu6LsRH7ZBJszy+VtpZJETLeqAZ3/dG0CzjDK0VRAew+8nkZhpvDu1IipHZqsIHtCIhYKOk5apdRXK0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-8Asyr1Oj+0aszi2rMqRkbyFC+SHTFxqcB6fNnfo7zB+T0CGlH4EdrDfShz08OuZqfj1B3rOTp5EFsqVnUhYNgw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-bOQciYjimEbSzmuUKZPciTEJTWWUwKn1PoU3AVNb5EZq+C0Roj5FnsMgP5/pKV54ZoSPR0nSedH+DVKUHxc8dA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-56WdCcORvLj4FHAG5AJTDSdzeV7m7at6CcYjcGpf1fZtWz/0gGz9zTC10125gewQZiKgD0/sxXcxTtxTCC3Fpw==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -7711,6 +7751,21 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -1828,8 +1828,6 @@ export function getProjectBridgeServiceForCwd(projectCwd: string): BridgeService
   const deps = getBridgeDeps();
   const service = new BridgeService(config, deps);
   projectBridgeRegistry.set(resolvedPath, service);
-  // Ensure bridges (and their child processes) are reclaimed on shutdown.
-  installBridgeShutdownHooks();
   return service;
 }
 
@@ -1847,37 +1845,28 @@ export async function disposeProjectBridge(projectCwd: string): Promise<void> {
 }
 
 /**
- * Dispose every registered project bridge (and its RPC child process) and clear
- * the registry. Wire this into the web server's shutdown path so per-project
- * bridges and their child processes are reclaimed instead of leaking for the
- * process lifetime. Previously only the test reset path disposed bridges.
+ * Dispose every registered project bridge (and its RPC child process) so they
+ * are reclaimed instead of leaking for the process lifetime. Previously only the
+ * test reset path disposed bridges; the web server's shutdown gate
+ * (`web/lib/shutdown-gate.ts`) now calls this on its exit paths.
+ *
+ * Each entry is removed right before it is disposed (rather than clearing the
+ * whole registry up front) so a concurrent `getProjectBridgeServiceForCwd`
+ * cannot observe a half-cleared registry and create a duplicate bridge for a
+ * path that has not started disposing yet.
  */
 export async function disposeAllProjectBridges(): Promise<void> {
-  const disposePromises: Promise<void>[] = [];
-  for (const service of projectBridgeRegistry.values()) {
-    disposePromises.push(service.dispose().catch(() => { /* swallow */ }));
-  }
-  projectBridgeRegistry.clear();
-  await Promise.all(disposePromises);
-}
-
-let bridgeShutdownHooksInstalled = false;
-
-/**
- * Install one-shot process-shutdown hooks that dispose all project bridges.
- * Idempotent — safe to call from multiple web entrypoints. Hooks are registered
- * with `process.once` so they don't accumulate across calls.
- */
-export function installBridgeShutdownHooks(): void {
-  if (bridgeShutdownHooksInstalled) return;
-  bridgeShutdownHooksInstalled = true;
-
-  const dispose = () => {
-    void disposeAllProjectBridges();
-  };
-  process.once("exit", dispose);
-  process.once("SIGINT", dispose);
-  process.once("SIGTERM", dispose);
+  const entries = [...projectBridgeRegistry.entries()];
+  await Promise.all(
+    entries.map(async ([path, service]) => {
+      // Only remove if this is still the registered instance — guards against a
+      // concurrent restart that replaced it with a fresh bridge.
+      if (projectBridgeRegistry.get(path) === service) {
+        projectBridgeRegistry.delete(path);
+      }
+      await service.dispose().catch(() => { /* swallow */ });
+    }),
+  );
 }
 
 /**

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -1542,6 +1542,7 @@ export class BridgeService {
   async dispose(): Promise<void> {
     this.detachStdoutReader?.();
     this.detachStdoutReader = null;
+    this.subscribers.clear();
     this.terminalSubscribers.clear();
     for (const pending of this.pendingRequests.values()) {
       clearTimeout(pending.timeout);
@@ -1827,7 +1828,56 @@ export function getProjectBridgeServiceForCwd(projectCwd: string): BridgeService
   const deps = getBridgeDeps();
   const service = new BridgeService(config, deps);
   projectBridgeRegistry.set(resolvedPath, service);
+  // Ensure bridges (and their child processes) are reclaimed on shutdown.
+  installBridgeShutdownHooks();
   return service;
+}
+
+/**
+ * Dispose the bridge for a single project and drop it from the registry,
+ * reclaiming its spawned RPC child process. Use when a project is no longer
+ * served (e.g. its last SSE subscriber disconnected).
+ */
+export async function disposeProjectBridge(projectCwd: string): Promise<void> {
+  const resolvedPath = resolve(projectCwd);
+  const service = projectBridgeRegistry.get(resolvedPath);
+  if (!service) return;
+  projectBridgeRegistry.delete(resolvedPath);
+  await service.dispose();
+}
+
+/**
+ * Dispose every registered project bridge (and its RPC child process) and clear
+ * the registry. Wire this into the web server's shutdown path so per-project
+ * bridges and their child processes are reclaimed instead of leaking for the
+ * process lifetime. Previously only the test reset path disposed bridges.
+ */
+export async function disposeAllProjectBridges(): Promise<void> {
+  const disposePromises: Promise<void>[] = [];
+  for (const service of projectBridgeRegistry.values()) {
+    disposePromises.push(service.dispose().catch(() => { /* swallow */ }));
+  }
+  projectBridgeRegistry.clear();
+  await Promise.all(disposePromises);
+}
+
+let bridgeShutdownHooksInstalled = false;
+
+/**
+ * Install one-shot process-shutdown hooks that dispose all project bridges.
+ * Idempotent — safe to call from multiple web entrypoints. Hooks are registered
+ * with `process.once` so they don't accumulate across calls.
+ */
+export function installBridgeShutdownHooks(): void {
+  if (bridgeShutdownHooksInstalled) return;
+  bridgeShutdownHooksInstalled = true;
+
+  const dispose = () => {
+    void disposeAllProjectBridges();
+  };
+  process.once("exit", dispose);
+  process.once("SIGINT", dispose);
+  process.once("SIGTERM", dispose);
 }
 
 /**

--- a/web/lib/pty-manager.ts
+++ b/web/lib/pty-manager.ts
@@ -32,6 +32,10 @@ interface LoadedNodePty {
 const GLOBAL_KEY = "__gsd_pty_sessions__" as const;
 const CLEANUP_GUARD_KEY = "__gsd_pty_cleanup_installed__" as const;
 const MAX_SESSION_BUFFER_BYTES = 1024 * 1024;
+// After a PTY exits, retain its (dead) session briefly so a late SSE reconnect
+// can still replay the exit message, then reclaim its buffer + listeners so
+// short-lived/unique session ids don't accumulate ~1MB buffers in the global map.
+const DEAD_SESSION_GRACE_MS = 30_000;
 
 function getSessions(): Map<string, PtySession> {
   const g = globalThis as Record<string, unknown>;
@@ -353,6 +357,20 @@ export function getOrCreateSession(sessionId: string, projectCwd?: string, comma
         // ignore
       }
     }
+
+    // Reclaim the dead session after a grace window unless it was replaced by a
+    // restart with the same id. unref so this never keeps the process alive.
+    const reclaim = setTimeout(() => {
+      const sessions = getSessions();
+      const current = sessions.get(session.id);
+      if (current === session && !current.alive) {
+        current.listeners.clear();
+        current.buffer = [];
+        current.bufferedBytes = 0;
+        sessions.delete(session.id);
+      }
+    }, DEAD_SESSION_GRACE_MS);
+    reclaim.unref?.();
   });
 
   map.set(sessionId, session);

--- a/web/lib/shutdown-gate.ts
+++ b/web/lib/shutdown-gate.ts
@@ -74,6 +74,24 @@ export function drainStreams(): void {
 
 function handleForcedExit(): void {
   drainStreams();
+  // Reclaim per-project RPC bridge child processes so they don't survive the
+  // server. Fire-and-forget here — a SIGTERM may not leave time to await.
+  void reclaimProjectBridges();
+}
+
+/**
+ * Best-effort teardown of all project bridges (and their RPC child processes).
+ * The bridge module is imported lazily so this lifecycle module doesn't pull the
+ * bridge graph at load time (keeps it loadable under the web package's bare
+ * --experimental-strip-types test runner, and out of the early server boot path).
+ */
+async function reclaimProjectBridges(): Promise<void> {
+  try {
+    const { disposeAllProjectBridges } = await import("../../src/web/bridge-service.ts");
+    await disposeAllProjectBridges();
+  } catch {
+    // best-effort; never let bridge teardown block shutdown
+  }
 }
 
 type HotDisposeApi = {
@@ -159,7 +177,9 @@ export function scheduleShutdown(): void {
     }
 
     drainStreams();
-    process.exit(0);
+    // Reclaim bridges (and their RPC children) before exiting so they aren't
+    // orphaned, then exit once teardown settles (or fails — never block exit).
+    void reclaimProjectBridges().finally(() => process.exit(0));
   }, SHUTDOWN_DELAY_MS);
 }
 


### PR DESCRIPTION
Audit of the long-lived surfaces (daemon, web server, TUI, agent core)
surfaced a set of leaks concentrated where the disconnect/terminal path
was not symmetric with the start path. Timer hygiene was already strong;
the fixes here target accumulating collections, orphaned subscriptions,
and unremoved listeners.

HIGH
- rpc-client (both impls): cap retained stderr tail (64KB) instead of
  appending every byte for the process lifetime.
- daemon SessionManager: never deleted sessions from its map. Add bounded
  terminal-session retention (cap 50, evict oldest + reclaim child
  process), allow restart over a terminal session, and clear on cleanup.
- daemon EventBridge: cancel path was not wired — emit 'session:cancelled'
  and tear down its batcher/channel maps/blocker collectors; track and
  stop the 24h button collectors on cleanup/shutdown.
- web pty-manager: reclaim exited PTY sessions (1MB buffer + listeners)
  after a grace window instead of retaining them forever.

MED
- web bridge-service: add production disposal (disposeAllProjectBridges +
  shutdown hooks, per-project eviction) so bridges and their RPC child
  processes are reclaimed; clear subscribers in dispose().
- pi-coding-agent sleep(): remove the abort listener on normal resolution
  so reused signals don't accumulate listeners.
- pi-tui terminal.start(): detach stale stdin/resize listeners up front so
  a mis-paired start/stop can't accumulate listeners on process streams.

LOW
- daemon verbosity: drop per-channel level on session teardown.
- daemon orchestrator wiring: name + remove the Discord messageCreate
  listener on shutdown and guard against a nulled orchestrator.
- cloud-mcp-gateway runtime-registry: remove abort listener on every
  pending-call resolution path.
- pi-ai openai-codex: unref the cached-websocket idle timer.
- daemon cloud-runtime: removeAllListeners on the replaced socket.

https://claude.ai/code/session_01UBnAsXT2ooUXJjnPiVVTfQ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782868115&installation_id=134682257&pr_number=327&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F327&signature=6d79e9c87565205ebee9ce526658d37ff8f514f08ad501eb1e76537d37c0f600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect daemon session lifecycle, Discord/cloud wiring, and web shutdown paths where incorrect teardown could drop active sessions or leave orphaned processes; mitigated by tests and best-effort disposal patterns.
> 
> **Overview**
> This PR hardens **long-lived processes** (daemon, web server, cloud gateway, TUI, RPC clients) against **unbounded memory and listener growth** by making teardown symmetric with startup and capping retained state.
> 
> **Daemon:** `SessionManager` now keeps at most **50 terminal** sessions (completed/cancelled/error), evicts the oldest (stopping child processes), allows **restart** over a terminal session for the same project dir, and clears maps on `cleanup`. **Cancel** emits `session:cancelled` so `EventBridge` can tear down batchers, channel maps, **24h blocker collectors**, and per-channel verbosity. Orchestrator gets a **named, removable** Discord `messageCreate` handler; cloud reconnect **strips listeners** from the replaced WebSocket.
> 
> **Web:** Per-project **bridge** disposal (`disposeProjectBridge` / `disposeAllProjectBridges`) and **shutdown-gate** hooks reclaim RPC children; `BridgeService.dispose` clears subscribers. **PTY** sessions are deleted after a **30s** grace window once exited (buffers/listeners).
> 
> **Clients / libs:** Both **RpcClient** implementations cap **stderr** at 64KB. `sleep()` and cloud **pending tool calls** remove **abort** listeners on normal completion; Codex WebSocket idle timers are **unref**’d; TUI `terminal.start()` detaches stale stdin/resize listeners on re-entry.
> 
> Tests cover retention, cancel emission, verbosity `clearLevel`, and cleanup. Lockfile adds optional **`@opengsd/engine-*`** platform packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19ec5d5bac8690836c63c1e86c3c51adbf1ee21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->