### PR TITLE
[codex] Prevent closed milestone resume drift

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -91,6 +91,7 @@ import { nativeHasChanges, nativeIsRepo, _resetHasChangesCache } from "./native-
 import { debugLog, isDebugEnabled } from "./debug-logger.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+import { detectWorktreeName } from "./worktree.js";
 import { probeGitConflictState } from "./git-conflict-state.js";
 import { runTurnGitAction } from "./git-service.js";
 import { parseUnitId } from "./unit-id.js";
@@ -338,6 +339,29 @@ function isRegistryMilestoneComplete(state: GSDState, mid: string): boolean {
   return state.registry.some((milestone) =>
     milestone.id === mid && milestone.status === "complete"
   );
+}
+
+function normalizeMilestoneScope(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !MILESTONE_ID_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+function resolveDispatchMilestoneScope(
+  ctx: DispatchContext,
+): { id: string; source: string } | null {
+  const sessionMilestone = normalizeMilestoneScope(ctx.session?.currentMilestoneId);
+  if (sessionMilestone) return { id: sessionMilestone, source: "session.currentMilestoneId" };
+
+  const sessionWorktree = normalizeMilestoneScope(
+    ctx.session?.basePath ? detectWorktreeName(ctx.session.basePath) : null,
+  );
+  if (sessionWorktree) return { id: sessionWorktree, source: "session.basePath worktree" };
+
+  const baseWorktree = normalizeMilestoneScope(detectWorktreeName(ctx.basePath));
+  if (baseWorktree) return { id: baseWorktree, source: "basePath worktree" };
+
+  return null;
 }
 
 function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
@@ -1631,6 +1655,19 @@ import { getRegistry } from "./rule-registry.js";
 export async function resolveDispatch(
   ctx: DispatchContext,
 ): Promise<DispatchAction> {
+  if (ctx.mid && isDbAvailable()) {
+    const milestone = getMilestone(ctx.mid);
+    if (milestone && isClosedStatus(milestone.status)) {
+      return {
+        action: "stop",
+        reason:
+          `Milestone ${ctx.mid} is closed (status: ${milestone.status}); auto-mode will not reopen or recover it implicitly. ` +
+          "Use an explicit reopen command before planning or executing more work for this milestone.",
+        level: "warning",
+      };
+    }
+  }
+
   const activeMid = ctx.state.activeMilestone?.id;
   if (activeMid && ctx.mid !== activeMid) {
     return {
@@ -1638,6 +1675,17 @@ export async function resolveDispatch(
       reason:
         `Dispatch milestone mismatch: context mid "${ctx.mid}" does not match active milestone "${activeMid}". ` +
         "This usually means a project-level deep setup pseudo-id leaked into milestone dispatch; rerun /gsd auto after setup state is reconciled.",
+      level: "warning",
+    };
+  }
+
+  const scopedMilestone = resolveDispatchMilestoneScope(ctx);
+  if (scopedMilestone && ctx.mid !== scopedMilestone.id) {
+    return {
+      action: "stop",
+      reason:
+        `Dispatch milestone mismatch: context mid "${ctx.mid}" does not match ${scopedMilestone.source} "${scopedMilestone.id}". ` +
+        "The active worktree/session and derived project state disagree; recover, park, or discard the stranded milestone before continuing.",
       level: "warning",
     };
   }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -60,12 +60,13 @@ import { getAutoWorktreePath, isInAutoWorktree, checkoutBranchWithStashGuard } f
 import { readResourceVersion, cleanStaleRuntimeUnits } from "./auto-worktree.js";
 import { worktreePath as getWorktreeDir, isInsideWorktreesDir } from "./worktree-manager.js";
 import { emitWorktreeOrphaned } from "./worktree-telemetry.js";
+import { queryJournal } from "./journal.js";
 import { initMetrics } from "./metrics.js";
 import { initRoutingHistory } from "./routing-history.js";
 import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
-import { isDbAvailable, getMilestone, getAllMilestones, insertMilestone, openDatabase, getDbStatus } from "./gsd-db.js";
+import { isDbAvailable, getMilestone, getAllMilestones, insertMilestone, openDatabase, getDbStatus, updateMilestoneStatus } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { extractVerdict } from "./verdict-parser.js";
@@ -185,6 +186,40 @@ export function reconcileProjectMilestonesFromDisk(basePath: string): number {
     );
     return 0;
   }
+}
+
+export function reconcileMergedMilestonesFromJournal(basePath: string): number {
+  if (!isDbAvailable()) return 0;
+
+  const mergedAtByMilestone = new Map<string, string>();
+  for (const entry of queryJournal(basePath, { eventType: "worktree-merged" })) {
+    const data = entry.data ?? {};
+    const milestoneId = typeof data.milestoneId === "string" ? data.milestoneId : null;
+    if (!milestoneId) continue;
+    if (data.conflict === true) continue;
+
+    const endedAt = typeof data.endedAt === "string" ? data.endedAt : entry.ts;
+    const previous = mergedAtByMilestone.get(milestoneId);
+    if (!previous || endedAt > previous) mergedAtByMilestone.set(milestoneId, endedAt);
+  }
+
+  let closed = 0;
+  for (const [milestoneId, completedAt] of mergedAtByMilestone) {
+    const existing = getMilestone(milestoneId);
+    if (!existing) {
+      insertMilestone({ id: milestoneId, title: milestoneId, status: "complete" });
+      updateMilestoneStatus(milestoneId, "complete", completedAt);
+      closed++;
+      continue;
+    }
+    if (!isClosedStatus(existing.status)) {
+      updateMilestoneStatus(milestoneId, "complete", completedAt);
+      closed++;
+    }
+  }
+
+  if (closed > 0) invalidateAllCaches();
+  return closed;
 }
 
 /**
@@ -332,6 +367,25 @@ function strandedWorkMessage(args: {
     wtSuffix +
     ` ${recovery} Park or discard explicitly if abandoning.`
   );
+}
+
+function formatStrandedWorkBlockerMessage(
+  action: OrphanAuditAction,
+  activeMilestoneId: string | null,
+): string {
+  const target = action.milestoneId;
+  const mode = action.recoveryMode === "worktree" ? "existing worktree" : "milestone branch";
+  const intro = activeMilestoneId
+    ? `Stranded work for ${target} blocks auto-mode before ${activeMilestoneId}.`
+    : `Stranded work for ${target} blocks auto-mode, but that milestone is not active in project state.`;
+
+  return [
+    intro,
+    "Choose one explicit next step:",
+    `1. Recover it: run \`/gsd auto ${target}\` to adopt the ${mode}.`,
+    `2. Defer it: run \`/gsd park ${target} "reason"\`, then rerun \`/gsd auto\`.`,
+    `3. Abandon it: run \`/gsd rethink\` and explicitly discard ${target}.`,
+  ].join("\n");
 }
 
 export function auditOrphanedMilestoneBranches(
@@ -1066,6 +1120,7 @@ export async function bootstrapAutoSession(
     await openProjectDbIfPresent(base);
     registerAutoWorkerForSession(base);
     reconcileProjectMilestonesFromDisk(base);
+    reconcileMergedMilestonesFromJournal(base);
 
     // Clean stale runtime unit files for completed milestones (#887).
     // DB-authoritative: when DB is available, require DB status to be closed
@@ -1177,14 +1232,14 @@ export async function bootstrapAutoSession(
     if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {
         ctx.ui.notify(
-          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode, but that milestone is not active in project state. Park or discard it explicitly before continuing.`,
+          formatStrandedWorkBlockerMessage(blockingStrandedRecoveryAction, null),
           "error",
         );
         return releaseLockAndReturn();
       }
       if (state.activeMilestone.id !== blockingStrandedRecoveryAction.milestoneId) {
         ctx.ui.notify(
-          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode before ${state.activeMilestone.id}. Recover, park, or discard ${blockingStrandedRecoveryAction.milestoneId} explicitly before continuing.`,
+          formatStrandedWorkBlockerMessage(blockingStrandedRecoveryAction, state.activeMilestone.id),
           "error",
         );
         return releaseLockAndReturn();

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -254,7 +254,12 @@ import {
   postUnitPreVerification,
   postUnitPostVerification,
 } from "./auto-post-unit.js";
-import { bootstrapAutoSession, openProjectDbIfPresent, type BootstrapDeps } from "./auto-start.js";
+import {
+  bootstrapAutoSession,
+  openProjectDbIfPresent,
+  reconcileMergedMilestonesFromJournal,
+  type BootstrapDeps,
+} from "./auto-start.js";
 import { initHealthWidget } from "./health-widget.js";
 import { runLegacyAutoLoop, runUokKernelLoop } from "./auto/loop.js";
 import { resolveAgentEnd, resolveAgentEndCancelled, _resetPendingResolve, isSessionSwitchInFlight } from "./auto/resolve.js";
@@ -2955,6 +2960,7 @@ export async function startAuto(
     if (!getLedger()) initMetrics(base);
     if (s.currentMilestoneId) setActiveMilestoneId(base, s.currentMilestoneId);
     await openProjectDbIfPresent(base);
+    reconcileMergedMilestonesFromJournal(base);
     registerAutoWorkerForSession(s, base);
 
     // Re-register health level notification callback lost across process restart

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2107,6 +2107,28 @@ export function createWiredDispatchAdapter(
     return null;
   }
 
+  function shouldAdoptActiveMilestone(
+    state: GSDState,
+    activeSession: AutoSession | undefined,
+    activeDispatchBasePath: string,
+  ): boolean {
+    const activeMilestoneId = state.activeMilestone?.id;
+    const currentMilestoneId = activeSession?.currentMilestoneId;
+    if (!activeSession || !activeMilestoneId || !currentMilestoneId || activeMilestoneId === currentMilestoneId) {
+      return false;
+    }
+
+    const scopedWorktreeMilestone =
+      (activeSession.basePath ? detectWorktreeName(activeSession.basePath) : null) ??
+      detectWorktreeName(activeDispatchBasePath);
+    if (scopedWorktreeMilestone && scopedWorktreeMilestone !== activeMilestoneId) {
+      return false;
+    }
+
+    const currentMilestone = state.registry.find((milestone) => milestone.id === currentMilestoneId);
+    return !!currentMilestone && isClosedStatus(currentMilestone.status);
+  }
+
   return {
     async decideNextUnit(input) {
       const state = input.stateSnapshot;
@@ -2115,6 +2137,9 @@ export function createWiredDispatchAdapter(
 
       const activeSession = input.session ?? session;
       const activeDispatchBasePath = activeSession?.basePath || dispatchBasePath;
+      if (activeSession && shouldAdoptActiveMilestone(state, activeSession, activeDispatchBasePath)) {
+        activeSession.currentMilestoneId = active.id;
+      }
       const prefs = loadEffectiveGSDPreferences(activeDispatchBasePath)?.preferences;
 
       // Derive session-derived dispatch inputs the same way phases.ts:runDispatch does

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -55,6 +55,7 @@ import {
 import { rowToGate } from "./db-gate-rows.js";
 import { rowToArtifact, rowToMilestone, type ArtifactRow, type MilestoneRow } from "./db-milestone-artifact-rows.js";
 import { backupDatabaseBeforeMigration } from "./db-migration-backup.js";
+import { isClosedStatus } from "./status-guards.js";
 import {
   applyMigrationV2Artifacts,
   applyMigrationV3Memories,
@@ -1665,16 +1666,50 @@ export function setMilestoneQueueOrder(order: string[]): void {
   }
 }
 
-/**
- * Update a milestone's status in the database.
- * Used by park/unpark to keep the DB in sync with the filesystem marker.
- * See: https://github.com/open-gsd/gsd-pi/issues/2694
- */
-export function updateMilestoneStatus(milestoneId: string, status: string, completedAt?: string | null): void {
+function getMilestoneStatusForUpdate(milestoneId: string): string | null {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const row = currentDb.prepare("SELECT status FROM milestones WHERE id = :id").get({ ":id": milestoneId });
+  return typeof row?.["status"] === "string" ? row["status"] : null;
+}
+
+function writeMilestoneStatus(milestoneId: string, status: string, completedAt?: string | null): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     `UPDATE milestones SET status = :status, completed_at = :completed_at WHERE id = :id`,
   ).run({ ":status": status, ":completed_at": completedAt ?? null, ":id": milestoneId });
+}
+
+/**
+ * Update a milestone's status in the database.
+ *
+ * Generic status updates may close milestones, park/unpark open milestones, or
+ * advance planned milestones. They may not reopen a closed milestone; callers
+ * must use reopenMilestoneStatus(), which is reserved for gsd_milestone_reopen.
+ */
+export function updateMilestoneStatus(milestoneId: string, status: string, completedAt?: string | null): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const currentStatus = getMilestoneStatusForUpdate(milestoneId);
+  if (currentStatus && isClosedStatus(currentStatus) && !isClosedStatus(status)) {
+    throw new Error(
+      `Cannot update closed milestone ${milestoneId} from ${currentStatus} to ${status}; use gsd_milestone_reopen for an explicit reopen.`,
+    );
+  }
+  writeMilestoneStatus(milestoneId, status, completedAt);
+}
+
+/**
+ * Explicit closed -> active transition for gsd_milestone_reopen only.
+ */
+export function reopenMilestoneStatus(milestoneId: string): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const currentStatus = getMilestoneStatusForUpdate(milestoneId);
+  if (!currentStatus) {
+    throw new Error(`Cannot reopen missing milestone ${milestoneId}`);
+  }
+  if (!isClosedStatus(currentStatus)) {
+    throw new Error(`Cannot reopen milestone ${milestoneId} from status ${currentStatus}; milestone is not closed.`);
+  }
+  writeMilestoneStatus(milestoneId, "active", null);
 }
 
 export function getActiveMilestoneFromDb(): MilestoneRow | null {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1246,6 +1246,92 @@ test("wired DispatchAdapter forwards constructor session when advance input omit
   }
 });
 
+test("wired DispatchAdapter adopts next active milestone after the session milestone is closed", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-milestone-adopt-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const stateSnapshot: GSDState = {
+    ...makeState(),
+    activeMilestone: { id: "M002", title: "Next" },
+    registry: [
+      { id: "M001", title: "First", status: "complete" },
+      { id: "M002", title: "Next", status: "active" },
+    ],
+  };
+  const captured: DispatchContext[] = [];
+  const captureRule: UnifiedRule = {
+    name: "test-milestone-adoption",
+    when: "dispatch",
+    evaluation: "first-match",
+    where: async (ctx: DispatchContext) => {
+      captured.push(ctx);
+      return {
+        action: "dispatch" as const,
+        unitType: "execute-task",
+        unitId: "M002/S01/T01",
+        prompt: "adopted-milestone-fixture",
+      };
+    },
+    then: (r: unknown) => r,
+  };
+  setRegistry(new RuleRegistry([captureRule]));
+
+  try {
+    const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;
+    const pi = { getActiveTools: () => [] } as any;
+    const session = {
+      basePath: base,
+      originalBasePath: base,
+      currentMilestoneId: "M001",
+    } as any;
+    const adapter = createWiredDispatchAdapter(ctx, pi, base, session);
+
+    const result = await adapter.decideNextUnit({ stateSnapshot });
+
+    assert.ok(result);
+    if (!("unitType" in result)) assert.fail(`expected dispatch decision, got ${JSON.stringify(result)}`);
+    assert.equal(result.unitId, "M002/S01/T01");
+    assert.equal(session.currentMilestoneId, "M002");
+    assert.equal(captured[0]?.session?.currentMilestoneId, "M002");
+  } finally {
+    resetRegistry();
+  }
+});
+
+test("wired DispatchAdapter keeps blocking stale milestone worktree scope", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-worktree-block-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const stateSnapshot: GSDState = {
+    ...makeState(),
+    activeMilestone: { id: "M002", title: "Next" },
+    registry: [
+      { id: "M001", title: "First", status: "complete" },
+      { id: "M002", title: "Next", status: "active" },
+    ],
+  };
+  const worktreePath = join(base, ".gsd", "worktrees", "M001");
+  mkdirSync(worktreePath, { recursive: true });
+  const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;
+  const pi = { getActiveTools: () => [] } as any;
+  const session = {
+    basePath: worktreePath,
+    originalBasePath: base,
+    currentMilestoneId: "M001",
+  } as any;
+  const adapter = createWiredDispatchAdapter(ctx, pi, base, session);
+
+  const result = await adapter.decideNextUnit({ stateSnapshot });
+
+  assert.deepEqual(result, {
+    kind: "blocked",
+    reason:
+      'Dispatch milestone mismatch: context mid "M002" does not match session.currentMilestoneId "M001". The active worktree/session and derived project state disagree; recover, park, or discard the stranded milestone before continuing.',
+    action: "pause",
+  });
+  assert.equal(session.currentMilestoneId, "M001");
+});
+
 test("wired DispatchAdapter replays pending verification retry dispatch", async () => {
   const stateSnapshot = makeState();
   const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;

--- a/src/resources/extensions/gsd/tests/auto-start-project-milestone-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-project-milestone-reconcile.test.ts
@@ -4,11 +4,33 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { closeDatabase, getAllMilestones, insertMilestone, isDbAvailable, openDatabase } from "../gsd-db.ts";
-import { reconcileProjectMilestonesFromDisk } from "../auto-start.ts";
+import { closeDatabase, getAllMilestones, getMilestone, insertMilestone, isDbAvailable, openDatabase } from "../gsd-db.ts";
+import { reconcileMergedMilestonesFromJournal, reconcileProjectMilestonesFromDisk } from "../auto-start.ts";
+import { emitWorktreeMerged } from "../worktree-telemetry.ts";
 
 test.afterEach(() => {
   if (isDbAvailable()) closeDatabase();
+});
+
+test("bootstrap reconciliation treats a successful worktree merge as milestone closed", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-merged-reconcile-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Merged Milestone", status: "active" });
+
+    emitWorktreeMerged(base, "M001", { reason: "milestone-complete", conflict: false });
+
+    const closed = reconcileMergedMilestonesFromJournal(base);
+    const row = getMilestone("M001");
+
+    assert.equal(closed, 1);
+    assert.equal(row?.status, "complete");
+    assert.ok(row?.completed_at);
+  } finally {
+    if (isDbAvailable()) closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("#5389: bootstrap reconciles PROJECT.md milestones that are missing from DB", () => {

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -19,6 +19,7 @@ import type { DispatchContext } from "../auto-dispatch.ts";
 import type { AutoSession } from "../auto/session.ts";
 import type { GSDState } from "../types.ts";
 import { enableDebug, disableDebug, getDebugLogPath } from "../debug-logger.ts";
+import { closeDatabase, insertMilestone, isDbAvailable, openDatabase } from "../gsd-db.ts";
 
 function makeState(overrides: Partial<GSDState> = {}): GSDState {
   return {
@@ -123,6 +124,29 @@ test("dispatch: missing task plan triggers plan-slice (not stop) — issue #909"
     `unitId should be M002/S03, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
 });
 
+test("dispatch: closed milestone is not implicitly recovered or reopened", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-closed-dispatch-"));
+  t.after(() => {
+    if (isDbAvailable()) closeDatabase();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  if (isDbAvailable()) closeDatabase();
+  mkdirSync(join(tmp, ".gsd"), { recursive: true });
+  openDatabase(join(tmp, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M002", title: "Closed Milestone", status: "complete" });
+  scaffoldMilestoneContext(tmp, "M002");
+  scaffoldSlicePlan(tmp, "M002", "S03");
+
+  const result = await resolveDispatch(makeContext(tmp));
+
+  assert.equal(result.action, "stop");
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "warning");
+  assert.match(result.reason, /Milestone M002 is closed/);
+  assert.match(result.reason, /will not reopen or recover it implicitly/);
+});
+
 test("dispatch: present task plan proceeds to execute-task normally", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-909-ok-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
@@ -139,6 +163,42 @@ test("dispatch: present task plan proceeds to execute-task normally", async (t) 
     `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
   assert.ok(result.action === "dispatch" && result.unitId === "M002/S03/T01",
     `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
+});
+
+test("dispatch: session milestone mismatch stops before missing-task-plan recovery", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-session-milestone-mismatch-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M002");
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  const ctx = makeContextFor(tmp, "M001", "S01", "T01", {
+    basePath: worktreeRoot,
+    originalBasePath: tmp,
+    currentMilestoneId: "M002",
+  });
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "stop");
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "warning");
+  assert.match(result.reason, /context mid "M001" does not match session\.currentMilestoneId "M002"/);
+});
+
+test("dispatch: worktree path mismatch stops before planning a different milestone", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-worktree-path-milestone-mismatch-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M002");
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  const ctx = makeContextFor(worktreeRoot, "M001", "S01", "T01");
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "stop");
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "warning");
+  assert.match(result.reason, /context mid "M001" does not match basePath worktree "M002"/);
 });
 
 test("dispatch: executing recovery checks active milestone worktree task plans before re-dispatching plan-slice", async (t) => {

--- a/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
@@ -50,6 +50,7 @@ import { handleCompleteSlice } from "../../tools/complete-slice.ts";
 import { handleCompleteMilestone } from "../../tools/complete-milestone.ts";
 import { handleReopenTask } from "../../tools/reopen-task.ts";
 import { handleReopenSlice } from "../../tools/reopen-slice.ts";
+import { handleReopenMilestone } from "../../tools/reopen-milestone.ts";
 
 // ── State derivation ──────────────────────────────────────────────────────
 import {
@@ -700,9 +701,7 @@ describe("state-machine-live-validation", () => {
       assert.match((result as any).error, /closed milestone/);
     });
 
-    test("no reopen-milestone tool exists — milestone completion is irrevocable (H5)", async () => {
-      // This test documents the H5 finding: there is no handleReopenMilestone function.
-      // A completed milestone can only be undone via direct DB manipulation.
+    test("closed milestone cannot be reopened by generic DB update", async () => {
       base = createFullFixture();
       openDatabase(join(base, ".gsd", "gsd.db"));
       insertMilestone({ id: "M001", title: "Done", status: "complete" });
@@ -710,10 +709,18 @@ describe("state-machine-live-validation", () => {
       const milestone = getMilestone("M001");
       assert.ok(isClosedStatus(milestone!.status), "milestone is closed");
 
-      // The only escape is direct DB manipulation — no handler exists
-      updateMilestoneStatus("M001", "active", null);
+      assert.throws(
+        () => updateMilestoneStatus("M001", "active", null),
+        /use gsd_milestone_reopen for an explicit reopen/,
+      );
+
+      const result = await handleReopenMilestone(
+        { milestoneId: "M001", reason: "regression surfaced after closure" },
+        base,
+      );
+      assert.ok(!("error" in result), `unexpected reopen error: ${"error" in result ? result.error : ""}`);
       const reopened = getMilestone("M001");
-      assert.equal(reopened!.status, "active", "direct DB manipulation can reopen, but no tool exposes this");
+      assert.equal(reopened!.status, "active", "explicit reopen handler reopens the milestone");
     });
   });
 

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -148,6 +148,7 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
   const freshStartSectionIdx = startAutoBody.indexOf("// ── Fresh start path — delegated to auto-start.ts ──");
   const resumeBody = startAutoBody.slice(resumeSectionIdx, freshStartSectionIdx);
   const resumeDbOpenIdx = resumeBody.indexOf("await openProjectDbIfPresent(base);");
+  const resumeMergeReconcileIdx = resumeBody.indexOf("reconcileMergedMilestonesFromJournal(base);");
   const resumeRegisterIdx = resumeBody.indexOf("registerAutoWorkerForSession(s, base);");
   const resumeEnterMilestoneIdx = resumeBody.indexOf("buildLifecycle().enterMilestone");
   const dbOpenIdx = bootstrapBody.indexOf("await openProjectDbIfPresent(base);");
@@ -164,6 +165,7 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
   assert.ok(resumeSectionIdx > -1, "startAuto should have resume milestone entry flow");
   assert.ok(freshStartSectionIdx > resumeSectionIdx, "resume assertions should be scoped before fresh start");
   assert.ok(resumeDbOpenIdx > -1, "resume should open DB before milestone entry");
+  assert.ok(resumeMergeReconcileIdx > -1, "resume should reconcile merged milestones before deriving dispatch state");
   assert.ok(resumeRegisterIdx > -1, "resume should register worker before milestone entry");
   assert.ok(resumeEnterMilestoneIdx > -1, "resume should enter milestones through lifecycle");
   assert.ok(bootstrapIdx > -1, "bootstrapAutoSession should exist");
@@ -179,8 +181,10 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
     "bootstrap must open DB and register worker before first enterMilestone",
   );
   assert.ok(
-    resumeDbOpenIdx < resumeRegisterIdx && resumeRegisterIdx < resumeEnterMilestoneIdx,
-    "resume must open DB and register worker before first enterMilestone",
+    resumeDbOpenIdx < resumeMergeReconcileIdx &&
+      resumeMergeReconcileIdx < resumeRegisterIdx &&
+      resumeRegisterIdx < resumeEnterMilestoneIdx,
+    "resume must open DB, reconcile merged milestones, and register worker before first enterMilestone",
   );
 });
 

--- a/src/resources/extensions/gsd/tools/reopen-milestone.ts
+++ b/src/resources/extensions/gsd/tools/reopen-milestone.ts
@@ -13,7 +13,7 @@ import {
   getMilestone,
   getMilestoneSlices,
   getSliceTasks,
-  updateMilestoneStatus,
+  reopenMilestoneStatus,
   updateSliceStatus,
   updateTaskStatus,
   transaction,
@@ -69,7 +69,7 @@ export async function handleReopenMilestone(
       return;
     }
 
-    updateMilestoneStatus(params.milestoneId, "active", null);
+    reopenMilestoneStatus(params.milestoneId);
 
     const slices = getMilestoneSlices(params.milestoneId);
     slicesResetCount = slices.length;

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -49,6 +49,8 @@ import {
 import { loadEffectiveGSDPreferences, getIsolationMode } from "./preferences.js";
 import { invalidateAllCaches } from "./cache.js";
 import { resolveMilestoneFile } from "./paths.js";
+import { getMilestone, insertMilestone, isDbAvailable, updateMilestoneStatus } from "./gsd-db.js";
+import { isClosedStatus } from "./status-guards.js";
 import type { WorktreeStateProjection } from "./worktree-state-projection.js";
 import { createWorkspace, scopeMilestone } from "./workspace.js";
 // ADR-016 phase 2 / C1 (#5624): file-system + git-CLI leaf primitives
@@ -83,6 +85,28 @@ const MERGE_FAILURE_DEDUPE_MS = 60_000;
 
 export function resetRecentWorktreeMergeFailuresForTest(): void {
   recentWorktreeMergeFailures.clear();
+}
+
+function markMilestoneClosedAfterMerge(milestoneId: string, completedAt: string): void {
+  if (!isDbAvailable()) return;
+  try {
+    const existing = getMilestone(milestoneId);
+    if (!existing) {
+      insertMilestone({ id: milestoneId, title: milestoneId, status: "complete" });
+      updateMilestoneStatus(milestoneId, "complete", completedAt);
+      invalidateAllCaches();
+      return;
+    }
+    if (!isClosedStatus(existing.status)) {
+      updateMilestoneStatus(milestoneId, "complete", completedAt);
+      invalidateAllCaches();
+    }
+  } catch (err) {
+    logWarning(
+      "worktree",
+      `Merged ${milestoneId} but failed to mark milestone complete in DB: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────
@@ -1716,6 +1740,8 @@ export class WorktreeLifecycle {
 
     // #4764 — record merge completion. Only reaches here when an actual
     // merge ran; failure paths throw out before this point.
+    const mergeCompletedAt = new Date().toISOString();
+    markMilestoneClosedAfterMerge(milestoneId, mergeCompletedAt);
     try {
       emitWorktreeMerged(
         this.s.originalBasePath || this.s.basePath,


### PR DESCRIPTION
## Summary

- Treat successful `worktree-merged` journal events as authoritative milestone closure on fresh bootstrap and paused-session resume.
- Mark milestones complete in the DB immediately after successful worktree merge.
- Block auto-dispatch and generic DB status writes from implicitly reopening closed milestones; only `gsd_milestone_reopen` can perform the explicit closed -> active transition.
- Add regression coverage for closed-milestone dispatch, session/worktree milestone mismatch, paused resume reconciliation order, and explicit reopen behavior.

## Root Cause

A milestone could be closed in Git/journal/project state while the DB still said it was active. On paused-session resume, GSD opened the DB and resumed from the persisted session/worktree before running the merge-journal reconciliation that fresh bootstrap used. That allowed stale derived state (`M001`) to collide with the active session/worktree milestone (`M002`) and produce the dispatch milestone mismatch pause.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-start-project-milestone-reconcile.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/start-auto-detached.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782954846&installation_id=134682257&pr_number=383&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F383&signature=ed10e22b2876abf92094860999f3d04745867e56b1b573acb463cf656839d590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto bootstrap/resume ordering, dispatch gating, and milestone status transitions in the DB; behavior changes are guarded by tests but affect core auto-mode flow.
> 
> **Overview**
> This PR aligns **milestone closure in the DB** with **successful worktree merges** and stops auto-mode from silently drifting across milestones on resume.
> 
> **Closure and reconciliation:** Successful `worktree-merged` journal events (non-conflict) now close milestones in SQLite via `reconcileMergedMilestonesFromJournal`, on **fresh bootstrap** and on **paused-session resume** (before state derivation). `worktree-lifecycle` also marks the milestone complete immediately after merge.
> 
> **Dispatch and DB guards:** `resolveDispatch` stops on closed milestones (no implicit reopen) and on mismatches between dispatch `mid`, `session.currentMilestoneId`, and worktree-derived scope. The wired orchestrator can adopt the project’s active milestone when the session still points at a **closed** milestone, unless a stale worktree scope blocks it. Stranded-work blockers now spell out recover / park / discard steps.
> 
> **Reopen path:** `updateMilestoneStatus` rejects closed → open transitions; only `reopenMilestoneStatus` (used by `gsd_milestone_reopen`) may reopen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 140a6df3daedb067e4a2353d680fcdd3dcfd4af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->