### PR TITLE
feat(pi-tui): add mouse support (clicks + wheel) to the TUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 packages/*/dist/
 pkg/dist/
 
+# Node.js V8 compile cache (created by builds/test runs)
+node-compile-cache/
+
 # Compiled output in src/ should only contain TypeScript source.
 src/**/*.js
 src/**/*.js.map

--- a/packages/pi-tui/src/components/box.ts
+++ b/packages/pi-tui/src/components/box.ts
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "../mouse.js";
 import type { Component } from "../tui.js";
 import { applyBackgroundToLine, visibleWidth } from "../utils.js";
 
@@ -19,6 +20,10 @@ export class Box implements Component {
 
 	// Cache for rendered output
 	private cache?: RenderCache;
+
+	// Row range each child occupied within the content area (excluding top
+	// padding) at the last render, used to route mouse events to children.
+	private childRanges: { component: Component; start: number; lineCount: number }[] = [];
 
 	constructor(paddingX = 1, paddingY = 1, bgFn?: (text: string) => string) {
 		this.paddingX = paddingX;
@@ -81,8 +86,10 @@ export class Box implements Component {
 
 		// Render all children
 		const childLines: string[] = [];
+		this.childRanges = [];
 		for (const child of this.children) {
 			const lines = child.render(contentWidth);
+			this.childRanges.push({ component: child, start: childLines.length, lineCount: lines.length });
 			for (const line of lines) {
 				childLines.push(leftPad + line);
 			}
@@ -122,6 +129,21 @@ export class Box implements Component {
 		this.cache = { childLines, width, bgSample, lines: result };
 
 		return result;
+	}
+
+	handleMouse(event: MouseEvent): void {
+		// Translate from box-local coordinates into the child content area by
+		// removing the top/left padding, then find the child under the pointer.
+		const contentRow = event.y - this.paddingY;
+		const contentCol = event.x - this.paddingX;
+		if (contentRow < 0 || contentCol < 0) return;
+
+		for (const range of this.childRanges) {
+			if (contentRow >= range.start && contentRow < range.start + range.lineCount) {
+				range.component.handleMouse?.({ ...event, x: contentCol, y: contentRow - range.start });
+				return;
+			}
+		}
 	}
 
 	private applyBg(line: string, width: number): string {

--- a/packages/pi-tui/src/components/select-list.ts
+++ b/packages/pi-tui/src/components/select-list.ts
@@ -1,4 +1,5 @@
 import { getKeybindings } from "../keybindings.js";
+import type { MouseEvent } from "../mouse.js";
 import type { Component } from "../tui.js";
 import { truncateToWidth, visibleWidth } from "../utils.js";
 
@@ -45,6 +46,11 @@ export class SelectList implements Component {
 	private theme: SelectListTheme;
 	private layout: SelectListLayoutOptions;
 
+	// First item index and item count of the most recently rendered window,
+	// used to map a clicked row back to an item.
+	private viewStartIndex = 0;
+	private viewItemCount = 0;
+
 	public onSelect?: (item: SelectItem) => void;
 	public onCancel?: () => void;
 	public onSelectionChange?: (item: SelectItem) => void;
@@ -89,6 +95,11 @@ export class SelectList implements Component {
 		);
 		const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
 
+		// Record the visible window so handleMouse can map rows to items.
+		// Items occupy rows 0..(count-1); the optional scroll indicator follows.
+		this.viewStartIndex = startIndex;
+		this.viewItemCount = endIndex - startIndex;
+
 		// Render visible items
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = this.filteredItems[i];
@@ -132,6 +143,38 @@ export class SelectList implements Component {
 		else if (kb.matches(keyData, "tui.select.cancel")) {
 			if (this.onCancel) {
 				this.onCancel();
+			}
+		}
+	}
+
+	handleMouse(event: MouseEvent): void {
+		if (this.filteredItems.length === 0) return;
+
+		// Wheel moves the selection (with wrap, matching arrow-key behavior).
+		if (event.button === "wheel-up") {
+			this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;
+			this.notifySelectionChange();
+			return;
+		}
+		if (event.button === "wheel-down") {
+			this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
+			this.notifySelectionChange();
+			return;
+		}
+
+		// Left click on a visible row selects and confirms that item.
+		if (event.type === "press" && event.button === "left") {
+			const row = event.y;
+			if (row >= 0 && row < this.viewItemCount) {
+				const index = this.viewStartIndex + row;
+				const item = this.filteredItems[index];
+				if (item) {
+					this.selectedIndex = index;
+					this.notifySelectionChange();
+					if (this.onSelect) {
+						this.onSelect(item);
+					}
+				}
 			}
 		}
 	}

--- a/packages/pi-tui/src/components/settings-list.ts
+++ b/packages/pi-tui/src/components/settings-list.ts
@@ -1,5 +1,6 @@
 import { fuzzyFilter } from "../fuzzy.js";
 import { getKeybindings } from "../keybindings.js";
+import type { MouseEvent } from "../mouse.js";
 import type { Component } from "../tui.js";
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils.js";
 import { Input } from "./input.js";
@@ -46,6 +47,13 @@ export class SettingsList implements Component {
 	private submenuComponent: Component | null = null;
 	private submenuItemIndex: number | null = null;
 
+	// Layout of the most recently rendered main list, used to map a clicked row
+	// back to an item: items start at row `itemRowStart` and there are
+	// `viewItemCount` of them, beginning at item index `viewStartIndex`.
+	private itemRowStart = 0;
+	private viewStartIndex = 0;
+	private viewItemCount = 0;
+
 	constructor(
 		items: SettingItem[],
 		maxVisible: number,
@@ -90,6 +98,11 @@ export class SettingsList implements Component {
 	private renderMainList(width: number): string[] {
 		const lines: string[] = [];
 
+		// Reset click-mapping state; updated below once items are laid out.
+		this.itemRowStart = 0;
+		this.viewStartIndex = 0;
+		this.viewItemCount = 0;
+
 		if (this.searchEnabled && this.searchInput) {
 			lines.push(...this.searchInput.render(width));
 			lines.push("");
@@ -116,6 +129,11 @@ export class SettingsList implements Component {
 			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), displayItems.length - this.maxVisible),
 		);
 		const endIndex = Math.min(startIndex + this.maxVisible, displayItems.length);
+
+		// Record where items begin and the visible window for mouse hit-testing.
+		this.itemRowStart = lines.length;
+		this.viewStartIndex = startIndex;
+		this.viewItemCount = endIndex - startIndex;
 
 		// Calculate max label width for alignment
 		const maxLabelWidth = Math.min(30, Math.max(...this.items.map((item) => visibleWidth(item.label))));
@@ -193,6 +211,37 @@ export class SettingsList implements Component {
 			}
 			this.searchInput.handleInput(sanitized);
 			this.applyFilter(this.searchInput.getValue());
+		}
+	}
+
+	handleMouse(event: MouseEvent): void {
+		// Submenu owns the full overlay area; forward with unchanged coordinates
+		// (render() returns the submenu's lines directly, so there is no offset).
+		if (this.submenuComponent) {
+			this.submenuComponent.handleMouse?.(event);
+			return;
+		}
+
+		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
+		if (displayItems.length === 0) return;
+
+		// Wheel moves the selection (with wrap, matching arrow-key behavior).
+		if (event.button === "wheel-up") {
+			this.selectedIndex = this.selectedIndex === 0 ? displayItems.length - 1 : this.selectedIndex - 1;
+			return;
+		}
+		if (event.button === "wheel-down") {
+			this.selectedIndex = this.selectedIndex === displayItems.length - 1 ? 0 : this.selectedIndex + 1;
+			return;
+		}
+
+		// Left click on a visible row selects and activates that item.
+		if (event.type === "press" && event.button === "left") {
+			const itemRow = event.y - this.itemRowStart;
+			if (itemRow >= 0 && itemRow < this.viewItemCount) {
+				this.selectedIndex = this.viewStartIndex + itemRow;
+				this.activateItem();
+			}
 		}
 	}
 

--- a/packages/pi-tui/src/index.ts
+++ b/packages/pi-tui/src/index.ts
@@ -74,6 +74,16 @@ export {
 	parseKey,
 	setKittyProtocolActive,
 } from "./keys.js";
+// Mouse input handling
+export {
+	DISABLE_MOUSE,
+	ENABLE_MOUSE,
+	isMouseEvent,
+	type MouseButton,
+	type MouseEvent,
+	type MouseEventType,
+	parseMouseEvent,
+} from "./mouse.js";
 // Input buffering for batch splitting
 export { StdinBuffer, type StdinBufferEventMap, type StdinBufferOptions } from "./stdin-buffer.js";
 // Terminal interface and implementations

--- a/packages/pi-tui/src/mouse.ts
+++ b/packages/pi-tui/src/mouse.ts
@@ -1,0 +1,139 @@
+/**
+ * Mouse event parsing for the TUI.
+ *
+ * Supports the two common terminal mouse report encodings:
+ * - SGR extended mode: `CSI < b ; x ; y M` (press/motion) or `... m` (release).
+ *   Preferred because it has no 223-cell coordinate limit and reports the button
+ *   on release.
+ * - Legacy X10/normal mode: `CSI M` followed by exactly three bytes (button,
+ *   column, row), each offset by 32.
+ *
+ * Mouse reporting is turned on with {@link ENABLE_MOUSE} and off with
+ * {@link DISABLE_MOUSE} (see terminal.ts). We request button-event tracking
+ * (mode 1000) plus SGR extended coordinates (mode 1006). Wheel events are
+ * reported as buttons 64/65 under mode 1000, so no separate mode is needed.
+ *
+ * Coordinates produced here are 1-based screen coordinates, matching the
+ * terminal protocol. The TUI translates them to component-local 0-based
+ * coordinates before dispatching to {@link Component.handleMouse}.
+ */
+
+export type MouseButton = "left" | "middle" | "right" | "wheel-up" | "wheel-down" | "none";
+export type MouseEventType = "press" | "release" | "move" | "drag";
+
+export interface MouseEvent {
+	/** Kind of interaction. Clicks arrive as "press" then "release". */
+	type: MouseEventType;
+	/** Which button (or wheel direction) triggered the event. */
+	button: MouseButton;
+	/** Column of the event (1-based when produced by the parser). */
+	x: number;
+	/** Row of the event (1-based when produced by the parser). */
+	y: number;
+	ctrl: boolean;
+	alt: boolean;
+	shift: boolean;
+}
+
+/** Enable button-event tracking (1000) plus SGR extended coordinates (1006). */
+export const ENABLE_MOUSE = "\x1b[?1000h\x1b[?1006h";
+/** Disable mouse reporting (reverse order of {@link ENABLE_MOUSE}). */
+export const DISABLE_MOUSE = "\x1b[?1006l\x1b[?1000l";
+
+// SGR mouse report: ESC [ < button ; col ; row (M | m)
+const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+
+// Modifier bits shared by both encodings.
+const SHIFT_BIT = 4;
+const ALT_BIT = 8;
+const CTRL_BIT = 16;
+const MOTION_BIT = 32;
+const WHEEL_BIT = 64;
+
+/** True when `data` is a complete mouse report sequence. */
+export function isMouseEvent(data: string): boolean {
+	if (SGR_MOUSE_RE.test(data)) {
+		return true;
+	}
+	// Legacy X10: ESC [ M followed by exactly three encoded bytes.
+	return data.length === 6 && data.startsWith("\x1b[M");
+}
+
+function decodeButton(code: number, isRelease: boolean): { button: MouseButton; type: MouseEventType } {
+	if ((code & WHEEL_BIT) !== 0) {
+		// Wheel events: low bit selects direction.
+		return { button: (code & 1) === 0 ? "wheel-up" : "wheel-down", type: "press" };
+	}
+
+	let button: MouseButton;
+	switch (code & 3) {
+		case 0:
+			button = "left";
+			break;
+		case 1:
+			button = "middle";
+			break;
+		case 2:
+			button = "right";
+			break;
+		default:
+			button = "none";
+			break;
+	}
+
+	let type: MouseEventType;
+	if (isRelease) {
+		type = "release";
+	} else if ((code & MOTION_BIT) !== 0) {
+		type = button === "none" ? "move" : "drag";
+	} else {
+		type = "press";
+	}
+
+	return { button, type };
+}
+
+/**
+ * Parse a single mouse report sequence into a structured event, or return null
+ * if `data` is not a recognized mouse sequence.
+ */
+export function parseMouseEvent(data: string): MouseEvent | null {
+	const sgr = data.match(SGR_MOUSE_RE);
+	if (sgr) {
+		const code = parseInt(sgr[1], 10);
+		const x = parseInt(sgr[2], 10);
+		const y = parseInt(sgr[3], 10);
+		const isRelease = sgr[4] === "m";
+		const { button, type } = decodeButton(code, isRelease);
+		return {
+			type,
+			button,
+			x,
+			y,
+			shift: (code & SHIFT_BIT) !== 0,
+			alt: (code & ALT_BIT) !== 0,
+			ctrl: (code & CTRL_BIT) !== 0,
+		};
+	}
+
+	if (data.length === 6 && data.startsWith("\x1b[M")) {
+		const code = data.charCodeAt(3) - 32;
+		const x = data.charCodeAt(4) - 32;
+		const y = data.charCodeAt(5) - 32;
+		// Legacy mode reports any button release with the low bits set to 3 and
+		// does not say which button was released.
+		const isRelease = (code & WHEEL_BIT) === 0 && (code & 3) === 3;
+		const { button, type } = decodeButton(code, isRelease);
+		return {
+			type,
+			button: isRelease ? "none" : button,
+			x,
+			y,
+			shift: (code & SHIFT_BIT) !== 0,
+			alt: (code & ALT_BIT) !== 0,
+			ctrl: (code & CTRL_BIT) !== 0,
+		};
+	}
+
+	return null;
+}

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { setKittyProtocolActive } from "./keys.js";
+import { DISABLE_MOUSE, ENABLE_MOUSE } from "./mouse.js";
 import { StdinBuffer } from "./stdin-buffer.js";
 
 const cjsRequire = createRequire(import.meta.url);
@@ -70,6 +71,7 @@ export class ProcessTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _kittyProtocolActive = false;
 	private _modifyOtherKeysActive = false;
+	private _mouseActive = false;
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
 	private progressInterval?: ReturnType<typeof setInterval>;
@@ -116,6 +118,14 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+
+		// Enable mouse reporting so clicks and the wheel reach the TUI. On by
+		// default; set PI_TUI_MOUSE=0 to opt out (preserves native click-drag
+		// text selection without holding Shift).
+		if (process.env.PI_TUI_MOUSE !== "0") {
+			process.stdout.write(ENABLE_MOUSE);
+			this._mouseActive = true;
+		}
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -263,6 +273,10 @@ export class ProcessTerminal implements Terminal {
 			process.stdout.write("\x1b[>4;0m");
 			this._modifyOtherKeysActive = false;
 		}
+		if (this._mouseActive) {
+			process.stdout.write(DISABLE_MOUSE);
+			this._mouseActive = false;
+		}
 
 		const previousHandler = this.inputHandler;
 		this.inputHandler = undefined;
@@ -296,6 +310,12 @@ export class ProcessTerminal implements Terminal {
 
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
+
+		// Disable mouse reporting if not already done by drainInput()
+		if (this._mouseActive) {
+			process.stdout.write(DISABLE_MOUSE);
+			this._mouseActive = false;
+		}
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this._kittyProtocolActive) {

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -7,6 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.js";
+import { isMouseEvent, type MouseEvent, parseMouseEvent } from "./mouse.js";
 import type { Terminal } from "./terminal.js";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
 import {
@@ -55,6 +56,16 @@ export interface Component {
 	 * Optional handler for keyboard input when component has focus
 	 */
 	handleInput?(data: string): void;
+
+	/**
+	 * Optional handler for mouse input (clicks and wheel).
+	 *
+	 * Coordinates are component-local and 0-based: `x` is the column and `y`
+	 * the row within this component's own rendered output. Container-style
+	 * components are responsible for translating coordinates before forwarding
+	 * to children.
+	 */
+	handleMouse?(event: MouseEvent): void;
 
 	/**
 	 * If true, component receives key release events (Kitty protocol).
@@ -234,6 +245,10 @@ export interface OverlayHandle {
 export class Container implements Component {
 	children: Component[] = [];
 
+	// Row range each child occupied at the last render, used to route mouse
+	// events to the child under the pointer.
+	private childRanges: { component: Component; start: number; lineCount: number }[] = [];
+
 	addChild(component: Component): void {
 		this.children.push(component);
 	}
@@ -264,13 +279,26 @@ export class Container implements Component {
 
 	render(width: number): string[] {
 		const lines: string[] = [];
+		this.childRanges = [];
 		for (const child of this.children) {
 			const childLines = child.render(width);
+			this.childRanges.push({ component: child, start: lines.length, lineCount: childLines.length });
 			for (const line of childLines) {
 				lines.push(line);
 			}
 		}
 		return lines;
+	}
+
+	handleMouse(event: MouseEvent): void {
+		// Children are stacked vertically at full width; find the one under the
+		// pointer and forward with row-local coordinates.
+		for (const range of this.childRanges) {
+			if (event.y >= range.start && event.y < range.start + range.lineCount) {
+				range.component.handleMouse?.({ ...event, y: event.y - range.start });
+				return;
+			}
+		}
 	}
 }
 
@@ -305,6 +333,10 @@ export class TUI extends Container {
 		process.platform !== "win32" && process.env.PI_DISABLE_SYNC_OUTPUT !== "1";
 	private _lastRenderedComponents: string[] | null = null;
 	private _lastFrameHadOverlays = false;
+	// Number of content lines in the last rendered frame. Content is bottom-
+	// aligned to the screen, so this lets dispatchMouse map a screen row back to
+	// a content line for hit-testing base (non-overlay) components.
+	private baseContentLineCount = 0;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -314,6 +346,18 @@ export class TUI extends Container {
 		preFocus: Component | null;
 		hidden: boolean;
 		focusOrder: number;
+	}[] = [];
+
+	// Screen regions (viewport-relative, 0-based) of overlays from the last
+	// render, used to hit-test mouse events. Refreshed by compositeOverlays.
+	private overlayRegions: {
+		component: Component;
+		row: number;
+		col: number;
+		width: number;
+		height: number;
+		focusOrder: number;
+		capturing: boolean;
 	}[] = [];
 
 	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
@@ -611,6 +655,17 @@ export class TUI extends Container {
 			data = current;
 		}
 
+		// Mouse reports are dispatched by screen position, not to the focused
+		// component as keystrokes. Handle them before anything else so the raw
+		// escape sequence never leaks into a focused editor/input.
+		if (isMouseEvent(data)) {
+			const event = parseMouseEvent(data);
+			if (event) {
+				this.dispatchMouse(event);
+			}
+			return;
+		}
+
 		// Consume terminal cell size responses without blocking unrelated input.
 		if (this.consumeCellSizeResponse(data)) {
 			return;
@@ -646,6 +701,70 @@ export class TUI extends Container {
 			this.focusedComponent.handleInput(data);
 			this.requestRender();
 		}
+	}
+
+	/**
+	 * Route a mouse event to the component under the pointer.
+	 *
+	 * Capturing overlays (menus, settings, dialogs shown via showOverlay) render
+	 * at known screen positions and take precedence: the event is hit-tested
+	 * against the topmost matching region and forwarded with component-local
+	 * coordinates. A capturing overlay is modal, so a miss is swallowed rather
+	 * than leaking to the content beneath it.
+	 *
+	 * Otherwise the event targets base content. Rendered content is bottom-
+	 * aligned to the screen, so a screen row maps to a content line and the
+	 * event is routed through the component tree (Container/Box translate
+	 * coordinates to their children). Components without handleMouse — plain text,
+	 * spacers — simply ignore it.
+	 */
+	private dispatchMouse(event: MouseEvent): void {
+		// Convert 1-based terminal coordinates to 0-based viewport coordinates.
+		const screenRow = event.y - 1;
+		const screenCol = event.x - 1;
+
+		// Topmost capturing overlay first (highest focusOrder).
+		const regions = this.overlayRegions
+			.filter((r) => r.capturing)
+			.sort((a, b) => b.focusOrder - a.focusOrder);
+
+		for (const region of regions) {
+			const within =
+				screenRow >= region.row &&
+				screenRow < region.row + region.height &&
+				screenCol >= region.col &&
+				screenCol < region.col + region.width;
+			if (!within) continue;
+
+			if (region.component.handleMouse) {
+				// A press inside an overlay focuses it (mirrors keyboard focus).
+				if (event.type === "press" && this.focusedComponent !== region.component) {
+					this.setFocus(region.component);
+				}
+				region.component.handleMouse({
+					...event,
+					x: screenCol - region.col,
+					y: screenRow - region.row,
+				});
+				this.requestRender();
+			}
+			return;
+		}
+
+		// A capturing overlay is showing but the pointer is outside it: swallow.
+		if (regions.length > 0) {
+			return;
+		}
+
+		// Base content: translate the screen row to a content-line row.
+		if (this.baseContentLineCount <= 0) return;
+		const contentRow = screenRow + (this.baseContentLineCount - this.terminal.rows);
+		if (contentRow < 0) return;
+
+		// Container.handleMouse walks this.children using the row ranges recorded
+		// during render, forwarding to the component under the pointer.
+		this.handleMouse({ ...event, x: screenCol, y: contentRow });
+		this.requestRender();
 	}
 
 	private consumeCellSizeResponse(data: string): boolean {
@@ -808,6 +927,7 @@ export class TUI extends Container {
 
 	/** Composite all overlays into content lines (sorted by focusOrder, higher = on top). */
 	private compositeOverlays(lines: string[], termWidth: number, termHeight: number): string[] {
+		this.overlayRegions = [];
 		if (this.overlayStack.length === 0) return lines;
 		const result = [...lines];
 
@@ -836,6 +956,19 @@ export class TUI extends Container {
 			const { row, col } = this.resolveOverlayLayout(options, overlayLines.length, termWidth, termHeight);
 
 			rendered.push({ overlayLines, row, col, w: width });
+			// Record the on-screen region for mouse hit-testing. Overlays force the
+			// working area to at least the terminal height (see below), so the
+			// viewport is bottom-aligned to the screen and `row`/`col` are also the
+			// viewport-relative screen coordinates.
+			this.overlayRegions.push({
+				component,
+				row,
+				col,
+				width,
+				height: overlayLines.length,
+				focusOrder: entry.focusOrder,
+				capturing: !options?.nonCapturing,
+			});
 			minLinesNeeded = Math.max(minLinesNeeded, row + overlayLines.length);
 		}
 
@@ -1036,7 +1169,10 @@ export class TUI extends Container {
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
 			newLines = this.compositeOverlays(newLines, width, height);
+		} else {
+			this.overlayRegions = [];
 		}
+		this.baseContentLineCount = newLines.length;
 
 		// Extract cursor position before applying line resets (marker must be found first)
 		const cursorPos = this.extractCursorPosition(newLines, height);

--- a/packages/pi-tui/test/mouse.test.ts
+++ b/packages/pi-tui/test/mouse.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { isMouseEvent, parseMouseEvent } from "../src/mouse.ts";
+
+describe("parseMouseEvent (SGR)", () => {
+	it("parses a left button press", () => {
+		const event = parseMouseEvent("\x1b[<0;12;5M");
+		assert.deepStrictEqual(event, {
+			type: "press",
+			button: "left",
+			x: 12,
+			y: 5,
+			shift: false,
+			alt: false,
+			ctrl: false,
+		});
+	});
+
+	it("parses a left button release (lowercase m)", () => {
+		const event = parseMouseEvent("\x1b[<0;12;5m");
+		assert.strictEqual(event?.type, "release");
+		assert.strictEqual(event?.button, "left");
+	});
+
+	it("parses middle and right button presses", () => {
+		assert.strictEqual(parseMouseEvent("\x1b[<1;1;1M")?.button, "middle");
+		assert.strictEqual(parseMouseEvent("\x1b[<2;1;1M")?.button, "right");
+	});
+
+	it("parses wheel up and wheel down", () => {
+		const up = parseMouseEvent("\x1b[<64;1;1M");
+		assert.strictEqual(up?.button, "wheel-up");
+		assert.strictEqual(up?.type, "press");
+		const down = parseMouseEvent("\x1b[<65;1;1M");
+		assert.strictEqual(down?.button, "wheel-down");
+	});
+
+	it("decodes modifier bits", () => {
+		// 0 + shift(4) + alt(8) + ctrl(16) = 28
+		const event = parseMouseEvent("\x1b[<28;3;4M");
+		assert.deepStrictEqual(
+			{ shift: event?.shift, alt: event?.alt, ctrl: event?.ctrl },
+			{ shift: true, alt: true, ctrl: true },
+		);
+	});
+
+	it("classifies motion-with-button as drag", () => {
+		// bit 5 (32) = motion, low bits 0 = left held
+		const event = parseMouseEvent("\x1b[<32;3;4M");
+		assert.strictEqual(event?.type, "drag");
+		assert.strictEqual(event?.button, "left");
+	});
+
+	it("handles large coordinates beyond the 223 X10 limit", () => {
+		const event = parseMouseEvent("\x1b[<0;400;300M");
+		assert.strictEqual(event?.x, 400);
+		assert.strictEqual(event?.y, 300);
+	});
+});
+
+describe("parseMouseEvent (legacy X10)", () => {
+	it("parses a left press encoded as ESC [ M plus three bytes", () => {
+		// button 0, col 32->0 +1? bytes are value+32. col byte = 32+10 = 42 ('*')
+		const data = `\x1b[M${String.fromCharCode(32)}${String.fromCharCode(42)}${String.fromCharCode(37)}`;
+		const event = parseMouseEvent(data);
+		assert.strictEqual(event?.button, "left");
+		assert.strictEqual(event?.type, "press");
+		assert.strictEqual(event?.x, 10);
+		assert.strictEqual(event?.y, 5);
+	});
+
+	it("reports a button release with low bits set to 3", () => {
+		const data = `\x1b[M${String.fromCharCode(35)}${String.fromCharCode(33)}${String.fromCharCode(33)}`;
+		const event = parseMouseEvent(data);
+		assert.strictEqual(event?.type, "release");
+		assert.strictEqual(event?.button, "none");
+	});
+});
+
+describe("isMouseEvent", () => {
+	it("recognizes SGR and X10 sequences", () => {
+		assert.ok(isMouseEvent("\x1b[<0;1;1M"));
+		assert.ok(isMouseEvent(`\x1b[M${"!".repeat(3)}`));
+	});
+
+	it("rejects non-mouse input", () => {
+		assert.ok(!isMouseEvent("a"));
+		assert.ok(!isMouseEvent("\x1b[A")); // arrow up
+		assert.ok(!isMouseEvent("\x1b[<0;1;1")); // incomplete
+	});
+
+	it("returns null from parseMouseEvent for non-mouse data", () => {
+		assert.strictEqual(parseMouseEvent("\x1b[A"), null);
+	});
+});

--- a/packages/pi-tui/test/tui-mouse-dispatch.test.ts
+++ b/packages/pi-tui/test/tui-mouse-dispatch.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Box } from "../src/components/box.ts";
+import { SelectList, type SelectListTheme } from "../src/components/select-list.ts";
+import { Container, type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+const theme: SelectListTheme = {
+	selectedPrefix: (t) => t,
+	selectedText: (t) => t,
+	description: (t) => t,
+	scrollInfo: (t) => t,
+	noMatch: (t) => t,
+};
+
+class InputRecorder implements Component {
+	readonly inputs: string[] = [];
+	render(): string[] {
+		return [""];
+	}
+	handleInput(data: string): void {
+		this.inputs.push(data);
+	}
+	invalidate(): void {}
+}
+
+class EmptyContent implements Component {
+	render(): string[] {
+		return [];
+	}
+	invalidate(): void {}
+}
+
+// A fixed-height filler so base content reaches/exceeds the screen height,
+// matching a real session where chat history fills the viewport.
+class Filler implements Component {
+	constructor(private lineCount: number) {}
+	render(): string[] {
+		return Array.from({ length: this.lineCount }, (_, i) => `line ${i}`);
+	}
+	invalidate(): void {}
+}
+
+async function renderAndFlush(tui: TUI, terminal: VirtualTerminal): Promise<void> {
+	tui.requestRender(true);
+	await new Promise<void>((resolve) => process.nextTick(resolve));
+	await terminal.waitForRender();
+}
+
+describe("TUI mouse dispatch", () => {
+	it("does not deliver mouse sequences to a focused component as keystrokes", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		const recorder = new InputRecorder();
+
+		tui.setFocus(recorder);
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		terminal.sendInput("\x1b[<0;5;5M");
+
+		assert.deepStrictEqual(recorder.inputs, []);
+		tui.stop();
+	});
+
+	it("routes a click inside an overlay list to the clicked item", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+
+		const items = [
+			{ value: "one", label: "One" },
+			{ value: "two", label: "Two" },
+			{ value: "three", label: "Three" },
+		];
+		const list = new SelectList(items, 10, theme);
+		const selected: string[] = [];
+		list.onSelect = (item) => selected.push(item.value);
+
+		tui.addChild(new EmptyContent());
+		// Anchor at a known top-left position so screen rows map to item rows.
+		tui.showOverlay(list, { anchor: "top-left", margin: 0, width: 40 });
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		// Overlay top-left => row 0 is "One", row 2 is "Three" (1-based y).
+		terminal.sendInput("\x1b[<0;3;3M");
+
+		assert.deepStrictEqual(selected, ["three"]);
+		tui.stop();
+	});
+
+	it("routes wheel events inside an overlay list to move the selection", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+
+		const items = [
+			{ value: "a", label: "A" },
+			{ value: "b", label: "B" },
+			{ value: "c", label: "C" },
+		];
+		const list = new SelectList(items, 10, theme);
+		const changes: string[] = [];
+		list.onSelectionChange = (item) => changes.push(item.value);
+
+		tui.addChild(new EmptyContent());
+		tui.showOverlay(list, { anchor: "top-left", margin: 0, width: 40 });
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		// Wheel down once: selection moves from "a" to "b".
+		terminal.sendInput("\x1b[<65;1;1M");
+		assert.strictEqual(list.getSelectedItem()?.value, "b");
+		assert.deepStrictEqual(changes, ["b"]);
+		tui.stop();
+	});
+
+	it("routes a click through a Box-wrapped overlay to its child", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+
+		const items = [
+			{ value: "one", label: "One" },
+			{ value: "two", label: "Two" },
+		];
+		const list = new SelectList(items, 10, theme);
+		const selected: string[] = [];
+		list.onSelect = (item) => selected.push(item.value);
+
+		// Box with 1 row of top padding and 2 cols of left padding.
+		const box = new Box(2, 1);
+		box.addChild(list);
+
+		tui.addChild(new EmptyContent());
+		tui.showOverlay(box, { anchor: "top-left", margin: 0, width: 40 });
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		// Box top padding pushes "One" to screen row 1 (y=2), col offset 2 (x>=3).
+		terminal.sendInput("\x1b[<0;4;2M");
+
+		assert.deepStrictEqual(selected, ["one"]);
+		tui.stop();
+	});
+
+	it("routes a click to a base-content list when content fills the screen", async () => {
+		const rows = 24;
+		const terminal = new VirtualTerminal(80, rows);
+		const tui = new TUI(terminal);
+
+		const items = [
+			{ value: "alpha", label: "Alpha" },
+			{ value: "beta", label: "Beta" },
+			{ value: "gamma", label: "Gamma" },
+		];
+		const list = new SelectList(items, 10, theme);
+		const selected: string[] = [];
+		list.onSelect = (item) => selected.push(item.value);
+
+		// editorContainer-style wrapper containing the focused list.
+		const editorContainer = new Container();
+		editorContainer.addChild(list);
+
+		// Tall history above the selector so content fills the viewport.
+		tui.addChild(new Filler(40));
+		tui.addChild(editorContainer);
+		tui.setFocus(list);
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		// Content is 43 lines (40 filler + 3 items), bottom-aligned in 24 rows:
+		// the 3 list items occupy the last 3 screen rows (y = 22, 23, 24).
+		// Click the middle item ("Beta") at y = 23.
+		terminal.sendInput("\x1b[<0;5;23M");
+
+		assert.deepStrictEqual(selected, ["beta"]);
+		tui.stop();
+	});
+
+	it("ignores base-content clicks above the rendered content", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+
+		const items = [{ value: "alpha", label: "Alpha" }];
+		const list = new SelectList(items, 10, theme);
+		const selected: string[] = [];
+		list.onSelect = (item) => selected.push(item.value);
+
+		const editorContainer = new Container();
+		editorContainer.addChild(list);
+		tui.addChild(editorContainer);
+		tui.setFocus(list);
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		// Only one content line; it sits at the bottom (y = 24). A click near the
+		// top of the screen lands in the empty area and must not select anything.
+		terminal.sendInput("\x1b[<0;5;3M");
+
+		assert.deepStrictEqual(selected, []);
+		tui.stop();
+	});
+});

--- a/packages/pi-tui/test/virtual-terminal.ts
+++ b/packages/pi-tui/test/virtual-terminal.ts
@@ -51,6 +51,11 @@ export class VirtualTerminal implements Terminal {
 		this.xterm.write(data);
 	}
 
+	get isTTY(): boolean {
+		// Report as interactive so the TUI runs its full input/render pipeline.
+		return true;
+	}
+
 	get columns(): number {
 		return this._columns;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,21 @@ importers:
       '@mariozechner/clipboard':
         specifier: 0.3.6
         version: 0.3.6
+      '@opengsd/engine-darwin-arm64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-darwin-x64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-arm64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-x64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.1.1
+        version: 1.1.1
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1909,6 +1924,31 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-Z0lJq5f+WCQnox3ZJzaz0hZWp0iC9Pmzx1A9TGZ95b/UX+3woDJf3mZ3HX2KiiuhKkMVTGyvzwyKfuvylA+7xw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-Wi7xWysu6LsRH7ZBJszy+VtpZJETLeqAZ3/dG0CzjDK0VRAew+8nkZhpvDu1IipHZqsIHtCIhYKOk5apdRXK0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-8Asyr1Oj+0aszi2rMqRkbyFC+SHTFxqcB6fNnfo7zB+T0CGlH4EdrDfShz08OuZqfj1B3rOTp5EFsqVnUhYNgw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-bOQciYjimEbSzmuUKZPciTEJTWWUwKn1PoU3AVNb5EZq+C0Roj5FnsMgP5/pKV54ZoSPR0nSedH+DVKUHxc8dA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-56WdCcORvLj4FHAG5AJTDSdzeV7m7at6CcYjcGpf1fZtWz/0gGz9zTC10125gewQZiKgD0/sxXcxTtxTCC3Fpw==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -7711,6 +7751,21 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
Enable terminal mouse reporting (SGR + X10) and route clicks and the
scroll wheel to components. Menus, settings, and dialogs are now
clickable; the wheel moves the selection.

- mouse.ts: parse SGR (CSI < b;x;y M/m) and legacy X10 mouse reports into
  structured MouseEvent values; ENABLE_MOUSE/DISABLE_MOUSE sequences.
- terminal.ts: turn on mouse reporting in start() (on by default; opt out
  with PI_TUI_MOUSE=0) and turn it off in stop()/drainInput().
- tui.ts: add an optional Component.handleMouse hook and a dispatcher.
  Capturing overlays are hit-tested by their rendered region; otherwise
  the screen row maps to a content line (content is bottom-aligned) and
  the event walks the component tree. Container forwards to children by
  row range.
- box.ts: forward mouse events to children, accounting for padding.
- select-list.ts / settings-list.ts: click to select/activate a row,
  wheel to move the selection.
- test helper: VirtualTerminal now reports isTTY (required by the Terminal
  interface) so TUI tests drive the full input/render pipeline.

https://claude.ai/code/session_01FjZSKysMz5YNyqU6uTGeCw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782871467&installation_id=134682257&pr_number=330&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F330&signature=84212db65c5d8d70a064b6345043eec92f5263f6cd1772cef8f542a1dc4b13f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default terminal behavior (mouse capture on unless PI_TUI_MOUSE=0) and adds coordinate routing for overlays and bottom-aligned content; mistakes could mis-route clicks or block native selection, but scope is localized to pi-tui with solid test coverage.
> 
> **Overview**
> Adds **terminal mouse support** to `pi-tui`: clicks and scroll wheel can drive lists and overlays instead of keyboard-only interaction.
> 
> A new **`mouse.ts`** module parses SGR and legacy X10 reports into `MouseEvent` values and exposes `ENABLE_MOUSE` / `DISABLE_MOUSE`. **`ProcessTerminal`** turns reporting on at startup (default on; **`PI_TUI_MOUSE=0`** opts out) and off on stop/drain.
> 
> **`TUI`** intercepts mouse sequences before keyboard handling (so escape sequences never reach focused inputs), maps screen coordinates to bottom-aligned content and overlay regions, and routes events via optional **`Component.handleMouse`**. **`Container`** and **`Box`** forward to children using row ranges recorded at render time (with padding adjustment for `Box`).
> 
> **`SelectList`** and **`SettingsList`** implement click-to-select/activate and wheel-to-move-selection (wrapping like arrow keys). **`compositeOverlays`** records overlay hit regions for modal overlays.
> 
> Tests cover parsing (`mouse.test.ts`) and end-to-end dispatch (`tui-mouse-dispatch.test.ts`); **`VirtualTerminal`** reports **`isTTY: true`** so tests exercise the full pipeline. Minor: **`.gitignore`** adds `node-compile-cache/`; lockfile adds optional **`@opengsd/engine-*`** platform packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d902b45d7b04237759308389aeee7bdd7da1920b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->