### PR TITLE
fix(gsd): prevent serialized subagent task arrays

### DIFF
--- a/src/resources/extensions/gsd/prompts/gate-evaluate.md
+++ b/src/resources/extensions/gsd/prompts/gate-evaluate.md
@@ -8,6 +8,8 @@
 
 You are evaluating **quality gates in parallel** for this slice. Each gate is an independent question that must be answered before task execution begins. Use the `subagent` tool to dispatch all gate evaluations simultaneously.
 
+**Tool call format:** Call `subagent` with `tasks: [...]` as a **native JSON array** — one object per gate. Do NOT JSON.stringify the array into a string; the tool validates that `tasks` is an array, and a serialized string will be rejected with "must be array".
+
 ## Slice Plan Context
 
 {{slicePlanContent}}
@@ -20,7 +22,7 @@ You are evaluating **quality gates in parallel** for this slice. Each gate is an
 
 ## Execution Protocol
 
-1. **Dispatch all gates** using `subagent` in parallel mode. Each subagent prompt is provided below.
+1. **Dispatch all gates** using `subagent` in parallel mode. Call `subagent` with `tasks: [{ agent: "tester", task: "<prompt>" }, ...]` — one object per gate. Each subagent prompt is provided below.
    Pass `tasks` as a **JSON array**, not a string. Example shape:
 
    ```json

--- a/src/resources/extensions/gsd/prompts/parallel-research-slices.md
+++ b/src/resources/extensions/gsd/prompts/parallel-research-slices.md
@@ -12,9 +12,11 @@ You are dispatching parallel research agents for **{{sliceCount}} slices** in mi
 
 Dispatch ALL slices simultaneously using the `subagent` tool in **parallel mode**. Each subagent will independently research its slice and write a RESEARCH file.
 
+**Tool call format:** Call `subagent` with `tasks: [...]` as a **native JSON array** — one object per slice. Do NOT JSON.stringify the array into a string; the tool validates that `tasks` is an array, and a serialized string will be rejected with "must be array".
+
 ## Execution Protocol
 
-1. Call `subagent` with `tasks: [...]` containing one entry per slice below
+1. Call `subagent` with `tasks: [{ agent: "scout", task: "<prompt>" }, ...]` containing one entry per slice below
 2. Wait for ALL subagents to complete
 3. Verify each slice's RESEARCH file was written (check `.gsd/milestones/{{mid}}/slices/<slice-id>/`)
 4. If a subagent failed to write its RESEARCH file, retry it **once** individually

--- a/src/resources/extensions/gsd/prompts/reactive-execute.md
+++ b/src/resources/extensions/gsd/prompts/reactive-execute.md
@@ -10,6 +10,8 @@ You are executing **multiple tasks in parallel** for this slice. The task graph 
 
 **Critical rule:** Use the `subagent` tool in **parallel mode** to dispatch all ready tasks simultaneously. Each subagent gets a task-specific execution packet (task plan + dependency carry-forward + completion contract) and is responsible for its own implementation, verification, task summary, and completion tool calls. The parent batch agent orchestrates, verifies, and records failures only when a dispatched task failed before it could leave its own summary behind.
 
+**Tool call format:** Call `subagent` with `tasks: [...]` as a **native JSON array** — one object per ready task. Do NOT JSON.stringify the array into a string; the tool validates that `tasks` is an array, and a serialized string will be rejected with "must be array".
+
 ## Task Dependency Graph
 
 {{graphContext}}
@@ -22,7 +24,7 @@ You are executing **multiple tasks in parallel** for this slice. The task graph 
 
 ## Execution Protocol
 
-1. **Dispatch all ready tasks** using `subagent` in parallel mode. Each subagent prompt is provided below.
+1. **Dispatch all ready tasks** using `subagent` in parallel mode. Call `subagent` with `tasks: [{ agent: "worker", task: "<prompt>" }, ...]` — one object per ready task. Each subagent prompt is provided below.
 2. **Wait for all subagents** to complete.
 3. **Verify each dispatched task's outputs** — check that expected files were created/modified, that verification commands pass where applicable, and that each task wrote its own `T##-SUMMARY.md`.
 4. **Do not rewrite successful task summaries or duplicate completion tool calls.** Treat a subagent-written summary as authoritative for that task.

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -475,6 +475,27 @@ test("reactive-execute prompt references tool calls instead of checkbox updates"
   assert.match(prompt, /completion tool calls/);
 });
 
+test("parallel subagent prompts forbid serialized tasks arrays", () => {
+  const expectations = [
+    { name: "reactive-execute", agent: "worker" },
+    { name: "parallel-research-slices", agent: "scout" },
+    { name: "gate-evaluate", agent: "tester" },
+  ] as const;
+
+  for (const { name, agent } of expectations) {
+    const prompt = readPrompt(name);
+    assert.match(prompt, /tasks:\s*\[\.\.\.\]/, `${name} must show the native array placeholder`);
+    assert.match(prompt, /native JSON array/i, `${name} must explicitly require a native JSON array`);
+    assert.match(prompt, /Do NOT JSON\.stringify/i, `${name} must forbid JSON.stringify on tasks`);
+    assert.match(prompt, /must be array/i, `${name} must mention the subagent validation failure`);
+    assert.match(
+      prompt,
+      new RegExp(`tasks:\\s*\\[\\{\\s*agent:\\s*"${agent}"`, "i"),
+      `${name} must show the concrete ${agent} task call shape`,
+    );
+  }
+});
+
 // ─── Project-shape classifier + 3-or-4-options-with-Other-hatch contract ──
 
 test("guided-discuss-project classifies project shape and persists the verdict to PROJECT.md", () => {


### PR DESCRIPTION
## Linked issue

Closes #376

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds explicit native-array subagent call instructions to the affected parallel dispatch prompts.
**Why:** Prevents models from passing `tasks` as a JSON-serialized string that the `subagent` tool rejects.
**How:** Pins the concrete `tasks: [{ agent, task }, ...]` shape for worker, scout, and tester dispatch prompts, with regression coverage.

## What

- Updated `reactive-execute`, `parallel-research-slices`, and `gate-evaluate` prompts to require `tasks: [...]` as a native JSON array.
- Added a prompt-contract regression test covering all three affected prompts.

## Why

Parallel dispatch can fail when the model serializes the entire `tasks` array into a string. The `subagent` tool validates `tasks` as an array, so the parent agent falls back to slower sequential recovery after the rejected call.

## How

The prompt wording now puts the native-array requirement before the large embedded subagent prompt sections and repeats the concrete call shape in the execution protocol for each agent class.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] New/updated tests included
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts`
- [x] `bash scripts/ci-fast-gates.sh`
- [ ] `pnpm run verify:merge` — ran locally; build, web host, `validate-pack`, workspace coverage, and extension coverage passed, then `test:unit:compiled` failed in unrelated existing tests: `checkEngineHealth treats explicit reopen as authoritative when dispatch timestamps are missing` (`table sqlite_master may not be modified`) and `repository registry uses external-state worktree checkout as project root` (`/private/var` vs `/var` temp path on macOS).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783043767&installation_id=134682257&pr_number=440&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F440&signature=8d43ac54f7bb4692a21f87f09d7ee34799276036629b365d6e1f0cd6b6018765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GSD prompt text and prompt-contract tests; no runtime orchestration or auth/data paths are modified.
> 
> **Overview**
> Parallel GSD dispatch prompts (`reactive-execute`, `parallel-research-slices`, `gate-evaluate`) now **require** calling `subagent` with `tasks` as a **native JSON array** (not a `JSON.stringify`’d string), including the concrete per-agent shapes (`worker`, `scout`, `tester`) in the execution steps.
> 
> A **prompt-contract regression test** locks in that wording across all three prompts so invalid `tasks` payloads that trigger the tool’s “must be array” rejection are less likely during parallel execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cab23366c17582510a6ce4412ab71d71c65ad4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->