### PR TITLE
fix(gsd): route slice discuss through worktree

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -51,6 +51,7 @@ import { nativeAddAll, nativeCommit, nativeHasCommittedHead, nativeIsRepo, nativ
 import { isInheritedRepo } from "./repo-identity.js";
 import { ensureGitignore, ensurePreferences, untrackRuntimeFiles } from "./gitignore.js";
 import { getIsolationMode, loadEffectiveGSDPreferences } from "./preferences.js";
+import { getAutoWorktreePath } from "./auto-worktree.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { ensurePlanV2Graph, isMissingFinalizedContextResult } from "./uok/plan-v2.js";
 import { detectProjectState, hasGsdBootstrapArtifacts } from "./detection.js";
@@ -1555,6 +1556,10 @@ async function loadDiscussNormSlices(basePath: string, mid: string): Promise<Dis
 
 export const _loadDiscussNormSlicesForTest = loadDiscussNormSlices;
 
+function resolveDiscussSliceBasePath(basePath: string, milestoneId: string): string {
+  return getAutoWorktreePath(basePath, milestoneId) ?? basePath;
+}
+
 /**
  * Build a rich inlined-context prompt for discussing a specific slice.
  * Preloads roadmap, milestone context, research, decisions, and completed
@@ -1717,13 +1722,14 @@ export async function showDiscuss(
         ctx.ui.notify(`Slice ${target} is already complete; nothing to discuss.`, "info");
         return;
       }
-      const contextFile = resolveSliceFile(basePath, mid, sid, "CONTEXT");
+      const discussBasePath = resolveDiscussSliceBasePath(basePath, mid);
+      const contextFile = resolveSliceFile(discussBasePath, mid, sid, "CONTEXT");
       const sqAvail = getStructuredQuestionsAvailability(pi, ctx);
-      const prompt = await buildDiscussSlicePrompt(mid, sid, chosen.title, basePath, {
+      const prompt = await buildDiscussSlicePrompt(mid, sid, chosen.title, discussBasePath, {
         rediscuss: !!contextFile,
         structuredQuestionsAvailable: sqAvail,
       });
-      await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-slice", { basePath });
+      await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-slice", { basePath: discussBasePath });
       return;
     }
 
@@ -1855,11 +1861,12 @@ export async function showDiscuss(
   while (true) {
     // Invalidate caches so we pick up CONTEXT files written by the just-completed discussion
     invalidateAllCaches();
+    const discussBasePath = resolveDiscussSliceBasePath(basePath, mid);
 
     // Build discussion-state map: which slices have CONTEXT files already?
     const discussedMap = new Map<string, boolean>();
     for (const s of pendingSlices) {
-      const contextFile = resolveSliceFile(basePath, mid, s.id, "CONTEXT");
+      const contextFile = resolveSliceFile(discussBasePath, mid, s.id, "CONTEXT");
       discussedMap.set(s.id, !!contextFile);
     }
 
@@ -1948,8 +1955,11 @@ export async function showDiscuss(
     }
 
     const sqAvail = getStructuredQuestionsAvailability(pi, ctx);
-    const prompt = await buildDiscussSlicePrompt(mid, chosen.id, chosen.title, basePath, { rediscuss: isRediscuss, structuredQuestionsAvailable: sqAvail });
-    await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-slice", { basePath });
+    const prompt = await buildDiscussSlicePrompt(mid, chosen.id, chosen.title, discussBasePath, {
+      rediscuss: isRediscuss,
+      structuredQuestionsAvailable: sqAvail,
+    });
+    await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-slice", { basePath: discussBasePath });
 
     // Wait for the discuss session to finish, then loop back to the picker
     await ctx.waitForIdle();
@@ -2903,8 +2913,13 @@ export async function showSmartEntry(
         { basePath },
       );
     } else if (choice === "discuss") {
+      const discussBasePath = resolveDiscussSliceBasePath(basePath, milestoneId);
       const sqAvail = getStructuredQuestionsAvailability(pi, ctx);
-      await dispatchWorkflow(pi, await buildDiscussSlicePrompt(milestoneId, sliceId, sliceTitle, basePath, { rediscuss: hasContext, structuredQuestionsAvailable: sqAvail }), "gsd-run", ctx, "discuss-slice", { basePath });
+      const prompt = await buildDiscussSlicePrompt(milestoneId, sliceId, sliceTitle, discussBasePath, {
+        rediscuss: hasContext,
+        structuredQuestionsAvailable: sqAvail,
+      });
+      await dispatchWorkflow(pi, prompt, "gsd-run", ctx, "discuss-slice", { basePath: discussBasePath });
     } else if (choice === "research") {
       const researchTemplates = inlineTemplate("research", "Research");
       await dispatchWorkflow(pi, loadPrompt("guided-research-slice", {

--- a/src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts
@@ -19,10 +19,12 @@ import { normalizeDiscussTarget } from "../milestone-ids.ts";
 import { _parseDiscussArgsForTest } from "../commands/handlers/workflow.ts";
 import { openDatabase, closeDatabase, isDbAvailable, insertMilestone } from "../gsd-db.ts";
 import { invalidateStateCache } from "../state.ts";
+import { clearGuidedUnitContext, getGuidedUnitContext } from "../guided-unit-context.ts";
 
 afterEach(() => {
   if (isDbAvailable()) closeDatabase();
   invalidateStateCache();
+  clearGuidedUnitContext();
 });
 
 function makeDiscussPi() {
@@ -167,6 +169,65 @@ describe("showDiscuss targeted slice roadmap fallback", () => {
       harness.restore();
       if (isDbAvailable()) closeDatabase();
       invalidateStateCache();
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("/gsd discuss M001/S01 routes slice discussion through the active worktree", async () => {
+    const base = mkdtempSync(join(tmpdir(), "gsd-discuss-target-worktree-"));
+    const notifications: Array<{ message: string; level?: string }> = [];
+    const harness = makeDiscussPi();
+    try {
+      mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+      const dbPath = join(base, ".gsd", "gsd.db");
+      assert.equal(openDatabase(dbPath), true);
+      insertMilestone({ id: "M001", title: "Target slice milestone", status: "active" });
+
+      const rootRoadmap = `# M001 Roadmap
+
+## Slices
+- [ ] **S01: Auth module** \`risk:medium\` \`depends:[]\`
+  > ROOT-ROADMAP-CONTENT
+`;
+      writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), rootRoadmap, "utf-8");
+
+      const worktreeBase = join(base, ".gsd", "worktrees", "M001");
+      mkdirSync(join(worktreeBase, ".gsd", "milestones", "M001"), { recursive: true });
+      writeFileSync(join(worktreeBase, ".git"), "gitdir: /tmp/gsd-discuss-target-worktree.git\n", "utf-8");
+      const worktreeRoadmap = `# M001 Roadmap
+
+## Slices
+- [ ] **S01: Auth module** \`risk:medium\` \`depends:[]\`
+  > WORKTREE-ROADMAP-CONTENT
+`;
+      writeFileSync(
+        join(worktreeBase, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+        worktreeRoadmap,
+        "utf-8",
+      );
+
+      await showDiscuss(
+        makeDiscussCtx(notifications) as any,
+        harness.pi as any,
+        base,
+        { target: "M001/S01" },
+      );
+
+      assert.equal(harness.sent.length, 1, "targeted slice must dispatch discuss-slice");
+      const content = String(harness.sent[0]?.content);
+      assert.match(content, /WORKTREE-ROADMAP-CONTENT/);
+      assert.doesNotMatch(content, /ROOT-ROADMAP-CONTENT/);
+      assert.equal(
+        getGuidedUnitContext(worktreeBase)?.unitType,
+        "discuss-slice",
+        "guided unit context must be keyed by the worktree base path",
+      );
+      assert.equal(getGuidedUnitContext(base), null, "project root must not receive the discuss-slice guided context");
+    } finally {
+      harness.restore();
+      if (isDbAvailable()) closeDatabase();
+      invalidateStateCache();
+      clearGuidedUnitContext();
       rmSync(base, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Linked issue

Closes #251

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Routes slice discussion dispatches through the active auto-worktree when one exists.
**Why:** `require_slice_discussion` reads slice `CONTEXT` from the worktree projection, but `/gsd discuss` previously dispatched from the project root.
**How:** Resolve the active worktree for slice-discuss prompt building, context detection, and guided workflow dispatch, with a regression proving targeted slice discuss uses the worktree projection.

## What

- Added a guided-flow helper that prefers `getAutoWorktreePath(basePath, milestoneId)` for slice discussions.
- Updated targeted `/gsd discuss Mxxx/Sxx`, interactive slice discuss, and the smart-entry `Discuss Sxx first` path to build prompts and dispatch with that effective base path.
- Added regression coverage that distinguishes root `.gsd` from worktree `.gsd` roadmap content and verifies the guided unit context is keyed by the worktree base path.

## Why

When worktree isolation is active, auto-mode checks the worktree `.gsd` projection for `Sxx-CONTEXT.md`. Dispatching slice discussion from the project root meant `gsd_summary_save` never saw a worktree base path, so its worktree projection mirror could not run and auto-mode kept blocking.

## How

The fix keeps the existing DB/project-root artifact contract intact. `gsd_summary_save` still writes the canonical artifact row and project-root projection, while its existing worktree mirror now activates because slice discussions are dispatched with the worktree base path.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Commands run:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts src/resources/extensions/gsd/tests/gsdroot-worktree-detection.test.ts src/resources/extensions/gsd/tests/db-writer-scope.test.ts`
- `pnpm run typecheck:extensions`
- `git diff --check`

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented and verified with Codex.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782918866&installation_id=134682257&pr_number=359&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F359&signature=7f34b70c744511eb2d8a95a713ee6c472dda7897868dd811e3644472c4d6191f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guided-flow routing change with regression tests; milestone discuss and DB/canonical artifact paths are unchanged.
> 
> **Overview**
> Slice **discuss** flows now resolve an effective base path via **`getAutoWorktreePath`** (new **`resolveDiscussSliceBasePath`** helper) instead of always using the project root when a valid milestone worktree exists.
> 
> **Targeted** `/gsd discuss Mxxx/Sxx`, the **interactive slice picker** loop, and smart-entry **“Discuss … first”** all use that path to detect existing slice `CONTEXT`, **inline roadmap/context** in prompts, and **`dispatchWorkflow`** / **`setGuidedUnitContext`**—so auto-mode checks and **`gsd_summary_save`** worktree mirroring see the same `.gsd` projection as execution.
> 
> **Milestone-level** discuss is unchanged. A regression test asserts discuss reads **worktree** roadmap content and registers guided context on the worktree base, not the root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c70a1f3cf4371c3d6415e4588809c88d7c80e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->