### PR TITLE
Fix UAT doctor recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1429,7 +1429,7 @@ export async function checkNeedsRunUat(
           // If the UAT file already contains a verdict, UAT has been run — skip
           if (hasVerdict(uatContent)) continue;
           // Also check the ASSESSMENT file — the run-uat prompt writes the verdict
-          // there (via gsd_summary_save artifact_type:"ASSESSMENT"), not into the
+          // there (via gsd_uat_result_save), not into the
           // UAT spec file. Without this check the unit re-dispatches indefinitely.
           const assessmentFile = resolveSliceFile(base, mid, sid, "ASSESSMENT");
           if (assessmentFile) {

--- a/src/resources/extensions/gsd/browser-evidence.ts
+++ b/src/resources/extensions/gsd/browser-evidence.ts
@@ -17,10 +17,19 @@ export function compactTextParts(parts: Array<string | string[] | null | undefin
 
 export function hasBrowserRequiredText(text: string): boolean {
   let inNonRequirementSection = false;
+  let nonRequirementDepth = 0;
   for (const line of text.split(/\r?\n/)) {
-    const headingMatch = line.match(/^#{1,6}\s+(.+?)\s*$/);
+    const headingMatch = line.match(/^(#{1,6})\s+(.+?)\s*$/);
     if (headingMatch) {
-      inNonRequirementSection = NON_REQUIREMENT_BROWSER_HEADING_RE.test(headingMatch[1] ?? "");
+      const depth = headingMatch[1]!.length;
+      const title = headingMatch[2] ?? "";
+      // Only update section context when at the same or higher level than the
+      // heading that opened the non-requirement zone. A sub-heading deeper than
+      // the opening heading must not escape or re-enter the zone on its own.
+      if (!inNonRequirementSection || depth <= nonRequirementDepth) {
+        inNonRequirementSection = NON_REQUIREMENT_BROWSER_HEADING_RE.test(title);
+        nonRequirementDepth = inNonRequirementSection ? depth : 0;
+      }
       continue;
     }
     if (inNonRequirementSection || NON_REQUIREMENT_BROWSER_LINE_RE.test(line)) continue;

--- a/src/resources/extensions/gsd/browser-evidence.ts
+++ b/src/resources/extensions/gsd/browser-evidence.ts
@@ -30,6 +30,9 @@ export function hasBrowserRequiredText(text: string): boolean {
         inNonRequirementSection = NON_REQUIREMENT_BROWSER_HEADING_RE.test(title);
         nonRequirementDepth = inNonRequirementSection ? depth : 0;
       }
+      // Check the heading title itself — section state is already updated, so
+      // we correctly skip headings that opened a non-requirement zone.
+      if (!inNonRequirementSection && BROWSER_REQUIREMENT_RE.test(title)) return true;
       continue;
     }
     if (inNonRequirementSection || NON_REQUIREMENT_BROWSER_LINE_RE.test(line)) continue;

--- a/src/resources/extensions/gsd/browser-evidence.ts
+++ b/src/resources/extensions/gsd/browser-evidence.ts
@@ -1,11 +1,13 @@
 // Project/App: gsd-pi
 // File Purpose: Shared browser-observable UAT requirement and evidence detection.
 
-export const BROWSER_REQUIREMENT_RE = /\b(?:browser|file:\/\/|localhost|dom|localstorage|click(?:ing|ed)?|button|screenshot|snapshot|reload(?:ed)?|page refresh|user-visible|strikethrough|search box)\b/i;
+export const BROWSER_REQUIREMENT_RE = /\b(?:file:\/\/|localhost|playwright|chrome|screenshot|snapshot|browser_(?:assert|batch|find|verify|snapshot_refs))\b|\b(?:open|launch|navigate|load|visit|serve|start)\b.{0,80}\b(?:browser|page|localhost|file:\/\/)\b|\bbrowser\s+(?:check|session|test|uat|tool|automation|interaction|flow)\b/i;
 export const NO_BROWSER_EVIDENCE_RE = /\b(?:no|without|not|wasn'?t|isn'?t)\s+(?:automated\s+)?(?:live\s+)?browser(?:\s+(?:session|test|uat))?|\bno\s+automated\s+browser\b|\bnot\s+conducted\b/i;
 export const BROWSER_RUNTIME_RE = /\b(?:browser|playwright|chrome|camoufox|browser_(?:assert|batch|find|verify|snapshot_refs)|screenshot|snapshot|file:\/\/|localhost)\b/i;
 export const BROWSER_ACTION_RE = /\b(?:open(?:ed)?|navigate(?:d)?|click(?:ed)?|type(?:d)?|reload(?:ed)?|capture(?:d)?|screenshot|snapshot)\b/i;
 export const BROWSER_ASSERTION_RE = /\b(?:assert(?:ed|ion)?|observed|confirmed|verified|expected|visible|text|count|label|strikethrough|localstorage|screenshot|snapshot|passed)\b/i;
+const NON_REQUIREMENT_BROWSER_HEADING_RE = /^(?:not\s+proven|not\s+covered|out\s+of\s+scope|deferred|follow-?ups?|known\s+limitations|notes\s+for\s+tester)\b/i;
+const NON_REQUIREMENT_BROWSER_LINE_RE = /\b(?:deferred|not\s+proven|not\s+covered|out\s+of\s+scope|future\s+slice|follow-?up|no\s+(?:live\s+)?browser|without\s+(?:a\s+)?browser|not\s+(?:a\s+)?browser)\b/i;
 
 export function compactTextParts(parts: Array<string | string[] | null | undefined>): string {
   return parts.flatMap((part) => Array.isArray(part) ? part : [part])
@@ -14,7 +16,17 @@ export function compactTextParts(parts: Array<string | string[] | null | undefin
 }
 
 export function hasBrowserRequiredText(text: string): boolean {
-  return BROWSER_REQUIREMENT_RE.test(text);
+  let inNonRequirementSection = false;
+  for (const line of text.split(/\r?\n/)) {
+    const headingMatch = line.match(/^#{1,6}\s+(.+?)\s*$/);
+    if (headingMatch) {
+      inNonRequirementSection = NON_REQUIREMENT_BROWSER_HEADING_RE.test(headingMatch[1] ?? "");
+      continue;
+    }
+    if (inNonRequirementSection || NON_REQUIREMENT_BROWSER_LINE_RE.test(line)) continue;
+    if (BROWSER_REQUIREMENT_RE.test(line)) return true;
+  }
+  return false;
 }
 
 export function hasBrowserEvidenceText(text: string): boolean {

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -269,14 +269,14 @@ export async function checkRuntimeHealth(
         } catch {
           count = MAX_UAT_ATTEMPTS + 1;
         }
-        if (count <= MAX_UAT_ATTEMPTS) continue;
+        if (count < MAX_UAT_ATTEMPTS) continue;
 
         issues.push({
           severity: "warning",
           code: "uat_retry_exhausted",
           scope: "slice",
           unitId: `${mid}/${sid}`,
-          message: `run-uat for ${mid}/${sid} exhausted ${count - 1} retry attempt(s) without an ASSESSMENT verdict. Reset the retry counter after fixing the underlying UAT/tool issue, then rerun /gsd auto.`,
+          message: `run-uat for ${mid}/${sid} exhausted ${count} attempt(s) without an ASSESSMENT verdict. Reset the retry counter after fixing the underlying UAT/tool issue, then rerun /gsd auto.`,
           file: `.gsd/runtime/${fileName}`,
           fixable: true,
         });

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -33,6 +33,10 @@ function hasRequiredExtensionAssets(rootDir: string, exists: ExistsFn = existsSy
   );
 }
 
+function isSourceExtensionDir(moduleDir: string): boolean {
+  return moduleDir.replaceAll("\\", "/").endsWith("/src/resources/extensions/gsd");
+}
+
 export function resolveExtensionDirFromCandidates(
   moduleDir: string,
   agentGsdDir: string,
@@ -40,6 +44,10 @@ export function resolveExtensionDirFromCandidates(
 ): string {
   const moduleUsable = hasRequiredExtensionAssets(moduleDir, exists);
   const agentUsable = hasRequiredExtensionAssets(agentGsdDir, exists);
+
+  // Source checkouts must use their own prompt tree. Otherwise local tests and
+  // dev runs can silently render stale prompts from ~/.gsd/agent/extensions/gsd.
+  if (moduleUsable && isSourceExtensionDir(moduleDir)) return moduleDir;
 
   // Prefer the user-local extension tree when both are valid. This avoids
   // leaking npm/global-install paths into prompts on Windows.

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -63,35 +63,51 @@ After running all checks, compute the **overall verdict**:
 - `FAIL` — one or more automatable checks failed
 - `PARTIAL` — one or more automatable checks were skipped or returned inconclusive results (not the same as `NEEDS-HUMAN` — use PARTIAL only when the agent itself could not determine pass/fail for a check it was supposed to automate)
 
-Call `gsd_summary_save` with `milestone_id: "{{milestoneId}}"`, `slice_id: "{{sliceId}}"`, `artifact_type: "ASSESSMENT"`, and the full UAT result markdown as `content`. The tool computes the assessment path, persists to DB/disk, and saves the aggregate UAT gate. The content should follow this logical shape:
+Call `gsd_uat_result_save` exactly once after all checks have been executed. This tool writes the ASSESSMENT artifact, records the UAT attempt, and saves the aggregate UAT gate. Do not call `gsd_summary_save`, `gsd_exec`, or `gsd_save_gate_result` during run-uat; record them as blocked in the `presentation.blockedTools` field.
 
-```markdown
----
-sliceId: {{sliceId}}
-uatType: {{uatType}}
-verdict: PASS | FAIL | PARTIAL
-date: <ISO 8601 timestamp>
----
+Use this argument shape:
 
-# UAT Result — {{sliceId}}
-
-## Checks
-
-| Check | Mode | Result | Notes |
-|-------|------|--------|-------|
-| <check description> | artifact / runtime / human-follow-up | PASS / FAIL / NEEDS-HUMAN | <observed output, evidence, or reason> |
-
-## Overall Verdict
-
-<PASS / FAIL / PARTIAL> — <one sentence summary>
-
-## Notes
-
-<any additional context, errors encountered, screenshots/logs gathered, or manual follow-up still required>
+```json
+{
+  "milestoneId": "{{milestoneId}}",
+  "sliceId": "{{sliceId}}",
+  "uatType": "{{uatType}}",
+  "verdict": "PASS | FAIL | PARTIAL",
+  "checks": [
+    {
+      "id": "UAT-01",
+      "description": "<check description from the UAT file>",
+      "mode": "artifact | runtime | browser | human-follow-up",
+      "result": "PASS | FAIL | NEEDS-HUMAN",
+      "evidence": [
+        { "kind": "gsd_uat_exec", "ref": "<evidence id>", "note": "<short note>" }
+      ],
+      "notes": "<observed output, failure notes, or human instruction>",
+      "nonAutomatable": false
+    }
+  ],
+  "presentation": {
+    "surface": "mcp",
+    "presentedTools": [
+      "gsd_uat_exec",
+      "gsd_uat_result_save",
+      "gsd_resume",
+      "gsd_milestone_status",
+      "gsd_journal_query"
+    ],
+    "blockedTools": [
+      { "name": "gsd_exec", "reason": "forbidden during run-uat" },
+      { "name": "gsd_summary_save", "reason": "forbidden during run-uat" },
+      { "name": "gsd_save_gate_result", "reason": "forbidden during run-uat" }
+    ]
+  },
+  "notes": "<overall verdict rationale>",
+  "attempt": "auto"
+}
 ```
 
 ---
 
-**You MUST call `gsd_summary_save` with `artifact_type: "ASSESSMENT"` and the UAT result content before finishing. Do not write the assessment file directly.**
+**You MUST call `gsd_uat_result_save` before finishing. Do not write the assessment file directly.**
 
 When done, say: "UAT {{sliceId}} complete."

--- a/src/resources/extensions/gsd/tests/browser-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/browser-evidence.test.ts
@@ -101,6 +101,21 @@ describe('hasBrowserRequiredText', () => {
     );
   });
 
+  test('detects browser requirement written only in a heading', () => {
+    // Regression: the line-by-line scan previously skip-continued past headings,
+    // missing browser obligations expressed only in heading text.
+    const text = '## Open browser session at localhost\n';
+    assert.ok(hasBrowserRequiredText(text), 'browser requirement in heading text must be detected');
+  });
+
+  test('heading that opens a non-requirement section is not itself detected as a requirement', () => {
+    const text = '## Not Proven\n\n- Some note.\n';
+    assert.ok(
+      !hasBrowserRequiredText(text),
+      'a non-requirement section heading should not trigger browser detection',
+    );
+  });
+
   test('returns false for empty text', () => {
     assert.ok(!hasBrowserRequiredText(''), 'empty string returns false');
   });

--- a/src/resources/extensions/gsd/tests/browser-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/browser-evidence.test.ts
@@ -1,0 +1,127 @@
+// Project/App: gsd-pi
+// File Purpose: Unit tests for hasBrowserRequiredText heading-depth section guard.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { hasBrowserRequiredText } from '../browser-evidence.ts';
+
+describe('hasBrowserRequiredText', () => {
+  test('detects browser requirement in a plain test-cases section', () => {
+    const text = [
+      '## Test Cases',
+      '',
+      '1. Open index.html in a browser and navigate to /dashboard.',
+      '',
+    ].join('\n');
+    assert.ok(hasBrowserRequiredText(text), 'plain browser step should be detected');
+  });
+
+  test('ignores browser mention under a top-level non-requirement heading', () => {
+    const text = [
+      '## Not Proven',
+      '',
+      '- Keyboard usability through a real browser.',
+      '- Browser console cleanliness.',
+      '',
+    ].join('\n');
+    assert.ok(!hasBrowserRequiredText(text), 'browser mention under "Not Proven" should be ignored');
+  });
+
+  test('sub-heading inside a non-requirement section does not re-enable detection', () => {
+    // BUG (pre-fix): ### sub-heading under ## Not Proven resets inNonRequirementSection
+    // to false, causing subsequent lines to be detected as browser requirements.
+    const text = [
+      '## Not Proven By This UAT',
+      '',
+      '- No live browser session was used.',
+      '',
+      '### Visual Checks',
+      '',
+      '- Browser visual polish deferred to next slice.',
+      '- Keyboard interaction in a real browser is not proven here.',
+      '',
+    ].join('\n');
+    assert.ok(
+      !hasBrowserRequiredText(text),
+      'sub-heading under a non-requirement section must not re-enable browser detection',
+    );
+  });
+
+  test('requirement-level heading after non-requirement section re-enables detection', () => {
+    const text = [
+      '## Not Proven',
+      '',
+      '- Browser polish deferred.',
+      '',
+      '## Test Cases',
+      '',
+      '1. Launch browser and open localhost.',
+      '',
+    ].join('\n');
+    assert.ok(
+      hasBrowserRequiredText(text),
+      'browser step under "Test Cases" (same depth as "Not Proven") must still be detected',
+    );
+  });
+
+  test('deferred sub-heading inside a requirement section scopes exclusion to its own block', () => {
+    const text = [
+      '## Test Cases',
+      '',
+      '1. Open browser at localhost.',
+      '',
+      '### Deferred: keyboard check',
+      '',
+      '- Keyboard UAT deferred to next slice.',
+      '',
+      '### Step 2: Verify DOM',
+      '',
+      '1. Navigate to /dashboard in the browser.',
+      '',
+    ].join('\n');
+    assert.ok(
+      hasBrowserRequiredText(text),
+      'browser step under "Step 2" sub-heading must be detected after a sibling "Deferred" sub-heading',
+    );
+  });
+
+  test('deferred sub-heading at same depth as test cases does not escape to parent', () => {
+    const text = [
+      '## Test Cases',
+      '',
+      '### Deferred: responsive layout',
+      '',
+      '- Responsive layout check is deferred to S02.',
+      '',
+    ].join('\n');
+    assert.ok(
+      !hasBrowserRequiredText(text),
+      'content under a "Deferred" sub-heading should be excluded from detection',
+    );
+  });
+
+  test('returns false for empty text', () => {
+    assert.ok(!hasBrowserRequiredText(''), 'empty string returns false');
+  });
+
+  test('notes-for-tester heading with sub-headings stays non-requirement', () => {
+    const text = [
+      '## Notes for Tester',
+      '',
+      '### Browser Setup',
+      '',
+      '- Run this spec without a browser; a DOM harness is sufficient.',
+      '- Browser-based visual checks are deferred.',
+      '',
+      '### Follow-up Items',
+      '',
+      '- Track browser session evidence in S02.',
+      '',
+    ].join('\n');
+    assert.ok(
+      !hasBrowserRequiredText(text),
+      'sub-headings under "Notes for Tester" should not re-enable browser detection',
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
@@ -45,3 +45,30 @@ test("doctor fix respects git.manage_gitignore false (#4161)", async (t) => {
   assert.equal(readFileSync(join(dir, ".gitignore"), "utf-8"), "node_modules/\n");
   assert.equal(existsSync(join(dir, ".gsd", "PREFERENCES.md")), true);
 });
+
+test("doctor fix resets run-uat counters at the dispatch cap", async (t) => {
+  const dir = createGitProject();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const runtimeDir = join(dir, ".gsd", "runtime");
+  mkdirSync(runtimeDir, { recursive: true });
+  const counterPath = join(runtimeDir, "uat-count-M002-S01.json");
+  writeFileSync(
+    counterPath,
+    JSON.stringify({ count: 3, updatedAt: "2026-06-02T19:40:23.289Z" }) + "\n",
+    "utf-8",
+  );
+
+  const detect = await runGSDDoctor(dir);
+  const issue = detect.issues.find((candidate) => candidate.code === "uat_retry_exhausted");
+  assert.ok(issue, "doctor reports the exhausted UAT retry counter at the dispatch cap");
+  assert.equal(issue.unitId, "M002/S01");
+  assert.match(issue.message, /3 attempt\(s\)/);
+
+  const fixed = await runGSDDoctor(dir, { fix: true, scope: "M002/S02" });
+  assert.ok(
+    fixed.fixesApplied.some((fix) => fix.includes("reset exhausted run-uat retry counter for M002/S01")),
+    "doctor --fix resets the blocked counter even when the current displayed scope has advanced",
+  );
+  assert.equal(existsSync(counterPath), false);
+});

--- a/src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts
@@ -119,8 +119,8 @@ test("resolveExpectedArtifactPath returns correct path for all slice-level types
 // ─── run-uat artifact path contract (#2873) ──────────────────────────────
 
 test("resolveExpectedArtifactPath for run-uat returns ASSESSMENT path, not UAT (#2873)", (t) => {
-  // The run-uat prompt instructs the agent to call gsd_summary_save with
-  // artifact_type: "ASSESSMENT", which writes S##-ASSESSMENT.md. The artifact
+  // The run-uat prompt instructs the agent to call gsd_uat_result_save, which
+  // writes S##-ASSESSMENT.md through the workflow persistence path. The artifact
   // verification path must match — otherwise verification fails and auto-mode
   // retries the unit in an infinite loop.
   const base = makeTmpBase();
@@ -147,12 +147,12 @@ test("diagnoseExpectedArtifact for run-uat references ASSESSMENT (#2873)", (t) =
 });
 
 test("verifyExpectedArtifact passes for run-uat when ASSESSMENT file exists (#2873)", (t) => {
-  // Regression test: run-uat writes S##-ASSESSMENT.md via gsd_summary_save,
+  // Regression test: run-uat writes S##-ASSESSMENT.md via gsd_uat_result_save,
   // but verification looked for S##-UAT.md, causing false stuck retries.
   const base = makeTmpBase();
   t.after(() => cleanup(base));
 
-  // Write the ASSESSMENT file (what gsd_summary_save actually produces)
+  // Write the ASSESSMENT file (what gsd_uat_result_save actually produces)
   const assessPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-ASSESSMENT.md");
   writeFileSync(assessPath, "---\nverdict: PASS\n---\n# UAT Assessment\n");
 

--- a/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
@@ -264,8 +264,8 @@ test('(k) run-uat prompt template', () => {
     `prompt contains detected dynamic uatType value "${uatType}" after substitution`,
   );
   assert.ok(
-    promptResult?.includes(`uatType: ${uatType}`) ?? false,
-    `prompt contains dynamic uatType frontmatter value "${uatType}" after substitution`,
+    promptResult?.includes(`"uatType": "${uatType}"`) ?? false,
+    `prompt contains dynamic uatType call argument value "${uatType}" after substitution`,
   );
   assert.ok(
     !/\{\{[^}]+\}\}/.test(promptResult ?? ''),
@@ -281,7 +281,7 @@ test('(k) run-uat prompt template', () => {
   );
 });
 
-test('(k2) run-uat prompt references gsd_summary_save, not direct write', () => {
+test('(k2) run-uat prompt references gsd_uat_result_save, not direct write', () => {
   const promptResult = loadPromptFromWorktree('run-uat', {
     workingDirectory: '/tmp/test-project',
     milestoneId: 'M001',
@@ -293,12 +293,16 @@ test('(k2) run-uat prompt references gsd_summary_save, not direct write', () => 
   });
 
   assert.ok(
-    promptResult.includes('gsd_summary_save'),
-    'run-uat prompt should reference gsd_summary_save tool',
+    promptResult.includes('gsd_uat_result_save'),
+    'run-uat prompt should reference gsd_uat_result_save tool',
   );
   assert.ok(
-    promptResult.includes('artifact_type: "ASSESSMENT"'),
-    'run-uat prompt should specify ASSESSMENT artifact type',
+    promptResult.includes('"presentedTools"') && promptResult.includes('"blockedTools"'),
+    'run-uat prompt should specify the tool presentation contract',
+  );
+  assert.ok(
+    !promptResult.includes('Call `gsd_summary_save`'),
+    'run-uat prompt should not instruct direct summary-save UAT persistence',
   );
   assert.ok(
     !promptResult.includes('MUST write'),
@@ -515,7 +519,7 @@ test('(n) stale replay guard', async () => {
 
 test('(q) verdict in ASSESSMENT file skips UAT dispatch (file-based path)', async () => {
     // Regression test for #2644: run-uat prompt writes the verdict to
-    // S{sid}-ASSESSMENT.md (via gsd_summary_save artifact_type:"ASSESSMENT"),
+    // S{sid}-ASSESSMENT.md (via gsd_uat_result_save),
     // but checkNeedsRunUat only checked S{sid}-UAT.md — causing a stuck loop.
     const base = createFixtureBase();
     try {
@@ -711,7 +715,7 @@ test('(u) run-uat prompt promotes artifact-driven browser specs to browser-execu
       const prompt = await buildRunUatPrompt('M001', 'S01', uatRel, uatContent, base);
 
       assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`browser-executable`/);
-      assert.match(prompt, /uatType: browser-executable/);
+      assert.match(prompt, /"uatType": "browser-executable"/);
       assert.match(prompt, /use gsd-browser tools/i);
     } finally {
       cleanup(base);
@@ -728,8 +732,8 @@ test('(v) run-uat prompt keeps deferred browser work artifact-driven', async () 
       const prompt = await buildRunUatPrompt('M001', 'S01', uatRel, uatContent, base);
 
       assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`artifact-driven`/);
-      assert.match(prompt, /uatType: artifact-driven/);
-      assert.doesNotMatch(prompt, /uatType: browser-executable/);
+      assert.match(prompt, /"uatType": "artifact-driven"/);
+      assert.doesNotMatch(prompt, /"uatType": "browser-executable"/);
     } finally {
       cleanup(base);
     }

--- a/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
@@ -72,6 +72,38 @@ function makeBrowserObservableUatContent(mode = 'artifact-driven'): string {
   ].join('\n');
 }
 
+function makeDeferredBrowserUatContent(): string {
+  return [
+    '# UAT File',
+    '',
+    '## UAT Type',
+    '',
+    '- UAT mode: artifact-driven',
+    '- Why this mode is sufficient: Node interaction tests exercise the real app.js render/event/localStorage loop through a DOM harness. Live browser, keyboard, responsive, and visual-polish UAT remain intentionally deferred to S02.',
+    '',
+    '## Smoke Test',
+    '',
+    'Run `node --test tests/s01-static-interactions.test.js` and confirm all tests pass.',
+    '',
+    '## Test Cases',
+    '',
+    '1. Click the todo row edit control in the DOM harness.',
+    '2. Save changed text and reload/recreate the app from persisted localStorage.',
+    '3. Expected: the stored record shape remains unchanged.',
+    '',
+    '## Not Proven By This UAT',
+    '',
+    '- Final visual polish of edit controls.',
+    '- Keyboard usability through a real browser.',
+    '- Browser console and local network cleanliness.',
+    '',
+    '## Notes for Tester',
+    '',
+    'S02 should capture browser evidence for the full loop rather than changing this persisted model.',
+    '',
+  ].join('\n');
+}
+
 describe('run-uat', () => {
 test('(a) artifact-driven', () => {
   assert.deepStrictEqual(
@@ -681,6 +713,23 @@ test('(u) run-uat prompt promotes artifact-driven browser specs to browser-execu
       assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`browser-executable`/);
       assert.match(prompt, /uatType: browser-executable/);
       assert.match(prompt, /use gsd-browser tools/i);
+    } finally {
+      cleanup(base);
+    }
+});
+
+test('(v) run-uat prompt keeps deferred browser work artifact-driven', async () => {
+    const base = createFixtureBase();
+    try {
+      const uatRel = '.gsd/milestones/M001/slices/S01/S01-UAT.md';
+      const uatContent = makeDeferredBrowserUatContent();
+      writeSliceFile(base, 'M001', 'S01', 'UAT', uatContent);
+
+      const prompt = await buildRunUatPrompt('M001', 'S01', uatRel, uatContent, base);
+
+      assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`artifact-driven`/);
+      assert.match(prompt, /uatType: artifact-driven/);
+      assert.doesNotMatch(prompt, /uatType: browser-executable/);
     } finally {
       cleanup(base);
     }

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -25,11 +25,15 @@ test("reactive-execute prompt keeps task summaries with subagents and avoids bat
 test("run-uat prompt branches on dynamic UAT mode and supports runtime evidence", () => {
   const prompt = readPrompt("run-uat");
   assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`\{\{uatType\}\}`/);
-  assert.match(prompt, /uatType:\s*\{\{uatType\}\}/);
+  assert.match(prompt, /"uatType":\s*"\{\{uatType\}\}"/);
+  assert.match(prompt, /gsd_uat_result_save/);
+  assert.match(prompt, /presentedTools/);
+  assert.match(prompt, /blockedTools/);
   assert.match(prompt, /live-runtime/);
   assert.match(prompt, /browser\/runtime\/network/i);
   assert.match(prompt, /NEEDS-HUMAN/);
   assert.doesNotMatch(prompt, /uatType:\s*artifact-driven/);
+  assert.doesNotMatch(prompt, /Call `gsd_summary_save`/);
 });
 
 test("run-uat prompt lists canonical gsd_uat_exec intent values", () => {

--- a/src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts
@@ -22,6 +22,20 @@ test("resolveExtensionDirFromCandidates prefers user-local dir when both trees a
   assert.equal(resolved, agentDir);
 });
 
+test("resolveExtensionDirFromCandidates prefers source checkout dir when both trees are valid", () => {
+  const moduleDir = "/repo/src/resources/extensions/gsd";
+  const agentDir = "/home/user/.gsd/agent/extensions/gsd";
+  const paths = new Set<string>([
+    join(moduleDir, "prompts"),
+    join(moduleDir, "templates", "task-summary.md"),
+    join(agentDir, "prompts"),
+    join(agentDir, "templates", "task-summary.md"),
+  ]);
+
+  const resolved = resolveExtensionDirFromCandidates(moduleDir, agentDir, makeExists(paths));
+  assert.equal(resolved, moduleDir);
+});
+
 test("resolveExtensionDirFromCandidates rejects module dir missing task-summary template", () => {
   const moduleDir = "/npm/global/gsd";
   const agentDir = "/home/user/.gsd/agent/extensions/gsd";

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -643,6 +643,86 @@ test("executeUatResultSave accepts gsd_uat_exec evidence written in a milestone 
   }
 });
 
+test("executeUatResultSave allows artifact-driven PASS with explicitly non-automatable follow-up checks", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const evidenceId = "uat-artifact-nonautomatable";
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S01", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: {
+          kind: "uat_exec",
+          milestoneId: "M001",
+          sliceId: "S01",
+          checkId: "UAT-01",
+          intent: "uat-artifact-check",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S01",
+      uatType: "artifact-driven",
+      verdict: "PASS",
+      checks: [
+        {
+          id: "UAT-01",
+          description: "Static contract passes",
+          mode: "artifact",
+          result: "PASS",
+          evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
+          notes: "Artifact check passed.",
+        },
+        {
+          id: "UAT-02",
+          description: "Browser polish is deferred to the next slice",
+          mode: "human-follow-up",
+          result: "NEEDS-HUMAN",
+          notes: "Out of scope for this artifact-driven UAT.",
+          nonAutomatable: true,
+        },
+      ],
+      presentation: {
+        surface: "mcp",
+        presentedTools: [
+          "gsd_uat_exec",
+          "gsd_uat_result_save",
+          "gsd_resume",
+          "gsd_milestone_status",
+          "gsd_journal_query",
+        ],
+        blockedTools: [
+          { name: "gsd_exec", reason: "forbidden during run-uat" },
+          { name: "gsd_summary_save", reason: "forbidden during run-uat" },
+          { name: "gsd_save_gate_result", reason: "forbidden during run-uat" },
+        ],
+      },
+      notes: "UAT passed; non-automatable browser polish is deferred.",
+    }, worktree));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.operation, "save_uat_result");
+    assert.equal(result.details.verdict, "PASS");
+    const assessment = readFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-ASSESSMENT.md"),
+      "utf-8",
+    );
+    assert.match(assessment, /Browser polish is deferred/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeSliceComplete coerces string enrichment entries and writes summary/UAT artifacts", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1167,7 +1167,12 @@ function validateUatMode(params: UatResultSaveParams): string | null {
   if (params.uatType === "live-runtime" && !modes.has("runtime") && !modes.has("browser")) {
     return "live-runtime UAT requires runtime or browser evidence";
   }
-  if (params.uatType === "artifact-driven" && hasHuman && params.verdict === "PASS") {
+  if (
+    params.uatType === "artifact-driven" &&
+    hasHuman &&
+    params.verdict === "PASS" &&
+    !params.checks.every((check) => check.result !== "NEEDS-HUMAN" || check.nonAutomatable === true)
+  ) {
     return "artifact-driven UAT cannot PASS with human-only checks";
   }
   return null;


### PR DESCRIPTION
## TL;DR

**What:** Fixes run-uat recovery by resetting retry counters at the actual cap and aligning UAT result persistence with `gsd_uat_result_save`.
**Why:** UAT could remain stuck after three failed attempts, and the run-uat prompt could ask for forbidden or missing tools during result save.
**How:** Updates doctor retry detection, tightens browser-UAT mode promotion, refreshes the run-uat prompt/presentation contract, and keeps source checkout prompt loading from using stale user-local prompt files.

## What

This updates the bundled GSD extension UAT path:

- Resets retry counters when they reach the dispatch cap of three attempts.
- Keeps artifact-driven browser-deferred specs artifact-driven while promoting truly browser-observable specs to browser-executable.
- Tells run-uat agents to save assessments with `gsd_uat_result_save`, including the expected presented and blocked tool lists.
- Allows artifact-driven PASS results when remaining human follow-up checks are explicitly marked non-automatable.
- Prefers the checked-out source prompt tree during source checkout runs so tests and dev runs do not render stale `~/.gsd` prompt copies.

## Why

The previous doctor recommendation did not fix the blocked state because the retry counter diagnosis only fired above the cap, while dispatch stops at the cap. Separately, the UAT result-save prompt still described the older `gsd_summary_save` path, which conflicted with current run-uat tool presentation validation and caused repeated save attempts to fail before the model corrected itself.

## How

The retry-cap check now matches dispatch behavior. The run-uat prompt now provides the structured `gsd_uat_result_save` payload shape and records forbidden tools as blocked. The UAT result validator keeps rejecting ordinary human-only PASS claims for artifact-driven UAT, but accepts explicitly non-automatable follow-up checks. Tests cover the retry-cap doctor fix, browser-mode classification, prompt contracts, source prompt resolution, and the non-automatable follow-up result-save case.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/run-uat.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts`
- `pnpm exec tsc --noEmit`
- `bash scripts/ci-fast-gates.sh`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes UAT dispatch classification, doctor retry reset thresholds, and run-uat persistence/validation paths that affect auto-mode loops; scope is extension workflow logic rather than app auth or payments.
> 
> **Overview**
> Fixes **run-uat** getting stuck after retries and misclassifying deferred browser work as **browser-executable**.
> 
> **Doctor / auto recovery:** Exhausted UAT retry counters are reported and reset when the count reaches the **dispatch cap** (was only above the cap), with messaging that matches actual attempt counts. Auto-dispatch still treats verdicts in **ASSESSMENT** as completion, now documented against **`gsd_uat_result_save`** instead of **`gsd_summary_save`**.
> 
> **Browser UAT mode:** **`hasBrowserRequiredText`** scans markdown by section—ignores headings like “Not proven”, “Deferred”, and “Notes for tester”, and keeps sub-headings from re-opening detection—so artifact-driven specs that defer live browser work stay **artifact-driven**. Requirement regex is tightened toward real browser/runtime signals.
> 
> **Run-uat agent contract:** The prompt requires a single **`gsd_uat_result_save`** call with structured checks and **`presentation`** (presented vs blocked tools); **`gsd_summary_save`** / **`gsd_exec`** / **`gsd_save_gate_result`** are forbidden during UAT. Validation allows **artifact-driven PASS** when remaining **NEEDS-HUMAN** checks are explicitly **`nonAutomatable`**.
> 
> **Dev ergonomics:** Source checkouts under **`src/resources/extensions/gsd`** load prompts from the repo tree, not stale **`~/.gsd`** copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99121bac8f99017ff99757a3c1087589def9d763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->