### PR TITLE
[codex] guard gsd recover and rebuild markdown projections

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -100,7 +100,9 @@ After writing the file, GSD attempts to open it in a browser using the local pla
 | `/gsd hooks` | Show configured post-unit and pre-dispatch hooks |
 | `/gsd run-hook` | Manually trigger a specific hook |
 | `/gsd migrate` | Migrate a v1 `.planning` directory to `.gsd` format |
-| `/gsd recover` | Explicitly reset database hierarchy plus persisted validation and quality-gate state, then reconstruct from rendered markdown after database loss or corruption |
+| `/gsd recover --confirm` | Explicitly reset database hierarchy plus persisted validation and quality-gate state, then reconstruct from rendered markdown after database loss or corruption |
+| `/gsd rebuild markdown` | Rebuild markdown projections from the canonical database; stale completion projections are quarantined, not imported |
+| `/gsd rebuild database` | Reserved for DB-native rebuilds; does not import markdown projections |
 | `/gsd language <language\|off\|clear>` | Set or clear the global response language |
 
 ## Milestone Management
@@ -388,7 +390,7 @@ Any `/gsd` subcommand works as a positional argument — `gsd headless status`, 
 
 ### `gsd headless recover` (v2.79)
 
-Non-TTY equivalent of `/gsd recover` — resets the DB hierarchy plus persisted validation and quality-gate state, then reconstructs from rendered markdown. Designed for CI, cron, and any environment where the interactive recover prompt cannot run.
+Non-TTY equivalent of `/gsd recover --confirm` — resets the DB hierarchy plus persisted validation and quality-gate state, then reconstructs from rendered markdown. Designed for CI, cron, and any environment where the interactive recover prompt cannot run.
 
 ```bash
 gsd headless recover

--- a/docs/user-docs/migration.md
+++ b/docs/user-docs/migration.md
@@ -58,7 +58,7 @@ This checks database and projection integrity and flags any structural issues. U
 If an existing project has markdown artifacts but a missing or damaged database, start GSD once so the database opens, then run:
 
 ```
-/gsd recover
+/gsd recover --confirm
 ```
 
-`/gsd recover` clears the persisted hierarchy plus validation-related state, including quality-gate rows and skipped-validation assessments, then reconstructs the milestone, slice, and task hierarchy from the rendered markdown on disk. It is an explicit destructive recovery/import operation; normal runtime does not silently derive state from markdown.
+`/gsd recover --confirm` clears the persisted hierarchy plus validation-related state, including quality-gate rows and skipped-validation assessments, then reconstructs the milestone, slice, and task hierarchy from the rendered markdown on disk. It is an explicit destructive recovery/import operation; normal runtime does not silently derive state from markdown.

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -477,10 +477,10 @@ Doctor checks the authoritative database, refreshes `STATE.md` from derived data
 Use this only when the database is missing, damaged, or known to be stale but the rendered milestone, slice, and task markdown on disk is the best available source:
 
 ```
-/gsd recover
+/gsd recover --confirm
 ```
 
-`/gsd recover` clears the database hierarchy tables plus persisted validation/gate state from prior runs, including quality-gate rows and skipped-validation assessments, then reconstructs the hierarchy from markdown and derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
+`/gsd recover --confirm` clears the database hierarchy tables plus persisted validation/gate state from prior runs, including quality-gate rows and skipped-validation assessments, then reconstructs the hierarchy from markdown and derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
 
 For non-TTY environments (CI, cron, scripted automation), v2.79 adds `gsd headless recover` — same semantics, no interactive prompt. Exits non-zero on failure.
 
@@ -527,7 +527,7 @@ For non-TTY environments (CI, cron, scripted automation), v2.79 adds `gsd headle
 
 **Cause:** The SQLite database was not initialized or could not be opened. Runtime state derivation will not silently fall back to markdown projections.
 
-**Fix:** Upgrade to the latest version, then run a GSD command from the project root to initialize or open the database. Use `/gsd inspect` for database diagnostics. If the database was lost or corrupted and markdown artifacts are the only usable state, run `/gsd recover` after GSD has opened the database.
+**Fix:** Upgrade to the latest version, then run a GSD command from the project root to initialize or open the database. Use `/gsd inspect` for database diagnostics. If the database was lost or corrupted and markdown artifacts are the only usable state, run `/gsd recover --confirm` after GSD has opened the database.
 
 ## Verification Issues
 

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -53,7 +53,9 @@
 | `/gsd skill-health` | Skill lifecycle dashboard |
 | `/gsd hooks` | Show configured hooks |
 | `/gsd migrate` | Migrate v1 `.planning` to DB-backed `.gsd` with backup and audit |
-| `/gsd recover` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
+| `/gsd recover --confirm` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
+| `/gsd rebuild markdown` | Rebuild markdown projections from the canonical database; stale completion projections are quarantined, not imported |
+| `/gsd rebuild database` | Reserved for DB-native rebuilds; does not import markdown projections |
 
 ## Milestone Management
 

--- a/gitbook/reference/migration.md
+++ b/gitbook/reference/migration.md
@@ -58,7 +58,7 @@ This checks `.gsd/` integrity and flags any structural issues.
 Use `/gsd inspect` for database diagnostics. If a project has markdown artifacts but a missing or damaged database, start GSD once so the database opens, then run:
 
 ```
-/gsd recover
+/gsd recover --confirm
 ```
 
-`/gsd recover` reconstructs the milestone, slice, and task hierarchy from rendered markdown. It is an explicit recovery/import operation; normal runtime does not silently derive state from markdown.
+`/gsd recover --confirm` reconstructs the milestone, slice, and task hierarchy from rendered markdown. It is an explicit recovery/import operation; normal runtime does not silently derive state from markdown.

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -205,10 +205,10 @@ Checks the authoritative database, refreshes `STATE.md` from derived database st
 Use this only when the database is missing, damaged, or known to be stale but the rendered milestone, slice, and task markdown on disk is the best available source:
 
 ```
-/gsd recover
+/gsd recover --confirm
 ```
 
-`/gsd recover` clears and reconstructs the database hierarchy tables from markdown, then derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
+`/gsd recover --confirm` clears and reconstructs the database hierarchy tables from markdown, then derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
 
 ## Getting Help
 

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2134,8 +2134,8 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
               await renderPlanCheckboxes(s.canonicalProjectRoot, mid, sid);
             } catch (dbErr) {
               // DB unavailable — fail explicitly rather than silently reverting to markdown mutation.
-              // Use 'gsd recover' to rebuild DB state from disk if needed.
-              logError("engine", `retry state-reset failed (DB unavailable): ${(dbErr as Error).message}. Run 'gsd recover' to reconcile.`);
+              // Use 'gsd recover --confirm' to import markdown into the DB if needed.
+              logError("engine", `retry state-reset failed (DB unavailable): ${(dbErr as Error).message}. Run 'gsd recover --confirm' to import markdown into the DB.`);
             }
           }
 

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -867,7 +867,7 @@ export function buildLoopRemediationSteps(
       return [
         `   1. Run \`gsd undo-task ${mid}/${sid}/${tid}\` to reset the task state`,
         `   2. Resume auto-mode — it will re-execute the task`,
-        `   3. If the task keeps failing, run \`gsd recover\` to rebuild DB state from disk`,
+        `   3. If the task keeps failing and markdown should repopulate the DB, run \`gsd recover --confirm\``,
       ].join("\n");
     }
     case "plan-slice":
@@ -879,7 +879,7 @@ export function buildLoopRemediationSteps(
           : relSliceFile(base, mid, sid, "RESEARCH");
       return [
         `   1. Write ${artifactRel} manually (or with the LLM in interactive mode)`,
-        `   2. Run \`gsd recover\` to rebuild DB state from disk`,
+        `   2. Run \`gsd recover --confirm\` to import the markdown into the DB`,
         `   3. Resume auto-mode`,
       ].join("\n");
     }
@@ -888,7 +888,7 @@ export function buildLoopRemediationSteps(
       return [
         `   1. Run \`gsd reset-slice ${mid}/${sid}\` to reset the slice and all its tasks`,
         `   2. Resume auto-mode — it will re-execute incomplete tasks and re-complete the slice`,
-        `   3. If the slice keeps failing, run \`gsd recover\` to rebuild DB state from disk`,
+        `   3. If the slice keeps failing and markdown should repopulate the DB, run \`gsd recover --confirm\``,
       ].join("\n");
     }
     case "validate-milestone": {
@@ -896,7 +896,7 @@ export function buildLoopRemediationSteps(
       const artifactRel = relMilestoneFile(base, mid, "VALIDATION");
       return [
         `   1. Write ${artifactRel} with verdict: pass`,
-        `   2. Run \`gsd recover\` to rebuild DB state from disk`,
+        `   2. Run \`gsd recover --confirm\` to import the markdown into the DB`,
         `   3. Resume auto-mode`,
       ].join("\n");
     }

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -1,11 +1,14 @@
 /**
  * GSD Maintenance — cleanup, skip, dry-run, and recover handlers.
  *
- * Contains: handleCleanupBranches, handleCleanupSnapshots, handleCleanupWorktrees, handleSkip, handleDryRun, handleRecover
+ * Contains: handleCleanupBranches, handleCleanupSnapshots, handleCleanupWorktrees, handleSkip, handleDryRun, handleRecover, handleRebuild
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, isAbsolute, join, relative } from "node:path";
 import { deriveState } from "./state.js";
+import { gsdProjectionRoot, gsdRoot } from "./paths.js";
 import { nativeBranchList, nativeDetectMainBranch, nativeBranchListMerged, nativeBranchDelete, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
 import { logWarning } from "./workflow-logger.js";
 
@@ -478,6 +481,39 @@ export async function handleCleanupProjects(args: string, ctx: ExtensionCommandC
   ctx.ui.notify(lines.join("\n"), "info");
 }
 
+function recoverConfirmed(args: string): boolean {
+  return args
+    .split(/\s+/)
+    .map((part) => part.trim().toLowerCase())
+    .some((part) => part === "--confirm" || part === "--yes" || part === "confirm");
+}
+
+async function confirmRecover(ctx: ExtensionCommandContext, args: string): Promise<boolean> {
+  if (recoverConfirmed(args)) return true;
+
+  const warning = [
+    "gsd recover imports markdown into the database.",
+    "It clears and reconstructs milestone, slice, and task hierarchy rows from rendered markdown.",
+    "Use /gsd rebuild markdown for normal DB-to-markdown realignment.",
+  ].join("\n");
+
+  if (typeof ctx.ui.confirm === "function") {
+    const confirmed = await ctx.ui.confirm(
+      "Import markdown into the DB?",
+      `${warning}\n\nContinue only if the DB is lost or corrupt and markdown is the source you intend to import.`,
+    );
+    if (confirmed) return true;
+    ctx.ui.notify("gsd recover cancelled. No database changes made.", "info");
+    return false;
+  }
+
+  ctx.ui.notify(
+    `${warning}\n\nNo database changes made. Re-run /gsd recover --confirm to proceed.`,
+    "warning",
+  );
+  return false;
+}
+
 /**
  * `gsd recover` — Reconstruct DB hierarchy state from rendered markdown on disk.
  *
@@ -487,7 +523,7 @@ export async function handleCleanupProjects(args: string, ctx: ExtensionCommandC
  *
  * Prints counts of recovered items and the resulting project phase.
  */
-export async function handleRecover(ctx: ExtensionCommandContext, basePath: string): Promise<void> {
+export async function handleRecover(ctx: ExtensionCommandContext, basePath: string, args = ""): Promise<void> {
   const { isDbAvailable: dbAvailable, clearEngineHierarchy, transaction: dbTransaction } = await import("./gsd-db.js");
   const { migrateHierarchyToDb } = await import("./md-importer.js");
   const { invalidateStateCache } = await import("./state.js");
@@ -496,6 +532,8 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
     ctx.ui.notify("gsd recover: No database open. Run a GSD command first to initialize the DB.", "error");
     return;
   }
+
+  if (!(await confirmRecover(ctx, args))) return;
 
   try {
     // 1. Delete + re-populate inside a single transaction for atomicity.
@@ -540,5 +578,162 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
     const msg = err instanceof Error ? err.message : String(err);
     logWarning("command", `recover failed: ${msg}`);
     ctx.ui.notify(`gsd recover failed: ${msg}`, "error");
+  }
+}
+
+function normalizeArtifactPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function pathWithin(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel.length === 0 || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function artifactPathForDb(basePath: string, absPath: string): string {
+  const projectionRoot = gsdProjectionRoot(basePath);
+  const root = pathWithin(projectionRoot, absPath) ? projectionRoot : gsdRoot(basePath);
+  return normalizeArtifactPath(relative(root, absPath));
+}
+
+function quarantineRelativePath(basePath: string, absPath: string): string {
+  for (const root of [gsdProjectionRoot(basePath), gsdRoot(basePath)]) {
+    if (pathWithin(root, absPath)) {
+      return normalizeArtifactPath(relative(root, absPath));
+    }
+  }
+  return normalizeArtifactPath(absPath.replace(/^[/\\]+/, ""));
+}
+
+function uniquePath(path: string): string {
+  if (!existsSync(path)) return path;
+  let idx = 2;
+  while (existsSync(`${path}.${idx}`)) idx++;
+  return `${path}.${idx}`;
+}
+
+function resolveDiskArtifactPath(basePath: string, artifactPath: string): string {
+  if (isAbsolute(artifactPath)) return artifactPath;
+  const candidates = [
+    join(gsdProjectionRoot(basePath), artifactPath),
+    join(gsdRoot(basePath), artifactPath),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]!;
+}
+
+function quarantineProjectionFile(basePath: string, absPath: string, stamp: string): string {
+  const rel = quarantineRelativePath(basePath, absPath);
+  const target = uniquePath(join(gsdProjectionRoot(basePath), "quarantine", "projections", stamp, rel));
+  mkdirSync(dirname(target), { recursive: true });
+  renameSync(absPath, target);
+  return target;
+}
+
+type RebuildTarget = "markdown" | "database" | "usage";
+
+function parseRebuildTarget(args: string): RebuildTarget {
+  const trimmed = args.trim().toLowerCase();
+  if (!trimmed || trimmed === "markdown") return "markdown";
+  if (trimmed === "database" || trimmed === "db") return "database";
+  return "usage";
+}
+
+/**
+ * `gsd rebuild markdown` — Re-render markdown projections from the authoritative DB.
+ *
+ * This is the DB-first realignment command. It does not import markdown into
+ * the DB. Completion SUMMARY files that contradict open DB rows are preserved
+ * under `.gsd/quarantine/projections/` before DB projections are rendered.
+ */
+export async function handleRebuild(ctx: ExtensionCommandContext, basePath: string, args = ""): Promise<void> {
+  const { isDbAvailable: dbAvailable, deleteArtifactByPath } = await import("./gsd-db.js");
+  const { detectArtifactDbDrift } = await import("./state-reconciliation/drift/artifact-db.js");
+  const { renderAllFromDb } = await import("./markdown-renderer.js");
+  const { invalidateStateCache } = await import("./state.js");
+
+  const target = parseRebuildTarget(args);
+  if (target === "usage") {
+    ctx.ui.notify(
+      [
+        "Usage:",
+        "  /gsd rebuild markdown   Rebuild markdown projections from the canonical DB",
+        "  /gsd rebuild database   Reserved for DB-native rebuilds; does not import markdown",
+      ].join("\n"),
+      "warning",
+    );
+    return;
+  }
+
+  if (target === "database") {
+    ctx.ui.notify(
+      [
+        "gsd rebuild database is reserved for DB-native rebuilds.",
+        "It will not import markdown projections into the DB.",
+        "For normal realignment, run /gsd rebuild markdown.",
+        "If the DB is lost or corrupt and markdown is the source to import, run /gsd recover --confirm.",
+      ].join("\n"),
+      "warning",
+    );
+    return;
+  }
+
+  if (!dbAvailable()) {
+    ctx.ui.notify("gsd rebuild markdown: No database open. Run a GSD command first to initialize the DB.", "error");
+    return;
+  }
+
+  try {
+    invalidateStateCache();
+    const state = await deriveState(basePath);
+    const drifts = detectArtifactDbDrift(state, { basePath, state });
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const quarantined: string[] = [];
+    const seen = new Set<string>();
+
+    for (const drift of drifts) {
+      if (drift.kind !== "artifact-db-status-divergence") continue;
+      if (drift.artifactType !== "SUMMARY" || !drift.artifactPath) continue;
+      const absPath = resolveDiskArtifactPath(basePath, drift.artifactPath);
+      if (seen.has(absPath) || !existsSync(absPath)) continue;
+      seen.add(absPath);
+      const artifactDbPath = artifactPathForDb(basePath, absPath);
+      const target = quarantineProjectionFile(basePath, absPath, stamp);
+      deleteArtifactByPath(artifactDbPath);
+      quarantined.push(target);
+    }
+
+    const rendered = await renderAllFromDb(basePath);
+    invalidateStateCache();
+
+    const lines = [
+      "gsd rebuild markdown: rebuilt markdown projections from the canonical DB",
+      `  Rendered:    ${rendered.rendered}`,
+      `  Skipped:     ${rendered.skipped}`,
+      `  Quarantined: ${quarantined.length}`,
+    ];
+    if (rendered.errors.length > 0) {
+      lines.push(`  Errors:      ${rendered.errors.length}`);
+      for (const err of rendered.errors.slice(0, 5)) {
+        lines.push(`    - ${err}`);
+      }
+      if (rendered.errors.length > 5) {
+        lines.push(`    - ${rendered.errors.length - 5} more`);
+      }
+    }
+    if (quarantined.length > 0) {
+      lines.push("", "  Quarantine:");
+      for (const target of quarantined.slice(0, 5)) {
+        lines.push(`    - ${target}`);
+      }
+      if (quarantined.length > 5) {
+        lines.push(`    - ${quarantined.length - 5} more`);
+      }
+    }
+
+    ctx.ui.notify(lines.join("\n"), rendered.errors.length > 0 ? "warning" : "success");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarning("command", `rebuild failed: ${msg}`);
+    ctx.ui.notify(`gsd rebuild failed: ${msg}`, "error");
   }
 }

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -44,6 +44,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "export", desc: "Alias for /gsd report" },
   { cmd: "cleanup", desc: "Remove merged branches or snapshots" },
   { cmd: "closeout", desc: "Recover failed git closeout actions (status, retry, resolve)" },
+  { cmd: "rebuild", desc: "Rebuild markdown projections from the canonical DB" },
   { cmd: "model", desc: "Switch the active session model or open a picker" },
   { cmd: "mode", desc: "Switch workflow mode (solo/team)" },
   { cmd: "prefs", desc: "Manage preferences (model selection, timeouts, etc.)" },
@@ -213,6 +214,10 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "status", desc: "Show unresolved git closeout failures" },
     { cmd: "retry", desc: "Retry the latest failed closeout git action" },
     { cmd: "resolve", desc: "Mark closeout resolved after the worktree is clean" },
+  ],
+  rebuild: [
+    { cmd: "markdown", desc: "Rebuild markdown projections from the canonical DB" },
+    { cmd: "database", desc: "Reserved for DB-native rebuilds; does not import markdown" },
   ],
   knowledge: [
     { cmd: "rule", desc: "Add a project rule (always/never do X)" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -56,6 +56,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd keys           API key manager (LLM + tool keys)",
     "  /gsd doctor         Diagnose and repair .gsd/ state",
     "  /gsd closeout       Recover failed git closeout actions",
+    "  /gsd rebuild        Rebuild markdown projections from the DB  [markdown]",
     "",
     "Use /gsd help full for the complete command reference.",
   ];
@@ -147,6 +148,9 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd export         Alias for /gsd report",
     "  /gsd cleanup        Remove merged branches or snapshots  [branches|snapshots]",
     "  /gsd closeout       Recover failed git closeout actions  [status|retry|resolve] [unit-id]",
+    "  /gsd rebuild markdown  Rebuild markdown projections from the canonical DB",
+    "  /gsd rebuild database  Reserved for DB-native rebuilds; does not import markdown",
+    "  /gsd recover --confirm Import markdown into the DB after DB loss/corruption",
     "  /gsd worktree       Manage worktrees from the TUI  [list|merge|clean|remove]",
     "  /gsd migrate        Migrate .planning/ (v1) to DB-backed .gsd/ with backup + audit",
     "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -9,7 +9,7 @@ import { handleDoctor, handleCapture, handleKnowledge, handleRunHook, handleSkil
 import { handleInspect } from "../../commands-inspect.js";
 import { handleLogs } from "../../commands-logs.js";
 import { handleDebug } from "../../commands-debug.js";
-import { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleCleanupProjects, handleCleanupWorktrees, handleRecover } from "../../commands-maintenance.js";
+import { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleCleanupProjects, handleCleanupWorktrees, handleRecover, handleRebuild } from "../../commands-maintenance.js";
 import { handleExport } from "../../export.js";
 import { handleHistory } from "../../history.js";
 import { handleUndo } from "../../undo.js";
@@ -146,8 +146,12 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
     await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, projectRoot());
     return true;
   }
-  if (trimmed === "recover") {
-    await handleRecover(ctx, projectRoot());
+  if (trimmed === "recover" || trimmed.startsWith("recover ")) {
+    await handleRecover(ctx, projectRoot(), trimmed.replace(/^recover\s*/, "").trim());
+    return true;
+  }
+  if (trimmed === "rebuild" || trimmed.startsWith("rebuild ")) {
+    await handleRebuild(ctx, projectRoot(), trimmed.replace(/^rebuild\s*/, "").trim());
     return true;
   }
   if (trimmed === "closeout" || trimmed.startsWith("closeout ")) {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -2708,7 +2708,7 @@ export function deleteArtifactByPath(path: string): void {
 
 /**
  * Drop hierarchy rows in dependency order inside a transaction. Used by
- * `gsd recover` to rebuild engine state from markdown.
+ * `gsd recover --confirm` to rebuild engine state from markdown.
  */
 export function clearEngineHierarchy(): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2374,7 +2374,7 @@ export async function showSmartEntry(
       if (result.action === "recovery-required") {
         ctx.ui.notify(
           result.message ??
-            `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd recover"}\` to import markdown explicitly.`,
+            `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd recover --confirm"}\` to import markdown explicitly.`,
           "warning",
         );
       }

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -118,10 +118,10 @@ export async function checkMarkdownHierarchyAgainstDb(
     markdown,
     beforeDb,
     afterDb: beforeDb,
-    recoveryCommand: "/gsd recover",
+    recoveryCommand: "/gsd recover --confirm",
     message:
       `Markdown planning artifacts (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) ` +
       `do not match the authoritative DB (${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T). ` +
-      "Runtime startup will not import markdown automatically; run `/gsd recover` if markdown should repopulate the database.",
+      "Runtime startup will not import markdown automatically; run `/gsd recover --confirm` if markdown should repopulate the database.",
   };
 }

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -434,7 +434,8 @@ export function repairArtifactDbDrift(
     `Artifact/DB status drift in ${record.milestoneId}` +
       `${record.sliceId ? `/${record.sliceId}` : ""}` +
       `${record.taskId ? `/${record.taskId}` : ""}: ${record.reason}. ` +
-      "Runtime will not silently import completion artifacts into DB state; run explicit recovery/repair after review.",
+      "Runtime will not silently import completion artifacts into DB state. " +
+      "Run `/gsd rebuild markdown` after review to quarantine stale projections and re-render from the DB; use `/gsd recover --confirm` only when markdown should repopulate a lost or corrupt DB.",
   );
 }
 
@@ -461,7 +462,8 @@ export function describeArtifactDbDriftBlocker(
     `Artifact/DB status drift in ${record.milestoneId}` +
     `${record.sliceId ? `/${record.sliceId}` : ""}` +
     `${record.taskId ? `/${record.taskId}` : ""}: ${record.reason}. ` +
-    "Runtime will not silently import completion artifacts into DB state; run explicit recovery/repair after review."
+    "Runtime will not silently import completion artifacts into DB state. " +
+    "Run `/gsd rebuild markdown` after review to quarantine stale projections and re-render from the DB; use `/gsd recover --confirm` only when markdown should repopulate a lost or corrupt DB."
   );
 }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
@@ -55,7 +55,7 @@ export function repairUnregisteredMilestone(
 ): void {
   throw new Error(
     `Milestone ${record.milestoneId} exists only as markdown projection. ` +
-      "Runtime reconciliation will not import markdown into the authoritative DB; run `/gsd recover` if this markdown should repopulate the database.",
+      "Runtime reconciliation will not import markdown into the authoritative DB; run `/gsd recover --confirm` if this markdown should repopulate the database.",
   );
 }
 

--- a/src/resources/extensions/gsd/tests/gsd-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-rebuild.test.ts
@@ -1,0 +1,199 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { handleRebuild } from "../commands-maintenance.ts";
+import {
+  closeDatabase,
+  getTask,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
+import { invalidateStateCache } from "../state.ts";
+
+type Note = { message: string; kind: string };
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-rebuild-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), {
+    recursive: true,
+  });
+  return base;
+}
+
+function cleanup(base: string): void {
+  closeDatabase();
+  invalidateStateCache();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function makeCtx(): { ctx: any; notes: Note[] } {
+  const notes: Note[] = [];
+  return {
+    ctx: {
+      ui: {
+        notify: (message: string, kind: string) => notes.push({ message, kind }),
+      },
+    },
+    notes,
+  };
+}
+
+function seedOpenTask(): void {
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Slice",
+    status: "in_progress",
+    risk: "low",
+    depends: [],
+  });
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task",
+    status: "pending",
+  });
+}
+
+function listFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  const stack = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+test("handleRebuild quarantines stale completion projections without mutating DB state", async () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    seedOpenTask();
+
+    const summaryPath = join(
+      base,
+      ".gsd",
+      "milestones",
+      "M001",
+      "slices",
+      "S01",
+      "tasks",
+      "T01-SUMMARY.md",
+    );
+    writeFileSync(summaryPath, "# T01 Summary\n\nDisk-only completion.\n", "utf-8");
+
+    const { ctx, notes } = makeCtx();
+    await handleRebuild(ctx, base, "markdown");
+
+    assert.equal(existsSync(summaryPath), false, "stale SUMMARY projection should be moved aside");
+    const task = getTask("M001", "S01", "T01");
+    assert.equal(task?.status, "pending", "DB task status remains authoritative");
+    assert.equal(task?.full_summary_md, "", "disk summary must not be imported into DB");
+
+    const quarantined = listFiles(join(base, ".gsd", "quarantine", "projections"));
+    assert.equal(quarantined.length, 1);
+    assert.match(readFileSync(quarantined[0]!, "utf-8"), /Disk-only completion/);
+    assert.match(notes.at(-1)?.message ?? "", /Quarantined:\s+1/);
+    assert.equal(notes.at(-1)?.kind, "success");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("handleRebuild re-renders missing task summary projections from DB", async () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    seedOpenTask();
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task",
+      status: "complete",
+      oneLiner: "Task complete",
+      narrative: "Finished through the DB.",
+      verificationResult: "passed",
+      fullSummaryMd: "# T01 Summary\n\nRendered from DB.\n",
+    });
+
+    const summaryPath = join(
+      base,
+      ".gsd",
+      "milestones",
+      "M001",
+      "slices",
+      "S01",
+      "tasks",
+      "T01-SUMMARY.md",
+    );
+    rmSync(summaryPath, { force: true });
+
+    const { ctx, notes } = makeCtx();
+    await handleRebuild(ctx, base);
+
+    assert.equal(existsSync(summaryPath), true, "missing SUMMARY projection should be regenerated");
+    assert.equal(readFileSync(summaryPath, "utf-8"), "# T01 Summary\n\nRendered from DB.\n");
+    assert.match(notes.at(-1)?.message ?? "", /rebuilt markdown projections from the canonical DB/);
+    assert.match(notes.at(-1)?.message ?? "", /Quarantined:\s+0/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("handleRebuild database target is reserved and does not import markdown", async () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    seedOpenTask();
+
+    const summaryPath = join(
+      base,
+      ".gsd",
+      "milestones",
+      "M001",
+      "slices",
+      "S01",
+      "tasks",
+      "T01-SUMMARY.md",
+    );
+    writeFileSync(summaryPath, "# T01 Summary\n\nShould not import.\n", "utf-8");
+
+    const { ctx, notes } = makeCtx();
+    await handleRebuild(ctx, base, "database");
+
+    assert.equal(existsSync(summaryPath), true, "reserved DB rebuild must not move projection files");
+    const task = getTask("M001", "S01", "T01");
+    assert.equal(task?.status, "pending", "reserved DB rebuild must not mutate task status");
+    assert.equal(task?.full_summary_md, "", "reserved DB rebuild must not import markdown");
+    assert.match(notes.at(-1)?.message ?? "", /reserved/);
+    assert.match(notes.at(-1)?.message ?? "", /\/gsd recover --confirm/);
+    assert.equal(notes.at(-1)?.kind, "warning");
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../gsd-db.ts';
 import { migrateHierarchyToDb } from '../md-importer.ts';
 import { deriveStateFromDb, invalidateStateCache } from '../state.ts';
+import { handleRecover } from '../commands-maintenance.ts';
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
 
 function createFixtureBase(): string {
@@ -40,6 +41,22 @@ function writeFile(base: string, relativePath: string, content: string): void {
 
 function cleanup(base: string): void {
   rmSync(base, { recursive: true, force: true });
+}
+
+function makeCtx(confirm?: () => Promise<boolean>): {
+  ctx: any;
+  notes: Array<{ message: string; kind: string }>;
+} {
+  const notes: Array<{ message: string; kind: string }> = [];
+  return {
+    ctx: {
+      ui: {
+        notify: (message: string, kind: string) => notes.push({ message, kind }),
+        ...(confirm ? { confirm: async () => confirm() } : {}),
+      },
+    },
+    notes,
+  };
 }
 
 // ─── Fixture Content ──────────────────────────────────────────────────────
@@ -432,6 +449,64 @@ describe('gsd-recover', async () => {
       assert.deepStrictEqual(all.length, 0, 'empty: no milestones in DB after recovery');
 
       closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('handleRecover warns and does not import markdown without confirmation', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
+
+      const { ctx, notes } = makeCtx();
+      await handleRecover(ctx, base);
+
+      assert.ok(getMilestone('M999'), 'existing DB row remains when recover is unconfirmed');
+      assert.equal(getMilestone('M001'), null, 'markdown milestone is not imported without confirmation');
+      assert.equal(notes.at(-1)?.kind, 'warning');
+      assert.match(notes.at(-1)?.message ?? '', /\/gsd recover --confirm/);
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('handleRecover interactive cancellation leaves DB unchanged', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
+
+      const { ctx, notes } = makeCtx(async () => false);
+      await handleRecover(ctx, base);
+
+      assert.ok(getMilestone('M999'), 'existing DB row remains when recover is cancelled');
+      assert.equal(getMilestone('M001'), null, 'markdown milestone is not imported after cancellation');
+      assert.match(notes.at(-1)?.message ?? '', /cancelled/);
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('handleRecover imports markdown after explicit confirmation', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
+
+      const { ctx, notes } = makeCtx();
+      await handleRecover(ctx, base, '--confirm');
+
+      assert.equal(getMilestone('M999'), null, 'confirmed recover clears old hierarchy rows');
+      assert.ok(getMilestone('M001'), 'confirmed recover imports markdown hierarchy');
+      assert.equal(notes.at(-1)?.kind, 'success');
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -102,8 +102,8 @@ test("migration auto-check preserves empty DB and reports explicit recovery", as
     assert.equal(result.action, "recovery-required");
     assert.equal(result.reason, "db-empty");
     assert.deepEqual(result.afterDb, { milestones: 0, slices: 0, tasks: 0 });
-    assert.equal(result.recoveryCommand, "/gsd recover");
-    assert.match(result.message ?? "", /run `\/gsd recover`/);
+    assert.equal(result.recoveryCommand, "/gsd recover --confirm");
+    assert.match(result.message ?? "", /run `\/gsd recover --confirm`/);
     assert.equal(getAllMilestones().length, 0);
     assert.equal(getSliceTasks("M001", "S01").length, 0);
   } finally {
@@ -125,7 +125,7 @@ test("migration auto-check preserves DB on hierarchy count mismatch", async () =
     assert.equal(result.reason, "count-mismatch");
     assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 0 });
     assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 0 });
-    assert.equal(result.recoveryCommand, "/gsd recover");
+    assert.equal(result.recoveryCommand, "/gsd recover --confirm");
     assert.equal(getSliceTasks("M001", "S01").length, 0);
   } finally {
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, getSliceTasks, getTask, getGateResults, updateTaskStatus } from '../gsd-db.ts';
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, getSlice, getSliceTasks, getTask, getGateResults, updateTaskStatus } from '../gsd-db.ts';
 import { handlePlanSlice } from '../tools/plan-slice.ts';
 import { parsePlan } from '../parsers-legacy.ts';
 import { parseTaskPlanFile } from '../files.ts';
@@ -260,6 +260,44 @@ test('handlePlanSlice renders plan artifacts under worktree-local .gsd while usi
     assert.ok(existsSync(worktreePlan), 'slice plan should be rendered to worktree-local .gsd');
     assert.ok(!existsSync(projectPlan), 'slice plan should not be rendered to project .gsd');
     assert.equal(result.planPath, realpathSync(worktreePlan));
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanSlice preserves completed task closeout state when replanning the same task', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    insertTask({
+      id: 'T01',
+      sliceId: 'S02',
+      milestoneId: 'M001',
+      title: 'Completed implementation',
+      status: 'complete',
+      oneLiner: 'Completed implementation',
+      narrative: 'Already finished.',
+      verificationResult: 'passed',
+      fullSummaryMd: '# T01 Summary\n\nAlready finished.\n',
+    });
+
+    const before = getTask('M001', 'S02', 'T01');
+    assert.equal(before?.status, 'complete');
+    assert.ok(before?.completed_at, 'completed task should have a completion timestamp');
+    assert.equal(before?.full_summary_md, '# T01 Summary\n\nAlready finished.\n');
+
+    const result = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    const after = getTask('M001', 'S02', 'T01');
+    assert.equal(after?.status, 'complete', 'replanning must not reset completed task status to pending');
+    assert.equal(after?.completed_at, before?.completed_at, 'replanning must not clear completed_at');
+    assert.equal(after?.full_summary_md, before?.full_summary_md, 'replanning must not clear task summary content');
+    assert.equal(after?.verification_result, 'passed', 'replanning must not clear closeout verification');
+    assert.equal(after?.description, 'Implement the slice planning handler.', 'planning fields should still refresh');
+    assert.equal(getTask('M001', 'S02', 'T02')?.status, 'pending', 'new tasks are still inserted as pending');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -355,15 +355,9 @@ export async function handlePlanSlice(
         deleteTask(params.milestoneId, params.sliceId, taskId);
       }
 
+      const existingTaskById = new Map(existingTasks.map((task) => [task.id, task]));
       for (const task of params.tasks) {
-        insertTask({
-          id: task.taskId,
-          sliceId: params.sliceId,
-          milestoneId: params.milestoneId,
-          title: task.title,
-          status: "pending",
-        });
-        upsertTaskPlanning(params.milestoneId, params.sliceId, task.taskId, {
+        const planning = {
           title: task.title,
           description: task.description,
           estimate: task.estimate,
@@ -374,7 +368,18 @@ export async function handlePlanSlice(
           observabilityImpact: task.observabilityImpact ?? "",
           fullPlanMd: task.fullPlanMd,
           targetRepositories: task.targetRepositories ?? params.targetRepositories ?? defaultTargets,
-        });
+        };
+        const existingTask = existingTaskById.get(task.taskId);
+        if (!existingTask || !isClosedStatus(existingTask.status)) {
+          insertTask({
+            id: task.taskId,
+            sliceId: params.sliceId,
+            milestoneId: params.milestoneId,
+            title: task.title,
+            status: "pending",
+          });
+        }
+        upsertTaskPlanning(params.milestoneId, params.sliceId, task.taskId, planning);
       }
 
       // Seed quality gate rows inside the transaction — all-or-nothing with


### PR DESCRIPTION
## Summary

- Add `/gsd rebuild markdown` to rebuild markdown projections from the canonical DB and quarantine stale completion projections.
- Reserve `/gsd rebuild database` as a non-importing warning path.
- Guard `/gsd recover` behind an interactive confirmation or explicit `/gsd recover --confirm`.
- Preserve completed task closeout state when replanning so plan refreshes do not reset closed tasks to pending.

## Root Cause

Step-mode kept pausing on Artifact/DB drift because runtime correctly refused to import completion markdown into DB state, but `plan-slice` could re-upsert completed tasks as `pending` during replanning. That left a `SUMMARY` projection on disk while the canonical DB said the task was still open.

## Impact

DB state stays canonical for normal operation. Operators now use `/gsd rebuild markdown` for DB-to-markdown realignment, while `/gsd recover --confirm` remains the explicit break-glass import-from-markdown path for lost or corrupt DBs.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gsd-recover.test.ts src/resources/extensions/gsd/tests/gsd-rebuild.test.ts src/resources/extensions/gsd/tests/migration-auto-check.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/plan-slice.test.ts src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts src/resources/extensions/gsd/tests/command-feedback.test.ts`
- `pnpm run typecheck:extensions`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782954855&installation_id=134682257&pr_number=384&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F384&signature=234a7b97c226e072eead5d808f2c93e4ab0de1ff5d3ad32362d53c68c4c8d94b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how operators repair canonical DB vs markdown (destructive import vs projection rebuild) and touches hierarchy clear/import paths; mitigated by confirmation gates, quarantine behavior, and expanded tests.
> 
> **Overview**
> This PR separates **DB→markdown realignment** from **markdown→DB import** and makes destructive recovery opt-in.
> 
> **`/gsd recover`** now requires interactive confirmation or **`--confirm` / `--yes`** before clearing hierarchy and re-importing from rendered markdown; headless/docs point at the same confirmed path. **`/gsd rebuild markdown`** re-renders projections from the canonical DB, **quarantines** stale completion `SUMMARY` files that disagree with open DB rows (without importing them), then runs `renderAllFromDb`. **`/gsd rebuild database`** is a reserved warning-only stub that does not import markdown.
> 
> Drift/recovery messaging across auto-recovery, guided flow, migration auto-check, and artifact-db drift now steers operators to **`/gsd rebuild markdown`** for projection mismatch vs **`/gsd recover --confirm`** only when markdown should repopulate a lost/corrupt DB. **`plan-slice`** no longer resets **completed** tasks to `pending` on replan—planning fields refresh while closeout state stays intact.
> 
> User/GitBook command references and the command catalog/help/ops wiring are updated; tests cover recover confirmation, rebuild quarantine/re-render, and the plan-slice preservation case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103f0ec0707be42c767992e8954d7636a8f7d030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->