### PR TITLE
fix(gsd): allow run-uat subagent dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-unit-tool-scope.ts
+++ b/src/resources/extensions/gsd/auto-unit-tool-scope.ts
@@ -44,7 +44,7 @@ export const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = {
   "execute-task": ["gsd_task_complete", "gsd_decision_save"],
   "execute-task-simple": ["gsd_task_complete", "gsd_decision_save"],
   "reactive-execute": ["gsd_task_complete", "gsd_decision_save"],
-  "run-uat": ["gsd_summary_save", ...RUN_UAT_BROWSER_TOOL_NAMES],
+  "run-uat": ["gsd_summary_save", "subagent", ...RUN_UAT_BROWSER_TOOL_NAMES],
   "gate-evaluate": ["gsd_save_gate_result"],
   "rewrite-docs": ["gsd_summary_save", "gsd_decision_save"],
   "workflow-preferences": ["gsd_summary_save"],

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -679,6 +679,7 @@ const PLANNING_SUBAGENT_TOOLS = new Set(["subagent", "task"]);
  * manifests still declare per-unit subsets via ToolsPolicy.allowedSubagents.
  */
 const PLANNING_DISPATCH_AGENT_REGISTRY = {
+  mnemo: { readOnlySpecialist: true },
   scout: { readOnlySpecialist: true },
   planner: { readOnlySpecialist: true },
   reviewer: { readOnlySpecialist: true },
@@ -692,7 +693,7 @@ export const ALLOWED_PLANNING_DISPATCH_AGENTS = new Set<string>(
     .map(([agentId]) => agentId),
 );
 
-let warnedMissingPlanningDispatchAgentClasses = false;
+let warnedMissingControlledDispatchAgentClasses = false;
 
 function isReadOnlySpecialist(agentId: string): boolean {
   const metadata = PLANNING_DISPATCH_AGENT_REGISTRY[agentId as keyof typeof PLANNING_DISPATCH_AGENT_REGISTRY];
@@ -703,11 +704,20 @@ function allowedPlanningDispatchAgentsList(): string {
   return [...ALLOWED_PLANNING_DISPATCH_AGENTS].join(", ");
 }
 
-function warnMissingPlanningDispatchAgentClasses(unitType: string, mode: string, toolName: string): void {
-  if (warnedMissingPlanningDispatchAgentClasses) return;
-  warnedMissingPlanningDispatchAgentClasses = true;
+function allowsControlledSubagentDispatch(
+  policy: ToolsPolicy,
+): policy is ToolsPolicy & { readonly allowedSubagents: readonly string[] } {
+  return (
+    (policy.mode === "planning-dispatch" || policy.mode === "verification") &&
+    Array.isArray((policy as { readonly allowedSubagents?: unknown }).allowedSubagents)
+  );
+}
+
+function warnMissingControlledDispatchAgentClasses(unitType: string, mode: string, toolName: string): void {
+  if (warnedMissingControlledDispatchAgentClasses) return;
+  warnedMissingControlledDispatchAgentClasses = true;
   // TODO(#5060): Remove this migration shim once all subagent/task callers are verified to forward agent identities.
-  const message = `[write-gate] planning-dispatch: shouldBlockPlanningUnit called for tool "${toolName}" ` +
+  const message = `[write-gate] controlled-dispatch: shouldBlockPlanningUnit called for tool "${toolName}" ` +
     `on unit "${unitType}" without agentClasses - stale caller; blocking dispatch.`;
   console.warn(message);
   logWarning("intercept", message, {
@@ -777,8 +787,9 @@ function blockReason(unitType: string, mode: string, what: string): string {
  *   - "docs"       → like "planning" but also allows writes to paths
  *                    matching `allowedPathGlobs` relative to basePath.
  *   - "verification"
- *                  → allows Bash for project verification commands, but keeps
- *                    writes restricted to .gsd/ and blocks subagent dispatch.
+ *                  → allows Bash for project verification commands, keeps
+ *                    writes restricted to .gsd/, and permits subagent dispatch
+ *                    only when the manifest declares allowedSubagents.
  *
  * `pathOrCommand` is the file path for write/edit-shaped tools and the
  * shell command for bash. Other tools ignore this argument.
@@ -825,7 +836,7 @@ export function shouldBlockPlanningUnit(
   if (tool.startsWith("gsd_")) return { block: false };
 
   if (PLANNING_SUBAGENT_TOOLS.has(tool)) {
-    if (policy.mode === "planning-dispatch") {
+    if (allowsControlledSubagentDispatch(policy)) {
       const requested = (agentClasses ?? []).map(a => a.trim()).filter(Boolean);
       const dispatchContract = compileSubagentPermissionContract(policy);
       const allowedSubagents = dispatchContract.allowedSubagents;
@@ -834,7 +845,7 @@ export function shouldBlockPlanningUnit(
       // agent identities yet. Block and warn so stale callers surface in telemetry
       // instead of silently bypassing the gate.
       if (agentClasses === undefined) {
-        warnMissingPlanningDispatchAgentClasses(unitType, policy.mode, tool);
+        warnMissingControlledDispatchAgentClasses(unitType, policy.mode, tool);
         return {
           block: true,
           reason: blockReason(
@@ -857,7 +868,7 @@ export function shouldBlockPlanningUnit(
           reason: blockReason(
             unitType,
             policy.mode,
-            `subagent dispatch of "${globallyDisallowed}" not permitted; only read-only specialists (${allowedPlanningDispatchAgentsList()}) may be dispatched from planning-dispatch units`,
+            `subagent dispatch of "${globallyDisallowed}" not permitted; only read-only specialists (${allowedPlanningDispatchAgentsList()}) may be dispatched from ${policy.mode} units`,
           ),
         };
       }

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -185,6 +185,7 @@ test("buildMinimalAutoGsdToolSet preserves browser tools for run-uat", () => {
     "browser_assert",
     "browser_screenshot",
     "browser_wait_for",
+    "subagent",
     "gsd_summary_save",
     "gsd_task_complete",
     "memory_query",
@@ -197,6 +198,7 @@ test("buildMinimalAutoGsdToolSet preserves browser tools for run-uat", () => {
   assert.ok(result.includes("browser_assert"));
   assert.ok(result.includes("browser_screenshot"));
   assert.ok(result.includes("browser_wait_for"));
+  assert.ok(result.includes("subagent"));
   assert.ok(result.includes("gsd_summary_save"));
   assert.ok(!result.includes("gsd_task_complete"));
 });

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -344,6 +344,7 @@ test("#5843: run-uat uses verification tools policy so build/test commands can r
   const manifest = UNIT_MANIFESTS["run-uat"];
 
   assert.strictEqual(manifest.tools.mode, "verification");
+  assert.deepEqual(manifest.tools.allowedSubagents, ["mnemo", "scout", "reviewer", "tester"]);
 
   const buildResult = shouldBlockPlanningUnit(
     "bash",
@@ -367,6 +368,20 @@ test("#5843: run-uat uses verification tools policy so build/test commands can r
   );
   assert.strictEqual(sourceWriteResult.block, true);
   assert.match(sourceWriteResult.reason!, /tools-policy "verification"/);
+
+  const subagentResult = shouldBlockPlanningUnit(
+    "subagent",
+    "",
+    process.cwd(),
+    "run-uat",
+    manifest.tools,
+    ["mnemo"],
+  );
+  assert.strictEqual(
+    subagentResult.block,
+    false,
+    `run-uat must allow listed verification subagents: ${subagentResult.reason}`,
+  );
 });
 
 test("planning-dispatch hard block message omits internal tracker references", () => {
@@ -420,6 +435,11 @@ test('Unit Tool Contract exposes subagent dispatch permissions', () => {
     allowedSubagents: ["reviewer", "security", "tester"],
     toolsMode: "planning-dispatch",
   });
+  assert.deepEqual(resolveSubagentPermissionContract("run-uat"), {
+    allowed: true,
+    allowedSubagents: ["mnemo", "scout", "reviewer", "tester"],
+    toolsMode: "verification",
+  });
   assert.deepEqual(resolveSubagentPermissionContract("discuss-milestone"), {
     allowed: false,
     allowedSubagents: [],
@@ -427,21 +447,24 @@ test('Unit Tool Contract exposes subagent dispatch permissions', () => {
   });
 });
 
-test('planning-dispatch manifests declare non-empty allowedSubagents lists', () => {
+test('dispatch-capable manifests declare globally allowed subagents', () => {
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
-    if (manifest.tools.mode !== "planning-dispatch") continue;
+    const allowedSubagents = "allowedSubagents" in manifest.tools
+      ? manifest.tools.allowedSubagents
+      : undefined;
+    if (!allowedSubagents) continue;
     assert.ok(
-      Array.isArray(manifest.tools.allowedSubagents) && manifest.tools.allowedSubagents.length > 0,
-      `manifest "${unitType}" has planning-dispatch policy but no allowedSubagents — explicit allowlist is required for runtime dispatch gating`,
+      Array.isArray(allowedSubagents) && allowedSubagents.length > 0,
+      `manifest "${unitType}" enables subagent dispatch but has no allowedSubagents — explicit allowlist is required for runtime dispatch gating`,
     );
-    for (const agent of manifest.tools.allowedSubagents) {
+    for (const agent of allowedSubagents) {
       assert.ok(
         typeof agent === "string" && agent.length > 0,
         `manifest "${unitType}" has empty/invalid allowedSubagents entry: ${JSON.stringify(agent)}`,
       );
       assert.ok(
         ALLOWED_PLANNING_DISPATCH_AGENTS.has(agent),
-        `manifest "${unitType}" allows "${agent}", but the runtime planning-dispatch registry will hard-block it`,
+        `manifest "${unitType}" allows "${agent}", but the runtime controlled-dispatch registry will hard-block it`,
       );
     }
   }

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -27,6 +27,10 @@ const PLANNING_DISPATCH_REVIEW: ToolsPolicy = {
 const READ_ONLY: ToolsPolicy = { mode: 'read-only' };
 const ALL: ToolsPolicy = { mode: 'all' };
 const VERIFICATION: ToolsPolicy = { mode: 'verification' };
+const VERIFICATION_UAT: ToolsPolicy = {
+  mode: 'verification',
+  allowedSubagents: ['mnemo', 'scout', 'reviewer', 'tester'],
+};
 const DOCS: ToolsPolicy = {
   mode: 'docs',
   allowedPathGlobs: ['docs/**', 'README.md', 'README.*.md', 'CHANGELOG.md', '*.md'],
@@ -467,6 +471,27 @@ test('verification-mode: run-uat still blocks subagent dispatch', () => {
   const r = shouldBlockPlanningUnit('subagent', '', BASE, 'run-uat', VERIFICATION);
   assert.strictEqual(r.block, true);
   assert.match(r.reason!, /subagent dispatch is not permitted/);
+});
+
+test('verification-mode: run-uat allows explicit UAT specialist subagents', () => {
+  for (const agent of ['mnemo', 'scout', 'reviewer', 'tester']) {
+    const r = shouldBlockPlanningUnit('subagent', '', BASE, 'run-uat', VERIFICATION_UAT, [agent]);
+    assert.strictEqual(r.block, false, `expected ${agent} to be allowed: ${r.reason}`);
+  }
+});
+
+test('verification-mode: run-uat blocks implementation-tier subagents', () => {
+  const r = shouldBlockPlanningUnit('subagent', '', BASE, 'run-uat', VERIFICATION_UAT, ['worker']);
+  assert.strictEqual(r.block, true);
+  assert.match(r.reason!, /"worker"/);
+  assert.match(r.reason!, /read-only specialists/);
+});
+
+test('verification-mode: run-uat blocks read-only specialists not listed by policy', () => {
+  const r = shouldBlockPlanningUnit('subagent', '', BASE, 'run-uat', VERIFICATION_UAT, ['security']);
+  assert.strictEqual(r.block, true);
+  assert.match(r.reason!, /"security"/);
+  assert.match(r.reason!, /ToolsPolicy\.allowedSubagents|permitted agents for this unit/);
 });
 
 // ─── read-only mode ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -137,7 +137,9 @@ export type ContextModePolicy =
  *                    edits project markdown outside .gsd/.
  *   - "verification"
  *                  — Read tools + Bash for verification commands, writes
- *                    restricted to .gsd/**, no subagents.
+ *                    restricted to .gsd/**. Subagent dispatch is denied unless
+ *                    `allowedSubagents` opts a unit into controlled read-only
+ *                    specialist delegation.
  *
  * The allowlist for "docs" is declared per-manifest rather than hardcoded so
  * projects with non-standard doc layouts can extend it without forking the
@@ -150,7 +152,7 @@ export type ToolsPolicy =
   | { readonly mode: "planning" }
   | { readonly mode: "planning-dispatch"; readonly allowedSubagents: readonly string[] }
   | { readonly mode: "docs"; readonly allowedPathGlobs: readonly string[] }
-  | { readonly mode: "verification" };
+  | { readonly mode: "verification"; readonly allowedSubagents?: readonly string[] };
 
 // ─── Computed-artifact registry (#4924 v2 contract) ───────────────────────
 
@@ -305,6 +307,10 @@ const COMMON_BUDGET_SMALL = 250_000;    // ~65K tokens
 const TOOLS_ALL: ToolsPolicy = { mode: "all" };
 const TOOLS_PLANNING: ToolsPolicy = { mode: "planning" };
 const TOOLS_VERIFICATION: ToolsPolicy = { mode: "verification" };
+const TOOLS_VERIFICATION_DISPATCH_UAT: ToolsPolicy = {
+  mode: "verification",
+  allowedSubagents: ["mnemo", "scout", "reviewer", "tester"],
+};
 // Like TOOLS_PLANNING but permits dispatch to read-only recon/planning
 // specialists. Runtime-enforced by write-gate.ts before the subagent tool runs.
 const TOOLS_PLANNING_DISPATCH_RECON: ToolsPolicy = {
@@ -601,7 +607,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     contextMode: "verification",
-    tools: TOOLS_VERIFICATION,
+    tools: TOOLS_VERIFICATION_DISPATCH_UAT,
     artifacts: {
       inline: ["slice-uat"],
       excerpt: ["slice-summary"],
@@ -792,9 +798,12 @@ export function compileSubagentPermissionContract(
   if (policy.mode === "all") {
     return { allowed: true, allowedSubagents: ["*"], toolsMode: policy.mode };
   }
-  if (policy.mode === "planning-dispatch") {
+  if (
+    (policy.mode === "planning-dispatch" || policy.mode === "verification") &&
+    Array.isArray(policy.allowedSubagents)
+  ) {
     return {
-      allowed: true,
+      allowed: policy.allowedSubagents.length > 0,
       allowedSubagents: [...policy.allowedSubagents],
       toolsMode: policy.mode,
     };


### PR DESCRIPTION
## Linked issue

Closes #394

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Allow `run-uat` to dispatch controlled read-only subagents.
**Why:** `run-uat` currently hits a hard tools-policy block when it attempts UAT delegation.
**How:** Add `subagent` to the run-uat scoped tool list and let verification-mode manifests opt into an explicit `allowedSubagents` allowlist.

## What

Updates the GSD auto-unit tool policy for `run-uat` so it can use `mnemo`, `scout`, `reviewer`, and `tester` subagents while preserving the existing verification-mode bash and write restrictions.

Adds regression coverage for:

- `run-uat` tool scoping preserving `subagent`
- verification-mode runtime gating allowing only listed UAT specialists
- manifest-level subagent permission contracts for verification policies

## Why

The current `run-uat` unit cannot perform delegated UAT work even when the delegation is read-only or verification-focused. That blocks workflows like memory retrieval, reconnaissance, and automated result validation during UAT.

## How

`run-uat` now declares `subagent` in `AUTO_UNIT_SCOPED_TOOLS`. Its manifest remains `mode: "verification"`, but carries an explicit `allowedSubagents` list. The write gate treats verification policies with `allowedSubagents` as controlled-dispatch policies, reusing the existing read-only specialist registry and per-unit allowlist checks.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/token-tool-gating.test.ts src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts src/resources/extensions/gsd/tests/unit-context-manifest.test.ts`
- `pnpm run build:rpc-client && pnpm run build:mcp-server`
- `pnpm run typecheck:extensions`

## AI disclosure

- [x] This PR includes AI-assisted code. Codex researched issue #394, implemented the scoped policy change, and ran the verification listed above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783006554&installation_id=134682257&pr_number=404&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F404&signature=8b31b41f0f52bf4db38cd64ca3492b5166350323199e5a16b1de8f147751c96d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands tool-policy surface for a verification unit by allowing subagent dispatch, though it remains gated by global specialist registry and per-unit allowlists.
> 
> **Overview**
> **`run-uat`** can delegate UAT work again: **`subagent`** is added to the unit’s auto tool scope, and the manifest keeps **`verification`** mode but opts into **`allowedSubagents`** (`mnemo`, `scout`, `reviewer`, `tester`).
> 
> The write gate now treats **`verification`** policies with an **`allowedSubagents`** list like **controlled dispatch** (same read-only specialist registry and per-unit allowlist as **`planning-dispatch`**), including registering **`mnemo`** as a dispatchable specialist. **`compileSubagentPermissionContract`** and manifest tests were updated so UAT still blocks source edits and unlisted agents (e.g. **`worker`**, **`security`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ecdcd7238246f8a80a8d3cb3dc60da04dc2e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->