### PR TITLE
fix(claude-code-cli): coalesce internal sub-turn streams

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -33,6 +33,7 @@ import { loadProjectGSDPreferences } from "../gsd/preferences.js";
 import { discoverBrowserMcpServerName, discoverMcpServerNames, discoverWorkflowMcpServerName, computeMcpDisallowedTools } from "../gsd/mcp-filter.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
+	BetaRawMessageStreamEvent,
 	SDKAssistantMessage,
 	SDKMessage,
 	SDKPartialAssistantMessage,
@@ -1872,6 +1873,25 @@ export function mergePendingToolCalls(
 	return intermediate;
 }
 
+export function handleClaudeCodePartialStreamEvent(
+	builder: PartialMessageBuilder | null,
+	event: BetaRawMessageStreamEvent,
+	modelId: string,
+): { builder: PartialMessageBuilder | null; assistantEvent: AssistantMessageEvent | null } {
+	if (event.type === "message_start") {
+		// Claude Code can emit repeated SDK message_start events inside one
+		// logical assistant response. Keep appending until a synthetic user
+		// tool-result boundary explicitly clears the builder.
+		return {
+			builder: builder ?? new PartialMessageBuilder((event as any).message?.model ?? modelId),
+			assistantEvent: null,
+		};
+	}
+
+	if (!builder) return { builder, assistantEvent: null };
+	return { builder, assistantEvent: builder.handleEvent(event) };
+}
+
 // ---------------------------------------------------------------------------
 // streamSimple implementation
 // ---------------------------------------------------------------------------
@@ -2008,32 +2028,24 @@ async function pumpSdkMessages(
 
 					const event = partial.event;
 
-					// New assistant turn starts with message_start
-					if (event.type === "message_start") {
-						builder = new PartialMessageBuilder(
-							(event as any).message?.model ?? modelId,
-						);
-						break;
-					}
-
-					if (!builder) break;
-
-						const assistantEvent = builder.handleEvent(event);
-						if (assistantEvent) {
-							stream.push(assistantEvent);
-							if (assistantEvent.type === "toolcall_start") {
-								const toolBlock = assistantEvent.partial.content[assistantEvent.contentIndex];
-								if (toolBlock?.type === "toolCall") {
-									try {
-										await onExternalToolCall?.(toolBlock);
-									} catch (error) {
-										console.warn("[claude-code] onExternalToolCall callback failed:", error);
-									}
+					const result = handleClaudeCodePartialStreamEvent(builder, event, modelId);
+					builder = result.builder;
+					const assistantEvent = result.assistantEvent;
+					if (assistantEvent) {
+						stream.push(assistantEvent);
+						if (assistantEvent.type === "toolcall_start") {
+							const toolBlock = assistantEvent.partial.content[assistantEvent.contentIndex];
+							if (toolBlock?.type === "toolCall") {
+								try {
+									await onExternalToolCall?.(toolBlock);
+								} catch (error) {
+									console.warn("[claude-code] onExternalToolCall callback failed:", error);
 								}
 							}
 						}
-						break;
 					}
+					break;
+				}
 
 				// -- Complete assistant message (non-streaming fallback) --
 				case "assistant": {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -12,6 +12,7 @@ import {
 	makeAbortedMessage,
 	mergePendingToolCalls,
 	buildFinalAssistantContent,
+	handleClaudeCodePartialStreamEvent,
 	resolveClaudePermissionMode,
 	buildPromptFromContext,
 	buildSdkQueryPrompt,
@@ -156,6 +157,40 @@ describe("stream-adapter — result error text (#3776)", () => {
 		});
 
 		assert.equal(message, "claude_code_request_failed");
+	});
+});
+
+describe("stream-adapter — Claude Code internal sub-turns (#337)", () => {
+	test("repeated SDK message_start events keep one growing partial message", () => {
+		let builder: Parameters<typeof handleClaudeCodePartialStreamEvent>[0] = null;
+		const contentLengths: number[] = [];
+
+		for (const event of [
+			{ type: "message_start", message: { model: "claude-opus-4-8" } },
+			{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+			{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "First internal turn." } },
+			{ type: "content_block_stop", index: 0 },
+			{ type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+			{ type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Still same SDK message." } },
+			{ type: "content_block_stop", index: 1 },
+			{ type: "message_start", message: { model: "claude-opus-4-8" } },
+			{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+			{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Second internal turn." } },
+			{ type: "content_block_stop", index: 0 },
+		]) {
+			const result = handleClaudeCodePartialStreamEvent(builder, event as any, "claude-opus-4-8");
+			builder = result.builder;
+			if (result.assistantEvent && "partial" in result.assistantEvent) {
+				contentLengths.push(result.assistantEvent.partial.content.length);
+			}
+		}
+
+		assert.ok(builder);
+		assert.deepEqual(
+			builder.message.content.map((block: any) => block.text),
+			["First internal turn.", "Still same SDK message.", "Second internal turn."],
+		);
+		assert.deepEqual(contentLengths, [1, 1, 1, 2, 2, 2, 3, 3, 3]);
 	});
 });
 


### PR DESCRIPTION
## Linked issue

Closes #337

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Coalesce repeated Claude Code SDK `message_start` events into the active assistant partial stream.
**Why:** Opus 4.8 adaptive thinking can emit internal sub-turns that made GSD render multiple duplicate assistant bubbles for one user turn.
**How:** Reuse the active `PartialMessageBuilder` until the existing synthetic user/tool-result boundary clears it, with a regression test for repeated SDK starts.

## What

- Adds a focused Claude Code partial stream handler for SDK stream events.
- Updates `pumpSdkMessages` so internal `message_start` events no longer reset assistant content mid-turn.
- Adds a #337 regression test proving partial content grows monotonically across repeated SDK `message_start` events.

## Why

The interactive renderer allocates new assistant rails when a provider partial shrinks. The Claude Code SDK can produce multiple internal sub-turns for one user prompt, especially with Opus 4.8 adaptive thinking, so resetting the builder on each SDK `message_start` caused one logical reply to be rendered as multiple GSD bubbles.

## How

The adapter now treats the first `message_start` as the beginning of a partial builder and ignores subsequent SDK `message_start` events while that builder is active. Existing synthetic user/tool-result messages still clear the builder, preserving real provider turn boundaries and external tool-result handling.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

Scope note: Claude Code CLI bundled extension.

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- [x] `pnpm run build:pi`
- [x] `pnpm run build:rpc-client`
- [x] `pnpm run build:mcp-server`
- [x] `pnpm run typecheck:extensions`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- [x] `pnpm run verify:fast`

## AI disclosure

- [x] This PR includes AI-assisted code. Codex implemented the adapter fix and regression test; the commands above were run locally.

## Impact analysis

- Blast radius: narrow.
- Affected workflow: Claude Code CLI provider streaming into interactive chat.
- Compatibility: existing synthetic user/tool-result boundaries still reset the builder, so external tool-result routing remains unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782917917&installation_id=134682257&pr_number=358&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F358&signature=06da43ed38cab3faf5d1e53552c9e233c0fdb13d1177d61a63e1cf171d86cb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Claude Code CLI partial streaming with a regression test; real turn boundaries still reset the builder on synthetic user messages.
> 
> **Overview**
> Fixes **duplicate assistant bubbles** when the Claude Code SDK emits multiple internal `message_start` events during one logical reply (e.g. Opus 4.8 adaptive thinking / issue **#337**).
> 
> **`handleClaudeCodePartialStreamEvent`** now starts a `PartialMessageBuilder` only on the first `message_start` and keeps appending deltas until an existing synthetic **`user`** tool-result message clears the builder—so later SDK `message_start` events no longer wipe partial content mid-turn. **`pumpSdkMessages`** delegates `stream_event` handling to that helper; behavior for tool callbacks and turn boundaries is unchanged.
> 
> Adds a regression test that partial text blocks grow monotonically across repeated `message_start` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d3e8174efd845c4bc0a4cc60467b7acfa4163e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->