### PR TITLE
fix(gsd): verify sidecar capture artifacts

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -172,6 +172,12 @@ export function resolveExpectedArtifactPath(
     case "replan-slice": {
       return resolveSliceArtifactPath(base, mid, sid!, "REPLAN");
     }
+    case "triage-captures":
+      // Verified against CAPTURES.md state in verifyExpectedArtifact.
+      return null;
+    case "quick-task":
+      // Verified against the capture's Executed field in CAPTURES.md.
+      return null;
     case "rewrite-docs":
       return null;
     case "gate-evaluate":
@@ -227,6 +233,10 @@ export function diagnoseExpectedArtifact(
       return `Slice ${sid} marked [x] in ${relMilestoneFile(base, mid, "ROADMAP")} + summary + UAT written`;
     case "replan-slice":
       return `${relSliceFile(base, mid, sid!, "REPLAN")} + updated ${relSliceFile(base, mid, sid!, "PLAN")}`;
+    case "triage-captures":
+      return ".gsd/CAPTURES.md with no pending captures";
+    case "quick-task":
+      return `.gsd/CAPTURES.md capture ${sid ?? "<capture-id>"} marked executed`;
     case "rewrite-docs":
       return "Active overrides resolved in .gsd/OVERRIDES.md + plan documents updated";
     case "reassess-roadmap":

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -116,6 +116,15 @@ function isParallelResearchUnit(unitType: string, unitId: string): boolean {
   return unitType === "research-slice" && unitId.endsWith("/parallel-research");
 }
 
+function shouldAttemptPlanRegeneration(unitType: string, unitId: string): boolean {
+  if (unitType === "triage-captures" || unitType === "quick-task") return false;
+  if (isParallelResearchUnit(unitType, unitId)) return false;
+  const { milestone: mid, slice: sid } = parseUnitId(unitId);
+  return !!mid && !!sid;
+}
+
+export const _shouldAttemptPlanRegenerationForTest = shouldAttemptPlanRegeneration;
+
 export function maybeWriteParallelResearchCostSpikeBlocker(
   unitType: string,
   unitId: string,
@@ -1638,7 +1647,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       if (!triggerArtifactVerified) {
         try {
           const { milestone: mid, slice: sid } = parseUnitId(s.currentUnit.id);
-          if (mid && sid && !isParallelResearchUnit(s.currentUnit.type, s.currentUnit.id)) {
+          if (mid && sid && shouldAttemptPlanRegeneration(s.currentUnit.type, s.currentUnit.id)) {
             // Phase C: write to the canonical project root (#5236 scope)
             // so non-symlinked worktrees no longer maintain a separate
             // local .gsd/ projection. copyPlanningArtifacts has been

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -53,6 +53,7 @@ import { getProjectResearchStatus } from "./project-research-policy.js";
 import { isGsdWorktreePath } from "./worktree-root.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
+import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
 
 // Re-export so existing consumers of auto-recovery.ts keep working.
 export { resolveExpectedArtifactPath, diagnoseExpectedArtifact };
@@ -305,6 +306,21 @@ export function verifyExpectedArtifact(
     return hasCapturedWorkflowPrefs(base);
   }
 
+  if (unitType === "triage-captures") {
+    const pending = loadPendingCaptures(base);
+    if (pending.length === 0) return true;
+    logWarning("recovery", `verify-fail triage-captures ${unitId}: ${pending.length} pending capture(s) remain in CAPTURES.md`);
+    return false;
+  }
+
+  if (unitType === "quick-task") {
+    const { slice: captureId } = parseUnitId(unitId);
+    const capture = captureId ? loadAllCaptures(base).find((entry) => entry.id === captureId) : undefined;
+    if (capture?.executed === true) return true;
+    logWarning("recovery", `verify-fail quick-task ${unitId}: capture ${captureId ?? "(missing capture id)"} not found or not marked executed`);
+    return false;
+  }
+
   if (unitType === "discuss-project") {
     const projectPath = resolveExpectedArtifactPath(unitType, unitId, base);
     return !!projectPath && existsSync(projectPath) && validateArtifact(projectPath, "project").ok;
@@ -445,10 +461,10 @@ export function verifyExpectedArtifact(
 
   const artifactBase = resolveArtifactVerificationBase(unitId, base);
   const absPath = resolveExpectedArtifactPath(unitType, unitId, artifactBase);
-  // For unit types with no verifiable artifact (null path), the parent directory
-  // is missing on disk — treat as stale completion state so the key gets evicted (#313).
+  // For unit types with no registered artifact contract (null path), treat the
+  // completion state as stale so the key gets evicted (#313).
   if (!absPath) {
-    logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveExpectedArtifactPath returned null (parent dir missing)`);
+    logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveExpectedArtifactPath returned null (no artifact contract registered for this unit type)`);
     return false;
   }
   if (!existsSync(absPath)) {

--- a/src/resources/extensions/gsd/tests/sidecar-artifact-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/sidecar-artifact-verification.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { appendCapture, markCaptureExecuted, markCaptureResolved } from "../captures.ts";
+import { resolveExpectedArtifactPath, verifyExpectedArtifact } from "../auto-recovery.ts";
+import { drainLogs } from "../workflow-logger.ts";
+
+function makeProject(t: { after: (fn: () => void) => void }): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-sidecar-artifact-"));
+  t.after(() => {
+    drainLogs();
+    rmSync(base, { recursive: true, force: true });
+  });
+  return base;
+}
+
+test("triage-captures verification passes when CAPTURES.md is absent", (t) => {
+  const base = makeProject(t);
+  drainLogs();
+
+  assert.equal(
+    verifyExpectedArtifact("triage-captures", "M001/S01/triage", base),
+    true,
+  );
+  assert.deepEqual(drainLogs(), []);
+});
+
+test("triage-captures verification passes when no pending captures remain", (t) => {
+  const base = makeProject(t);
+  const captureId = appendCapture(base, "Already handled.");
+  markCaptureResolved(base, captureId, "note", "acknowledged", "No action needed");
+  markCaptureExecuted(base, captureId);
+  drainLogs();
+
+  assert.equal(
+    verifyExpectedArtifact("triage-captures", "M001/S01/triage", base),
+    true,
+  );
+  assert.deepEqual(drainLogs(), []);
+});
+
+test("triage-captures verification fails while pending captures remain", (t) => {
+  const base = makeProject(t);
+  appendCapture(base, "Still needs triage.");
+  drainLogs();
+
+  assert.equal(
+    verifyExpectedArtifact("triage-captures", "M001/S01/triage", base),
+    false,
+  );
+  const logs = drainLogs();
+  assert.equal(logs.length, 1);
+  assert.match(logs[0].message, /1 pending capture\(s\) remain in CAPTURES\.md/);
+});
+
+test("quick-task verification passes when the capture is marked executed", (t) => {
+  const base = makeProject(t);
+  const captureId = appendCapture(base, "Fix a tiny typo.");
+  markCaptureResolved(base, captureId, "quick-task", "fixed inline", "Small isolated change");
+  markCaptureExecuted(base, captureId);
+  drainLogs();
+
+  assert.equal(
+    verifyExpectedArtifact("quick-task", `M001/${captureId}`, base),
+    true,
+  );
+  assert.deepEqual(drainLogs(), []);
+});
+
+test("quick-task verification fails when the capture is not marked executed", (t) => {
+  const base = makeProject(t);
+  const captureId = appendCapture(base, "Fix a tiny typo.");
+  markCaptureResolved(base, captureId, "quick-task", "fixed inline", "Small isolated change");
+  drainLogs();
+
+  assert.equal(
+    verifyExpectedArtifact("quick-task", `M001/${captureId}`, base),
+    false,
+  );
+  const logs = drainLogs();
+  assert.equal(logs.length, 1);
+  assert.match(logs[0].message, new RegExp(`capture ${captureId} not found or not marked executed`));
+});
+
+test("sidecar unit path resolver documents CAPTURES.md state verification", (t) => {
+  const base = makeProject(t);
+
+  assert.equal(
+    resolveExpectedArtifactPath("triage-captures", "M001/S01/triage", base),
+    null,
+  );
+  assert.equal(
+    resolveExpectedArtifactPath("quick-task", "M001/CAP-12345678", base),
+    null,
+  );
+});
+
+test("unknown artifact contract warning distinguishes missing contracts from missing dirs", (t) => {
+  const base = makeProject(t);
+  drainLogs();
+
+  assert.equal(
+    verifyExpectedArtifact("unknown-unit", "M001/S01", base),
+    false,
+  );
+  const logs = drainLogs();
+  assert.equal(logs.length, 1);
+  assert.match(logs[0].message, /no artifact contract registered for this unit type/);
+});

--- a/src/resources/extensions/gsd/tests/triage-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/triage-dispatch.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../captures.ts";
 import { checkPostUnitHooks } from "../post-unit-hooks.ts";
 import {
+  _shouldAttemptPlanRegenerationForTest,
   _shouldDispatchQuickTaskForTest,
   _shouldDispatchTriageForTest,
 } from "../auto-post-unit.ts";
@@ -47,6 +48,13 @@ function makeProject(): string {
 test("post-unit hooks exclude triage and quick-task units", () => {
   assert.equal(checkPostUnitHooks("triage-captures", "M001/S01/triage", "/tmp/project"), null);
   assert.equal(checkPostUnitHooks("quick-task", "M001/CAP-1", "/tmp/project"), null);
+});
+
+test("PLAN regeneration skips triage and quick-task sidecar unit ids", () => {
+  assert.equal(_shouldAttemptPlanRegenerationForTest("triage-captures", "M001/S01/triage"), false);
+  assert.equal(_shouldAttemptPlanRegenerationForTest("quick-task", "M001/CAP-test"), false);
+  assert.equal(_shouldAttemptPlanRegenerationForTest("research-slice", "M001/parallel-research"), false);
+  assert.equal(_shouldAttemptPlanRegenerationForTest("execute-task", "M001/S01/T01"), true);
 });
 
 test("triage dispatch guard excludes step mode, hook units, triage units, and quick tasks", () => {


### PR DESCRIPTION
## Linked issue

Closes #339

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds CAPTURES.md-based artifact verification for `triage-captures` and `quick-task` sidecar units.
**Why:** These units mutate capture state but previously fell through path-based verification, producing misleading recovery warnings and bogus PLAN regeneration attempts.
**How:** Verifies triage units by requiring zero pending captures, verifies quick-task units by requiring the capture to be marked executed, documents their null artifact paths, and skips PLAN regeneration for sidecar unit IDs.

## What

- Added explicit `verifyExpectedArtifact` branches for `triage-captures` and `quick-task`.
- Documented sidecar unit artifact paths as `null` because their contract is CAPTURES.md state, not a generated file path.
- Updated the generic null-path warning to distinguish missing artifact contracts from missing directories.
- Skipped `regenerateIfMissing(..., "PLAN")` for triage and quick-task unit IDs.
- Added targeted regression tests for pass/fail sidecar verification and regeneration gating.

## Why

`triage-captures` and `quick-task` were falling into generic artifact verification. That logged noisy `resolveExpectedArtifactPath returned null` failures and could treat capture IDs as slice IDs during missing PLAN regeneration, hiding the actual CAPTURES.md state contract.

## How

The verifier now uses existing capture helpers:

- `triage-captures`: passes when `loadPendingCaptures(base).length === 0`; missing `CAPTURES.md` naturally passes as no work remains.
- `quick-task`: parses the capture ID from the unit ID and passes only when that capture exists with `executed === true`.

The post-unit regeneration branch now goes through a small predicate that excludes these sidecar unit types before attempting PLAN projection repair.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/sidecar-artifact-verification.test.ts src/resources/extensions/gsd/tests/triage-dispatch.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

Impact analysis:

- Blast radius: moderate and contained to GSD auto-mode sidecar artifact verification/recovery.
- Affected workflows: capture triage, quick-task sidecar completion, artifact verification retry handling, missing PLAN regeneration fallback.
- Compatibility notes: no public API or file format changes; CAPTURES.md parsing uses existing helpers.

## AI disclosure

- [x] This PR includes AI-assisted code via Codex; targeted tests, typecheck, package builds, and fast gates were run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782909263&installation_id=134682257&pr_number=344&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F344&signature=80bac8ee9471f5413837cf60f3aa5ff78a8f42326f7091d006ad326f660c0c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to GSD auto-mode artifact verification and post-unit PLAN regeneration for capture sidecars, with no auth or public API impact.
> 
> **Overview**
> **Capture sidecar units** (`triage-captures`, `quick-task`) now complete against **`.gsd/CAPTURES.md` state** instead of file-path artifact checks, which previously logged misleading null-path failures and could run **PLAN regeneration** on capture IDs mistaken for slice IDs.
> 
> **`verifyExpectedArtifact`** passes triage when there are no pending captures (missing file counts as done) and passes quick-task only when the unit’s capture id is marked **executed**. **`resolveExpectedArtifactPath`** / **`diagnoseExpectedArtifact`** document these contracts with `null` paths and human-readable expectations. The generic null-path warning now says **no artifact contract** rather than implying a missing parent directory.
> 
> Post-unit **`regenerateIfMissing(..., "PLAN")`** is gated by **`shouldAttemptPlanRegeneration`**, which excludes triage, quick-task, and parallel-research units. New tests cover sidecar verification pass/fail cases and regeneration gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f19782120df2e83ea886e800138a2f0f1136854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->