### PR TITLE
[codex] add mcp discover command

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -91,7 +91,7 @@ After writing the file, GSD attempts to open it in a browser using the local pla
 | `/gsd init` | Project init wizard — detect, configure, bootstrap `.gsd/`; if `.gsd/` already exists, opens an "Already Initialized" menu with `Re-configure preferences`, `Suggest & install skills`, or `Cancel` |
 | `/gsd setup` | Global setup status and configuration |
 | `/gsd onboarding` | Re-run the setup wizard (`--resume`, `--reset`, `--step <name>`) |
-| `/gsd mcp` | Manage MCP servers (`status`, `check`, `test`, `enable`, `disable`, `import`, `delete`, `init`) |
+| `/gsd mcp` | Manage MCP servers (`status`, `check`, `discover`, `test`, `enable`, `disable`, `import`, `delete`, `init`) |
 | `/gsd context` | Show a context breakdown chart for skills, injections, history, and MCP tool schema usage |
 | `/gsd skill-health` | Skill lifecycle dashboard — usage stats, success rates, token trends, staleness warnings |
 | `/gsd skill-health <name>` | Detailed view for a single skill |

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -7,6 +7,7 @@
  *   /gsd mcp             — Overview of all servers (alias: /gsd mcp status)
  *   /gsd mcp status      — Same as bare /gsd mcp
  *   /gsd mcp check <srv> — Detailed status for a specific server
+ *   /gsd mcp discover [srv] — Connect and list tools for a server
  *   /gsd mcp test <srv>  — Test handshake + tools/list for a server
  *   /gsd mcp enable <srv> / disable <srv> — Toggle local server exposure
  *   /gsd mcp import <srv> [as <name>] — Copy a discovered server into local config
@@ -103,8 +104,8 @@ export function formatMcpStatusReport(servers: McpServerStatus[]): string {
 
   lines.push("");
   lines.push("Use /gsd mcp check <server> for details on a specific server.");
+  lines.push("Use /gsd mcp discover <server> to connect and list tools.");
   lines.push("Use /gsd mcp test <server> to verify handshake and tool discovery.");
-  lines.push("Use mcp_discover to connect and list tools for a server.");
 
   return lines.join("\n");
 }
@@ -133,7 +134,7 @@ export function formatMcpServerDetail(server: McpServerDetail): string {
   } else {
     lines.push(`  Status:    disconnected`);
     lines.push("");
-    lines.push(`  Run mcp_discover("${server.name}") to connect and list tools.`);
+    lines.push(`  Run /gsd mcp discover ${server.name} to connect and list tools.`);
   }
 
   if (server.envWarnings?.length) {
@@ -167,10 +168,32 @@ export function formatMcpConnectionTestResult(result: ManagedMcpConnectionTestRe
   ].join("\n");
 }
 
+export function formatMcpDiscoveryResult(result: ManagedMcpConnectionTestResult): string {
+  if (result.ok) {
+    return [
+      `MCP discovery completed for ${result.server}.`,
+      "",
+      `Transport: ${result.transport}`,
+      `Tools:     ${result.toolCount}`,
+      ...(result.tools.length > 0 ? ["", "Discovered tools:", ...result.tools.map((tool) => `  - ${tool}`)] : []),
+      "",
+      `Call with: mcp_call(server="${result.server}", tool="<tool_name>", args={...})`,
+    ].join("\n");
+  }
+
+  return [
+    `MCP discovery failed for ${result.server}.`,
+    "",
+    `Transport: ${result.transport}`,
+    `Error:     ${result.error ?? "Unknown error"}`,
+    ...(result.warnings.length > 0 ? ["", "Warnings:", ...result.warnings.map((warning) => `  - ${warning}`)] : []),
+  ].join("\n");
+}
+
 // ─── Command handler ────────────────────────────────────────────────────────
 
 /**
- * Handle `/gsd mcp [status|check <server>]`.
+ * Handle `/gsd mcp [status|check <server>|discover [server]|...]`.
  */
 export async function handleMcpStatus(
   args: string,
@@ -197,6 +220,28 @@ export async function handleMcpStatus(
         "error",
       );
     }
+    return;
+  }
+
+  // /gsd mcp discover [server]
+  if (lowered === "discover" || lowered.startsWith("discover ")) {
+    const requestedServerName = trimmed.slice("discover".length).trim();
+    let serverName = requestedServerName;
+    if (!serverName) {
+      if (configs.length === 1) {
+        serverName = configs[0]!.name;
+      } else {
+        const available = configs.map((config) => config.name).join(", ") || "(none)";
+        ctx.ui.notify(
+          `Usage: /gsd mcp discover <server>\n\nAvailable: ${available}`,
+          "warning",
+        );
+        return;
+      }
+    }
+
+    const result = await testMcpServerConnection(serverName);
+    ctx.ui.notify(formatMcpDiscoveryResult(result), result.ok ? "info" : "warning");
     return;
   }
 
@@ -389,9 +434,10 @@ export async function handleMcpStatus(
 
   // Unknown subcommand
   ctx.ui.notify(
-    "Usage: /gsd mcp [status|check <server>|test <server>|enable <server>|disable <server>|delete <server> --confirm|import <server> [as <name>]|init [dir]]\n\n" +
+    "Usage: /gsd mcp [status|check <server>|discover [server]|test <server>|enable <server>|disable <server>|delete <server> --confirm|import <server> [as <name>]|init [dir]]\n\n" +
     "  status           Show all MCP server statuses (default)\n" +
     "  check <server>   Detailed status for a specific server\n" +
+    "  discover [server] Connect and list tools for a server\n" +
     "  test <server>    Verify MCP handshake and tools/list\n" +
     "  enable <server>  Enable a local GSD-managed server\n" +
     "  disable <server> Disable a local GSD-managed server\n" +

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -138,7 +138,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd skill-health   Skill lifecycle dashboard",
     "  /gsd extensions     Manage extensions  [list|enable|disable|info]",
     "  /gsd fast           Toggle OpenAI service tier  [on|off|flex|status]",
-    "  /gsd mcp            MCP server management  [status|check|test|enable|disable|import|delete|init]",
+    "  /gsd mcp            MCP server management  [status|check|discover|test|enable|disable|import|delete|init]",
     "",
     "MAINTENANCE",
     "  /gsd doctor         Diagnose and repair .gsd/ state  [audit|fix|heal] [scope]",

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -1,14 +1,23 @@
 import test, { describe } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import {
+  formatMcpDiscoveryResult,
   formatMcpInitResult,
   formatMcpConnectionTestResult,
   formatMcpStatusReport,
   formatMcpServerDetail,
   hasHostMcpTool,
+  handleMcpStatus,
   type McpServerStatus,
 } from "../commands-mcp-status.ts";
+import { clearMcpConfigCache } from "../../mcp-client/manager.ts";
 
 // ─── formatMcpStatusReport ──────────────────────────────────────────────────
 
@@ -124,6 +133,94 @@ describe("formatMcpServerDetail", () => {
       envWarnings: ["headers.Authorization references unset environment variable TOKEN."],
     });
     assert.match(result, /Warnings/);
+    assert.match(result, /TOKEN/);
+  });
+});
+
+describe("handleMcpStatus", () => {
+  test("discovers the only configured server when no server name is provided", async () => {
+    const previousGsdHome = process.env.GSD_HOME;
+    const originalCwd = process.cwd();
+    const projectDir = mkdtempSync(join(tmpdir(), "gsd-mcp-discover-project-"));
+    const gsdHomeDir = mkdtempSync(join(tmpdir(), "gsd-mcp-discover-home-"));
+    try {
+      process.env.GSD_HOME = gsdHomeDir;
+      process.chdir(projectDir);
+
+      const require = createRequire(import.meta.url);
+      const mcpModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/mcp.js")).href;
+      const stdioModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/stdio.js")).href;
+      const serverPath = join(projectDir, "discover-mcp-server.mjs");
+      writeFileSync(
+        serverPath,
+        [
+          `const { McpServer } = await import(${JSON.stringify(mcpModuleUrl)});`,
+          `const { StdioServerTransport } = await import(${JSON.stringify(stdioModuleUrl)});`,
+          'const server = new McpServer({ name: "fake", version: "1.0.0" }, { capabilities: { tools: {} } });',
+          'server.tool("discover_tool", "Discover-visible tool", {}, async () => ({ content: [{ type: "text", text: "ok" }] }));',
+          'await server.connect(new StdioServerTransport());',
+        ].join("\n"),
+        "utf-8",
+      );
+      writeFileSync(
+        join(projectDir, ".mcp.json"),
+        JSON.stringify({ mcpServers: { "gsd-workflow": { command: process.execPath, args: [serverPath] } } }),
+        "utf-8",
+      );
+
+      let message = "";
+      const ctx = {
+        getSystemPrompt: () => "",
+        ui: {
+          notify: (text: string) => {
+            message = text;
+          },
+        },
+      };
+
+      await handleMcpStatus("discover", ctx as unknown as ExtensionCommandContext);
+
+      assert.match(message, /MCP discovery completed for gsd-workflow/);
+      assert.match(message, /discover_tool/);
+      assert.doesNotMatch(message, /Usage: \/gsd mcp/);
+    } finally {
+      process.chdir(originalCwd);
+      if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = previousGsdHome;
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(gsdHomeDir, { recursive: true, force: true });
+      clearMcpConfigCache();
+    }
+  });
+});
+
+describe("formatMcpDiscoveryResult", () => {
+  test("summarizes discovered tools", () => {
+    const result = formatMcpDiscoveryResult({
+      ok: true,
+      server: "demo",
+      transport: "stdio",
+      toolCount: 1,
+      tools: ["ping"],
+      warnings: [],
+    });
+    assert.match(result, /discovery completed/i);
+    assert.match(result, /ping/);
+    assert.match(result, /mcp_call/);
+  });
+
+  test("summarizes discovery failures", () => {
+    const result = formatMcpDiscoveryResult({
+      ok: false,
+      server: "demo",
+      transport: "http",
+      toolCount: 0,
+      tools: [],
+      warnings: ["url references unset environment variable TOKEN."],
+      error: "bad config",
+    });
+    assert.match(result, /discovery failed/i);
+    assert.match(result, /bad config/);
     assert.match(result, /TOKEN/);
   });
 });


### PR DESCRIPTION
## Summary

Adds `/gsd mcp discover [server]` so users can run MCP tool discovery from the slash-command surface instead of being pointed at the lower-level `mcp_discover` tool name.

The command reuses the existing MCP handshake and `tools/list` path, auto-selects the server when exactly one MCP server is configured, and otherwise shows usage with the available server names. Help text and user docs now list `discover` alongside the other MCP subcommands.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/mcp-status.test.ts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`

Note: the fresh PR worktree needed `pnpm install --frozen-lockfile --ignore-scripts` before validation because it had no local dependencies installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782954916&installation_id=134682257&pr_number=385&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F385&signature=177c731c39d7bf58abe6cc5430ef639d496a30a500bb98f97ae8e8243643ba0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing extension command and docs only; discovery delegates to the existing MCP connection test without changing auth or config persistence.
> 
> **Overview**
> Adds **`/gsd mcp discover [server]`** so MCP tool discovery runs from the slash-command UX instead of being directed at the lower-level **`mcp_discover`** name.
> 
> The handler reuses the existing handshake and **`tools/list`** path via **`testMcpServerConnection`**, auto-picks the server when exactly one is configured, and otherwise shows usage with available names. Success output is formatted by **`formatMcpDiscoveryResult`** (tool list plus an **`mcp_call`** hint); status/detail copy and user docs now point at **`discover`** alongside **`test`** and other MCP subcommands.
> 
> Tests cover the new formatter and an integration path where bare **`discover`** discovers the sole configured server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7d91373fe41e654fd2ab56a2d5724fdb1d7930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->