### PR TITLE
fix(gsd): pause unresolved task escalations

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1620,7 +1620,7 @@ const taskCompleteParams = {
     recommendation: z.string().describe("Option id the executor recommends."),
     recommendationRationale: z.string().describe("Why the recommendation — 1-2 sentences."),
     continueWithDefault: z.boolean().describe(
-      "When true, loop continues (artifact logged for later review). When false, auto-mode pauses until the user resolves via /gsd escalate resolve.",
+      "When true, the recommendation is recorded as the default, but auto-mode still pauses until the user resolves via /gsd escalate resolve.",
     ),
   }).optional().describe("ADR-011 Phase 2: optional escalation payload. Only honored when phases.mid_execution_escalation is true."),
   verificationEvidence: z.array(z.union([

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -832,7 +832,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
         recommendation: Type.String({ description: "Option id the executor recommends." }),
         recommendationRationale: Type.String({ description: "Why the recommendation — 1–2 sentences." }),
         continueWithDefault: Type.Boolean({
-          description: "When true, loop continues (artifact logged for later review). When false, auto-mode pauses until the user resolves via /gsd escalate resolve.",
+          description: "When true, the recommendation is recorded as the default, but auto-mode still pauses until the user resolves via /gsd escalate resolve.",
         }),
       }, { description: "ADR-011 Phase 2: optional escalation payload. Only honored when phases.mid_execution_escalation is true." })),
       verificationEvidence: Type.Optional(Type.Array(

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -159,13 +159,13 @@ export function readEscalationArtifact(path: string): EscalationArtifact | null 
 // ─── Detection ────────────────────────────────────────────────────────────
 
 /**
- * Returns the task id of the first task with an un-resolved pause-escalation
- * (escalation_pending=1, not yet respondedAt). awaiting_review slices are NOT
- * returned — they don't pause the loop.
+ * Returns the task id of the first task with an unresolved escalation.
+ * `continueWithDefault=true` artifacts keep the awaiting_review flag for
+ * compatibility, but still pause dispatch until the user explicitly responds.
  */
 export function detectPendingEscalation(tasks: TaskRow[], basePath: string): string | null {
   for (const t of tasks) {
-    if (t.escalation_pending !== 1) continue;
+    if (t.escalation_pending !== 1 && t.escalation_awaiting_review !== 1) continue;
     if (!t.escalation_artifact_path) continue;
     const art = readEscalationArtifact(t.escalation_artifact_path);
     if (art && !art.respondedAt) return t.id;

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1488,7 +1488,7 @@ export function setTaskEscalationPending(
   ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
 }
 
-/** Set awaiting-review state (artifact exists but continueWithDefault=true, no pause). Mutually exclusive with pending. */
+/** Set awaiting-review state (artifact exists and requires explicit user review). Mutually exclusive with pending. */
 export function setTaskEscalationAwaitingReview(
   milestoneId: string, sliceId: string, taskId: string,
   artifactPath: string,

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -896,8 +896,8 @@ export async function deriveStateFromDb(
   }
 
   // ADR-011 Phase 2: pause-on-escalation takes precedence over dispatching the
-  // next task. `awaiting_review` tasks (continueWithDefault=true) are NOT
-  // surfaced here — they let the loop continue.
+  // next task. `awaiting_review` tasks (continueWithDefault=true) still pause
+  // here so silence is never treated as consent.
   //
   // We do NOT gate this on `phases.mid_execution_escalation` — creation of
   // new escalations is gated at the write site (tools/complete-task.ts:315),

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -106,7 +106,7 @@ test("ADR-011 P2: writeEscalationArtifact persists canonical JSON at tasks/T##-E
   assert.equal(row?.escalation_artifact_path, path);
 });
 
-test("ADR-011 P2: continueWithDefault=true sets awaiting_review (NOT pending) — no pause", (t) => {
+test("ADR-011 P2: continueWithDefault=true sets awaiting_review (NOT pending)", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   seedCompletedTask(base, "T04");
@@ -126,7 +126,7 @@ test("ADR-011 P2: continueWithDefault=true sets awaiting_review (NOT pending) �
   assert.equal(row?.escalation_awaiting_review, 1);
 });
 
-test("ADR-011 P2: detectPendingEscalation returns only pause-scoped escalations", (t) => {
+test("ADR-011 P2: detectPendingEscalation pauses on unresolved awaiting_review escalations", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   seedCompletedTask(base, "T01");
@@ -147,7 +147,7 @@ test("ADR-011 P2: detectPendingEscalation returns only pause-scoped escalations"
 
   const tasks = [getTask("M001", "S01", "T01")!, getTask("M001", "S01", "T02")!];
   const id = detectPendingEscalation(tasks, base);
-  assert.equal(id, "T02", "only T02 is pause-worthy; T01 is awaiting_review");
+  assert.equal(id, "T01", "unresolved awaiting_review escalations must pause before later tasks");
 });
 
 test("ADR-011 P2: resolveEscalation(accept) marks artifact + clears flags", (t) => {
@@ -677,26 +677,19 @@ test("ADR-011 P3 #23: concurrent escalations across parallel slices — only the
   assert.equal(detectPendingEscalation([getTask("M001", "S02", "T70")!], base), null);
 });
 
-test("ADR-011 P3 #24: continueWithDefault timeout — late user response injects into the next task dispatched AFTER the response", (t) => {
-  // Timeline this test pins (the "timeout" is implicit — it's just the
-  // elapsed wall-clock where the loop keeps running after T80's
-  // continueWithDefault=true write):
+test("ADR-011 P3 #24: continueWithDefault requires explicit response before override injection", (t) => {
+  // Timeline this test pins:
   //
-  //   1. T80 writes continueWithDefault=true → awaiting_review=1, loop
-  //      continues dispatching T81, T82. Neither claim fires because the
-  //      user has not responded (pins Bug 2 behavior, tested at line 244).
-  //   2. The user responds LATE (after T81/T82 already dispatched).
-  //   3. The very next prompt build (for T83) claims the override exactly
-  //      once. T81/T82 are in the past — they must not retroactively
-  //      receive the injection even though they ran during the window.
+  //   1. T80 writes continueWithDefault=true → awaiting_review=1.
+  //   2. Scheduler detection pauses on T80 instead of treating silence as
+  //      consent. Prompt injection still waits until the user responds.
+  //   3. After the response, the next prompt build claims the override once.
   const base = makeBase();
   t.after(() => cleanup(base));
   seedCompletedTask(base, "T80");
-  seedCompletedTask(base, "T81");
-  seedCompletedTask(base, "T82");
   seedCompletedTask(base, "T83");
 
-  // Phase 1 — T80 escalates with continueWithDefault=true, loop continues.
+  // Phase 1 — T80 escalates with continueWithDefault=true.
   writeEscalationArtifact(base, buildEscalationArtifact({
     taskId: "T80", sliceId: "S01", milestoneId: "M001",
     question: "Which cache strategy?", options: sampleOptions,
@@ -704,21 +697,17 @@ test("ADR-011 P3 #24: continueWithDefault timeout — late user response injects
     continueWithDefault: true,
   }));
 
-  // T80 is awaiting_review (not pending) — scheduler does not pause.
+  // T80 is awaiting_review (not pending), but scheduler detection still
+  // pauses until the user explicitly responds.
   assert.equal(getTask("M001", "S01", "T80")?.escalation_awaiting_review, 1);
   assert.equal(getTask("M001", "S01", "T80")?.escalation_pending, 0);
-  assert.equal(detectPendingEscalation([getTask("M001", "S01", "T80")!], base), null);
+  assert.equal(detectPendingEscalation([getTask("M001", "S01", "T80")!], base), "T80");
 
-  // T81 + T82 dispatch during the response window — neither gets the injection.
+  // Prompt injection must still wait for a response.
   assert.equal(
     claimOverrideForInjection(base, "M001", "S01"),
     null,
-    "T81's prompt build must not claim the unresolved awaiting_review",
-  );
-  assert.equal(
-    claimOverrideForInjection(base, "M001", "S01"),
-    null,
-    "T82's prompt build must also not claim the unresolved awaiting_review",
+    "unresolved awaiting_review must not be claimed as a default response",
   );
 
   // The response window remains open across N tasks — still no override applied.
@@ -728,7 +717,7 @@ test("ADR-011 P3 #24: continueWithDefault timeout — late user response injects
     "applied_at must stay null throughout the response window",
   );
 
-  // Phase 2 — user responds LATE with a different option than the recommendation.
+  // Phase 2 — user responds with a different option than the recommendation.
   const resolveResult = resolveEscalation(
     base, "M001", "S01", "T80", "B", "after reviewing, B is the call",
   );

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -235,6 +235,62 @@ test("executeTaskComplete derives missing verification from evidence", async () 
   }
 });
 
+test("executeTaskComplete surfaces escalation questions and metadata", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    writeFileSync(join(base, ".gsd", "PREFERENCES.md"), [
+      "---",
+      "version: 1",
+      "phases:",
+      "  mid_execution_escalation: true",
+      "---",
+    ].join("\n"));
+    const planDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "S01-PLAN.md"), "# S01\n\n- [ ] **T01: Demo** `est:5m`\n");
+
+    const result = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work but found an ambiguity.",
+      verification: "npm test",
+      escalation: {
+        question: "Should the cache use write-through or write-back?",
+        options: [
+          { id: "A", label: "Write-through", tradeoffs: "Simpler reads; slower writes." },
+          { id: "B", label: "Write-back", tradeoffs: "Faster writes; more flush complexity." },
+        ],
+        recommendation: "A",
+        recommendationRationale: "Current usage favors correctness over write latency.",
+        continueWithDefault: true,
+      },
+    }, base));
+
+    assert.equal(result.details.operation, "complete_task");
+    assert.match(
+      String(result.content[0]?.text),
+      /Task completed with escalation decision required: Should the cache use write-through or write-back\?/,
+    );
+    assert.match(String(result.content[0]?.text), /Resolve with: \/gsd escalate resolve T01/);
+    assert.equal((result.details.escalation as { question?: string }).question, "Should the cache use write-through or write-back?");
+
+    const db = _getAdapter();
+    assert.ok(db, "DB should be open");
+    const row = db!.prepare(
+      "SELECT escalation_pending, escalation_awaiting_review, escalation_artifact_path FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?",
+    ).get("M001", "S01", "T01") as Record<string, unknown> | undefined;
+    assert.equal(row?.escalation_pending, 0);
+    assert.equal(row?.escalation_awaiting_review, 1);
+    assert.ok(String(row?.escalation_artifact_path ?? "").endsWith("T01-ESCALATION.json"));
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeTaskComplete returns a tool error when verification cannot be derived", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -12,7 +12,7 @@
 
 import { join } from "node:path";
 
-import type { CompleteTaskParams } from "../types.js";
+import type { CompleteTaskParams, EscalationArtifact } from "../types.js";
 import { isClosedStatus } from "../status-guards.js";
 import {
   transaction,
@@ -48,6 +48,14 @@ export interface CompleteTaskResult {
   sliceId: string;
   milestoneId: string;
   summaryPath: string;
+  escalation?: {
+    artifactPath: string;
+    question: string;
+    options: EscalationArtifact["options"];
+    recommendation: string;
+    recommendationRationale: string;
+    continueWithDefault: boolean;
+  };
   /**
    * True when this call re-completed an already-closed task from a turn that
    * had been superseded by timeout recovery or cancellation. The underlying
@@ -407,9 +415,18 @@ export async function handleCompleteTask(
   // overwrite it; gate rows are UPSERT-keyed per task and will also be
   // overwritten. This restores the invariant that deriveState() sees a
   // consistent "task not done" view so the loop re-dispatches the task.
+  let escalationMetadata: CompleteTaskResult["escalation"] | undefined;
   if (validatedEscalationArtifact) {
     try {
-      writeEscalationArtifact(artifactBasePath, validatedEscalationArtifact);
+      const escalationPath = writeEscalationArtifact(artifactBasePath, validatedEscalationArtifact);
+      escalationMetadata = {
+        artifactPath: escalationPath,
+        question: validatedEscalationArtifact.question,
+        options: validatedEscalationArtifact.options,
+        recommendation: validatedEscalationArtifact.recommendation,
+        recommendationRationale: validatedEscalationArtifact.recommendationRationale,
+        continueWithDefault: validatedEscalationArtifact.continueWithDefault,
+      };
     } catch (escalationErr) {
       const msg = `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`;
       logWarning("tool", msg);
@@ -477,6 +494,7 @@ export async function handleCompleteTask(
     sliceId: params.sliceId,
     milestoneId: params.milestoneId,
     summaryPath,
+    ...(escalationMetadata ? { escalation: escalationMetadata } : {}),
     ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -24,7 +24,7 @@ import { isAbsolute, join, resolve } from "node:path";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
 import { handleCompleteMilestone } from "./complete-milestone.js";
 import { handleCompleteTask } from "./complete-task.js";
-import type { CompleteSliceParams } from "../types.js";
+import type { CompleteSliceParams, EscalationOption } from "../types.js";
 import { handleCompleteSlice } from "./complete-slice.js";
 import type { PlanMilestoneParams } from "./plan-milestone.js";
 import { handlePlanMilestone } from "./plan-milestone.js";
@@ -347,6 +347,14 @@ type VerificationEvidenceInput =
     }
   | string;
 
+interface TaskEscalationInput {
+  question: string;
+  options: EscalationOption[];
+  recommendation: string;
+  recommendationRationale: string;
+  continueWithDefault: boolean;
+}
+
 export interface TaskCompleteParams {
   taskId: string;
   sliceId: string;
@@ -359,6 +367,7 @@ export interface TaskCompleteParams {
   keyFiles?: string[];
   keyDecisions?: string[];
   blockerDiscovered?: boolean;
+  escalation?: TaskEscalationInput;
   verificationEvidence?: VerificationEvidenceInput[];
 }
 
@@ -509,6 +518,28 @@ export async function executeTaskComplete(
         content: [{ type: "text", text: `Error completing task: ${result.error}` }],
         details: { operation: "complete_task", error: result.error },
       isError: true,
+      };
+    }
+    if (result.escalation) {
+      const recommended = result.escalation.options.find((option) => option.id === result.escalation?.recommendation);
+      const optionIds = result.escalation.options.map((option) => option.id).join("|");
+      return {
+        content: [{
+          type: "text",
+          text: [
+            `Task completed with escalation decision required: ${result.escalation.question}`,
+            `Recommendation: ${result.escalation.recommendation}${recommended ? ` (${recommended.label})` : ""} — ${result.escalation.recommendationRationale}`,
+            `Resolve with: /gsd escalate resolve ${result.taskId} <${optionIds}|accept|reject-blocker> [rationale...]`,
+          ].join("\n"),
+        }],
+        details: {
+          operation: "complete_task",
+          taskId: result.taskId,
+          sliceId: result.sliceId,
+          milestoneId: result.milestoneId,
+          summaryPath: result.summaryPath,
+          escalation: result.escalation,
+        },
       };
     }
     return {

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -384,10 +384,10 @@ export interface EscalationArtifact {
   /** Why the executor recommends that option (1-2 sentences). */
   recommendationRationale: string;
   /**
-   * When true, the executor proceeds with the recommendation as the answer
-   * and the loop continues. User's later choice becomes a carry-forward
-   * override for the NEXT task. When false, auto-mode pauses until the
-   * user resolves via `/gsd escalate resolve`.
+   * When true, the recommendation is recorded as the default path but the
+   * loop still pauses until the user explicitly resolves the escalation.
+   * When false, auto-mode also pauses until the user resolves via
+   * `/gsd escalate resolve`.
    */
   continueWithDefault: boolean;
   createdAt: string;


### PR DESCRIPTION
## Linked issue

Closes #418

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Makes unresolved task escalations pause auto-mode even when `continueWithDefault=true`.  
**Why:** Silence should not be treated as consent after an escalation question is created.  
**How:** Keeps the existing `awaiting_review` flag shape, but includes it in pending-escalation detection and returns explicit escalation metadata/text from task completion.

## What

This updates the GSD mid-execution escalation path across the task-completion handler, workflow executor response, scheduler detection, and model-facing tool schemas.

Unresolved `continueWithDefault=true` escalations still persist as `escalation_awaiting_review=1` rather than `escalation_pending=1`, preserving the existing row shape. The scheduler now treats both unresolved flags as pause-worthy, so `deriveState` enters `escalating-task` instead of advancing to the next task. `handleCompleteTask` returns the escalation question metadata, and `executeTaskComplete` surfaces a decision-required response with the question, recommendation, and resolve command.

## Why

Before this change, a task could emit an escalation artifact, return generic `Completed task` output, and allow auto-mode to continue. That made a missing user response indistinguishable from agreement with the default path.

## How

The implementation keeps the existing schema and changes behavior at the read/response boundary:

- `detectPendingEscalation()` now considers unresolved `escalation_awaiting_review` rows pause-worthy.
- `handleCompleteTask()` carries successful escalation artifact metadata in its result.
- `executeTaskComplete()` changes the tool response from generic completion to decision-required text when an escalation was created.
- GSD and MCP tool schema descriptions now describe `continueWithDefault` as a recorded recommendation, not permission to continue without a user response.
- Regression coverage updates the old ADR-011 expectations and adds executor-level coverage for surfaced escalation text and metadata.

## Change type

- [ ] `feat` - New feature or capability
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` - Terminal UI
- [ ] `pi-ai` - AI/LLM layer
- [ ] `pi-agent-core` - Agent orchestration
- [ ] `pi-coding-agent` - Coding agent
- [x] `gsd extension` - GSD workflow
- [ ] `native` - Native bindings
- [ ] `ci/build` - Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes - described above

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/escalation.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts src/resources/extensions/gsd/tests/workflow-mcp.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/workflow-tools.test.ts packages/mcp-server/src/workflow-tools-parity.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/escalation.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts packages/mcp-server/src/workflow-tools.test.ts packages/mcp-server/src/workflow-tools-parity.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run test:compile`
- [x] `pnpm --filter @opengsd/mcp-server run build`
- [x] `bash scripts/ci-fast-gates.sh`
- [x] `git diff --check`
- [ ] `pnpm run verify:pr` - attempted locally; build and extension typecheck passed, then compiled unit tests failed on unrelated existing local failures in `doctor-scope-db-unavailable.test.ts` (`sqlite_master may not be modified`) and `repository-registry.test.ts` (`/private/var` vs `/var` temp-path assertion). The run reported `9998 passed, 2 failed, 10 skipped` before exiting.
- [ ] `pnpm run verify:merge` - not run locally; PR remains draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode scheduling and task-completion tool behavior for mid-execution escalations; scope is focused but affects workflow control paths agents rely on.
> 
> **Overview**
> **Unresolved mid-execution escalations now always pause auto-mode**, including when `continueWithDefault=true`. The recommendation is still stored as the default path, but the loop no longer treats silence as consent.
> 
> `detectPendingEscalation()` treats unresolved `escalation_awaiting_review` rows the same as `escalation_pending`, so `deriveState` enters `escalating-task` instead of dispatching the next task. GSD/MCP tool schema text for `continueWithDefault` is updated to match.
> 
> Task completion **returns escalation metadata** from `handleCompleteTask`, and `executeTaskComplete` responds with explicit “decision required” text (question, recommendation, `/gsd escalate resolve` hint) instead of a generic “Completed task” message when an escalation artifact was written. Tests cover the new pause behavior and executor output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fc65d467ba48e8cb64d1773ea0b49aab73118c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->