### PR TITLE
[codex] Default GSD widget to small

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium
+
       - uses: ./.github/actions/restore-ci-build-artifacts
 
       - uses: ./.github/actions/cache-nextjs

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -516,8 +516,9 @@ export const hideFooter = (_tui: unknown, theme: Theme, footerData: ReadonlyFoot
 
 /** Widget display modes: full → small → min → off → full */
 export type WidgetMode = "full" | "small" | "min" | "off";
+export const DEFAULT_WIDGET_MODE: WidgetMode = "small";
 const WIDGET_MODES: WidgetMode[] = ["full", "small", "min", "off"];
-let widgetMode: WidgetMode = "full";
+let widgetMode: WidgetMode = DEFAULT_WIDGET_MODE;
 let widgetModeInitialized = false;
 let widgetModePreferencePath: string | null = null;
 
@@ -628,7 +629,7 @@ export function getWidgetMode(projectPath?: string, globalPath?: string): Widget
 
 /** Test-only reset for widget mode caching. */
 export function _resetWidgetModeForTests(): void {
-  widgetMode = "full";
+  widgetMode = DEFAULT_WIDGET_MODE;
   widgetModeInitialized = false;
   widgetModePreferencePath = null;
 }

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -733,6 +733,7 @@ export function updateProgressWidget(
         logWarning("dashboard", `DB status update failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }, 15_000);
+    progressRefreshTimer.unref?.();
 
     return {
       render(width: number): string[] {

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -23,6 +23,9 @@ import {
 import { loadFile, saveFile, splitFrontmatter, parseFrontmatterMap } from "./files.js";
 import { runClaudeImportFlow } from "./claude-import.js";
 
+const DEFAULT_WIDGET_MODE = "small";
+const WIDGET_MODE_OPTIONS = [DEFAULT_WIDGET_MODE, "full", "min", "off"] as const;
+
 /** Extract body content after frontmatter closing delimiter, or null if none. */
 function extractBodyAfterFrontmatter(content: string): string | null {
   const closingIdx = content.indexOf("\n---", content.indexOf("---"));
@@ -1558,7 +1561,7 @@ async function configureAdvanced(ctx: ExtensionCommandContext, prefs: Record<str
     prefs.min_request_interval_ms = minRequestInterval;
   }
 
-  const widget = await promptEnum(ctx, "Auto-mode widget display", prefs.widget_mode, ["full", "small", "min", "off"], "full");
+  const widget = await promptEnum(ctx, "Auto-mode widget display", prefs.widget_mode, WIDGET_MODE_OPTIONS, DEFAULT_WIDGET_MODE);
   if (widget !== undefined) prefs.widget_mode = widget;
 
   const experimental = (prefs.experimental as Record<string, unknown> | undefined) ?? {};

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -23,6 +23,8 @@ import {
   resolveAutoSupervisorConfig,
 } from "./preferences.js";
 
+const DEFAULT_WIDGET_MODE = "small";
+
 // ─── Data Collection ──────────────────────────────────────────────────────
 
 interface ConfigSection {
@@ -160,7 +162,7 @@ function collectConfigSections(): ConfigSection[] {
   if (prefs?.service_tier) toggleRows.push({ label: "service_tier", value: prefs.service_tier });
   if (prefs?.search_provider && prefs.search_provider !== "auto") toggleRows.push({ label: "search_provider", value: prefs.search_provider });
   if (prefs?.context_selection) toggleRows.push({ label: "context_selection", value: prefs.context_selection });
-  if (prefs?.widget_mode && prefs.widget_mode !== "full") toggleRows.push({ label: "widget_mode", value: prefs.widget_mode });
+  if (prefs?.widget_mode && prefs.widget_mode !== DEFAULT_WIDGET_MODE) toggleRows.push({ label: "widget_mode", value: prefs.widget_mode });
   if (prefs?.experimental?.rtk) toggleRows.push({ label: "experimental.rtk", value: "on" });
   if (toggleRows.length > 0) sections.push({ title: "Toggles", rows: toggleRows });
 

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -423,7 +423,7 @@ export interface GSDPreferences {
   search_provider?: "brave" | "tavily" | "ollama" | "native" | "auto";
   /** Context selection mode for file inlining. "full" inlines entire files, "smart" uses semantic chunking. Default derived from token profile. */
   context_selection?: ContextSelectionMode;
-  /** Default widget display mode for auto-mode dashboard. "full" | "small" | "min" | "off". Default: "full". */
+  /** Default widget display mode for auto-mode dashboard. "full" | "small" | "min" | "off". Default: "small". */
   widget_mode?: "full" | "small" | "min" | "off";
   /** Reactive (graph-derived parallel) task execution within slices. Disabled by default. */
   reactive_execution?: ReactiveExecutionConfig;

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -21,6 +21,7 @@ import {
   clearSliceProgressCache,
   getWidgetMode,
   cycleWidgetMode,
+  setWidgetMode,
   _resetWidgetModeForTests,
   _resetLastCommitCacheForTests,
   _refreshLastCommitForTests,
@@ -571,13 +572,20 @@ test("updateProgressWidget refreshes slice progress cache immediately", (t) => {
 test("updateProgressWidget full mode keeps footer-owned signals out of auto deck", (t) => {
   const dir = makeTempDir("command-deck");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const projectPrefsPath = join(dir, ".gsd", "preferences.md");
+  const globalPrefsPath = join(dir, ".gsd", "global-preferences.md");
+  writeFileSync(projectPrefsPath, "---\nversion: 1\n---\n", "utf-8");
   let widget: { render(width: number): string[]; dispose?: () => void } | null = null;
 
   t.after(() => {
     widget?.dispose?.();
+    _resetWidgetModeForTests();
     clearSliceProgressCache();
     cleanup(dir);
   });
+
+  _resetWidgetModeForTests();
+  setWidgetMode("full", projectPrefsPath, globalPrefsPath);
 
   updateProgressWidget(
     {
@@ -811,4 +819,26 @@ test("widget mode respects project preference precedence and persists there", (t
   const globalPrefs = readFileSync(globalPrefsPath, "utf-8");
   assert.match(projectPrefs, /widget_mode:\s*min/);
   assert.match(globalPrefs, /widget_mode:\s*off/);
+});
+
+test("widget mode defaults to small when preferences do not set it", (t) => {
+  const homeDir = makeTempDir("home-no-widget-pref");
+  const projectDir = makeTempDir("project-no-widget-pref");
+  const globalPrefsPath = join(homeDir, ".gsd", "preferences.md");
+  const projectPrefsPath = join(projectDir, ".gsd", "preferences.md");
+
+  mkdirSync(join(homeDir, ".gsd"), { recursive: true });
+  mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+  writeFileSync(globalPrefsPath, "---\nversion: 1\n---\n", "utf-8");
+  writeFileSync(projectPrefsPath, "---\nversion: 1\n---\n", "utf-8");
+
+  t.after(() => {
+    cleanup(homeDir);
+    cleanup(projectDir);
+    _resetWidgetModeForTests();
+  });
+
+  _resetWidgetModeForTests();
+
+  assert.equal(getWidgetMode(projectPrefsPath, globalPrefsPath), "small");
 });

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -7,12 +7,17 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { visibleWidth } from "@gsd/pi-tui";
 
-import { setCompletionProgressWidget, updateProgressWidget } from "../auto-dashboard.ts";
+import {
+  _resetWidgetModeForTests,
+  setCompletionProgressWidget,
+  setWidgetMode,
+  updateProgressWidget,
+} from "../auto-dashboard.ts";
 import type { GSDState } from "../types.ts";
 
 interface CapturedSetHeader {
@@ -143,10 +148,18 @@ test("updateProgressWidget gracefully no-ops when ctx.ui lacks setHeader/setStat
 
 // ── NEXT-mode footer guidance ───────────────────────────────────────────
 
-test("auto-dashboard widget render output includes /gsd next guidance when isStepMode is true", (t) => {
+test("auto-dashboard full widget render output includes /gsd next guidance when isStepMode is true", (t) => {
   const dir = makeTempDir("step-hint");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
-  t.after(() => cleanup(dir));
+  const projectPrefsPath = join(dir, ".gsd", "preferences.md");
+  const globalPrefsPath = join(dir, ".gsd", "global-preferences.md");
+  writeFileSync(projectPrefsPath, "---\nversion: 1\n---\n", "utf-8");
+  _resetWidgetModeForTests();
+  setWidgetMode("full", projectPrefsPath, globalPrefsPath);
+  t.after(() => {
+    _resetWidgetModeForTests();
+    cleanup(dir);
+  });
 
   let widgetFactory: ((tui: unknown, theme: unknown) => any) | undefined;
 
@@ -173,6 +186,7 @@ test("auto-dashboard widget render output includes /gsd next guidance when isSte
     bold: (text: string) => text,
   };
   const component = widgetFactory!(fakeTui, fakeTheme);
+  t.after(() => component.dispose?.());
   const lines = component.render(120);
 
   const hasStepHint = lines.some((line: string) => line.includes("/gsd next to advance one step"));
@@ -181,10 +195,18 @@ test("auto-dashboard widget render output includes /gsd next guidance when isSte
   if (component.dispose) component.dispose();
 });
 
-test("auto-dashboard widget render output omits /gsd next guidance when isStepMode is false", (t) => {
+test("auto-dashboard full widget render output omits /gsd next guidance when isStepMode is false", (t) => {
   const dir = makeTempDir("no-step-hint");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
-  t.after(() => cleanup(dir));
+  const projectPrefsPath = join(dir, ".gsd", "preferences.md");
+  const globalPrefsPath = join(dir, ".gsd", "global-preferences.md");
+  writeFileSync(projectPrefsPath, "---\nversion: 1\n---\n", "utf-8");
+  _resetWidgetModeForTests();
+  setWidgetMode("full", projectPrefsPath, globalPrefsPath);
+  t.after(() => {
+    _resetWidgetModeForTests();
+    cleanup(dir);
+  });
 
   let widgetFactory: ((tui: unknown, theme: unknown) => any) | undefined;
 
@@ -211,6 +233,7 @@ test("auto-dashboard widget render output omits /gsd next guidance when isStepMo
     bold: (text: string) => text,
   };
   const component = widgetFactory!(fakeTui, fakeTheme);
+  t.after(() => component.dispose?.());
   const lines = component.render(120);
 
   const hasStepHint = lines.some((line: string) => line.includes("/gsd next to advance one step"));


### PR DESCRIPTION
## Summary

- Default the `/gsd` auto dashboard widget mode to `small` when no preference is set.
- Update the preferences wizard and configuration overlay so `small` is treated as the implicit/default widget mode.
- Add regression coverage for unset widget preferences while keeping explicit `full` mode coverage intact.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts src/resources/extensions/gsd/tests/show-config-command.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783005356&installation_id=134682257&pr_number=401&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F401&signature=4fc78f6229926b64c14632e17bfd15a51e8c3017165f0c04114a8291a9ca90be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI default and preference-display behavior only; explicit `widget_mode` values unchanged, with added regression tests.
> 
> **Overview**
> Changes the **default auto-mode dashboard widget** from `full` to **`small`** when `widget_mode` is unset, via a shared `DEFAULT_WIDGET_MODE` in `auto-dashboard.ts` and aligned defaults in the prefs wizard and config overlay (non-default modes only show in toggles).
> 
> **Prefs & docs:** Wizard enum order/default and `preferences-types` comment now treat `small` as implicit default.
> 
> **Runtime:** Progress widget’s 15s refresh timer calls `unref()` so it doesn’t keep the process alive.
> 
> **CI:** Integration job installs Playwright Chromium before `test:integration`.
> 
> **Tests:** Regression for unset `widget_mode` → `small`; full-widget tests explicitly `setWidgetMode("full")`; TUI lifecycle tests pin full mode for `/gsd next` hint coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf7c5ffaf23017ab24e14537d9904d2866386e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->