### PR TITLE
fix(web): capture keyboard selection for UI questions

### DIFF
--- a/web/components/gsd/chat-mode.tsx
+++ b/web/components/gsd/chat-mode.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/comp
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { ChatMessage, TuiPrompt } from "@/lib/pty-chat-parser"
 import { PendingImage, processImageFile, generateImageId, MAX_PENDING_IMAGES } from "@/lib/image-utils"
+import { clampSelectIndex, getSingleSelectKeyAction } from "@/lib/select-keyboard"
 import {
   useGSDWorkspaceState,
   useGSDWorkspaceActions,
@@ -499,12 +500,12 @@ function TuiSelectPrompt({
 
   useEffect(() => {
     console.log("[TuiSelectPrompt] mounted kind=select label=%s", prompt.label)
-    // Auto-focus the container so keyboard events are captured immediately
-    containerRef.current?.focus()
+    requestAnimationFrame(() => containerRef.current?.focus())
   }, [prompt.label])
 
   const submitIndex = useCallback(
     (clickedIndex: number) => {
+      if (clickedIndex < 0 || clickedIndex >= prompt.options.length) return
       const delta = clickedIndex - localIndex
       let keystrokes = ""
       if (delta > 0) {
@@ -524,22 +525,24 @@ function TuiSelectPrompt({
       setSubmitted(true)
       onSubmit(keystrokes)
     },
-    [localIndex, onSubmit],
+    [localIndex, onSubmit, prompt.options.length],
   )
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (submitted) return
-      if (e.key === "ArrowUp") {
-        e.preventDefault()
-        setLocalIndex((i) => Math.max(0, i - 1))
-      } else if (e.key === "ArrowDown") {
-        e.preventDefault()
-        setLocalIndex((i) => Math.min(prompt.options.length - 1, i + 1))
-      } else if (e.key === "Enter") {
-        e.preventDefault()
-        submitIndex(localIndex)
+      const action = getSingleSelectKeyAction(e.key, localIndex, prompt.options.length)
+      if (action.type === "none") return
+
+      e.preventDefault()
+      e.stopPropagation()
+
+      if (action.type === "select") {
+        setLocalIndex(action.index)
+        return
       }
+
+      submitIndex(action.index)
     },
     [submitted, localIndex, prompt.options.length, submitIndex],
   )
@@ -563,7 +566,7 @@ function TuiSelectPrompt({
       data-testid="tui-select-prompt"
       tabIndex={0}
       onKeyDown={handleKeyDown}
-      className="mt-2 rounded-xl border border-border bg-background p-1.5 shadow-sm outline-none focus-visible:ring-1 focus-visible:ring-border"
+      className="mt-2 rounded-xl border border-border bg-background p-1.5 shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`Select: ${prompt.label}`}
       role="listbox"
       aria-activedescendant={`tui-select-option-${localIndex}`}
@@ -591,6 +594,9 @@ function TuiSelectPrompt({
                 : "text-foreground hover:bg-muted",
             )}
           >
+            <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center font-mono text-[11px] text-muted-foreground">
+              {i + 1}
+            </span>
             <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center">
               {isSelected ? (
                 <Check className="h-3 w-3 text-primary" />
@@ -1643,69 +1649,137 @@ function InlineSelect({
   disabled: boolean
 }) {
   const isMulti = Boolean(request.allowMultiple)
-  const [singleValue, setSingleValue] = useState("")
-  const [multiValues, setMultiValues] = useState<Set<string>>(new Set())
+  const [singleIndex, setSingleIndex] = useState(() => clampSelectIndex(0, request.options.length))
+  const [multiValues, setMultiValues] = useState<Set<string>>(() => new Set())
   const [submitted, setSubmitted] = useState(false)
+  const selectRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isMulti) {
+      requestAnimationFrame(() => selectRef.current?.focus())
+    }
+  }, [isMulti])
 
   const handleSubmit = useCallback(() => {
     setSubmitted(true)
-    onSubmit({ value: isMulti ? Array.from(multiValues) : singleValue })
-  }, [isMulti, singleValue, multiValues, onSubmit])
+    onSubmit({ value: isMulti ? Array.from(multiValues) : request.options[singleIndex] })
+  }, [isMulti, multiValues, onSubmit, request.options, singleIndex])
+
+  const submitSingleIndex = useCallback(
+    (index: number) => {
+      const option = request.options[index]
+      if (!option || disabled) return
+      setSingleIndex(index)
+      setSubmitted(true)
+      onSubmit({ value: option })
+    },
+    [disabled, onSubmit, request.options],
+  )
+
+  const handleSingleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (disabled || submitted) return
+      const action = getSingleSelectKeyAction(event.key, singleIndex, request.options.length)
+      if (action.type === "none") return
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (action.type === "select") {
+        setSingleIndex(action.index)
+        return
+      }
+
+      submitSingleIndex(action.index)
+    },
+    [disabled, request.options.length, singleIndex, submitted, submitSingleIndex],
+  )
 
   if (submitted) {
+    const selectedLabel = isMulti ? `${multiValues.size} selected` : request.options[singleIndex] ?? ""
     return (
       <div className="flex items-center gap-1.5 rounded-lg bg-primary/10 px-3 py-2 text-sm text-primary">
         <Check className="h-3.5 w-3.5 flex-shrink-0" />
-        <span className="font-medium">{isMulti ? `${multiValues.size} selected` : singleValue}</span>
+        <span className="font-medium">{selectedLabel}</span>
       </div>
     )
   }
 
-  const canSubmit = isMulti ? multiValues.size > 0 : singleValue !== ""
+  const canSubmit = isMulti ? multiValues.size > 0 : singleIndex >= 0
+
+  if (!isMulti) {
+    return (
+      <div className="space-y-1.5">
+        <div
+          ref={selectRef}
+          role="listbox"
+          tabIndex={0}
+          aria-activedescendant={singleIndex >= 0 ? `inline-select-option-${request.id}-${singleIndex}` : undefined}
+          onKeyDown={handleSingleKeyDown}
+          className="space-y-1.5 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {request.options.map((option: string, i: number) => {
+            const selected = i === singleIndex
+            return (
+              <button
+                key={i}
+                id={`inline-select-option-${request.id}-${i}`}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => submitSingleIndex(i)}
+                disabled={disabled}
+                className={cn(
+                  "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  selected ? "bg-primary/15 text-primary font-medium" : "text-foreground hover:bg-muted",
+                  disabled && "cursor-not-allowed opacity-60",
+                )}
+              >
+                <span className="w-4 shrink-0 text-center font-mono text-[11px] text-muted-foreground">
+                  {i + 1}
+                </span>
+                <span className="min-w-0 flex-1">{option}</span>
+                {selected && <Check className="h-3 w-3 shrink-0 text-primary" />}
+              </button>
+            )
+          })}
+        </div>
+        <button
+          onClick={handleSubmit}
+          disabled={disabled || !canSubmit}
+          className={cn(
+            "mt-2 flex w-full items-center justify-center rounded-lg px-3 py-2 text-xs font-medium transition-[background-color,color,box-shadow,transform]",
+            canSubmit && !disabled
+              ? "bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.96] shadow-sm"
+              : "bg-muted text-muted-foreground cursor-not-allowed",
+          )}
+        >
+          Submit
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-1.5">
-      {request.options.map((option, i) => {
-        if (isMulti) {
-          const checked = multiValues.has(option)
-          return (
-            <button
-              key={i}
-              onClick={() => {
-                const next = new Set(multiValues)
-                if (checked) next.delete(option); else next.add(option)
-                setMultiValues(next)
-              }}
-              disabled={disabled}
-              className={cn(
-                "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm transition-colors",
-                checked ? "bg-primary/15 text-primary font-medium" : "text-foreground hover:bg-muted",
-              )}
-            >
-              <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border border-border">
-                {checked && <Check className="h-2.5 w-2.5 text-primary" />}
-              </span>
-              <span>{option}</span>
-            </button>
-          )
-        }
-        const selected = singleValue === option
+      {request.options.map((option: string, i: number) => {
+        const checked = multiValues.has(option)
         return (
           <button
             key={i}
-            onClick={() => setSingleValue(option)}
+            onClick={() => {
+              const next = new Set(multiValues)
+              if (checked) next.delete(option); else next.add(option)
+              setMultiValues(next)
+            }}
             disabled={disabled}
             className={cn(
               "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm transition-colors",
-              selected ? "bg-primary/15 text-primary font-medium" : "text-foreground hover:bg-muted",
+              checked ? "bg-primary/15 text-primary font-medium" : "text-foreground hover:bg-muted",
             )}
           >
-            <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
-              {selected ? (
-                <Check className="h-3 w-3 text-primary" />
-              ) : (
-                <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/30" />
-              )}
+            <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border border-border">
+              {checked && <Check className="h-2.5 w-2.5 text-primary" />}
             </span>
             <span>{option}</span>
           </button>
@@ -1928,7 +2002,8 @@ function ToolExecutionBlock({ tool }: { tool: CompletedToolExecution }) {
     const hasVisibleResult = Boolean(diff || resultText.trim() || isError)
     if (!hasVisibleResult) return
     autoExpandedRef.current = true
-    setExpanded(true)
+    const frame = requestAnimationFrame(() => setExpanded(true))
+    return () => cancelAnimationFrame(frame)
   }, [diff, resultText, isError])
 
   return (
@@ -2027,6 +2102,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
   const state = useGSDWorkspaceState()
   const { submitInput, sendCommand, pushChatUserMessage } = useGSDWorkspaceActions()
   const [terminalFontSize] = useTerminalFontSize()
+  const [renderTimestamp] = useState(() => Date.now())
 
   const connected = state.connectionState === "connected"
   const isStreaming = state.boot?.bridge.sessionState?.isStreaming ?? false
@@ -2153,7 +2229,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
             role: "assistant",
             content: seg.content,
             complete: true,
-            timestamp: Date.now(),
+            timestamp: renderTimestamp,
           },
         })
       } else if (seg.kind === "tool") {
@@ -2198,7 +2274,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
     }
 
     return items
-  }, [state.liveTranscript, state.completedTurnSegments, state.currentTurnSegments, state.streamingAssistantText, state.streamingThinkingText, state.activeToolExecution, state.pendingUiRequests, state.chatUserMessages, isStreaming])
+  }, [state.liveTranscript, state.completedTurnSegments, state.currentTurnSegments, state.streamingAssistantText, state.streamingThinkingText, state.activeToolExecution, state.pendingUiRequests, state.chatUserMessages, isStreaming, renderTimestamp])
 
   // Prompt submit handler for TUI prompts (select/text/password)
   const handlePromptSubmit = useCallback((data: string) => {
@@ -2288,7 +2364,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
                         role: "assistant",
                         content: item.content,
                         complete: false,
-                        timestamp: Date.now(),
+                        timestamp: renderTimestamp,
                       }}
                       isThinking={item.isThinking}
                     />

--- a/web/components/gsd/focused-panel.tsx
+++ b/web/components/gsd/focused-panel.tsx
@@ -1,13 +1,11 @@
 "use client"
 
-import { useState } from "react"
-import { CheckSquare, MessageSquare, Send, TextCursorInput, Type } from "lucide-react"
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react"
+import { Check, CheckSquare, MessageSquare, Send, TextCursorInput, Type } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import {
   Sheet,
   SheetContent,
@@ -22,6 +20,7 @@ import {
   useGSDWorkspaceActions,
   useGSDWorkspaceState,
 } from "@/lib/gsd-workspace-store"
+import { clampSelectIndex, getSingleSelectKeyAction } from "@/lib/select-keyboard"
 import { cn } from "@/lib/utils"
 
 function methodIcon(method: PendingUiRequest["method"]) {
@@ -48,6 +47,7 @@ function methodLabel(method: PendingUiRequest["method"]): string {
     case "editor":
       return "Editor"
   }
+  return method
 }
 
 // --- Renderers for each blocking UI request type ---
@@ -62,26 +62,63 @@ function SelectRenderer({
   disabled: boolean
 }) {
   const isMulti = Boolean(request.allowMultiple)
-  const [singleValue, setSingleValue] = useState("")
-  const [multiValues, setMultiValues] = useState<Set<string>>(new Set())
+  const [singleIndex, setSingleIndex] = useState(() => clampSelectIndex(0, request.options.length))
+  const [multiValues, setMultiValues] = useState<Set<string>>(() => new Set())
+  const selectRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isMulti) {
+      requestAnimationFrame(() => selectRef.current?.focus())
+    }
+  }, [isMulti])
 
   const handleSubmit = () => {
     if (isMulti) {
       onSubmit({ value: Array.from(multiValues) })
     } else {
-      onSubmit({ value: singleValue })
+      const option = request.options[singleIndex]
+      if (option) onSubmit({ value: option })
     }
   }
 
-  const canSubmit = isMulti ? multiValues.size > 0 : singleValue !== ""
+  const submitSingleIndex = useCallback(
+    (index: number) => {
+      const option = request.options[index]
+      if (!option || disabled) return
+      setSingleIndex(index)
+      onSubmit({ value: option })
+    },
+    [disabled, onSubmit, request.options],
+  )
+
+  const handleSingleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return
+      const action = getSingleSelectKeyAction(event.key, singleIndex, request.options.length)
+      if (action.type === "none") return
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (action.type === "select") {
+        setSingleIndex(action.index)
+        return
+      }
+
+      submitSingleIndex(action.index)
+    },
+    [disabled, request.options.length, singleIndex, submitSingleIndex],
+  )
+
+  const canSubmit = isMulti ? multiValues.size > 0 : singleIndex >= 0
 
   if (isMulti) {
     return (
       <div className="space-y-4">
         <div className="space-y-2">
-          {request.options.map((option) => (
+          {request.options.map((option: string, index: number) => (
             <label
-              key={option}
+              key={`${option}-${index}`}
               className="flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-3 py-2.5 transition-colors hover:bg-accent/40"
             >
               <Checkbox
@@ -111,19 +148,42 @@ function SelectRenderer({
 
   return (
     <div className="space-y-4">
-      <RadioGroup value={singleValue} onValueChange={setSingleValue} disabled={disabled}>
-        {request.options.map((option) => (
-          <label
-            key={option}
-            className="flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-3 py-2.5 transition-colors hover:bg-accent/40"
-          >
-            <RadioGroupItem value={option} id={`select-${option}`} />
-            <Label htmlFor={`select-${option}`} className="cursor-pointer text-sm font-normal">
-              {option}
-            </Label>
-          </label>
-        ))}
-      </RadioGroup>
+      <div
+        ref={selectRef}
+        role="listbox"
+        tabIndex={0}
+        aria-activedescendant={singleIndex >= 0 ? `focused-select-option-${singleIndex}` : undefined}
+        onKeyDown={handleSingleKeyDown}
+        className="space-y-2 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {request.options.map((option: string, index: number) => {
+          const selected = index === singleIndex
+          return (
+            <button
+              key={`${option}-${index}`}
+              id={`focused-select-option-${index}`}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              onClick={() => submitSingleIndex(index)}
+              disabled={disabled}
+              className={cn(
+                "flex w-full cursor-pointer items-center gap-3 rounded-lg border bg-background px-3 py-2.5 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                selected
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "border-border hover:bg-accent/40",
+                disabled && "cursor-not-allowed opacity-60",
+              )}
+            >
+              <span className="w-4 shrink-0 text-center font-mono text-[11px] text-muted-foreground">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">{option}</span>
+              {selected && <Check className="h-4 w-4 shrink-0" />}
+            </button>
+          )
+        })}
+      </div>
       <Button onClick={handleSubmit} disabled={disabled || !canSubmit} className="w-full">
         <Send className="h-4 w-4" />
         Submit
@@ -306,6 +366,7 @@ export function FocusedPanel() {
 
             <div className="flex-1 overflow-y-auto px-4 py-2">
               <RequestBody
+                key={current.id}
                 request={current}
                 onSubmit={handleSubmit}
                 onCancel={handleDismiss}

--- a/web/lib/__tests__/select-keyboard.test.ts
+++ b/web/lib/__tests__/select-keyboard.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  clampSelectIndex,
+  getSingleSelectKeyAction,
+  numberKeyToSelectIndex,
+} from "../select-keyboard.ts"
+
+test("numberKeyToSelectIndex maps visible option numbers to zero-based indexes", () => {
+  assert.equal(numberKeyToSelectIndex("1", 3), 0)
+  assert.equal(numberKeyToSelectIndex("2", 3), 1)
+  assert.equal(numberKeyToSelectIndex("3", 3), 2)
+})
+
+test("numberKeyToSelectIndex ignores unavailable and non-number keys", () => {
+  assert.equal(numberKeyToSelectIndex("4", 3), null)
+  assert.equal(numberKeyToSelectIndex("0", 3), null)
+  assert.equal(numberKeyToSelectIndex("a", 3), null)
+  assert.equal(numberKeyToSelectIndex("1", 0), null)
+})
+
+test("getSingleSelectKeyAction moves within option bounds", () => {
+  assert.deepEqual(getSingleSelectKeyAction("2", 0, 3), { type: "select", index: 1 })
+  assert.deepEqual(getSingleSelectKeyAction("ArrowUp", 0, 3), { type: "select", index: 0 })
+  assert.deepEqual(getSingleSelectKeyAction("ArrowDown", 0, 3), { type: "select", index: 1 })
+  assert.deepEqual(getSingleSelectKeyAction("End", 0, 3), { type: "select", index: 2 })
+  assert.deepEqual(getSingleSelectKeyAction("Home", 2, 3), { type: "select", index: 0 })
+})
+
+test("getSingleSelectKeyAction submits the active option on Enter or Space", () => {
+  assert.deepEqual(getSingleSelectKeyAction("Enter", 2, 3), { type: "submit", index: 2 })
+  assert.deepEqual(getSingleSelectKeyAction(" ", 1, 3), { type: "submit", index: 1 })
+})
+
+test("clampSelectIndex returns -1 when there are no options", () => {
+  assert.equal(clampSelectIndex(0, 0), -1)
+})

--- a/web/lib/select-keyboard.ts
+++ b/web/lib/select-keyboard.ts
@@ -1,0 +1,44 @@
+export type SingleSelectKeyAction =
+  | { type: "none" }
+  | { type: "select"; index: number }
+  | { type: "submit"; index: number }
+
+export function clampSelectIndex(index: number, optionCount: number): number {
+  if (optionCount <= 0) return -1
+  return Math.max(0, Math.min(optionCount - 1, index))
+}
+
+export function numberKeyToSelectIndex(key: string, optionCount: number): number | null {
+  if (!/^[1-9]$/.test(key)) return null
+  const index = Number(key) - 1
+  return index < optionCount ? index : null
+}
+
+export function getSingleSelectKeyAction(
+  key: string,
+  currentIndex: number,
+  optionCount: number,
+): SingleSelectKeyAction {
+  if (optionCount <= 0) return { type: "none" }
+
+  const numberIndex = numberKeyToSelectIndex(key, optionCount)
+  if (numberIndex !== null) return { type: "select", index: numberIndex }
+
+  if (key === "ArrowUp") {
+    return { type: "select", index: clampSelectIndex(currentIndex - 1, optionCount) }
+  }
+  if (key === "ArrowDown") {
+    return { type: "select", index: clampSelectIndex(currentIndex + 1, optionCount) }
+  }
+  if (key === "Home") {
+    return { type: "select", index: 0 }
+  }
+  if (key === "End") {
+    return { type: "select", index: optionCount - 1 }
+  }
+  if (key === "Enter" || key === " ") {
+    return { type: "submit", index: clampSelectIndex(currentIndex, optionCount) }
+  }
+
+  return { type: "none" }
+}


### PR DESCRIPTION
## TL;DR

**What:** Gives web UI question selects focus, number-key/arrow/Enter handling, and clickable single-select option rows.
**Why:** `ask_user_questions` dialogs could render while keyboard input still went to the chat textarea, leaving depth gates stuck.
**How:** Shares select-key handling across the chat inline request, focused panel, and PTY select prompt, with helper tests.

## What

- Add a shared `web/lib/select-keyboard.ts` helper for number-key, arrow, Home/End, Enter, and Space handling.
- Update Chat Mode inline UI requests so single-select dialogs autofocus, show option numbers, support keyboard selection, and submit when an option row is clicked.
- Update the global FocusedPanel select renderer with the same keyboard/click behavior for non-chat/power-user surfaces.
- Update PTY-derived select prompts so numbered option keys select the visible option before Enter submits.

## Why

Closes #210

The reported failure path is a focus/input-routing bug: the dialog is visible, but the textarea can keep keyboard ownership, so `1`, `2`, `3`, and Enter are treated as chat input rather than a structured answer.

## How

The web select surfaces now explicitly focus their listbox container after mount and stop handled keyboard events from bubbling. Number keys update the active option, Enter/Space submit the active option, and mouse clicks submit single-select rows directly.

Current `main` already includes backend coverage proving remote `ask_user_questions` answers mark depth gates verified, so this PR keeps the implementation scoped to the remaining web focus/input path.

## Verification

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --filter gsd-web test`
- [x] `pnpm --filter gsd-web exec eslint components/gsd/chat-mode.tsx components/gsd/focused-panel.tsx lib/select-keyboard.ts lib/__tests__/select-keyboard.test.ts` (passes with pre-existing warnings in `chat-mode.tsx`)
- [x] `pnpm --filter @opengsd/contracts build`
- [x] `pnpm --filter @opengsd/rpc-client build`
- [x] `pnpm --filter @opengsd/mcp-server test`
- [x] `git diff --check`

## Impact analysis

- Blast radius: Moderate, UI-local. Touches the web chat/focused question surfaces and the existing PTY select prompt.
- Affected workflows: `gsd --web` structured UI questions, including depth confirmation gates in chat and power-user views.
- Risks or compatibility notes: Multi-select behavior remains submit-button based. Single-select option rows now submit directly, matching the issue's requested redundant mouse path.

## Notes

- Draft because repo-wide `pnpm --filter gsd-web lint` and raw `pnpm --filter gsd-web exec tsc --noEmit` still fail on existing unrelated web/package build-order issues outside this slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782919975&installation_id=134682257&pr_number=361&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F361&signature=a097367c86c817a90c168eb66a03dd2df10b2d6f4888f1c011c8bb16b289c7eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI-only blast radius across chat, focused panel, and PTY prompts; behavior change (single-select row click submits immediately) could surprise users but does not touch auth or data paths.
> 
> **Overview**
> Fixes **web UI single-select questions** so keyboard input reaches the dialog instead of the chat textarea (e.g. depth gates stuck on `ask_user_questions`).
> 
> Adds shared **`select-keyboard`** helpers (1–9, arrows, Home/End, Enter/Space) with unit tests, then wires them into **inline chat requests**, the **FocusedPanel** sheet (replacing radio controls with a focusable listbox), and **PTY TUI select** prompts. Single-select rows show **numbered options**, **autofocus** via `requestAnimationFrame`, **`preventDefault` / `stopPropagation`** on handled keys, and **click-to-submit** on a row; multi-select still uses checkboxes plus Submit.
> 
> Smaller chat tweaks: stable **timestamps** for in-flight assistant bubbles, **reset** focused-panel body state when the pending request id changes, and **rAF** for tool-result auto-expand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b51683c6037abe5884790c6c07ca3faa233891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->