### PR TITLE
[codex] auto-init Claude Code MCP servers

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -28,7 +28,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import { buildWorkflowMcpServers, resolveWorkflowMcpProjectRoot } from "../gsd/workflow-mcp.js";
-import { buildProjectGsdMcpServers } from "../gsd/mcp-project-config.js";
+import { buildProjectGsdMcpServers, ensureProjectWorkflowMcpConfig } from "../gsd/mcp-project-config.js";
 import { loadProjectGSDPreferences } from "../gsd/preferences.js";
 import { discoverBrowserMcpServerName, discoverMcpServerNames, discoverWorkflowMcpServerName, computeMcpDisallowedTools } from "../gsd/mcp-filter.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
@@ -1477,6 +1477,19 @@ function browserMcpServerNameFromAllowedTools(allowedTools: unknown): string | u
 	return allowedTools.includes("mcp__gsd-browser__*") ? "gsd-browser" : undefined;
 }
 
+export function autoInitClaudeCodeWorkflowMcp(cwd: string): void {
+	const projectRoot = resolveWorkflowMcpProjectRoot(cwd);
+	try {
+		ensureProjectWorkflowMcpConfig(projectRoot);
+	} catch (err) {
+		if (process.env.GSD_DEBUG === "1") {
+			console.warn(
+				`[claude-code] workflow MCP auto-init failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+}
+
 /**
  * Build the options object passed to the Claude Agent SDK's `query()` call.
  *
@@ -1619,7 +1632,7 @@ export function buildSdkOptions(
 		cwd: sdkCwd,
 		permissionMode,
 		allowDangerouslySkipPermissions: permissionMode === "bypassPermissions",
-		settingSources: ["project"],
+		settingSources: ["project", "local"],
 		systemPrompt: { type: "preset", preset: "claude_code" },
 		disallowedTools,
 		...(allowedTools.length > 0 ? { allowedTools } : {}),
@@ -1954,6 +1967,7 @@ async function pumpSdkMessages(
 		const onExternalToolCall = (options as ClaudeCodeStreamOptions | undefined)?.onExternalToolCall;
 		const onExternalToolResult = (options as ClaudeCodeStreamOptions | undefined)?.onExternalToolResult;
 		const cwd = resolveClaudeCodeCwd(options);
+		autoInitClaudeCodeWorkflowMcp(cwd);
 		const canUseToolHandler = createClaudeCodeCanUseToolHandler(uiContext);
 		// When no UI is available (headless / auto-mode), auto-approve all
 		// tool requests. This replaces the old bypassPermissions workaround.

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,7 +1,7 @@
 // gsd-pi - Claude Code stream adapter regression tests
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -33,6 +33,7 @@ import {
 	resolveBundledClaudeCliPath,
 	normalizeClaudePathForSdk,
 	roundResultToElicitationContent,
+	autoInitClaudeCodeWorkflowMcp,
 } from "../stream-adapter.ts";
 import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
 import type { SDKUserMessage } from "../sdk-types.ts";
@@ -794,6 +795,11 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		assert.equal(options.persistSession, true, "persistSession must default to true");
 	});
 
+	test("buildSdkOptions loads project and local settings so approved .mcp.json servers are active", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test prompt");
+		assert.deepEqual(options.settingSources, ["project", "local"]);
+	});
+
 	test("buildSdkOptions sets model and prompt correctly", () => {
 		const options = buildSdkOptions("claude-sonnet-4-20250514", "hello world");
 		assert.equal(options.model, "claude-sonnet-4-20250514");
@@ -826,6 +832,29 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		} finally {
 			restore();
 			rmSync(explicitCwd, { recursive: true, force: true });
+		}
+	});
+
+	test("autoInitClaudeCodeWorkflowMcp writes and approves project GSD MCP config", () => {
+		const projectRoot = realpathSync(mkdtempSync(join(tmpdir(), "claude-sdk-auto-init-")));
+		const restore = setWorkflowMcpEnv({
+			GSD_WORKFLOW_MCP_COMMAND: "node",
+			GSD_WORKFLOW_MCP_NAME: "gsd-workflow",
+			GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["server.js"]),
+			GSD_WORKFLOW_MCP_CWD: projectRoot,
+		});
+
+		try {
+			autoInitClaudeCodeWorkflowMcp(projectRoot);
+			assert.equal(existsSync(join(projectRoot, ".mcp.json")), true);
+
+			const settings = JSON.parse(readFileSync(join(projectRoot, ".claude", "settings.local.json"), "utf-8")) as {
+				enabledMcpjsonServers?: string[];
+			};
+			assert.deepEqual(settings.enabledMcpjsonServers, ["gsd-workflow", "gsd-browser"]);
+		} finally {
+			restore();
+			rmSync(projectRoot, { recursive: true, force: true });
 		}
 	});
 

--- a/src/resources/extensions/gsd/mcp-filter.ts
+++ b/src/resources/extensions/gsd/mcp-filter.ts
@@ -40,9 +40,11 @@ function collectServerEntries(servers: unknown): DiscoveredMcpServer[] {
 export function discoverMcpServers(projectDir: string): DiscoveredMcpServer[] {
   const mcpJsonPath = resolve(projectDir, ".mcp.json");
   const settingsPath = resolve(projectDir, ".claude", "settings.json");
+  const localSettingsPath = resolve(projectDir, ".claude", "settings.local.json");
 
   const mcpJson = readJsonFile(mcpJsonPath) as McpJsonFile | undefined;
   const settings = readJsonFile(settingsPath, true) as ClaudeSettingsFile | undefined;
+  const localSettings = readJsonFile(localSettingsPath, true) as ClaudeSettingsFile | undefined;
 
   const seen = new Set<string>();
   const discovered: DiscoveredMcpServer[] = [];
@@ -50,6 +52,7 @@ export function discoverMcpServers(projectDir: string): DiscoveredMcpServer[] {
     ...collectServerEntries(mcpJson?.mcpServers),
     ...collectServerEntries(mcpJson?.servers),
     ...collectServerEntries(settings?.mcpServers),
+    ...collectServerEntries(localSettings?.mcpServers),
   ]) {
     if (seen.has(entry.name)) continue;
     seen.add(entry.name);

--- a/src/resources/extensions/gsd/mcp-project-config.ts
+++ b/src/resources/extensions/gsd/mcp-project-config.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,6 +33,12 @@ interface ProjectMcpServerSpec {
 interface McpConfigFile {
   mcpServers?: Record<string, ProjectMcpServerConfig>;
   servers?: Record<string, ProjectMcpServerConfig>;
+  [key: string]: unknown;
+}
+
+interface ClaudeCodeLocalSettingsFile {
+  enabledMcpjsonServers?: unknown;
+  disabledMcpjsonServers?: unknown;
   [key: string]: unknown;
 }
 
@@ -223,6 +229,78 @@ function readExistingConfig(configPath: string): McpConfigFile {
   }
 }
 
+function readExistingClaudeCodeSettings(settingsPath: string): ClaudeCodeLocalSettingsFile {
+  if (!existsSync(settingsPath)) return {};
+
+  const raw = readFileSync(settingsPath, "utf-8");
+  try {
+    const parsed = JSON.parse(raw) as ClaudeCodeLocalSettingsFile;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${settingsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export function ensureClaudeCodeMcpJsonServersEnabled(
+  projectRoot: string,
+  serverNames: string[],
+): boolean {
+  const resolvedProjectRoot = resolve(projectRoot);
+  assertSafeDirectory(resolvedProjectRoot);
+
+  const targetServerNames = [...new Set(serverNames.filter((name) => name.trim().length > 0))];
+  if (targetServerNames.length === 0) return false;
+
+  const settingsDir = resolve(resolvedProjectRoot, ".claude");
+  const settingsPath = resolve(settingsDir, "settings.local.json");
+  const existing = readExistingClaudeCodeSettings(settingsPath);
+
+  const enabled = Array.isArray(existing.enabledMcpjsonServers)
+    ? [...existing.enabledMcpjsonServers]
+    : [];
+  const enabledNames = new Set(enabled.filter((value): value is string => typeof value === "string"));
+  let changed = !Array.isArray(existing.enabledMcpjsonServers);
+
+  for (const serverName of targetServerNames) {
+    if (!enabledNames.has(serverName)) {
+      enabled.push(serverName);
+      enabledNames.add(serverName);
+      changed = true;
+    }
+  }
+
+  let nextDisabled = existing.disabledMcpjsonServers;
+  if (Array.isArray(existing.disabledMcpjsonServers)) {
+    const blockedNames = new Set(targetServerNames);
+    const filtered = existing.disabledMcpjsonServers.filter((value) => !blockedNames.has(String(value)));
+    if (filtered.length !== existing.disabledMcpjsonServers.length) {
+      nextDisabled = filtered;
+      changed = true;
+    }
+  }
+
+  if (!changed) return false;
+
+  const nextSettings: ClaudeCodeLocalSettingsFile = {
+    ...existing,
+    enabledMcpjsonServers: enabled,
+    ...(Array.isArray(existing.disabledMcpjsonServers) ? { disabledMcpjsonServers: nextDisabled } : {}),
+  };
+
+  mkdirSync(settingsDir, { recursive: true });
+  writeFileSync(settingsPath, `${JSON.stringify(nextSettings, null, 2)}\n`, "utf-8");
+  return true;
+}
+
+export function ensureClaudeCodeMcpJsonServerEnabled(
+  projectRoot: string,
+  serverName: string,
+): boolean {
+  return ensureClaudeCodeMcpJsonServersEnabled(projectRoot, [serverName]);
+}
+
 export function ensureProjectWorkflowMcpConfig(
   projectRoot: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -241,14 +319,25 @@ export function ensureProjectWorkflowMcpConfig(
   const desiredServerNames = Object.keys(desiredServers);
 
   const alreadyPresent = existsSync(configPath);
-  const unchanged =
+  const mcpConfigUnchanged =
     desiredServerNames.every((serverName) => (
       JSON.stringify(previousServers[serverName] ?? null)
         === JSON.stringify(desiredServers[serverName])
     ))
     && existing.mcpServers !== undefined;
 
-  if (unchanged) {
+  if (!mcpConfigUnchanged) {
+    const nextConfig: McpConfigFile = {
+      ...existing,
+      mcpServers: nextServers,
+    };
+
+    writeFileSync(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf-8");
+  }
+
+  const localSettingsChanged = ensureClaudeCodeMcpJsonServersEnabled(resolvedProjectRoot, desiredServerNames);
+
+  if (mcpConfigUnchanged && !localSettingsChanged) {
     return {
       configPath,
       serverName: workflowServerName,
@@ -256,13 +345,6 @@ export function ensureProjectWorkflowMcpConfig(
       status: "unchanged",
     };
   }
-
-  const nextConfig: McpConfigFile = {
-    ...existing,
-    mcpServers: nextServers,
-  };
-
-  writeFileSync(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf-8");
 
   return {
     configPath,

--- a/src/resources/extensions/gsd/tests/mcp-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-filter.test.ts
@@ -48,6 +48,21 @@ describe("discoverMcpServerNames", () => {
     assert.deepEqual(result.sort(), ["server-a", "server-b", "shared"]);
   });
 
+  it("reads from .claude/settings.local.json for Claude Code project-local servers", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mcp-filter-test-"));
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(
+      join(dir, ".claude", "settings.local.json"),
+      JSON.stringify({ mcpServers: { "local-server": {}, "shared": {} } }),
+    );
+    writeFileSync(
+      join(dir, ".claude", "settings.json"),
+      JSON.stringify({ mcpServers: { "project-server": {}, "shared": {} } }),
+    );
+    const result = discoverMcpServerNames(dir);
+    assert.deepEqual(result.sort(), ["local-server", "project-server", "shared"]);
+  });
+
   it("handles .claude/settings.json missing gracefully", () => {
     const dir = mkdtempSync(join(tmpdir(), "mcp-filter-test-"));
     writeFileSync(

--- a/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  ensureClaudeCodeMcpJsonServerEnabled,
   ensureProjectWorkflowMcpConfig,
   GSD_BROWSER_MCP_SERVER_NAME,
   GSD_WORKFLOW_MCP_SERVER_NAME,
@@ -54,6 +55,14 @@ test("ensureProjectWorkflowMcpConfig creates .mcp.json with workflow and browser
     ]);
     assert.equal(browserArgs[mcpArgIndex + 6], projectRoot);
     assert.equal((browserServer as { cwd?: string })?.cwd, projectRoot);
+
+    const settings = JSON.parse(readFileSync(join(projectRoot, ".claude", "settings.local.json"), "utf-8")) as {
+      enabledMcpjsonServers?: string[];
+    };
+    assert.deepEqual(settings.enabledMcpjsonServers, [
+      GSD_WORKFLOW_MCP_SERVER_NAME,
+      GSD_BROWSER_MCP_SERVER_NAME,
+    ]);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -115,6 +124,11 @@ test("ensureProjectWorkflowMcpConfig uses custom workflow server name from env",
     assert.ok(parsed.mcpServers?.["custom-workflow"]);
     assert.ok(parsed.mcpServers?.[GSD_BROWSER_MCP_SERVER_NAME]);
     assert.equal(parsed.mcpServers?.[GSD_WORKFLOW_MCP_SERVER_NAME], undefined);
+
+    const settings = JSON.parse(readFileSync(join(projectRoot, ".claude", "settings.local.json"), "utf-8")) as {
+      enabledMcpjsonServers?: string[];
+    };
+    assert.deepEqual(settings.enabledMcpjsonServers, ["custom-workflow", GSD_BROWSER_MCP_SERVER_NAME]);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -136,6 +150,11 @@ test("ensureProjectWorkflowMcpConfig can disable the default browser MCP server"
     };
     assert.ok(parsed.mcpServers?.[GSD_WORKFLOW_MCP_SERVER_NAME]);
     assert.equal(parsed.mcpServers?.[GSD_BROWSER_MCP_SERVER_NAME], undefined);
+
+    const settings = JSON.parse(readFileSync(join(projectRoot, ".claude", "settings.local.json"), "utf-8")) as {
+      enabledMcpjsonServers?: string[];
+    };
+    assert.deepEqual(settings.enabledMcpjsonServers, [GSD_WORKFLOW_MCP_SERVER_NAME]);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -152,6 +171,55 @@ test("ensureProjectWorkflowMcpConfig is idempotent when config is already curren
     assert.equal(first.status, "created");
     assert.equal(second.status, "unchanged");
     assert.equal(first.configPath, second.configPath);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("ensureProjectWorkflowMcpConfig updates stale Claude Code MCP approval state", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-init-"));
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+  const settingsPath = join(projectRoot, ".claude", "settings.local.json");
+
+  try {
+    const first = ensureProjectWorkflowMcpConfig(projectRoot);
+    assert.equal(first.status, "created");
+
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify({
+        permissions: { allow: ["Bash(gh issue *)"] },
+        enabledMcpjsonServers: [],
+        disabledMcpjsonServers: [GSD_WORKFLOW_MCP_SERVER_NAME, GSD_BROWSER_MCP_SERVER_NAME],
+      }, null, 2)}\n`,
+      "utf-8",
+    );
+
+    const second = ensureProjectWorkflowMcpConfig(projectRoot);
+    assert.equal(second.status, "updated");
+
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as {
+      permissions?: { allow?: string[] };
+      enabledMcpjsonServers?: string[];
+      disabledMcpjsonServers?: string[];
+    };
+    assert.deepEqual(settings.permissions?.allow, ["Bash(gh issue *)"]);
+    assert.deepEqual(settings.enabledMcpjsonServers, [
+      GSD_WORKFLOW_MCP_SERVER_NAME,
+      GSD_BROWSER_MCP_SERVER_NAME,
+    ]);
+    assert.deepEqual(settings.disabledMcpjsonServers, []);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeCodeMcpJsonServerEnabled is idempotent", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-init-"));
+
+  try {
+    assert.equal(ensureClaudeCodeMcpJsonServerEnabled(projectRoot, "gsd-workflow"), true);
+    assert.equal(ensureClaudeCodeMcpJsonServerEnabled(projectRoot, "gsd-workflow"), false);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
@@ -19,6 +19,14 @@ test("shouldAutoPrepareWorkflowMcp enables prep for externalCli local transport"
   assert.equal(result, true);
 });
 
+test("shouldAutoPrepareWorkflowMcp enables prep when Claude Code provider is known before auth mode settles", () => {
+  const result = shouldAutoPrepareWorkflowMcp({
+    model: { provider: "claude-code", baseUrl: "local://claude-code" },
+  });
+
+  assert.equal(result, true);
+});
+
 test("prepareWorkflowMcpForProject uses the selected unit model when session provider differs", (t) => {
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-unit-model-"));
   const notifications: Array<{ message: string; level: "info" | "warning" | "error" | "success" }> = [];
@@ -163,6 +171,13 @@ test("before_agent_start auto-prepares project workflow MCP for Claude Code CLI"
   };
   assert.ok(parsed.mcpServers?.[GSD_WORKFLOW_MCP_SERVER_NAME]);
   assert.ok(parsed.mcpServers?.[GSD_BROWSER_MCP_SERVER_NAME]);
+  const settings = JSON.parse(readFileSync(join(projectRoot, ".claude", "settings.local.json"), "utf-8")) as {
+    enabledMcpjsonServers?: string[];
+  };
+  assert.deepEqual(settings.enabledMcpjsonServers, [
+    GSD_WORKFLOW_MCP_SERVER_NAME,
+    GSD_BROWSER_MCP_SERVER_NAME,
+  ]);
   assert.match(notifications.join("\n"), /Claude Code MCP prepared/);
 });
 

--- a/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
+++ b/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
@@ -58,6 +58,7 @@ export function shouldAutoPrepareWorkflowMcp(ctx: WorkflowMcpAutoPrepContext): b
   const authMode = getAuthModeSafe(ctx, provider);
 
   if (provider !== "claude-code") return false;
+  if (authMode === undefined) return true;
   return usesWorkflowMcpTransport(authMode as any, baseUrl) || authMode === "externalCli";
 }
 


### PR DESCRIPTION
## Summary

This PR makes Claude Code CLI sessions prepare GSD MCP servers automatically before the Claude SDK query starts.

## What changed

- Auto-initialize the project GSD MCP config from the Claude Code stream adapter before building SDK options.
- Load both `project` and `local` Claude Code settings so approved `.mcp.json` servers are available to the SDK.
- Update `.claude/settings.local.json` with `enabledMcpjsonServers` for every GSD-managed server written to `.mcp.json`, including `gsd-workflow` and `gsd-browser`, and remove those names from `disabledMcpjsonServers`.
- Include `.claude/settings.local.json` in MCP discovery so local project server config participates in filtering.
- Allow MCP prep as soon as the active provider is `claude-code`, even if auth-mode metadata has not settled yet.

## Why

Claude Code can reject calls like `mcp__gsd-workflow__gsd_exec` when GSD has written `.mcp.json` but Claude has not approved or loaded the project-scoped server. That leaves GSD advertising workflow MCP tools that are not actually available in the Claude Code run.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/mcp-project-config.test.ts src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts src/resources/extensions/gsd/tests/mcp-filter.test.ts src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm exec tsc --noEmit --pretty false`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782929575&installation_id=134682257&pr_number=369&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F369&signature=76caa365ac9f2012578d7abe26279b778f3edf76bfca1a2af542fca2cbd2a9ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically writes or updates project `.mcp.json` and `.claude/settings.local.json` on each Claude Code stream start, which could surprise repos with hand-tuned MCP settings.
> 
> **Overview**
> Claude Code sessions now **auto-prepare GSD MCP** before the Agent SDK `query()` runs: the stream adapter calls `autoInitClaudeCodeWorkflowMcp`, which ensures project `.mcp.json` and Claude’s local approval state stay in sync.
> 
> **SDK settings:** `buildSdkOptions` loads **`project` and `local`** `settingSources` so approved `.mcp.json` servers are actually available to Claude Code.
> 
> **On-disk approval:** When GSD writes workflow/browser entries to `.mcp.json`, it also updates **`.claude/settings.local.json`**—merging `enabledMcpjsonServers` for each GSD-managed server and removing those names from `disabledMcpjsonServers`. MCP discovery now includes **`settings.local.json`** so local server definitions participate in filtering.
> 
> **Prep timing:** Workflow MCP auto-prep runs as soon as the active provider is **`claude-code`**, even before auth-mode metadata is known.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c6d217fdef250bc18b9bc42a46fb594a5e80aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->