### PR TITLE
fix(issue): auto-mode hard-stops on workflow-capability when bundled MCP CLI exists but project mcp.json is missing — should pause with remediation instead

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -2273,6 +2273,7 @@ export async function runUnitPhase(
       activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
     },
   );
+  const workflowMcpPrepModel = s.currentUnitModel;
   if (compatibilityError) {
     s.currentUnitRouting = prevUnitRouting;
     s.currentUnitModel = prevUnitModel;
@@ -2291,7 +2292,7 @@ export async function runUnitPhase(
       }
     }
 
-    const workflowMcpPrep = prepareWorkflowMcpForProject(ctx, s.basePath);
+    const workflowMcpPrep = prepareWorkflowMcpForProject(ctx, s.basePath, workflowMcpPrepModel);
     if (workflowMcpPrep && workflowMcpPrep.status !== "unchanged") {
       const pauseMsg =
         "GSD workflow MCP config has been written. Restart Claude Code (or reload MCP servers), then run /gsd auto to continue.";

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -82,6 +82,7 @@ import {
   getRequiredWorkflowToolsForAutoUnit,
   supportsStructuredQuestions,
 } from "../workflow-mcp.js";
+import { prepareWorkflowMcpForProject } from "../workflow-mcp-auto-prep.js";
 import type { DispatchAction } from "../auto-dispatch.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { createWorktreeSafetyModule, type WorktreeSafetyResult } from "../worktree-safety.js";
@@ -2289,6 +2290,20 @@ export async function runUnitPhase(
         pi.setThinkingLevel(prevSessionThinkingLevel);
       }
     }
+
+    const workflowMcpPrep = prepareWorkflowMcpForProject(ctx, s.basePath);
+    if (workflowMcpPrep && workflowMcpPrep.status !== "unchanged") {
+      const pauseMsg =
+        "GSD workflow MCP config has been written. Restart Claude Code (or reload MCP servers), then run /gsd auto to continue.";
+      ctx.ui.notify(pauseMsg, "warning");
+      await deps.pauseAuto(ctx, pi, {
+        category: "provider",
+        isTransient: true,
+        message: pauseMsg,
+      });
+      return { action: "break", reason: "workflow-capability" };
+    }
+
     ctx.ui.notify(compatibilityError, "error");
     await deps.stopAuto(ctx, pi, compatibilityError);
     return { action: "break", reason: "workflow-capability" };

--- a/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
@@ -4,9 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { registerHooks } from "../bootstrap/register-hooks.ts";
 import { GSD_BROWSER_MCP_SERVER_NAME, GSD_WORKFLOW_MCP_SERVER_NAME } from "../mcp-project-config.ts";
-import { clearSkillSnapshot, snapshotSkills } from "../skill-discovery.js";
 import { prepareWorkflowMcpForProject, shouldAutoPrepareWorkflowMcp } from "../workflow-mcp-auto-prep.ts";
 
 test("shouldAutoPrepareWorkflowMcp enables prep for externalCli local transport", () => {
@@ -19,6 +17,36 @@ test("shouldAutoPrepareWorkflowMcp enables prep for externalCli local transport"
   });
 
   assert.equal(result, true);
+});
+
+test("prepareWorkflowMcpForProject uses the selected unit model when session provider differs", (t) => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-unit-model-"));
+  const notifications: Array<{ message: string; level: "info" | "warning" | "error" | "success" }> = [];
+
+  t.after(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  const result = prepareWorkflowMcpForProject(
+    {
+      model: { provider: "openai", baseUrl: "https://api.openai.com" },
+      modelRegistry: {
+        getProviderAuthMode: (provider: string) => provider === "claude-code" ? "externalCli" : "apiKey",
+        isProviderRequestReady: () => true,
+      },
+      ui: {
+        notify: (message: string, level?: "info" | "warning" | "error" | "success") => {
+          notifications.push({ message, level: level ?? "info" });
+        },
+      },
+    },
+    projectRoot,
+    { provider: "claude-code", baseUrl: "local://claude-code" },
+  );
+
+  assert.equal(result?.status, "created");
+  assert.equal(existsSync(join(projectRoot, ".mcp.json")), true);
+  assert.match(notifications.map((entry) => entry.message).join("\n"), /Claude Code MCP prepared/);
 });
 
 test("shouldAutoPrepareWorkflowMcp stays disabled for non-Claude active provider even when claude-code is ready", () => {
@@ -82,6 +110,7 @@ test("prepareWorkflowMcpForProject warns with /gsd mcp init guidance when prep f
 });
 
 test("before_agent_start auto-prepares project workflow MCP for Claude Code CLI", async (t) => {
+  const { registerHooks } = await import("../bootstrap/register-hooks.ts");
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-before-agent-"));
   const originalCwd = process.cwd();
   const notifications: string[] = [];
@@ -138,6 +167,8 @@ test("before_agent_start auto-prepares project workflow MCP for Claude Code CLI"
 });
 
 test("before_agent_start returns discovered skill fallback without project .gsd", async (t) => {
+  const { registerHooks } = await import("../bootstrap/register-hooks.ts");
+  const { clearSkillSnapshot, snapshotSkills } = await import("../skill-discovery.js");
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-skill-before-agent-"));
   const skillHome = mkdtempSync(join(tmpdir(), "gsd-skill-home-"));
   const originalCwd = process.cwd();

--- a/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
+++ b/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
@@ -15,6 +15,29 @@ interface WorkflowMcpAutoPrepContext {
   ui?: Pick<ExtensionContext["ui"], "notify">;
 }
 
+interface WorkflowMcpAutoPrepModel {
+  provider?: string;
+  baseUrl?: string;
+}
+
+function withModelOverride(
+  ctx: WorkflowMcpAutoPrepContext,
+  modelOverride: WorkflowMcpAutoPrepModel | null | undefined,
+): WorkflowMcpAutoPrepContext {
+  if (!modelOverride) return ctx;
+
+  const provider = modelOverride.provider ?? ctx.model?.provider;
+  return {
+    model: {
+      provider,
+      baseUrl: modelOverride.baseUrl
+        ?? (provider === ctx.model?.provider ? ctx.model?.baseUrl : undefined),
+    },
+    modelRegistry: ctx.modelRegistry,
+    ui: ctx.ui,
+  };
+}
+
 function getAuthModeSafe(
   ctx: WorkflowMcpAutoPrepContext,
   provider: string | undefined,
@@ -41,17 +64,19 @@ export function shouldAutoPrepareWorkflowMcp(ctx: WorkflowMcpAutoPrepContext): b
 export function prepareWorkflowMcpForProject(
   ctx: WorkflowMcpAutoPrepContext,
   projectRoot: string,
+  modelOverride?: WorkflowMcpAutoPrepModel | null,
 ): EnsureProjectWorkflowMcpConfigResult | null {
-  if (!shouldAutoPrepareWorkflowMcp(ctx)) return null;
+  const prepCtx = withModelOverride(ctx, modelOverride);
+  if (!shouldAutoPrepareWorkflowMcp(prepCtx)) return null;
 
   try {
     const result = ensureProjectWorkflowMcpConfig(projectRoot);
     if (result.status !== "unchanged") {
-      ctx.ui?.notify?.(`Claude Code MCP prepared at ${result.configPath}`, "info");
+      prepCtx.ui?.notify?.(`Claude Code MCP prepared at ${result.configPath}`, "info");
     }
     return result;
   } catch (err) {
-    ctx.ui?.notify?.(
+    prepCtx.ui?.notify?.(
       `Claude Code MCP prep failed: ${err instanceof Error ? err.message : String(err)}. Detected Claude Code model but no workflow MCP. Please run /gsd mcp init . from your project root.`,
       "warning",
     );


### PR DESCRIPTION
## Summary
- Added a targeted auto-mode recovery path to write workflow MCP config and pause with restart guidance instead of hard-stopping on workflow-capability errors when config is newly created.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #347
- [#347 auto-mode hard-stops on workflow-capability when bundled MCP CLI exists but project mcp.json is missing — should pause with remediation instead](https://github.com/open-gsd/gsd-pi/issues/347)

## User
- @mattiaverio

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/347-auto-mode-hard-stops-on-workflow-capabil-1780327345`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782919446&installation_id=134682257&pr_number=360&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F360&signature=360d38fe6f9ebc10de796195946b82bbc63fa20fd6a12329fa5c7f638af164d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted auto-loop recovery and optional model override in MCP prep; behavior change is limited to workflow-capability failures with new config creation.
> 
> **Overview**
> When **auto-mode** hits a **workflow-capability** failure (missing project workflow MCP), it now tries **`prepareWorkflowMcpForProject`** using the **dispatched unit model**, not only the session model. If that writes new MCP config, auto **pauses** with restart/reload guidance instead of **hard-stopping**.
> 
> **`prepareWorkflowMcpForProject`** accepts an optional **model override** so Claude Code units still get `.mcp.json` when the session provider is something else (e.g. OpenAI). Tests cover unit-model prep and lazy-import hook registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86b1ef19a63af944dbb10f5fbccc30cd167ae7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->