### PR TITLE
[codex] Disable TUI mouse reporting by default

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -260,6 +260,7 @@ With this configuration, a Haiku-4-5 subagent sees only `gsd-workflow` and `goog
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in list) | Comma-separated command prefixes allowed for `!command` value resolution. Overrides `allowedCommandPrefixes` in settings.json. See [Custom Models — Command Allowlist](custom-models.md#command-allowlist). |
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempted from `fetch_page` URL blocking. Overrides `fetchAllowedUrls` in settings.json. See [URL Blocking](#url-blocking-fetch_page). |
 | `PI_DISABLE_SYNC_OUTPUT` | (unset) | Set to literal `1` to disable synchronized terminal output mode in the TUI on non-Windows platforms. By default synchronized output is enabled on macOS/Linux and always disabled on Windows. |
+| `PI_TUI_MOUSE` | (unset) | Set to literal `1` to enable terminal mouse reporting for TUI clicks and wheel events. Native drag selection is preserved by default; when mouse reporting is enabled, most terminals require Shift+drag to select text. |
 | `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |
 
 ### Token Telemetry

--- a/gitbook/reference/environment-variables.md
+++ b/gitbook/reference/environment-variables.md
@@ -13,6 +13,7 @@
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in) | Comma-separated command prefixes allowed for value resolution. |
 | `GSD_WEB_PROJECT_CWD` | — | Default project path for `gsd --web` when `?project=` is not specified. |
 | `PI_DISABLE_SYNC_OUTPUT` | (unset) | Set to literal `1` to disable synchronized terminal output mode in the TUI on non-Windows platforms. By default synchronized output is enabled on macOS/Linux and always disabled on Windows. |
+| `PI_TUI_MOUSE` | (unset) | Set to literal `1` to enable terminal mouse reporting for TUI clicks and wheel events. Native drag selection is preserved by default; when mouse reporting is enabled, most terminals require Shift+drag to select text. |
 | `PI_TOKEN_AUDIT` | (unset) | Set to literal `1` to emit metadata-only provider-boundary prompt/tool audit JSONL on stderr. Other values are ignored. |
 | `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |
 

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -12,6 +12,10 @@ const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 
+export function shouldEnableMouseReporting(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env.PI_TUI_MOUSE === "1";
+}
+
 /**
  * Minimal terminal interface for TUI
  */
@@ -137,10 +141,11 @@ export class ProcessTerminal implements Terminal {
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
 
-		// Enable mouse reporting so clicks and the wheel reach the TUI. On by
-		// default; set PI_TUI_MOUSE=0 to opt out (preserves native click-drag
-		// text selection without holding Shift).
-		if (process.env.PI_TUI_MOUSE !== "0") {
+		// Mouse reporting lets clicks and the wheel reach the TUI, but terminal
+		// mouse capture prevents native click-drag text selection in most
+		// emulators. Keep native selection as the default; set PI_TUI_MOUSE=1 to
+		// opt into mouse reporting.
+		if (shouldEnableMouseReporting()) {
 			process.stdout.write(ENABLE_MOUSE);
 			this._mouseActive = true;
 		}

--- a/packages/pi-tui/test/terminal.test.ts
+++ b/packages/pi-tui/test/terminal.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { ProcessTerminal } from "../src/terminal.ts";
+import { ProcessTerminal, shouldEnableMouseReporting } from "../src/terminal.ts";
 
 describe("ProcessTerminal dimensions", () => {
 	it("falls back to COLUMNS and LINES before default dimensions", () => {
@@ -41,5 +41,16 @@ describe("ProcessTerminal dimensions", () => {
 				process.env.LINES = previousLines;
 			}
 		}
+	});
+});
+
+describe("shouldEnableMouseReporting", () => {
+	it("keeps native terminal selection by default", () => {
+		assert.equal(shouldEnableMouseReporting({}), false);
+		assert.equal(shouldEnableMouseReporting({ PI_TUI_MOUSE: "0" }), false);
+	});
+
+	it("enables terminal mouse reporting only when explicitly requested", () => {
+		assert.equal(shouldEnableMouseReporting({ PI_TUI_MOUSE: "1" }), true);
 	});
 });


### PR DESCRIPTION
## Summary

Disable terminal mouse reporting by default in the TUI so fresh installs preserve native terminal drag selection.

## Why

The current mouse reporting mode lets the TUI receive clicks and wheel events, but it also captures normal mouse drag events in most terminal emulators. Until GSD owns app-level text selection, the safer default is to keep native terminal highlighting available and make TUI mouse support opt-in.

## Changes

- Add `shouldEnableMouseReporting()` and only enable terminal mouse reporting when `PI_TUI_MOUSE=1`.
- Update terminal tests to cover default-off and explicit opt-in behavior.
- Document `PI_TUI_MOUSE` in user and GitBook environment-variable references.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts` in the clean PR worktree
- `pnpm run build:pi-tui`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/test/terminal.test.ts`
- `node --experimental-strip-types --test packages/pi-tui/test/mouse.test.ts packages/pi-tui/test/stdin-buffer.test.ts`
- `pnpm exec esbuild packages/pi-tui/test/tui-mouse-dispatch.test.ts --bundle --platform=node --format=esm --outfile=/tmp/tui-mouse-dispatch.test.mjs`
- `node --test /tmp/tui-mouse-dispatch.test.mjs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004380&installation_id=134682257&pr_number=398&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F398&signature=69165abc81b18eded72c7a906a4c79c8b7ddcfdcf119f40d8fd79853714bde56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default UX change in terminal setup only; no auth, data, or API surface changes. Users who relied on implicit mouse-on must set `PI_TUI_MOUSE=1`.
> 
> **Overview**
> **Terminal mouse reporting is now opt-in** instead of on by default. The TUI only enables click/wheel handling when `PI_TUI_MOUSE=1`, so normal drag-to-select text works out of the box; users who want TUI mouse support set the env var explicitly.
> 
> `shouldEnableMouseReporting()` centralizes that check in `pi-tui`, and **user + GitBook env docs** document the new semantics (including Shift+drag for selection when mouse mode is on). Tests cover default-off, `PI_TUI_MOUSE=0`, and opt-in with `1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178563437eee2cfa07c04a25e8033855f7ecc8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->