### PR TITLE
fix(gsd): avoid workflow MCP transport gate false positive

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -780,6 +780,43 @@ test("transport compatibility now allows replan-slice over workflow MCP surface"
   assert.equal(error, null);
 });
 
+test("transport compatibility accepts workflow MCP tools absent from parent active tool surface", () => {
+  const error = getWorkflowTransportSupportError(
+    "claude-code",
+    ["gsd_summary_save"],
+    {
+      projectRoot: "/tmp/project",
+      env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
+      surface: "auto-mode",
+      unitType: "run-uat",
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      activeTools: ["ScheduleWakeup", "ToolSearch", "bash", "read", "write"],
+    },
+  );
+
+  assert.equal(error, null);
+});
+
+test("transport compatibility still checks non-MCP tools against parent active tool surface", () => {
+  const error = getWorkflowTransportSupportError(
+    "claude-code",
+    ["gsd_summary_save", "secure_env_collect"],
+    {
+      projectRoot: "/tmp/project",
+      env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
+      surface: "auto-mode",
+      unitType: "run-uat",
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      activeTools: ["ScheduleWakeup", "ToolSearch", "bash", "read", "write"],
+    },
+  );
+
+  assert.match(error ?? "", /requires secure_env_collect/);
+  assert.doesNotMatch(error ?? "", /gsd_summary_save/);
+});
+
 test("transport compatibility still blocks units whose MCP tools are not exposed", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -539,9 +539,10 @@ export function getWorkflowTransportSupportError(
   }
 
   const uniqueRequired = [...new Set(requiredTools)];
+  const piRuntimeRequired = uniqueRequired.filter((tool) => !MCP_WORKFLOW_TOOL_SURFACE.has(tool));
   const missing = (options.activeTools && options.activeTools.length > 0)
-    ? uniqueRequired.filter((tool) => !hasRequiredTool(tool, options.activeTools!))
-    : uniqueRequired.filter((tool) => !MCP_WORKFLOW_TOOL_SURFACE.has(tool));
+    ? piRuntimeRequired.filter((tool) => !hasRequiredTool(tool, options.activeTools!))
+    : piRuntimeRequired;
   if (missing.length === 0) return null;
 
   if (options.activeTools && options.activeTools.length > 0) {


### PR DESCRIPTION
## Linked issue

Closes #332

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** The workflow MCP transport gate now treats workflow-MCP-surface tools as satisfied by a discovered workflow MCP transport instead of requiring them in the parent Pi active tool list.
**Why:** `/gsd auto` on `claude-code` could stop before dispatch because the parent orchestrator intentionally does not expose spawned-subprocess `mcp__gsd-workflow__*` tools.
**How:** `getWorkflowTransportSupportError` filters workflow MCP tools out of the Pi-runtime active-tool check while continuing to validate non-MCP required tools against `activeTools`.

## What

This changes the shared GSD workflow transport compatibility helper in `src/resources/extensions/gsd/workflow-mcp.ts`. The helper is used by auto-mode dispatch, direct phase dispatch, and guided flow compatibility checks.

Regression coverage in `src/resources/extensions/gsd/tests/workflow-mcp.test.ts` now covers a `claude-code` local workflow MCP launch where the parent active tool surface contains Pi-native tools only and lacks `gsd_summary_save`.

## Why

v1.1.1 tool-surface narrowing made `pi.getActiveTools()` reflect the parent runtime's native surface. Workflow MCP tools such as `gsd_summary_save`, `gsd_plan_slice`, and `gsd_task_complete` live in the spawned Claude Code subprocess, so validating them against the parent active surface created a false missing-tool error.

## How

The transport gate already requires a discoverable workflow MCP launch config before it checks required tools. Once that transport exists, tools in `MCP_WORKFLOW_TOOL_SURFACE` are transport-backed and are removed from the parent active-tool missing calculation. Non-MCP required tools still use the previous `hasRequiredTool` check against `activeTools`.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — source workflow MCP suite and extension typecheck run locally
- [ ] No tests needed — explained above

Local verification:

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp.test.ts`
- [x] `pnpm run typecheck:extensions`
- [ ] `pnpm run test:changed:src` — blocked locally after `dist-test` compilation because the compiled harness redirects `@opengsd/rpc-client` into `packages/rpc-client/src/rpc-client.ts`, whose relative `./jsonl.js` sibling is unresolved in that path. The source workflow MCP suite passes.

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented with Codex; verified with the commands above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782882664&installation_id=134682257&pr_number=336&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F336&signature=74ca45a31645949c6c47160613b35f3f481f57a9a51d5d5f831b70d9b0dce49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to GSD dispatch gating logic with targeted regression tests; no auth, data, or broad API surface changes.
> 
> **Overview**
> Fixes a **false “missing tool” block** on local `claude-code` workflow dispatch when the parent Pi runtime’s `activeTools` list omits workflow-MCP tools (e.g. `gsd_summary_save`) that only exist on the spawned workflow MCP server.
> 
> `getWorkflowTransportSupportError` now treats tools in `MCP_WORKFLOW_TOOL_SURFACE` as satisfied once workflow MCP launch config is discoverable, and only compares **non–workflow-MCP** required tools to `activeTools` via `hasRequiredTool`. Regression tests cover mixed requirements (`gsd_summary_save` + `secure_env_collect`) so MCP tools are not blamed while Pi-native gaps still fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1632d65218c41af156068b38b78e9876dc98a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->