### PR TITLE
test(pi-tui): cover opt-in mouse reporting

### DIFF
--- a/packages/pi-tui/test/terminal.test.ts
+++ b/packages/pi-tui/test/terminal.test.ts
@@ -1,6 +1,76 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
+import { DISABLE_MOUSE, ENABLE_MOUSE } from "../src/mouse.ts";
 import { ProcessTerminal, shouldEnableMouseReporting } from "../src/terminal.ts";
+
+function withProcessTerminalHarness(env: Record<string, string | undefined>, run: (writes: string[]) => void): void {
+	const previousStdoutIsTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	const previousStdinIsRaw = Object.getOwnPropertyDescriptor(process.stdin, "isRaw");
+	const previousSetRawMode = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
+	const previousSetEncoding = process.stdin.setEncoding;
+	const previousResume = process.stdin.resume;
+	const previousPause = process.stdin.pause;
+	const previousWrite = process.stdout.write;
+	const previousKill = process.kill;
+	const previousSetTimeout = globalThis.setTimeout;
+	const previousMouseEnv = process.env.PI_TUI_MOUSE;
+	const writes: string[] = [];
+	let terminal: ProcessTerminal | undefined;
+
+	try {
+		if (env.PI_TUI_MOUSE === undefined) {
+			delete process.env.PI_TUI_MOUSE;
+		} else {
+			process.env.PI_TUI_MOUSE = env.PI_TUI_MOUSE;
+		}
+
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdin, "isRaw", { value: false, configurable: true });
+		Object.defineProperty(process.stdin, "setRawMode", { value: () => process.stdin, configurable: true });
+		process.stdin.setEncoding = (() => process.stdin) as typeof process.stdin.setEncoding;
+		process.stdin.resume = (() => process.stdin) as typeof process.stdin.resume;
+		process.stdin.pause = (() => process.stdin) as typeof process.stdin.pause;
+		process.stdout.write = ((data: string | Uint8Array) => {
+			writes.push(typeof data === "string" ? data : data.toString());
+			return true;
+		}) as typeof process.stdout.write;
+		process.kill = (() => true) as typeof process.kill;
+		globalThis.setTimeout = (() => 0) as unknown as typeof globalThis.setTimeout;
+
+		terminal = new ProcessTerminal();
+		terminal.start(() => {}, () => {});
+		run(writes);
+	} finally {
+		terminal?.stop();
+
+		if (previousMouseEnv === undefined) {
+			delete process.env.PI_TUI_MOUSE;
+		} else {
+			process.env.PI_TUI_MOUSE = previousMouseEnv;
+		}
+		if (previousStdoutIsTty) {
+			Object.defineProperty(process.stdout, "isTTY", previousStdoutIsTty);
+		} else {
+			Reflect.deleteProperty(process.stdout, "isTTY");
+		}
+		if (previousStdinIsRaw) {
+			Object.defineProperty(process.stdin, "isRaw", previousStdinIsRaw);
+		} else {
+			Reflect.deleteProperty(process.stdin, "isRaw");
+		}
+		if (previousSetRawMode) {
+			Object.defineProperty(process.stdin, "setRawMode", previousSetRawMode);
+		} else {
+			Reflect.deleteProperty(process.stdin, "setRawMode");
+		}
+		process.stdin.setEncoding = previousSetEncoding;
+		process.stdin.resume = previousResume;
+		process.stdin.pause = previousPause;
+		process.stdout.write = previousWrite;
+		process.kill = previousKill;
+		globalThis.setTimeout = previousSetTimeout;
+	}
+}
 
 describe("ProcessTerminal dimensions", () => {
 	it("falls back to COLUMNS and LINES before default dimensions", () => {
@@ -52,5 +122,27 @@ describe("shouldEnableMouseReporting", () => {
 
 	it("enables terminal mouse reporting only when explicitly requested", () => {
 		assert.equal(shouldEnableMouseReporting({ PI_TUI_MOUSE: "1" }), true);
+	});
+});
+
+describe("ProcessTerminal mouse reporting", () => {
+	it("does not emit mouse tracking enable sequences by default", () => {
+		withProcessTerminalHarness({}, (writes) => {
+			const output = writes.join("");
+			assert.equal(output.includes(ENABLE_MOUSE), false);
+			assert.equal(output.includes("\x1b[?1002h"), false);
+			assert.equal(output.includes("\x1b[?1003h"), false);
+		});
+	});
+
+	it("emits and clears mouse reporting only when explicitly enabled", () => {
+		let capturedWrites: string[] = [];
+		withProcessTerminalHarness({ PI_TUI_MOUSE: "1" }, (writes) => {
+			capturedWrites = writes;
+			assert.equal(writes.join("").includes(ENABLE_MOUSE), true);
+		});
+
+		const output = capturedWrites.join("");
+		assert.equal(output.includes(DISABLE_MOUSE), true);
 	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Adds regression coverage for `ProcessTerminal` mouse reporting startup writes.
**Why:** #390 reported global mouse tracking blocking native terminal scroll and selection; current `main` already keeps mouse reporting opt-in, and this locks that behavior down.
**How:** Captures stdout writes from `ProcessTerminal.start()` and `stop()` for default and `PI_TUI_MOUSE=1` environments.

## What

Adds focused `pi-tui` tests that assert default terminal startup does not emit mouse tracking enable sequences, including the problematic `1002h` and `1003h` modes, while explicit opt-in emits and clears the configured mouse reporting sequence.

Refs #390

## Why

The current implementation already preserves native terminal selection by default via `PI_TUI_MOUSE=1` opt-in behavior. This PR protects that behavior at the startup/write boundary where the regression was reported.

## How

The test harness temporarily patches the process TTY/write surfaces around `ProcessTerminal.start()` so the test can inspect terminal escape output without requiring a real interactive terminal.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/test/terminal.test.ts`
- [x] `pnpm --filter @gsd/pi-tui run build`
- [x] `pnpm run build:core`
- [x] `pnpm run test:packages`
- [x] `pnpm run verify:fast`

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## Notes

Draft because #390 is still labeled `blocked` / `needs-maintainer-review`, and this PR adds regression coverage rather than product-code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783042545&installation_id=134682257&pr_number=439&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F439&signature=c3e681ba6e2a060ac31e2847f78a13d0dcb7b29639bf2312aa0c5cb7cdfba651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> Adds regression tests in `terminal.test.ts` so **`ProcessTerminal` startup/shutdown** is checked at the **stdout escape-sequence** boundary, not only via `shouldEnableMouseReporting`.
> 
> A new **`withProcessTerminalHarness`** stubs TTY, stdin, stdout writes, and related globals, then runs `start()` / `stop()` while recording written bytes. **Default / unset `PI_TUI_MOUSE`** must not write `ENABLE_MOUSE` or the **`1002h` / `1003h`** tracking modes tied to #390. **`PI_TUI_MOUSE=1`** must write **`ENABLE_MOUSE` on start** and **`DISABLE_MOUSE` on teardown**.
> 
> No production changes—test-only coverage locking opt-in mouse reporting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c14e8d091e713602baac38c8cb2521d07d7c840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->