### PR TITLE
fix(gsd): unblock needs-remediation reassess dispatch

### DIFF
--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -238,7 +238,7 @@ export async function handleVerdict(
 
   if (effectiveVerdict === "needs-remediation") {
     ctx.ui.notify(
-      "Follow up with gsd_reassess_roadmap to add remediation slices, then re-run /gsd auto.",
+      "Follow up with /gsd dispatch reassess to add remediation slices, then re-run /gsd auto.",
       "info",
     );
   }

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -75,7 +75,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd new-milestone  Create milestone from headless context (used by gsd headless)",
     "  /gsd new-project    Bootstrap a new project (use --deep for staged project-level discovery)",
     "  /gsd quick          Execute a quick task without full planning overhead",
-    "  /gsd dispatch       Dispatch a specific phase directly  [research|plan|execute|complete|uat|replan]",
+    "  /gsd dispatch       Dispatch a specific phase directly  [research|plan|execute|complete|validate|reassess|uat|replan]",
     "  /gsd verdict <v>    Override milestone validation verdict  [pass|needs-attention|needs-remediation] [--milestone Mxxx] [--rationale \"...\"]",
     "  /gsd parallel       Parallel milestone orchestration  [start|status|stop|pause|resume|merge|watch]",
     "  /gsd workflow       Custom workflow lifecycle  [new|run|list|validate|pause|resume]",

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -83,7 +83,7 @@ function formatNeedsRemediationBlocker(milestoneId: string): string {
   return [
     `Milestone ${milestoneId} is blocked because milestone validation returned needs-remediation, but all slices are complete.`,
     `Fix options:`,
-    `1. Add remediation slices with \`gsd_reassess_roadmap\`, then run \`/gsd auto\``,
+    `1. Run \`/gsd dispatch reassess\` to add remediation slices, then run \`/gsd auto\``,
     `2. If the finding is acceptable, override it: \`/gsd verdict pass --rationale "why this is okay"\``,
     `3. If this should wait, defer it explicitly: \`/gsd park ${milestoneId}\``,
   ].join("\n");

--- a/src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts
@@ -40,10 +40,12 @@ function makeMockCtx(base: string): {
   calls: NotifyCall[];
   widgets: Array<[string, unknown]>;
   statuses: Array<[string, string | undefined]>;
+  newSessions: Array<{ workspaceRoot?: string }>;
 } {
   const calls: NotifyCall[] = [];
   const widgets: Array<[string, unknown]> = [];
   const statuses: Array<[string, string | undefined]> = [];
+  const newSessions: Array<{ workspaceRoot?: string }> = [];
   return {
     ctx: {
       cwd: base,
@@ -58,10 +60,15 @@ function makeMockCtx(base: string): {
           statuses.push([key, value]);
         },
       },
+      newSession: async (options?: { workspaceRoot?: string }) => {
+        newSessions.push(options ?? {});
+        return { cancelled: false };
+      },
     },
     calls,
     widgets,
     statuses,
+    newSessions,
   };
 }
 
@@ -77,7 +84,10 @@ function makeMockPi(): { pi: any; messages: SentMessage[] } {
   };
 }
 
-function seedValidationBlockedMilestone(base: string): void {
+function seedValidationBlockedMilestone(
+  base: string,
+  status: "needs-attention" | "needs-remediation" = "needs-attention",
+): void {
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M006", title: "Mark All Complete", status: "active" });
   insertSlice({
@@ -91,9 +101,9 @@ function seedValidationBlockedMilestone(base: string): void {
   insertAssessment({
     path: "milestones/M006/M006-VALIDATION.md",
     milestoneId: "M006",
-    status: "needs-attention",
+    status,
     scope: "milestone-validation",
-    fullContent: "verdict: needs-attention",
+    fullContent: `verdict: ${status}`,
   });
   invalidateStateCache();
 }
@@ -152,6 +162,31 @@ test("dispatcher blocks workflow-advancing aliases while validation is blocked",
       invalidateStateCache();
       cleanup(base);
     }
+  }
+});
+
+test("dispatcher allows reassess dispatch while validation needs remediation", async () => {
+  const base = makeBase();
+  try {
+    seedValidationBlockedMilestone(base, "needs-remediation");
+    const { ctx, calls, newSessions } = makeMockCtx(base);
+    const { pi, messages } = makeMockPi();
+
+    await handleGSDCommand("dispatch reassess", ctx, pi);
+
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].customType, "gsd-dispatch");
+    assert.equal(messages[0].display, false);
+    assert.match(messages[0].content, /UNIT: Reassess Roadmap/);
+    assert.ok(
+      calls.some((call) => call.kind === "info" && /Dispatching reassess-roadmap for M006\/S01/.test(call.message)),
+      `expected reassess dispatch notification, got: ${JSON.stringify(calls)}`,
+    );
+    assert.deepEqual(newSessions, [{ workspaceRoot: base }]);
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
   }
 });
 

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -399,8 +399,12 @@ test("handleVerdict needs-remediation override with --rationale rewrites verdict
     assert.match(rewritten, /found missing slice/);
 
     assert.ok(
-      calls.some((c) => /gsd_reassess_roadmap/.test(c.message)),
-      "needs-remediation override should suggest gsd_reassess_roadmap follow-up",
+      calls.some((c) => /\/gsd dispatch reassess/.test(c.message)),
+      "needs-remediation override should suggest the reassess dispatch follow-up",
+    );
+    assert.ok(
+      calls.every((c) => !/gsd_reassess_roadmap/.test(c.message)),
+      "needs-remediation override should not expose the internal tool name",
     );
   } finally {
     closeDatabase();

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -868,6 +868,14 @@ describe('derive-state-db', async () => {
         dbState.blockers.some(b => b.includes('needs-remediation') && b.includes('M001')),
         'remediation-stuck-db: blocker message mentions milestone and verdict',
       );
+      assert.ok(
+        dbState.blockers.some(b => b.includes('/gsd dispatch reassess')),
+        'remediation-stuck-db: blocker message points users to the reassess command',
+      );
+      assert.ok(
+        dbState.blockers.every(b => !b.includes('gsd_reassess_roadmap')),
+        'remediation-stuck-db: blocker message does not expose the internal tool name',
+      );
 
       closeDatabase();
     } finally {

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -555,6 +555,14 @@ describe('derive-state-helpers', () => {
         state.blockers.some(b => b.includes('needs-remediation') && b.includes('M001')),
         'remediation-stuck: blocker message mentions milestone and verdict',
       );
+      assert.ok(
+        state.blockers.some(b => b.includes('/gsd dispatch reassess')),
+        'remediation-stuck: blocker message points users to the reassess command',
+      );
+      assert.ok(
+        state.blockers.every(b => !b.includes('gsd_reassess_roadmap')),
+        'remediation-stuck: blocker message does not expose the internal tool name',
+      );
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/validation-block-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validation-block-guard.test.ts
@@ -54,6 +54,8 @@ test("validation block allows recovery, diagnostics, and unrelated commands", ()
     "status",
     "verdict pass --rationale ok",
     "validate-milestone",
+    "dispatch reassess",
+    "dispatch reassess-roadmap",
     "dispatch validate",
     "dispatch validate-milestone",
     "park M006",
@@ -121,4 +123,23 @@ test("validation block message includes attempted command and recovery options",
   assert.match(message, /\/gsd validate-milestone/);
   assert.match(message, /\/gsd verdict pass --rationale/);
   assert.match(message, /\/gsd park M006/);
+});
+
+test("validation block message can guide remediation through dispatch reassess", () => {
+  const message = formatValidationBlockedMessage({
+    ...blockedState(),
+    blockers: [
+      [
+        "Milestone M006 is blocked because milestone validation returned needs-remediation, but all slices are complete.",
+        "Fix options:",
+        "1. Run `/gsd dispatch reassess` to add remediation slices, then run `/gsd auto`",
+        "2. If the finding is acceptable, override it: `/gsd verdict pass --rationale \"why this is okay\"`",
+        "3. If this should wait, defer it explicitly: `/gsd park M006`",
+      ].join("\n"),
+    ],
+  }, "auto");
+
+  assert.ok(message);
+  assert.match(message, /\/gsd dispatch reassess/);
+  assert.doesNotMatch(message, /gsd_reassess_roadmap/);
 });

--- a/src/resources/extensions/gsd/validation-block-guard.ts
+++ b/src/resources/extensions/gsd/validation-block-guard.ts
@@ -14,6 +14,8 @@ const VALIDATION_BLOCK_RE =
   /milestone validation returned needs-(?:attention|remediation)|validation verdict is needs-(?:attention|remediation)/i;
 
 const VALIDATION_SAFE_DISPATCH_COMMANDS = new Set([
+  "reassess",
+  "reassess-roadmap",
   "validate",
   "validate-milestone",
 ]);


### PR DESCRIPTION
## Linked issue

Closes #395

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Allows `/gsd dispatch reassess` to run while a milestone is blocked by `needs-remediation` and updates remediation guidance to use that command.
**Why:** The current blocker points users at the internal `gsd_reassess_roadmap` tool while the command that should fix it is blocked by the same guard.
**How:** Whitelist reassess direct dispatch in the validation block guard, update user-facing remediation copy, and add regression coverage for the blocked dispatcher path and derived blocker text.

## What

- Allows `dispatch reassess` and `dispatch reassess-roadmap` through `validation-block-guard.ts`.
- Changes needs-remediation blocker and verdict follow-up text from the internal agent tool to `/gsd dispatch reassess`.
- Updates `/gsd help` dispatch phase copy to include `validate` and `reassess`.
- Adds regressions for the dispatcher, guard allowlist, state-derived blocker text, and verdict follow-up message.

## Why

A milestone with all slices complete and validation verdict `needs-remediation` needs roadmap reassessment to add remediation slices. The previous UX created a circular deadlock: users were told to invoke an agent tool directly, while `/gsd dispatch reassess` was blocked before it could launch the reassess unit.

## How

The validation guard remains strict for normal workflow-advancing dispatches, but treats reassess dispatch like validate dispatch because both are remediation/recovery commands for validation-blocked states. ADR-003's default `reassess_after_slice: false` behavior is unchanged.

## Impact analysis

- Blast radius: narrow.
- Affected workflows: validation-blocked milestones, manual `/gsd dispatch reassess`, `/gsd verdict needs-remediation` follow-up guidance, and `/gsd help` command text.
- Risks or compatibility notes: no persistence, schema, provider, or auto-mode default changes. `dispatch complete`, `dispatch uat`, and other advancing dispatches remain blocked while validation is unresolved.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- `pnpm install --frozen-lockfile`
- `pnpm run build:pi`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/validation-block-guard.test.ts src/resources/extensions/gsd/tests/commands-dispatcher-validation-block.test.ts src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/derive-state-helpers.test.ts src/resources/extensions/gsd/tests/commands-verdict.test.ts`
- `pnpm run test:compile`
- `git diff --check`

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented with Codex and verified with the commands listed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow GSD UX/guard change with tests; no auth, persistence, or auto-mode default changes beyond allowing reassess dispatch when validation-blocked.
> 
> **Overview**
> Fixes a **deadlock** when milestone validation is `needs-remediation` and all slices are done: users were told to use the internal `gsd_reassess_roadmap` tool while **`/gsd dispatch reassess`** was blocked by the same validation guard.
> 
> **`/gsd dispatch reassess`** and **`dispatch reassess-roadmap`** are now treated like validate dispatch—allowed while validation blocks `auto`, `next`, and other advancing commands. Remediation guidance in blockers, verdict follow-ups, and help now points to **`/gsd dispatch reassess`** instead of the internal tool name; full help lists **`validate`** and **`reassess`** among dispatch phases.
> 
> Regression tests cover the guard allowlist, dispatcher path for `needs-remediation`, derived blocker text, and verdict notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9131ffa07457c0b26dce1e3cdb2948c2fc20b9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783006689&installation_id=134682257&pr_number=406&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F406&signature=bda1ad6863b67144ee334888abf0e8a6c43ce90a41a48f13f092cf930f09d596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->