### PR TITLE
fix(gsd): hard gate auto unit lifecycle tools

### DIFF
--- a/src/resources/extensions/gsd/auto-unit-tool-scope.ts
+++ b/src/resources/extensions/gsd/auto-unit-tool-scope.ts
@@ -1,0 +1,208 @@
+import { parseUnitId } from "./unit-id.js";
+
+export const RUN_UAT_BROWSER_TOOL_NAMES = [
+  "browser_navigate",
+  "browser_click",
+  "browser_type",
+  "browser_fill_form",
+  "browser_click_ref",
+  "browser_fill_ref",
+  "browser_wait_for",
+  "browser_assert",
+  "browser_verify",
+  "browser_screenshot",
+  "browser_snapshot_refs",
+  "browser_find",
+  "browser_get_console_logs",
+  "browser_get_network_logs",
+  "browser_evaluate",
+  "browser_reload",
+  "browser_batch",
+  "browser_act",
+] as const;
+
+export const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = {
+  "research-milestone": ["gsd_summary_save", "gsd_decision_save"],
+  "plan-milestone": ["gsd_plan_milestone", "gsd_decision_save", "gsd_requirement_update"],
+  "discuss-milestone": [
+    "gsd_summary_save",
+    "gsd_decision_save",
+    "gsd_requirement_save",
+    "gsd_requirement_update",
+    "gsd_plan_milestone",
+    "gsd_milestone_generate_id",
+  ],
+  "discuss-slice": ["gsd_summary_save", "gsd_decision_save"],
+  "validate-milestone": ["gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
+  "complete-milestone": ["gsd_complete_milestone", "subagent"],
+  "research-slice": ["gsd_summary_save", "gsd_decision_save"],
+  "plan-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
+  "refine-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
+  "replan-slice": ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
+  "complete-slice": ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice", "gsd_decision_save", "gsd_requirement_update", "subagent"],
+  "reassess-roadmap": ["gsd_reassess_roadmap"],
+  "execute-task": ["gsd_task_complete", "gsd_decision_save"],
+  "execute-task-simple": ["gsd_task_complete", "gsd_decision_save"],
+  "reactive-execute": ["gsd_task_complete", "gsd_decision_save"],
+  "run-uat": ["gsd_summary_save", ...RUN_UAT_BROWSER_TOOL_NAMES],
+  "gate-evaluate": ["gsd_save_gate_result"],
+  "rewrite-docs": ["gsd_summary_save", "gsd_decision_save"],
+  "workflow-preferences": ["gsd_summary_save"],
+  "discuss-project": ["gsd_summary_save", "gsd_decision_save", "gsd_requirement_save"],
+  "discuss-requirements": ["gsd_requirement_save", "gsd_summary_save"],
+  "research-decision": ["gsd_summary_save"],
+  "research-project": ["gsd_summary_save", "gsd_decision_save"],
+};
+
+const WORKFLOW_TOOL_ALIASES: Record<string, string> = {
+  gsd_save_decision: "gsd_decision_save",
+  gsd_update_requirement: "gsd_requirement_update",
+  gsd_save_requirement: "gsd_requirement_save",
+  gsd_save_summary: "gsd_summary_save",
+  gsd_generate_milestone_id: "gsd_milestone_generate_id",
+  gsd_milestone_plan: "gsd_plan_milestone",
+  gsd_slice_plan: "gsd_plan_slice",
+  gsd_task_plan: "gsd_plan_task",
+  gsd_slice_replan: "gsd_replan_slice",
+  gsd_complete_slice: "gsd_slice_complete",
+  gsd_milestone_complete: "gsd_complete_milestone",
+  gsd_milestone_validate: "gsd_validate_milestone",
+  gsd_roadmap_reassess: "gsd_reassess_roadmap",
+  gsd_complete_task: "gsd_task_complete",
+  gsd_reopen_task: "gsd_task_reopen",
+  gsd_reopen_slice: "gsd_slice_reopen",
+  gsd_reopen_milestone: "gsd_milestone_reopen",
+};
+
+const EXECUTE_TASK_UNIT_TYPES = new Set([
+  "execute-task",
+  "execute-task-simple",
+  "reactive-execute",
+]);
+
+const EXTRA_SCOPED_GSD_LIFECYCLE_TOOLS = [
+  "gsd_skip_slice",
+  "gsd_slice_reopen",
+  "gsd_milestone_reopen",
+] as const;
+
+const SCOPED_GSD_LIFECYCLE_TOOLS = new Set(
+  [
+    ...Object.values(AUTO_UNIT_SCOPED_TOOLS).flat(),
+    ...Object.values(WORKFLOW_TOOL_ALIASES),
+    ...EXTRA_SCOPED_GSD_LIFECYCLE_TOOLS,
+  ]
+    .filter((tool) => tool.startsWith("gsd_"))
+    .map(canonicalWorkflowToolName),
+);
+
+function stripMcpToolPrefix(toolName: string): string {
+  if (!toolName.startsWith("mcp__")) return toolName;
+  const toolSeparator = toolName.indexOf("__", "mcp__".length);
+  return toolSeparator >= 0 ? toolName.slice(toolSeparator + 2) : toolName;
+}
+
+export function canonicalWorkflowToolName(toolName: string): string {
+  const base = stripMcpToolPrefix(toolName);
+  return WORKFLOW_TOOL_ALIASES[base] ?? base;
+}
+
+export function isWorkflowAliasTool(toolName: string): boolean {
+  return Object.prototype.hasOwnProperty.call(WORKFLOW_TOOL_ALIASES, stripMcpToolPrefix(toolName));
+}
+
+function hardBlockReason(unitType: string, what: string): string {
+  return [
+    `HARD BLOCK: unit "${unitType}" is constrained by auto-unit tool scope — ${what}.`,
+    "This is a mechanical phase-boundary gate. You MUST NOT proceed, retry the same call,",
+    "or route around this block; the orchestrator owns phase transitions.",
+  ].join(" ");
+}
+
+function allowedGsdToolsForUnit(unitType: string): string[] {
+  return [...new Set(
+    (AUTO_UNIT_SCOPED_TOOLS[unitType] ?? [])
+      .filter((tool) => tool.startsWith("gsd_"))
+      .map(canonicalWorkflowToolName),
+  )].sort();
+}
+
+function isNativeWorkflowTool(toolName: string): boolean {
+  return stripMcpToolPrefix(toolName) === "Workflow";
+}
+
+function readStringField(input: unknown, camel: string, snake: string): string | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const record = input as Record<string, unknown>;
+  const value = record[camel] ?? record[snake];
+  return typeof value === "string" ? value : undefined;
+}
+
+function shouldBlockTaskCompletionScope(
+  unitType: string,
+  unitId: string | undefined,
+  toolName: string,
+  input: unknown,
+): { block: boolean; reason?: string } {
+  if (!EXECUTE_TASK_UNIT_TYPES.has(unitType)) return { block: false };
+  if (canonicalWorkflowToolName(toolName) !== "gsd_task_complete") return { block: false };
+  if (!unitId) return { block: false };
+
+  const expected = parseUnitId(unitId);
+  if (!expected.milestone || !expected.slice || !expected.task) return { block: false };
+
+  const actualMilestone = readStringField(input, "milestoneId", "milestone_id");
+  const actualSlice = readStringField(input, "sliceId", "slice_id");
+  const actualTask = readStringField(input, "taskId", "task_id");
+
+  if (!actualMilestone || !actualSlice || !actualTask) return { block: false };
+  if (
+    actualMilestone === expected.milestone &&
+    actualSlice === expected.slice &&
+    actualTask === expected.task
+  ) {
+    return { block: false };
+  }
+
+  return {
+    block: true,
+    reason: hardBlockReason(
+      unitType,
+      `gsd_task_complete may only complete the active task ${expected.milestone}/${expected.slice}/${expected.task}; requested ${actualMilestone}/${actualSlice}/${actualTask}`,
+    ),
+  };
+}
+
+export function shouldBlockAutoUnitToolCall(
+  unitType: string,
+  toolName: string,
+  input?: unknown,
+  unitId?: string,
+): { block: boolean; reason?: string } {
+  const scopedTools = AUTO_UNIT_SCOPED_TOOLS[unitType];
+  if (!scopedTools) return { block: false };
+
+  if (isNativeWorkflowTool(toolName)) {
+    return {
+      block: true,
+      reason: hardBlockReason(unitType, "native Workflow is not permitted inside a dispatched GSD auto-mode unit"),
+    };
+  }
+
+  const taskScope = shouldBlockTaskCompletionScope(unitType, unitId, toolName, input);
+  if (taskScope.block) return taskScope;
+
+  const canonicalTool = canonicalWorkflowToolName(toolName);
+  if (!SCOPED_GSD_LIFECYCLE_TOOLS.has(canonicalTool)) return { block: false };
+
+  const allowedTools = allowedGsdToolsForUnit(unitType);
+  if (allowedTools.includes(canonicalTool)) return { block: false };
+
+  return {
+    block: true,
+    reason: hardBlockReason(
+      unitType,
+      `GSD lifecycle tool "${canonicalTool}" is not permitted; allowed GSD tools: ${allowedTools.length > 0 ? allowedTools.join(", ") : "(none)"}`,
+    ),
+  };
+}

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -36,6 +36,7 @@ import { resolveSkillManifest } from "../skill-manifest.js";
 import { applyUnitSkillVisibility, unitHasSkillManifest } from "../skill-scope.js";
 import { getGuidedUnitContext } from "../guided-unit-context.js";
 import { registerPlanMilestoneSchemaRecovery } from "./plan-milestone-schema-recovery.js";
+import { AUTO_UNIT_SCOPED_TOOLS, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -147,38 +148,6 @@ function withPreservedShimTools(toolNames: readonly string[]): string[] {
   return [...new Set([...toolNames, ...ALWAYS_PRESERVED_SHIM_TOOL_NAMES])];
 }
 
-/**
- * Backwards-compatibility workflow tool aliases (each forwards to a canonical
- * twin). Mirrors WORKFLOW_TOOL_CONTRACTS[].aliases in @opengsd/contracts. These
- * stay registered/callable but are dropped from the model-advertised tool set
- * (~5.6K tokens/turn of duplicate schemas) — the canonical name is always
- * advertised, and prompts/scoped tool sets already use canonical names.
- */
-const WORKFLOW_ALIAS_TOOL_NAMES = new Set<string>([
-  "gsd_save_decision",
-  "gsd_update_requirement",
-  "gsd_save_requirement",
-  "gsd_save_summary",
-  "gsd_generate_milestone_id",
-  "gsd_milestone_plan",
-  "gsd_slice_plan",
-  "gsd_task_plan",
-  "gsd_slice_replan",
-  "gsd_complete_slice",
-  "gsd_milestone_complete",
-  "gsd_milestone_validate",
-  "gsd_roadmap_reassess",
-  "gsd_complete_task",
-  "gsd_reopen_task",
-  "gsd_reopen_slice",
-  "gsd_reopen_milestone",
-]);
-
-/** True when a (possibly mcp-scoped) tool name is a workflow alias. */
-function isWorkflowAliasTool(toolName: string): boolean {
-  return WORKFLOW_ALIAS_TOOL_NAMES.has(canonicalToolName(toolName));
-}
-
 /** True for the browser automation tools (browser_navigate, browser_click, ...). */
 function isBrowserTool(toolName: string): boolean {
   return canonicalToolName(toolName).startsWith("browser_");
@@ -196,60 +165,6 @@ export function requestHasGsdCustomType(
     (message) => typeof message.customType === "string" && message.customType.startsWith("gsd-"),
   );
 }
-
-const RUN_UAT_BROWSER_TOOL_NAMES = [
-  "browser_navigate",
-  "browser_click",
-  "browser_type",
-  "browser_fill_form",
-  "browser_click_ref",
-  "browser_fill_ref",
-  "browser_wait_for",
-  "browser_assert",
-  "browser_verify",
-  "browser_screenshot",
-  "browser_snapshot_refs",
-  "browser_find",
-  "browser_get_console_logs",
-  "browser_get_network_logs",
-  "browser_evaluate",
-  "browser_reload",
-  "browser_batch",
-  "browser_act",
-] as const;
-
-const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = {
-  "research-milestone": ["gsd_summary_save", "gsd_decision_save"],
-  "plan-milestone": ["gsd_plan_milestone", "gsd_decision_save", "gsd_requirement_update"],
-  "discuss-milestone": [
-    "gsd_summary_save",
-    "gsd_decision_save",
-    "gsd_requirement_save",
-    "gsd_requirement_update",
-    "gsd_plan_milestone",
-    "gsd_milestone_generate_id",
-  ],
-  "discuss-slice": ["gsd_summary_save", "gsd_decision_save"],
-  "validate-milestone": ["gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
-  "complete-milestone": ["gsd_complete_milestone", "subagent"],
-  "research-slice": ["gsd_summary_save", "gsd_decision_save"],
-  "plan-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "refine-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "replan-slice": ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "complete-slice": ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice", "gsd_decision_save", "gsd_requirement_update", "subagent"],
-  "reassess-roadmap": ["gsd_reassess_roadmap"],
-  "execute-task": ["gsd_task_complete", "gsd_decision_save"],
-  "execute-task-simple": ["gsd_task_complete", "gsd_decision_save"],
-  "reactive-execute": ["gsd_task_complete", "gsd_decision_save"],
-  "run-uat": ["gsd_summary_save", ...RUN_UAT_BROWSER_TOOL_NAMES],
-  "gate-evaluate": ["gsd_save_gate_result"],
-  "rewrite-docs": ["gsd_summary_save", "gsd_decision_save"],
-  "workflow-preferences": ["gsd_summary_save"],
-  "discuss-project": ["gsd_summary_save", "gsd_decision_save", "gsd_requirement_save"],
-  "discuss-requirements": ["gsd_requirement_save", "gsd_summary_save"],
-  "research-decision": ["gsd_summary_save"],
-  "research-project": ["gsd_summary_save", "gsd_decision_save"],
-};
 
 const WORKFLOW_GSD_TOOL_NAMES = [
   ...MINIMAL_GSD_TOOL_NAMES,
@@ -1035,29 +950,29 @@ export function registerHooks(
     const activeUnitType = dash.currentUnit?.type ?? guidedUnit?.unitType;
     if (activeUnitType) {
       const manifest = resolveManifest(activeUnitType);
-      if (manifest) {
-        let planningInput = "";
-        let agentClasses: string[] | undefined;
-        if (isToolCallEventType("write", event)) {
-          planningInput = event.input.path;
-        } else if (isToolCallEventType("edit", event)) {
-          planningInput = event.input.path;
-        } else if (isToolCallEventType("bash", event)) {
-          planningInput = event.input.command;
-        } else if (event.toolName === "subagent" || event.toolName === "task") {
-          // Subagent inputs use { agent }, { tasks: [{ agent }] }, or { chain: [{ agent }] }.
-          agentClasses = extractSubagentAgentClasses((event as { input?: unknown }).input);
-        }
-        const planningGuard = shouldBlockPlanningUnit(
-          event.toolName,
-          planningInput,
-          dash.basePath || guidedUnit?.basePath || discussionBasePath,
-          activeUnitType,
-          manifest.tools,
-          agentClasses,
-        );
-        if (planningGuard.block) return planningGuard;
+      let planningInput = "";
+      let agentClasses: string[] | undefined;
+      if (isToolCallEventType("write", event)) {
+        planningInput = event.input.path;
+      } else if (isToolCallEventType("edit", event)) {
+        planningInput = event.input.path;
+      } else if (isToolCallEventType("bash", event)) {
+        planningInput = event.input.command;
+      } else if (event.toolName === "subagent" || event.toolName === "task") {
+        // Subagent inputs use { agent }, { tasks: [{ agent }] }, or { chain: [{ agent }] }.
+        agentClasses = extractSubagentAgentClasses((event as { input?: unknown }).input);
       }
+      const planningGuard = shouldBlockPlanningUnit(
+        event.toolName,
+        planningInput,
+        dash.basePath || guidedUnit?.basePath || discussionBasePath,
+        activeUnitType,
+        manifest?.tools,
+        agentClasses,
+        (event as { input?: unknown }).input,
+        dash.currentUnit?.id,
+      );
+      if (planningGuard.block) return planningGuard;
     }
 
     // ── Worktree-isolation write gate (#5199) ────────────────────────────

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { minimatch } from "minimatch";
 
+import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
 import { getIsolationMode } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
@@ -798,11 +799,15 @@ export function shouldBlockPlanningUnit(
   unitType: string,
   policy: ToolsPolicy | null | undefined,
   agentClasses?: readonly string[],
+  toolInput?: unknown,
+  unitId?: string,
 ): { block: boolean; reason?: string } {
+  const tool = canonicalToolName(toolName);
+  const autoScopeGuard = shouldBlockAutoUnitToolCall(unitType, toolName, toolInput, unitId);
+  if (autoScopeGuard.block) return autoScopeGuard;
+
   if (!policy) return { block: false };
   if (policy.mode === "all") return { block: false };
-
-  const tool = canonicalToolName(toolName);
 
   // Read-only mode: only Read-class tools are permitted.
   if (policy.mode === "read-only") {

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -42,6 +42,8 @@ You execute. The inlined task plan is authoritative. Verify referenced files and
 6. Add or update tests. Tests must use git-tracked files or inline fixtures, never .gitignore/gitignored local paths such as `.gsd/`, `.planning/`, or `.audits/`.
 7. Preserve useful observability for non-trivial async, API, background, or error-path work.
 
+**Phase boundary:** Complete only `{{taskId}}`. Do NOT call `gsd_slice_complete`, `gsd_validate_milestone`, `gsd_complete_milestone`, complete any other task, or spawn `Workflow`. The orchestrator owns slice/milestone closure and phase transitions.
+
 **Background process rule:** never run bare `command &`. Redirect output first, e.g. `command > /dev/null 2>&1 &`, or use `bg_shell` when available.
 
 ## Gates And Verification

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -211,6 +211,14 @@ test("execute-task prompt uses gsd_task_complete as canonical summary write path
   assert.doesNotMatch(prompt, /^\d+\.\s+Write `?\{\{taskSummaryPath\}\}`?\s*$/m);
 });
 
+test("execute-task prompt forbids phase escalation tools and native Workflow", () => {
+  const prompt = readPrompt("execute-task");
+  assert.match(prompt, /Complete only `\{\{taskId\}\}`/);
+  assert.match(prompt, /Do NOT call `gsd_slice_complete`, `gsd_validate_milestone`, `gsd_complete_milestone`/);
+  assert.match(prompt, /spawn `Workflow`/);
+  assert.match(prompt, /orchestrator owns slice\/milestone closure and phase transitions/i);
+});
+
 test("execute-task prompt does not instruct LLM to toggle checkboxes manually", () => {
   const prompt = readPrompt("execute-task");
   assert.doesNotMatch(prompt, /change \[ \] to \[x\]/);

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -15,6 +15,7 @@ import {
   getAllMilestones,
 } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 import { markApprovalGateVerified, markDepthVerified, clearDiscussionFlowState, loadWriteGateSnapshot, setPendingGate } from "../bootstrap/write-gate.ts";
 import {
   executeCompleteMilestone,
@@ -54,6 +55,29 @@ async function inProjectDir<T>(dir: string, fn: () => Promise<T>): Promise<T> {
     process.chdir(originalCwd);
   }
 }
+
+test("closeout executors reject phase escalation from the wrong active auto unit", async () => {
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.basePath = "/tmp/project";
+  autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+
+  try {
+    const slice = await executeSliceComplete({} as Parameters<typeof executeSliceComplete>[0], "/tmp/project");
+    assert.equal(slice.isError, true);
+    assert.match(String(slice.details.error), /complete_slice may only run from complete-slice/);
+
+    const validate = await executeValidateMilestone({} as Parameters<typeof executeValidateMilestone>[0], "/tmp/project");
+    assert.equal(validate.isError, true);
+    assert.match(String(validate.details.error), /validate_milestone may only run from validate-milestone/);
+
+    const milestone = await executeCompleteMilestone({} as Parameters<typeof executeCompleteMilestone>[0], "/tmp/project");
+    assert.equal(milestone.isError, true);
+    assert.match(String(milestone.details.error), /complete_milestone may only run from complete-milestone/);
+  } finally {
+    autoSession.reset();
+  }
+});
 
 function seedMilestone(milestoneId: string, title: string, status = "active"): void {
   const db = _getAdapter();

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -344,6 +344,84 @@ test('planning-unit: allows web research tools', () => {
   assert.strictEqual(r.block, false);
 });
 
+// ─── auto-unit scoped GSD lifecycle tools ─────────────────────────────────
+
+test('auto-unit scope: execute-task allows only its task completion lifecycle tool', () => {
+  const allowed = shouldBlockPlanningUnit(
+    'gsd_task_complete',
+    '',
+    BASE,
+    'execute-task',
+    ALL,
+    undefined,
+    { milestoneId: 'M001', sliceId: 'S01', taskId: 'T01' },
+    'M001/S01/T01',
+  );
+  assert.strictEqual(allowed.block, false);
+
+  const blocked = shouldBlockPlanningUnit('gsd_save_gate_result', '', BASE, 'execute-task', ALL);
+  assert.strictEqual(blocked.block, true);
+  assert.match(blocked.reason!, /HARD BLOCK/);
+  assert.match(blocked.reason!, /gsd_save_gate_result/);
+  assert.strictEqual(isDeterministicPolicyError(blocked.reason!), true);
+});
+
+test('auto-unit scope: execute-task blocks sibling task completion', () => {
+  const r = shouldBlockPlanningUnit(
+    'gsd_complete_task',
+    '',
+    BASE,
+    'execute-task',
+    ALL,
+    undefined,
+    { milestoneId: 'M001', sliceId: 'S01', taskId: 'T02' },
+    'M001/S01/T01',
+  );
+  assert.strictEqual(r.block, true);
+  assert.match(r.reason!, /only complete the active task M001\/S01\/T01/);
+  assert.match(r.reason!, /requested M001\/S01\/T02/);
+});
+
+test('auto-unit scope: execute-task blocks slice and milestone lifecycle aliases even in all mode', () => {
+  const slice = shouldBlockPlanningUnit('mcp__gsd-workflow__gsd_complete_slice', '', BASE, 'execute-task', ALL);
+  assert.strictEqual(slice.block, true);
+  assert.match(slice.reason!, /gsd_slice_complete/);
+
+  const milestone = shouldBlockPlanningUnit('gsd_milestone_complete', '', BASE, 'execute-task', ALL);
+  assert.strictEqual(milestone.block, true);
+  assert.match(milestone.reason!, /gsd_complete_milestone/);
+
+  const skip = shouldBlockPlanningUnit('gsd_skip_slice', '', BASE, 'execute-task', ALL);
+  assert.strictEqual(skip.block, true);
+  assert.match(skip.reason!, /gsd_skip_slice/);
+
+  const reopen = shouldBlockPlanningUnit('gsd_reopen_milestone', '', BASE, 'execute-task', ALL);
+  assert.strictEqual(reopen.block, true);
+  assert.match(reopen.reason!, /gsd_milestone_reopen/);
+});
+
+test('auto-unit scope: complete-slice blocks milestone validation and native Workflow', () => {
+  const closeSlice = shouldBlockPlanningUnit('gsd_slice_complete', '', BASE, 'complete-slice', ALL);
+  assert.strictEqual(closeSlice.block, false);
+
+  const validate = shouldBlockPlanningUnit('gsd_validate_milestone', '', BASE, 'complete-slice', ALL);
+  assert.strictEqual(validate.block, true);
+  assert.match(validate.reason!, /gsd_validate_milestone/);
+
+  const workflow = shouldBlockPlanningUnit('Workflow', '', BASE, 'complete-slice', ALL);
+  assert.strictEqual(workflow.block, true);
+  assert.match(workflow.reason!, /native Workflow/);
+});
+
+test('auto-unit scope: gate-evaluate can save gate results but cannot complete tasks', () => {
+  const saveGate = shouldBlockPlanningUnit('gsd_save_gate_result', '', BASE, 'gate-evaluate', PLANNING_DISPATCH_REVIEW);
+  assert.strictEqual(saveGate.block, false);
+
+  const completeTask = shouldBlockPlanningUnit('gsd_task_complete', '', BASE, 'gate-evaluate', PLANNING_DISPATCH_REVIEW);
+  assert.strictEqual(completeTask.block, true);
+  assert.match(completeTask.reason!, /gsd_task_complete/);
+});
+
 // ─── all mode: never blocks ───────────────────────────────────────────────
 
 test('all-mode: execute-task can edit user source', () => {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -44,6 +44,7 @@ import { logError, logWarning } from "../workflow-logger.js";
 import { invalidateStateCache } from "../state.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
+import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
 
 export const SUPPORTED_SUMMARY_ARTIFACT_TYPES = [
   "SUMMARY",
@@ -74,6 +75,19 @@ export interface ToolExecutionResult {
   content: Array<{ type: "text"; text: string }>;
   details: Record<string, unknown>;
   isError?: boolean;
+}
+
+function blockIfWrongAutoUnit(requiredUnitType: string, operation: string): ToolExecutionResult | null {
+  const snapshot = getAutoRuntimeSnapshot();
+  if (!snapshot.active || !snapshot.currentUnit) return null;
+  if (snapshot.currentUnit.type === requiredUnitType) return null;
+
+  const error = `HARD BLOCK: ${operation} may only run from ${requiredUnitType}; active unit is ${snapshot.currentUnit.type}. The orchestrator owns phase transitions.`;
+  return {
+    content: [{ type: "text", text: error }],
+    details: { operation, error },
+    isError: true,
+  };
 }
 
 export interface SummarySaveParams {
@@ -587,6 +601,9 @@ export async function executeSliceComplete(
   params: SliceCompleteExecutorParams,
   basePath: string = process.cwd(),
 ): Promise<ToolExecutionResult> {
+  const unitGuard = blockIfWrongAutoUnit("complete-slice", "complete_slice");
+  if (unitGuard) return unitGuard;
+
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) {
     return {
@@ -699,6 +716,9 @@ export async function executeCompleteMilestone(
   params: CompleteMilestoneExecutorParams,
   basePath: string = process.cwd(),
 ): Promise<ToolExecutionResult> {
+  const unitGuard = blockIfWrongAutoUnit("complete-milestone", "complete_milestone");
+  if (unitGuard) return unitGuard;
+
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) {
     return {
@@ -746,6 +766,9 @@ export async function executeValidateMilestone(
   basePath: string = process.cwd(),
   opts?: ValidateMilestoneOptions,
 ): Promise<ToolExecutionResult> {
+  const unitGuard = blockIfWrongAutoUnit("validate-milestone", "validate_milestone");
+  if (unitGuard) return unitGuard;
+
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) {
     return {


### PR DESCRIPTION
## Linked issue

Closes #353

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Hard-enforce GSD auto-unit lifecycle tool boundaries at runtime.
**Why:** The claude-code native `Workflow` tool and callable-but-hidden GSD lifecycle tools could bypass advisory per-unit scoping.
**How:** Share the auto-unit allowlist with the write gate, block phase-escalation tools before execution, add closeout executor backstops, and pin the behavior with regression tests.

## What

- Adds a shared `auto-unit-tool-scope` contract for per-unit GSD lifecycle allowlists and alias normalization.
- Enforces scoped GSD lifecycle tools before the `tools.mode === "all"` early return, including MCP-scoped aliases.
- Blocks native `Workflow` inside dispatched auto-mode units and blocks `execute-task` from completing sibling tasks.
- Adds defense-in-depth closeout executor checks for slice completion, milestone validation, and milestone completion.
- Updates the execute-task prompt to explicitly forbid phase escalation.

## Why

Issue #353 reports execute-task units escalating through native `Workflow`, saving gate results, planning slices, completing sibling tasks, and closing slices/milestones inside one dispatched unit. This makes tool scoping a runtime invariant instead of an advertised-schema hint.

## How

The write gate now consults the shared auto-unit scope before applying manifest tool policy. Source edits, bash, and normal `TOOLS_ALL` behavior remain available to execution/closeout units, but GSD lifecycle mutations must be in the active unit allowlist. Closeout executors also reject calls from the wrong active auto unit if a tool-call gate is bypassed.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

Verification run locally:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts src/resources/extensions/gsd/tests/prompt-contracts.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
pnpm run typecheck:extensions
```

## AI disclosure

- [x] This PR includes AI-assisted code via Codex. The scoped runtime gates, prompt contract, and regression tests above were run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782915278&installation_id=134682257&pr_number=356&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F356&signature=5b87a40d3b2a74128e4ba14a78e12832e2e9a7d44c7207f7defb761663def8e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration and lifecycle tool enforcement in auto-mode (phase boundaries and closeout paths); behavior is well covered by new tests but affects critical workflow control flow.
> 
> **Overview**
> This PR turns GSD auto-mode **per-unit tool scoping** from an advertised hint into a **runtime invariant** so dispatched units cannot skip phase boundaries.
> 
> A new shared module **`auto-unit-tool-scope`** centralizes per-unit GSD lifecycle allowlists, workflow tool alias normalization, and **`shouldBlockAutoUnitToolCall`**. The write gate invokes it **before** manifest `tools.mode === "all"`, so even “all tools” execution units still cannot call out-of-phase lifecycle tools (including MCP-prefixed names). It also blocks native **`Workflow`** inside auto units and restricts **`gsd_task_complete`** on execute-task units to the active task IDs from the unit id.
> 
> **`register-hooks`** now always runs the planning guard when a unit type is active (not only when a manifest exists) and passes tool input and unit id for task-scoping. Closeout executors add a second line of defense: **`executeSliceComplete`**, **`executeValidateMilestone`**, and **`executeCompleteMilestone`** error if the active auto unit type does not match.
> 
> The **execute-task** prompt explicitly forbids slice/milestone closure and **`Workflow`**. Regression tests cover write-gate scope, prompt contracts, and wrong-unit executor calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef90e41ceb8093c88b160e499bb55fd8fbb8db40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->