### PR TITLE
fix(gsd): preserve decision memories during decay

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -3233,7 +3233,10 @@ export function decayMemoriesBefore(cutoffTs: string, now: string): void {
   currentDb.prepare(
     `UPDATE memories
      SET confidence = MAX(0.1, confidence - 0.1), updated_at = :now
-     WHERE superseded_by IS NULL AND updated_at < :cutoff AND confidence > 0.1`,
+     WHERE superseded_by IS NULL
+       AND updated_at < :cutoff
+       AND confidence > 0.1
+       AND (structured_fields IS NULL OR structured_fields NOT LIKE '%"sourceDecisionId"%')`,
   ).run({ ":now": now, ":cutoff": cutoffTs });
 }
 

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -777,7 +777,10 @@ export function decayStaleMemories(thresholdUnits = 20): string[] {
     const cutoff = row['processed_at'] as string;
     const affected = adapter.prepare(
       `SELECT id FROM memories
-       WHERE superseded_by IS NULL AND updated_at < :cutoff AND confidence > 0.1`,
+       WHERE superseded_by IS NULL
+         AND updated_at < :cutoff
+         AND confidence > 0.1
+         AND (structured_fields IS NULL OR structured_fields NOT LIKE '%"sourceDecisionId"%')`,
     ).all({ ':cutoff': cutoff }).map((r) => r['id'] as string);
 
     decayMemoriesBefore(cutoff, new Date().toISOString());

--- a/src/resources/extensions/gsd/tests/memory-maintenance.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-maintenance.test.ts
@@ -11,6 +11,16 @@ import {
 import { createMemoryRelation, listRelationsFor } from '../memory-relations.ts';
 import { saveEmbedding, getEmbeddingForMemory } from '../memory-embeddings.ts';
 
+function markProcessedUnits(count = 21): void {
+  const now = Date.now();
+  for (let i = 0; i < count; i++) {
+    markUnitProcessed(`unit/${i}`, `file-${i}`);
+    _getAdapter()!
+      .prepare('UPDATE memory_processed_units SET processed_at = :ts WHERE unit_key = :key')
+      .run({ ':ts': new Date(now + i * 1000).toISOString(), ':key': `unit/${i}` });
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // enforceMemoryCap — cascade cleanup of embeddings and relations
 // ═══════════════════════════════════════════════════════════════════════════
@@ -71,14 +81,7 @@ test('memory-decay: returns decayed memory IDs', () => {
   openDatabase(':memory:');
 
   // Insert processed units — decayStaleMemories needs at least N rows.
-  const now = Date.now();
-  for (let i = 0; i < 21; i++) {
-    markUnitProcessed(`unit/${i}`, `file-${i}`);
-    // small spacing to create deterministic ordering
-    const row = _getAdapter()!
-      .prepare('UPDATE memory_processed_units SET processed_at = :ts WHERE unit_key = :key');
-    row.run({ ':ts': new Date(now + i * 1000).toISOString(), ':key': `unit/${i}` });
-  }
+  markProcessedUnits();
 
   // Create memory with updated_at in the distant past
   createMemory({ category: 'pattern', content: 'stale entry', confidence: 0.9 });
@@ -94,6 +97,34 @@ test('memory-decay: returns decayed memory IDs', () => {
     .prepare("SELECT confidence FROM memories WHERE id = 'MEM001'")
     .get();
   assert.ok((row?.['confidence'] as number) < 0.9);
+
+  closeDatabase();
+});
+
+test('memory-decay: skips stale decision-sourced memories', () => {
+  openDatabase(':memory:');
+  markProcessedUnits();
+
+  createMemory({ category: 'pattern', content: 'stale working note', confidence: 0.9 });
+  createMemory({
+    category: 'architecture',
+    content: 'decision-backed architecture memory',
+    confidence: 0.85,
+    structuredFields: { sourceDecisionId: 'D001' },
+  });
+  _getAdapter()!
+    .prepare("UPDATE memories SET updated_at = '2000-01-01T00:00:00Z' WHERE id IN ('MEM001', 'MEM002')")
+    .run({});
+
+  const decayed = decayStaleMemories(20);
+  assert.ok(decayed.includes('MEM001'));
+  assert.ok(!decayed.includes('MEM002'));
+
+  const rows = _getAdapter()!
+    .prepare("SELECT id, confidence FROM memories WHERE id IN ('MEM001', 'MEM002') ORDER BY id")
+    .all() as Array<{ id: string; confidence: number }>;
+  assert.ok(rows.find((row) => row.id === 'MEM001')!.confidence < 0.9);
+  assert.equal(rows.find((row) => row.id === 'MEM002')!.confidence, 0.85);
 
   closeDatabase();
 });


### PR DESCRIPTION
## TL;DR

**What:** Excludes decision-sourced memories from the stale-memory confidence decay pass.  
**Why:** Confirmed architecture decisions should not decay out of the critical memory injection cap.  
**How:** Adds the `structured_fields.sourceDecisionId` exclusion to both the decay UPDATE and its affected-ID preview query, with regression coverage.

## What

This updates the GSD memory maintenance path so stale memories tagged with `structured_fields.sourceDecisionId` are not confidence-decayed. It also keeps `decayStaleMemories()` observability aligned with the actual UPDATE by applying the same predicate to the SELECT that returns affected IDs.

The focused regression test now covers both sides of the behavior: ordinary stale memories still decay, while decision-sourced architecture memories keep their original confidence.

## Why

Decision-backed architecture memories are durable context. Without this exclusion, repeated maintenance cycles can lower their confidence to the floor, causing confirmed decisions to fall below the critical memory injection cap.

Closes #419

## How

The change uses the conservative predicate suggested in the issue instead of adding a new schema flag. That keeps the fix scoped to existing persisted data and avoids a migration while preserving the current memory schema.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

Affected workflows: GSD memory maintenance, stale-memory decay observability, and decision-backed architecture memory retention.

Blast radius: moderate. The SQL predicate is narrow, but it sits in the persistence maintenance path that affects injected context ranking over long-running projects.

## Breaking changes

None. No public API, CLI behavior, config format, schema, or file layout changes.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/memory-maintenance.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/memory-store.test.ts src/resources/extensions/gsd/tests/decisions-stop-table-writes.test.ts src/resources/extensions/gsd/tests/context-store-decisions-from-memories.test.ts src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run test:compile`
- [x] `bash scripts/ci-fast-gates.sh`
- [x] `git diff --check`
- [ ] `pnpm run verify:pr` — attempted locally; blocked by unrelated failures in `doctor-scope-db-unavailable.test.ts` (`sqlite_master may not be modified`) and `repository-registry.test.ts` (`/private/var` vs `/var` temp-path assertion). A third MCP timeout from the full run passed on focused rerun.
- [ ] `pnpm run verify:merge` — not run locally; PR remains draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running memory maintenance and ranking for injected context, but the SQL guard is narrow and covered by new regression tests.
> 
> **Overview**
> Stale-memory **confidence decay** no longer touches memories whose `structured_fields` include **`sourceDecisionId`**. The same filter is applied in **`decayMemoriesBefore`** (the UPDATE) and in **`decayStaleMemories`** (the SELECT that returns affected IDs), so observability matches what actually gets decayed.
> 
> Ordinary stale memories still lose confidence over maintenance cycles; decision-backed architecture memories keep their scores so they are less likely to fall below critical injection thresholds. Tests add a **`markProcessedUnits`** helper and a case asserting **MEM001** decays while **MEM002** (with `sourceDecisionId: 'D001'`) does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daac76636f5f039bc1d8ff12a5b06b69ed16c3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->