### PR TITLE
fix(web): make packaged standalone host bootable and fail fast on boot errors (#328)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,21 @@ importers:
       '@mariozechner/clipboard':
         specifier: 0.3.6
         version: 0.3.6
+      '@opengsd/engine-darwin-arm64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-darwin-x64':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-arm64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-linux-x64-gnu':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.1.1
+        version: 1.1.1
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1909,6 +1924,31 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-Z0lJq5f+WCQnox3ZJzaz0hZWp0iC9Pmzx1A9TGZ95b/UX+3woDJf3mZ3HX2KiiuhKkMVTGyvzwyKfuvylA+7xw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-Wi7xWysu6LsRH7ZBJszy+VtpZJETLeqAZ3/dG0CzjDK0VRAew+8nkZhpvDu1IipHZqsIHtCIhYKOk5apdRXK0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-8Asyr1Oj+0aszi2rMqRkbyFC+SHTFxqcB6fNnfo7zB+T0CGlH4EdrDfShz08OuZqfj1B3rOTp5EFsqVnUhYNgw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-bOQciYjimEbSzmuUKZPciTEJTWWUwKn1PoU3AVNb5EZq+C0Roj5FnsMgP5/pKV54ZoSPR0nSedH+DVKUHxc8dA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-56WdCcORvLj4FHAG5AJTDSdzeV7m7at6CcYjcGpf1fZtWz/0gGz9zTC10125gewQZiKgD0/sxXcxTtxTCC3Fpw==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -7711,6 +7751,21 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opengsd/engine-darwin-arm64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-darwin-x64@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.1.1':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/scripts/stage-web-standalone.cjs
+++ b/scripts/stage-web-standalone.cjs
@@ -1,18 +1,16 @@
 #!/usr/bin/env node
 
-const { cpSync, existsSync, mkdirSync, readdirSync, rmSync } = require('node:fs')
-const { join, resolve } = require('node:path')
-
-const root = resolve(__dirname, '..')
-const webRoot = join(root, 'web')
-const standaloneRoot = join(webRoot, '.next', 'standalone')
-const standaloneAppRoot = join(standaloneRoot, 'web')
-const standaloneNodeModulesRoot = join(standaloneRoot, 'node_modules')
-const staticRoot = join(webRoot, '.next', 'static')
-const publicRoot = join(webRoot, 'public')
-const distWebRoot = join(root, 'dist', 'web')
-const distStandaloneRoot = join(distWebRoot, 'standalone')
-const sourceNodePtyRoot = join(webRoot, 'node_modules', 'node-pty')
+const {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} = require('node:fs')
+const { dirname, join, resolve } = require('node:path')
 
 const COPY_OPTIONS = {
   recursive: true,
@@ -20,7 +18,7 @@ const COPY_OPTIONS = {
   dereference: true,
 }
 
-function overlayNodePty(targetRoot) {
+function overlayNodePty(targetRoot, sourceNodePtyRoot) {
   if (!existsSync(sourceNodePtyRoot)) return []
 
   const hydrated = []
@@ -42,32 +40,200 @@ function overlayNodePty(targetRoot) {
   return hydrated
 }
 
-if (!existsSync(standaloneAppRoot)) {
-  console.error('[gsd] Web standalone build not found at web/.next/standalone/web. Run `npm --prefix web run build` first.')
-  process.exit(1)
+// ─── pnpm virtual store flattening ──────────────────────────────────────────
+//
+// pnpm lays dependencies down as symlinks into a `.pnpm/` virtual store, but
+// `npm publish`/`npm pack` SILENTLY DROP symlinks from the tarball. The Next
+// standalone output therefore loses its top-level `next`/`react`/`react-dom`
+// entries (and every nested dependency edge) once published, and the host
+// crashes on boot with `Cannot find module 'next'` (#328).
+//
+// `cpSync({ dereference: true })` does NOT help: it dereferences only the entry
+// passed to it, leaving nested symlinks inside the tree intact. We instead
+// flatten the store into a real, hoisted `node_modules` so every package
+// survives packing as a plain directory and resolves by ordinary directory
+// walking.
+
+/**
+ * Map every real package in the `.pnpm` store to its source directory, keyed by
+ * package name. Within `.pnpm/<name>@<version>_<peers>/node_modules/`, the real
+ * (non-symlink) directories are the packages themselves; sibling symlinks are
+ * just dependency edges into other store entries.
+ */
+function collectStorePackages(pnpmRoot) {
+  const packages = new Map()
+  if (!existsSync(pnpmRoot)) return packages
+
+  const record = (name, dir) => {
+    if (!packages.has(name)) packages.set(name, dir)
+  }
+
+  for (const entry of readdirSync(pnpmRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const entryNodeModules = join(pnpmRoot, entry.name, 'node_modules')
+    if (!existsSync(entryNodeModules)) continue
+
+    for (const pkg of readdirSync(entryNodeModules, { withFileTypes: true })) {
+      if (pkg.isSymbolicLink() || pkg.name === '.bin') continue
+      const pkgPath = join(entryNodeModules, pkg.name)
+
+      if (pkg.name.startsWith('@')) {
+        if (!pkg.isDirectory()) continue
+        for (const scoped of readdirSync(pkgPath, { withFileTypes: true })) {
+          if (scoped.isSymbolicLink() || !scoped.isDirectory()) continue
+          record(`${pkg.name}/${scoped.name}`, join(pkgPath, scoped.name))
+        }
+        continue
+      }
+
+      if (pkg.isDirectory()) record(pkg.name, pkgPath)
+    }
+  }
+
+  return packages
 }
 
-rmSync(distWebRoot, { recursive: true, force: true })
-mkdirSync(distStandaloneRoot, { recursive: true })
+/**
+ * Versions pnpm hoisted to the public top level win when the store holds more
+ * than one copy of a package name. Read them straight off the (still-present)
+ * top-level symlinks so the hoisted tree mirrors what pnpm itself resolved.
+ */
+function collectPreferredTopLevelTargets(nodeModulesRoot) {
+  const preferred = new Map()
 
-cpSync(standaloneAppRoot, distStandaloneRoot, COPY_OPTIONS)
+  const recordIfLink = (name, linkPath) => {
+    try {
+      if (!lstatSync(linkPath).isSymbolicLink()) return
+      const real = realpathSync(linkPath)
+      if (statSync(real).isDirectory()) preferred.set(name, real)
+    } catch {
+      // Dangling link — nothing usable to hoist.
+    }
+  }
 
-if (existsSync(standaloneNodeModulesRoot)) {
-  cpSync(standaloneNodeModulesRoot, join(distStandaloneRoot, 'node_modules'), COPY_OPTIONS)
+  for (const entry of readdirSync(nodeModulesRoot, { withFileTypes: true })) {
+    if (entry.name === '.pnpm') continue
+    const entryPath = join(nodeModulesRoot, entry.name)
+    if (entry.isSymbolicLink()) {
+      recordIfLink(entry.name, entryPath)
+    } else if (entry.name.startsWith('@') && entry.isDirectory()) {
+      for (const scoped of readdirSync(entryPath, { withFileTypes: true })) {
+        recordIfLink(`${entry.name}/${scoped.name}`, join(entryPath, scoped.name))
+      }
+    }
+  }
+
+  return preferred
 }
 
-if (existsSync(staticRoot)) {
-  mkdirSync(join(distStandaloneRoot, '.next'), { recursive: true })
-  cpSync(staticRoot, join(distStandaloneRoot, '.next', 'static'), COPY_OPTIONS)
+function removeSymlinksRecursively(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = join(dir, entry.name)
+    if (entry.isSymbolicLink()) {
+      rmSync(entryPath, { force: true })
+    } else if (entry.isDirectory()) {
+      removeSymlinksRecursively(entryPath)
+    }
+  }
 }
 
-if (existsSync(publicRoot)) {
-  cpSync(publicRoot, join(distStandaloneRoot, 'public'), COPY_OPTIONS)
+/**
+ * Flatten a pnpm `.pnpm` virtual store into a real hoisted `node_modules`.
+ * Returns the number of packages materialised. Idempotent on a store-free tree.
+ */
+function hoistPnpmVirtualStore(nodeModulesRoot) {
+  const pnpmRoot = join(nodeModulesRoot, '.pnpm')
+  if (!existsSync(pnpmRoot)) return 0
+
+  const preferred = collectPreferredTopLevelTargets(nodeModulesRoot)
+  const storePackages = collectStorePackages(pnpmRoot)
+
+  let hoisted = 0
+  const writePackage = (name, sourceDir) => {
+    const segments = name.startsWith('@') ? name.split('/') : [name]
+    const dest = join(nodeModulesRoot, ...segments)
+    rmSync(dest, { recursive: true, force: true })
+    mkdirSync(dirname(dest), { recursive: true })
+    cpSync(sourceDir, dest, COPY_OPTIONS)
+    hoisted++
+  }
+
+  for (const [name, sourceDir] of storePackages) {
+    writePackage(name, preferred.get(name) ?? sourceDir)
+  }
+  // A package may have been public-hoisted without a matching store entry name
+  // (e.g. shipped only via a top-level link); honour those too.
+  for (const [name, sourceDir] of preferred) {
+    if (!storePackages.has(name)) writePackage(name, sourceDir)
+  }
+
+  // The store and every dependency-edge symlink into it are now redundant: each
+  // package they referenced is resolvable from the flat top-level tree, and the
+  // dangling links would not survive packing anyway.
+  rmSync(pnpmRoot, { recursive: true, force: true })
+  removeSymlinksRecursively(nodeModulesRoot)
+
+  return hoisted
 }
 
-const hydratedTargets = overlayNodePty(distStandaloneRoot)
+function stageWebStandalone(root = resolve(__dirname, '..')) {
+  const webRoot = join(root, 'web')
+  const standaloneRoot = join(webRoot, '.next', 'standalone')
+  const standaloneAppRoot = join(standaloneRoot, 'web')
+  const standaloneNodeModulesRoot = join(standaloneRoot, 'node_modules')
+  const staticRoot = join(webRoot, '.next', 'static')
+  const publicRoot = join(webRoot, 'public')
+  const distWebRoot = join(root, 'dist', 'web')
+  const distStandaloneRoot = join(distWebRoot, 'standalone')
+  const sourceNodePtyRoot = join(webRoot, 'node_modules', 'node-pty')
 
-console.log(`[gsd] Staged web standalone host at ${distStandaloneRoot}`)
-if (hydratedTargets.length > 0) {
-  console.log(`[gsd] Hydrated node-pty native assets in ${hydratedTargets.length} location(s).`)
+  if (!existsSync(standaloneAppRoot)) {
+    console.error('[gsd] Web standalone build not found at web/.next/standalone/web. Run `npm --prefix web run build` first.')
+    process.exit(1)
+  }
+
+  rmSync(distWebRoot, { recursive: true, force: true })
+  mkdirSync(distStandaloneRoot, { recursive: true })
+
+  cpSync(standaloneAppRoot, distStandaloneRoot, COPY_OPTIONS)
+
+  let hoistedCount = 0
+  if (existsSync(standaloneNodeModulesRoot)) {
+    const distNodeModulesRoot = join(distStandaloneRoot, 'node_modules')
+    cpSync(standaloneNodeModulesRoot, distNodeModulesRoot, COPY_OPTIONS)
+    hoistedCount = hoistPnpmVirtualStore(distNodeModulesRoot)
+  }
+
+  if (existsSync(staticRoot)) {
+    mkdirSync(join(distStandaloneRoot, '.next'), { recursive: true })
+    cpSync(staticRoot, join(distStandaloneRoot, '.next', 'static'), COPY_OPTIONS)
+  }
+
+  if (existsSync(publicRoot)) {
+    cpSync(publicRoot, join(distStandaloneRoot, 'public'), COPY_OPTIONS)
+  }
+
+  const hydratedTargets = overlayNodePty(distStandaloneRoot, sourceNodePtyRoot)
+
+  console.log(`[gsd] Staged web standalone host at ${distStandaloneRoot}`)
+  if (hoistedCount > 0) {
+    console.log(`[gsd] Flattened ${hoistedCount} package(s) from the pnpm virtual store so they survive npm pack.`)
+  }
+  if (hydratedTargets.length > 0) {
+    console.log(`[gsd] Hydrated node-pty native assets in ${hydratedTargets.length} location(s).`)
+  }
+}
+
+module.exports = {
+  COPY_OPTIONS,
+  collectStorePackages,
+  collectPreferredTopLevelTargets,
+  hoistPnpmVirtualStore,
+  removeSymlinksRecursively,
+  overlayNodePty,
+  stageWebStandalone,
+}
+
+if (require.main === module) {
+  stageWebStandalone()
 }

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -396,6 +396,37 @@ try {
   }
   console.log(`    All ${getLinkablePackages().length} linkable packages are resolvable.`);
 
+  // --- Verify the packaged standalone web host resolves its runtime deps ---
+  // pnpm lays top-level deps down as symlinks into a `.pnpm/` store, and
+  // `npm pack` silently drops symlinks — so the published standalone host can
+  // lose its `next`/`react`/`react-dom` entries and crash on boot with
+  // `Cannot find module 'next'` (#328). Resolving them from the installed
+  // standalone dir turns that fatal, silent packaging gap into a hard publish
+  // gate. (The staging step flattens the store; this proves it stuck.)
+  console.log('==> Verifying packaged standalone web host resolves runtime deps...');
+  const standaloneDir = join(installedRoot, 'dist', 'web', 'standalone');
+  try {
+    execFileSync(
+      process.execPath,
+      ['-e', "require.resolve('next'); require.resolve('react'); require.resolve('react-dom')"],
+      {
+        cwd: standaloneDir,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    standalone host resolves next/react/react-dom.');
+  } catch (err) {
+    console.log('ERROR: packaged standalone web host cannot resolve next/react/react-dom after install.');
+    console.log(`    Checked from: ${standaloneDir}`);
+    console.log('    pnpm symlinks were likely dropped by npm pack — staging must flatten the .pnpm store.');
+    if (err.stdout) console.log(err.stdout);
+    if (err.stderr) console.log(err.stderr);
+    process.exit(1);
+  }
+
   // --- Run the binary to confirm end-to-end resolution ---
   console.log('==> Running installed binary (gsd -v)...');
   const loaderPath = join(installedRoot, 'dist', 'loader.js');

--- a/src/tests/integration/web-mode-cli.test.ts
+++ b/src/tests/integration/web-mode-cli.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -119,6 +119,7 @@ test('launchWebMode prefers the packaged standalone host and opens the resolved 
         openedUrl = url
       },
       pidFilePath,
+      hostLogDir: tmp,
       writePidFile: (path, pid) => {
         writtenPid = { path, pid }
         webMode.writePidFile(path, pid)
@@ -144,31 +145,36 @@ test('launchWebMode prefers the packaged standalone host and opens the resolved 
   // Extract the auth token the launcher generated so we can verify it was
   // passed consistently to both the env and the browser URL.
   const authToken = openedUrl.replace('http://127.0.0.1:45123/#token=', '')
-  assert.deepEqual(spawnInvocation, {
-    command: '/custom/node',
-    args: [serverPath],
-    options: {
-      cwd: standaloneRoot,
-      detached: true,
-      stdio: 'ignore',
-      windowsHide: true,
-      shell: false,
-      env: {
-        TEST_ENV: '1',
-        HOSTNAME: '127.0.0.1',
-        PORT: '45123',
-        GSD_WEB_HOST: '127.0.0.1',
-        GSD_WEB_PORT: '45123',
-        GSD_WEB_AUTH_TOKEN: authToken,
-        GSD_WEB_PROJECT_CWD: '/tmp/current-project',
-        GSD_WEB_PROJECT_SESSIONS_DIR: '/tmp/.gsd/sessions/--tmp-current-project--',
-        GSD_WEB_PACKAGE_ROOT: tmp,
-        GSD_WEB_HOST_KIND: 'packaged-standalone',
-      },
-    },
+  assert.ok(spawnInvocation, 'spawn must have been called')
+  assert.equal(spawnInvocation!.command, '/custom/node')
+  assert.deepEqual(spawnInvocation!.args, [serverPath])
+  assert.equal(spawnInvocation!.options.cwd, standaloneRoot)
+  assert.equal(spawnInvocation!.options.detached, true)
+  assert.equal(spawnInvocation!.options.windowsHide, true)
+  assert.equal(spawnInvocation!.options.shell, false)
+  assert.deepEqual(spawnInvocation!.options.env, {
+    TEST_ENV: '1',
+    HOSTNAME: '127.0.0.1',
+    PORT: '45123',
+    GSD_WEB_HOST: '127.0.0.1',
+    GSD_WEB_PORT: '45123',
+    GSD_WEB_AUTH_TOKEN: authToken,
+    GSD_WEB_PROJECT_CWD: '/tmp/current-project',
+    GSD_WEB_PROJECT_SESSIONS_DIR: '/tmp/.gsd/sessions/--tmp-current-project--',
+    GSD_WEB_PACKAGE_ROOT: tmp,
+    GSD_WEB_HOST_KIND: 'packaged-standalone',
   })
+  // The child's stderr is redirected to a log file (fd), not dropped to
+  // /dev/null and not a pipe (which would EPIPE the detached host on exit).
+  const stdio = spawnInvocation!.options.stdio as [string, string, number]
+  assert.equal(stdio[0], 'ignore')
+  assert.equal(stdio[1], 'ignore')
+  assert.equal(typeof stdio[2], 'number', 'child stderr should be redirected to a log file descriptor')
   assert.match(stderrOutput, /status=started/)
   assert.match(stderrOutput, /port=45123/)
+  // The launch log distinguishes the real bind target from the entry script.
+  assert.match(stderrOutput, /listen=127\.0\.0\.1:45123/)
+  assert.match(stderrOutput, new RegExp(`entry=${serverPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
   // PID file must be written with the spawned process's PID
   assert.deepEqual(writtenPid, { path: pidFilePath, pid: 99999 })
   assert.equal(webMode.readPidFile(pidFilePath), 99999)
@@ -422,6 +428,69 @@ test('launch failure surfaces status and reason before browser open', async (t) 
   assert.match(status.failureReason, /host bootstrap not found/)
   assert.match(stderrOutput, /status=failed/)
   assert.match(stderrOutput, /reason=host bootstrap not found/)
+})
+
+test('launchWebMode fails fast when the host exits before boot and surfaces its stderr', async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-web-fastfail-'))
+  const standaloneRoot = join(tmp, 'dist', 'web', 'standalone')
+  const serverPath = join(standaloneRoot, 'server.js')
+  mkdirSync(standaloneRoot, { recursive: true })
+  writeFileSync(serverPath, 'console.log("stub")\n')
+
+  const pidFilePath = join(tmp, 'web-server.pid')
+  const registryPath = join(tmp, 'web-instances.json')
+  const port = 46555
+  let stderrOutput = ''
+  let killed = false
+  let openedBrowser = false
+
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+  const status = await webMode.launchWebMode(
+    {
+      cwd: '/tmp/fastfail-project',
+      projectSessionsDir: '/tmp/.gsd/sessions/fastfail',
+      agentDir: '/tmp/.gsd/agent',
+      packageRoot: tmp,
+    },
+    {
+      initResources: () => {},
+      resolvePort: async () => port,
+      execPath: '/custom/node',
+      env: { TEST_ENV: '1' },
+      hostLogDir: tmp,
+      spawn: () => {
+        // Simulate the host writing a fatal error to its redirected stderr, then dying.
+        appendFileSync(join(tmp, `gsd-web-host-${port}.log`), "Error: Cannot find module 'next'\n")
+        const child: any = {
+          pid: 70123,
+          unref: () => {},
+          kill: () => { killed = true; return true },
+          once: (event: string, cb: (...a: any[]) => void) => {
+            if (event === 'exit') setImmediate(() => cb(1, null))
+            return child
+          },
+        }
+        return child
+      },
+      // Never resolves — readiness must lose the race to the child's early exit
+      // instead of waiting out the full 180s boot window on ECONNREFUSED.
+      waitForBootReady: () => new Promise<void>(() => {}),
+      openBrowser: () => { openedBrowser = true },
+      pidFilePath,
+      registryPath,
+      writePidFile: webMode.writePidFile,
+      stderr: { write: (chunk: string) => { stderrOutput += chunk; return true } },
+    },
+  )
+
+  assert.equal(status.ok, false)
+  if (status.ok) throw new Error('expected fast-fail status')
+  assert.match(status.failureReason, /child-exit:code=1 signal=null/)
+  assert.match(status.failureReason, /Cannot find module 'next'/)
+  assert.equal(killed, true, 'the dead child should be reaped on the failure path')
+  assert.equal(openedBrowser, false, 'browser must not open when the host never came up')
+  assert.match(stderrOutput, /status=failed/)
 })
 
 // ─── Instance registry tests ─────────────────────────────────────────

--- a/src/tests/integration/web-standalone-staging.test.ts
+++ b/src/tests/integration/web-standalone-staging.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Load the packaging helper the way the build invokes it (a CommonJS script).
+const require = createRequire(import.meta.url)
+const staging = require(join(process.cwd(), 'scripts', 'stage-web-standalone.cjs')) as {
+  hoistPnpmVirtualStore: (nodeModulesRoot: string) => number
+}
+
+/** Recursively assert no symbolic links remain (what `npm pack` would drop). */
+function findSymlinks(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = join(dir, entry.name)
+    if (entry.isSymbolicLink()) found.push(entryPath)
+    else if (entry.isDirectory()) findSymlinks(entryPath, found)
+  }
+  return found
+}
+
+function writePackage(dir: string, name: string, indexBody: string): void {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, version: '1.0.0', main: 'index.js' }))
+  writeFileSync(join(dir, 'index.js'), indexBody)
+}
+
+/**
+ * Build a pnpm-style standalone `node_modules`: a `.pnpm/` virtual store holding
+ * the real packages, top-level symlinks for the directly-depended packages, and
+ * dependency-edge symlinks inside the store. This mirrors the exact layout that
+ * crashes `gsd web` after publish (#328), where `next` depends on a NON-hoisted
+ * `styled-jsx` and a scoped `@swc/helpers`.
+ */
+function buildPnpmFixture(nm: string): void {
+  const pnpm = join(nm, '.pnpm')
+
+  // Real packages in the store.
+  writePackage(
+    join(pnpm, 'next@16.2.4', 'node_modules', 'next'),
+    'next',
+    "require('react'); require('styled-jsx'); require('@swc/helpers'); process.stdout.write('OK')",
+  )
+  writePackage(join(pnpm, 'react@19.0.0', 'node_modules', 'react'), 'react', 'module.exports = {}')
+  writePackage(join(pnpm, 'styled-jsx@5.1.0', 'node_modules', 'styled-jsx'), 'styled-jsx', 'module.exports = {}')
+  writePackage(join(pnpm, '@swc+helpers@0.5.0', 'node_modules', '@swc', 'helpers'), '@swc/helpers', 'module.exports = {}')
+
+  // Dependency-edge symlinks inside next's store entry.
+  const nextNm = join(pnpm, 'next@16.2.4', 'node_modules')
+  symlinkSync('../../react@19.0.0/node_modules/react', join(nextNm, 'react'))
+  symlinkSync('../../styled-jsx@5.1.0/node_modules/styled-jsx', join(nextNm, 'styled-jsx'))
+  mkdirSync(join(nextNm, '@swc'), { recursive: true })
+  symlinkSync('../../../@swc+helpers@0.5.0/node_modules/@swc/helpers', join(nextNm, '@swc', 'helpers'))
+
+  // Public top-level links pnpm lays down for the app's direct dependencies.
+  symlinkSync('.pnpm/next@16.2.4/node_modules/next', join(nm, 'next'))
+  symlinkSync('.pnpm/react@19.0.0/node_modules/react', join(nm, 'react'))
+}
+
+test('hoistPnpmVirtualStore flattens the .pnpm store into pack-safe real directories', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-stage-hoist-'))
+  const nm = join(root, 'node_modules')
+  mkdirSync(nm, { recursive: true })
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+
+  buildPnpmFixture(nm)
+
+  const hoisted = staging.hoistPnpmVirtualStore(nm)
+  assert.ok(hoisted >= 4, `expected at least 4 packages hoisted, got ${hoisted}`)
+
+  // Every package is now a real top-level directory (survives npm pack).
+  for (const pkg of ['next', 'react', 'styled-jsx']) {
+    assert.ok(existsSync(join(nm, pkg)), `${pkg} should exist at top level`)
+    assert.equal(lstatSync(join(nm, pkg)).isSymbolicLink(), false, `${pkg} must be a real dir, not a symlink`)
+  }
+  // The non-hoisted private dependency must be lifted to top level too — this is
+  // the entry whose absence produced `Cannot find module` at runtime.
+  assert.ok(existsSync(join(nm, 'styled-jsx', 'package.json')), 'styled-jsx must be materialised')
+  assert.ok(existsSync(join(nm, '@swc', 'helpers', 'package.json')), 'scoped @swc/helpers must be materialised')
+
+  // The store and all symlinks are gone — nothing left for npm pack to drop.
+  assert.equal(existsSync(join(nm, '.pnpm')), false, '.pnpm store should be removed after flattening')
+  assert.deepEqual(findSymlinks(nm), [], 'no symlinks should remain in the flattened tree')
+
+  // Prove resolution works exactly as it would for a published, symlink-free
+  // install: requiring `next` must transitively resolve its (now hoisted) deps.
+  const output = execFileSync(process.execPath, ['-e', `require(${JSON.stringify(join(nm, 'next'))})`], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15_000,
+  })
+  assert.equal(output, 'OK', 'standalone host must resolve next and its transitive deps after flattening')
+})
+
+test('hoistPnpmVirtualStore is a no-op when there is no pnpm store', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-stage-noop-'))
+  const nm = join(root, 'node_modules')
+  writePackage(join(nm, 'next'), 'next', 'module.exports = {}')
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+
+  assert.equal(staging.hoistPnpmVirtualStore(nm), 0)
+  assert.ok(existsSync(join(nm, 'next', 'package.json')), 'existing flat packages are left untouched')
+})

--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -1,8 +1,9 @@
 import { randomBytes } from 'node:crypto'
 import { exec, execFile, spawn, type ChildProcess, type SpawnOptions } from 'node:child_process'
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { closeSync, existsSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { request as httpRequest } from 'node:http'
 import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { appRoot, webPidFilePath as defaultWebPidFilePath } from './app-paths.js'
@@ -27,7 +28,16 @@ type ResourceBootstrapLike = {
   initResources: (agentDir: string) => void
 }
 
-type SpawnedChildLike = Pick<ChildProcess, 'once' | 'unref' | 'pid'>
+type SpawnedChildLike = Pick<ChildProcess, 'once' | 'unref' | 'pid' | 'kill'>
+
+/** Outcome of a child process exiting on its own. */
+interface ChildExitInfo {
+  code: number | null
+  signal: NodeJS.Signals | null
+}
+
+/** Largest slice of the host log we fold into a failure reason. */
+const HOST_LOG_TAIL_BYTES = 4_096
 
 export interface WebModeLaunchOptions {
   cwd: string
@@ -104,6 +114,14 @@ export interface WebModeDeps {
   deletePidFile?: (path: string) => void
   /** Path to the multi-instance registry JSON (for testing). */
   registryPath?: string
+  /**
+   * Directory the spawned host's stderr log is written to (defaults to the OS
+   * temp dir). The launcher detaches the child and then `process.exit()`s, so
+   * the child's stderr is redirected to a file rather than a pipe — a pipe
+   * whose reader has exited would crash the long-lived host with EPIPE. The
+   * log is tailed into the failure reason when boot fails.
+   */
+  hostLogDir?: string
 }
 
 export interface WebModeStopResult {
@@ -358,11 +376,16 @@ function needsWindowsShell(command: string, platform: NodeJS.Platform): boolean 
 }
 
 function formatLaunchStatus(status: WebModeLaunchStatus): string {
+  // `listen` is the real bind target (host:port); `entry` is the spawned host
+  // script/manifest path. These were previously conflated under a single
+  // misleading `host=<entryPath>` field, which sent every reader chasing an
+  // argv-parsing red herring when the real failure was elsewhere.
+  const listen = `${status.host}:${status.port ?? 'n/a'}`
   if (status.ok) {
-    return `[gsd] Web mode startup: status=started cwd=${status.cwd} port=${status.port} host=${status.hostPath} kind=${status.hostKind} url=${status.url}\n`
+    return `[gsd] Web mode startup: status=started cwd=${status.cwd} port=${status.port} listen=${listen} entry=${status.hostPath} kind=${status.hostKind} url=${status.url}\n`
   }
 
-  return `[gsd] Web mode startup: status=failed cwd=${status.cwd} port=${status.port ?? 'n/a'} host=${status.hostPath ?? 'unresolved'} kind=${status.hostKind} reason=${status.failureReason}\n`
+  return `[gsd] Web mode startup: status=failed cwd=${status.cwd} port=${status.port ?? 'n/a'} listen=${listen} entry=${status.hostPath ?? 'unresolved'} kind=${status.hostKind} reason=${status.failureReason}\n`
 }
 
 function emitLaunchStatus(stderr: WritableLike, status: WebModeLaunchStatus): void {
@@ -396,23 +419,50 @@ async function spawnDetachedProcess(
   command: string,
   args: string[],
   options: SpawnOptions,
-): Promise<{ ok: true; child: SpawnedChildLike } | { ok: false; error: unknown }> {
+): Promise<{ ok: true; child: SpawnedChildLike; exited: Promise<ChildExitInfo> } | { ok: false; error: unknown }> {
   return await new Promise((resolve) => {
     try {
       const child = spawnCommand(command, args, options)
+
+      // A child that dies in <1s (e.g. `Cannot find module 'next'`) must be
+      // noticed immediately. Without this, `waitForBootReady` polls a dead
+      // address for the full 180s window before reporting `ECONNREFUSED`.
+      const exited = new Promise<ChildExitInfo>((resolveExit) => {
+        child.once?.('exit', (code: number | null, signal: NodeJS.Signals | null) =>
+          resolveExit({ code: code ?? null, signal: signal ?? null }),
+        )
+      })
+
       let settled = false
-      const finish = (result: { ok: true; child: SpawnedChildLike } | { ok: false; error: unknown }) => {
+      const finish = (result: { ok: true; child: SpawnedChildLike; exited: Promise<ChildExitInfo> } | { ok: false; error: unknown }) => {
         if (settled) return
         settled = true
         resolve(result)
       }
 
       child.once?.('error', (error) => finish({ ok: false, error }))
-      setImmediate(() => finish({ ok: true, child }))
+      setImmediate(() => finish({ ok: true, child, exited }))
     } catch (error) {
       resolve({ ok: false, error })
     }
   })
+}
+
+/** Best-effort terminate a child on a failed launch so we don't leak orphans. */
+function terminateChild(child: SpawnedChildLike): void {
+  try {
+    child.kill?.('SIGTERM')
+  } catch {
+    // Child may already be gone — nothing to clean up.
+  }
+  const escalation = setTimeout(() => {
+    try {
+      child.kill?.('SIGKILL')
+    } catch {
+      // Already reaped.
+    }
+  }, 2_000)
+  escalation.unref?.()
 }
 
 async function requestLocalJson(url: string, timeoutMs: number, authToken?: string): Promise<{ statusCode: number; body: string }> {
@@ -631,6 +681,28 @@ export async function launchWebMode(
 
   stderr.write(`[gsd] Launching web host on port ${port}…\n`)
 
+  // Redirect the detached host's stderr to a log file rather than dropping it
+  // to /dev/null. When the host dies on boot (e.g. `Cannot find module 'next'`)
+  // its real error is the only useful signal; tailing the log into the failure
+  // reason turns a silent 180s ECONNREFUSED into an actionable diagnostic. A
+  // file (not a pipe) is used deliberately: the launcher detaches and exits, so
+  // a pipe whose reader is gone would crash the long-lived host with EPIPE.
+  const hostLogPath = join(deps.hostLogDir ?? tmpdir(), `gsd-web-host-${port}.log`)
+  let hostLogFd: number | null = null
+  try {
+    hostLogFd = openSync(hostLogPath, 'w')
+  } catch {
+    hostLogFd = null
+  }
+  const readHostLogTail = (): string => {
+    if (hostLogFd === null) return ''
+    try {
+      return readFileSync(hostLogPath, 'utf8').slice(-HOST_LOG_TAIL_BYTES).trim()
+    } catch {
+      return ''
+    }
+  }
+
   const spawnResult = await spawnDetachedProcess(
     deps.spawn ?? ((command, args, spawnOptions) => spawn(command, args, spawnOptions)),
     spawnSpec.command,
@@ -638,12 +710,22 @@ export async function launchWebMode(
     {
       cwd: spawnSpec.cwd,
       detached: true,
-      stdio: 'ignore',
+      stdio: hostLogFd !== null ? ['ignore', 'ignore', hostLogFd] : 'ignore',
       windowsHide: true,
       shell: needsWindowsShell(spawnSpec.command, deps.platform ?? process.platform),
       env,
     },
   )
+
+  // The child inherited its own copy of the log fd; the launcher no longer
+  // needs it (failures are read back from the path).
+  if (hostLogFd !== null) {
+    try {
+      closeSync(hostLogFd)
+    } catch {
+      // Already closed.
+    }
+  }
 
   if (!spawnResult.ok) {
     const failure: WebModeLaunchFailure = {
@@ -663,23 +745,49 @@ export async function launchWebMode(
     return failure
   }
 
+  const buildBootFailure = (failureReason: string): WebModeLaunchFailure => ({
+    mode: 'web',
+    ok: false,
+    cwd: options.cwd,
+    projectSessionsDir: options.projectSessionsDir,
+    host,
+    port,
+    url,
+    hostKind: resolution.kind,
+    hostPath: resolution.entryPath,
+    hostRoot: resolution.hostRoot,
+    failureReason,
+  })
+
   try {
     const bootReadyFn = deps.waitForBootReady ?? ((u: string) => waitForBootReady(u, 180_000, stderr, authToken))
-    await bootReadyFn(url)
-  } catch (error) {
-    const failure: WebModeLaunchFailure = {
-      mode: 'web',
-      ok: false,
-      cwd: options.cwd,
-      projectSessionsDir: options.projectSessionsDir,
-      host,
-      port,
-      url,
-      hostKind: resolution.kind,
-      hostPath: resolution.entryPath,
-      hostRoot: resolution.hostRoot,
-      failureReason: `boot-ready:${error instanceof Error ? error.message : String(error)}`,
+    // Race readiness against the child exiting. A dead child resolves the exit
+    // promise long before `waitForBootReady` would give up, so we fail fast
+    // with the host's own stderr instead of an opaque connection timeout.
+    type BootOutcome = { kind: 'ready' } | { kind: 'exit'; exit: ChildExitInfo }
+    const readyOutcome = bootReadyFn(url).then((): BootOutcome => ({ kind: 'ready' }))
+    // If the child-exit branch wins, `readyOutcome` may reject later; swallow it
+    // so it never surfaces as an unhandledRejection after the race has settled.
+    readyOutcome.catch(() => {})
+    const exitOutcome = spawnResult.exited.then((exit): BootOutcome => ({ kind: 'exit', exit }))
+    const outcome = await Promise.race([readyOutcome, exitOutcome])
+
+    if (outcome.kind === 'exit') {
+      terminateChild(spawnResult.child)
+      const tail = readHostLogTail()
+      const failure = buildBootFailure(
+        `child-exit:code=${outcome.exit.code ?? 'null'} signal=${outcome.exit.signal ?? 'null'}${tail ? ` stderr=${tail}` : ''}`,
+      )
+      emitLaunchStatus(stderr, failure)
+      return failure
     }
+  } catch (error) {
+    // Readiness probing itself failed (timeout / repeated 5xx). Reap the child
+    // so we don't leak an orphan that may still be flailing.
+    terminateChild(spawnResult.child)
+    const tail = readHostLogTail()
+    const reason = error instanceof Error ? error.message : String(error)
+    const failure = buildBootFailure(`boot-ready:${reason}${tail ? ` stderr=${tail}` : ''}`)
     emitLaunchStatus(stderr, failure)
     return failure
   }


### PR DESCRIPTION
Packaging (fatal): pnpm lays top-level deps down as symlinks into a `.pnpm/`
virtual store, and `npm pack` silently DROPS symlinks — so the published
`dist/web/standalone/node_modules/` lost its `next`/`react`/`react-dom`
entries and the host crashed on boot with `Cannot find module 'next'`.
`cpSync({dereference:true})` does not help (it leaves nested symlinks intact).
The staging step now flattens the store into a real, hoisted `node_modules`
so every package survives packing as a plain directory, and `validate-pack`
gains a publish gate that resolves next/react/react-dom from the installed
standalone dir.

Launcher observability: the child was spawned with `stdio: 'ignore'` and its
crash output vanished, so an instant `MODULE_NOT_FOUND` looked like a silent
180s `ECONNREFUSED`. The child's stderr is now redirected to a log file
(a file, not a pipe — the launcher detaches and `process.exit()`s, which would
EPIPE a piped long-lived host), boot readiness is raced against the child
exiting so a dead child fails fast with `child-exit:code=… signal=… stderr=…`,
the child is reaped on the failure path, and the launch log distinguishes the
real bind target (`listen=host:port`) from the entry script (`entry=…`)
instead of the misleading `host=<entryPath>`.

https://claude.ai/code/session_01CuhXcrPfWq7LPWNTA8gaV5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782873217&installation_id=134682257&pr_number=331&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F331&signature=dae69fee016f25653d07366c3ba74a9c7752728967d5d96c8da399d964bcc5cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packaging layout and launch/runtime behavior for the standalone web host; mistakes could affect published installs or orphan processes, but scope is bounded with new validate-pack and integration tests.
> 
> **Overview**
> Fixes **packaged `gsd web`** failing after publish when **`npm pack` drops pnpm symlinks** (#328), and makes **boot failures visible and fast** instead of a long silent timeout.
> 
> **Packaging:** `stage-web-standalone.cjs` now **flattens the `.pnpm` virtual store** into real top-level `node_modules` directories (nested symlinks are not fixed by `cpSync` dereference alone), removes leftover symlinks, and is **exported/testable**. **`validate-pack`** adds a **publish gate** that `require.resolve`s `next` / `react` / `react-dom` from the installed standalone tree. Lockfile adds optional **`@opengsd/engine-*`** platform packages.
> 
> **Launcher (`web-mode.ts`):** Detached host **stderr goes to a log file** (not ignored, not a pipe—avoids EPIPE after detach). Boot **races readiness against child exit**, **tails the log** into `child-exit:… stderr=…`, **reaps the child** on failure, and startup logs use **`listen=host:port`** vs **`entry=script`**. Tests cover hoisting and fast-fail with `Cannot find module 'next'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f025e0a4b1d80fdf631521dbf84cba3808e020f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->