### PR TITLE
Fix threshold compaction context estimate

### DIFF
--- a/packages/gsd-agent-core/src/compaction-threshold.test.ts
+++ b/packages/gsd-agent-core/src/compaction-threshold.test.ts
@@ -3,8 +3,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { AgentMessage } from "@gsd/pi-agent-core";
+import type { AssistantMessage } from "@gsd/pi-ai";
 import { shouldCompact, type CompactionSettings } from "./compaction/compaction.js";
 import { SettingsManager } from "@gsd/pi-coding-agent/core/settings-manager.js";
+import { resolveThresholdContextTokens } from "./session/agent-session-compaction.js";
 
 const REGISTRY_DEFAULTS: CompactionSettings = {
 	enabled: true,
@@ -117,5 +120,42 @@ describe("end-to-end — getCompactionSettings + shouldCompact (#5475)", () => {
 		assert.equal(shouldCompact(140_001, 200_000, settings), true);
 		// Pre-fix behavior would have required 183_617 — verify we no longer wait that long
 		assert.equal(shouldCompact(150_000, 200_000, settings), true);
+	});
+
+	it("uses the footer-style context estimate when trailing messages exceed the threshold", () => {
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "read result" }],
+			api: "faux",
+			provider: "faux",
+			model: "faux-context",
+			usage: {
+				input: 100_000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 100_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const messages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "inspect a large result" }], timestamp: Date.now() - 1 },
+			assistant,
+			{
+				role: "toolResult",
+				toolCallId: "tool-1",
+				toolName: "read",
+				content: [{ type: "text", text: "x".repeat(100_000) }],
+				timestamp: Date.now() + 1,
+			},
+		];
+
+		const tokens = resolveThresholdContextTokens(assistant, messages);
+
+		assert.equal(tokens, 125_000);
+		assert.equal(shouldCompact(tokens, 200_000, { ...REGISTRY_DEFAULTS, thresholdPercent: 0.6 }), true);
+		assert.equal(shouldCompact(assistant.usage.input, 200_000, { ...REGISTRY_DEFAULTS, thresholdPercent: 0.6 }), false);
 	});
 });

--- a/packages/gsd-agent-core/src/session/agent-session-compaction.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-compaction.ts
@@ -4,6 +4,7 @@ import { formatNoModelSelectedMessage } from "@gsd/pi-coding-agent/core/auth-gui
 import type { CompactionEntry } from "@gsd/pi-coding-agent/core/session-manager.js";
 import { getLatestCompactionEntry } from "@gsd/pi-coding-agent/core/session-manager.js";
 import type { SessionBeforeCompactResult } from "@gsd/pi-coding-agent/core/extensions/index.js";
+import type { AgentMessage } from "@gsd/pi-agent-core";
 import {
 	type CompactionResult,
 	calculateContextTokens,
@@ -13,6 +14,11 @@ import {
 	shouldCompact,
 } from "../compaction/index.js";
 import type { AgentSessionHost } from "./agent-session-host.js";
+
+export function resolveThresholdContextTokens(assistantMessage: AssistantMessage, messages: AgentMessage[]): number {
+	const estimate = estimateContextTokens(messages);
+	return Math.max(calculateContextTokens(assistantMessage.usage), estimate.tokens);
+}
 
 export class AgentSessionCompactionModule {
 	constructor(readonly host: AgentSessionHost) {}
@@ -208,7 +214,9 @@ export class AgentSessionCompactionModule {
 			return await this.runAutoCompaction("overflow", true);
 		}
 
-		// Case 2: Threshold - context is getting large
+		// Case 2: Threshold - context is getting large.
+		// Use the same session estimate as the footer so trailing tool/custom
+		// messages after the last provider usage can still trigger compaction.
 		// For error messages (no usage data), estimate from last successful response.
 		// This ensures sessions that hit persistent API errors (e.g. 529) can still compact.
 		let contextTokens: number;
@@ -229,7 +237,7 @@ export class AgentSessionCompactionModule {
 			}
 			contextTokens = estimate.tokens;
 		} else {
-			contextTokens = calculateContextTokens(assistantMessage.usage);
+			contextTokens = resolveThresholdContextTokens(assistantMessage, this.host.agent.state.messages);
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			return await this.runAutoCompaction("threshold", false);


### PR DESCRIPTION
## TL;DR

**What:** Align threshold auto-compaction with the same session context estimate used by the footer.
**Why:** The footer could show the session over the configured threshold while the compaction check only saw the last assistant usage and skipped compaction.
**How:** Compare the last assistant usage with the full session estimate and use the larger value for threshold decisions, with a regression test for trailing tool output.

## What

This updates `AgentSessionCompactionModule` so non-error threshold checks account for trailing session messages after the last provider usage. It also adds a regression test in the compaction threshold suite covering a session where the assistant usage is below threshold but a trailing tool result pushes the estimated context above threshold.

## Why

The context footer uses the full session estimate, but threshold compaction previously used only `calculateContextTokens(assistantMessage.usage)` for successful assistant responses. When large tool/custom output followed that assistant usage, the UI could report context above the threshold while auto-compaction did not trigger.

## How

The compaction module now resolves threshold context tokens by taking the maximum of provider usage and the session-wide estimate. That keeps the provider usage path intact while allowing trailing tool/custom messages to trip the same threshold the footer reports.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `pnpm --filter @gsd/agent-core run test -- src/compaction-threshold.test.ts`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783048934&installation_id=134682257&pr_number=444&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F444&signature=b7344297a32245a746109f37bda01056808a6a61d1823d5abd01040246a94260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to when threshold compaction runs; uses existing estimation helpers and adds a regression test.
> 
> **Overview**
> **Threshold auto-compaction** now uses the same context size the session footer shows, instead of only the last assistant’s provider usage.
> 
> For successful assistant turns, `checkCompaction` resolves context via **`resolveThresholdContextTokens`**: the **maximum** of provider usage and the full-session **`estimateContextTokens`** result. That way **trailing tool/custom messages** after the last usage can trigger compaction when the footer already reports you’re over the configured threshold.
> 
> A **regression test** covers the mismatch: assistant usage below threshold, but a large trailing tool result pushes the estimate over—compaction should fire on the combined estimate, not on usage alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daee0bd1dc9c709480248f8cf8aa4022701eb366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->