### PR TITLE
[codex] compact small GSD widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:packages",
     "prototype:tui-design": "pnpm run build:pi-tui && pnpm run build:pi-coding-agent && node packages/pi-coding-agent/scripts/run-design-prototype.mjs",
     "prototype:tui-density": "pnpm run build:pi-tui && pnpm run build:pi-coding-agent && node packages/pi-coding-agent/scripts/run-density-prototype.mjs",
+    "prototype:tui-widget": "pnpm run build:pi-tui && pnpm run build:pi-coding-agent && node --experimental-strip-types packages/gsd-agent-modes/scripts/run-widget-prototype.mjs",
     "test:smoke": "node --experimental-strip-types tests/smoke/run.ts",
     "test:live": "node scripts/with-env.mjs GSD_LIVE_TESTS=1 -- node --experimental-strip-types tests/live/run.ts",
     "test:browser-tools": "node --test src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs",

--- a/packages/gsd-agent-modes/scripts/run-widget-prototype.mjs
+++ b/packages/gsd-agent-modes/scripts/run-widget-prototype.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// PROTOTYPE runner - compare compact /gsd auto progress widget options.
+// Usage: pnpm run prototype:tui-widget [-- all|recommended|current-small|horizontal-bar|split-ribbon|dense-grid]
+// Env: PROTOTYPE_WIDTH=<cols>  PROTOTYPE_THEME=dark|light
+
+import stripAnsi from "strip-ansi";
+import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+import {
+	WIDGET_PROTOTYPES,
+	RECOMMENDED_WIDGET_PROTOTYPE_ID,
+	lineStats,
+	listWidgetPrototypeIds,
+	renderWidgetPrototypeBanner,
+	resolveWidgetPrototypeSet,
+} from "../src/modes/interactive/components/__prototype__/gsd-widget-prototype.ts";
+
+function resolveWidth() {
+	if (process.env.PROTOTYPE_WIDTH) {
+		const n = Number(process.env.PROTOTYPE_WIDTH);
+		if (Number.isFinite(n) && n > 0) return Math.floor(n);
+	}
+	const envCols = Number(process.env.COLUMNS);
+	const cols =
+		(process.stdout.columns && process.stdout.columns > 0 ? process.stdout.columns : undefined) ??
+		(Number.isFinite(envCols) && envCols > 0 ? envCols : 120);
+	return Math.max(40, Math.floor(cols));
+}
+
+const themeName = process.env.PROTOTYPE_THEME === "light" ? "light" : "dark";
+initTheme(themeName, false);
+
+const width = resolveWidth();
+const arg = process.argv.slice(2).find((value) => value !== "--") ?? "all";
+const prototypes = resolveWidgetPrototypeSet(arg);
+
+for (const prototype of prototypes) {
+	const rendered = prototype.render(width);
+	const stats = lineStats(rendered.map((line) => stripAnsi(line)));
+
+	process.stdout.write(renderWidgetPrototypeBanner(prototype, width).join("\n"));
+	process.stdout.write("\n");
+	process.stdout.write(rendered.join("\n"));
+	process.stdout.write("\n\n");
+	process.stdout.write(
+		`  lines: ${stats.total} total · ${stats.nonBlank} content · ${stats.blank} blank (${stats.total ? Math.round((stats.blank / stats.total) * 100) : 0}% air)\n`,
+	);
+	process.stdout.write("\n");
+}
+
+if (prototypes.length > 1) {
+	process.stdout.write(`Rendered at ${width} columns.\n\n`);
+	process.stdout.write("Widget comparison:\n");
+	for (const prototype of WIDGET_PROTOTYPES) {
+		const stats = lineStats(prototype.render(width).map((line) => stripAnsi(line)));
+		const mark = prototype.id === RECOMMENDED_WIDGET_PROTOTYPE_ID ? "★" : " ";
+		process.stdout.write(`  ${mark} ${prototype.id.padEnd(16)} ${String(stats.total).padStart(3)} lines (${stats.blank} blank)\n`);
+	}
+	process.stdout.write("\n");
+	process.stdout.write(`Recommended: pnpm run prototype:tui-widget -- ${RECOMMENDED_WIDGET_PROTOTYPE_ID}\n`);
+	process.stdout.write(`IDs: ${listWidgetPrototypeIds().join(", ")}\n`);
+}

--- a/packages/gsd-agent-modes/src/modes/interactive/components/__prototype__/WIDGET-NOTES.md
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__prototype__/WIDGET-NOTES.md
@@ -1,0 +1,17 @@
+# PROTOTYPE - /gsd Auto Widget
+
+Question: which compact `/gsd` auto-progress widget keeps the widget small while using horizontal terminal space well?
+
+Run:
+
+```bash
+pnpm run prototype:tui-widget
+pnpm run prototype:tui-widget -- horizontal-bar
+PROTOTYPE_WIDTH=100 pnpm run prototype:tui-widget -- all
+```
+
+Verdict placeholder:
+
+- Ship: D `dense-grid`
+- Defer: A/B/C
+- Delete prototype after: `/gsd` small widget ships and stays stable

--- a/packages/gsd-agent-modes/src/modes/interactive/components/__prototype__/gsd-widget-prototype.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__prototype__/gsd-widget-prototype.ts
@@ -1,0 +1,259 @@
+// PROTOTYPE - throwaway /gsd auto progress widget layout options.
+// Question: can the widget stay small while using terminal width horizontally?
+// Run: pnpm run prototype:tui-widget [-- current-small|horizontal-bar|split-ribbon|dense-grid|all]
+
+import { alignRight, padRight, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { theme, type ThemeColor } from "@gsd/pi-coding-agent/theme/theme.js";
+
+export type WidgetPrototypeId = "current-small" | "horizontal-bar" | "split-ribbon" | "dense-grid";
+
+export interface WidgetPrototype {
+	id: WidgetPrototypeId;
+	label: string;
+	tagline: string;
+	render: (width: number) => string[];
+}
+
+const SAMPLE = {
+	mode: "AUTO",
+	state: "running",
+	health: "green",
+	elapsed: "1h 42m",
+	eta: "18m left",
+	phase: "execute-task",
+	verb: "Execute",
+	milestone: "M004",
+	slice: "S02",
+	unit: "T03",
+	title: "Compare horizontal dashboard density",
+	slicesDone: 2,
+	slicesTotal: 5,
+	tasksDone: 2,
+	tasksTotal: 4,
+	tokens: "182k",
+	cost: "$1.83",
+};
+
+const RECOMMENDED_WIDGET_PROTOTYPE_ID: WidgetPrototypeId = "dense-grid";
+export { RECOMMENDED_WIDGET_PROTOTYPE_ID };
+
+function lineStats(lines: string[]): { total: number; blank: number; nonBlank: number } {
+	const total = lines.length;
+	const blank = lines.filter((line) => line.trim().length === 0).length;
+	return { total, blank, nonBlank: total - blank };
+}
+
+export { lineStats };
+
+function padLine(line: string, width: number): string {
+	return padRight(truncateToWidth(line, width, ""), width);
+}
+
+function rule(width: number, color: ThemeColor = "borderMuted"): string {
+	return theme.fg(color, "─".repeat(Math.max(1, width)));
+}
+
+function dim(text: string): string {
+	return theme.fg("dim", text);
+}
+
+function accent(text: string): string {
+	return theme.fg("accent", text);
+}
+
+function success(text: string): string {
+	return theme.fg("success", text);
+}
+
+function text(textValue: string): string {
+	return theme.fg("text", textValue);
+}
+
+function label(textValue: string, color: ThemeColor = "borderAccent"): string {
+	return theme.fg(color, theme.bold(textValue.toUpperCase()));
+}
+
+function progressBar(width: number): string {
+	const done = SAMPLE.slicesDone;
+	const total = SAMPLE.slicesTotal;
+	const filled = Math.max(0, Math.min(width, Math.round((done / total) * width)));
+	return `${success("█".repeat(filled))}${dim("░".repeat(Math.max(0, width - filled)))}`;
+}
+
+function metric(name: string, value: string, width: number): string {
+	const raw = `${dim(name)} ${text(value)}`;
+	return truncateToWidth(raw, width, "…");
+}
+
+function column(content: string, width: number): string {
+	return padRight(truncateToWidth(content, width, "…"), width);
+}
+
+function fitColumns(width: number, parts: string[]): string {
+	if (parts.length === 0) return "";
+	const gap = dim(" │ ");
+	const gapWidth = visibleWidth(gap) * (parts.length - 1);
+	const available = Math.max(parts.length * 8, width - gapWidth);
+	const base = Math.floor(available / parts.length);
+	let remaining = available - base * parts.length;
+	const cols = parts.map((part) => {
+		const w = base + (remaining > 0 ? 1 : 0);
+		remaining--;
+		return column(part, w);
+	});
+	return truncateToWidth(cols.join(gap), width, "…");
+}
+
+function stateLine(id: WidgetPrototypeId, width: number, renderedLineCount: number): string {
+	const state = [
+		`variant=${id}`,
+		"mode=small-prototype",
+		`width=${width}`,
+		`lines=${renderedLineCount}`,
+		`unit=${SAMPLE.milestone}/${SAMPLE.slice}/${SAMPLE.unit}`,
+	];
+	return padLine(dim(`STATE ${state.join(" ")}`), width);
+}
+
+function actionTarget(maxWidth: number): string {
+	return truncateToWidth(`${SAMPLE.unit}: ${SAMPLE.title}`, Math.max(8, maxWidth), "…");
+}
+
+function renderCurrentSmall(width: number): string[] {
+	const pad = "  ";
+	const lines: string[] = [];
+	lines.push(rule(width));
+	lines.push(alignRight(
+		`${pad}${accent("◒")} ${accent(theme.bold("GSD"))} ${success(SAMPLE.mode)} ${success(SAMPLE.state)}`,
+		dim(`${SAMPLE.elapsed} · ${SAMPLE.eta}`),
+		width,
+	));
+	lines.push("");
+	lines.push(alignRight(
+		`${pad}${accent("▸")} ${accent(SAMPLE.verb)}  ${text(actionTarget(Math.floor(width * 0.58)))}`,
+		dim(SAMPLE.phase),
+		width,
+	));
+	const barWidth = Math.max(6, Math.min(18, Math.floor(width * 0.25)));
+	lines.push(`${pad}${progressBar(barWidth)} ${text(`${SAMPLE.slicesDone}`)}${dim(`/${SAMPLE.slicesTotal} slices · task `)}${accent(String(SAMPLE.tasksDone + 1))}${dim(`/${SAMPLE.tasksTotal}`)}`);
+	lines.push(rule(width));
+	lines.push(stateLine("current-small", width, lines.length + 1));
+	return lines.map((line) => padLine(line, width));
+}
+
+function renderHorizontalBar(width: number): string[] {
+	const lines: string[] = [];
+	const left = `${accent("◒ GSD")} ${success(SAMPLE.mode)} ${dim("·")} ${success(SAMPLE.state)} ${dim("·")} ${text(`${SAMPLE.verb} ${actionTarget(Math.floor(width * 0.45))}`)}`;
+	const right = dim(`${SAMPLE.phase} · ${SAMPLE.elapsed} · ${SAMPLE.eta}`);
+	lines.push(rule(width, "borderAccent"));
+	lines.push(alignRight(left, right, width));
+
+	const barWidth = Math.max(8, Math.min(16, Math.floor(width * 0.14)));
+	const progressLeft = `${progressBar(barWidth)} ${text(`${SAMPLE.slicesDone}/${SAMPLE.slicesTotal}`)}${dim(" slices")} ${dim("· task ")}${accent(String(SAMPLE.tasksDone + 1))}${dim(`/${SAMPLE.tasksTotal}`)}`;
+	const rightBudget = Math.max(20, width - visibleWidth(progressLeft) - 4);
+	const progressRight = truncateToWidth(
+		`${metric("tokens", SAMPLE.tokens, 18)} ${dim("·")} ${metric("cost", SAMPLE.cost, 12)}`,
+		rightBudget,
+		"…",
+	);
+	lines.push(alignRight(progressLeft, progressRight, width));
+	lines.push(rule(width, "borderAccent"));
+	lines.push(stateLine("horizontal-bar", width, lines.length + 1));
+	return lines.map((line) => padLine(line, width));
+}
+
+function renderSplitRibbon(width: number): string[] {
+	const lines: string[] = [];
+	const title = `${accent("GSD")} ${success(SAMPLE.mode)} ${dim("·")} ${SAMPLE.milestone}/${SAMPLE.slice}/${SAMPLE.unit}`;
+	const time = dim(`${SAMPLE.elapsed} · ${SAMPLE.eta}`);
+	lines.push(rule(width));
+	lines.push(alignRight(title, time, width));
+
+	const actionWidth = Math.max(18, Math.floor(width * 0.42));
+	const phaseWidth = Math.max(14, Math.floor(width * 0.18));
+	const progressWidth = Math.max(22, Math.floor(width * 0.22));
+	const action = `${label("work")} ${text(actionTarget(actionWidth))}`;
+	const phase = `${label("phase", "border")} ${dim(SAMPLE.phase)}`;
+	const progress = `${label("progress")} ${progressBar(Math.max(8, progressWidth - 18))} ${text(`${SAMPLE.slicesDone}/${SAMPLE.slicesTotal}`)}`;
+	const run = `${label("run", "border")} ${dim(`${SAMPLE.tokens} · ${SAMPLE.cost}`)}`;
+	lines.push(fitColumns(width, [action, phase, progress, run]));
+	lines.push(rule(width));
+	lines.push(stateLine("split-ribbon", width, lines.length + 1));
+	return lines.map((line) => padLine(line, width));
+}
+
+function renderDenseGrid(width: number): string[] {
+	const lines: string[] = [];
+	const rowOne = fitColumns(width, [
+		`${label("status", "border")} ${success(`${SAMPLE.mode} ${SAMPLE.state}`)}`,
+		`${label("unit")} ${text(`${SAMPLE.milestone}/${SAMPLE.slice}/${SAMPLE.unit}`)}`,
+		`${label("spend", "border")} ${dim(`${SAMPLE.tokens} · ${SAMPLE.cost}`)}`,
+		`${label("time")} ${dim(`${SAMPLE.elapsed} · ${SAMPLE.eta}`)}`,
+	]);
+	const rowTwo = fitColumns(width, [
+		`${label("phase", "border")} ${dim(SAMPLE.phase)}`,
+		`${label("work")} ${text(actionTarget(Math.floor(width * 0.28)))}`,
+		`${label("task", "border")} ${accent(String(SAMPLE.tasksDone + 1))}${dim(`/${SAMPLE.tasksTotal}`)}`,
+		`${label("slice")} ${progressBar(Math.max(8, Math.min(16, Math.floor(width * 0.16))))} ${text(`${SAMPLE.slicesDone}/${SAMPLE.slicesTotal}`)}`,
+	]);
+	lines.push(rule(width, "borderAccent"));
+	lines.push(rowOne);
+	lines.push(rowTwo);
+	lines.push(rule(width, "borderAccent"));
+	lines.push(stateLine("dense-grid", width, lines.length + 1));
+	return lines.map((line) => padLine(line, width));
+}
+
+export const WIDGET_PROTOTYPES: WidgetPrototype[] = [
+	{
+		id: "current-small",
+		label: "A · Current small",
+		tagline: "Baseline: existing small mode shape, vertical action/progress stack",
+		render: renderCurrentSmall,
+	},
+	{
+		id: "horizontal-bar",
+		label: "B · Horizontal bar",
+		tagline: "3-line widget, action + status use the full terminal width",
+		render: renderHorizontalBar,
+	},
+	{
+		id: "split-ribbon",
+		label: "C · Split ribbon",
+		tagline: "Four labeled columns without duplicating footer commands",
+		render: renderSplitRibbon,
+	},
+	{
+		id: "dense-grid",
+		label: "D · Dense grid",
+		tagline: "Selected: two metric rows, maximum scan data without growing height",
+		render: renderDenseGrid,
+	},
+];
+
+export function getWidgetPrototype(id: string): WidgetPrototype {
+	const found = WIDGET_PROTOTYPES.find((prototype) => prototype.id === id);
+	if (!found) {
+		throw new Error(`Unknown widget prototype: ${id}. Options: ${WIDGET_PROTOTYPES.map((p) => p.id).join(", ")}`);
+	}
+	return found;
+}
+
+export function resolveWidgetPrototypeSet(arg: string): WidgetPrototype[] {
+	if (arg === "all") return WIDGET_PROTOTYPES;
+	if (arg === "recommended") return [getWidgetPrototype(RECOMMENDED_WIDGET_PROTOTYPE_ID)];
+	return [getWidgetPrototype(arg)];
+}
+
+export function listWidgetPrototypeIds(): WidgetPrototypeId[] {
+	return WIDGET_PROTOTYPES.map((prototype) => prototype.id);
+}
+
+export function renderWidgetPrototypeBanner(prototype: WidgetPrototype, width: number): string[] {
+	const labelText = `${prototype.label}  ${prototype.id === RECOMMENDED_WIDGET_PROTOTYPE_ID ? "★ " : ""}${prototype.tagline}`;
+	return [
+		rule(width, prototype.id === RECOMMENDED_WIDGET_PROTOTYPE_ID ? "borderAccent" : "borderMuted"),
+		padLine(labelText, width),
+		rule(width, prototype.id === RECOMMENDED_WIDGET_PROTOTYPE_ID ? "borderAccent" : "borderMuted"),
+	];
+}

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -13,10 +13,11 @@ import type {
   ExtensionCommandContext,
   ReadonlyFooterDataProvider,
   Theme,
+  ThemeColor,
 } from "@gsd/pi-coding-agent";
 import type { GSDState } from "./types.js";
 import { getActiveHook } from "./post-unit-hooks.js";
-import { getLedger } from "./metrics.js";
+import { getLedger, getProjectTotals } from "./metrics.js";
 import { getErrorMessage } from "./error-utils.js";
 import { nativeIsRepo } from "./native-git-bridge.js";
 import {
@@ -302,6 +303,40 @@ export function shouldRenderRoadmapProgress(
   progress: { total: number; activeSliceTasks?: { total: number } | null } | null,
 ): progress is { total: number; activeSliceTasks?: { total: number } | null } {
   return !!progress && progress.total > 0;
+}
+
+function widgetGridLabel(theme: Theme, text: string, color: ThemeColor = "borderAccent"): string {
+  return theme.fg(color, theme.bold(text.toUpperCase()));
+}
+
+function widgetGridColumn(content: string, width: number): string {
+  return padRightVisible(truncateToWidth(content, width, "…"), width);
+}
+
+function widgetGridColumns(theme: Theme, width: number, parts: string[]): string {
+  if (parts.length === 0) return "";
+  const gap = theme.fg("dim", " │ ");
+  const gapWidth = visibleWidth(gap) * (parts.length - 1);
+  const available = Math.max(parts.length * 8, width - gapWidth);
+  const base = Math.floor(available / parts.length);
+  let remaining = available - base * parts.length;
+  const columns = parts.map((part) => {
+    const columnWidth = base + (remaining > 0 ? 1 : 0);
+    remaining--;
+    return widgetGridColumn(part, columnWidth);
+  });
+  return truncateToWidth(columns.join(gap), width, "…");
+}
+
+function formatSmallWidgetSpend(): string {
+  const ledger = getLedger();
+  if (!ledger || ledger.units.length === 0) return "--";
+
+  const totals = getProjectTotals(ledger.units);
+  const parts: string[] = [];
+  if (totals.tokens.total > 0) parts.push(formatWidgetTokens(totals.tokens.total));
+  if (totals.cost > 0) parts.push(`$${totals.cost.toFixed(2)}`);
+  return parts.length > 0 ? parts.join(" · ") : "--";
 }
 
 // ─── ETA Estimation ──────────────────────────────────────────────────────────
@@ -836,29 +871,62 @@ export function updateProgressWidget(
           return lines;
         }
 
-        // ── Mode: small — header + active work progress ───────────────
+        // ── Mode: small — dense horizontal grid ───────────────────────
         if (widgetMode === "small") {
-          lines.push("");
+          lines.length = 0;
+          lines.push(...ui.bar());
 
-          // Action line
-          const target = task ? `${task.id}: ${task.title}` : unitId;
-          const actionLeft = `${pad}${theme.fg("accent", "▸")} ${theme.fg("accent", verb)}  ${theme.fg("text", target)}`;
-          lines.push(rightAlign(actionLeft, theme.fg("dim", phaseLabel), width));
-
-          // Progress bar
           const roadmapSlices = mid ? getRoadmapSlicesSync() : null;
-          if (shouldRenderRoadmapProgress(roadmapSlices)) {
-            const { done, total, activeSliceTasks } = roadmapSlices;
-            const barWidth = Math.max(6, Math.min(18, Math.floor(width * 0.25)));
-            const bar = renderProgressBar(theme, done, total, barWidth);
-            let meta = `${theme.fg("text", `${done}`)}${theme.fg("dim", `/${total} slices`)}`;
-            if (activeSliceTasks && activeSliceTasks.total > 0) {
-              const tn = Math.min(activeSliceTasks.done + 1, activeSliceTasks.total);
-              meta += `${theme.fg("dim", " · task ")}${theme.fg("accent", `${tn}`)}${theme.fg("dim", `/${activeSliceTasks.total}`)}`;
-            }
-            lines.push(`${pad}${bar} ${meta}`);
+          const unitLabel = unitId || [mid?.id, slice?.id, task?.id].filter(Boolean).join("/");
+          const statusParts = [
+            spinner,
+            theme.fg("success", modeTag),
+            theme.fg(stateColor, activeState),
+          ];
+          if (runtimeSignal?.summary) {
+            statusParts.push(theme.fg(healthColor, healthSummary));
+          } else if (healthLevel !== "green") {
+            statusParts.push(`${theme.fg(healthColor, healthIcon)} ${theme.fg(healthColor, healthSummary)}`);
           }
 
+          const timeValue = [elapsed, etaShort].filter(Boolean).join(" · ") || "--";
+          const rowOne = widgetGridColumns(theme, width, [
+            `${widgetGridLabel(theme, "status", "border")} ${statusParts.join(" ")}`,
+            `${widgetGridLabel(theme, "unit")} ${theme.fg("text", unitLabel || "--")}`,
+            `${widgetGridLabel(theme, "spend", "border")} ${theme.fg("dim", formatSmallWidgetSpend())}`,
+            `${widgetGridLabel(theme, "time")} ${theme.fg("dim", timeValue)}`,
+          ]);
+
+          const target = task
+            ? `${task.id}: ${task.title}`
+            : slice
+              ? `${slice.id}: ${slice.title}`
+              : unitId;
+
+          let taskValue = task?.id ?? "--";
+          let sliceValue = slice?.id ?? "--";
+          if (shouldRenderRoadmapProgress(roadmapSlices)) {
+            const { done, total, activeSliceTasks } = roadmapSlices;
+            const barWidth = Math.max(4, Math.min(14, Math.floor(width * 0.12)));
+            const bar = renderProgressBar(theme, done, total, barWidth);
+            sliceValue = `${bar} ${theme.fg("text", `${done}/${total}`)}`;
+            if (activeSliceTasks && activeSliceTasks.total > 0) {
+              const taskNum = isHook
+                ? Math.max(activeSliceTasks.done, 1)
+                : Math.min(activeSliceTasks.done + 1, activeSliceTasks.total);
+              taskValue = `${theme.fg("accent", `${taskNum}`)}${theme.fg("dim", `/${activeSliceTasks.total}`)}`;
+            }
+          }
+
+          const rowTwo = widgetGridColumns(theme, width, [
+            `${widgetGridLabel(theme, "phase", "border")} ${theme.fg("dim", unitType)}`,
+            `${widgetGridLabel(theme, "work")} ${theme.fg("text", target || "--")}`,
+            `${widgetGridLabel(theme, "task", "border")} ${taskValue}`,
+            `${widgetGridLabel(theme, "slice")} ${sliceValue}`,
+          ]);
+
+          lines.push(rowOne);
+          lines.push(rowTwo);
           lines.push(...ui.bar());
           cachedLines = lines;
           cachedWidth = width;

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
+import { visibleWidth } from "@gsd/pi-tui";
 
 import {
   unitVerb,
@@ -56,6 +57,17 @@ function cleanup(dir: string): void {
     // best-effort
   }
 }
+
+function assertLinesFit(lines: string[], width: number): void {
+  for (const line of lines) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `line exceeds width ${width}: ${visibleWidth(line)} "${line}"`,
+    );
+  }
+}
+
+type RenderableWidget = { render(width: number): string[]; invalidate(): void; dispose?: () => void };
 
 // ─── unitVerb ─────────────────────────────────────────────────────────────
 
@@ -662,6 +674,95 @@ test("updateProgressWidget full mode keeps footer-owned signals out of auto deck
   assert.doesNotMatch(rendered, /\$/, "footer owns session cost display");
 });
 
+test("updateProgressWidget small mode renders the dense horizontal grid", (t) => {
+  const dir = makeTempDir("small-dense-grid");
+  const homeDir = makeTempDir("small-dense-grid-home");
+  const projectPrefsPath = join(dir, ".gsd", "preferences.md");
+  const globalPrefsPath = join(homeDir, ".gsd", "preferences.md");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  mkdirSync(join(homeDir, ".gsd"), { recursive: true });
+  writeFileSync(projectPrefsPath, "---\nversion: 1\nwidget_mode: full\n---\n", "utf-8");
+  writeFileSync(globalPrefsPath, "---\nversion: 1\nwidget_mode: full\n---\n", "utf-8");
+
+  const holder: { widget?: RenderableWidget } = {};
+
+  t.after(() => {
+    holder.widget?.dispose?.();
+    closeDatabase();
+    clearSliceProgressCache();
+    _resetWidgetModeForTests();
+    cleanup(dir);
+    cleanup(homeDir);
+  });
+
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M004", title: "Budget Tracking", status: "active" });
+  insertSlice({ milestoneId: "M004", id: "S01", title: "Schema migration", status: "complete", sequence: 1 });
+  insertSlice({ milestoneId: "M004", id: "S02", title: "Expense add", status: "pending", sequence: 2 });
+  insertTask({ milestoneId: "M004", sliceId: "S01", id: "T01", title: "Add repeat column via idempotent ALTER TABLE", status: "complete" });
+  insertTask({ milestoneId: "M004", sliceId: "S01", id: "T02", title: "Backfill repeat metadata", status: "pending" });
+
+  _resetWidgetModeForTests();
+  setWidgetMode("small", projectPrefsPath, globalPrefsPath);
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setHeader() {},
+        setStatus() {},
+        setWidget(_key: string, factory: any) {
+          if (_key === "gsd-progress") {
+            holder.widget = factory(
+              { requestRender() {} },
+              { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+            );
+          }
+        },
+      },
+    } as any,
+    "execute-task",
+    "M004/S01/T02",
+    {
+      phase: "executing",
+      activeMilestone: { id: "M004", title: "Budget Tracking" },
+      activeSlice: { id: "S01", title: "Schema migration" },
+      activeTask: { id: "T02", title: "Backfill repeat metadata" },
+    } as any,
+    {
+      getAutoStartTime: () => Date.now() - 18_000,
+      isStepMode: () => false,
+      getCmdCtx: () => null,
+      getBasePath: () => dir,
+      isVerbose: () => false,
+      isSessionSwitching: () => false,
+      getCurrentDispatchedModelId: () => null,
+    },
+  );
+
+  assert.ok(holder.widget, "progress widget should be installed");
+  const widget = holder.widget;
+  const lines = widget.render(120);
+  const rendered = lines.join("\n");
+
+  assert.equal(lines.length, 4, `small widget should render as rule + two dense rows + rule:\n${rendered}`);
+  assert.match(rendered, /STATUS\s+.*AUTO\s+running/);
+  assert.match(rendered, /UNIT\s+M004\/S01\/T02/);
+  assert.match(rendered, /SPEND/);
+  assert.match(rendered, /TIME/);
+  assert.match(rendered, /PHASE\s+execute-task/);
+  assert.match(rendered, /WORK\s+T02: Backfill repeat m/);
+  assert.match(rendered, /TASK\s+2\/2/);
+  assert.match(rendered, /SLICE.*1\/2/);
+  assert.doesNotMatch(rendered, /\/gsd next|\/gsd status/);
+  assert.doesNotMatch(rendered, /dashboard|esc pause/);
+
+  for (const width of [40, 80, 120]) {
+    widget.invalidate();
+    assertLinesFit(widget.render(width), width);
+  }
+});
+
 test("updateProgressWidget shows provider-waiting state consistently for auto and next modes", (t) => {
   const dir = makeTempDir("auto-next-dashboard");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
@@ -720,14 +821,14 @@ test("updateProgressWidget shows provider-waiting state consistently for auto an
   const autoRendered = renderDashboard(false);
   const nextRendered = renderDashboard(true);
 
-  assert.match(autoRendered, /GSD\s+·\s+AUTO\s+·\s+running/);
-  assert.match(nextRendered, /GSD\s+·\s+NEXT\s+·\s+running/);
+  assert.match(autoRendered, /STATUS\s+.*AUTO\s+running/);
+  assert.match(nextRendered, /STATUS\s+.*NEXT\s+running/);
   assert.doesNotMatch(autoRendered.split("\n")[1] ?? "", /completing M003\/S01/);
   assert.doesNotMatch(nextRendered.split("\n")[1] ?? "", /completing M003\/S01/);
   assert.doesNotMatch(autoRendered, /waiting on provider.*Waiting on provider/i);
   assert.doesNotMatch(nextRendered, /waiting on provider.*Waiting on provider/i);
-  assert.match(autoRendered, /completing\s+M003\/S01/);
-  assert.match(nextRendered, /completing\s+M003\/S01/);
+  assert.match(autoRendered, /PHASE\s+complete-slice/);
+  assert.match(nextRendered, /PHASE\s+complete-slice/);
   assert.doesNotMatch(autoRendered, /Working/);
   assert.doesNotMatch(nextRendered, /Working/);
 });


### PR DESCRIPTION
## Summary

- Render `/gsd` small widget mode as the selected dense horizontal grid.
- Remove duplicated command-hint/path noise from the small widget surface.
- Add a throwaway TUI prototype runner and record D `dense-grid` as the selected option.

## Impact

The compact auto-mode widget now uses horizontal terminal space for status, unit, spend, time, phase, work, task, and slice progress while leaving workspace path, branch, model, and context details to the default footer.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts`
- `./node_modules/.bin/tsc --noEmit --project tsconfig.extensions.json`
- Prototype width check for 60, 80, 100, and 120 columns

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783022029&installation_id=134682257&pr_number=424&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F424&signature=24ab671de0b70d82d2072233832546dc80af7fe0e1d80062985978a984172716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to small widget rendering with new tests; full/min/off modes and core auto logic are untouched.
> 
> **Overview**
> **Small** `/gsd` auto progress widget mode is reworked from a stacked header/action/progress layout into a **dense horizontal grid**: two rows of labeled columns (status, unit, spend, time; then phase, work, task, slice) between horizontal rules, with **no** duplicate footer hints (`/gsd next`, `esc pause`, etc.).
> 
> Production rendering in `auto-dashboard.ts` adds shared **grid column** helpers and **`formatSmallWidgetSpend()`** (ledger tokens/cost via `getProjectTotals`). Slice progress can show an inline bar in the **SLICE** cell; task numbering keeps the existing hook vs normal behavior.
> 
> A throwaway **`prototype:tui-widget`** script and `__prototype__` layouts document the design exploration; **`dense-grid`** is marked as the chosen option. Tests assert the new small layout, width fitting at 40/80/120 cols, and updated STATUS/PHASE assertions for auto vs next modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55851c536c656f00dce1b68013a915cee01a4ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->