### PR TITLE
fix(pi-ai): scope stream handlers by provider

### DIFF
--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -1219,14 +1219,20 @@ async function generateModels() {
 		if (
 			(candidate.provider === "anthropic" ||
 				candidate.provider === "opencode" ||
-				candidate.provider === "opencode-go" ||
-				candidate.provider === "github-copilot") &&
+				candidate.provider === "opencode-go") &&
 			(candidate.id === "claude-opus-4-6" ||
 				candidate.id === "claude-sonnet-4-6" ||
 				candidate.id === "claude-opus-4.6" ||
 				candidate.id === "claude-sonnet-4.6")
 		) {
 			candidate.contextWindow = 1000000;
+		}
+		if (
+			candidate.provider === "github-copilot" &&
+			(candidate.id === "claude-opus-4.6" || candidate.id === "claude-sonnet-4.6")
+		) {
+			candidate.contextWindow = 200000;
+			candidate.maxTokens = 32000;
 		}
 
 		// OpenCode variants list Claude Sonnet 4/4.5 with 1M context, actual limit is 200K

--- a/packages/pi-ai/src/api-registry.ts
+++ b/packages/pi-ai/src/api-registry.ts
@@ -38,6 +38,11 @@ type RegisteredApiProvider = {
 };
 
 const apiProviderRegistry = new Map<string, RegisteredApiProvider>();
+const providerApiProviderRegistry = new Map<string, RegisteredApiProvider>();
+
+function providerApiKey(provider: string, api: Api): string {
+	return JSON.stringify([provider, api]);
+}
 
 function wrapStream<TApi extends Api, TOptions extends StreamOptions>(
 	api: TApi,
@@ -77,8 +82,29 @@ export function registerApiProvider<TApi extends Api, TOptions extends StreamOpt
 	});
 }
 
+export function registerProviderApiProvider<TApi extends Api, TOptions extends StreamOptions>(
+	providerName: string,
+	provider: ApiProvider<TApi, TOptions>,
+	sourceId?: string,
+): void {
+	providerApiProviderRegistry.set(providerApiKey(providerName, provider.api), {
+		provider: {
+			api: provider.api,
+			stream: wrapStream(provider.api, provider.stream),
+			streamSimple: wrapStreamSimple(provider.api, provider.streamSimple),
+		},
+		sourceId,
+	});
+}
+
 export function getApiProvider(api: Api): ApiProviderInternal | undefined {
 	return apiProviderRegistry.get(api)?.provider;
+}
+
+export function getApiProviderForModel(model: Model<Api>): ApiProviderInternal | undefined {
+	return (
+		providerApiProviderRegistry.get(providerApiKey(model.provider, model.api))?.provider ?? getApiProvider(model.api)
+	);
 }
 
 export function getApiProviders(): ApiProviderInternal[] {
@@ -91,8 +117,14 @@ export function unregisterApiProviders(sourceId: string): void {
 			apiProviderRegistry.delete(api);
 		}
 	}
+	for (const [key, entry] of providerApiProviderRegistry.entries()) {
+		if (entry.sourceId === sourceId) {
+			providerApiProviderRegistry.delete(key);
+		}
+	}
 }
 
 export function clearApiProviders(): void {
 	apiProviderRegistry.clear();
+	providerApiProviderRegistry.clear();
 }

--- a/packages/pi-ai/src/models.generated.ts
+++ b/packages/pi-ai/src/models.generated.ts
@@ -4137,7 +4137,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 1000000,
+			contextWindow: 200000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-opus-4.7": {
@@ -4215,7 +4215,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 1000000,
+			contextWindow: 200000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"gemini-2.5-pro": {

--- a/packages/pi-ai/src/stream.ts
+++ b/packages/pi-ai/src/stream.ts
@@ -1,6 +1,6 @@
 import "./providers/register-builtins.js";
 
-import { getApiProvider } from "./api-registry.js";
+import { getApiProviderForModel } from "./api-registry.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -14,10 +14,10 @@ import type {
 
 export { getEnvApiKey } from "./env-api-keys.js";
 
-function resolveApiProvider(api: Api) {
-	const provider = getApiProvider(api);
+function resolveApiProvider(model: Model<Api>) {
+	const provider = getApiProviderForModel(model);
 	if (!provider) {
-		throw new Error(`No API provider registered for api: ${api}`);
+		throw new Error(`No API provider registered for provider/api: ${model.provider}/${model.api}`);
 	}
 	return provider;
 }
@@ -27,7 +27,7 @@ export function stream<TApi extends Api>(
 	context: Context,
 	options?: ProviderStreamOptions,
 ): AssistantMessageEventStream {
-	const provider = resolveApiProvider(model.api);
+	const provider = resolveApiProvider(model);
 	return provider.stream(model, context, options as StreamOptions);
 }
 
@@ -45,7 +45,7 @@ export function streamSimple<TApi extends Api>(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
-	const provider = resolveApiProvider(model.api);
+	const provider = resolveApiProvider(model);
 	return provider.streamSimple(model, context, options);
 }
 

--- a/packages/pi-ai/test/generated-models.test.ts
+++ b/packages/pi-ai/test/generated-models.test.ts
@@ -58,4 +58,15 @@ describe("models.generated.ts", () => {
 			});
 		}
 	});
+
+	test("keeps GitHub Copilot Claude 4.6 context at Copilot's 200K limit", () => {
+		for (const id of ["claude-opus-4.6", "claude-sonnet-4.6"] as const) {
+			const model = MODELS["github-copilot"][id];
+
+			expect(model.provider).toBe("github-copilot");
+			expect(model.api).toBe("anthropic-messages");
+			expect(model.contextWindow).toBe(200000);
+			expect(model.maxTokens).toBe(32000);
+		}
+	});
 });

--- a/packages/pi-ai/test/provider-scoped-api-registry.test.ts
+++ b/packages/pi-ai/test/provider-scoped-api-registry.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	registerApiProvider,
+	registerProviderApiProvider,
+	unregisterApiProviders,
+	type ApiProvider,
+} from "../src/api-registry.ts";
+import { resetApiProviders } from "../src/providers/register-builtins.ts";
+import { stream, streamSimple } from "../src/stream.ts";
+import type { Api, Context, Model } from "../src/types.ts";
+
+const TEST_API = "test-provider-scoped-api" as Api;
+
+const context: Context = {
+	messages: [],
+};
+
+function makeModel(provider: string): Model<Api> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: TEST_API,
+		provider,
+		baseUrl: "https://provider.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+}
+
+function throwingProvider(label: string): ApiProvider<Api> {
+	return {
+		api: TEST_API,
+		stream: () => {
+			throw new Error(`${label} stream`);
+		},
+		streamSimple: () => {
+			throw new Error(`${label} simple`);
+		},
+	};
+}
+
+describe("provider-scoped API registry", () => {
+	afterEach(() => {
+		resetApiProviders();
+	});
+
+	it("resolves a provider-scoped handler before the shared API fallback", () => {
+		registerApiProvider(throwingProvider("shared"), "test:shared");
+		registerProviderApiProvider("scoped-provider", throwingProvider("scoped"), "test:scoped");
+
+		expect(() => stream(makeModel("scoped-provider"), context)).toThrow("scoped stream");
+		expect(() => streamSimple(makeModel("scoped-provider"), context)).toThrow("scoped simple");
+		expect(() => stream(makeModel("other-provider"), context)).toThrow("shared stream");
+		expect(() => streamSimple(makeModel("other-provider"), context)).toThrow("shared simple");
+	});
+
+	it("unregisters provider-scoped handlers by source id", () => {
+		registerApiProvider(throwingProvider("shared"), "test:shared");
+		registerProviderApiProvider("scoped-provider", throwingProvider("scoped"), "test:scoped");
+
+		unregisterApiProviders("test:scoped");
+
+		expect(() => streamSimple(makeModel("scoped-provider"), context)).toThrow("shared simple");
+	});
+});

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -14,7 +14,7 @@ import {
 	type OAuthProviderInterface,
 	type OpenAICompletionsCompat,
 	type OpenAIResponsesCompat,
-	registerApiProvider,
+	registerProviderApiProvider,
 	resetApiProviders,
 	type SimpleStreamOptions,
 } from "@gsd/pi-ai";
@@ -911,7 +911,8 @@ export class ModelRegistry {
 
 		if (config.streamSimple) {
 			const streamSimple = config.streamSimple;
-			registerApiProvider(
+			registerProviderApiProvider(
+				providerName,
 				{
 					api: config.api!,
 					stream: (model, context, options) => streamSimple(model, context, options as SimpleStreamOptions),

--- a/packages/pi-coding-agent/test/model-registry.test.ts
+++ b/packages/pi-coding-agent/test/model-registry.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AnthropicMessagesCompat, Api, Context, Model, OpenAICompletionsCompat } from "@earendil-works/pi-ai";
-import { getApiProvider } from "@earendil-works/pi-ai";
+import { getApiProvider, streamSimple } from "@earendil-works/pi-ai";
 import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
@@ -1025,34 +1025,42 @@ describe("ModelRegistry", () => {
 			expect(getOAuthProvider("anthropic")?.name).not.toBe("Custom Anthropic OAuth");
 		});
 
-		test("unregisterProvider removes custom streamSimple override and restores built-in API stream handler", () => {
+		test("provider streamSimple is scoped to that provider and removed on unregister", () => {
 			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
 
 			registry.registerProvider("stream-override-provider", {
 				api: "openai-completions",
+				baseUrl: "https://provider.test/v1",
+				apiKey: "TEST_KEY",
+				models: [
+					{
+						id: "scoped-model",
+						name: "Scoped Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128000,
+						maxTokens: 4096,
+					},
+				],
 				streamSimple: () => {
 					throw new Error("custom streamSimple override");
 				},
 			});
 
-			let threwCustomOverride = false;
-			try {
-				getApiProvider("openai-completions")?.streamSimple(openAiModel, emptyContext);
-			} catch (error) {
-				threwCustomOverride = error instanceof Error && error.message === "custom streamSimple override";
+			const scopedModel = registry.find("stream-override-provider", "scoped-model");
+			if (!scopedModel) {
+				throw new Error("Expected scoped model to be registered");
 			}
-			expect(threwCustomOverride).toBe(true);
+
+			expect(() => streamSimple(scopedModel, emptyContext)).toThrow("custom streamSimple override");
+			expect(() => getApiProvider("openai-completions")?.streamSimple(openAiModel, emptyContext)).not.toThrow(
+				"custom streamSimple override",
+			);
 
 			registry.unregisterProvider("stream-override-provider");
 
-			let threwCustomOverrideAfterUnregister = false;
-			try {
-				getApiProvider("openai-completions")?.streamSimple(openAiModel, emptyContext);
-			} catch (error) {
-				threwCustomOverrideAfterUnregister =
-					error instanceof Error && error.message === "custom streamSimple override";
-			}
-			expect(threwCustomOverrideAfterUnregister).toBe(false);
+			expect(() => streamSimple(scopedModel, emptyContext)).not.toThrow("custom streamSimple override");
 		});
 
 		describe("dynamic provider override persistence", () => {


### PR DESCRIPTION
## Linked issue

Closes #425

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Scope provider-specific stream handlers by provider plus API instead of API alone, and correct Copilot Claude 4.6 context metadata.
**Why:** GitHub Copilot Claude models can otherwise be dispatched through the Claude Code adapter, and the selector advertised a 1M context window instead of Copilot's 200K limit.
**How:** Add provider-aware API handler registration/resolution with shared API fallback, register extension stream handlers through that scoped path, and keep generated Copilot Claude 4.6 limits at 200K.

## What

- Adds provider-scoped API handler registration in `@gsd/pi-ai` and resolves streams by provider/API before falling back to the shared API handler.
- Updates `ModelRegistry.registerProvider` so extension `streamSimple` handlers are scoped to their provider.
- Corrects generated GitHub Copilot Claude Opus/Sonnet 4.6 context windows from 1M to 200K and updates the model generator override.
- Adds regression coverage for provider-scoped dispatch and Copilot Claude 4.6 metadata.

## Why

`claude-code` and GitHub Copilot Claude models both use the `anthropic-messages` API shape. Registering the Claude Code provider-specific stream handler globally by API allowed it to replace the shared Anthropic Messages transport for unrelated providers, so selecting `github-copilot/claude-sonnet-4.6` could route through `claude-code`.

## How

`pi-ai` now keeps provider-scoped handlers in a separate registry keyed by provider/API. `stream()` and `streamSimple()` resolve the exact provider/API handler first, then fall back to the existing shared API registry. This preserves shared API behavior for built-ins while preventing one provider-specific transport from replacing every model that has the same API shape.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run locally:

- [x] `pnpm exec vitest run packages/pi-ai/test/provider-scoped-api-registry.test.ts packages/pi-ai/test/generated-models.test.ts`
- [x] `pnpm exec vitest run packages/pi-coding-agent/test/model-registry.test.ts -t "provider streamSimple is scoped"`
- [x] `pnpm --filter @gsd/pi-ai exec tsc -p tsconfig.json --noEmit --incremental false`
- [x] `pnpm --filter @gsd/pi-coding-agent run build`
- [x] `bash scripts/ci-fast-gates.sh`

Notes:

- Full `packages/pi-coding-agent/test/model-registry.test.ts` under the root Vitest runner still has unrelated command-backed API-key cases blocked by the local command allowlist.
- `pnpm --filter @gsd/pi-coding-agent exec tsc -p tsconfig.json --noEmit --incremental false` hit an unrelated stale-dist/source private-type conflict in package lifecycle files; the package build script cleans dist first and passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783037207&installation_id=134682257&pr_number=431&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F431&signature=8edded27b1bae340454346b31ff3d43a3a935962f61b954f42dd1b39f7e4c210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming dispatch for all models sharing an API shape; incorrect resolution could route requests to the wrong transport, though fallback behavior and new tests mitigate this.
> 
> **Overview**
> **Provider-scoped stream dispatch** stops one vendor’s custom `streamSimple` from replacing every model that shares the same API shape (e.g. `anthropic-messages`). `stream()` / `streamSimple()` now resolve handlers by **provider + API** first, then fall back to the shared API registry; extension providers register overrides via `registerProviderApiProvider`, and `ModelRegistry` uses that path instead of global `registerApiProvider`.
> 
> **GitHub Copilot Claude 4.6 metadata** is corrected so Opus/Sonnet 4.6 are **200K** context (not 1M) with **32K** max tokens in generated models and the model generator override. Tests cover scoped registry behavior, Copilot limits, and provider-only `streamSimple` overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b37f13fe8b24ead6be849891abdcdffebafcb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->