### PR TITLE
fix(gsd): classify WebSocket errors as network

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -53,10 +53,11 @@ const RATE_LIMIT_RE = /rate.?limit|too many requests|429|hit your limit|usage li
 // OpenRouter affordability-style quota errors should be treated as transient
 // so core retry logic can lower maxTokens and continue in-session.
 const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient credits|not enough credits|fewer max_tokens/i;
-// "Stream idle timeout" and "partial response received" are emitted by the SDK/harness
-// for mid-stream disconnects. Both indicate a transient network-level interruption.
+// "Stream idle timeout", "partial response received", and WebSocket errors
+// are emitted by SDK/harness transports for mid-stream disconnects.
+// These indicate transient network-level interruptions.
 // See: https://github.com/open-gsd/gsd-pi/issues/4558
-const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns|unexpected eof|stream idle timeout|partial response received/i;
+const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|web ?socket|fetch failed|connection.*reset|dns|unexpected eof|stream idle timeout|partial response received/i;
 // Context overflow errors (context window/length exceeded) should be treated as server-class
 // transient errors so auto-mode can retry with reduced budget or fall back to a larger-context model.
 // See: https://github.com/open-gsd/gsd-pi/issues/4528

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -152,6 +152,15 @@ test("classifyError treats plain 'Connection error.' as transient connection fai
   assert.ok("retryAfterMs" in result && result.retryAfterMs === 15_000);
 });
 
+test("classifyError treats WebSocket transport errors as transient network failures (#338)", () => {
+  for (const message of ["WebSocket error", "WebSocket disconnected", "web socket disconnected"]) {
+    const result = classifyError(message);
+    assert.ok(isTransient(result), `${message} should be transient`);
+    assert.equal(result.kind, "network");
+    assert.ok("retryAfterMs" in result && result.retryAfterMs === 3_000);
+  }
+});
+
 test("classifyError treats unknown error as not transient", () => {
   const result = classifyError("something went wrong");
   assert.ok(!isTransient(result));
@@ -274,6 +283,10 @@ test("isTransientNetworkError detects socket hang up", () => {
   assert.ok(isTransientNetworkError("socket hang up"));
 });
 
+test("isTransientNetworkError detects WebSocket transport errors", () => {
+  assert.ok(isTransientNetworkError("WebSocket error"));
+});
+
 test("isTransientNetworkError detects fetch failed", () => {
   assert.ok(isTransientNetworkError("fetch failed"));
 });
@@ -387,6 +400,50 @@ test("pauseAutoForProviderError schedules auto-resume for rate limit errors", as
     assert.equal(resumeCalled, true);
     assert.deepEqual(notifications[1], {
       message: "Rate limit window elapsed. Resuming auto-mode.",
+      level: "info",
+    });
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});
+
+test("pauseAutoForProviderError schedules auto-resume for WebSocket network errors", async () => {
+  const cls = classifyError("WebSocket error");
+  if (cls.kind !== "network") {
+    assert.fail(`expected WebSocket error to classify as network, got ${cls.kind}`);
+  }
+
+  const notifications: Array<{ message: string; level: string }> = [];
+  let pauseCalls = 0;
+  let resumeCalled = false;
+
+  const originalSetTimeout = globalThis.setTimeout;
+  const timers: Array<{ fn: () => void; delay: number }> = [];
+  globalThis.setTimeout = ((fn: () => void, delay: number) => {
+    timers.push({ fn, delay });
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    await pauseAutoForProviderError(
+      { notify(message, level?) { notifications.push({ message, level: level ?? "info" }); } },
+      ": WebSocket error",
+      async () => { pauseCalls += 1; },
+      { isTransient: isTransient(cls), retryAfterMs: cls.retryAfterMs, resume: () => { resumeCalled = true; } },
+    );
+
+    assert.equal(pauseCalls, 1);
+    assert.equal(timers.length, 1);
+    assert.equal(timers[0].delay, 3_000);
+    assert.deepEqual(notifications[0], {
+      message: "Server error (transient): WebSocket error. Auto-resuming in 3s...",
+      level: "warning",
+    });
+
+    timers[0].fn();
+    assert.equal(resumeCalled, true);
+    assert.deepEqual(notifications[1], {
+      message: "Server error recovery delay elapsed. Resuming auto-mode.",
       level: "info",
     });
   } finally {


### PR DESCRIPTION
## Linked issue

Closes #338

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Classify WebSocket transport failures as transient network errors.
**Why:** Auto-mode should auto-resume after recoverable WebSocket drops instead of pausing indefinitely.
**How:** Add `web ?socket` to the existing network classifier and cover the classification/resume path in provider-error tests.

## What

Updates `src/resources/extensions/gsd/error-classifier.ts` so messages like `WebSocket error`, `WebSocket disconnected`, and `web socket disconnected` classify as `network` with the existing short retry delay.

Adds regression coverage in `src/resources/extensions/gsd/tests/provider-errors.test.ts` for:

- `classifyError` returning `network`
- `isTransientNetworkError` accepting WebSocket errors
- `pauseAutoForProviderError` scheduling an auto-resume when fed the WebSocket network classification

## Why

A provider transport WebSocket drop is the same recoverable mid-stream network failure family as `socket hang up`, `stream idle timeout`, and `partial response received`. Before this change, `WebSocket error` fell through as `unknown`, so auto-mode paused indefinitely and required manual `/gsd auto` recovery.

## How

The implementation extends the existing `NETWORK_RE` token list with `web ?socket`, preserving the current classifier ordering and retry behavior. No pause/resume control flow changed; the existing transient path now receives the correct classification.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Commands run:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`
- `pnpm run test:compile`
- `git diff --check`

## AI disclosure

- [x] This PR includes AI-assisted code — implemented by Codex and verified with the commands above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782911109&installation_id=134682257&pr_number=348&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F348&signature=2b698720e518581687acaa65b47f0cc392f7745a5a4d5906fcd9da60a99f421c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small regex extension and tests in the GSD error classifier; no auth, data, or pause/resume control-flow changes beyond correct classification.
> 
> **Overview**
> **WebSocket transport failures** (e.g. `WebSocket error`, `WebSocket disconnected`) are now classified as **transient `network`** errors via an added `web ?socket` pattern in `NETWORK_RE`, alongside existing mid-stream disconnect handling.
> 
> That routes them through the same **3s retry** and **auto-resume** path as other network interruptions, instead of falling through as `unknown` and leaving auto-mode paused until manual recovery.
> 
> Tests cover classification, `isTransientNetworkError`, and `pauseAutoForProviderError` scheduling resume after a WebSocket error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52118802a4ba2df42ccc889d5ed368c26ad409c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->