### PR TITLE
fix(gsd): route status command to dashboard

### DIFF
--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -22,7 +22,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "auto", desc: "Autonomous mode — research, plan, execute, commit, repeat" },
   { cmd: "stop", desc: "Stop auto mode gracefully" },
   { cmd: "pause", desc: "Pause auto-mode (preserves state, /gsd auto to resume)" },
-  { cmd: "status", desc: "Open 10-tab workflow visualizer" },
+  { cmd: "status", desc: "Open the status dashboard" },
   { cmd: "widget", desc: "Cycle widget: full → small → min → off" },
   { cmd: "visualize", desc: "Open 10-tab workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)" },
   { cmd: "brief", desc: "Generate a visual HTML brief: diagram, plan, diff review, recap, table, or slides" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -26,10 +26,10 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd stop          Stop auto-mode gracefully",
     "",
     "VISIBILITY",
-    `  /gsd status         Interactive 10-tab TUI  (${formattedShortcutPair("dashboard")})`,
+    `  /gsd status         Status dashboard  (${formattedShortcutPair("dashboard")})`,
     `  /gsd parallel watch Parallel monitor  (${formattedShortcutPair("parallel")})`,
     `  /gsd notifications  Notification history  (${formattedShortcutPair("notifications")})`,
-    "  /gsd visualize      Interactive 10-tab TUI",
+    "  /gsd visualize      Workflow visualizer",
     "  /gsd report         Generate all HTML reports and open browser",
     "  /gsd brief <mode>   Visual HTML brief (diagram, plan, diff, recap, table, slides)",
     "  /gsd queue          Show queued/dispatched units",
@@ -80,10 +80,10 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd workflow       Custom workflow lifecycle  [new|run|list|validate|pause|resume]",
     "",
     "VISIBILITY",
-    `  /gsd status         Interactive 10-tab TUI  (${formattedShortcutPair("dashboard")})`,
+    `  /gsd status         Status dashboard  (${formattedShortcutPair("dashboard")})`,
     `  /gsd parallel watch Open parallel worker monitor  (${formattedShortcutPair("parallel")})`,
     "  /gsd widget         Cycle status widget  [full|small|min|off]",
-    "  /gsd visualize      Interactive 10-tab TUI (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)",
+    "  /gsd visualize      Workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)",
     "  /gsd brief <mode>   Generate a visual HTML brief  [diagram|plan|diff|recap|table|slides] [topic] [--slides]",
     "  /gsd queue          Show queued/dispatched units and execution order",
     "  /gsd history        View execution history  [--cost] [--phase] [--model] [N]",
@@ -469,7 +469,7 @@ export async function handleCoreCommand(
     return true;
   }
   if (trimmed === "status") {
-    await handleVisualize(ctx);
+    await handleStatus(ctx);
     return true;
   }
   if (trimmed === "visualize") {

--- a/src/resources/extensions/gsd/tests/brief-command.test.ts
+++ b/src/resources/extensions/gsd/tests/brief-command.test.ts
@@ -84,6 +84,6 @@ test("/gsd help full lists brief separately from visualize", () => {
   showHelp(ctx as any, "full");
 
   const help = ctx.notifications.at(0)?.message ?? "";
-  assert.match(help, /\/gsd visualize\s+Interactive 10-tab TUI/);
+  assert.match(help, /\/gsd visualize\s+Workflow visualizer/);
   assert.match(help, /\/gsd brief <mode>\s+Generate a visual HTML brief/);
 });

--- a/src/resources/extensions/gsd/tests/core-overlay-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/core-overlay-fallback.test.ts
@@ -1,20 +1,53 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { handleCoreCommand } from "../commands/handlers/core.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+import { invalidateStateCache } from "../state.ts";
 
 function makeCtx(customResult: unknown) {
   const notices: Array<{ message: string; type?: string }> = [];
+  const customCalls: Array<{ options: any }> = [];
   return {
     hasUI: true,
     ui: {
-      custom: async () => customResult,
+      custom: async (_factory: unknown, options: any) => {
+        customCalls.push({ options });
+        return customResult;
+      },
       notify: (message: string, type?: string) => {
         notices.push({ message, type });
       },
     },
     notices,
+    customCalls,
   };
+}
+
+function createGsdProjectWithActiveMilestone(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-status-route-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Status Dashboard", status: "active", depends_on: [] });
+  closeDatabase();
+  return base;
+}
+
+async function withProjectCwd<T>(base: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  closeDatabase();
+  invalidateStateCache();
+  process.chdir(base);
+  try {
+    return await fn();
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    process.chdir(previous);
+  }
 }
 
 test("visualize only falls back when ctx.ui.custom() is unavailable", async () => {
@@ -30,12 +63,19 @@ test("visualize only falls back when ctx.ui.custom() is unavailable", async () =
   assert.match(fallbackCtx.notices[0]!.message, /interactive terminal/i);
 });
 
-test("status routes to the visualizer overlay", async () => {
-  const successCtx = makeCtx(true);
-  const handled = await handleCoreCommand("status", successCtx as any);
+test("status routes to the dashboard overlay", async () => {
+  const base = createGsdProjectWithActiveMilestone();
+  try {
+    const successCtx = makeCtx(true);
+    const handled = await withProjectCwd(base, () => handleCoreCommand("status", successCtx as any));
 
-  assert.equal(handled, true);
-  assert.equal(successCtx.notices.length, 0, "status should use the visualizer overlay path");
+    assert.equal(handled, true);
+    assert.equal(successCtx.notices.length, 0, "status should use the dashboard overlay path");
+    assert.equal(successCtx.customCalls.length, 1, "status should open an overlay");
+    assert.equal(successCtx.customCalls[0]!.options?.overlayOptions?.width, "90%");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("show-config only falls back when ctx.ui.custom() is unavailable", async () => {

--- a/src/resources/extensions/gsd/tests/status-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/status-db-open.test.ts
@@ -4,26 +4,61 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { handleCoreCommand } from "../commands/handlers/core.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
 import { buildQuickCommitInstruction } from "../quick.ts";
+import { invalidateStateCache } from "../state.ts";
+
+function createGsdProjectWithActiveMilestone(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-status-db-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Status Dashboard", status: "active", depends_on: [] });
+  closeDatabase();
+  return base;
+}
+
+async function withProjectCwd<T>(base: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  closeDatabase();
+  invalidateStateCache();
+  process.chdir(base);
+  try {
+    return await fn();
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    process.chdir(previous);
+  }
+}
 
 describe("status command routing", () => {
-  test("core handler routes status command to visualizer fallback in non-UI contexts", async () => {
-    const notifications: Array<{ message: string; level: string }> = [];
-    const ctx = {
-      ui: {
-        custom: async () => undefined,
-        notify: (message: string, level: string) => {
-          notifications.push({ message, level });
+  test("core handler opens the status dashboard and falls back to DB-backed text status", async () => {
+    const base = createGsdProjectWithActiveMilestone();
+    try {
+      const notifications: Array<{ message: string; level: string }> = [];
+      const ctx = {
+        ui: {
+          custom: async () => undefined,
+          notify: (message: string, level: string) => {
+            notifications.push({ message, level });
+          },
         },
-      },
-    };
+      };
 
-    const handled = await handleCoreCommand("status", ctx as any);
+      const handled = await withProjectCwd(base, () => handleCoreCommand("status", ctx as any));
 
-    assert.equal(handled, true);
-    assert.match(notifications[0]?.message ?? "", /interactive terminal/i);
+      assert.equal(handled, true);
+      assert.match(notifications[0]?.message ?? "", /GSD Status/);
+      assert.match(notifications[0]?.message ?? "", /Status Dashboard/);
+      assert.doesNotMatch(notifications[0]?.message ?? "", /interactive terminal/i);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 
   test("quick task commit instructions handle external .gsd roots without staging quick files", () => {


### PR DESCRIPTION
## Linked issue

Closes #235

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Route terminal `/gsd status` to the status dashboard instead of the workflow visualizer.
**Why:** The documented status command currently opens the same visualizer overlay as `/gsd visualize`, making the dashboard command path unreachable.
**How:** Dispatch `status` through `handleStatus`, separate the status/visualize help and catalog copy, and update regression tests for dashboard routing and DB-backed text fallback.

## What

Updates the bundled GSD extension command dispatcher and command metadata:

- `/gsd status` now calls `handleStatus(ctx)`.
- `/gsd visualize` remains the 10-tab workflow visualizer path.
- Help text and completion catalog descriptions now distinguish the status dashboard from the visualizer.
- Status routing tests now create a temp `.gsd` database and assert dashboard overlay/text fallback behavior.

## Why

`/gsd status` and `/gsd visualize` were behaving identically in terminal sessions because the `status` branch delegated to `handleVisualize`. The dashboard handler already existed and was used by the home menu, so the command dispatcher was the missing link.

## How

This keeps the fix narrow to the terminal GSD extension command surface reported in the issue. The regression tests exercise both successful overlay routing and non-interactive fallback with DB-backed status data.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/core-overlay-fallback.test.ts src/resources/extensions/gsd/tests/status-db-open.test.ts src/resources/extensions/gsd/tests/brief-command.test.ts src/resources/extensions/gsd/tests/help-menu-coverage.test.ts`
- `pnpm run typecheck:extensions`

## Impact analysis

- Blast radius: narrow; terminal GSD extension command routing, command descriptions, and focused tests.
- Affected workflows: `/gsd status`, `/gsd visualize`, `/gsd help`, and command completions.
- Risks or compatibility notes: `/gsd visualize` keeps the prior visualizer behavior; `/gsd status` now matches the documented dashboard behavior and the existing home-menu status action.

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented with Codex and verified with targeted command tests plus extension typecheck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782912281&installation_id=134682257&pr_number=352&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F352&signature=42c808d400b0560d3a741f73f0aa1c66a5ed5a45b636ce7d67afe3164419652c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow GSD extension command routing and copy changes; `/gsd visualize` behavior is unchanged.
> 
> **Overview**
> **`/gsd status` now opens the status dashboard** instead of the same 10-tab workflow visualizer as `/gsd visualize`. The core dispatcher calls `handleStatus` for `status` and leaves `visualize` on `handleVisualize`.
> 
> Help text and the command catalog were updated so **status** is described as the status dashboard and **visualize** as the workflow visualizer. Regression tests were extended with temporary `.gsd` databases to assert dashboard overlay routing (including overlay width) and DB-backed text fallback when the UI overlay is unavailable—not the visualizer’s interactive-terminal warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbdc4372ebdfc7c470a13b6e4ead0359beeb604e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->