### PR TITLE
[codex] Make MCP and onboarding copy provider-neutral

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -110,7 +110,7 @@ export const OTHER_PROVIDERS = [
   { value: 'xai', label: 'xAI (Grok)', hint: 'console.x.ai' },
   { value: 'openrouter', label: 'OpenRouter', hint: '200+ models — openrouter.ai/keys' },
   { value: 'mistral', label: 'Mistral', hint: 'console.mistral.ai/api-keys' },
-  { value: 'minimax', label: 'MiniMax', hint: 'platform.minimax.io (Anthropic-compatible recommended)' },
+  { value: 'minimax', label: 'MiniMax', hint: 'platform.minimax.io (Anthropic-compatible)' },
   { value: 'minimax-cn', label: 'MiniMax CN', hint: 'api.minimaxi.com (Anthropic-compatible)' },
   { value: 'ollama-cloud', label: 'Ollama Cloud' },
   { value: 'custom-openai', label: 'Custom (OpenAI-compatible)', hint: 'Ollama, LM Studio, vLLM, proxies — see docs/providers.md' },
@@ -406,7 +406,7 @@ export async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: Au
   // This is the only TOS-compliant path for Anthropic subscription users.
   if (isClaudeCliReady()) {
     authOptions.push(
-      { value: 'claude-cli', label: 'Use Claude Code CLI', hint: 'recommended — uses your existing Claude subscription' },
+      { value: 'claude-cli', label: 'Use Claude Code CLI', hint: 'uses your existing Claude subscription' },
     )
   }
 

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -10,7 +10,7 @@
  *   /gsd mcp test <srv>  — Test handshake + tools/list for a server
  *   /gsd mcp enable <srv> / disable <srv> — Toggle local server exposure
  *   /gsd mcp import <srv> [as <name>] — Copy a discovered server into local config
- *   /gsd mcp init [dir]  — Write project-local GSD workflow + browser MCP config
+ *   /gsd mcp init [dir]  — Write project-local GSD workflow MCP config
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
@@ -68,7 +68,8 @@ export function formatMcpInitResult(
     `Project: ${targetPath}`,
     `Config:   ${configPath}`,
     "",
-    "Claude Code can now load the GSD workflow and browser MCP servers from this folder.",
+    "MCP-capable clients can now load the GSD workflow MCP server from this folder.",
+    "Restart or reconnect any client that already has this project open.",
   ].join("\n");
 }
 
@@ -80,7 +81,7 @@ export function formatMcpStatusReport(servers: McpServerStatus[]): string {
       "No MCP servers configured.",
       "",
       "Add servers to .mcp.json, .gsd/mcp.json, or $GSD_HOME/mcp.json (default: ~/.gsd/mcp.json) to enable MCP integrations.",
-      "Tip: run /gsd mcp init . to write the local GSD workflow + browser MCP config.",
+      "Tip: run /gsd mcp init . to write the local GSD workflow MCP config.",
       "See: https://modelcontextprotocol.io/quickstart",
     ].join("\n");
   }

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -163,7 +163,8 @@ describe("formatMcpInitResult", () => {
     const result = formatMcpInitResult("created", "/tmp/project/.mcp.json", "/tmp/project");
     assert.match(result, /created project mcp config/i);
     assert.match(result, /\/tmp\/project\/\.mcp\.json/);
-    assert.match(result, /claude code/i);
+    assert.match(result, /mcp-capable clients/i);
+    assert.doesNotMatch(result, /claude code/i);
   });
 
   test("shows unchanged message when config is current", () => {

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -754,7 +754,7 @@ test("claude-code ExternalCli provider is recognized as configured and unlocks o
   assert.equal(claudeCodeProvider.supports.externalCli, true);
   assert.equal(claudeCodeProvider.supports.apiKey, false);
   assert.equal(claudeCodeProvider.supports.oauth, false);
-  assert.equal(claudeCodeProvider.recommended, true);
+  assert.equal(claudeCodeProvider.recommended, false);
 });
 
 test("ExternalCli auth sentinels do not unlock onboarding when CLI is missing", async (t) => {

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -174,7 +174,7 @@ type ProviderFlowRuntime = {
  * as configured only when their official CLI command is present on PATH.
  */
 const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
-  { id: "anthropic", label: "Anthropic (Claude)", supportsApiKey: true, supportsOAuth: false, recommended: true },
+  { id: "anthropic", label: "Anthropic (Claude)", supportsApiKey: true, supportsOAuth: false },
   { id: "openai", label: "OpenAI", supportsApiKey: true, supportsOAuth: false },
   { id: "github-copilot", label: "GitHub Copilot", supportsApiKey: false, supportsOAuth: true },
   { id: "openai-codex", label: "ChatGPT Plus/Pro (Codex Subscription)", supportsApiKey: false, supportsOAuth: true },
@@ -194,7 +194,7 @@ const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "azure-openai-responses", label: "Azure OpenAI", supportsApiKey: false, supportsOAuth: false },
   { id: "alibaba-coding-plan", label: "Alibaba Coding Plan", supportsApiKey: false, supportsOAuth: false },
   { id: "alibaba-dashscope", label: "Alibaba DashScope", supportsApiKey: false, supportsOAuth: false },
-  { id: "claude-code", label: "Claude Code (Local CLI)", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true, recommended: true },
+  { id: "claude-code", label: "Claude Code (Local CLI)", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true },
 ];
 
 const OPTIONAL_SECTION_CATALOG: OptionalSectionCatalogEntry[] = [


### PR DESCRIPTION
## Summary

- Make `/gsd mcp init` success copy refer to MCP-capable clients instead of Claude Code specifically.
- Remove provider preference signals from onboarding copy and provider metadata.
- Update tests so generic MCP copy stays provider-neutral.

## Why

Generic runtime messages should not imply a preferred model or provider. Provider names should appear only when the flow is actually provider-specific.

## Validation

- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/mcp-status.test.js dist-test/src/resources/extensions/gsd/tests/mcp-project-config.test.js dist-test/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.js` in the source checkout: 27 pass
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=180000 src/tests/integration/web-onboarding-contract.test.ts` in the source checkout: 12 pass
- `pnpm run typecheck:extensions`
- `git diff --check HEAD~1..HEAD` on the PR branch

Note: the PR branch was created in a clean worktree from `origin/main` to avoid unrelated local dirty files and local commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782911623&installation_id=134682257&pr_number=350&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F350&signature=c1765bdf3ffbf78db50277ff17c6906167344020e7adcf13aae27a1c2c492e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and catalog metadata only; no auth, MCP wiring, or runtime behavior changes beyond UI labels and `recommended` booleans defaulting to false.
> 
> **Overview**
> User-facing copy and onboarding metadata no longer steer users toward specific vendors.
> 
> **`/gsd mcp init`** success and empty-state messages now refer to **MCP-capable clients** and the **GSD workflow MCP server** only, with a note to restart/reconnect clients—**Claude Code** and **browser MCP** wording is removed from comments and tips.
> 
> **Onboarding** drops “recommended” signals: TUI Claude Code CLI hint no longer says “recommended”; web `REQUIRED_PROVIDER_CATALOG` no longer marks **anthropic** or **claude-code** as recommended (API still exposes `recommended: false`). Minor hint tweaks (e.g. MiniMax label).
> 
> **Tests** assert the new MCP init copy and that `claude-code` is not `recommended` when configured via external CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e98231307e7651c6a5f4fd4089ae37c5933f2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->