### PR TITLE
fix mcp diagnostics and stranded guidance

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -334,6 +334,25 @@ function strandedWorkMessage(args: {
   );
 }
 
+function formatStrandedWorkBlockerMessage(
+  action: OrphanAuditAction,
+  activeMilestoneId: string | null,
+): string {
+  const target = action.milestoneId;
+  const mode = action.recoveryMode === "worktree" ? "existing worktree" : "milestone branch";
+  const intro = activeMilestoneId
+    ? `Stranded work for ${target} blocks auto-mode before ${activeMilestoneId}.`
+    : `Stranded work for ${target} blocks auto-mode, but that milestone is not active in project state.`;
+
+  return [
+    intro,
+    "Choose one explicit next step:",
+    `1. Recover it: run \`/gsd auto ${target}\` to adopt the ${mode}.`,
+    `2. Defer it: run \`/gsd park ${target} "reason"\`, then rerun \`/gsd auto\`.`,
+    `3. Abandon it: run \`/gsd rethink\` and explicitly discard ${target}.`,
+  ].join("\n");
+}
+
 export function auditOrphanedMilestoneBranches(
   basePath: string,
   _isolationMode: "worktree" | "branch" | "none",
@@ -1177,14 +1196,14 @@ export async function bootstrapAutoSession(
     if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {
         ctx.ui.notify(
-          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode, but that milestone is not active in project state. Park or discard it explicitly before continuing.`,
+          formatStrandedWorkBlockerMessage(blockingStrandedRecoveryAction, null),
           "error",
         );
         return releaseLockAndReturn();
       }
       if (state.activeMilestone.id !== blockingStrandedRecoveryAction.milestoneId) {
         ctx.ui.notify(
-          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode before ${state.activeMilestone.id}. Recover, park, or discard ${blockingStrandedRecoveryAction.milestoneId} explicitly before continuing.`,
+          formatStrandedWorkBlockerMessage(blockingStrandedRecoveryAction, state.activeMilestone.id),
           "error",
         );
         return releaseLockAndReturn();

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -321,6 +321,9 @@ test("headless bootstrap checks stranded work before recovered-complete shortcut
     const messages = notifications.map((entry) => entry.message).join("\n");
     assert.equal(ready, false);
     assert.match(messages, /Stranded work for M002 blocks auto-mode/);
+    assert.match(messages, /\/gsd auto M002/);
+    assert.match(messages, /\/gsd park M002 "reason"/);
+    assert.match(messages, /\/gsd rethink/);
     assert.doesNotMatch(messages, /all milestones complete/);
   } finally {
     if (previousHeadless === undefined) {
@@ -409,6 +412,9 @@ test("bootstrap blocks active stranded recovery when another open milestone also
     assert.equal(ready, false);
     assert.deepEqual(adoptCalls, []);
     assert.match(messages, /Stranded work for M002 blocks auto-mode before M001/);
+    assert.match(messages, /\/gsd auto M002/);
+    assert.match(messages, /\/gsd park M002 "reason"/);
+    assert.match(messages, /explicitly discard M002/);
   } finally {
     try {
       closeDatabase();

--- a/src/resources/extensions/mcp-client/manager.ts
+++ b/src/resources/extensions/mcp-client/manager.ts
@@ -103,6 +103,8 @@ const CHILD_ENV_ALLOWLIST = new Set([
 	"XDG_CACHE_HOME",
 ]);
 
+const MCP_STDERR_MAX_BYTES = 4096;
+
 let cachedStatus: ManagedMcpStatus | null = null;
 let cachedStatusKey = "";
 
@@ -231,6 +233,34 @@ export function resolveMcpString(value: string): string {
 	);
 }
 
+function captureTransportStderr(transport: StdioClientTransport): () => string {
+	const chunks: Buffer[] = [];
+	let totalBytes = 0;
+	const stderr = transport.stderr;
+	stderr?.on("data", (chunk: Buffer | string) => {
+		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+		totalBytes += buffer.byteLength;
+		chunks.push(buffer);
+		while (chunks.reduce((sum, entry) => sum + entry.byteLength, 0) > MCP_STDERR_MAX_BYTES) {
+			chunks.shift();
+		}
+	});
+
+	return () => {
+		const captured = Buffer.concat(chunks).toString("utf-8").trim();
+		if (!captured) return "";
+		return totalBytes > MCP_STDERR_MAX_BYTES
+			? `[stderr truncated to last ${MCP_STDERR_MAX_BYTES} bytes]\n${captured}`
+			: captured;
+	};
+}
+
+function formatConnectionError(error: unknown, stderr: string): string {
+	const message = error instanceof Error ? error.message : String(error);
+	if (!stderr) return message;
+	return `${message}\nStderr:\n${stderr}`;
+}
+
 export function upsertProjectLocalMcpServer(
 	input: ManagedMcpServerInput,
 	options: { projectDir?: string; previousName?: string } = {},
@@ -348,6 +378,7 @@ export async function testMcpServerConnection(
 
 	const client = new Client({ name: "gsd", version: "1.0.0" });
 	let transport: StdioClientTransport | StreamableHTTPClientTransport | undefined;
+	let readCapturedStderr: (() => string) | undefined;
 	const timeout = options.timeoutMs ?? 30_000;
 	try {
 		if (config.transport === "stdio") {
@@ -358,6 +389,7 @@ export async function testMcpServerConnection(
 				cwd: config.cwd,
 				stderr: "pipe",
 			});
+			readCapturedStderr = captureTransportStderr(transport);
 		} else {
 			const resolvedUrl = resolveMcpString(config.url ?? "");
 			transport = new StreamableHTTPClientTransport(
@@ -385,7 +417,7 @@ export async function testMcpServerConnection(
 			toolCount: 0,
 			tools: [],
 			warnings: config.envWarnings,
-			error: error instanceof Error ? error.message : String(error),
+			error: formatConnectionError(error, readCapturedStderr?.() ?? ""),
 		};
 	} finally {
 		if (transport) {

--- a/src/resources/extensions/mcp-client/tests/manager.test.ts
+++ b/src/resources/extensions/mcp-client/tests/manager.test.ts
@@ -163,3 +163,38 @@ test("MCP connection test performs handshake and tools/list without invoking too
 		cleanup();
 	}
 });
+
+test("MCP connection test includes stdio stderr when discovery fails", async () => {
+	const { projectDir, cleanup } = makeProject();
+	try {
+		const serverPath = join(projectDir, "crashing-mcp-server.mjs");
+		writeFileSync(
+			serverPath,
+			[
+				'console.error("fatal browser bootstrap failed");',
+				'console.error("missing browser profile");',
+				"process.exit(1);",
+			].join("\n"),
+			"utf-8",
+		);
+
+		const result = await testMcpServerConnection({
+			name: "crashing",
+			transport: "stdio",
+			sourcePath: join(projectDir, ".gsd", "mcp.json"),
+			sourceKind: "project-local",
+			disabled: false,
+			command: process.execPath,
+			args: [serverPath],
+			envWarnings: [],
+		} satisfies ManagedMcpServerConfig, { projectDir, timeoutMs: 10_000 });
+
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /Connection closed|closed|exit/i);
+		assert.match(result.error ?? "", /Stderr:/);
+		assert.match(result.error ?? "", /fatal browser bootstrap failed/);
+		assert.match(result.error ?? "", /missing browser profile/);
+	} finally {
+		cleanup();
+	}
+});


### PR DESCRIPTION
## Summary
- Capture stderr from stdio MCP discovery probes and append it to failed connection errors so `Connection closed` includes the child process failure details.
- Add explicit stranded-work next steps to auto-mode blocker messages: recover with `/gsd auto`, defer with `/gsd park`, or abandon via `/gsd rethink`.
- Cover both changes with focused tests.

## Validation
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/mcp-client/tests/manager.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/mcp-status.test.ts`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782954946&installation_id=134682257&pr_number=386&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F386&signature=df59f9688fd9ebf23150fce1007efc0d6cc347752d18b0a4a59bccc4d29fe59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing messaging and MCP test error formatting only; no auth, persistence, or execution-path changes beyond clearer failures.
> 
> **Overview**
> Improves operator-facing diagnostics in two places.
> 
> **Auto-mode:** When stranded milestone work blocks bootstrap, error notifications now use a shared `formatStrandedWorkBlockerMessage` helper with numbered next steps—recover via `/gsd auto`, defer with `/gsd park`, or abandon via `/gsd rethink`—instead of a single vague “park or discard” line.
> 
> **MCP:** Stdio connection tests pipe and retain the child’s stderr (last 4KB) and append it under `Stderr:` when `testMcpServerConnection` fails, so opaque errors like “Connection closed” surface the real process failure (e.g. browser bootstrap messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f1a16252bdd51e1f90e2f6f7effd1d5bd2a9dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->