### PR TITLE
fix(pi-ai): restore anthropic vertex provider

### DIFF
--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/providers/anthropic.d.ts",
       "import": "./dist/providers/anthropic.js"
     },
+    "./anthropic-vertex": {
+      "types": "./dist/providers/anthropic-vertex.d.ts",
+      "import": "./dist/providers/anthropic-vertex.js"
+    },
     "./azure-openai-responses": {
       "types": "./dist/providers/azure-openai-responses.d.ts",
       "import": "./dist/providers/azure-openai-responses.js"
@@ -74,6 +78,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.91.1",
+    "@anthropic-ai/vertex-sdk": "0.14.4",
     "@aws-sdk/client-bedrock-runtime": "3.1048.0",
     "@smithy/node-http-handler": "4.7.3",
     "@google/genai": "1.52.0",

--- a/packages/pi-ai/src/env-api-keys.ts
+++ b/packages/pi-ai/src/env-api-keys.ts
@@ -105,6 +105,10 @@ export function getApiKeyEnvVars(provider: string): readonly string[] | undefine
 		return ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"];
 	}
 
+	if (provider === "anthropic-vertex") {
+		return ["ANTHROPIC_VERTEX_PROJECT_ID"];
+	}
+
 	const envMap: Record<string, string> = {
 		openai: "OPENAI_API_KEY",
 		"azure-openai-responses": "AZURE_OPENAI_API_KEY",
@@ -141,11 +145,11 @@ export function getApiKeyEnvVars(provider: string): readonly string[] | undefine
 }
 
 /**
- * Find configured environment variables that can provide an API key for a provider.
+ * Find configured environment variables that can provide an API key or auth marker for a provider.
  *
- * This only reports actual API key variables. It intentionally excludes ambient
- * credential sources such as AWS profiles, AWS IAM credentials, and Google
- * Application Default Credentials.
+ * This only reports explicit environment variables. It intentionally excludes
+ * ambient credential sources such as AWS profiles, AWS IAM credentials, and
+ * Google Application Default Credentials.
  */
 export function findEnvKeys(provider: KnownProvider): string[] | undefined;
 export function findEnvKeys(provider: string): string[] | undefined;
@@ -165,6 +169,26 @@ export function findEnvKeys(provider: string): string[] | undefined {
 export function getEnvApiKey(provider: KnownProvider): string | undefined;
 export function getEnvApiKey(provider: string): string | undefined;
 export function getEnvApiKey(provider: string): string | undefined {
+	if (provider === "anthropic-vertex") {
+		const hasProject = !!(
+			process.env.ANTHROPIC_VERTEX_PROJECT_ID ||
+			getProcEnv("ANTHROPIC_VERTEX_PROJECT_ID")
+		);
+		if (hasProject) {
+			return "<authenticated>";
+		}
+
+		const hasGoogleProject = !!(
+			process.env.GOOGLE_CLOUD_PROJECT ||
+			process.env.GCLOUD_PROJECT ||
+			getProcEnv("GOOGLE_CLOUD_PROJECT") ||
+			getProcEnv("GCLOUD_PROJECT")
+		);
+		if (hasGoogleProject && hasVertexAdcCredentials()) {
+			return "<authenticated>";
+		}
+	}
+
 	const envKeys = findEnvKeys(provider);
 	if (envKeys?.[0]) {
 		return process.env[envKeys[0]] || getProcEnv(envKeys[0]);

--- a/packages/pi-ai/src/index.ts
+++ b/packages/pi-ai/src/index.ts
@@ -9,6 +9,7 @@ export * from "./images-api-registry.js";
 export * from "./models.js";
 export type { BedrockOptions, BedrockThinkingDisplay } from "./providers/amazon-bedrock.js";
 export type { AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay } from "./providers/anthropic.js";
+export type { AnthropicVertexOptions } from "./providers/anthropic-vertex.js";
 export type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses.js";
 export * from "./providers/faux.js";
 export type { GoogleOptions } from "./providers/google.js";

--- a/packages/pi-ai/src/providers/anthropic-vertex.ts
+++ b/packages/pi-ai/src/providers/anthropic-vertex.ts
@@ -1,0 +1,173 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
+import { getEnvApiKey } from "../env-api-keys.js";
+import type {
+	Api,
+	AssistantMessage,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	StreamFunction,
+} from "../types.js";
+import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import {
+	type AnthropicEffort,
+	type AnthropicOptions,
+	streamAnthropic,
+} from "./anthropic.js";
+import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
+
+export type AnthropicVertexOptions = Omit<AnthropicOptions, "client">;
+
+let anthropicVertexClass: typeof AnthropicVertex | undefined;
+
+async function getAnthropicVertexClass(): Promise<typeof AnthropicVertex> {
+	if (!anthropicVertexClass) {
+		const mod = await import("@anthropic-ai/vertex-sdk");
+		anthropicVertexClass = mod.AnthropicVertex;
+	}
+	return anthropicVertexClass;
+}
+
+function resolveProjectId(): string {
+	const projectId =
+		process.env.ANTHROPIC_VERTEX_PROJECT_ID ||
+		process.env.GOOGLE_CLOUD_PROJECT ||
+		process.env.GCLOUD_PROJECT;
+	if (!projectId) {
+		throw new Error(
+			"Anthropic Vertex requires a project ID. Set ANTHROPIC_VERTEX_PROJECT_ID, GOOGLE_CLOUD_PROJECT, or GCLOUD_PROJECT.",
+		);
+	}
+	return projectId;
+}
+
+function resolveRegion(): string {
+	return process.env.CLOUD_ML_REGION || process.env.GOOGLE_CLOUD_LOCATION || "us-central1";
+}
+
+async function createVertexClient(): Promise<AnthropicVertex> {
+	const AnthropicVertexClass = await getAnthropicVertexClass();
+	return new AnthropicVertexClass({
+		projectId: resolveProjectId(),
+		region: resolveRegion(),
+	});
+}
+
+function createErrorMessage(model: Model<"anthropic-vertex">, error: unknown): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api as Api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		errorMessage: error instanceof Error ? error.message : String(error),
+		timestamp: Date.now(),
+	};
+}
+
+function asAnthropicMessagesModel(model: Model<"anthropic-vertex">): Model<"anthropic-messages"> {
+	return model as unknown as Model<"anthropic-messages">;
+}
+
+function mapThinkingLevelToEffort(
+	model: Model<"anthropic-vertex">,
+	level: SimpleStreamOptions["reasoning"],
+): AnthropicEffort {
+	const mapped = level ? model.thinkingLevelMap?.[level] : undefined;
+	if (typeof mapped === "string") return mapped as AnthropicEffort;
+
+	switch (level) {
+		case "minimal":
+		case "low":
+			return "low";
+		case "medium":
+			return "medium";
+		case "high":
+			return "high";
+		default:
+			return "high";
+	}
+}
+
+export const streamAnthropicVertex: StreamFunction<"anthropic-vertex", AnthropicVertexOptions> = (
+	model: Model<"anthropic-vertex">,
+	context: Context,
+	options?: AnthropicVertexOptions,
+): AssistantMessageEventStream => {
+	const stream = new AssistantMessageEventStream();
+
+	(async () => {
+		try {
+			const client = await createVertexClient();
+			const inner = streamAnthropic(asAnthropicMessagesModel(model), context, {
+				...options,
+				client: client as unknown as Anthropic,
+			});
+
+			for await (const event of inner) {
+				stream.push(event);
+			}
+		} catch (error) {
+			const message = createErrorMessage(model, error);
+			stream.push({ type: "error", reason: "error", error: message });
+			stream.end(message);
+		}
+	})();
+
+	return stream;
+};
+
+export const streamSimpleAnthropicVertex: StreamFunction<"anthropic-vertex", SimpleStreamOptions> = (
+	model: Model<"anthropic-vertex">,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream => {
+	const apiKey = options?.apiKey || getEnvApiKey(model.provider) || getEnvApiKey("anthropic-vertex");
+	if (!apiKey) {
+		throw new Error(
+			`No API key for provider: ${model.provider}. Set ANTHROPIC_VERTEX_PROJECT_ID or configure Google Application Default Credentials to use Claude on Vertex AI.`,
+		);
+	}
+
+	const base = buildBaseOptions(model, options, apiKey);
+	if (!options?.reasoning) {
+		return streamAnthropicVertex(
+			model,
+			context,
+			{ ...base, thinkingEnabled: false } satisfies AnthropicVertexOptions,
+		);
+	}
+
+	if (model.compat?.forceAdaptiveThinking === true) {
+		const effort = mapThinkingLevelToEffort(model, options.reasoning);
+		return streamAnthropicVertex(model, context, {
+			...base,
+			thinkingEnabled: true,
+			effort,
+		} satisfies AnthropicVertexOptions);
+	}
+
+	const adjusted = adjustMaxTokensForThinking(
+		base.maxTokens,
+		model.maxTokens,
+		options.reasoning,
+		options.thinkingBudgets,
+	);
+
+	return streamAnthropicVertex(model, context, {
+		...base,
+		maxTokens: adjusted.maxTokens,
+		thinkingEnabled: true,
+		thinkingBudgetTokens: adjusted.thinkingBudget,
+	} satisfies AnthropicVertexOptions);
+};

--- a/packages/pi-ai/src/providers/register-builtins.ts
+++ b/packages/pi-ai/src/providers/register-builtins.ts
@@ -13,6 +13,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import type { BedrockOptions } from "./amazon-bedrock.js";
 import type { AnthropicOptions } from "./anthropic.js";
+import type { AnthropicVertexOptions } from "./anthropic-vertex.js";
 import type { AzureOpenAIResponsesOptions } from "./azure-openai-responses.js";
 import type { GoogleOptions } from "./google.js";
 import type { GoogleVertexOptions } from "./google-vertex.js";
@@ -37,6 +38,11 @@ interface LazyProviderModule<
 interface AnthropicProviderModule {
 	streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOptions>;
 	streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleStreamOptions>;
+}
+
+interface AnthropicVertexProviderModule {
+	streamAnthropicVertex: StreamFunction<"anthropic-vertex", AnthropicVertexOptions>;
+	streamSimpleAnthropicVertex: StreamFunction<"anthropic-vertex", SimpleStreamOptions>;
 }
 
 interface AzureOpenAIResponsesProviderModule {
@@ -94,6 +100,9 @@ const importNodeOnlyProvider = (specifier: string): Promise<unknown> => {
 
 let anthropicProviderModulePromise:
 	| Promise<LazyProviderModule<"anthropic-messages", AnthropicOptions, SimpleStreamOptions>>
+	| undefined;
+let anthropicVertexProviderModulePromise:
+	| Promise<LazyProviderModule<"anthropic-vertex", AnthropicVertexOptions, SimpleStreamOptions>>
 	| undefined;
 let azureOpenAIResponsesProviderModulePromise:
 	| Promise<LazyProviderModule<"azure-openai-responses", AzureOpenAIResponsesOptions, SimpleStreamOptions>>
@@ -217,6 +226,19 @@ function loadAnthropicProviderModule(): Promise<
 	return anthropicProviderModulePromise;
 }
 
+function loadAnthropicVertexProviderModule(): Promise<
+	LazyProviderModule<"anthropic-vertex", AnthropicVertexOptions, SimpleStreamOptions>
+> {
+	anthropicVertexProviderModulePromise ||= import("./anthropic-vertex.js").then((module) => {
+		const provider = module as AnthropicVertexProviderModule;
+		return {
+			stream: provider.streamAnthropicVertex,
+			streamSimple: provider.streamSimpleAnthropicVertex,
+		};
+	});
+	return anthropicVertexProviderModulePromise;
+}
+
 function loadAzureOpenAIResponsesProviderModule(): Promise<
 	LazyProviderModule<"azure-openai-responses", AzureOpenAIResponsesOptions, SimpleStreamOptions>
 > {
@@ -326,6 +348,8 @@ function loadBedrockProviderModule(): Promise<
 
 export const streamAnthropic = createLazyStream(loadAnthropicProviderModule);
 export const streamSimpleAnthropic = createLazySimpleStream(loadAnthropicProviderModule);
+export const streamAnthropicVertex = createLazyStream(loadAnthropicVertexProviderModule);
+export const streamSimpleAnthropicVertex = createLazySimpleStream(loadAnthropicVertexProviderModule);
 export const streamAzureOpenAIResponses = createLazyStream(loadAzureOpenAIResponsesProviderModule);
 export const streamSimpleAzureOpenAIResponses = createLazySimpleStream(loadAzureOpenAIResponsesProviderModule);
 export const streamGoogle = createLazyStream(loadGoogleProviderModule);
@@ -348,6 +372,12 @@ export function registerBuiltInApiProviders(): void {
 		api: "anthropic-messages",
 		stream: streamAnthropic,
 		streamSimple: streamSimpleAnthropic,
+	});
+
+	registerApiProvider({
+		api: "anthropic-vertex",
+		stream: streamAnthropicVertex,
+		streamSimple: streamSimpleAnthropicVertex,
 	});
 
 	registerApiProvider({

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -10,6 +10,7 @@ export type KnownApi =
 	| "azure-openai-responses"
 	| "openai-codex-responses"
 	| "anthropic-messages"
+	| "anthropic-vertex"
 	| "bedrock-converse-stream"
 	| "google-generative-ai"
 	| "google-vertex";
@@ -23,6 +24,7 @@ export type ImagesApi = KnownImagesApi | (string & {});
 export type KnownProvider =
 	| "amazon-bedrock"
 	| "anthropic"
+	| "anthropic-vertex"
 	| "google"
 	| "google-vertex"
 	| "openai"
@@ -621,7 +623,7 @@ export interface Model<TApi extends Api> {
 		? OpenAICompletionsCompat
 		: TApi extends "openai-responses"
 			? OpenAIResponsesCompat
-			: TApi extends "anthropic-messages"
+			: TApi extends "anthropic-messages" | "anthropic-vertex"
 				? AnthropicMessagesCompat
 				: never;
 	/** Provider-specific options passed through to stream handlers. */

--- a/packages/pi-ai/test/anthropic-vertex.test.ts
+++ b/packages/pi-ai/test/anthropic-vertex.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getApiProvider } from "../src/api-registry.ts";
+import { resetApiProviders } from "../src/providers/register-builtins.ts";
+
+describe("anthropic-vertex provider", () => {
+	it("registers anthropic-vertex as a built-in API provider", () => {
+		resetApiProviders();
+
+		const provider = getApiProvider("anthropic-vertex");
+
+		expect(provider).toBeDefined();
+		expect(provider?.api).toBe("anthropic-vertex");
+	});
+});

--- a/packages/pi-ai/test/env-api-keys.test.ts
+++ b/packages/pi-ai/test/env-api-keys.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { findEnvKeys, getEnvApiKey } from "../src/env-api-keys.ts";
+import { findEnvKeys, getApiKeyEnvVars, getEnvApiKey } from "../src/env-api-keys.ts";
 
 const originalCopilotGitHubToken = process.env.COPILOT_GITHUB_TOKEN;
 const originalGhToken = process.env.GH_TOKEN;
 const originalGitHubToken = process.env.GITHUB_TOKEN;
+const originalAnthropicVertexProjectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+const originalGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
+const originalGcloudProject = process.env.GCLOUD_PROJECT;
 
 afterEach(() => {
 	if (originalCopilotGitHubToken === undefined) {
@@ -22,6 +25,24 @@ afterEach(() => {
 		delete process.env.GITHUB_TOKEN;
 	} else {
 		process.env.GITHUB_TOKEN = originalGitHubToken;
+	}
+
+	if (originalAnthropicVertexProjectId === undefined) {
+		delete process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+	} else {
+		process.env.ANTHROPIC_VERTEX_PROJECT_ID = originalAnthropicVertexProjectId;
+	}
+
+	if (originalGoogleCloudProject === undefined) {
+		delete process.env.GOOGLE_CLOUD_PROJECT;
+	} else {
+		process.env.GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
+	}
+
+	if (originalGcloudProject === undefined) {
+		delete process.env.GCLOUD_PROJECT;
+	} else {
+		process.env.GCLOUD_PROJECT = originalGcloudProject;
 	}
 });
 
@@ -42,5 +63,15 @@ describe("environment API keys", () => {
 
 		expect(findEnvKeys("github-copilot")).toEqual(["COPILOT_GITHUB_TOKEN"]);
 		expect(getEnvApiKey("github-copilot")).toBe("copilot-token");
+	});
+
+	it("treats ANTHROPIC_VERTEX_PROJECT_ID as Anthropic Vertex auth", () => {
+		process.env.ANTHROPIC_VERTEX_PROJECT_ID = "vertex-project";
+		delete process.env.GOOGLE_CLOUD_PROJECT;
+		delete process.env.GCLOUD_PROJECT;
+
+		expect(getApiKeyEnvVars("anthropic-vertex")).toEqual(["ANTHROPIC_VERTEX_PROJECT_ID"]);
+		expect(findEnvKeys("anthropic-vertex")).toEqual(["ANTHROPIC_VERTEX_PROJECT_ID"]);
+		expect(getEnvApiKey("anthropic-vertex")).toBe("<authenticated>");
 	});
 });

--- a/packages/pi-ai/test/lazy-module-load.test.ts
+++ b/packages/pi-ai/test/lazy-module-load.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const aiEntryUrl = new URL("../src/index.ts", import.meta.url).href;
+const tsResolver = resolve(packageRoot, "../../src/resources/extensions/gsd/tests/resolve-ts.mjs");
 
 const SDK_SPECIFIERS = [
 	"@anthropic-ai/sdk",
+	"@anthropic-ai/vertex-sdk",
 	"openai",
 	"@google/genai",
 	"@mistralai/mistralai",
@@ -39,10 +41,14 @@ function runProbe(action: string): ProbeResult {
 		console.log(JSON.stringify({ loadedSpecifiers: [...new Set(loaded)] }));
 	`;
 
-	const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
-		cwd: packageRoot,
-		encoding: "utf8",
-	});
+	const result = spawnSync(
+		process.execPath,
+		["--import", tsResolver, "--experimental-strip-types", "--input-type=module", "--eval", script],
+		{
+			cwd: packageRoot,
+			encoding: "utf8",
+		},
+	);
 
 	if (result.status !== 0) {
 		throw new Error(`Probe failed (exit ${result.status})\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);

--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -19,6 +19,7 @@ function isValidThinkingLevel(level: string): level is ThinkingLevel {
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
 	anthropic: "claude-opus-4-8",
+	"anthropic-vertex": "claude-sonnet-4-6",
 	openai: "gpt-5.4",
 	"azure-openai-responses": "gpt-5.4",
 	"openai-codex": "gpt-5.5",

--- a/packages/pi-coding-agent/src/core/provider-display-names.ts
+++ b/packages/pi-coding-agent/src/core/provider-display-names.ts
@@ -1,5 +1,6 @@
 export const BUILT_IN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	anthropic: "Anthropic",
+	"anthropic-vertex": "Anthropic on Vertex AI",
 	"amazon-bedrock": "Amazon Bedrock",
 	"azure-openai-responses": "Azure OpenAI Responses",
 	cerebras: "Cerebras",

--- a/packages/pi-coding-agent/test/model-resolver.test.ts
+++ b/packages/pi-coding-agent/test/model-resolver.test.ts
@@ -378,6 +378,10 @@ describe("default model selection", () => {
 		expect(defaultModelPerProvider["openai-codex"]).toBe("gpt-5.5");
 	});
 
+	test("anthropic vertex default tracks current model", () => {
+		expect(defaultModelPerProvider["anthropic-vertex"]).toBe("claude-sonnet-4-6");
+	});
+
 	test("zai, minimax, and cerebras defaults track current models", () => {
 		expect(defaultModelPerProvider.zai).toBe("glm-5.1");
 		expect(defaultModelPerProvider.minimax).toBe("MiniMax-M2.7");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
         version: 0.91.1(zod@3.25.76)
+      '@anthropic-ai/vertex-sdk':
+        specifier: 0.14.4
+        version: 0.14.4(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
@@ -6440,6 +6443,15 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - zod
 
   '@anthropic-ai/vertex-sdk@0.14.4(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Linked issue

Closes #351

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Restores `anthropic-vertex` as a built-in `pi-ai` provider/API.
**Why:** Configured Vertex Claude models currently fail before dispatch or auth resolution because the provider was removed from the registry and env auth path.
**How:** Adds a lazy Anthropic Vertex provider that injects `AnthropicVertex` into the current Anthropic Messages stream implementation, restores provider/API typing and env auth detection, and adds focused regression tests.

## What

- Reintroduced `packages/pi-ai/src/providers/anthropic-vertex.ts` using `@anthropic-ai/vertex-sdk` with `ANTHROPIC_VERTEX_PROJECT_ID`, Google project env fallbacks, and default `us-central1` region behavior.
- Registered `api: "anthropic-vertex"` through the lazy built-in provider registry.
- Restored `KnownApi` / `KnownProvider` support and the package export/dependency for `@gsd/pi-ai/anthropic-vertex`.
- Added regression tests for env auth detection, built-in API registration, and lazy SDK loading.

## Why

`anthropic-vertex` is still documented and used by GSD provider tooling, but `streamSimple()` currently cannot resolve auth or a registered API provider for models configured with `api: "anthropic-vertex"`.

## How

The provider creates an `AnthropicVertex` client lazily, then reuses the existing Anthropic Messages streaming path via its injected-client option. This keeps the Anthropic/Vertex SDKs out of root imports and browser-facing bundles until the Vertex provider is actually used.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- `pnpm --filter @gsd/pi-ai exec vitest run test/env-api-keys.test.ts test/anthropic-vertex.test.ts test/lazy-module-load.test.ts`
- `pnpm --filter @gsd/pi-ai exec tsc -p tsconfig.json --incremental false`
- `pnpm --filter @gsd/pi-ai run build`
- `env ANTHROPIC_VERTEX_PROJECT_ID=my-project-id node --experimental-strip-types -e "import('./packages/pi-ai/src/env-api-keys.ts').then(m => console.log(m.getEnvApiKey('anthropic-vertex')))"`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types -e "await import('./packages/pi-ai/src/providers/register-builtins.ts'); const { getApiProvider } = await import('./packages/pi-ai/src/api-registry.ts'); console.log(getApiProvider('anthropic-vertex')?.api ?? 'missing');"`

Known broader-suite result:

- `pnpm --filter @gsd/pi-ai test` currently fails in unrelated tests:
  - `test/google-shared-gemini3-unsigned-tool-call.test.ts` expects no `skip_thought_signature_validator` placeholder.
  - `test/anthropic-adaptive-thinking-models.test.ts` has a stale expected adaptive-thinking model list missing `cloudflare-ai-gateway/claude-opus-4-8` and `github-copilot/claude-opus-4.8`.

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented with Codex and verified with the commands above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782914091&installation_id=134682257&pr_number=354&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F354&signature=a6c0f8d1a389fb2b68c3a6ae4c8bfdf0a10807e319261b97c02c2b4029c6f42c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud auth resolution and LLM dispatch for a Vertex-backed path, but behavior is mostly re-wiring through the existing Anthropic stream implementation with added regression tests.
> 
> **Overview**
> Restores **`anthropic-vertex`** so Claude-on-Vertex models can resolve auth and dispatch again. **`pi-ai`** adds a lazy **`AnthropicVertex`** provider that injects the Vertex client into the existing Anthropic Messages stream path, registers **`api: "anthropic-vertex"`**, exports **`@gsd/pi-ai/anthropic-vertex`**, and depends on **`@anthropic-ai/vertex-sdk`**.
> 
> **Auth** now treats **`ANTHROPIC_VERTEX_PROJECT_ID`** (and optionally Google project env vars plus Application Default Credentials) as configured via **`getEnvApiKey`** returning **`&lt;authenticated&gt;`**, not a literal API key. **`pi-coding-agent`** picks up a default model (**`claude-sonnet-4-6`**) and display name **Anthropic on Vertex AI**.
> 
> Regression tests cover env detection, built-in API registration, and lazy SDK loading (root import still avoids loading Vertex SDK until used).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d52038518d0b0d42672c6b71b6b8c014af6cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->