### PR TITLE
fix(gsd): skip roadmap drift during slice planning

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from "node:fs";
 import {
   getMilestone,
   getMilestoneSlices,
+  getSliceTasks,
   isDbAvailable,
 } from "../../gsd-db.js";
 import { renderRoadmapFromDb } from "../../markdown-renderer.js";
@@ -30,6 +31,19 @@ function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
   return true;
 }
 
+function getSlicesReadyForDivergenceCheck(
+  milestoneId: string,
+  dbSlices: ReturnType<typeof getMilestoneSlices>,
+): Set<string> {
+  const ready = new Set<string>();
+  for (const slice of dbSlices) {
+    if (isClosedStatus(slice.status) || getSliceTasks(milestoneId, slice.id).length > 0) {
+      ready.add(slice.id);
+    }
+  }
+  return ready;
+}
+
 function milestoneHasDivergence(
   basePath: string,
   milestoneId: string,
@@ -46,6 +60,10 @@ function milestoneHasDivergence(
 
   const dbSlices = getMilestoneSlices(milestoneId);
   const dbSliceMap = new Map(dbSlices.map((s) => [s.id, s]));
+  const readySliceIds = getSlicesReadyForDivergenceCheck(milestoneId, dbSlices);
+  if (dbSlices.length > 0 && readySliceIds.size === 0) {
+    return false;
+  }
   const roadmapSliceIds = new Set<string>();
 
   for (let i = 0; i < roadmap.slices.length; i++) {
@@ -54,11 +72,13 @@ function milestoneHasDivergence(
     const expectedSequence = i + 1;
     const dbSlice = dbSliceMap.get(roadmapSlice.id);
     if (!dbSlice) return true; // Roadmap has a slice the DB doesn't.
+    if (!readySliceIds.has(dbSlice.id)) continue;
     if (dbSlice.sequence !== expectedSequence) return true;
     if (!arraysEqual(dbSlice.depends, roadmapSlice.depends)) return true;
     if (isClosedStatus(dbSlice.status) !== roadmapSlice.done) return true;
   }
   for (const dbSlice of dbSlices) {
+    if (!readySliceIds.has(dbSlice.id)) continue;
     if (!roadmapSliceIds.has(dbSlice.id)) return true;
   }
   return false;

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -6,6 +6,7 @@ import {
   deriveState as defaultDeriveState,
   invalidateStateCache as defaultInvalidate,
 } from "../state.js";
+import { clearParseCache as defaultClearParseCache } from "../files.js";
 import type { GSDState } from "../types.js";
 
 import {
@@ -37,6 +38,7 @@ const MAX_PASSES = 2;
 const defaultDeps: ReconciliationDeps = {
   invalidateStateCache: defaultInvalidate,
   deriveState: defaultDeriveState,
+  clearParseCache: defaultClearParseCache,
 };
 
 /**
@@ -58,6 +60,7 @@ export async function reconcileBeforeDispatch(
   deps: ReconciliationDeps = defaultDeps,
 ): Promise<ReconciliationResult> {
   const registry = deps.registry ?? DRIFT_REGISTRY;
+  const clearParseCache = deps.clearParseCache ?? defaultClearParseCache;
   const repaired: DriftRecord[] = [];
 
   for (let pass = 0; pass < MAX_PASSES; pass++) {
@@ -103,6 +106,9 @@ export async function reconcileBeforeDispatch(
       }
     }
 
+    if (repairedThisPass) {
+      clearParseCache();
+    }
     if (blockers.length > 0) {
       let blockerState = stateSnapshot;
       if (repairedThisPass) {

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -101,6 +101,7 @@ export interface ReconciliationDeps {
     basePath: string,
     opts?: DeriveStateOptions,
   ) => Promise<GSDState>;
+  clearParseCache?: () => void;
   /**
    * Override of the drift handler catalog. Defaults to DRIFT_REGISTRY. Each
    * handler is parameterized over its own DriftRecord variant; the union of

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -906,6 +906,51 @@ test("ADR-017 (#5704): registered milestone (DB row present) → no drift", asyn
 
 // ─── #5705: roadmap-divergence drift ─────────────────────────────────────────
 
+test("ADR-017 (#391): roadmap-divergence skips slices before task planning completes", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-unplanned-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const roadmapPath = join(milestoneDir, "M001-ROADMAP.md");
+  mkdirSync(milestoneDir, { recursive: true });
+  const originalRoadmap = [
+    "# M001: Test",
+    "",
+    "**Vision:** Verify transient milestone planning state",
+    "",
+    "## Slices",
+    "",
+    "- [ ] **S01: Foundation** `risk:medium` `depends:[]`",
+    "- [ ] **S02: Feature** `risk:medium` `depends:[S01]`",
+    "",
+  ].join("\n");
+  writeFileSync(roadmapPath, originalRoadmap);
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+
+  assert.equal(getSliceTasks("M001", "S01").length, 0, "pre: S01 has not been planned");
+  assert.equal(getSliceTasks("M001", "S02").length, 0, "pre: S02 has not been planned");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "roadmap-divergence"),
+    false,
+    "unplanned slices should not trigger roadmap-divergence repair",
+  );
+  assert.equal(readFileSync(roadmapPath, "utf-8"), originalRoadmap);
+  assert.deepEqual(getSlice("M001", "S02")?.depends, [], "DB remains unchanged");
+});
+
 test("ADR-017 (#5705): roadmap-divergence re-renders projection without syncing depends into DB", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-"));
   const milestoneDir = join(base, ".gsd", "milestones", "M001");
@@ -936,6 +981,8 @@ test("ADR-017 (#5705): roadmap-divergence re-renders projection without syncing 
   // Seed DB with S02 depending on []  — diverges from ROADMAP.md
   insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
   insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Plan S01", status: "pending" });
+  insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", title: "Plan S02", status: "pending" });
 
   assert.deepEqual(getSlice("M001", "S02")?.depends, [], "pre: DB has S02.depends = []");
 
@@ -987,6 +1034,7 @@ test("ADR-017 (#5705): ROADMAP-only slice is removed from projection and not ins
   insertMilestone({ id: "M001", title: "Test", status: "active" });
   // Only insert S01 — S02 is intentionally absent from the DB.
   insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Plan S01", status: "pending" });
 
   assert.equal(getSlice("M001", "S02"), null, "pre: S02 has no DB row");
 
@@ -1035,6 +1083,8 @@ test("ADR-017 (#5705): ROADMAP sequence drift re-renders from DB order without m
   insertMilestone({ id: "M001", title: "Test", status: "active" });
   insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
   insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Plan S01", status: "pending" });
+  insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", title: "Plan S02", status: "pending" });
 
   const result = await reconcileBeforeDispatch(base, {
     invalidateStateCache: () => {},
@@ -1078,6 +1128,7 @@ test("ADR-017 (#5705): ROADMAP checkbox drift re-renders from DB status without 
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Test", status: "active" });
   insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Plan S01", status: "pending" });
 
   const result = await reconcileBeforeDispatch(base, {
     invalidateStateCache: () => {},
@@ -1119,6 +1170,7 @@ test("ADR-017 (#5705): in-sync ROADMAP and DB → no roadmap-divergence drift", 
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Test", status: "active" });
   insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "low", depends: [], demo: "", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Plan S01", status: "pending" });
 
   const result = await reconcileBeforeDispatch(base, {
     invalidateStateCache: () => {},


### PR DESCRIPTION
## TL;DR

**What:** Skip roadmap-divergence repair for slices that have not reached task planning yet, and clear parser caches after reconciliation repairs.
**Why:** Prevents auto-mode from looping on transient ROADMAP/DB mismatches during the milestone-to-slice planning window.
**How:** Treat slices with task rows, or closed slices, as ready for roadmap divergence checks; leave zero-task pending slices alone until planning material exists.

## What

- Adds a planning-state guard to the `roadmap-divergence` detector so pending zero-task slices do not trigger ROADMAP regeneration.
- Keeps existing roadmap repair behavior for planned slices by updating the ADR-017 roadmap drift fixtures to include task rows.
- Clears parse caches after successful reconciliation repairs before the next derive/detect pass.
- Adds a regression test for the transient zero-task planning window.

## Why

`roadmap-divergence` was repairable even while `gsd_plan_milestone` had created slice rows but `gsd_plan_slice` had not populated task rows yet. In that transient state, repair could regenerate from incomplete DB state and re-detect the same drift until `MAX_PASSES` threw.

Closes #391

## How

The detector now builds a set of slices ready for divergence comparison. A slice is ready when it has planned task rows or is already closed. If a milestone has DB slices but none are ready, the detector skips roadmap-divergence for that milestone. For mixed milestones, unplanned slices are ignored while planned slices still reconcile normally.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts`
- [x] `pnpm run typecheck:extensions`
- [x] `git diff --check`

## Impact analysis

- Blast radius: narrow, limited to the State Reconciliation roadmap drift detector and reconciliation cache invalidation.
- Affected workflows: `/gsd auto` and `/gsd next` pre-dispatch reconciliation when ROADMAP.md and DB slice rows temporarily disagree during planning.
- Compatibility notes: Planned slices still repair ROADMAP projections from DB. Pending zero-task slices defer roadmap-divergence until slice planning creates task rows.

## Notes

- PR #363 is already merged into `main` and covers the pipe/table-parser half mentioned in the issue.
- AI-assisted implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007543&installation_id=134682257&pr_number=409&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F409&signature=0cb9530784688b4be5aaa4abe274de13b6b5ac6fa8873ef9442f68605a26a77b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to ADR-017 roadmap drift gating and post-repair cache invalidation; no auth or data-model changes, with planned-slice repair behavior preserved via tests.
> 
> **Overview**
> **Roadmap-divergence** detection no longer treats pending slices with **zero task rows** as authoritative for `ROADMAP.md` vs DB comparison. A slice is included only when it is **closed** or has **planned tasks**; if every DB slice is still unplanned, the milestone is skipped entirely so transient mismatches after milestone planning do not trigger repair loops.
> 
> **`reconcileBeforeDispatch`** now calls **`clearParseCache`** after any successful repairs in a pass so the next derive/detect cycle does not reuse stale parsed markdown.
> 
> Tests add a regression for the unplanned-slice window and seed task rows in existing roadmap-divergence fixtures so “planned” behavior stays covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b96c045571682c934ff3c28cb662c2e1d4bb7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->