### PR TITLE
[codex] Rename GSD MCP prep notification

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
@@ -54,7 +54,7 @@ test("prepareWorkflowMcpForProject uses the selected unit model when session pro
 
   assert.equal(result?.status, "created");
   assert.equal(existsSync(join(projectRoot, ".mcp.json")), true);
-  assert.match(notifications.map((entry) => entry.message).join("\n"), /Claude Code MCP prepared/);
+  assert.match(notifications.map((entry) => entry.message).join("\n"), /GSD MCP Server Prepared/);
 });
 
 test("shouldAutoPrepareWorkflowMcp stays disabled for non-Claude active provider even when claude-code is ready", () => {
@@ -178,7 +178,7 @@ test("before_agent_start auto-prepares project workflow MCP for Claude Code CLI"
     GSD_WORKFLOW_MCP_SERVER_NAME,
     GSD_BROWSER_MCP_SERVER_NAME,
   ]);
-  assert.match(notifications.join("\n"), /Claude Code MCP prepared/);
+  assert.match(notifications.join("\n"), /GSD MCP Server Prepared/);
 });
 
 test("before_agent_start returns discovered skill fallback without project .gsd", async (t) => {

--- a/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
+++ b/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
@@ -73,7 +73,7 @@ export function prepareWorkflowMcpForProject(
   try {
     const result = ensureProjectWorkflowMcpConfig(projectRoot);
     if (result.status !== "unchanged") {
-      prepCtx.ui?.notify?.(`Claude Code MCP prepared at ${result.configPath}`, "info");
+      prepCtx.ui?.notify?.(`GSD MCP Server Prepared at ${result.configPath}`, "info");
     }
     return result;
   } catch (err) {


### PR DESCRIPTION
## Summary

Updates the Claude Code auto-prep success notification so the user-facing label names the product surface as `GSD MCP Server Prepared at ...` instead of `Claude Code MCP prepared at ...`.

## Why

The generated config is the GSD MCP server config, even though the auto-prep path is triggered by the Claude Code provider. The previous wording made the prepared server sound Claude-owned rather than GSD-owned.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts`

## Notes

Created from a clean worktree off `origin/main` so unrelated local edits in the primary checkout were not included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004300&installation_id=134682257&pr_number=397&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F397&signature=96eff0b207c01dcdacccfba1c548f8070534ace5a9fab720a52a6f6c3fc7132c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and test expectations only; no behavior or config logic changes.
> 
> **Overview**
> Renames the **info** notification shown when workflow MCP auto-prep creates or updates project config from `Claude Code MCP prepared at …` to **`GSD MCP Server Prepared at …`**, so the label matches the GSD MCP server being written (still on the Claude Code auto-prep path).
> 
> Tests in `workflow-mcp-auto-prep.test.ts` now assert the new message text. **Warning** copy on prep failure is unchanged (`Claude Code MCP prep failed`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee9376657e68d502f1138f49b3cfe0646d46787a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->