### PR TITLE
fix(rpc-client): handle child process spawn errors

### DIFF
--- a/packages/mcp-server/src/cli-errors.ts
+++ b/packages/mcp-server/src/cli-errors.ts
@@ -1,0 +1,25 @@
+type GlobalErrorEvent = 'uncaughtException' | 'unhandledRejection';
+
+interface GlobalErrorRuntime {
+  on(event: GlobalErrorEvent, listener: (error: unknown) => void): unknown;
+  stderr: {
+    write(message: string): unknown;
+  };
+}
+
+export function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+export function installGlobalErrorHandlers(runtime: GlobalErrorRuntime = process as GlobalErrorRuntime): void {
+  runtime.on('uncaughtException', (error) => {
+    runtime.stderr.write(`[gsd-mcp-server] Uncaught exception: ${formatUnknownError(error)}\n`);
+  });
+
+  runtime.on('unhandledRejection', (reason) => {
+    runtime.stderr.write(`[gsd-mcp-server] Unhandled rejection: ${formatUnknownError(reason)}\n`);
+  });
+}

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -7,9 +7,12 @@
 
 import { SessionManager } from './session-manager.js';
 import { createMcpServer } from './server.js';
+import { installGlobalErrorHandlers } from './cli-errors.js';
 import { loadStoredCredentialEnvKeys } from './tool-credentials.js';
 
 const MCP_PKG = '@modelcontextprotocol/sdk';
+
+installGlobalErrorHandlers();
 
 async function main(): Promise<void> {
   loadStoredCredentialEnvKeys();

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -18,6 +18,7 @@ import { delimiter, join, resolve } from 'node:path';
 import { EventEmitter } from 'node:events';
 
 import { SessionManager } from './session-manager.js';
+import { installGlobalErrorHandlers } from './cli-errors.js';
 import {
   askUserQuestionsHandler,
   buildAskUserQuestionsElicitRequest,
@@ -27,6 +28,29 @@ import {
 } from './server.js';
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
+
+describe('installGlobalErrorHandlers', () => {
+  it('logs uncaught exceptions and unhandled rejections to stderr', () => {
+    const writes: string[] = [];
+    const runtime = new EventEmitter() as EventEmitter & {
+      stderr: { write(message: string): boolean };
+    };
+    runtime.stderr = {
+      write(message: string): boolean {
+        writes.push(message);
+        return true;
+      },
+    };
+
+    installGlobalErrorHandlers(runtime);
+    runtime.emit('uncaughtException', new Error('boom'));
+    runtime.emit('unhandledRejection', 'bad rejection');
+
+    const output = writes.join('');
+    assert.match(output, /\[gsd-mcp-server\] Uncaught exception: Error: boom/);
+    assert.match(output, /\[gsd-mcp-server\] Unhandled rejection: bad rejection/);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Mock RpcClient (duck-typed to match RpcClient interface)

--- a/packages/rpc-client/src/rpc-client.test.ts
+++ b/packages/rpc-client/src/rpc-client.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { once } from "node:events";
 import { serializeJsonLine, attachJsonlLineReader } from "./jsonl.js";
@@ -318,6 +321,22 @@ describe("RpcClient construction", () => {
 		});
 		assert.ok(client);
 	});
+
+	it("starts the agent with the current Node executable", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "rpc-client-"));
+		const scriptPath = join(dir, "agent.js");
+		writeFileSync(scriptPath, "setInterval(() => {}, 1000);\n");
+
+		const client = new RpcClient({ cliPath: scriptPath });
+
+		try {
+			await client.start();
+			assert.equal((client as any).process.spawnfile, process.execPath);
+		} finally {
+			await client.stop();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
 });
 
 // ============================================================================
@@ -621,5 +640,16 @@ describe("v2 command serialization", () => {
 
 		assert.equal(sent[0].events.length, 1);
 		assert.equal(sent[0].events[0], "*");
+	});
+
+	it("rejects pending requests when the agent process emits an error", async () => {
+		const { client } = createMockClient();
+
+		const initPromise = client.init();
+		const processError = new Error("spawn ENOENT");
+		(client as any).handleProcessError(processError);
+
+		await assert.rejects(initPromise, /Agent process error: spawn ENOENT/);
+		assert.equal((client as any).pendingRequests.size, 0);
 	});
 });

--- a/packages/rpc-client/src/rpc-client.ts
+++ b/packages/rpc-client/src/rpc-client.ts
@@ -95,11 +95,19 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		this.process = spawn("node", [cliPath, ...args], {
+		let startupError: Error | null = null;
+
+		this.process = spawn(process.execPath, [cliPath, ...args], {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],
 		});
+
+		const onProcessError = (error: Error) => {
+			startupError = this.handleProcessError(error);
+		};
+		this.process.on("error", onProcessError);
+		this.process.stdin?.on("error", onProcessError);
 
 		// Collect stderr for debugging. The agent process can run for hours/days,
 		// so cap the retained tail to avoid unbounded heap growth — only the most
@@ -122,15 +130,16 @@ export class RpcClient {
 			if (this.pendingRequests.size > 0) {
 				const reason = signal ? `signal ${signal}` : `code ${code}`;
 				const error = new Error(`Agent process exited unexpectedly (${reason}). Stderr: ${this.stderr}`);
-				for (const [id, pending] of this.pendingRequests) {
-					this.pendingRequests.delete(id);
-					pending.reject(error);
-				}
+				this.rejectPendingRequests(error);
 			}
 		});
 
 		// Wait a moment for process to initialize
 		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		if (startupError) {
+			throw startupError;
+		}
 
 		if (this.process.exitCode !== null) {
 			throw new Error(`Agent process exited immediately with code ${this.process.exitCode}. Stderr: ${this.stderr}`);
@@ -627,6 +636,20 @@ export class RpcClient {
 			}
 		} catch {
 			// Ignore non-JSON lines
+		}
+	}
+
+	private handleProcessError(error: Error): Error {
+		const stderr = this.stderr ? ` Stderr: ${this.stderr}` : "";
+		const wrapped = new Error(`Agent process error: ${error.message}.${stderr}`, { cause: error });
+		this.rejectPendingRequests(wrapped);
+		return wrapped;
+	}
+
+	private rejectPendingRequests(error: Error): void {
+		for (const [id, pending] of this.pendingRequests) {
+			this.pendingRequests.delete(id);
+			pending.reject(error);
 		}
 	}
 


### PR DESCRIPTION
## Linked issue

Closes #343

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Makes RPC agent process spawn/pipe errors reject pending RPC calls and adds MCP CLI crash logging.
**Why:** An unhandled child process error can kill the MCP server and surface to clients as a silent disconnect.
**How:** Spawn with `process.execPath`, attach child/stdin error listeners, centralize pending-request rejection, and install MCP CLI global error logging.

## What

- Updated `RpcClient.start()` to invoke the current Node executable instead of bare `node`.
- Added child process and stdin error handling that rejects pending RPC requests with diagnostic context.
- Added MCP CLI `uncaughtException` / `unhandledRejection` stderr logging as a last-resort diagnostic path.
- Added regression coverage for the executable choice, pending-request rejection, and MCP global error logging.

## Why

A `ChildProcess` error without an `error` listener is an uncaught exception in Node. For background MCP sessions, that can take down the whole MCP server process instead of marking the individual session startup as failed with a useful diagnostic.

## How

`RpcClient` now spawns using `process.execPath`, listens for child process and stdin errors, wraps those errors with stderr context, and rejects all pending RPC calls through a shared helper. The MCP CLI installs a small global error handler that logs otherwise uncaught exceptions and unhandled rejections to stderr.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config
- [x] `rpc-client/mcp-server` — Background MCP/RPC process lifecycle

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Commands run:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @opengsd/contracts run build && pnpm --filter @opengsd/rpc-client run build`
- `pnpm --filter @opengsd/rpc-client run test`
- `pnpm --filter @opengsd/mcp-server run build:test`
- `pnpm --filter @opengsd/mcp-server run test`
- `pnpm --filter @opengsd/mcp-server run build`
- `pnpm run verify:fast`

## AI disclosure

- [x] This PR includes AI-assisted code from Codex; the commands above were run locally in a clean worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782909856&installation_id=134682257&pr_number=345&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F345&signature=db6d334dc2779441a7e8ffbd05fe5ed51a9d41905c87a34d20e5c24df4731000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subprocess spawn and global error handling for long-lived MCP/RPC sessions; failures should surface as rejected RPC calls rather than silent disconnects, but process lifecycle behavior is security-adjacent for stability.
> 
> **Overview**
> Fixes background MCP/RPC reliability when agent child processes fail to start or error at runtime.
> 
> **`RpcClient`** now spawns the agent with **`process.execPath`** instead of a bare `node` on PATH, listens for **child process and stdin `error` events**, and **rejects all in-flight RPC requests** (including during `start()`) via shared **`handleProcessError` / `rejectPendingRequests`**, with stderr context on the wrapped error. Unexpected exit still uses the same rejection helper.
> 
> The **MCP stdio CLI** installs **`installGlobalErrorHandlers`** at boot so **`uncaughtException`** and **`unhandledRejection`** are logged to stderr with a `[gsd-mcp-server]` prefix instead of taking down the process as an unhandled Node error.
> 
> Regression tests cover spawn executable choice, pending-request rejection on process error, and MCP global error logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8dbf5d501819d87dd683110d6113e8cfef0773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->