### PR TITLE
fix(pi-coding-agent): use GSD config dir for vendored package

### DIFF
--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -9,8 +9,8 @@
     "name": "pi-coding-agent"
   },
   "piConfig": {
-    "name": "pi",
-    "configDir": ".pi"
+    "name": "gsd",
+    "configDir": ".gsd"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/__tests__/apply-gsd-pi-package-json.test.mjs
+++ b/scripts/__tests__/apply-gsd-pi-package-json.test.mjs
@@ -1,0 +1,43 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for GSD metadata applied to vendored Pi packages.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+
+test("apply-gsd-pi-package-json writes GSD runtime config for pi-coding-agent", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-apply-pkg-json-"));
+
+  try {
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    copyFileSync(
+      join(repoRoot, "scripts", "apply-gsd-pi-package-json.cjs"),
+      join(root, "scripts", "apply-gsd-pi-package-json.cjs"),
+    );
+
+    for (const dir of ["pi-agent-core", "pi-ai", "pi-tui", "pi-coding-agent"]) {
+      mkdirSync(join(root, "packages", dir), { recursive: true });
+      writeFileSync(
+        join(root, "packages", dir, "package.json"),
+        `${JSON.stringify({ name: dir, dependencies: {}, devDependencies: {} }, null, 2)}\n`,
+      );
+    }
+
+    execFileSync(process.execPath, [join(root, "scripts", "apply-gsd-pi-package-json.cjs")], {
+      cwd: root,
+      stdio: "pipe",
+    });
+
+    const pkg = JSON.parse(readFileSync(join(root, "packages", "pi-coding-agent", "package.json"), "utf8"));
+    assert.deepEqual(pkg.piConfig, { name: "gsd", configDir: ".gsd" });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/apply-gsd-pi-package-json.cjs
+++ b/scripts/apply-gsd-pi-package-json.cjs
@@ -44,7 +44,7 @@ const GSD_BASE = {
     },
     build: 'node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false && pnpm run copy-assets',
     extraScripts: { 'copy-assets': 'node scripts/copy-assets.cjs' },
-    piConfig: { name: 'pi', configDir: '.pi' },
+    piConfig: { name: 'gsd', configDir: '.gsd' },
   },
 }
 


### PR DESCRIPTION
## Linked issue

Closes #365

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Updates the vendored `@gsd/pi-coding-agent` package metadata to use GSD's `.gsd` runtime config directory.
**Why:** `pi-coding-agent` reads its own `package.json` for `piConfig`, so shipping `.pi` makes GSD silently ignore extensions installed under `~/.gsd/agent/extensions/`.
**How:** Changes the GSD package-json apply script and committed vendored package JSON, with a regression test that runs a temp copy of the apply script.

## What

This changes `piConfig` for `packages/pi-coding-agent/package.json` from `{ name: "pi", configDir: ".pi" }` to `{ name: "gsd", configDir: ".gsd" }`.

It also updates `scripts/apply-gsd-pi-package-json.cjs` so future vendoring/regeneration keeps that GSD runtime config, and adds script-policy regression coverage for the generated `pi-coding-agent` package JSON.

## Why

GSD users install community extensions under `~/.gsd/agent/extensions/`, but the vendored `pi-coding-agent` runtime derives all user-directory paths from its own package metadata. With `.pi` in that package, extension discovery and related agent config paths point at `~/.pi/agent/` instead of the intended GSD location.

## How

The fix keeps the runtime source code unchanged and corrects the package metadata source of truth. The new regression test copies the apply script into a temporary fixture repository, runs it against minimal vendored package fixtures, and asserts that `pi-coding-agent` receives the GSD `piConfig`.

## Impact analysis

- Blast radius: moderate; this is a small metadata/build-script change, but `piConfig.configDir` feeds `getAgentDir()` and therefore extensions, settings, auth, sessions, prompts, themes, blobs, and managed binaries for `pi-coding-agent`.
- Affected workflows: packaged GSD runtime directory resolution and future vendoring via `scripts/apply-gsd-pi-package-json.cjs`.
- Risks or compatibility notes: restores the intended GSD-branded path; it does not add a legacy `~/.pi` fallback for this runtime path.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — `node --experimental-strip-types --input-type=module -e "import { APP_NAME, CONFIG_DIR_NAME, getAgentDir } from './packages/pi-coding-agent/src/config.ts'; console.log(JSON.stringify({APP_NAME, CONFIG_DIR_NAME, agentDir: getAgentDir()}));"`
- [ ] No tests needed — explained above

Verification run locally:

- `node --test scripts/__tests__/apply-gsd-pi-package-json.test.mjs`
- `pnpm run verify:version-sync`
- `pnpm run verify:fast`

Note: `pnpm --filter @gsd/pi-coding-agent exec vitest run test/config.test.ts` is currently blocked by pre-existing stale imports of non-exported helpers (`detectInstallMethod`, `getSelfUpdateCommand`, etc.); this PR does not modify that suite.

## AI disclosure

- [x] This PR includes AI-assisted code; Codex implemented the package metadata fix, added regression coverage, and ran the verification listed above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782925134&installation_id=134682257&pr_number=366&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F366&signature=1ea7b9c9cf589f7cee8410bf16c9f905e677fbcd877096df89729939027424b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `piConfig.configDir` drives all default user agent paths; wrong metadata silently pointed at `~/.pi` instead of GSD installs—this corrects behavior but changes effective paths for anyone relying on the broken `.pi` default.
> 
> **Overview**
> The vendored **`@gsd/pi-coding-agent`** package now declares **`piConfig`** as **`gsd`** / **`.gsd`** instead of **`pi`** / **`.pi`**, so runtime path resolution (extensions, settings, auth, sessions, etc. under **`getAgentDir()`**) aligns with GSD’s user config tree (e.g. **`~/.gsd/agent/extensions/`**).
> 
> **`scripts/apply-gsd-pi-package-json.cjs`** is updated so re-vendoring keeps that metadata. A new **`scripts/__tests__/apply-gsd-pi-package-json.test.mjs`** runs the apply script in a temp repo and asserts **`pi-coding-agent`** gets the GSD **`piConfig`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf34436cd7cc22941968d1a7d1d5f64770b9d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->