### PR TITLE
fix(login): restore provider auth flows

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/login-dialog.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/login-dialog.test.ts
@@ -1,6 +1,37 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { buildAuthUrlPresentation } from "../login-dialog.js";
+import {
+	EditorKeybindingsManager,
+	setEditorKeybindings,
+	TUI,
+	type Terminal,
+} from "@gsd/pi-tui";
+import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+import { buildAuthUrlPresentation, LoginDialogComponent } from "../login-dialog.js";
+
+function makeTerminal(): Terminal {
+	return {
+		isTTY: true,
+		columns: 80,
+		rows: 24,
+		kittyProtocolActive: false,
+		start() {},
+		stop() {},
+		drainInput: async () => {},
+		write() {},
+		moveBy() {},
+		hideCursor() {},
+		showCursor() {},
+		clearLine() {},
+		clearFromCursor() {},
+		clearScreen() {},
+		setTitle() {},
+	};
+}
+
+function plain(component: LoginDialogComponent): string {
+	return component.render(80).join("\n").replace(/\x1b\][^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
+}
 
 describe("LoginDialogComponent", () => {
 	test("shows the full OAuth URL when the hyperlink label is truncated", () => {
@@ -20,5 +51,48 @@ describe("LoginDialogComponent", () => {
 			presentation.fullUrlLines[presentation.fullUrlLines.length - 1] ?? "",
 			/state=needs-full-visibility/,
 		);
+	});
+
+	test("submits an empty prompt through the configured confirm binding", async () => {
+		initTheme("dark", false);
+		setEditorKeybindings(new EditorKeybindingsManager({ selectConfirm: "ctrl+s" }));
+
+		try {
+			const dialog = new LoginDialogComponent(new TUI(makeTerminal()), "github-copilot", () => {}, undefined, {
+				openUrl: () => {},
+			});
+			const result = dialog.showPrompt("GitHub Enterprise URL/domain (blank for github.com)", "company.ghe.com", {
+				allowEmpty: true,
+			});
+
+			dialog.handleInput("\x13");
+
+			assert.equal(await result, "");
+		} finally {
+			setEditorKeybindings(new EditorKeybindingsManager());
+		}
+	});
+
+	test("renders device-code login details and opens the verification URL", () => {
+		initTheme("dark", false);
+		let openedUrl: string | undefined;
+		const dialog = new LoginDialogComponent(new TUI(makeTerminal()), "github-copilot", () => {}, undefined, {
+			openUrl: (url) => {
+				openedUrl = url;
+			},
+		});
+
+		dialog.showDeviceCode({
+			userCode: "ABCD-EFGH",
+			verificationUri: "https://github.com/login/device",
+			expiresInSeconds: 900,
+		});
+
+		const output = plain(dialog);
+		assert.match(output, /Enter this code:/);
+		assert.match(output, /ABCD-EFGH/);
+		assert.match(output, /https:\/\/github\.com\/login\/device/);
+		assert.match(output, /Code expires in 15 minutes/);
+		assert.equal(openedUrl, "https://github.com/login/device");
 	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
@@ -1,5 +1,6 @@
 // GSD Login Dialog Component — OAuth login flow UI
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+import type { OAuthDeviceCodeInfo } from "@gsd/pi-ai";
 import { getOAuthProviders } from "@gsd/pi-ai/oauth";
 import { Container, type Focusable, getEditorKeybindings, Input, Spacer, Text, truncateToWidth, type TUI } from "@gsd/pi-tui";
 import { execFile } from "child_process";
@@ -28,6 +29,17 @@ export function buildAuthUrlPresentation(url: string, terminalColumns: number): 
 	};
 }
 
+function openExternalUrl(url: string): void {
+	// PowerShell's Start-Process handles URLs with '&' safely; cmd /c start does not.
+	if (process.platform === "win32") {
+		execFile("powershell", ["-c", `Start-Process '${url.replace(/'/g, "''")}'`], () => {});
+		return;
+	}
+
+	const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
+	execFile(openCmd, [url], () => {});
+}
+
 /**
  * Login dialog component - replaces editor during OAuth login flow.
  *
@@ -44,6 +56,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	private inputResolver?: (value: string) => void;
 	private inputRejecter?: (error: Error) => void;
 	private disposed = false;
+	private openUrl: (url: string) => void;
 
 	// Focusable implementation - propagate to input for IME cursor positioning
 	private _focused = false;
@@ -60,9 +73,11 @@ export class LoginDialogComponent extends Container implements Focusable {
 		providerId: string,
 		private onComplete: (success: boolean, message?: string) => void,
 		providerDisplayName?: string,
+		options?: { openUrl?: (url: string) => void },
 	) {
 		super();
 		this.tui = tui;
+		this.openUrl = options?.openUrl ?? openExternalUrl;
 
 		const providerInfo = getOAuthProviders().find((p) => p.id === providerId);
 		const providerName = providerDisplayName || providerInfo?.name || providerId;
@@ -80,11 +95,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		// Input (always present, used when needed)
 		this.input = new Input();
 		this.input.onSubmit = () => {
-			if (this.inputResolver) {
-				this.inputResolver(this.input.getValue());
-				this.inputResolver = undefined;
-				this.inputRejecter = undefined;
-			}
+			this.submitInput();
 		};
 		this.input.onEscape = () => {
 			this.cancel();
@@ -114,6 +125,14 @@ export class LoginDialogComponent extends Container implements Focusable {
 			this.inputRejecter = undefined;
 			rejecter(new Error(reason));
 		}
+	}
+
+	private submitInput(): void {
+		if (!this.inputResolver) return;
+		const resolver = this.inputResolver;
+		this.inputResolver = undefined;
+		this.inputRejecter = undefined;
+		resolver(this.input.getValue());
 	}
 
 	private cancel(): void {
@@ -166,14 +185,44 @@ export class LoginDialogComponent extends Container implements Focusable {
 			this.contentContainer.addChild(new Text(theme.fg("warning", instructions), 1, 0));
 		}
 
-		// PowerShell's Start-Process handles URLs with '&' safely; cmd /c start does not.
-		if (process.platform === "win32") {
-			execFile("powershell", ["-c", `Start-Process '${url.replace(/'/g, "''")}'`], () => {});
-		} else {
-			const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-			execFile(openCmd, [url], () => {});
+		this.openUrl(url);
+
+		this.tui.requestRender();
+	}
+
+	/**
+	 * Called by onDeviceCode callback - show device code and verification URL.
+	 */
+	showDeviceCode(info: OAuthDeviceCodeInfo): void {
+		this.contentContainer.clear();
+		this.contentContainer.addChild(new Spacer(1));
+		this.contentContainer.addChild(new Text(theme.fg("text", "Enter this code:"), 1, 0));
+		this.contentContainer.addChild(new Text(theme.fg("accent", info.userCode), 1, 0));
+		this.contentContainer.addChild(new Spacer(1));
+
+		const { displayUrl, fullUrlLines } = buildAuthUrlPresentation(info.verificationUri, this.tui.terminal.columns);
+		const urlLink = `\x1b]8;;${info.verificationUri}\x07${theme.fg("accent", displayUrl)}\x1b]8;;\x07`;
+		this.contentContainer.addChild(new Text(urlLink, 1, 0));
+
+		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
+		this.contentContainer.addChild(new Text(theme.fg("dim", clickHint), 1, 0));
+
+		if (fullUrlLines.length > 0) {
+			this.contentContainer.addChild(new Spacer(1));
+			this.contentContainer.addChild(new Text(theme.fg("dim", "Full URL:"), 1, 0));
+			for (const line of fullUrlLines) {
+				this.contentContainer.addChild(new Text(theme.fg("dim", line), 1, 0));
+			}
 		}
 
+		if (info.expiresInSeconds) {
+			this.contentContainer.addChild(new Spacer(1));
+			this.contentContainer.addChild(
+				new Text(theme.fg("dim", `Code expires in ${Math.ceil(info.expiresInSeconds / 60)} minutes.`), 1, 0),
+			);
+		}
+
+		this.openUrl(info.verificationUri);
 		this.tui.requestRender();
 	}
 
@@ -200,7 +249,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Called by onPrompt callback - show prompt and wait for input
 	 * Note: Does NOT clear content, appends to existing (preserves URL from showAuth)
 	 */
-	showPrompt(message: string, placeholder?: string): Promise<string> {
+	showPrompt(message: string, placeholder?: string, options?: { allowEmpty?: boolean }): Promise<string> {
 		// Reject any previous pending promise before creating a new one
 		this.rejectPending("Superseded by new input prompt");
 
@@ -211,7 +260,14 @@ export class LoginDialogComponent extends Container implements Focusable {
 		}
 		this.contentContainer.addChild(this.input);
 		this.contentContainer.addChild(
-			new Text(`(${keyHint("selectCancel", "to cancel,")} ${keyHint("selectConfirm", "to submit")})`, 1, 0),
+			new Text(
+				`(${keyHint("selectCancel", "to cancel,")} ${keyHint(
+					"selectConfirm",
+					options?.allowEmpty ? "to submit blank" : "to submit",
+				)})`,
+				1,
+				0,
+			),
 		);
 
 		this.input.setValue("");
@@ -248,6 +304,11 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 		if (kb.matches(data, "selectCancel")) {
 			this.cancel();
+			return;
+		}
+
+		if (kb.matches(data, "selectConfirm")) {
+			this.submitInput();
 			return;
 		}
 

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { AuthStorage } from "@gsd/pi-coding-agent/core/auth-storage.js";
+import { ModelRegistry } from "@gsd/pi-coding-agent/core/model-registry.js";
+import { buildApiKeyLoginPrompt, buildLoginProviderOptions } from "./interactive-selectors-auth.js";
+
+describe("buildApiKeyLoginPrompt", () => {
+	test("uses Hugging Face token wording and HF_TOKEN hint", () => {
+		const prompt = buildApiKeyLoginPrompt("huggingface", "Hugging Face");
+
+		assert.equal(prompt.message, "Paste your Hugging Face user access token (or set HF_TOKEN):");
+		assert.equal(prompt.placeholder, "hf_...");
+	});
+
+	test("uses known environment variable hints for API-key providers", () => {
+		const prompt = buildApiKeyLoginPrompt("openrouter", "OpenRouter");
+
+		assert.equal(prompt.message, "Paste your OpenRouter API key (or set OPENROUTER_API_KEY):");
+		assert.equal(prompt.placeholder, undefined);
+	});
+
+	test("falls back cleanly for custom API-key providers", () => {
+		const prompt = buildApiKeyLoginPrompt("local-proxy", "Local Proxy");
+
+		assert.equal(prompt.message, "Paste your Local Proxy API key:");
+		assert.equal(prompt.placeholder, undefined);
+	});
+
+	test("uses plain Anthropic naming when browser OAuth is blocked into API-key login", () => {
+		const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory());
+		const host = { session: { modelRegistry } };
+		const providers = buildLoginProviderOptions(host as never);
+		const anthropic = providers.find((provider) => provider.id === "anthropic");
+
+		assert.equal(anthropic?.authType, "api_key");
+		assert.equal(anthropic?.name, "Anthropic");
+	});
+});

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts
@@ -3,7 +3,9 @@
 // @ts-nocheck
 
 import type { OAuthProviderId } from "@gsd/pi-ai";
+import { getApiKeyEnvVars } from "@gsd/pi-ai";
 import { getAuthPath } from "@gsd/pi-coding-agent/config.js";
+import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "@gsd/pi-coding-agent/core/provider-display-names.js";
 import { LoginDialogComponent } from "./components/login-dialog.js";
 import { type AuthSelectorProvider, OAuthSelectorComponent } from "./components/oauth-selector.js";
 import type { InteractiveModeDelegateHost } from "./interactive-mode-delegate-host.js";
@@ -36,6 +38,37 @@ function formatAuthStatus(status: { source?: string; label?: string } | undefine
 	return undefined;
 }
 
+function formatEnvHint(envVars: readonly string[] | undefined): string {
+	if (!envVars || envVars.length === 0) return "";
+	return ` (or set ${envVars.join(" / ")})`;
+}
+
+function apiKeyCredentialLabel(providerId: string): string {
+	if (providerId === "huggingface") return "user access token";
+	return "API key";
+}
+
+function apiKeyPlaceholder(providerId: string): string | undefined {
+	if (providerId === "huggingface") return "hf_...";
+	return undefined;
+}
+
+export function buildApiKeyLoginPrompt(providerId: string, providerName: string): {
+	message: string;
+	placeholder?: string;
+} {
+	const credentialLabel = apiKeyCredentialLabel(providerId);
+	const envHint = formatEnvHint(getApiKeyEnvVars(providerId));
+	return {
+		message: `Paste your ${providerName} ${credentialLabel}${envHint}:`,
+		placeholder: apiKeyPlaceholder(providerId),
+	};
+}
+
+function getApiKeyProviderDisplayName(host: InteractiveModeDelegateHost, providerId: string): string {
+	return BUILT_IN_PROVIDER_DISPLAY_NAMES[providerId] ?? host.session.modelRegistry.getProviderDisplayName(providerId);
+}
+
 export function buildLoginProviderOptions(host: InteractiveModeDelegateHost): AuthSelectorProvider[] {
 	const modelRegistry = host.session.modelRegistry;
 	const oauthProviders = modelRegistry.authStorage
@@ -58,7 +91,7 @@ export function buildLoginProviderOptions(host: InteractiveModeDelegateHost): Au
 		.filter((providerId) => !oauthProviderIds.has(providerId))
 		.map((providerId) => ({
 			id: providerId,
-			name: modelRegistry.getProviderDisplayName(providerId),
+			name: getApiKeyProviderDisplayName(host, providerId),
 			authType: "api_key" as const,
 			statusLabel: formatAuthStatus(modelRegistry.getProviderAuthStatus(providerId)),
 		}));
@@ -202,7 +235,8 @@ async function showApiKeyLoginDialog(host: InteractiveModeDelegateHost, provider
 	};
 
 	try {
-		const apiKey = (await dialog.showPrompt(`Paste your ${providerName} API key:`)).trim();
+		const prompt = buildApiKeyLoginPrompt(providerId, providerName);
+		const apiKey = (await dialog.showPrompt(prompt.message, prompt.placeholder)).trim();
 		if (!apiKey) {
 			throw new Error("API key is required");
 		}
@@ -262,8 +296,8 @@ export async function showLoginDialog(host: InteractiveModeDelegateHost, provide
 				}
 			},
 
-			onPrompt: async (prompt: { message: string; placeholder?: string }) => {
-				return dialog.showPrompt(prompt.message, prompt.placeholder);
+			onPrompt: async (prompt: { message: string; placeholder?: string; allowEmpty?: boolean }) => {
+				return dialog.showPrompt(prompt.message, prompt.placeholder, { allowEmpty: prompt.allowEmpty });
 			},
 
 			onProgress: (message: string) => {
@@ -274,7 +308,10 @@ export async function showLoginDialog(host: InteractiveModeDelegateHost, provide
 				? () => dialog.showManualInput("Paste redirect URL below, or complete login in browser:")
 				: undefined,
 
-			onDeviceCode: async () => "",
+			onDeviceCode: (info) => {
+				dialog.showDeviceCode(info);
+				dialog.showWaiting("Waiting for browser authentication...");
+			},
 			onSelect: async (prompt) => prompt.options[0]?.id,
 
 			signal: dialog.signal,

--- a/packages/pi-ai/src/env-api-keys.ts
+++ b/packages/pi-ai/src/env-api-keys.ts
@@ -93,7 +93,9 @@ function hasVertexAdcCredentials(): boolean {
 	return cachedVertexAdcCredentialsExists;
 }
 
-function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
+export function getApiKeyEnvVars(provider: KnownProvider): readonly string[] | undefined;
+export function getApiKeyEnvVars(provider: string): readonly string[] | undefined;
+export function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 	if (provider === "github-copilot") {
 		return ["COPILOT_GITHUB_TOKEN"];
 	}


### PR DESCRIPTION
## Summary
- restore interactive device-code rendering for OAuth providers such as GitHub Copilot
- allow blank OAuth prompts, so Copilot Enterprise URL blank correctly means github.com
- add provider-specific API-key prompt hints, including Hugging Face user access token / HF_TOKEN wording

## Tests
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/gsd-agent-modes/src/modes/interactive/components/__tests__/login-dialog.test.ts packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.test.ts
- pnpm --filter @gsd/pi-ai run build
- pnpm --filter @gsd/agent-modes run build
- pnpm --filter @gsd/agent-modes test
- pnpm --filter @gsd/pi-ai exec vitest run test/github-copilot-oauth.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication UI and credential entry paths; changes are localized with new tests but affect how users log in to providers.
> 
> **Overview**
> Restores **interactive login** for OAuth and API-key providers in the agent UI.
> 
> The login dialog now renders **device-code** flows (user code, verification link, expiry) and opens the verification URL, with injectable `openUrl` for tests. OAuth prompts can **submit blank** via the confirm keybinding (`allowEmpty`), fixing cases like GitHub Copilot Enterprise where an empty domain means github.com.
> 
> API-key login uses **`buildApiKeyLoginPrompt`** for provider-specific copy (e.g. Hugging Face user access token / `HF_TOKEN`, env var hints from exported **`getApiKeyEnvVars`**). Provider labels in the login selector use built-in display names where applicable (e.g. Anthropic when browser OAuth is blocked).
> 
> Tests cover URL truncation, empty prompt submit, device-code rendering, and prompt/selector wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6f9f5c1a3152aa3dcfd76c3bd942321079d121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782905405&installation_id=134682257&pr_number=340&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F340&signature=33d3fa81c5cf9f4d39f12b66f8ec221cf1140b7c0915bc56aafab876ce9e3429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->