### PR TITLE
[codex] fix stranded milestone recovery

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -83,6 +83,31 @@ describe("Extension warning notifications", () => {
 		}
 	});
 
+	it("routes extension errors to the sticky blocker without duplicating chat output", () => {
+		const chat = new Container();
+		const blocker = new Container();
+		const host = {
+			chatContainer: chat,
+			blockingErrorContainer: blocker,
+			lastBlockingError: undefined,
+			ui: makeMockTUI(),
+		};
+
+		showExtensionNotify(host, "stranded work blocks auto-mode", "error");
+
+		assert.equal(host.lastBlockingError, "stranded work blocks auto-mode");
+		assert.match(
+			blocker.render(100).map(stripAnsi).join("\n"),
+			/Error: stranded work blocks auto-mode/,
+		);
+		assert.equal(
+			chat.render(100).map(stripAnsi).join("\n"),
+			"",
+			"extension error notifications must not duplicate the sticky blocker in chat",
+		);
+		assert.equal(host.ui.renderCount, 1);
+	});
+
 	it("preserves explicit ANSI styling in info notifications", () => {
 		const chat = new Container();
 		const styled = "\x1b[32mStyled external notice\x1b[0m";

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-extension-dialogs.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-extension-dialogs.ts
@@ -276,6 +276,8 @@ export function showExtensionNotify(host: InteractiveModeDelegateHost, message: 
 		if (type === "error") {
 			host.lastBlockingError = message;
 			renderBlockingErrorBanner(host.blockingErrorContainer, host.lastBlockingError);
+			host.ui.requestRender();
+			return;
 		}
 		const result = renderExtensionNotifyInChat(host.chatContainer, message, type);
 		if (!result.rendered) {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -91,6 +91,7 @@ import { nativeHasChanges, nativeIsRepo, _resetHasChangesCache } from "./native-
 import { debugLog, isDebugEnabled } from "./debug-logger.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+import { detectWorktreeName } from "./worktree.js";
 import { probeGitConflictState } from "./git-conflict-state.js";
 import { runTurnGitAction } from "./git-service.js";
 import { parseUnitId } from "./unit-id.js";
@@ -338,6 +339,29 @@ function isRegistryMilestoneComplete(state: GSDState, mid: string): boolean {
   return state.registry.some((milestone) =>
     milestone.id === mid && milestone.status === "complete"
   );
+}
+
+function normalizeMilestoneScope(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !MILESTONE_ID_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+function resolveDispatchMilestoneScope(
+  ctx: DispatchContext,
+): { id: string; source: string } | null {
+  const sessionMilestone = normalizeMilestoneScope(ctx.session?.currentMilestoneId);
+  if (sessionMilestone) return { id: sessionMilestone, source: "session.currentMilestoneId" };
+
+  const sessionWorktree = normalizeMilestoneScope(
+    ctx.session?.basePath ? detectWorktreeName(ctx.session.basePath) : null,
+  );
+  if (sessionWorktree) return { id: sessionWorktree, source: "session.basePath worktree" };
+
+  const baseWorktree = normalizeMilestoneScope(detectWorktreeName(ctx.basePath));
+  if (baseWorktree) return { id: baseWorktree, source: "basePath worktree" };
+
+  return null;
 }
 
 function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
@@ -1638,6 +1662,17 @@ export async function resolveDispatch(
       reason:
         `Dispatch milestone mismatch: context mid "${ctx.mid}" does not match active milestone "${activeMid}". ` +
         "This usually means a project-level deep setup pseudo-id leaked into milestone dispatch; rerun /gsd auto after setup state is reconciled.",
+      level: "warning",
+    };
+  }
+
+  const scopedMilestone = resolveDispatchMilestoneScope(ctx);
+  if (scopedMilestone && ctx.mid !== scopedMilestone.id) {
+    return {
+      action: "stop",
+      reason:
+        `Dispatch milestone mismatch: context mid "${ctx.mid}" does not match ${scopedMilestone.source} "${scopedMilestone.id}". ` +
+        "The active worktree/session and derived project state disagree; recover, park, or discard the stranded milestone before continuing.",
       level: "warning",
     };
   }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -334,6 +334,25 @@ function strandedWorkMessage(args: {
   );
 }
 
+function formatStrandedWorkBlockerMessage(
+  action: OrphanAuditAction,
+  activeMilestoneId: string | null,
+): string {
+  const target = action.milestoneId;
+  const mode = action.recoveryMode === "worktree" ? "existing worktree" : "milestone branch";
+  const intro = activeMilestoneId
+    ? `Stranded work for ${target} blocks auto-mode before ${activeMilestoneId}.`
+    : `Stranded work for ${target} blocks auto-mode, but that milestone is not active in project state.`;
+
+  return [
+    intro,
+    "Choose one explicit next step:",
+    `1. Recover it: run \`/gsd auto ${target}\` to adopt the ${mode}.`,
+    `2. Defer it: run \`/gsd park ${target} "reason"\`, then rerun \`/gsd auto\`.`,
+    `3. Abandon it: run \`/gsd rethink\` and explicitly discard ${target}.`,
+  ].join("\n");
+}
+
 export function auditOrphanedMilestoneBranches(
   basePath: string,
   _isolationMode: "worktree" | "branch" | "none",
@@ -1177,14 +1196,14 @@ export async function bootstrapAutoSession(
     if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {
         ctx.ui.notify(
-          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode, but that milestone is not active in project state. Park or discard it explicitly before continuing.`,
+          formatStrandedWorkBlockerMessage(blockingStrandedRecoveryAction, null),
           "error",
         );
         return releaseLockAndReturn();
       }
       if (state.activeMilestone.id !== blockingStrandedRecoveryAction.milestoneId) {
         ctx.ui.notify(
-          `Stranded work for ${blockingStrandedRecoveryAction.milestoneId} blocks auto-mode before ${state.activeMilestone.id}. Recover, park, or discard ${blockingStrandedRecoveryAction.milestoneId} explicitly before continuing.`,
+          formatStrandedWorkBlockerMessage(blockingStrandedRecoveryAction, state.activeMilestone.id),
           "error",
         );
         return releaseLockAndReturn();

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2102,6 +2102,28 @@ export function createWiredDispatchAdapter(
     return null;
   }
 
+  function shouldAdoptActiveMilestone(
+    state: GSDState,
+    activeSession: AutoSession | undefined,
+    activeDispatchBasePath: string,
+  ): boolean {
+    const activeMilestoneId = state.activeMilestone?.id;
+    const currentMilestoneId = activeSession?.currentMilestoneId;
+    if (!activeSession || !activeMilestoneId || !currentMilestoneId || activeMilestoneId === currentMilestoneId) {
+      return false;
+    }
+
+    const scopedWorktreeMilestone =
+      (activeSession.basePath ? detectWorktreeName(activeSession.basePath) : null) ??
+      detectWorktreeName(activeDispatchBasePath);
+    if (scopedWorktreeMilestone && scopedWorktreeMilestone !== activeMilestoneId) {
+      return false;
+    }
+
+    const currentMilestone = state.registry.find((milestone) => milestone.id === currentMilestoneId);
+    return !!currentMilestone && isClosedStatus(currentMilestone.status);
+  }
+
   return {
     async decideNextUnit(input) {
       const state = input.stateSnapshot;
@@ -2110,6 +2132,9 @@ export function createWiredDispatchAdapter(
 
       const activeSession = input.session ?? session;
       const activeDispatchBasePath = activeSession?.basePath || dispatchBasePath;
+      if (activeSession && shouldAdoptActiveMilestone(state, activeSession, activeDispatchBasePath)) {
+        activeSession.currentMilestoneId = active.id;
+      }
       const prefs = loadEffectiveGSDPreferences(activeDispatchBasePath)?.preferences;
 
       // Derive session-derived dispatch inputs the same way phases.ts:runDispatch does

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -279,10 +279,17 @@ export function invalidateStateCache(): void {
 /**
  * Returns the ID of the first incomplete milestone, or null if all are complete.
  */
+function getRequestedMilestoneLock(): string | undefined {
+  const lock = process.env.GSD_MILESTONE_LOCK?.trim();
+  return lock || undefined;
+}
+
 export async function getActiveMilestoneId(basePath: string): Promise<string | null> {
-  // Parallel worker isolation. Normal DB state derivation remains DB-only;
-  // lock env vars are execution routing for explicit worker processes.
-  const milestoneLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_MILESTONE_LOCK : undefined;
+  // Milestone-scoped execution. Parallel workers and explicit solo commands
+  // such as `/gsd auto M002` both set GSD_MILESTONE_LOCK; state derivation must
+  // honor it so recovery/adoption sees the requested milestone, not the first
+  // open milestone in queue order.
+  const milestoneLock = getRequestedMilestoneLock();
   if (milestoneLock) {
     if (isDbAvailable()) {
       const locked = getAllMilestones().find(m => m.id === milestoneLock);
@@ -720,7 +727,7 @@ export async function deriveStateFromDb(
 
   const allMilestones = getAllMilestones();
 
-  const milestoneLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_MILESTONE_LOCK : undefined;
+  const milestoneLock = getRequestedMilestoneLock();
   const milestones = milestoneLock
     ? allMilestones.filter(m => m.id === milestoneLock)
     : allMilestones;
@@ -959,13 +966,10 @@ export async function _deriveStateImpl(
   const customOrder = loadQueueOrder(basePath);
   const milestoneIds = sortByQueueOrder(diskIds, customOrder);
 
-  // ── Parallel worker isolation ──────────────────────────────────────────
-  // When GSD_PARALLEL_WORKER and GSD_MILESTONE_LOCK are set, this process is a parallel worker
-  // scoped to a single milestone. Filter the milestone list so this worker
-  // only sees its assigned milestone (all others are treated as if they
-  // don't exist). This gives each worker complete isolation without
-  // modifying any other state derivation logic.
-  const milestoneLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_MILESTONE_LOCK : undefined;
+  // ── Milestone-scoped execution ─────────────────────────────────────────
+  // Parallel workers and explicit solo recovery both scope auto-mode to one
+  // milestone through GSD_MILESTONE_LOCK.
+  const milestoneLock = getRequestedMilestoneLock();
   if (milestoneLock && milestoneIds.includes(milestoneLock)) {
     milestoneIds.length = 0;
     milestoneIds.push(milestoneLock);

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1246,6 +1246,92 @@ test("wired DispatchAdapter forwards constructor session when advance input omit
   }
 });
 
+test("wired DispatchAdapter adopts next active milestone after the session milestone is closed", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-milestone-adopt-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const stateSnapshot: GSDState = {
+    ...makeState(),
+    activeMilestone: { id: "M002", title: "Next" },
+    registry: [
+      { id: "M001", title: "First", status: "complete" },
+      { id: "M002", title: "Next", status: "active" },
+    ],
+  };
+  const captured: DispatchContext[] = [];
+  const captureRule: UnifiedRule = {
+    name: "test-milestone-adoption",
+    when: "dispatch",
+    evaluation: "first-match",
+    where: async (ctx: DispatchContext) => {
+      captured.push(ctx);
+      return {
+        action: "dispatch" as const,
+        unitType: "execute-task",
+        unitId: "M002/S01/T01",
+        prompt: "adopted-milestone-fixture",
+      };
+    },
+    then: (r: unknown) => r,
+  };
+  setRegistry(new RuleRegistry([captureRule]));
+
+  try {
+    const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;
+    const pi = { getActiveTools: () => [] } as any;
+    const session = {
+      basePath: base,
+      originalBasePath: base,
+      currentMilestoneId: "M001",
+    } as any;
+    const adapter = createWiredDispatchAdapter(ctx, pi, base, session);
+
+    const result = await adapter.decideNextUnit({ stateSnapshot });
+
+    assert.ok(result);
+    if (!("unitType" in result)) assert.fail(`expected dispatch decision, got ${JSON.stringify(result)}`);
+    assert.equal(result.unitId, "M002/S01/T01");
+    assert.equal(session.currentMilestoneId, "M002");
+    assert.equal(captured[0]?.session?.currentMilestoneId, "M002");
+  } finally {
+    resetRegistry();
+  }
+});
+
+test("wired DispatchAdapter keeps blocking stale milestone worktree scope", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-worktree-block-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const stateSnapshot: GSDState = {
+    ...makeState(),
+    activeMilestone: { id: "M002", title: "Next" },
+    registry: [
+      { id: "M001", title: "First", status: "complete" },
+      { id: "M002", title: "Next", status: "active" },
+    ],
+  };
+  const worktreePath = join(base, ".gsd", "worktrees", "M001");
+  mkdirSync(worktreePath, { recursive: true });
+  const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;
+  const pi = { getActiveTools: () => [] } as any;
+  const session = {
+    basePath: worktreePath,
+    originalBasePath: base,
+    currentMilestoneId: "M001",
+  } as any;
+  const adapter = createWiredDispatchAdapter(ctx, pi, base, session);
+
+  const result = await adapter.decideNextUnit({ stateSnapshot });
+
+  assert.deepEqual(result, {
+    kind: "blocked",
+    reason:
+      'Dispatch milestone mismatch: context mid "M002" does not match session.currentMilestoneId "M001". The active worktree/session and derived project state disagree; recover, park, or discard the stranded milestone before continuing.',
+    action: "pause",
+  });
+  assert.equal(session.currentMilestoneId, "M001");
+});
+
 test("wired DispatchAdapter replays pending verification retry dispatch", async () => {
   const stateSnapshot = makeState();
   const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -118,6 +118,37 @@ function makeRepoWithMultipleStrandedMilestones(): string {
   return base;
 }
 
+function makeRepoWithActiveMismatchAndStrandedTarget(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-targeted-stranded-bootstrap-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M002"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: \"worktree\"\n---\n",
+  );
+  runGit(base, ["init"]);
+  runGit(base, ["config", "user.email", "test@test.com"]);
+  runGit(base, ["config", "user.name", "Test"]);
+  writeFileSync(join(base, "README.md"), "# test\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "init"]);
+  runGit(base, ["branch", "-M", "main"]);
+
+  runGit(base, ["checkout", "-b", "milestone/M002"]);
+  writeFileSync(join(base, "m002.txt"), "target stranded work\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M002 in progress"]);
+  runGit(base, ["checkout", "main"]);
+  runGit(base, ["worktree", "add", ".gsd/worktrees/M002", "milestone/M002"]);
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Incorrect active milestone", status: "active" });
+  insertMilestone({ id: "M002", title: "Target stranded milestone", status: "active" });
+  closeDatabase();
+
+  return base;
+}
+
 function makeRepoWithRecoveredCleanupAndStrandedMismatch(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-headless-stranded-bootstrap-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
@@ -321,6 +352,9 @@ test("headless bootstrap checks stranded work before recovered-complete shortcut
     const messages = notifications.map((entry) => entry.message).join("\n");
     assert.equal(ready, false);
     assert.match(messages, /Stranded work for M002 blocks auto-mode/);
+    assert.match(messages, /\/gsd auto M002/);
+    assert.match(messages, /\/gsd park M002 "reason"/);
+    assert.match(messages, /\/gsd rethink/);
     assert.doesNotMatch(messages, /all milestones complete/);
   } finally {
     if (previousHeadless === undefined) {
@@ -409,7 +443,101 @@ test("bootstrap blocks active stranded recovery when another open milestone also
     assert.equal(ready, false);
     assert.deepEqual(adoptCalls, []);
     assert.match(messages, /Stranded work for M002 blocks auto-mode before M001/);
+    assert.match(messages, /\/gsd auto M002/);
+    assert.match(messages, /\/gsd park M002 "reason"/);
+    assert.match(messages, /explicitly discard M002/);
   } finally {
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap honors explicit solo milestone lock when recovering stranded target worktree", async () => {
+  const base = makeRepoWithActiveMismatchAndStrandedTarget();
+  const previousCwd = process.cwd();
+  const previousLock = process.env.GSD_MILESTONE_LOCK;
+  const previousWorker = process.env.GSD_PARALLEL_WORKER;
+  const s = new AutoSession();
+  const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    delete process.env.GSD_PARALLEL_WORKER;
+    process.env.GSD_MILESTONE_LOCK = "M002";
+
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: () => ({ ok: true, mode: "worktree", path: base }),
+          adoptStrandedMilestone: (
+            milestoneId: string,
+            sessionBase: string,
+            _ctx: unknown,
+            opts: { mode: "worktree" | "branch" },
+          ) => {
+            adoptCalls.push({ milestoneId, mode: opts.mode });
+            s.basePath = sessionBase;
+            s.originalBasePath = sessionBase;
+            s.strandedRecoveryIsolationMode = opts.mode;
+            return { ok: true, mode: opts.mode, path: sessionBase };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    const messages = notifications.map((entry) => entry.message).join("\n");
+    assert.equal(ready, true);
+    assert.deepEqual(adoptCalls, [{ milestoneId: "M002", mode: "worktree" }]);
+    assert.equal(s.currentMilestoneId, "M002");
+    assert.match(messages, /Recovering stranded work for M002/);
+    assert.doesNotMatch(messages, /blocks auto-mode before M001/);
+  } finally {
+    if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+    else process.env.GSD_MILESTONE_LOCK = previousLock;
+    if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
+    else process.env.GSD_PARALLEL_WORKER = previousWorker;
     try {
       closeDatabase();
     } catch {}

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -473,13 +473,13 @@ describe('derive-state-helpers', () => {
     }
   });
 
-	  test('getActiveMilestoneId: DB lock path ignores PARKED flag projection', async () => {
-	    const base = createFixtureBase();
-	    const previousLock = process.env.GSD_MILESTONE_LOCK;
-	    const previousWorker = process.env.GSD_PARALLEL_WORKER;
-	    try {
-	      process.env.GSD_MILESTONE_LOCK = 'M001';
-	      process.env.GSD_PARALLEL_WORKER = '1';
+  test('getActiveMilestoneId: DB lock path ignores PARKED flag projection', async () => {
+    const base = createFixtureBase();
+    const previousLock = process.env.GSD_MILESTONE_LOCK;
+    const previousWorker = process.env.GSD_PARALLEL_WORKER;
+    try {
+      process.env.GSD_MILESTONE_LOCK = 'M001';
+      process.env.GSD_PARALLEL_WORKER = '1';
       writeFile(base, 'milestones/M001/M001-PARKED.md', '# Parked on disk');
 
       openDatabase(':memory:');
@@ -487,12 +487,41 @@ describe('derive-state-helpers', () => {
 
       const id = await getActiveMilestoneId(base);
       assert.equal(id, 'M001', 'DB status remains authoritative despite PARKED projection');
-	    } finally {
-	      if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
-	      else process.env.GSD_MILESTONE_LOCK = previousLock;
-	      if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
-	      else process.env.GSD_PARALLEL_WORKER = previousWorker;
-	      closeDatabase();
+    } finally {
+      if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+      else process.env.GSD_MILESTONE_LOCK = previousLock;
+      if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
+      else process.env.GSD_PARALLEL_WORKER = previousWorker;
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('deriveStateFromDb: solo milestone lock scopes state to the requested milestone', async () => {
+    const base = createFixtureBase();
+    const previousLock = process.env.GSD_MILESTONE_LOCK;
+    const previousWorker = process.env.GSD_PARALLEL_WORKER;
+    try {
+      delete process.env.GSD_PARALLEL_WORKER;
+      process.env.GSD_MILESTONE_LOCK = 'M002';
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Earlier', status: 'active' });
+      insertMilestone({ id: 'M002', title: 'Requested', status: 'active' });
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+      const id = await getActiveMilestoneId(base);
+
+      assert.equal(state.activeMilestone?.id, 'M002', 'explicit lock chooses requested milestone');
+      assert.deepEqual(state.registry.map((entry) => entry.id), ['M002'], 'registry is scoped to requested milestone');
+      assert.equal(id, 'M002', 'active milestone helper honors solo lock');
+    } finally {
+      if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+      else process.env.GSD_MILESTONE_LOCK = previousLock;
+      if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
+      else process.env.GSD_PARALLEL_WORKER = previousWorker;
+      closeDatabase();
       cleanup(base);
     }
   });

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -141,6 +141,42 @@ test("dispatch: present task plan proceeds to execute-task normally", async (t) 
     `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
 });
 
+test("dispatch: session milestone mismatch stops before missing-task-plan recovery", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-session-milestone-mismatch-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M002");
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  const ctx = makeContextFor(tmp, "M001", "S01", "T01", {
+    basePath: worktreeRoot,
+    originalBasePath: tmp,
+    currentMilestoneId: "M002",
+  });
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "stop");
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "warning");
+  assert.match(result.reason, /context mid "M001" does not match session\.currentMilestoneId "M002"/);
+});
+
+test("dispatch: worktree path mismatch stops before planning a different milestone", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-worktree-path-milestone-mismatch-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M002");
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  const ctx = makeContextFor(worktreeRoot, "M001", "S01", "T01");
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "stop");
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "warning");
+  assert.match(result.reason, /context mid "M001" does not match basePath worktree "M002"/);
+});
+
 test("dispatch: executing recovery checks active milestone worktree task plans before re-dispatching plan-slice", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-6192-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));


### PR DESCRIPTION
## What changed

- Honor explicit solo milestone locks during state derivation so `/gsd auto M002` scopes recovery to M002 instead of falling back to the first active milestone.
- Stop dispatch when the active session/worktree milestone disagrees with the dispatch milestone, preventing M002 worktrees from planning M001 units.
- Replace terse stranded-work blockers with explicit recovery, park, and abandon commands.
- Avoid rendering the same extension error notification twice in the interactive TUI.

## Why

A stranded M002 worktree could block auto-mode before M001, while the suggested recovery command `/gsd auto M002` still derived M001 as active. That made the recovery instruction circular. The mismatch also allowed missing-task-plan recovery to dispatch M001 planning from an M002 session/worktree.

## Validation

- `pnpm run typecheck:extensions`
- `pnpm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.js dist-test/src/resources/extensions/gsd/tests/derive-state-helpers.test.js dist-test/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.js dist-test/packages/gsd-agent-modes/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.js`

All focused tests passed: 46 pass, 0 fail.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782955180&installation_id=134682257&pr_number=387&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F387&signature=5cd3abb6755934036093f9a7a76af9f116e43adcdc5aed951a0fb05368c3900b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode bootstrap, state derivation, and dispatch guards on milestone/worktree mismatch—core orchestration paths with broad regression test coverage but non-trivial behavior change.
> 
> **Overview**
> Fixes **stranded milestone recovery** when project state, session, and worktree disagree—especially suggesting `/gsd auto M002` while state still treated **M001** as active.
> 
> **State & dispatch:** `GSD_MILESTONE_LOCK` now scopes state derivation for solo `/gsd auto <id>` (not only parallel workers), so targeted recovery sees the requested milestone. `resolveDispatch` stops early if `session.currentMilestoneId` or the session/base worktree path does not match the dispatch milestone—blocking wrong-milestone planning (e.g. M001 plans from an M002 worktree). The wired dispatch adapter can **adopt** `session.currentMilestoneId` to the new active milestone when the prior one is closed, unless a conflicting worktree scope blocks it.
> 
> **Bootstrap UX:** Stranded-work blockers are replaced with explicit **recover / park / abandon** steps. Extension **error** notifications update only the sticky blocker (no duplicate chat line).
> 
> **Tests** cover lock scoping, dispatch mismatches, milestone adoption, bootstrap lock recovery, and TUI error routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88622dc6a8ca7cd623ca31cafc7b3ecf5c94f45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->