### PR TITLE
[codex] Fix browser evidence visible false positive

### DIFF
--- a/src/resources/extensions/gsd/browser-evidence.ts
+++ b/src/resources/extensions/gsd/browser-evidence.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: Shared browser-observable UAT requirement and evidence detection.
 
-export const BROWSER_REQUIREMENT_RE = /\b(?:browser|file:\/\/|localhost|dom|localstorage|click(?:ing|ed)?|button|visible|screenshot|snapshot|reload(?:ed)?|page refresh|user-visible|strikethrough|search box)\b/i;
+export const BROWSER_REQUIREMENT_RE = /\b(?:browser|file:\/\/|localhost|dom|localstorage|click(?:ing|ed)?|button|screenshot|snapshot|reload(?:ed)?|page refresh|user-visible|strikethrough|search box)\b/i;
 export const NO_BROWSER_EVIDENCE_RE = /\b(?:no|without|not|wasn'?t|isn'?t)\s+(?:automated\s+)?(?:live\s+)?browser(?:\s+(?:session|test|uat))?|\bno\s+automated\s+browser\b|\bnot\s+conducted\b/i;
 export const BROWSER_RUNTIME_RE = /\b(?:browser|playwright|chrome|camoufox|browser_(?:assert|batch|find|verify|snapshot_refs)|screenshot|snapshot|file:\/\/|localhost)\b/i;
 export const BROWSER_ACTION_RE = /\b(?:open(?:ed)?|navigate(?:d)?|click(?:ed)?|type(?:d)?|reload(?:ed)?|capture(?:d)?|screenshot|snapshot)\b/i;

--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -212,6 +212,7 @@ export async function handleVerdict(
       remediationPlan: current.remediationPlan,
     },
     basePath,
+    parsed.verdict === "pass" ? { skipBrowserEvidenceGate: true } : undefined,
   );
 
   if (result.isError) {

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -286,7 +286,7 @@ test("handleVerdict pass override flips verdict and preserves sections", async (
   }
 });
 
-test("handleVerdict reports downgraded effective verdict after validation gates", async () => {
+test("handleVerdict pass override bypasses browser evidence gate", async () => {
   const base = makeBase();
   try {
     openTestDb(base);
@@ -302,15 +302,14 @@ test("handleVerdict reports downgraded effective verdict after validation gates"
     await handleVerdict("pass --milestone M001", ctx, base);
 
     const rewritten = readFileSync(validationPath, "utf-8");
-    assert.match(rewritten, /^verdict: needs-attention$/m, "browser gate should downgrade pass");
+    assert.match(rewritten, /^verdict: pass$/m, "manual verdict pass should persist");
     assert.ok(
-      calls.some((c) => c.kind === "warning" &&
-        /requested: pass, effective: needs-attention/.test(c.message)),
-      `expected downgraded effective verdict warning, got: ${JSON.stringify(calls)}`,
+      calls.some((c) => c.kind === "success" && /needs-attention.*->.*pass/.test(c.message)),
+      `expected pass override success notification, got: ${JSON.stringify(calls)}`,
     );
     assert.ok(
-      !calls.some((c) => c.kind === "success" && /->.*pass/.test(c.message)),
-      `must not report pass when effective verdict stayed needs-attention: ${JSON.stringify(calls)}`,
+      !calls.some((c) => c.kind === "warning" && /effective: needs-attention/.test(c.message)),
+      `manual pass override should not be downgraded by browser gate: ${JSON.stringify(calls)}`,
     );
   } finally {
     closeDatabase();

--- a/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
@@ -266,6 +266,43 @@ describe("handleValidateMilestone write ordering (#2725)", () => {
     assert.match(validationMd, /Browser evidence gate/);
   });
 
+  it("does not require browser evidence for visible in non-browser prose", async () => {
+    base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({
+      id: "M001",
+      planning: {
+        successCriteria: [
+          "Priority scores visible in EmpireMemory",
+          "Profitability visible in haul task creation",
+        ],
+        verificationUat: "Run CLI checks and inspect memory state.",
+      },
+    });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      demo: "Priority scores visible in EmpireMemory after worker planning.",
+      planning: {
+        goal: "Expose runtime scoring in memory for operator inspection.",
+        successCriteria: "Memory fields are available for CLI inspection.",
+      },
+    });
+
+    const result = await handleValidateMilestone(
+      {
+        ...VALID_PARAMS,
+        verificationClasses:
+          `${VALID_PARAMS.verificationClasses}\n- UAT: CLI memory inspection complete`,
+      },
+      base,
+    );
+
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+    assert.equal(result.verdict, "pass");
+  });
+
   it("keeps pass when browser criteria have persisted browser evidence", async () => {
     base = makeTmpBase();
     const dbPath = join(base, ".gsd", "gsd.db");

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -57,6 +57,7 @@ export interface ValidateMilestoneOptions {
   uokGatesEnabled?: boolean;
   traceId?: string;
   turnId?: string;
+  skipBrowserEvidenceGate?: boolean;
 }
 
 function isVerificationNotApplicable(value: string): boolean {
@@ -194,7 +195,9 @@ export async function handleValidateMilestone(
   }
 
   const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, params.milestoneId);
-  const effectiveParams = await browserEvidenceGateRequiresAttention(params, artifactBasePath)
+  const shouldApplyBrowserEvidenceGate = !opts?.skipBrowserEvidenceGate &&
+    await browserEvidenceGateRequiresAttention(params, artifactBasePath);
+  const effectiveParams = shouldApplyBrowserEvidenceGate
     ? applyBrowserEvidenceGate(params)
     : params;
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -38,7 +38,7 @@ import type { ReopenTaskParams } from "./reopen-task.js";
 import { handleReopenTask } from "./reopen-task.js";
 import type { ReassessRoadmapParams } from "./reassess-roadmap.js";
 import { handleReassessRoadmap } from "./reassess-roadmap.js";
-import type { ValidateMilestoneParams } from "./validate-milestone.js";
+import type { ValidateMilestoneOptions, ValidateMilestoneParams } from "./validate-milestone.js";
 import { handleValidateMilestone } from "./validate-milestone.js";
 import { logError, logWarning } from "../workflow-logger.js";
 import { invalidateStateCache } from "../state.js";
@@ -744,6 +744,7 @@ export async function executeCompleteMilestone(
 export async function executeValidateMilestone(
   params: ValidateMilestoneExecutorParams,
   basePath: string = process.cwd(),
+  opts?: ValidateMilestoneOptions,
 ): Promise<ToolExecutionResult> {
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) {
@@ -754,7 +755,7 @@ export async function executeValidateMilestone(
       };
   }
   try {
-    const result = await handleValidateMilestone(params, basePath);
+    const result = await handleValidateMilestone(params, basePath, opts);
     if ("error" in result) {
       return {
         content: [{ type: "text", text: `Error validating milestone: ${result.error}` }],


### PR DESCRIPTION
## Linked issue

Closes #315
Refs #346

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Stops bare `visible` prose from requiring browser evidence and lets explicit `/gsd verdict pass` persist as a manual override.
**Why:** Non-browser milestones were being downgraded to `needs-attention` because CLI/domain prose used the word `visible`.
**How:** Removes the bare `visible` requirement token while keeping `user-visible` and browser evidence assertions, and routes `/gsd verdict pass` through an internal skip for the browser evidence gate.

## What

- Narrows browser-requirement detection so ordinary non-browser phrases like “scores visible in memory” do not trigger the browser evidence gate.
- Adds an internal `skipBrowserEvidenceGate` validation option used only by `/gsd verdict pass`; normal `gsd_validate_milestone` tool/MCP callers still apply the browser evidence gate.
- Updates regression coverage for non-browser `visible` prose and manual verdict pass overrides.

## Why

`BROWSER_REQUIREMENT_RE` treated bare `visible` as browser-observable evidence language. That blocked CLI/IaC/non-browser milestones and also made `/gsd verdict pass` ineffective because the same gate re-ran and rewrote the requested pass back to `needs-attention`.

## How

The browser evidence requirement regex now keeps explicit browser signals such as `browser`, `localhost`, `button`, `screenshot`, and `user-visible`, but no longer treats `visible` alone as enough. Manual verdict pass still reuses the normal validation write path, but passes an internal executor option so the user override can persist.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] `pnpm run build:pi`
- [x] `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts src/resources/extensions/gsd/tests/commands-verdict.test.ts`
- [x] `pnpm run verify:fast`

## Impact analysis

- Blast radius: moderate, limited to GSD milestone validation, browser-evidence requirement detection, and the manual verdict command.
- Affected workflows: `gsd_validate_milestone`, `/gsd verdict pass`, validation persistence, and UAT browser-detection helpers that share `hasBrowserRequiredText`.
- Compatibility notes: normal tool/MCP validation still enforces browser evidence; only the explicit manual pass override skips the browser evidence gate.

## AI disclosure

- [x] This PR includes AI-assisted code. The change was implemented with Codex and verified with the commands above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782911305&installation_id=134682257&pr_number=349&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F349&signature=86732c9770dd1a10cbb51590abae71b214cb5e3c61be5a0e1d0d9e00fbcd4d12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes milestone validation verdict behavior and manual pass overrides in the GSD extension; automated validation still enforces browser evidence, but operators can bypass it via `/gsd verdict pass`.
> 
> **Overview**
> **Browser evidence detection** no longer treats the word `visible` alone as a browser UAT signal in `BROWSER_REQUIREMENT_RE`; explicit terms like `user-visible`, `browser`, `button`, and `localhost` still trigger the gate. That stops CLI/memory-style criteria (e.g. “scores visible in EmpireMemory”) from being downgraded to `needs-attention` when no Playwright-style evidence exists.
> 
> **Manual `/gsd verdict pass`** now passes an internal `skipBrowserEvidenceGate` option through `executeValidateMilestone` → `handleValidateMilestone`, so an operator override can persist `pass` even when browser-oriented UAT text is present. Automated `gsd_validate_milestone` / MCP validation still runs the browser evidence gate unless that flag is set.
> 
> Regression tests cover non-browser `visible` prose and pass overrides that previously were rewritten to `needs-attention`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f303d98edd9f18b25c3c59c7cfdf58e3dabdfbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->