### PR TITLE
fix(gsd): pause after discuss dispatches

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -622,6 +622,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           structuredQuestionsAvailable,
           { headless: !!process.env.GSD_HEADLESS },
         ),
+        pauseAfterDispatch: !process.env.GSD_HEADLESS,
       };
     },
   },
@@ -772,6 +773,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           structuredQuestionsAvailable,
           { headless: !!process.env.GSD_HEADLESS },
         ),
+        pauseAfterDispatch: !process.env.GSD_HEADLESS,
       };
     },
   },
@@ -805,6 +807,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         unitType: "discuss-project",
         unitId: "PROJECT",
         prompt: await buildDiscussProjectPrompt(basePath, structuredQuestionsAvailable),
+        pauseAfterDispatch: !process.env.GSD_HEADLESS,
       };
     },
   },
@@ -826,6 +829,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         unitType: "discuss-requirements",
         unitId: "REQUIREMENTS",
         prompt: await buildDiscussRequirementsPrompt(basePath, structuredQuestionsAvailable),
+        pauseAfterDispatch: !process.env.GSD_HEADLESS,
       };
     },
   },
@@ -940,6 +944,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           structuredQuestionsAvailable,
           { headless: !!process.env.GSD_HEADLESS },
         ),
+        pauseAfterDispatch: !process.env.GSD_HEADLESS,
       };
     },
   },

--- a/src/resources/extensions/gsd/tests/deep-planning-mode-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-planning-mode-dispatch.test.ts
@@ -229,6 +229,24 @@ function makeIsolatedBaseWithCleanup(t: TestContext): string {
   return base;
 }
 
+function setGsdHeadless(t: TestContext): void {
+  const previous = process.env.GSD_HEADLESS;
+  process.env.GSD_HEADLESS = "1";
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+}
+
+function unsetGsdHeadless(t: TestContext): void {
+  const previous = process.env.GSD_HEADLESS;
+  delete process.env.GSD_HEADLESS;
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+}
+
 function writeValidProject(base: string): void {
   writeFileSync(join(base, ".gsd", "PROJECT.md"), VALID_PROJECT_MD);
 }
@@ -364,13 +382,30 @@ test("Deep mode: discuss-project does NOT dispatch when planning_depth is 'light
 test("Deep mode: discuss-project DOES dispatch when planning_depth is 'deep' and PROJECT.md missing", async (t) => {
   const base = makeIsolatedBaseWithCleanup(t);
 
+  unsetGsdHeadless(t);
+
   const prefs = { planning_depth: "deep" } as GSDPreferences;
   const result = await rule(PROJECT_RULE_NAME).match(makeCtx(base, prefs));
   assert.ok(result && result.action === "dispatch", "deep mode + missing PROJECT.md must dispatch");
   if (result.action === "dispatch") {
     assert.strictEqual(result.unitType, "discuss-project");
     assert.strictEqual(result.unitId, "PROJECT");
+    assert.strictEqual(result.pauseAfterDispatch, true);
     assert.ok(result.prompt.length > 0, "prompt must be non-empty");
+  }
+});
+
+test("Deep mode: discuss-project does not pause when GSD_HEADLESS is set", async (t) => {
+  const base = makeIsolatedBaseWithCleanup(t);
+
+  setGsdHeadless(t);
+
+  const prefs = { planning_depth: "deep" } as GSDPreferences;
+  const result = await rule(PROJECT_RULE_NAME).match(makeCtx(base, prefs));
+  assert.ok(result && result.action === "dispatch", "deep mode + missing PROJECT.md must dispatch");
+  if (result.action === "dispatch") {
+    assert.strictEqual(result.unitType, "discuss-project");
+    assert.strictEqual(result.pauseAfterDispatch, false);
   }
 });
 
@@ -432,6 +467,8 @@ test("Deep mode: discuss-requirements does NOT dispatch when PROJECT.md missing 
 test("Deep mode: discuss-requirements DOES dispatch when PROJECT.md exists and REQUIREMENTS.md missing", async (t) => {
   const base = makeIsolatedBaseWithCleanup(t);
 
+  unsetGsdHeadless(t);
+
   writeValidProject(base);
   const prefs = { planning_depth: "deep" } as GSDPreferences;
   const result = await rule(REQUIREMENTS_RULE_NAME).match(makeCtx(base, prefs));
@@ -439,6 +476,22 @@ test("Deep mode: discuss-requirements DOES dispatch when PROJECT.md exists and R
   if (result.action === "dispatch") {
     assert.strictEqual(result.unitType, "discuss-requirements");
     assert.strictEqual(result.unitId, "REQUIREMENTS");
+    assert.strictEqual(result.pauseAfterDispatch, true);
+  }
+});
+
+test("Deep mode: discuss-requirements does not pause when GSD_HEADLESS is set", async (t) => {
+  const base = makeIsolatedBaseWithCleanup(t);
+
+  setGsdHeadless(t);
+
+  writeValidProject(base);
+  const prefs = { planning_depth: "deep" } as GSDPreferences;
+  const result = await rule(REQUIREMENTS_RULE_NAME).match(makeCtx(base, prefs));
+  assert.ok(result && result.action === "dispatch", "deep mode + PROJECT.md present + REQUIREMENTS.md missing must dispatch");
+  if (result.action === "dispatch") {
+    assert.strictEqual(result.unitType, "discuss-requirements");
+    assert.strictEqual(result.pauseAfterDispatch, false);
   }
 });
 

--- a/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
@@ -44,14 +44,26 @@ function setGsdHeadless(t: { after: (fn: () => void) => void }): void {
   });
 }
 
+function unsetGsdHeadless(t: { after: (fn: () => void) => void }): void {
+  const previous = process.env.GSD_HEADLESS;
+  delete process.env.GSD_HEADLESS;
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+}
+
 test("auto-dispatch passes structuredQuestionsAvailable=true into discuss-milestone prompt", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-structured-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  unsetGsdHeadless(t);
 
   const result = await resolveDispatch(makeContext(tmp, "needs-discussion", "true"));
 
   assert.equal(result.action, "dispatch");
   assert.equal(result.unitType, "discuss-milestone");
+  assert.equal(result.pauseAfterDispatch, true);
   assert.match(
     result.prompt,
     /\*\*Structured questions available: true\*\*/,
@@ -62,10 +74,13 @@ test("auto-dispatch preserves structuredQuestionsAvailable=false for discuss-mil
   const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-plain-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
 
+  unsetGsdHeadless(t);
+
   const result = await resolveDispatch(makeContext(tmp, "pre-planning", "false"));
 
   assert.equal(result.action, "dispatch");
   assert.equal(result.unitType, "discuss-milestone");
+  assert.equal(result.pauseAfterDispatch, true);
   assert.match(
     result.prompt,
     /\*\*Structured questions available: false\*\*/,
@@ -82,6 +97,7 @@ test("auto-dispatch uses discuss-headless prompt when GSD_HEADLESS is set", asyn
 
   assert.equal(result.action, "dispatch");
   assert.equal(result.unitType, "discuss-milestone");
+  assert.equal(result.pauseAfterDispatch, false);
   assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
   assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
 });
@@ -96,8 +112,22 @@ test("auto-dispatch uses discuss-headless prompt for needs-discussion when GSD_H
 
   assert.equal(result.action, "dispatch");
   assert.equal(result.unitType, "discuss-milestone");
+  assert.equal(result.pauseAfterDispatch, false);
   assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
   assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
+});
+
+test("auto-dispatch pauses after execution-entry discuss-milestone recovery", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-executing-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  unsetGsdHeadless(t);
+
+  const result = await resolveDispatch(makeContext(tmp, "executing", "true"));
+
+  assert.equal(result.action, "dispatch");
+  assert.equal(result.unitType, "discuss-milestone");
+  assert.equal(result.pauseAfterDispatch, true);
 });
 
 test("auto-dispatch uses discuss-headless prompt for executing when GSD_HEADLESS is set", async (t) => {
@@ -110,6 +140,7 @@ test("auto-dispatch uses discuss-headless prompt for executing when GSD_HEADLESS
 
   assert.equal(result.action, "dispatch");
   assert.equal(result.unitType, "discuss-milestone");
+  assert.equal(result.pauseAfterDispatch, false);
   assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
   assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
 });


### PR DESCRIPTION
## TL;DR

**What:** Adds `pauseAfterDispatch` to the five auto-mode `discuss-*` dispatch results.
**Why:** `/gsd auto` should yield for milestone, project, and requirements discussion instead of immediately continuing into repeated discuss dispatches.
**How:** Mirrors the existing non-headless pause contract used by `run-uat` and adds regression coverage for interactive and `GSD_HEADLESS` behavior.

## What

Updates `src/resources/extensions/gsd/auto-dispatch.ts` so these dispatch rules set `pauseAfterDispatch: !process.env.GSD_HEADLESS`:

- `execution-entry phase (no context) → discuss-milestone`
- `needs-discussion → discuss-milestone`
- `deep: pre-planning (no PROJECT) → discuss-project`
- `deep: pre-planning (no REQUIREMENTS) → discuss-requirements`
- `pre-planning (no context) → discuss-milestone`

Adds focused tests for interactive pause behavior and headless non-pause behavior across milestone, project, and requirements discussion dispatches.

## Why

Without the flag, `auto/phases.ts` defaults `dispatchResult.pauseAfterDispatch` to `false`, so the pause gate never runs for discussion units. That lets auto-mode continue after dispatching discussion work and can repeat the same `discuss-milestone` unit.

Closes #417

## How

The implementation keeps the existing dispatch contract intact and only populates its optional pause field for the discuss rules that require user input. `GSD_HEADLESS` remains the bypass so automated/headless flows continue without pausing.

## Change type

- [ ] `feat` - New feature or capability
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Scope

GSD extension auto-dispatch rules and focused dispatch tests.

## Breaking changes

None.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts src/resources/extensions/gsd/tests/deep-planning-mode-dispatch.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/deep-mode-integration.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run test:compile`
- [x] `bash scripts/ci-fast-gates.sh`
- [ ] `pnpm run verify:pr` - currently fails on existing unrelated compiled-test failures: `checkEngineHealth treats explicit reopen as authoritative when dispatch timestamps are missing` cannot modify `sqlite_master`, and `repository registry uses external-state worktree checkout as project root` expects `/var/...` while macOS returns `/private/var/...`.

## Notes

Draft because the issue has `blocked` / `needs-maintainer-review` labels and full `verify:pr` is blocked by unrelated existing compiled-test failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized GSD auto-dispatch flag and tests; behavior change is intentional (pause for interactive discussion) with headless bypass unchanged for automation.
> 
> **Overview**
> Interactive **`/gsd auto`** now **pauses after discussion dispatches** instead of immediately re-dispatching the same `discuss-*` unit.
> 
> **`auto-dispatch.ts`** sets `pauseAfterDispatch: !process.env.GSD_HEADLESS` on five rules: milestone discussion (`needs-discussion`, `pre-planning` without context, execution-entry recovery without context) and deep-mode **`discuss-project`** / **`discuss-requirements`**. That matches the existing **`run-uat`** pause contract; **`auto/phases.ts`** already treats a missing flag as no pause.
> 
> **Tests** assert `pauseAfterDispatch` is **true** when `GSD_HEADLESS` is unset and **false** when it is set, with helpers to toggle the env var in **`deep-planning-mode-dispatch.test.ts`** and **`discuss-milestone-structured-questions.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0153db2e768b53e0d262d55b0a373bc487d48fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->