### PR TITLE
test(closeout): cover task/slice/milestone close-out edge cases and failures

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,21 @@ importers:
       '@mariozechner/clipboard':
         specifier: 0.3.6
         version: 0.3.6
+      '@opengsd/engine-darwin-arm64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-darwin-x64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-arm64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-x64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.1.1
+        version: 1.1.1
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1909,6 +1924,31 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-Z0lJq5f+WCQnox3ZJzaz0hZWp0iC9Pmzx1A9TGZ95b/UX+3woDJf3mZ3HX2KiiuhKkMVTGyvzwyKfuvylA+7xw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-Wi7xWysu6LsRH7ZBJszy+VtpZJETLeqAZ3/dG0CzjDK0VRAew+8nkZhpvDu1IipHZqsIHtCIhYKOk5apdRXK0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-8Asyr1Oj+0aszi2rMqRkbyFC+SHTFxqcB6fNnfo7zB+T0CGlH4EdrDfShz08OuZqfj1B3rOTp5EFsqVnUhYNgw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-bOQciYjimEbSzmuUKZPciTEJTWWUwKn1PoU3AVNb5EZq+C0Roj5FnsMgP5/pKV54ZoSPR0nSedH+DVKUHxc8dA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-56WdCcORvLj4FHAG5AJTDSdzeV7m7at6CcYjcGpf1fZtWz/0gGz9zTC10125gewQZiKgD0/sxXcxTtxTCC3Fpw==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -7711,6 +7751,21 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -1,0 +1,399 @@
+// Project/App: gsd-pi
+// File Purpose: Handler tests for complete-milestone (gsd_complete_milestone).
+//
+// Covers the milestone close-out "turn" end-to-end: required-field validation,
+// the explicit verificationPassed gate, the milestone-validation verdict gate
+// (defense-in-depth), incomplete-slice and incomplete-task guards, idempotent
+// re-completion (alreadyComplete), and the #4598 "do not overwrite an existing
+// SUMMARY.md" guard. complete-milestone previously had NO dedicated handler
+// test — this file is that coverage.
+
+import { createTestContext } from './test-helpers.ts';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  insertAssessment,
+  updateSliceStatus,
+  getMilestone,
+} from '../gsd-db.ts';
+import {
+  handleCompleteMilestone,
+  type CompleteMilestoneParams,
+} from '../tools/complete-milestone.ts';
+
+const { assertEq, assertTrue, assertMatch, report } = createTestContext();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-complete-milestone-'));
+  return path.join(dir, 'test.db');
+}
+
+function cleanup(dbPath: string): void {
+  closeDatabase();
+  try {
+    const dir = path.dirname(dbPath);
+    for (const f of fs.readdirSync(dir)) fs.unlinkSync(path.join(dir, f));
+    fs.rmdirSync(dir);
+  } catch {
+    // best effort
+  }
+}
+
+function cleanupDir(dirPath: string): void {
+  try {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  } catch {
+    // best effort
+  }
+}
+
+/** Count complete-milestone entries in the JSONL event log under basePath. */
+function countCompleteMilestoneEvents(basePath: string): number {
+  const logPath = path.join(basePath, '.gsd', 'event-log.jsonl');
+  if (!fs.existsSync(logPath)) return 0;
+  return fs
+    .readFileSync(logPath, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as { cmd?: string };
+      } catch {
+        return {};
+      }
+    })
+    .filter((ev) => ev.cmd === 'complete-milestone').length;
+}
+
+/** Temp project with the M001 milestone directory present for projections. */
+function createTempProject(): { basePath: string; milestoneDir: string } {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-milestone-handler-'));
+  const milestoneDir = path.join(basePath, '.gsd', 'milestones', 'M001');
+  fs.mkdirSync(path.join(milestoneDir, 'slices', 'S01', 'tasks'), { recursive: true });
+  return { basePath, milestoneDir };
+}
+
+/**
+ * Seed a milestone whose slices+tasks are all complete and (optionally) record
+ * a milestone-validation assessment with the given verdict. This is the state
+ * the loop is in when it reaches completing-milestone.
+ */
+function seedCompletedMilestone(opts: {
+  basePath: string;
+  milestoneStatus?: string;
+  validationVerdict?: string | null;
+  taskStatus?: string; // override to simulate a lingering incomplete task
+  sliceStatus?: string; // override to simulate an incomplete slice
+}): void {
+  insertMilestone({ id: 'M001', title: 'Test Milestone', status: opts.milestoneStatus ?? 'active' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice One' });
+  insertTask({
+    id: 'T01',
+    sliceId: 'S01',
+    milestoneId: 'M001',
+    status: opts.taskStatus ?? 'complete',
+    title: 'Task One',
+  });
+  // Mark the slice complete (insertSlice defaults to pending).
+  updateSliceStatus('M001', 'S01', opts.sliceStatus ?? 'complete', new Date().toISOString());
+
+  if (opts.validationVerdict !== null && opts.validationVerdict !== undefined) {
+    insertAssessment({
+      path: path.join(opts.basePath, '.gsd', 'milestones', 'M001', 'M001-VALIDATION.md'),
+      milestoneId: 'M001',
+      sliceId: null,
+      taskId: null,
+      status: opts.validationVerdict,
+      scope: 'milestone-validation',
+      fullContent: `verdict: ${opts.validationVerdict}\n`,
+    });
+  }
+}
+
+function makeValidParams(): CompleteMilestoneParams {
+  return {
+    milestoneId: 'M001',
+    title: 'M001: Test Milestone',
+    oneLiner: 'Delivered the test milestone end to end.',
+    narrative: 'All slices landed, validation passed, and the suite is green.',
+    verificationPassed: true,
+    successCriteriaResults: 'All success criteria met.',
+    definitionOfDoneResults: 'DoD satisfied.',
+    requirementOutcomes: 'R001 validated.',
+    keyDecisions: ['D001'],
+    keyFiles: ['src/foo.ts'],
+    lessonsLearned: ['Keep the loop idempotent.'],
+    followUps: 'None.',
+    deviations: 'None.',
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: handler happy path
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: handler happy path ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass' });
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+
+  assertTrue(!('error' in result), 'handler should succeed on a fully-complete, validated milestone');
+  if (!('error' in result)) {
+    assertEq(result.milestoneId, 'M001', 'result milestoneId');
+    assertTrue(result.summaryPath.endsWith('M001-SUMMARY.md'), 'summaryPath should end with M001-SUMMARY.md');
+    assertTrue(result.alreadyComplete !== true, 'first completion should not be flagged alreadyComplete');
+
+    // (a) DB status flipped to complete with completed_at set.
+    const m = getMilestone('M001');
+    assertTrue(m !== null, 'milestone should exist after completion');
+    assertEq(m!.status, 'complete', 'milestone status should be complete in DB');
+    assertTrue(m!.completed_at !== null && m!.completed_at !== '', 'completed_at should be set');
+
+    // (b) SUMMARY.md rendered with frontmatter + sections.
+    assertTrue(fs.existsSync(result.summaryPath), 'summary file should exist on disk');
+    const summary = fs.readFileSync(result.summaryPath, 'utf-8');
+    assertMatch(summary, /^---\n/, 'summary should start with YAML frontmatter');
+    assertMatch(summary, /id: M001/, 'summary frontmatter should contain id: M001');
+    assertMatch(summary, /status: complete/, 'summary frontmatter should mark status complete');
+    assertMatch(summary, /# M001: Test Milestone/, 'summary should have H1 with stripped title');
+    assertMatch(summary, /## Success Criteria Results/, 'summary should have Success Criteria section');
+    assertMatch(summary, /All success criteria met\./, 'summary should inline successCriteriaResults');
+    assertMatch(summary, /## Definition of Done Results/, 'summary should have DoD section');
+
+    // (c) A complete-milestone event was appended exactly once.
+    assertEq(countCompleteMilestoneEvents(basePath), 1, 'exactly one complete-milestone event should be recorded');
+  }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: required-field validation
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: required-field validation ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const params = makeValidParams();
+
+  const r1 = await handleCompleteMilestone({ ...params, milestoneId: '' }, '/tmp/fake');
+  assertTrue('error' in r1, 'empty milestoneId should error');
+  if ('error' in r1) assertMatch(r1.error, /milestoneId/, 'error should mention milestoneId');
+
+  const r2 = await handleCompleteMilestone({ ...params, title: '' }, '/tmp/fake');
+  assertTrue('error' in r2, 'empty title should error');
+  if ('error' in r2) assertMatch(r2.error, /title/, 'error should mention title');
+
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: verificationPassed must be explicitly true
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: verificationPassed gate ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass' });
+
+  const rFalse = await handleCompleteMilestone(
+    { ...makeValidParams(), verificationPassed: false },
+    basePath,
+  );
+  assertTrue('error' in rFalse, 'verificationPassed=false should block completion');
+  if ('error' in rFalse) assertMatch(rFalse.error, /verification did not pass/i, 'error should explain verification gate');
+
+  // Milestone must remain not-complete after the rejected call.
+  assertEq(getMilestone('M001')!.status, 'active', 'milestone should stay active when verification did not pass');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: milestone not found
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: milestone not found ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+  // No milestone seeded.
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue('error' in result, 'unknown milestone should error');
+  if ('error' in result) assertMatch(result.error, /milestone not found/i, 'error should say milestone not found');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: validation verdict gate (defense-in-depth)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: validation verdict must be pass ===');
+{
+  // (a) No validation assessment at all → blocked.
+  {
+    const dbPath = tempDbPath();
+    openDatabase(dbPath);
+    const { basePath } = createTempProject();
+    seedCompletedMilestone({ basePath, validationVerdict: null });
+
+    const result = await handleCompleteMilestone(makeValidParams(), basePath);
+    assertTrue('error' in result, 'absent validation should block completion');
+    if ('error' in result) {
+      assertMatch(result.error, /Refusing to complete/i, 'error should refuse completion');
+      assertMatch(result.error, /absent/i, 'error should report verdict as absent');
+    }
+    assertEq(getMilestone('M001')!.status, 'active', 'milestone should remain active when validation is absent');
+
+    cleanupDir(basePath);
+    cleanup(dbPath);
+  }
+
+  // (b) Failing validation verdict → blocked.
+  {
+    const dbPath = tempDbPath();
+    openDatabase(dbPath);
+    const { basePath } = createTempProject();
+    seedCompletedMilestone({ basePath, validationVerdict: 'fail' });
+
+    const result = await handleCompleteMilestone(makeValidParams(), basePath);
+    assertTrue('error' in result, 'fail verdict should block completion');
+    if ('error' in result) assertMatch(result.error, /verdict is "fail"/i, 'error should report the fail verdict');
+
+    cleanupDir(basePath);
+    cleanup(dbPath);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: incomplete slices block closeout
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: incomplete slices block closeout ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+  // Validation passes, but the slice is still pending.
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass', sliceStatus: 'pending' });
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue('error' in result, 'pending slice should block milestone completion');
+  if ('error' in result) {
+    assertMatch(result.error, /incomplete slices/i, 'error should mention incomplete slices');
+    assertMatch(result.error, /S01/, 'error should name the incomplete slice');
+  }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: deep task check (slice closed, task not)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: deep task check blocks closeout ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+  // Slice marked complete but one task lingers pending — the deep check must catch it.
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass', sliceStatus: 'complete', taskStatus: 'pending' });
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue('error' in result, 'lingering pending task should block milestone completion');
+  if ('error' in result) {
+    assertMatch(result.error, /incomplete tasks/i, 'error should mention incomplete tasks');
+    assertMatch(result.error, /T01/, 'error should name the incomplete task');
+  }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: idempotent re-completion (alreadyComplete)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: idempotent re-completion ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass' });
+
+  const r1 = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue(!('error' in r1), 'first completion should succeed');
+
+  const r2 = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue(!('error' in r2), 'second completion should be a non-error no-op');
+  if (!('error' in r2)) {
+    assertEq(r2.alreadyComplete, true, 'second completion should be flagged alreadyComplete');
+  }
+
+  // No duplicate completion event was appended on the retry.
+  assertEq(countCompleteMilestoneEvents(basePath), 1, 'retry must not append a duplicate complete-milestone event');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: existing SUMMARY.md is not overwritten (#4598)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: existing SUMMARY.md preserved (#4598) ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath, milestoneDir } = createTempProject();
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass' });
+
+  // Pre-write a richer SUMMARY.md as if a prior completion run produced it.
+  const summaryPath = path.join(milestoneDir, 'M001-SUMMARY.md');
+  const sentinel = '# M001: Pre-existing richer summary\n\nDO NOT OVERWRITE ME\n';
+  fs.writeFileSync(summaryPath, sentinel, 'utf-8');
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue(!('error' in result), 'completion should still succeed when SUMMARY.md already exists');
+  if (!('error' in result)) {
+    assertEq(
+      fs.readFileSync(summaryPath, 'utf-8'),
+      sentinel,
+      'existing SUMMARY.md must be preserved, not overwritten by the mechanical renderer',
+    );
+    // DB completion still happened.
+    assertEq(getMilestone('M001')!.status, 'complete', 'milestone should still be marked complete in DB');
+  }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+report();

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -15,6 +15,9 @@ import {
   updateSliceStatus,
   getSliceTasks,
   setSliceSummaryMd,
+  insertGateRow,
+  getGateResults,
+  updateMilestoneStatus,
   SCHEMA_VERSION,
 } from '../gsd-db.ts';
 import { handleCompleteSlice } from '../tools/complete-slice.ts';
@@ -576,6 +579,102 @@ console.log('\n=== complete-slice: PROJECT refresh uses gsd_summary_save ===');
   assertTrue(prompt.includes('gsd_summary_save'), 'PROJECT refresh must use gsd_summary_save');
   assertTrue(prompt.includes('artifact_type: "PROJECT"'), 'PROJECT refresh must use artifact_type PROJECT');
   assertTrue(!/with a full `write`/i.test(prompt), 'prompt must not instruct direct PROJECT.md writes');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: blocked/failed verification content gate (#3580)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: rejects blocked/failed verification content ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+
+  // (a) Blocked/failed signal in the verification field.
+  const rVer = await handleCompleteSlice(
+    { ...makeValidSliceParams(), verification: 'verification failed — gate did not pass' },
+    basePath,
+  );
+  assertTrue('error' in rVer, 'blocked/failed verification text should be rejected');
+  if ('error' in rVer) assertMatch(rVer.error, /verification/i, 'error should explain verification was not passed');
+
+  // (b) Blocked signal in the UAT content.
+  const rUat = await handleCompleteSlice(
+    { ...makeValidSliceParams(), uatContent: 'status: blocked — cannot complete this slice yet' },
+    basePath,
+  );
+  assertTrue('error' in rUat, 'blocked UAT content should be rejected');
+
+  // The slice must remain not-complete after both rejected calls.
+  assertEq(getSlice('M001', 'S01')!.status, 'pending', 'slice should stay pending after blocked-signal rejection');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: cannot complete a slice in a CLOSED milestone
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: rejects completion in a closed milestone ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+  updateMilestoneStatus('M001', 'complete', new Date().toISOString());
+
+  const result = await handleCompleteSlice(makeValidSliceParams(), basePath);
+  assertTrue('error' in result, 'should reject slice completion in a closed milestone');
+  if ('error' in result) assertMatch(result.error, /closed milestone/i, 'error should mention closed milestone');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: closes the Q8 (operational readiness) slice gate
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: closes Q8 gate (pass when populated) ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+
+  // Seed Q8 as a pending slice-scoped gate.
+  insertGateRow({ milestoneId: 'M001', sliceId: 'S01', gateId: 'Q8', scope: 'slice' });
+
+  const params = {
+    ...makeValidSliceParams(),
+    operationalReadiness: 'Dashboards updated, alert thresholds set, rollback documented.',
+  };
+  const result = await handleCompleteSlice(params, basePath);
+  assertTrue(!('error' in result), 'Q8 gate-closing completion should succeed');
+
+  const gates = getGateResults('M001', 'S01', 'slice');
+  const q8 = gates.find((g) => g.gate_id === 'Q8');
+  assertTrue(q8 !== undefined, 'Q8 gate row should exist');
+  assertEq(q8!.status, 'complete', 'Q8 should be closed after completion');
+  assertEq(q8!.verdict, 'pass', 'Q8 populated → pass');
+
+  const stillPending = gates.filter((g) => g.status === 'pending');
+  assertEq(stillPending.length, 0, 'no slice gates should remain pending after completion');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -15,6 +15,10 @@ import {
   getSlice,
   getSliceTasks,
   insertVerificationEvidence,
+  insertGateRow,
+  getGateResults,
+  updateMilestoneStatus,
+  updateSliceStatus,
   SCHEMA_VERSION,
 } from '../gsd-db.ts';
 import { handleCompleteTask } from '../tools/complete-task.ts';
@@ -503,6 +507,121 @@ console.log('\n=== complete-task: minimal params (no keyFiles, keyDecisions, ver
     assertMatch(summaryContent, /key_decisions:\n  - \(none\)/, 'empty key_decisions should use (none) sentinel for parseSummary compatibility');
     assertTrue(summaryContent.includes('  - (none)'), 'empty frontmatter lists use (none) sentinel to preserve parseSummary key_files.length > 0 invariant');
   }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-task: remaining required-field validation (oneLiner/narrative/verification)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: remaining required-field validation ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const params = makeValidParams();
+
+  const rOne = await handleCompleteTask({ ...params, oneLiner: '' }, '/tmp/fake');
+  assertTrue('error' in rOne, 'empty oneLiner should error');
+  if ('error' in rOne) assertMatch(rOne.error, /oneLiner/, 'error should mention oneLiner');
+
+  const rNarr = await handleCompleteTask({ ...params, narrative: '   ' }, '/tmp/fake');
+  assertTrue('error' in rNarr, 'whitespace-only narrative should error');
+  if ('error' in rNarr) assertMatch(rNarr.error, /narrative/, 'error should mention narrative');
+
+  const rVer = await handleCompleteTask({ ...params, verification: '' }, '/tmp/fake');
+  assertTrue('error' in rVer, 'empty verification should error');
+  if ('error' in rVer) assertMatch(rVer.error, /verification/, 'error should mention verification');
+
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-task: cannot complete a task in a CLOSED milestone
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: rejects completion in a closed milestone ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+  // Close the milestone after seeding.
+  updateMilestoneStatus('M001', 'complete', new Date().toISOString());
+
+  const result = await handleCompleteTask(makeValidParams(), basePath);
+  assertTrue('error' in result, 'should reject task completion in a closed milestone');
+  if ('error' in result) assertMatch(result.error, /closed milestone/i, 'error should mention closed milestone');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-task: cannot complete a task in a CLOSED slice
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: rejects completion in a closed slice ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+  updateSliceStatus('M001', 'S01', 'complete', new Date().toISOString());
+
+  const result = await handleCompleteTask(makeValidParams(), basePath);
+  assertTrue('error' in result, 'should reject task completion in a closed slice');
+  if ('error' in result) assertMatch(result.error, /closed slice/i, 'error should mention closed slice');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-task: closes execute-task gates Q5/Q6/Q7 (pass when populated, omitted when empty)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: closes Q5/Q6/Q7 gates (pass vs omitted) ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+
+  // Seed the three task-scoped gates as pending for T01.
+  insertGateRow({ milestoneId: 'M001', sliceId: 'S01', gateId: 'Q5', scope: 'task', taskId: 'T01' });
+  insertGateRow({ milestoneId: 'M001', sliceId: 'S01', gateId: 'Q6', scope: 'task', taskId: 'T01' });
+  insertGateRow({ milestoneId: 'M001', sliceId: 'S01', gateId: 'Q7', scope: 'task', taskId: 'T01' });
+
+  // Populate Q5 (failureModes) and Q7 (negativeTests); leave Q6 (loadProfile) empty.
+  const params = {
+    ...makeValidParams(),
+    failureModes: 'Network partition mid-write leaves a half-flushed record.',
+    negativeTests: 'Reject malformed payloads; verify rollback on constraint violation.',
+    // loadProfile intentionally omitted → Q6 should be recorded omitted
+  };
+
+  const result = await handleCompleteTask(params as any, basePath);
+  assertTrue(!('error' in result), 'gate-closing completion should succeed');
+
+  const gates = getGateResults('M001', 'S01', 'task');
+  const byId = new Map(gates.map((g) => [g.gate_id, g]));
+  assertEq(byId.size, 3, 'all three task gates should be present');
+  assertEq(byId.get('Q5')?.status, 'complete', 'Q5 should be closed');
+  assertEq(byId.get('Q5')?.verdict, 'pass', 'Q5 populated → pass');
+  assertEq(byId.get('Q7')?.verdict, 'pass', 'Q7 populated → pass');
+  assertEq(byId.get('Q6')?.verdict, 'omitted', 'Q6 empty → omitted');
+
+  // No task-scoped gates remain pending for the loop to stall on.
+  const stillPending = getGateResults('M001', 'S01', 'task').filter((g) => g.status === 'pending');
+  assertEq(stillPending.length, 0, 'no task gates should remain pending after completion');
 
   cleanupDir(basePath);
   cleanup(dbPath);

--- a/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
@@ -7,7 +7,22 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { openDatabase, insertMilestone, closeDatabase } from "../gsd-db.js";
-import { isMilestoneCloseoutSettled } from "../milestone-closeout.js";
+import {
+  isMilestoneCloseoutSettled,
+  evaluateCompleteMilestoneDispatch,
+} from "../milestone-closeout.js";
+import type { DispatchContext } from "../auto-dispatch.js";
+
+/** Build a minimal DispatchContext for the dispatch-policy branches under test. */
+function makeDispatchCtx(base: string, phase: string): DispatchContext {
+  return {
+    basePath: base,
+    mid: "M001",
+    midTitle: "M001: Test",
+    state: { phase } as DispatchContext["state"],
+    prefs: undefined,
+  } as DispatchContext;
+}
 
 const tmpDirs: string[] = [];
 
@@ -41,4 +56,33 @@ test("isMilestoneCloseoutSettled returns false when summary artifact is missing"
 
   const settled = await isMilestoneCloseoutSettled("M001", base);
   assert.equal(settled, false);
+});
+
+// ─── evaluateCompleteMilestoneDispatch: early-return branches ──────────────
+// These two branches resolve before the git-commit step, so they are pure of
+// any working-tree/git state and safe to unit test.
+
+test("evaluateCompleteMilestoneDispatch returns null when phase is not completing-milestone", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dispatch-phase-"));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Open", status: "active" });
+
+  const action = await evaluateCompleteMilestoneDispatch(makeDispatchCtx(base, "executing"));
+  assert.equal(action, null, "non-closeout phase should not produce a dispatch action");
+});
+
+test("evaluateCompleteMilestoneDispatch skips when milestone is already closed", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dispatch-closed-"));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Done", status: "complete" });
+
+  const action = await evaluateCompleteMilestoneDispatch(
+    makeDispatchCtx(base, "completing-milestone"),
+  );
+  assert.ok(action, "an already-closed milestone in completing-milestone should yield an action");
+  assert.equal(action!.action, "skip", "already-closed milestone should resolve to skip (idempotent)");
 });

--- a/src/resources/extensions/gsd/tests/status-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/status-guards.test.ts
@@ -3,7 +3,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isClosedStatus, isFutureMilestoneStatus } from '../status-guards.ts';
+import {
+  isClosedStatus,
+  isFutureMilestoneStatus,
+  isDeferredStatus,
+  isInactiveStatus,
+  isSkippedForDispatch,
+} from '../status-guards.ts';
 
 test('isClosedStatus: "complete" returns true', () => {
   assert.equal(isClosedStatus('complete'), true);
@@ -47,4 +53,45 @@ test('isFutureMilestoneStatus excludes active and closed milestones', () => {
   assert.equal(isFutureMilestoneStatus('active'), false);
   assert.equal(isFutureMilestoneStatus('complete'), false);
   assert.equal(isFutureMilestoneStatus('parked'), false);
+});
+
+// ─── isDeferredStatus ──────────────────────────────────────────────────────
+
+test('isDeferredStatus is true only for "deferred"', () => {
+  assert.equal(isDeferredStatus('deferred'), true);
+  assert.equal(isDeferredStatus('complete'), false);
+  assert.equal(isDeferredStatus('pending'), false);
+  assert.equal(isDeferredStatus('skipped'), false);
+});
+
+// ─── isInactiveStatus (closed OR deferred) ─────────────────────────────────
+
+test('isInactiveStatus covers every closed status', () => {
+  for (const s of ['complete', 'done', 'skipped', 'closed']) {
+    assert.equal(isInactiveStatus(s), true, `${s} should count as inactive`);
+  }
+});
+
+test('isInactiveStatus also covers deferred', () => {
+  assert.equal(isInactiveStatus('deferred'), true);
+});
+
+test('isInactiveStatus excludes runnable statuses', () => {
+  for (const s of ['pending', 'active', 'planned', 'queued', '']) {
+    assert.equal(isInactiveStatus(s), false, `${s} should not count as inactive`);
+  }
+});
+
+// ─── isSkippedForDispatch (closed, parked, or deferred) ────────────────────
+
+test('isSkippedForDispatch covers closed, parked, and deferred', () => {
+  for (const s of ['complete', 'done', 'skipped', 'closed', 'parked', 'deferred']) {
+    assert.equal(isSkippedForDispatch(s), true, `${s} should be skipped for dispatch ordering`);
+  }
+});
+
+test('isSkippedForDispatch does NOT skip pending/active/planned', () => {
+  for (const s of ['pending', 'active', 'planned', 'queued']) {
+    assert.equal(isSkippedForDispatch(s), false, `${s} should block dispatch ordering`);
+  }
 });


### PR DESCRIPTION
Adds a dedicated complete-milestone handler test (previously absent) and
extends the task/slice/status-guard/dispatch coverage for the close-out
process:

- complete-milestone (new): happy path, required-field validation, the
  explicit verificationPassed gate, the milestone-validation verdict gate
  (absent + fail), incomplete-slice and deep incomplete-task guards,
  idempotent re-completion (alreadyComplete + no duplicate event), and the
  #4598 "existing SUMMARY.md is not overwritten" guard.
- complete-task: remaining required-field validation (oneLiner/narrative/
  verification), closed-milestone and closed-slice guards, and Q5/Q6/Q7
  gate closing (pass when populated, omitted when empty).
- complete-slice: blocked/failed verification content gate (#3580),
  closed-milestone guard, and Q8 operational-readiness gate closing.
- status-guards: isDeferredStatus, isInactiveStatus, isSkippedForDispatch.
- milestone-closeout: evaluateCompleteMilestoneDispatch early branches
  (phase mismatch -> null, already-closed -> skip).

All touched files run green under the project's node --test runner.

https://claude.ai/code/session_017uRxFcust7gkjBwBX6eBCk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782869550&installation_id=134682257&pr_number=329&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F329&signature=de7ed6f146858d2d5ebcaaf3accedd13f67eaf95833ccdb7b327cffd6f1bedf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are tests and lockfile optional dependencies only; no application logic is modified in the diff.
> 
> **Overview**
> This PR **expands automated coverage** for GSD task/slice/milestone close-out—no production handler changes in the diff.
> 
> It adds a **new** `complete-milestone` handler test suite (previously missing) for happy path, required fields, `verificationPassed`, validation verdict gates, incomplete slice/task guards, idempotent re-completion, and preserving an existing `SUMMARY.md` (#4598).
> 
> **`complete-task`** and **`complete-slice`** tests gain guards for closed milestones/slices, extra required-field checks, blocked verification content (#3580), and gate closure behavior (Q5–Q7 / Q8). **`status-guards`** tests cover `isDeferredStatus`, `isInactiveStatus`, and `isSkippedForDispatch`. **`milestone-closeout`** tests cover `evaluateCompleteMilestoneDispatch` early branches (wrong phase → null, already closed → skip).
> 
> `pnpm-lock.yaml` also records optional `@opengsd/engine-*` platform packages at 1.1.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20926ee567f3e09110d4a8e53f978cd696a16f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->