### PR TITLE
Instrument TUI first-visible response latency

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,7 @@
 - **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; unit-execution failure recovery is classified by the Recovery Classification module.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
+- **First-visible response latency**: the user-perceived delay from submitting a prompt to seeing the first assistant output. Distinct from total completion time, Unit duration, or tool execution duration.
 - **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves a durable final closeout surface visible in the live terminal, not merely scrollback or a cleared progress area.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false && node scripts/copy-assets.cjs",
-    "test": "node --import ../../src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/**/*.test.ts"
+    "test": "node --import ../../src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/*.test.ts src/**/*.test.ts"
   },
   "dependencies": {
     "@gsd/native": "workspace:*",

--- a/packages/gsd-agent-core/src/agent-session.ts
+++ b/packages/gsd-agent-core/src/agent-session.ts
@@ -56,6 +56,20 @@ import {
 	type ToolDefinitionEntry,
 	parseSkillBlock,
 } from "./session/agent-session-types.js";
+import {
+	beginTurnLatency,
+	finishTurnLatency,
+	formatTurnLatencyRecords,
+	getTurnLatencyRecords,
+	markFirstStreamActivity,
+	markFirstVisibleTurnLatency,
+	markTurnLatency,
+	updateTurnLatencyModel,
+	type BeginTurnLatencyOptions,
+	type TurnLatencyRecord,
+	type TurnLatencyStatus,
+	type TurnLatencyVisibleKind,
+} from "./turn-latency.js";
 import type { AgentSessionHost } from "./session/agent-session-host.js";
 import { AgentSessionEventsModule } from "./session/agent-session-events.js";
 import { AgentSessionPromptModule } from "./session/agent-session-prompt.js";
@@ -133,6 +147,7 @@ export class AgentSession implements AgentSessionHost {
 	_baseSystemPrompt = "";
 	_baseSystemPromptOptions!: BuildSystemPromptOptions;
 	_lastAssistantMessage: AssistantMessage | undefined = undefined;
+	_activeTurnLatency: TurnLatencyRecord | undefined = undefined;
 
 	private readonly _events = new AgentSessionEventsModule(this);
 	private readonly _prompt = new AgentSessionPromptModule(this);
@@ -235,6 +250,43 @@ export class AgentSession implements AgentSessionHost {
 
 	get pendingMessageCount(): number {
 		return this._steeringMessages.length + this._followUpMessages.length;
+	}
+
+	beginTurnLatency(options: BeginTurnLatencyOptions = {}): TurnLatencyRecord | undefined {
+		if (this._activeTurnLatency && this._activeTurnLatency.endedAtMs === undefined) {
+			updateTurnLatencyModel(this._activeTurnLatency, options.model ?? this.model);
+			if (options.trigger) {
+				markTurnLatency(this._activeTurnLatency, "turn.trigger", { trigger: options.trigger });
+			}
+			return this._activeTurnLatency;
+		}
+		this._activeTurnLatency = beginTurnLatency({ ...options, model: options.model ?? this.model });
+		return this._activeTurnLatency;
+	}
+
+	markTurnLatency(phase: string, data?: Record<string, unknown>): void {
+		markTurnLatency(this._activeTurnLatency, phase, data);
+	}
+
+	markFirstStreamActivity(kind: string, data?: Record<string, unknown>): void {
+		markFirstStreamActivity(this._activeTurnLatency, kind, data);
+	}
+
+	markFirstVisibleTurnLatency(kind: TurnLatencyVisibleKind, data?: Record<string, unknown>): void {
+		markFirstVisibleTurnLatency(this._activeTurnLatency, kind, data);
+	}
+
+	finishTurnLatency(status: TurnLatencyStatus): void {
+		finishTurnLatency(this._activeTurnLatency, status);
+		this._activeTurnLatency = undefined;
+	}
+
+	getTurnLatencyRecords(): readonly TurnLatencyRecord[] {
+		return getTurnLatencyRecords();
+	}
+
+	formatTurnLatencyRecords(): string {
+		return formatTurnLatencyRecords();
 	}
 
 	get resourceLoader(): ResourceLoader {

--- a/packages/gsd-agent-core/src/index.ts
+++ b/packages/gsd-agent-core/src/index.ts
@@ -71,3 +71,10 @@ export {
 } from "./sdk.js";
 export { ContextualTips } from "./contextual-tips.js";
 export * from "./agent-session-runtime.js";
+export {
+	formatTurnLatencyRecords,
+	getTurnLatencyRecords,
+	type TurnLatencyRecord,
+	type TurnLatencyStatus,
+	type TurnLatencyVisibleKind,
+} from "./turn-latency.js";

--- a/packages/gsd-agent-core/src/session/agent-session-host.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-host.ts
@@ -39,6 +39,12 @@ import type {
 	ToolDefinitionEntry,
 } from "./agent-session-types.js";
 import type { SessionStartEvent } from "@gsd/pi-coding-agent/core/extensions/index.js";
+import type {
+	BeginTurnLatencyOptions,
+	TurnLatencyRecord,
+	TurnLatencyStatus,
+	TurnLatencyVisibleKind,
+} from "../turn-latency.js";
 
 /**
  * Internal surface shared by AgentSession submodule classes.
@@ -91,6 +97,7 @@ export interface AgentSessionHost {
 	_baseSystemPrompt: string;
 	_baseSystemPromptOptions: BuildSystemPromptOptions;
 	_lastAssistantMessage: AssistantMessage | undefined;
+	_activeTurnLatency: TurnLatencyRecord | undefined;
 
 	// Read-only derived state
 	readonly model: Model<any> | undefined;
@@ -111,6 +118,11 @@ export interface AgentSessionHost {
 	// Cross-module internal API
 	emit(event: AgentSessionEvent): void;
 	emitQueueUpdate(): void;
+	beginTurnLatency(options?: BeginTurnLatencyOptions): TurnLatencyRecord | undefined;
+	markTurnLatency(phase: string, data?: Record<string, unknown>): void;
+	markFirstStreamActivity(kind: string, data?: Record<string, unknown>): void;
+	markFirstVisibleTurnLatency(kind: TurnLatencyVisibleKind, data?: Record<string, unknown>): void;
+	finishTurnLatency(status: TurnLatencyStatus): void;
 	disconnectFromAgent(): void;
 	reconnectToAgent(): void;
 	isRetryableError(message: AssistantMessage): boolean;

--- a/packages/gsd-agent-core/src/session/agent-session-prompt.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-prompt.ts
@@ -14,12 +14,22 @@ export class AgentSessionPromptModule {
 	constructor(readonly host: AgentSessionHost) {}
 
 	async runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
+		const previousLatencyMark = this.host.agent.latencyMark;
+		this.host.agent.latencyMark = (phase, data) => {
+			previousLatencyMark?.(phase, data);
+			if (phase === "agent_loop.first_stream_activity") {
+				this.host.markFirstStreamActivity(String(data?.eventType ?? "unknown"), data);
+			} else {
+				this.host.markTurnLatency(phase, data);
+			}
+		};
 		try {
 			await this.host.agent.prompt(messages);
 			while (await this.handlePostAgentRun()) {
 				await this.host.agent.continue();
 			}
 		} finally {
+			this.host.agent.latencyMark = previousLatencyMark;
 			this.host.flushPendingBashMessages();
 		}
 	}
@@ -49,32 +59,47 @@ export class AgentSessionPromptModule {
 	}
 
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
+		const source = options?.source ?? "interactive";
+		const latency = this.host.beginTurnLatency({ source, trigger: "session.prompt" });
+		let latencyStatus: "completed" | "queued" | "handled" | "error" = "completed";
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
 		let messages: AgentMessage[] | undefined;
 
 		try {
+			this.host.markTurnLatency("session.prompt.enter", {
+				source,
+				hasImages: !!options?.images?.length,
+				expandPromptTemplates,
+			});
 			// Handle extension commands first (execute immediately, even during streaming)
 			// Extension commands manage their own LLM interaction via pi.sendMessage()
 			if (expandPromptTemplates && text.startsWith("/")) {
+				this.host.markTurnLatency("session.extension_command.start");
 				const handled = await this.tryExecuteExtensionCommand(text);
 				if (handled) {
 					// Extension command executed, no prompt to send
+					this.host.markTurnLatency("session.extension_command.handled");
+					latencyStatus = "handled";
 					preflightResult?.(true);
 					return;
 				}
+				this.host.markTurnLatency("session.extension_command.miss");
 			}
 
 			// Emit input event for extension interception (before skill/template expansion)
 			let currentText = text;
 			let currentImages = options?.images;
 			if (this.host._extensionRunner.hasHandlers("input")) {
+				this.host.markTurnLatency("session.input_handlers.start");
 				const inputResult = await this.host._extensionRunner.emitInput(
 					currentText,
 					currentImages,
 					options?.source ?? "interactive",
 				);
 				if (inputResult.action === "handled") {
+					this.host.markTurnLatency("session.input_handlers.handled");
+					latencyStatus = "handled";
 					preflightResult?.(true);
 					return;
 				}
@@ -82,13 +107,18 @@ export class AgentSessionPromptModule {
 					currentText = inputResult.text;
 					currentImages = inputResult.images ?? currentImages;
 				}
+				this.host.markTurnLatency("session.input_handlers.end", { action: inputResult.action });
 			}
 
 			// Expand skill commands (/skill:name args) and prompt templates (/template args)
 			let expandedText = currentText;
 			if (expandPromptTemplates) {
+				this.host.markTurnLatency("session.prompt_expansion.start");
 				expandedText = this.expandSkillCommand(expandedText);
 				expandedText = expandPromptTemplate(expandedText, [...this.host.promptTemplates]);
+				this.host.markTurnLatency("session.prompt_expansion.end", {
+					changed: expandedText !== currentText,
+				});
 			}
 
 			// If streaming, queue via steer() or followUp() based on option
@@ -103,14 +133,18 @@ export class AgentSessionPromptModule {
 				} else {
 					await this.queueSteer(expandedText, currentImages);
 				}
+				this.host.markTurnLatency("session.prompt.queued", { mode: options.streamingBehavior });
+				latencyStatus = "queued";
 				preflightResult?.(true);
 				return;
 			}
 
 			// Flush any pending bash messages before the new prompt
 			this.host.flushPendingBashMessages();
+			this.host.markTurnLatency("session.pending_bash_flushed");
 
 			// Validate model
+			this.host.markTurnLatency("session.model_auth_check.start");
 			if (!this.host.model) {
 				throw new Error(formatNoModelSelectedMessage());
 			}
@@ -126,19 +160,27 @@ export class AgentSessionPromptModule {
 				}
 				throw new Error(formatNoApiKeyFoundMessage(this.host.model.provider));
 			}
+			this.host.markTurnLatency("session.model_auth_check.end", {
+				provider: this.host.model.provider,
+				model: this.host.model.id,
+			});
 
 			// Check if we need to compact before sending (catches aborted responses)
 			const lastAssistant = this.host.findLastAssistantMessage();
+			this.host.markTurnLatency("session.compaction_check.start", { hasLastAssistant: !!lastAssistant });
 			if (lastAssistant && (await this.host.checkCompaction(lastAssistant, false))) {
 				try {
+					this.host.markTurnLatency("session.compaction_continue.start");
 					await this.host.agent.continue();
 					while (await this.handlePostAgentRun()) {
 						await this.host.agent.continue();
 					}
+					this.host.markTurnLatency("session.compaction_continue.end");
 				} finally {
 					this.host.flushPendingBashMessages();
 				}
 			}
+			this.host.markTurnLatency("session.compaction_check.end");
 
 			// Build messages array (custom message if any, then user message)
 			messages = [];
@@ -161,6 +203,7 @@ export class AgentSessionPromptModule {
 			this.host._pendingNextTurnMessages = [];
 
 			// Emit before_agent_start extension event
+			this.host.markTurnLatency("session.before_agent_start.start");
 			const result = await this.host._extensionRunner.emitBeforeAgentStart(
 				expandedText,
 				currentImages,
@@ -187,9 +230,18 @@ export class AgentSessionPromptModule {
 				// Ensure we're using the base prompt (in case previous turn had modifications)
 				this.host.agent.state.systemPrompt = this.host._baseSystemPrompt;
 			}
+			this.host.markTurnLatency("session.before_agent_start.end", {
+				customMessages: result?.messages?.length ?? 0,
+				systemPromptChanged: !!result?.systemPrompt,
+			});
 		} catch (error) {
+			latencyStatus = "error";
 			preflightResult?.(false);
 			throw error;
+		} finally {
+			if (latencyStatus !== "completed" || !messages) {
+				this.host.finishTurnLatency(latencyStatus);
+			}
 		}
 
 		if (!messages) {
@@ -197,7 +249,19 @@ export class AgentSessionPromptModule {
 		}
 
 		preflightResult?.(true);
-		await this.runAgentPrompt(messages);
+		try {
+			this.host.markTurnLatency("session.agent_run.start", { messages: messages.length });
+			await this.runAgentPrompt(messages);
+			this.host.markTurnLatency("session.agent_run.end");
+		} catch (error) {
+			latencyStatus = "error";
+			this.host.markTurnLatency("session.agent_run.error", {
+				error: error instanceof Error ? error.name : typeof error,
+			});
+			throw error;
+		} finally {
+			this.host.finishTurnLatency(latencyStatus);
+		}
 	}
 
 	async tryExecuteExtensionCommand(text: string): Promise<boolean> {

--- a/packages/gsd-agent-core/src/turn-latency.test.ts
+++ b/packages/gsd-agent-core/src/turn-latency.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+import {
+	beginTurnLatency,
+	clearTurnLatencyRecordsForTest,
+	finishTurnLatency,
+	formatTurnLatencyRecords,
+	formatTurnLatencySummary,
+	getTurnLatencyRecords,
+	markFirstStreamActivity,
+	markFirstVisibleTurnLatency,
+	markTurnLatency,
+} from "./turn-latency.js";
+
+describe("turn latency diagnostics", () => {
+	beforeEach(() => {
+		clearTurnLatencyRecordsForTest();
+	});
+
+	it("captures metadata-only marks and first signals once", () => {
+		const record = beginTurnLatency({
+			source: "interactive",
+			trigger: "editor_submit",
+			model: { provider: "anthropic", id: "claude-sonnet" } as any,
+		});
+
+		assert.ok(record);
+		markTurnLatency(record, "session.prompt.enter", { hasImages: false });
+		markFirstStreamActivity(record, "start");
+		markFirstStreamActivity(record, "text_delta");
+		markFirstVisibleTurnLatency(record, "text");
+		markFirstVisibleTurnLatency(record, "tool");
+		finishTurnLatency(record, "completed", {} as NodeJS.ProcessEnv);
+
+		assert.equal(record.firstStreamActivity?.kind, "start");
+		assert.equal(record.firstVisible?.kind, "text");
+		assert.equal(record.status, "completed");
+
+		const formatted = formatTurnLatencyRecords();
+		assert.match(formatted, /model=anthropic\/claude-sonnet/);
+		assert.match(formatted, /first_visible=\d+ms:text/);
+		assert.match(formatted, /session\.prompt\.enter/);
+		assert.doesNotMatch(formatted, /editor_submit.*hello/i);
+	});
+
+	it("keeps only the latest records", () => {
+		for (let i = 0; i < 30; i++) {
+			const record = beginTurnLatency({ source: "tui" });
+			assert.ok(record);
+			finishTurnLatency(record, "completed", {} as NodeJS.ProcessEnv);
+		}
+
+		const records = getTurnLatencyRecords();
+		assert.equal(records.length, 25);
+		assert.equal(records[0]?.id, "tui-turn-6");
+		assert.equal(records.at(-1)?.id, "tui-turn-30");
+	});
+
+	it("ignores non-TUI sources", () => {
+		assert.equal(beginTurnLatency({ source: "rpc" }), undefined);
+		assert.equal(getTurnLatencyRecords().length, 0);
+	});
+
+	it("classifies slow first-visible latency in summaries", () => {
+		const record = beginTurnLatency({ source: "tui" });
+		assert.ok(record);
+		record.startedAtMs -= 6_000;
+		markFirstVisibleTurnLatency(record, "thinking");
+		finishTurnLatency(record, "completed", {} as NodeJS.ProcessEnv);
+
+		assert.match(formatTurnLatencySummary(record), /class=slow/);
+	});
+});

--- a/packages/gsd-agent-core/src/turn-latency.ts
+++ b/packages/gsd-agent-core/src/turn-latency.ts
@@ -1,0 +1,186 @@
+import type { Model } from "@gsd/pi-ai";
+
+export type TurnLatencyStatus = "completed" | "queued" | "handled" | "error";
+export type TurnLatencyVisibleKind = "text" | "thinking" | "tool" | "message_end_only";
+
+export interface TurnLatencyMark {
+	phase: string;
+	atMs: number;
+	data?: Record<string, unknown>;
+}
+
+export interface TurnLatencyFirstSignal {
+	kind: string;
+	atMs: number;
+	data?: Record<string, unknown>;
+}
+
+export interface TurnLatencyRecord {
+	id: string;
+	source: "tui";
+	startedAt: string;
+	startedAtMs: number;
+	provider?: string;
+	model?: string;
+	status?: TurnLatencyStatus;
+	endedAtMs?: number;
+	durationMs?: number;
+	firstStreamActivity?: TurnLatencyFirstSignal;
+	firstVisible?: TurnLatencyFirstSignal & { kind: TurnLatencyVisibleKind };
+	marks: TurnLatencyMark[];
+}
+
+export interface BeginTurnLatencyOptions {
+	source?: "interactive" | "tui" | string;
+	model?: Model<any>;
+	trigger?: string;
+}
+
+const MAX_RECORDS = 25;
+const NOTICEABLE_MS = 2_000;
+const SLOW_MS = 5_000;
+
+let nextTurnLatencyId = 1;
+const turnLatencyRecords: TurnLatencyRecord[] = [];
+
+export function shouldTrackTurnLatency(source: string | undefined): boolean {
+	return source === undefined || source === "interactive" || source === "tui";
+}
+
+export function isLiveTurnTimingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	const value = (env.GSD_TUI_TIMING ?? "").toLowerCase();
+	return value === "1" || value === "true" || value === "yes";
+}
+
+export function beginTurnLatency(options: BeginTurnLatencyOptions = {}): TurnLatencyRecord | undefined {
+	if (!shouldTrackTurnLatency(options.source)) return undefined;
+
+	const now = performance.now();
+	const record: TurnLatencyRecord = {
+		id: `tui-turn-${nextTurnLatencyId++}`,
+		source: "tui",
+		startedAt: new Date().toISOString(),
+		startedAtMs: now,
+		provider: options.model?.provider,
+		model: options.model?.id,
+		marks: [],
+	};
+	turnLatencyRecords.push(record);
+	while (turnLatencyRecords.length > MAX_RECORDS) {
+		turnLatencyRecords.shift();
+	}
+	markTurnLatency(record, "turn.start", options.trigger ? { trigger: options.trigger } : undefined);
+	return record;
+}
+
+export function markTurnLatency(
+	record: TurnLatencyRecord | undefined,
+	phase: string,
+	data?: Record<string, unknown>,
+): void {
+	if (!record || record.endedAtMs !== undefined) return;
+	record.marks.push({
+		phase,
+		atMs: elapsedSinceStart(record),
+		...(data ? { data } : {}),
+	});
+}
+
+export function updateTurnLatencyModel(record: TurnLatencyRecord | undefined, model: Model<any> | undefined): void {
+	if (!record || !model) return;
+	record.provider = model.provider;
+	record.model = model.id;
+}
+
+export function markFirstStreamActivity(
+	record: TurnLatencyRecord | undefined,
+	kind: string,
+	data?: Record<string, unknown>,
+): void {
+	if (!record || record.firstStreamActivity) return;
+	record.firstStreamActivity = {
+		kind,
+		atMs: elapsedSinceStart(record),
+		...(data ? { data } : {}),
+	};
+	markTurnLatency(record, "agent_loop.first_stream_activity", { kind, ...(data ?? {}) });
+}
+
+export function markFirstVisibleTurnLatency(
+	record: TurnLatencyRecord | undefined,
+	kind: TurnLatencyVisibleKind,
+	data?: Record<string, unknown>,
+): void {
+	if (!record || record.firstVisible) return;
+	record.firstVisible = {
+		kind,
+		atMs: elapsedSinceStart(record),
+		...(data ? { data } : {}),
+	};
+	markTurnLatency(record, "tui.first_visible", { kind, ...(data ?? {}) });
+}
+
+export function finishTurnLatency(
+	record: TurnLatencyRecord | undefined,
+	status: TurnLatencyStatus,
+	env: NodeJS.ProcessEnv = process.env,
+): void {
+	if (!record || record.endedAtMs !== undefined) return;
+	record.status = status;
+	markTurnLatency(record, "turn.end", { status });
+	record.endedAtMs = performance.now();
+	record.durationMs = Math.round(record.endedAtMs - record.startedAtMs);
+	if (isLiveTurnTimingEnabled(env)) {
+		process.stderr.write(`${formatTurnLatencySummary(record)}\n`);
+	}
+}
+
+export function getTurnLatencyRecords(): readonly TurnLatencyRecord[] {
+	return turnLatencyRecords;
+}
+
+export function clearTurnLatencyRecordsForTest(): void {
+	turnLatencyRecords.length = 0;
+	nextTurnLatencyId = 1;
+}
+
+export function formatTurnLatencyRecords(records: readonly TurnLatencyRecord[] = turnLatencyRecords): string {
+	if (records.length === 0) return "No TUI turn latency records captured.";
+	return records.map(formatTurnLatencyDetails).join("\n");
+}
+
+export function formatTurnLatencySummary(record: TurnLatencyRecord): string {
+	const firstVisibleMs = record.firstVisible?.atMs;
+	const firstStreamMs = record.firstStreamActivity?.atMs;
+	const classification =
+		firstVisibleMs === undefined ? "no-visible-output"
+			: firstVisibleMs >= SLOW_MS ? "slow"
+				: firstVisibleMs >= NOTICEABLE_MS ? "noticeable"
+					: "ok";
+	const provider = [record.provider, record.model].filter(Boolean).join("/");
+	const parts = [
+		`[gsd timing] ${record.id}`,
+		`status=${record.status ?? "active"}`,
+		provider ? `model=${provider}` : undefined,
+		firstStreamMs !== undefined ? `first_stream=${Math.round(firstStreamMs)}ms` : "first_stream=n/a",
+		firstVisibleMs !== undefined
+			? `first_visible=${Math.round(firstVisibleMs)}ms:${record.firstVisible?.kind}`
+			: "first_visible=n/a",
+		record.durationMs !== undefined ? `duration=${record.durationMs}ms` : undefined,
+		`class=${classification}`,
+	];
+	return parts.filter(Boolean).join(" ");
+}
+
+function formatTurnLatencyDetails(record: TurnLatencyRecord): string {
+	const lines = [formatTurnLatencySummary(record)];
+	for (const mark of record.marks) {
+		const data = mark.data && Object.keys(mark.data).length > 0 ? ` ${JSON.stringify(mark.data)}` : "";
+		lines.push(`  +${Math.round(mark.atMs)}ms ${mark.phase}${data}`);
+	}
+	return lines.join("\n");
+}
+
+function elapsedSinceStart(record: TurnLatencyRecord): number {
+	return Math.round((performance.now() - record.startedAtMs) * 100) / 100;
+}

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -102,6 +102,7 @@ function registerPendingToolComponent(
 	const component = createComponent();
 	component.setExpanded(host.toolOutputExpanded);
 	host.chatContainer.addChild(component);
+	markFirstVisibleAssistantOutput(host, "tool", { toolName, source });
 	host.pendingTools.set(toolCallId, component);
 	toolRegistrationSources.set(component, new Set([source]));
 	return { component, created: true };
@@ -127,6 +128,22 @@ function startLoadingAnimation(host: InteractiveModeStateHost): void {
 		}
 		host.pendingWorkingMessage = undefined;
 	}
+}
+
+function markTuiLatency(
+	host: InteractiveModeStateHost,
+	phase: string,
+	data?: Record<string, unknown>,
+): void {
+	host.session.markTurnLatency?.(phase, data);
+}
+
+function markFirstVisibleAssistantOutput(
+	host: InteractiveModeStateHost,
+	kind: "text" | "thinking" | "tool" | "message_end_only",
+	data?: Record<string, unknown>,
+): void {
+	host.session.markFirstVisibleTurnLatency?.(kind, data);
 }
 
 function getVisibleTextLikeBlockType(block: any): "text" | "thinking" | undefined {
@@ -642,6 +659,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			}
 			host.statusContainer.clear();
 			startLoadingAnimation(host);
+			markTuiLatency(host, "tui.loader_visible");
 			host.ui.requestRender();
 			break;
 
@@ -658,6 +676,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// External-tool providers can stream multiple assistant turns through
 				// one response. Delay component creation until visible assistant text
 				// arrives so tool outputs keep chronological ordering.
+				markTuiLatency(host, "tui.assistant_message_start", {
+					provider: event.message.provider,
+					model: event.message.model,
+				});
 				host.ui.requestRender();
 			}
 			break;
@@ -895,6 +917,9 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 									connectedToUser,
 								);
 								host.chatContainer.addChild(comp);
+								markFirstVisibleAssistantOutput(host, seg.contentType, {
+									contentIndex: seg.startIndex,
+								});
 								renderedSegments.push({
 									kind: "text-run",
 									startIndex: seg.startIndex,
@@ -1134,6 +1159,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 								continue;
 							}
 							host.chatContainer.addChild(comp);
+							markFirstVisibleAssistantOutput(host, seg.contentType, {
+								contentIndex: seg.startIndex,
+								source: "message_end_rebuild",
+							});
 							renderedSegments.push({
 								kind: "text-run",
 								startIndex: seg.startIndex,
@@ -1158,6 +1187,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 							connectedToUser,
 						);
 						host.chatContainer.addChild(host.streamingComponent);
+						markFirstVisibleAssistantOutput(host, "message_end_only");
 						reconcileChatTurnConnections(host.chatContainer.children);
 					}
 					if (host.streamingComponent) {

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/input-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/input-controller.ts
@@ -14,6 +14,11 @@ function consumePendingImages(host: InteractiveModeStateHost): ImageContent[] | 
 	return images;
 }
 
+function markEditorSubmitLatency(host: InteractiveModeStateHost, images: ImageContent[] | undefined): void {
+	host.session.beginTurnLatency?.({ source: "tui", trigger: "editor_submit" });
+	host.session.markTurnLatency?.("tui.editor_submit", { images: images?.length ?? 0 });
+}
+
 export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 	getSlashCommandContext: () => any;
 	handleBashCommand: (command: string, excludeFromContext?: boolean) => Promise<void>;
@@ -121,6 +126,7 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 		if (host.options?.submitPromptsDirectly) {
 			host.editor.addToHistory?.(text);
 			try {
+				markEditorSubmitLatency(host, images);
 				await host.session.prompt(text, { images });
 			} catch (error: unknown) {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
@@ -130,9 +136,10 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 		}
 
 		host.editor.addToHistory?.(text);
-		// submitPromptsDirectly is false — still dispatch via session.prompt so user input
+		// submitPromptsDirectly is false; still dispatch via session.prompt so user input
 		// is not silently discarded.
 		try {
+			markEditorSubmitLatency(host, images);
 			await host.session.prompt(text, { images });
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-command-handlers.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-command-handlers.ts
@@ -119,37 +119,43 @@ export async function handleClearCommand(host: InteractiveModeDelegateHost): Pro
 	}
 
 export function handleDebugCommand(host: InteractiveModeDelegateHost): void {
-		const width = host.ui.terminal.columns;
-		const height = host.ui.terminal.rows;
-		const allLines = host.ui.render(width);
+	const width = host.ui.terminal.columns;
+	const height = host.ui.terminal.rows;
+	const allLines = host.ui.render(width);
+	const turnLatency = typeof host.session.formatTurnLatencyRecords === "function"
+		? host.session.formatTurnLatencyRecords()
+		: "TUI turn latency records unavailable.";
 
-		const debugLogPath = getDebugLogPath();
-		const debugData = [
-			`Debug output at ${new Date().toISOString()}`,
-			`Terminal: ${width}x${height}`,
-			`Total lines: ${allLines.length}`,
-			"",
-			"=== All rendered lines with visible widths ===",
-			...allLines.map((line, idx) => {
-				const vw = visibleWidth(line);
-				const escaped = JSON.stringify(line);
-				return `[${idx}] (w=${vw}) ${escaped}`;
-			}),
-			"",
-			"=== Agent messages (JSONL) ===",
-			...host.session.messages.map((msg) => JSON.stringify(msg)),
-			"",
-		].join("\n");
+	const debugLogPath = getDebugLogPath();
+	const debugData = [
+		`Debug output at ${new Date().toISOString()}`,
+		`Terminal: ${width}x${height}`,
+		`Total lines: ${allLines.length}`,
+		"",
+		"=== TUI turn latency ===",
+		turnLatency,
+		"",
+		"=== All rendered lines with visible widths ===",
+		...allLines.map((line, idx) => {
+			const vw = visibleWidth(line);
+			const escaped = JSON.stringify(line);
+			return `[${idx}] (w=${vw}) ${escaped}`;
+		}),
+		"",
+		"=== Agent messages (JSONL) ===",
+		...host.session.messages.map((msg) => JSON.stringify(msg)),
+		"",
+	].join("\n");
 
-		fs.mkdirSync(path.dirname(debugLogPath), { recursive: true });
-		fs.writeFileSync(debugLogPath, debugData);
+	fs.mkdirSync(path.dirname(debugLogPath), { recursive: true });
+	fs.writeFileSync(debugLogPath, debugData);
 
-		host.chatContainer.addChild(new Spacer(1));
-		host.chatContainer.addChild(
-			new Text(`${theme.fg("accent", "✓ Debug log written")}\n${theme.fg("muted", debugLogPath)}`, 1, 1),
-		);
-		host.ui.requestRender();
-	}
+	host.chatContainer.addChild(new Spacer(1));
+	host.chatContainer.addChild(
+		new Text(`${theme.fg("accent", "✓ Debug log written")}\n${theme.fg("muted", debugLogPath)}`, 1, 1),
+	);
+	host.ui.requestRender();
+}
 
 export function handleDaxnuts(host: InteractiveModeDelegateHost): void {
 		host.chatContainer.addChild(new Spacer(1));

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -338,11 +338,17 @@ async function streamAssistantResponse(
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
+		const stop = startLatencyTimer(config, "agent_loop.context_transform");
 		messages = await config.transformContext(messages, signal);
+		stop({ inputMessages: context.messages.length, outputMessages: messages.length });
+	} else {
+		markLatency(config, "agent_loop.context_transform.skipped", { inputMessages: context.messages.length });
 	}
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
+	const stopConvert = startLatencyTimer(config, "agent_loop.convert_to_llm");
 	const llmMessages = await config.convertToLlm(messages);
+	stopConvert({ inputMessages: messages.length, outputMessages: llmMessages.length });
 
 	// Build LLM context
 	const llmContext: Context = {
@@ -354,21 +360,39 @@ async function streamAssistantResponse(
 	const streamFunction = streamFn || streamSimple;
 
 	// Resolve API key (important for expiring tokens)
+	const stopApiKey = startLatencyTimer(config, "agent_loop.api_key");
 	const resolvedApiKey =
 		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
+	stopApiKey({ provider: config.model.provider, resolved: !!resolvedApiKey });
 
+	const stopStreamCreate = startLatencyTimer(config, "agent_loop.stream_create");
 	const response = await streamFunction(config.model, llmContext, {
 		...config,
 		apiKey: resolvedApiKey,
 		signal,
 	});
+	stopStreamCreate({
+		provider: config.model.provider,
+		model: config.model.id,
+		contextMessages: llmMessages.length,
+		tools: llmContext.tools?.length ?? 0,
+	});
 
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
+	let sawStreamActivity = false;
 
 	for await (const event of response) {
+		if (!sawStreamActivity) {
+			sawStreamActivity = true;
+			markLatency(config, "agent_loop.first_stream_activity", { eventType: event.type });
+		}
 		switch (event.type) {
 			case "start":
+				markLatency(config, "agent_loop.assistant_start", {
+					provider: event.partial.provider,
+					model: event.partial.model,
+				});
 				partialMessage = event.partial;
 				context.messages.push(partialMessage);
 				addedPartial = true;
@@ -421,6 +445,24 @@ async function streamAssistantResponse(
 	}
 	await emit({ type: "message_end", message: finalMessage });
 	return finalMessage;
+}
+
+function markLatency(config: AgentLoopConfig, phase: string, data?: Record<string, unknown>): void {
+	config.latencyMark?.(phase, data);
+}
+
+function startLatencyTimer(
+	config: AgentLoopConfig,
+	phase: string,
+): (data?: Record<string, unknown>) => void {
+	const start = performance.now();
+	markLatency(config, `${phase}.start`);
+	return (data?: Record<string, unknown>) => {
+		markLatency(config, `${phase}.end`, {
+			elapsedMs: Math.round((performance.now() - start) * 100) / 100,
+			...(data ?? {}),
+		});
+	};
 }
 
 /**

--- a/packages/pi-agent-core/src/agent.ts
+++ b/packages/pi-agent-core/src/agent.ts
@@ -14,6 +14,7 @@ import type {
 	AfterToolCallResult,
 	AgentContext,
 	AgentEvent,
+	AgentLatencyMarkSink,
 	AgentLoopConfig,
 	AgentLoopTurnUpdate,
 	AgentMessage,
@@ -98,6 +99,8 @@ export interface AgentOptions {
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 	streamFn?: StreamFn;
+	/** @internal Diagnostic hook for low-level turn latency marks. */
+	latencyMark?: AgentLatencyMarkSink;
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	onPayload?: SimpleStreamOptions["onPayload"];
 	onResponse?: SimpleStreamOptions["onResponse"];
@@ -172,6 +175,8 @@ export class Agent {
 	public convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	public transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 	public streamFn: StreamFn;
+	/** @internal Diagnostic hook for low-level turn latency marks. */
+	public latencyMark?: AgentLatencyMarkSink;
 	public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	public onPayload?: SimpleStreamOptions["onPayload"];
 	public onResponse?: SimpleStreamOptions["onResponse"];
@@ -203,6 +208,7 @@ export class Agent {
 		this.convertToLlm = options.convertToLlm ?? defaultConvertToLlm;
 		this.transformContext = options.transformContext;
 		this.streamFn = options.streamFn ?? streamSimple;
+		this.latencyMark = options.latencyMark;
 		this.getApiKey = options.getApiKey;
 		this.onPayload = options.onPayload;
 		this.onResponse = options.onResponse;
@@ -436,6 +442,7 @@ export class Agent {
 			prepareNextTurn: this.prepareNextTurn ? async () => await this.prepareNextTurn?.(this.signal) : undefined,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
+			latencyMark: this.latencyMark,
 			getApiKey: this.getApiKey,
 			getSteeringMessages: async () => {
 				if (skipInitialSteeringPoll) {

--- a/packages/pi-agent-core/src/types.ts
+++ b/packages/pi-agent-core/src/types.ts
@@ -132,6 +132,8 @@ export interface AgentLoopTurnUpdate {
 
 export interface PrepareNextTurnContext extends ShouldStopAfterTurnContext {}
 
+export type AgentLatencyMarkSink = (phase: string, data?: Record<string, unknown>) => void;
+
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
 
@@ -194,6 +196,9 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Contract: must not throw or reject. Return undefined when no key is available.
 	 */
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+
+	/** @internal Diagnostic hook for low-level turn latency marks. */
+	latencyMark?: AgentLatencyMarkSink;
 
 	/**
 	 * Called after each turn fully completes and `turn_end` has been emitted.

--- a/packages/pi-agent-core/test/agent.test.ts
+++ b/packages/pi-agent-core/test/agent.test.ts
@@ -169,6 +169,41 @@ describe("Agent", () => {
 		expect(agent.state.isStreaming).toBe(false);
 	});
 
+	it("forwards latency marks to the agent loop", async () => {
+		const marks: Array<{ phase: string; data?: Record<string, unknown> }> = [];
+		const agent = new Agent({
+			latencyMark: (phase, data) => {
+				marks.push({ phase, data });
+			},
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("ok") });
+				});
+				return stream;
+			},
+		});
+
+		await agent.prompt("hello");
+
+		const phases = marks.map((mark) => mark.phase);
+		expect(phases).toEqual(
+			expect.arrayContaining([
+				"agent_loop.context_transform.skipped",
+				"agent_loop.convert_to_llm.start",
+				"agent_loop.convert_to_llm.end",
+				"agent_loop.api_key.start",
+				"agent_loop.api_key.end",
+				"agent_loop.stream_create.start",
+				"agent_loop.stream_create.end",
+				"agent_loop.first_stream_activity",
+			]),
+		);
+		expect(marks.find((mark) => mark.phase === "agent_loop.first_stream_activity")?.data).toMatchObject({
+			eventType: "done",
+		});
+	});
+
 	it("waitForIdle should wait for async subscribers", async () => {
 		const barrier = createDeferred();
 		const agent = new Agent({


### PR DESCRIPTION
## Summary

- Add TUI turn latency records for first-stream and first-visible response timing
- Surface the latest timing records in `/debug`, with opt-in live summaries via `GSD_TUI_TIMING=1`
- Add focused tests for latency record behavior and low-level agent-loop mark forwarding

## Verification

- `pnpm --filter @gsd/pi-agent-core run build`
- `pnpm --filter @gsd/agent-core run build`
- `pnpm --filter @gsd/agent-modes run build`
- `pnpm --filter @gsd/agent-core test`
- `pnpm --filter @gsd/agent-modes test`
- `pnpm --filter @gsd/pi-agent-core exec vitest run test/agent.test.ts`
- `git diff --check`

## Known test caveat

- `pnpm --filter @gsd/pi-agent-core test` still fails in a broader faux-provider / harness-stream pattern, including empty assistant responses and `No API provider registered for api: faux...`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783022019&installation_id=134682257&pr_number=423&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F423&signature=7587010556f3efe01ac902b66ad7e240739191a083d4aff1cee10e606e8705bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes on the prompt and render path; optional env-gated stderr output with no auth or persistence impact.
> 
> **Overview**
> Adds **first-visible response latency** instrumentation for the interactive TUI: time from submit to the first user-visible assistant output (text, thinking, tool UI, or message-end-only), separate from total turn time.
> 
> A new **`turn-latency`** module in `@gsd/agent-core` keeps a rolling buffer of TUI/interactive turn records with phase marks, **first stream activity**, and **first visible** signals. **`AgentSession.prompt`** and **`runAgentPrompt`** record session preflight steps and forward the agent loop’s **`latencyMark`** hook into those records. **`@gsd/pi-agent-core`** gains optional **`latencyMark`** on the agent loop (context transform, LLM conversion, API key, stream creation, first stream event).
> 
> The interactive mode marks TUI milestones (editor submit, loader, assistant stream, visible segments/tools) and includes formatted records in **`/debug`**. Live one-line summaries on stderr are opt-in via **`GSD_TUI_TIMING=1`**. Glossary and tests cover record retention, source filtering, and mark forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440249d9be9c5a2ea4f4363be87759622bb0d2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->