### PR TITLE
test(gsd): cover guided workflow MCP surface

### DIFF
--- a/src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts
@@ -104,3 +104,89 @@ test("guided dispatch passes the explicit project root through model and compati
     rmSync(otherRoot, { recursive: true, force: true });
   }
 });
+
+test("guided dispatch accepts workflow MCP tools absent from parent active tool surface", async () => {
+  const explicitRoot = mkdtempSync(join(tmpdir(), "gsd-guided-mcp-surface-"));
+  const workflowPath = join(explicitRoot, "GSD-WORKFLOW.md");
+  const originalWorkflowPath = process.env.GSD_WORKFLOW_PATH;
+  const originalMcpCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const notifications: string[] = [];
+  let sent = false;
+
+  const ctx = {
+    model: { provider: "claude-code", baseUrl: "local://claude-code" },
+    modelRegistry: {
+      getProviderAuthMode: () => "externalCli",
+    },
+    ui: {
+      notify: (message: string) => {
+        notifications.push(message);
+      },
+    },
+  };
+
+  let activeTools = [
+    "ScheduleWakeup",
+    "ToolSearch",
+    "ask_user_questions",
+    "bash",
+    "read",
+    "write",
+  ];
+
+  const pi = {
+    getActiveTools: () => [...activeTools],
+    setActiveTools: (tools: string[]) => {
+      activeTools = [...tools];
+    },
+    sendMessage: () => {
+      sent = true;
+    },
+  };
+
+  try {
+    writeFileSync(workflowPath, "# Workflow\n", "utf-8");
+    process.env.GSD_WORKFLOW_PATH = workflowPath;
+    process.env.GSD_WORKFLOW_MCP_COMMAND = "node";
+
+    await _dispatchWorkflowForTest(
+      pi as any,
+      "Discuss the milestone.",
+      "gsd-discuss",
+      ctx as any,
+      "discuss-milestone",
+      {
+        basePath: explicitRoot,
+        deps: {
+          loadPreferences: () => ({ preferences: {} }) as any,
+          selectModel: (async () => ({
+            routing: null,
+            appliedModel: {
+              provider: "claude-code",
+              id: "claude-opus-4-8",
+              baseUrl: "local://claude-code",
+            },
+          })) as any,
+        },
+      },
+    );
+
+    assert.equal(sent, true);
+    assert.equal(
+      notifications.some((message) => message.includes("cannot run guided flow")),
+      false,
+    );
+  } finally {
+    if (originalWorkflowPath === undefined) {
+      delete process.env.GSD_WORKFLOW_PATH;
+    } else {
+      process.env.GSD_WORKFLOW_PATH = originalWorkflowPath;
+    }
+    if (originalMcpCommand === undefined) {
+      delete process.env.GSD_WORKFLOW_MCP_COMMAND;
+    } else {
+      process.env.GSD_WORKFLOW_MCP_COMMAND = originalMcpCommand;
+    }
+    rmSync(explicitRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds guided-flow regression coverage for the Claude Code workflow MCP active-tool false positive.
**Why:** Issue #389 reports `/gsd discuss-milestone` failing because guided flow passed Pi-native `activeTools` that do not include workflow MCP tools.
**How:** Exercises `_dispatchWorkflowForTest` with `claude-code`, a discoverable workflow MCP launch config, and a parent active-tool surface that lacks `gsd_summary_save`, `gsd_plan_milestone`, and the other workflow MCP tools required by `discuss-milestone`.

## What

This updates `src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts` with a regression test for the exact guided-flow call path from issue #389.

The test verifies that guided `discuss-milestone` dispatch queues a message instead of notifying `cannot run guided flow` when:

- the selected provider is `claude-code`
- auth mode is `externalCli`
- base URL is `local://claude-code`
- workflow MCP is discoverable through `GSD_WORKFLOW_MCP_COMMAND`
- parent `pi.getActiveTools()` only exposes Pi-native tools

## Why

The current production code on `main` already contains the shared helper fix from merged PR #336: `getWorkflowTransportSupportError` filters workflow-MCP-surface tools out of the parent `activeTools` check. Because `guided-flow.ts` calls that same helper, the residual issue is best closed by a call-path regression test that prevents the guided-flow path from drifting back into the false-positive state.

Closes #389

## How

The new test uses the real transport compatibility helper through `_dispatchWorkflowForTest`, while stubbing model selection just enough to simulate Claude Code. If the gate regresses, the test will see the `cannot run guided flow` notification and fail because no guided workflow message is queued.

## Change type

- [ ] `feat` - New feature or capability
- [ ] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Scope

GSD extension guided-flow regression coverage.

## Breaking changes

None.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/guided-dispatch-root.test.js`
- [x] `bash scripts/ci-fast-gates.sh`

## Notes

Draft because the issue carries `blocked` / `needs-maintainer-review` labels and this is a test-only PR confirming the already-applied shared-helper fix on the guided-flow path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic or security surface modified.
> 
> **Overview**
> Adds a **regression test** in `guided-dispatch-root.test.ts` for issue #389: guided `discuss-milestone` must not fail when the parent Pi session’s `activeTools` only lists native tools (e.g. `bash`, `read`, `write`) while workflow MCP tools are provided via `GSD_WORKFLOW_MCP_COMMAND`.
> 
> The test drives `_dispatchWorkflowForTest` with **Claude Code** (`externalCli`, `local://claude-code`), a discoverable workflow file, and asserts a message is **queued** and no **“cannot run guided flow”** notification appears—locking in the shared `getWorkflowTransportSupportError` behavior on the guided path without changing production code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55f26eccd1efd1ce688b2a8b8e092d0d0b8d595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->