### PR TITLE
docs(adr): add ADR-021 — unified .gsd/ root with platform sub-namespaces

### DIFF
--- a/docs/dev/ADR-021-unified-gsd-root-namespacing.md
+++ b/docs/dev/ADR-021-unified-gsd-root-namespacing.md
@@ -1,0 +1,85 @@
+# ADR-021: Unified `.gsd/` root with platform sub-namespaces for cross-platform compatibility
+
+**Status:** Proposed
+**Date:** 2026-06-02
+**Related:** open-gsd/gsd-pi#430 (originating enhancement) · open-gsd/gsd-core#627 + gsd-core `docs/adr/627-unified-gsd-root-namespacing.md` (sibling decision) · ADR-002 (external-state-directory) · ADR-016 (worktree-lifecycle-and-projection) · ADR-016 (worktree-safety-fail-closed)
+**Deciders:** gsd-pi maintainers, gsd-core maintainers
+
+> This is the gsd-pi side of a coordinated, two-repo decision. The gsd-core sibling is open-gsd/gsd-core#627 (ADR committed there as `docs/adr/627-unified-gsd-root-namespacing.md`). Both must stay in lockstep on the `.gsd/<platform>/` convention.
+
+## Context
+
+gsd-pi and gsd-core are sibling platforms in the GSD family. Each persists its long-horizon runtime state in a different top-level directory at the repo root:
+
+- gsd-pi → `.gsd/`.
+- gsd-core → `.planning/` — gitignored, local-only, resolved through a single path-projection seam (gsd-core ADR-0006).
+
+These roots are conceptually parallel — both are "the agent's long-horizon working memory" — but they share no convention. A single repository cannot cleanly host both platforms, and a user who wants to move a project from gsd-core to gsd-pi (or run both) has no defined migration path; they end up with two unrelated top-level directories. Both platforms are built around autonomous, long-running operation, which makes a durable, predictable on-disk home for state — and for the worktrees agents run in — a shared concern.
+
+Separately, agent worktree storage that lands in `/tmp` is not durable across reboots (a poor fit for multi-hour autonomous runs) and is not guaranteed to share a filesystem with the repo.
+
+## Decision
+
+Adopt a **single `.gsd/` root at the repo root, partitioned by platform**, shared by convention across the GSD family:
+
+```
+.gsd/
+├── gsd-core/                 # gsd-core runtime state (formerly .planning/)
+├── gsd-pi/                   # gsd-pi runtime state
+└── gsd-worktree/             # shared, gitignored, ephemeral agent worktrees
+    ├── gsd-core/agent-<id>/  # per-platform leaf
+    └── gsd-pi/agent-<id>/
+```
+
+1. **gsd-pi formalizes its state under `.gsd/gsd-pi/`** — the per-platform namespace — rather than the bare `.gsd/` root, reserving the root for the shared convention.
+2. **gsd-core relocates `.planning/` → `.gsd/gsd-core/`** behind its existing projection seam (its side; gsd-core#627).
+3. **Agent worktrees move to a per-platform leaf `.gsd/gsd-worktree/<platform>/`** — gitignored, co-located on the repo filesystem, platform-neutral — replacing `/tmp`. Keeping the leaf namespaced per platform means each platform's garbage collection only ever touches its own worktrees and can never reap a concurrent platform's live worktree.
+
+Keeping the **root shared and the leaf namespaced** is what lets both platforms occupy the same working tree without collision and gives migration tooling a deterministic mapping (`.gsd/gsd-core/ ⇄ .gsd/gsd-pi/`).
+
+### Worktree location — options evaluated
+
+| Option | Pros | Cons |
+|---|---|---|
+| **`/tmp` / `$TMPDIR`** | OS auto-cleanup; never git-tracked | Lost on reboot (kills resumable long runs); possibly different filesystem; not co-located; not a portable cross-platform concept |
+| **Tool-specific dir** (e.g. an agent harness's own worktree dir) | Co-located, same filesystem | Harness-specific; not portable across platforms |
+| **Single shared `.gsd/gsd-worktree/` pool** | Co-located; one directory | One platform's GC can reap the other's live worktree |
+| **`.gsd/gsd-worktree/<platform>/`** (chosen) | Co-located & same filesystem (fast adds, no cross-device edge cases); unified under the shared root; platform-neutral; per-platform GC isolation; gitignorable; reboot-durable; visible for debugging | Must be gitignored; nested-worktree-in-repo needs care; not OS-cleaned — needs explicit lock/heartbeat GC |
+
+**Chosen: `.gsd/gsd-worktree/<platform>/`** — the only option that is co-located (same filesystem as the repo), reboot-durable, and platform-neutral at once, with per-platform GC isolation.
+
+### Worktree garbage collection — lock/heartbeat
+
+The OS gave `/tmp` free liveness (reboot wipes it); a repo-local directory does not, so GC needs an explicit liveness signal to avoid deleting a worktree a concurrent run is using:
+
+- The owning agent writes a **lock/heartbeat file** into its worktree for the life of its run.
+- A **GC sweep runs at the start of any worktree-creating command**, scoped to the current platform's leaf only, and removes an `agent-<id>/` directory only when **both** its owning branch is merged/absent **and** its lock is stale/dead.
+- **mtime-TTL is a crash backstop** for locks orphaned by a hard kill — not the primary signal.
+
+Chosen over branch-state-only (cannot distinguish a live-but-unmerged run from an abandoned one) and TTL-only (reaps a long quiet run mid-flight).
+
+## Consequences
+
+- **Positive.** One cross-platform on-disk contract both platforms honor; a real migration path between them; reboot-durable worktrees on a guaranteed-local filesystem; per-platform GC isolation; one worktree convention.
+- **Negative / cost.** gsd-pi must formalize state under `.gsd/gsd-pi/` and point worktrees at `.gsd/gsd-worktree/gsd-pi/`; add `.gsd/gsd-worktree/` to ignore rules; add lock/heartbeat GC (this directory is not OS-cleaned). On the gsd-core side, a one-time local relocation of `.planning/` (no committed-history break — it is gitignored).
+- **Coordination.** Both platforms must keep the `.gsd/<platform>/` convention in lockstep; this ADR and the gsd-core sibling (open-gsd/gsd-core#627) are the coordination record.
+
+## Alternatives Considered
+
+- **Status quo (`.gsd/` for pi, `.planning/` for core, separate).** No migration cost, but permanently blocks interop and migration — the whole motivation.
+- **Both platforms share a bare `.gsd/` root with no sub-namespace.** State collides; dual-hosting is impossible. The `gsd-pi/`/`gsd-core/` leaf is what prevents collision.
+- **Symlink / dual-read compatibility shim** as the end state. Solves cross-clone propagation of a committed path — not a problem for gitignored local-only state — at the cost of fragility (Windows, archives, CI) or two code paths.
+- **Worktrees on `/tmp`, or under a tool-specific dir, or in a single shared pool.** Rejected for the reasons in the options table above (reboot-fragility, non-portability, and cross-platform GC cross-talk respectively).
+- **Worktree GC by branch-state-only or mtime-TTL-only.** Rejected as primary signals in favor of lock/heartbeat (TTL kept as a crash backstop).
+
+## Validation
+
+- Decision shape and the worktree-location trade-offs were stress-tested via a grilling pass against the gsd-core codebase (confirmed `.planning/` is gitignored/local-only, which is what makes gsd-core's migration a local `fs.rename` rather than a git operation).
+- Cross-checked against gsd-pi's existing worktree ADRs (ADR-016 lifecycle/projection and worktree-safety-fail-closed) and external-state ADR-002.
+
+## Action Items
+
+- [ ] Confirm gsd-pi's state-directory resolution centralizes on `.gsd/gsd-pi/` (single seam), mirroring gsd-core ADR-0006.
+- [ ] Point gsd-pi agent worktrees at `.gsd/gsd-worktree/gsd-pi/`; add ignore rule for `.gsd/gsd-worktree/`.
+- [ ] Implement lock/heartbeat GC scoped to the gsd-pi leaf.
+- [ ] Keep the `.gsd/<platform>/` convention synchronized with gsd-core (open-gsd/gsd-core#627).


### PR DESCRIPTION
## Linked issue

Closes #430

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds `docs/dev/ADR-021-unified-gsd-root-namespacing.md` — the decision record for converging gsd-pi and gsd-core onto a single, platform-namespaced `.gsd/` root and moving agent worktrees off `/tmp`.
**Why:** Lets one repo host both platforms and gives users a real migration path between gsd-pi and gsd-core; makes long autonomous runs reboot-durable.
**How:** Documents the layout (`.gsd/gsd-pi/`, `.gsd/gsd-core/`, per-platform `.gsd/gsd-worktree/<platform>/` leaf with lock/heartbeat GC). Decision record only (Status: Proposed) — no behavior change in this PR.

## Change type

- [x] `docs` — Documentation only

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [x] No tests needed — docs-only decision record (ADR, Status: Proposed); no code touched.

---

This is the gsd-pi side of a coordinated two-repo decision. The sibling ADR is committed on gsd-core in [open-gsd/gsd-core#629](https://github.com/open-gsd/gsd-core/pull/629) (issue open-gsd/gsd-core#627). The two platforms must keep the `.gsd/<platform>/` convention in lockstep. Implementation (the actual state-dir + worktree changes) lands in a separate follow-up PR.

Authored in gsd-pi's native ADR convention (`docs/dev/ADR-NNN-slug.md`, next number 021), not gsd-core's `docs/adr/<issue#>-slug.md` scheme.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783041878&installation_id=134682257&pr_number=436&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F436&signature=6b1567ae55d0b0dbd361c1a811388bd9f1541b3462f3d2288a52e3b8938039cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->