### PR TITLE
fix(gsd): preload milestone discuss context

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1569,10 +1569,9 @@ export async function buildDiscussMilestonePrompt(
     });
   }
 
-  const discussTemplates = [
-    await buildDiscussMilestoneInlinedContext(mid, base),
-    contextTemplate,
-  ].join("\n\n---\n\n");
+  const rawInlinedContext = await buildDiscussMilestoneInlinedContext(mid, base);
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  const discussTemplates = [cappedInlinedContext, contextTemplate].join("\n\n---\n\n");
 
   const basePrompt = loadPrompt("guided-discuss-milestone", {
     workingDirectory: base,

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -45,6 +45,7 @@ import { classifyProject, type ProjectClassification } from "./detection.js";
 import { hasBrowserRequiredText } from "./browser-evidence.js";
 import { debugLog } from "./debug-logger.js";
 import { buildSkillActivationBlock, buildSkillDiscoveryVars } from "./skill-activation.js";
+import { findMilestoneIds } from "./milestone-ids.js";
 
 export { buildSkillActivationBlock, buildSkillDiscoveryVars };
 
@@ -1482,21 +1483,84 @@ export async function checkNeedsRunUat(
  * as a seed when present. The discussion agent interviews the user, writes
  * a full CONTEXT.md, and the phase transitions to pre-planning automatically.
  */
+export interface DiscussMilestonePromptOptions {
+  headless?: boolean;
+  commitInstruction?: string;
+  fastPathInstruction?: string;
+  includeDraftSeed?: boolean;
+  includeContextMode?: boolean;
+}
+
+export async function buildDiscussMilestoneInlinedContext(mid: string, base: string): Promise<string> {
+  const inlined: string[] = [];
+
+  const roadmapInline = await inlineFileOptional(
+    resolveMilestoneFile(base, mid, "ROADMAP"),
+    relMilestoneFile(base, mid, "ROADMAP"),
+    "Milestone Roadmap",
+  );
+  if (roadmapInline) inlined.push(roadmapInline);
+
+  const contextInline = await inlineFileOptional(
+    resolveMilestoneFile(base, mid, "CONTEXT"),
+    relMilestoneFile(base, mid, "CONTEXT"),
+    "Milestone Context",
+  );
+  if (contextInline) inlined.push(contextInline);
+
+  const researchInline = await inlineFileOptional(
+    resolveMilestoneFile(base, mid, "RESEARCH"),
+    relMilestoneFile(base, mid, "RESEARCH"),
+    "Milestone Research",
+  );
+  if (researchInline) inlined.push(researchInline);
+
+  const decisionsPath = resolveGsdRootFile(base, "DECISIONS");
+  if (existsSync(decisionsPath)) {
+    const decisionsContent = await loadFile(decisionsPath);
+    if (decisionsContent) {
+      inlined.push(`### Decisions Register\nSource: \`${relGsdRootFile("DECISIONS")}\`\n\n${decisionsContent.trim()}`);
+    }
+  }
+
+  const milestoneIds = findMilestoneIds(base);
+  const currentIndex = milestoneIds.indexOf(mid);
+  const priorMilestoneIds = currentIndex >= 0 ? milestoneIds.slice(0, currentIndex) : milestoneIds;
+  for (const priorMid of priorMilestoneIds) {
+    const summaryInline = await inlineFileOptional(
+      resolveMilestoneFile(base, priorMid, "SUMMARY"),
+      relMilestoneFile(base, priorMid, "SUMMARY"),
+      `${priorMid} Prior Milestone Summary`,
+    );
+    if (summaryInline) inlined.push(summaryInline);
+  }
+
+  return inlined.length > 0
+    ? `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`
+    : "## Inlined Context\n\n_(no milestone context files found yet — go in blind and ask broad questions)_";
+}
+
 export async function buildDiscussMilestonePrompt(
   mid: string,
   midTitle: string,
   base: string,
   structuredQuestionsAvailable = "false",
-  { headless = false }: { headless?: boolean } = {},
+  {
+    headless = false,
+    commitInstruction = "Do not commit planning artifacts — .gsd/ is managed externally.",
+    fastPathInstruction = "",
+    includeDraftSeed = true,
+    includeContextMode = true,
+  }: DiscussMilestonePromptOptions = {},
 ): Promise<string> {
-  const discussTemplates = inlineTemplate("context", "Context");
+  const contextTemplate = inlineTemplate("context", "Context");
 
   if (headless) {
     const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
     const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
     return loadPrompt("discuss-headless", {
       seedContext: roadmapContent ?? "",
-      inlinedTemplates: discussTemplates,
+      inlinedTemplates: contextTemplate,
       workingDirectory: base,
       milestoneId: mid,
       contextPath: relMilestoneFile(base, mid, "CONTEXT"),
@@ -1505,7 +1569,10 @@ export async function buildDiscussMilestonePrompt(
     });
   }
 
-  const contextModeInstructions = renderContextModeForPrompt("discuss-milestone", base);
+  const discussTemplates = [
+    await buildDiscussMilestoneInlinedContext(mid, base),
+    contextTemplate,
+  ].join("\n\n---\n\n");
 
   const basePrompt = loadPrompt("guided-discuss-milestone", {
     workingDirectory: base,
@@ -1513,20 +1580,22 @@ export async function buildDiscussMilestonePrompt(
     milestoneTitle: midTitle,
     inlinedTemplates: discussTemplates,
     structuredQuestionsAvailable,
-    commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
-    fastPathInstruction: "",
+    commitInstruction,
+    fastPathInstruction,
   });
-  const promptWithContextMode = prependContextModeToBlock("discuss-milestone", base, basePrompt);
+  const promptWithContextMode = includeContextMode
+    ? prependContextModeToBlock("discuss-milestone", base, basePrompt)
+    : basePrompt;
 
   // If a CONTEXT-DRAFT.md exists, append it as seed material
   const draftPath = resolveMilestoneFile(base, mid, "CONTEXT-DRAFT");
   const draftContent = draftPath ? await loadFile(draftPath) : null;
 
-  if (draftContent) {
+  if (includeDraftSeed && draftContent) {
     return `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${draftContent}`;
   }
 
-  return contextModeInstructions ? promptWithContextMode : basePrompt;
+  return promptWithContextMode;
 }
 
 /**

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1372,6 +1372,7 @@ async function buildDiscussPreparationContext(
   ctx: ExtensionCommandContext,
   basePath: string,
   mode: "greenfield" | "milestone" = "greenfield",
+  skipPriorContext = false,
 ): Promise<string> {
   const prefs = loadEffectiveGSDPreferences()?.preferences ?? {};
   if (prefs.discuss_preparation === false) return "";
@@ -1389,7 +1390,7 @@ async function buildDiscussPreparationContext(
     const priorContextBrief = prepResult.priorContextBrief || formatPriorContextBrief(prepResult.priorContext);
     const parts: string[] = [];
     if (codebaseBrief) parts.push(`### Codebase Brief\n\n${codebaseBrief}`);
-    if (priorContextBrief) parts.push(`### Prior Context Brief\n\n${priorContextBrief}`);
+    if (priorContextBrief && !skipPriorContext) parts.push(`### Prior Context Brief\n\n${priorContextBrief}`);
     if (parts.length === 0) return "";
 
     const guidance = mode === "milestone"
@@ -1442,7 +1443,7 @@ async function dispatchNewMilestoneDiscuss(
     return;
   }
 
-  const preparationContext = await buildDiscussPreparationContext(ctx, basePath, "milestone");
+  const preparationContext = await buildDiscussPreparationContext(ctx, basePath, "milestone", true);
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
   let prompt = await buildDiscussMilestonePrompt(
     nextId,

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -227,21 +227,22 @@ async function dispatchDiscussForNextMilestoneWithBacklog(
   nextId: string,
 ): Promise<void> {
   const backlogContext = buildRequirementsBacklogDiscussContext(nextId);
-  const discussMilestoneTemplates = inlineTemplate("context", "Context");
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
-  const basePrompt = loadPrompt("guided-discuss-milestone", {
-    workingDirectory: basePath,
-    milestoneId: nextId,
-    milestoneTitle: `New milestone ${nextId}`,
-    inlinedTemplates: discussMilestoneTemplates,
+  const basePrompt = await buildDiscussMilestonePrompt(
+    nextId,
+    `New milestone ${nextId}`,
+    basePath,
     structuredQuestionsAvailable,
-    commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): milestone context from discuss`),
-    fastPathInstruction: [
-      "> **Requirements backlog active.**",
-      "> Map unmapped active requirements to this milestone before finalizing context.",
-      "> Confirm ownership with the user when scope is ambiguous.",
-    ].join("\n"),
-  });
+    {
+      commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): milestone context from discuss`),
+      includeContextMode: false,
+      fastPathInstruction: [
+        "> **Requirements backlog active.**",
+        "> Map unmapped active requirements to this milestone before finalizing context.",
+        "> Confirm ownership with the user when scope is ambiguous.",
+      ].join("\n"),
+    },
+  );
   const prompt = backlogContext ? `${basePrompt}\n\n${backlogContext}` : basePrompt;
   await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone", { basePath });
 }
@@ -1442,17 +1443,17 @@ async function dispatchNewMilestoneDiscuss(
   }
 
   const preparationContext = await buildDiscussPreparationContext(ctx, basePath, "milestone");
-  const discussMilestoneTemplates = inlineTemplate("context", "Context");
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
-  let prompt = loadPrompt("guided-discuss-milestone", {
-    workingDirectory: basePath,
-    milestoneId: nextId,
-    milestoneTitle: `New milestone ${nextId}`,
-    inlinedTemplates: discussMilestoneTemplates,
+  let prompt = await buildDiscussMilestonePrompt(
+    nextId,
+    `New milestone ${nextId}`,
+    basePath,
     structuredQuestionsAvailable,
-    commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): milestone context from discuss`),
-    fastPathInstruction: "",
-  });
+    {
+      commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): milestone context from discuss`),
+      includeContextMode: false,
+    },
+  );
   if (preparationContext) prompt += preparationContext;
   await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone", { basePath });
 }
@@ -1759,9 +1760,6 @@ export async function showDiscuss(
   // Special case: milestone is in needs-discussion phase (has CONTEXT-DRAFT.md but no roadmap yet).
   // Route to the draft discussion flow instead of erroring — the discussion IS how the roadmap gets created.
   if (state.phase === "needs-discussion") {
-    const draftFile = resolveMilestoneFile(basePath, mid, "CONTEXT-DRAFT");
-    const draftContent = draftFile ? await loadFile(draftFile) : null;
-
     const choice = await showNextAction(ctx, {
       title: `GSD — ${mid}: ${milestoneTitle}`,
       summary: ["This milestone has a draft context from a prior discussion.", "It needs a dedicated discussion before auto-planning can begin."],
@@ -1787,29 +1785,34 @@ export async function showDiscuss(
     });
 
     if (choice === "discuss_draft") {
-      const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
-      const basePrompt = loadPrompt("guided-discuss-milestone", {
-        workingDirectory: basePath,
-        milestoneId: mid, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
-        commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
-        fastPathInstruction: "",
-      });
-      const seed = draftContent
-        ? `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\n${draftContent}`
-        : basePrompt;
+      const seed = await buildDiscussMilestonePrompt(
+        mid,
+        milestoneTitle,
+        basePath,
+        structuredQuestionsAvailable,
+        {
+          commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
+          includeContextMode: false,
+        },
+      );
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: mid, step: true });
       await dispatchWorkflow(pi, seed, "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "discuss_fresh") {
-      const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
+      const prompt = await buildDiscussMilestonePrompt(
+        mid,
+        milestoneTitle,
+        basePath,
+        structuredQuestionsAvailable,
+        {
+          commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
+          includeContextMode: false,
+          includeDraftSeed: false,
+        },
+      );
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: mid, step: true });
-      await dispatchWorkflow(pi, loadPrompt("guided-discuss-milestone", {
-        workingDirectory: basePath,
-        milestoneId: mid, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
-        commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
-        fastPathInstruction: "",
-      }), "gsd-discuss", ctx, "discuss-milestone", { basePath });
+      await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "skip_milestone") {
       const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
       await ensureDbOpen(basePath);
@@ -2068,20 +2071,18 @@ async function dispatchDiscussForMilestone(
         "> Ask only questions where the answer would materially change scope.",
       ].join("\n")
     : "";
-  const discussMilestoneTemplates = inlineTemplate("context", "Context");
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
-  const basePrompt = loadPrompt("guided-discuss-milestone", {
-    workingDirectory: basePath,
-    milestoneId: mid,
+  const prompt = await buildDiscussMilestonePrompt(
+    mid,
     milestoneTitle,
-    inlinedTemplates: discussMilestoneTemplates,
+    basePath,
     structuredQuestionsAvailable,
-    commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
-    fastPathInstruction,
-  });
-  const prompt = draftContent
-    ? `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\n${draftContent}`
-    : basePrompt;
+    {
+      commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
+      includeContextMode: false,
+      fastPathInstruction,
+    },
+  );
   await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone", { basePath });
 }
 
@@ -2612,9 +2613,6 @@ export async function showSmartEntry(
 
   // ── Draft milestone — needs discussion before planning ────────────────
   if (state.phase === "needs-discussion") {
-    const draftFile = resolveMilestoneFile(basePath, milestoneId, "CONTEXT-DRAFT");
-    const draftContent = draftFile ? await loadFile(draftFile) : null;
-
     const choice = await showNextAction(ctx, {
       title: `GSD — ${milestoneId}: ${milestoneTitle}`,
       summary: ["This milestone has a draft context from a prior discussion.", "It needs a dedicated discussion before auto-planning can begin."],
@@ -2640,29 +2638,34 @@ export async function showSmartEntry(
     });
 
     if (choice === "discuss_draft") {
-      const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
-      const basePrompt = loadPrompt("guided-discuss-milestone", {
-        workingDirectory: basePath,
-        milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
-        commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
-        fastPathInstruction: "",
-      });
-      const seed = draftContent
-        ? `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\n${draftContent}`
-        : basePrompt;
+      const seed = await buildDiscussMilestonePrompt(
+        milestoneId,
+        milestoneTitle,
+        basePath,
+        structuredQuestionsAvailable,
+        {
+          commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
+          includeContextMode: false,
+        },
+      );
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
       await dispatchWorkflow(pi, seed, "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "discuss_fresh") {
-      const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
+      const prompt = await buildDiscussMilestonePrompt(
+        milestoneId,
+        milestoneTitle,
+        basePath,
+        structuredQuestionsAvailable,
+        {
+          commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
+          includeContextMode: false,
+          includeDraftSeed: false,
+        },
+      );
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
-      await dispatchWorkflow(pi, loadPrompt("guided-discuss-milestone", {
-        workingDirectory: basePath,
-        milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
-        commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
-        fastPathInstruction: "",
-      }), "gsd-discuss", ctx, "discuss-milestone", { basePath });
+      await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "skip_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
@@ -2783,14 +2786,18 @@ export async function showSmartEntry(
           { basePath },
         );
       } else if (choice === "discuss") {
-        const discussMilestoneTemplates = inlineTemplate("context", "Context");
         const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
-        await dispatchWorkflow(pi, loadPrompt("guided-discuss-milestone", {
-          workingDirectory: basePath,
-          milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
-          commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
-          fastPathInstruction: "",
-        }), "gsd-run", ctx, "discuss-milestone", { basePath });
+        const prompt = await buildDiscussMilestonePrompt(
+          milestoneId,
+          milestoneTitle,
+          basePath,
+          structuredQuestionsAvailable,
+          {
+            commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
+            includeContextMode: false,
+          },
+        );
+        await dispatchWorkflow(pi, prompt, "gsd-run", ctx, "discuss-milestone", { basePath });
       } else if (choice === "skip_milestone") {
         const milestoneIds = findMilestoneIds(basePath);
         const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;

--- a/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
@@ -3,10 +3,11 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VISION_ASK_VARIANTS } from "../vision-ask.ts";
+import { buildDiscussMilestonePrompt } from "../auto-prompts.ts";
 
 test("guided milestone prompt renders compact interview and context guidance", async (t) => {
   const previousGsdHome = process.env.GSD_HOME;
@@ -46,4 +47,42 @@ test("guided milestone prompt renders compact interview and context guidance", a
   assert.match(prompt, /artifact_type: "CONTEXT"/);
   assert.match(prompt, /milestone_id: M001/);
   assert.doesNotMatch(prompt, /\{\{[a-zA-Z][a-zA-Z0-9_]*\}\}/);
+});
+
+test("guided milestone prompt builder preloads milestone planning context", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-guided-milestone-context-"));
+  try {
+    const milestonesRoot = join(base, ".gsd", "milestones");
+    const priorDir = join(milestonesRoot, "M001");
+    const currentDir = join(milestonesRoot, "M002");
+    const futureDir = join(milestonesRoot, "M003");
+    mkdirSync(priorDir, { recursive: true });
+    mkdirSync(currentDir, { recursive: true });
+    mkdirSync(futureDir, { recursive: true });
+
+    writeFileSync(join(base, ".gsd", "DECISIONS.md"), "# Decisions\n\nDECISION-SIGNAL", "utf-8");
+    writeFileSync(join(priorDir, "M001-SUMMARY.md"), "# M001 Summary\n\nPRIOR-SUMMARY-SIGNAL", "utf-8");
+    writeFileSync(join(currentDir, "M002-ROADMAP.md"), "# M002 Roadmap\n\nROADMAP-SIGNAL", "utf-8");
+    writeFileSync(join(currentDir, "M002-CONTEXT.md"), "# M002 Context\n\nCONTEXT-SIGNAL", "utf-8");
+    writeFileSync(join(currentDir, "M002-RESEARCH.md"), "# M002 Research\n\nRESEARCH-SIGNAL", "utf-8");
+    writeFileSync(join(futureDir, "M003-SUMMARY.md"), "# M003 Summary\n\nFUTURE-SUMMARY-SIGNAL", "utf-8");
+
+    const prompt = await buildDiscussMilestonePrompt("M002", "Checkout Polish", base, "true");
+
+    assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+    assert.match(prompt, /### Milestone Roadmap/);
+    assert.match(prompt, /ROADMAP-SIGNAL/);
+    assert.match(prompt, /### Milestone Context/);
+    assert.match(prompt, /CONTEXT-SIGNAL/);
+    assert.match(prompt, /### Milestone Research/);
+    assert.match(prompt, /RESEARCH-SIGNAL/);
+    assert.match(prompt, /### Decisions Register/);
+    assert.match(prompt, /DECISION-SIGNAL/);
+    assert.match(prompt, /### M001 Prior Milestone Summary/);
+    assert.match(prompt, /PRIOR-SUMMARY-SIGNAL/);
+    assert.doesNotMatch(prompt, /FUTURE-SUMMARY-SIGNAL/);
+    assert.match(prompt, /### Output Template: Context/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/tests/guided-flow.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow.test.ts
@@ -8,14 +8,17 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 test("guided milestone discussion callsites pass workingDirectory to loadPrompt", () => {
   const source = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
-  const calls = [...source.matchAll(/loadPrompt\("guided-discuss-milestone",\s*\{([\s\S]*?)\}\)/g)];
 
-  assert.equal(calls.length, 8, "all guided-flow guided-discuss-milestone callsites should be covered");
-  for (const call of calls) {
-    assert.match(
-      call[1] ?? "",
-      /\bworkingDirectory:\s*basePath\b/,
-      "guided-discuss-milestone prompts need workingDirectory so template validation does not crash",
-    );
-  }
+  // All guided-discuss-milestone dispatches now go through buildDiscussMilestonePrompt,
+  // which centralises the loadPrompt call and always passes workingDirectory.
+  // Verify no callsite bypasses the builder by calling loadPrompt directly.
+  const directCalls = [...source.matchAll(/loadPrompt\("guided-discuss-milestone"/g)];
+  assert.equal(
+    directCalls.length,
+    0,
+    'guided-flow.ts must not call loadPrompt("guided-discuss-milestone") directly — use buildDiscussMilestonePrompt',
+  );
+
+  const calls = [...source.matchAll(/\bawait buildDiscussMilestonePrompt\(/g)];
+  assert.equal(calls.length, 9, "all guided-flow guided-discuss-milestone callsites should be covered");
 });

--- a/src/resources/extensions/gsd/tests/new-milestone-discuss-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/new-milestone-discuss-routing.test.ts
@@ -24,7 +24,7 @@ test("dispatchNewMilestoneDiscuss uses discuss.md only on greenfield projects", 
 test("dispatchNewMilestoneDiscuss uses milestone-specific preparation guidance", () => {
   const source = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
   const fnBody = extractSourceRegion(source, "async function dispatchNewMilestoneDiscuss(");
-  assert.match(fnBody, /buildDiscussPreparationContext\(ctx, basePath, "milestone"\)/);
+  assert.match(fnBody, /buildDiscussPreparationContext\(ctx, basePath, "milestone", true\)/);
 });
 
 test("launchNextMilestoneDiscuss routes through dispatchNewMilestoneDiscuss for normal path", () => {

--- a/src/resources/extensions/gsd/tests/new-milestone-discuss-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/new-milestone-discuss-routing.test.ts
@@ -13,10 +13,10 @@ test("dispatchNewMilestoneDiscuss uses discuss.md only on greenfield projects", 
 
   assert.match(fnBody, /findMilestoneIds\(basePath\)\.length === 0/);
   assert.match(fnBody, /prepareAndBuildDiscussPrompt/);
-  assert.match(fnBody, /loadPrompt\("guided-discuss-milestone"/);
+  assert.match(fnBody, /buildDiscussMilestonePrompt/);
   assert.match(
     fnBody,
-    /if \(isGreenfield\)[\s\S]*prepareAndBuildDiscussPrompt[\s\S]*loadPrompt\("guided-discuss-milestone"/,
+    /if \(isGreenfield\)[\s\S]*prepareAndBuildDiscussPrompt[\s\S]*buildDiscussMilestonePrompt/,
     "greenfield branch must precede guided-discuss-milestone branch",
   );
 });

--- a/src/resources/extensions/gsd/tests/queued-discuss-fast-path.test.ts
+++ b/src/resources/extensions/gsd/tests/queued-discuss-fast-path.test.ts
@@ -24,25 +24,24 @@ describe("queued-discuss-fast-path", () => {
     );
   });
 
-  test("2. dispatchDiscussForMilestone computes fastPathInstruction and passes it to loadPrompt", () => {
+  test("2. dispatchDiscussForMilestone computes fastPathInstruction and passes it to buildDiscussMilestonePrompt", () => {
     const source = guidedFlowSrc();
     const fnStart = source.indexOf("async function dispatchDiscussForMilestone(");
     assert.ok(fnStart > 0, "dispatchDiscussForMilestone must exist");
-    const fnEnd = source.indexOf("\nasync function ", fnStart + 1);
     const fnBody = extractSourceRegion(source, "async function dispatchDiscussForMilestone(");
     assert.ok(
       fnBody.includes("fastPathInstruction"),
       "dispatchDiscussForMilestone must compute fastPathInstruction",
     );
     assert.ok(
-      fnBody.includes("loadPrompt("),
-      "dispatchDiscussForMilestone must call loadPrompt",
+      fnBody.includes("buildDiscussMilestonePrompt("),
+      "dispatchDiscussForMilestone must call buildDiscussMilestonePrompt",
     );
-    const loadPromptIdx = fnBody.indexOf("loadPrompt(");
-    const fastPathIdx = fnBody.indexOf("fastPathInstruction", loadPromptIdx);
+    const buildPromptIdx = fnBody.indexOf("buildDiscussMilestonePrompt(");
+    const fastPathIdx = fnBody.indexOf("fastPathInstruction", buildPromptIdx);
     assert.ok(
-      fastPathIdx > loadPromptIdx,
-      "fastPathInstruction must be passed to loadPrompt in dispatchDiscussForMilestone",
+      fastPathIdx > buildPromptIdx,
+      "fastPathInstruction must be passed to buildDiscussMilestonePrompt in dispatchDiscussForMilestone",
     );
   });
 


### PR DESCRIPTION
## Linked issue

Closes #421

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Milestone discussion prompts now preload roadmap, context, research, decisions, and prior milestone summaries.
**Why:** Guided milestone discussions started without the planning context that slice discussions already receive, forcing extra reads and causing blind first questions.
**How:** The reusable milestone prompt builder now composes an inlined context block, and interactive guided-flow milestone-discuss routes use that builder instead of loading the raw template directly.

## What

- Added `buildDiscussMilestoneInlinedContext` to preload milestone ROADMAP, existing CONTEXT, RESEARCH, DECISIONS, and prior milestone SUMMARY files.
- Extended `buildDiscussMilestonePrompt` with options for commit instruction, fast-path instruction, draft seeding, and context-mode preservation.
- Routed interactive guided-flow milestone discussion paths through the shared builder so `/gsd auto`, smart entry, queued milestone discussion, backlog-driven discussion, and `/gsd discuss` share the same preloaded context behavior.
- Added a regression test that builds a real milestone fixture and verifies the prompt includes current milestone artifacts, decisions, and prior summaries without pulling future summaries.

## Why

The slice discussion path already preloads surrounding planning context before asking the user questions. The milestone discussion path only injected the Context output template, even though the prompt tells the agent to check roadmap context above. That made milestone discussions start blind.

## How

The builder uses existing GSD path resolvers and inline helpers to load optional milestone artifacts, then places them in a `## Inlined Context` block ahead of the Context output template. Guided-flow branches that previously loaded `guided-discuss-milestone` directly now call the shared builder while preserving their existing commit, fast-path, draft/fresh, and context-mode behavior.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described below
- [ ] No tests needed — explained above

Local verification:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run test:compile`
- `bash scripts/ci-fast-gates.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783039018&installation_id=134682257&pr_number=433&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F433&signature=ca33b6dcb9a3cb88ea2c61b8460db3358df4ac4ccd82b01982aabcef468e1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes GSD prompt assembly and guided-flow routing only; no auth, data, or persistence logic. Main risk is larger prompts or duplicated context if caps/options are wrong.
> 
> **Overview**
> Milestone discussion prompts now **preload planning context** instead of shipping only the Context output template. A shared **`buildDiscussMilestoneInlinedContext`** block inlines the current milestone’s roadmap, context, research, **DECISIONS**, and **prior milestone summaries** (not future ones), then **`capPreamble`** trims the block before it is merged with the template.
> 
> **`buildDiscussMilestonePrompt`** gains options for commit/fast-path text, optional **CONTEXT-DRAFT** seeding, and whether to prepend context-mode instructions. **Interactive `guided-flow` paths** (new milestone, backlog, draft/fresh discuss, queued fast path, etc.) call this builder with **`includeContextMode: false`** so behavior stays aligned with prior guided dispatches while sharing the same inlined payload.
> 
> **`buildDiscussPreparationContext`** can skip the prior-context brief for milestone prep when that would duplicate the new preload. Regression tests assert the built prompt contains the expected signals and that **`guided-flow.ts`** no longer calls **`loadPrompt("guided-discuss-milestone")`** directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea812a4a33afd77e8971c96b739973d99325ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->