### PR TITLE
fix(gsd): block failed post-unit hook completion

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -55,6 +55,7 @@ import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
 import { consumeSignal } from "./session-status-io.js";
 import {
   checkPostUnitHooks,
+  consumeHookFailure,
   isRetryPending,
   consumeRetryTrigger,
   persistHookState,
@@ -2238,6 +2239,16 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
         { kind: "hook", unitType: hookUnit.unitType, unitId: hookUnit.unitId, prompt: hookUnit.prompt, model: hookUnit.model },
         { hookName: hookUnit.hookName },
       );
+    }
+
+    const hookFailure = consumeHookFailure();
+    if (hookFailure) {
+      ctx.ui.notify(
+        `Post-unit hook ${hookFailure.hookName} failed for ${hookFailure.unitId}: ${hookFailure.reason}. Pausing auto-mode.`,
+        "warning",
+      );
+      await pauseAuto(ctx, pi);
+      return "stopped";
     }
 
     // Check if a hook requested a retry of the trigger unit

--- a/src/resources/extensions/gsd/post-unit-hooks.ts
+++ b/src/resources/extensions/gsd/post-unit-hooks.ts
@@ -37,6 +37,10 @@ export function consumeRetryTrigger(): { unitType: string; unitId: string; retry
   return getOrCreateRegistry().consumeRetryTrigger();
 }
 
+export function consumeHookFailure(): { hookName: string; unitType: string; unitId: string; reason: string } | null {
+  return getOrCreateRegistry().consumeHookFailure();
+}
+
 export function resetHookState(): void {
   getOrCreateRegistry().resetState();
 }

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -22,6 +22,8 @@ import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js"
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
+import { queryJournal, type JournalEntry } from "./journal.js";
+import { readUnitRuntimeRecord, type UnitRuntimePhase } from "./unit-runtime.js";
 
 // ─── Artifact Path Resolution ──────────────────────────────────────────────
 
@@ -56,6 +58,24 @@ export function convertDispatchRules(rules: DispatchRule[]): UnifiedRule[] {
 // ─── RuleRegistry ─────────────────────────────────────────────────────────
 
 const HOOK_STATE_FILE = "hook-state.json";
+const FAILED_HOOK_RUNTIME_PHASES: ReadonlySet<UnitRuntimePhase> = new Set([
+  "timeout",
+  "finalize-timeout",
+  "crashed",
+  "paused",
+]);
+
+interface HookFailureState {
+  hookName: string;
+  unitType: string;
+  unitId: string;
+  reason: string;
+}
+
+type HookCompletionAssessment =
+  | { outcome: "success" }
+  | { outcome: "failed"; reason: string }
+  | { outcome: "unknown" };
 
 export class RuleRegistry {
   /** Static dispatch rules provided at construction time. */
@@ -72,6 +92,7 @@ export class RuleRegistry {
   cycleCounts: Map<string, number> = new Map();
   retryPending: boolean = false;
   retryTrigger: { unitType: string; unitId: string; retryArtifact: string } | null = null;
+  hookFailure: HookFailureState | null = null;
 
   constructor(dispatchRules: UnifiedRule[]) {
     this.dispatchRules = dispatchRules;
@@ -192,42 +213,28 @@ export class RuleRegistry {
       // Check idempotency — if artifact already exists, skip
       if (config.artifact) {
         const artifactPath = resolveHookArtifactPath(basePath, triggerUnitId, config.artifact);
-        if (existsSync(artifactPath)) continue;
+        if (existsSync(artifactPath)) {
+          const completion = this._assessConfiguredHookCompletion(basePath, config.name, triggerUnitId);
+          if (completion.outcome === "failed") {
+            return this._handleFailedHookCompletion(
+              basePath,
+              {
+                hookName: config.name,
+                triggerUnitType,
+                triggerUnitId,
+                cycle: this.cycleCounts.get(`${config.name}/${triggerUnitType}/${triggerUnitId}`) ?? 0,
+                pendingRetry: false,
+              },
+              config,
+              completion.reason,
+            );
+          }
+          continue;
+        }
       }
 
-      // Check cycle limit
-      const cycleKey = `${config.name}/${triggerUnitType}/${triggerUnitId}`;
-      const currentCycle = (this.cycleCounts.get(cycleKey) ?? 0) + 1;
-      const maxCycles = config.max_cycles ?? 1;
-      if (currentCycle > maxCycles) continue;
-
-      this.cycleCounts.set(cycleKey, currentCycle);
-
-      this.activeHook = {
-        hookName: config.name,
-        triggerUnitType,
-        triggerUnitId,
-        cycle: currentCycle,
-        pendingRetry: false,
-      };
-
-      // Build prompt with variable substitution
-      const { milestone: mid, slice: sid, task: tid } = parseUnitId(triggerUnitId);
-      let prompt = config.prompt
-        .replace(/\{milestoneId\}/g, mid ?? "")
-        .replace(/\{sliceId\}/g, sid ?? "")
-        .replace(/\{taskId\}/g, tid ?? "");
-
-      // Inject browser safety instruction
-      prompt += "\n\n**Browser tool safety:** Do NOT use `browser_wait_for` with `condition: \"network_idle\"` — it hangs indefinitely when dev servers keep persistent connections (Vite HMR, WebSocket). Use `selector_visible`, `text_visible`, or `delay` instead.";
-
-      return {
-        hookName: config.name,
-        prompt,
-        model: config.model,
-        unitType: `hook/${config.name}`,
-        unitId: triggerUnitId,
-      };
+      const dispatch = this._startHook(config, triggerUnitType, triggerUnitId);
+      if (dispatch) return dispatch;
     }
 
     // No more hooks — clear active state
@@ -239,6 +246,11 @@ export class RuleRegistry {
     const hook = this.activeHook!;
     const hooks = resolvePostUnitHooks(basePath);
     const config = hooks.find(h => h.name === hook.hookName);
+
+    const completion = this._assessHookCompletion(basePath, hook);
+    if (completion.outcome === "failed") {
+      return this._handleFailedHookCompletion(basePath, hook, config, completion.reason);
+    }
 
     // Check if retry was requested via retry_on artifact
     if (config?.retry_on) {
@@ -265,6 +277,129 @@ export class RuleRegistry {
     // Hook completed normally — try next hook in queue
     this.activeHook = null;
     return this._dequeueNextHook(basePath);
+  }
+
+  private _startHook(
+    config: PostUnitHookConfig,
+    triggerUnitType: string,
+    triggerUnitId: string,
+  ): HookDispatchResult | null {
+    const cycleKey = `${config.name}/${triggerUnitType}/${triggerUnitId}`;
+    const currentCycle = (this.cycleCounts.get(cycleKey) ?? 0) + 1;
+    const maxCycles = config.max_cycles ?? 1;
+    if (currentCycle > maxCycles) return null;
+
+    this.cycleCounts.set(cycleKey, currentCycle);
+
+    this.activeHook = {
+      hookName: config.name,
+      triggerUnitType,
+      triggerUnitId,
+      cycle: currentCycle,
+      pendingRetry: false,
+    };
+
+    const { milestone: mid, slice: sid, task: tid } = parseUnitId(triggerUnitId);
+    let prompt = config.prompt
+      .replace(/\{milestoneId\}/g, mid ?? "")
+      .replace(/\{sliceId\}/g, sid ?? "")
+      .replace(/\{taskId\}/g, tid ?? "");
+
+    prompt += "\n\n**Browser tool safety:** Do NOT use `browser_wait_for` with `condition: \"network_idle\"` — it hangs indefinitely when dev servers keep persistent connections (Vite HMR, WebSocket). Use `selector_visible`, `text_visible`, or `delay` instead.";
+
+    return {
+      hookName: config.name,
+      prompt,
+      model: config.model,
+      unitType: `hook/${config.name}`,
+      unitId: triggerUnitId,
+    };
+  }
+
+  private _assessHookCompletion(
+    basePath: string,
+    hook: HookExecutionState,
+  ): HookCompletionAssessment {
+    return this._assessConfiguredHookCompletion(basePath, hook.hookName, hook.triggerUnitId);
+  }
+
+  private _assessConfiguredHookCompletion(
+    basePath: string,
+    hookName: string,
+    unitId: string,
+  ): HookCompletionAssessment {
+    const unitType = `hook/${hookName}`;
+    const latestUnitEnd = this._latestHookUnitEnd(basePath, unitType, unitId);
+    if (latestUnitEnd) {
+      const data = latestUnitEnd.data ?? {};
+      const status = data.status;
+      const artifactVerified = data.artifactVerified;
+      if (status === "completed" && artifactVerified !== false) {
+        return { outcome: "success" };
+      }
+      return {
+        outcome: "failed",
+        reason: this._formatHookFailureReason(status, artifactVerified, data.errorContext),
+      };
+    }
+
+    const runtime = readUnitRuntimeRecord(basePath, unitType, unitId);
+    if (runtime && FAILED_HOOK_RUNTIME_PHASES.has(runtime.phase)) {
+      return { outcome: "failed", reason: `runtime phase ${runtime.phase}` };
+    }
+
+    return { outcome: "unknown" };
+  }
+
+  private _latestHookUnitEnd(
+    basePath: string,
+    unitType: string,
+    unitId: string,
+  ): JournalEntry | null {
+    const unitEnds = queryJournal(basePath, { eventType: "unit-end", unitId })
+      .filter(entry => entry.data?.unitType === unitType);
+    return unitEnds[unitEnds.length - 1] ?? null;
+  }
+
+  private _formatHookFailureReason(
+    status: unknown,
+    artifactVerified: unknown,
+    errorContext: unknown,
+  ): string {
+    const parts = [`status ${typeof status === "string" ? status : "unknown"}`];
+    if (artifactVerified === false) {
+      parts.push("artifact not verified");
+    }
+    if (typeof errorContext === "object" && errorContext !== null && "message" in errorContext) {
+      const message = (errorContext as { message?: unknown }).message;
+      if (typeof message === "string" && message.length > 0) {
+        parts.push(message);
+      }
+    }
+    return parts.join("; ");
+  }
+
+  private _handleFailedHookCompletion(
+    basePath: string,
+    hook: HookExecutionState,
+    config: PostUnitHookConfig | undefined,
+    reason: string,
+  ): HookDispatchResult | null {
+    if (config) {
+      const retry = this._startHook(config, hook.triggerUnitType, hook.triggerUnitId);
+      if (retry) return retry;
+    }
+
+    this.hookFailure = {
+      hookName: hook.hookName,
+      unitType: `hook/${hook.hookName}`,
+      unitId: hook.triggerUnitId,
+      reason,
+    };
+    this.activeHook = null;
+    this.hookQueue = [];
+    this.persistState(basePath);
+    return null;
   }
 
   // ── Pre-dispatch hook evaluation (sync, all-matching with compose) ──
@@ -351,6 +486,13 @@ export class RuleRegistry {
     return this.retryPending;
   }
 
+  consumeHookFailure(): HookFailureState | null {
+    if (!this.hookFailure) return null;
+    const failure = { ...this.hookFailure };
+    this.hookFailure = null;
+    return failure;
+  }
+
   /**
    * Returns the trigger unit info for a pending retry, or null.
    * Clears the retry state after reading.
@@ -370,6 +512,7 @@ export class RuleRegistry {
     this.cycleCounts.clear();
     this.retryPending = false;
     this.retryTrigger = null;
+    this.hookFailure = null;
   }
 
   // ── Persistence ─────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
@@ -8,6 +8,7 @@ import { mock } from "node:test";
 import { postUnitPostVerification, type PostUnitContext } from "../auto-post-unit.ts";
 import { AutoSession } from "../auto/session.ts";
 import { checkPostUnitHooks, resetHookState, resolveHookArtifactPath } from "../post-unit-hooks.ts";
+import { emitJournalEvent } from "../journal.ts";
 import { _clearGsdRootCache } from "../paths.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
@@ -22,6 +23,26 @@ post_unit_hooks:
     artifact: REVIEW-DEBATE.md
     retry_on: NEEDS-REWORK.md
     max_cycles: 3
+    enabled: true
+---
+`;
+  writeFileSync(join(basePath, ".gsd", "PREFERENCES.md"), content, "utf-8");
+}
+
+function writeFailingHookPreferences(basePath: string): void {
+  const content = `---
+post_unit_hooks:
+  - name: review-arbiter
+    after:
+      - execute-task
+    prompt: Review {taskId}
+    artifact: REVIEW-DEBATE.md
+    max_cycles: 1
+    enabled: true
+  - name: follow-up-review
+    after:
+      - execute-task
+    prompt: Follow-up review {taskId}
     enabled: true
 ---
 `;
@@ -83,6 +104,79 @@ test("post-unit retry_on marks trigger unit as retry in orchestrator before redi
       unitType: "execute-task",
       unitId: "M001/S01/T01",
     });
+  } finally {
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("failed post-unit hook pauses auto-mode even when its artifact exists", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-hook-failed-"));
+  const taskDir = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+  mkdirSync(taskDir, { recursive: true });
+
+  try {
+    process.chdir(base);
+    _clearGsdRootCache();
+    invalidateAllCaches();
+    resetHookState();
+    writeFailingHookPreferences(base);
+
+    const hookDispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.equal(hookDispatch?.hookName, "review-arbiter");
+
+    const artifactPath = resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW-DEBATE.md");
+    writeFileSync(artifactPath, "partial review", "utf-8");
+    emitJournalEvent(base, {
+      ts: "2026-06-03T12:00:00.000Z",
+      flowId: "flow-hook-failed",
+      seq: 3,
+      eventType: "unit-end",
+      data: {
+        unitType: "hook/review-arbiter",
+        unitId: "M001/S01/T01",
+        status: "cancelled",
+        artifactVerified: false,
+      },
+    });
+
+    const pauseAuto = mock.fn(async () => {});
+    const notifications: string[] = [];
+    const s = new AutoSession();
+    s.basePath = base;
+    s.active = true;
+    s.currentUnit = { type: "hook/review-arbiter", id: "M001/S01/T01", startedAt: Date.now() };
+
+    const pctx: PostUnitContext = {
+      s,
+      ctx: {
+        ui: {
+          notify: (message: string) => { notifications.push(message); },
+          setStatus: () => {},
+          setWidget: () => {},
+          setFooter: () => {},
+        },
+        model: { id: "test-model" },
+      } as any,
+      pi: { sendMessage: async () => {}, setModel: async () => true } as any,
+      buildSnapshotOpts: () => ({}),
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto,
+      updateProgressWidget: () => {},
+    };
+
+    const result = await postUnitPostVerification(pctx);
+    assert.equal(result, "stopped");
+    assert.equal(pauseAuto.mock.callCount(), 1);
+    assert.ok(
+      notifications.some(message => message.includes("Post-unit hook review-arbiter failed")),
+      "pause notification should explain the failed hook",
+    );
   } finally {
     process.chdir(originalCwd);
     resetHookState();

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -8,6 +8,7 @@ import { test, describe, beforeEach } from "node:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { emitJournalEvent } from "../journal.ts";
 import {
   RuleRegistry,
   getRegistry,
@@ -16,6 +17,7 @@ import {
   resetRegistry,
   convertDispatchRules,
   getOrCreateRegistry,
+  resolveHookArtifactPath,
 } from "../rule-registry.ts";
 import type { UnifiedRule } from "../rule-types.ts";
 import type { DispatchAction, DispatchContext } from "../auto-dispatch.ts";
@@ -439,6 +441,79 @@ describe("RuleRegistry", () => {
       else process.env.GSD_HOME = originalGsdHome;
       rmSync(projectRoot, { recursive: true, force: true });
       rmSync(worktreeRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  });
+
+  test("failed hook completion with an artifact does not dequeue the next hook", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-failed-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    const unitId = "M001/S01/T01";
+
+    try {
+      mkdirSync(join(projectRoot, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+      writeFileSync(
+        join(projectRoot, ".gsd", "PREFERENCES.md"),
+        [
+          "---",
+          "version: 1",
+          "post_unit_hooks:",
+          "  - name: review-arbiter",
+          "    after: [execute-task]",
+          "    prompt: Review {taskId}",
+          "    artifact: REVIEW.md",
+          "    max_cycles: 1",
+          "  - name: follow-up-review",
+          "    after: [execute-task]",
+          "    prompt: Follow-up review {taskId}",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.GSD_HOME = tempGsdHome;
+
+      const registry = new RuleRegistry([]);
+      const firstHook = registry.evaluatePostUnit("execute-task", unitId, projectRoot);
+      assert.equal(firstHook?.hookName, "review-arbiter");
+
+      writeFileSync(
+        resolveHookArtifactPath(projectRoot, unitId, "REVIEW.md"),
+        "partial review output",
+        "utf-8",
+      );
+      emitJournalEvent(projectRoot, {
+        ts: "2026-06-03T12:00:00.000Z",
+        flowId: "flow-hook-failed",
+        seq: 3,
+        eventType: "unit-end",
+        data: {
+          unitType: "hook/review-arbiter",
+          unitId,
+          status: "cancelled",
+          artifactVerified: false,
+          errorContext: {
+            message: "Provider error: Stream ended without finish_reason",
+            category: "provider",
+          },
+        },
+      });
+
+      const nextHook = registry.evaluatePostUnit("hook/review-arbiter", unitId, projectRoot);
+      assert.equal(nextHook, null, "failed hook must not allow follow-up hook dispatch");
+      const failure = registry.consumeHookFailure();
+      assert.equal(failure?.hookName, "review-arbiter");
+      assert.match(failure?.reason ?? "", /status cancelled/);
+
+      const resumedRegistry = new RuleRegistry([]);
+      resumedRegistry.restoreState(projectRoot);
+      const resumedHook = resumedRegistry.evaluatePostUnit("execute-task", unitId, projectRoot);
+      assert.equal(resumedHook, null, "resumed hook evaluation must not skip failed hook artifact");
+      assert.equal(resumedRegistry.consumeHookFailure()?.hookName, "review-arbiter");
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
       rmSync(tempGsdHome, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Linked issue

Closes #448

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Prevent post-unit hook artifacts from being accepted as completion when the hook unit failed or was cancelled.
**Why:** A failed hook can leave partial output behind and previously allowed auto-mode to advance.
**How:** Check the latest hook unit-end/runtime state before completing or artifact-skipping a hook; retry through `max_cycles`, then pause auto-mode with a clear failure.

## What

- `RuleRegistry` now assesses hook completion before clearing active hooks or skipping artifact-backed hooks.
- Failed hooks retry while cycles remain; once exhausted, the hook queue is cleared and a failure is surfaced to post-unit processing.
- `auto-post-unit` consumes hook failure state and pauses auto-mode instead of advancing.
- Added regressions for active hook completion and resumed artifact-idempotency paths.

## Why

Artifact existence means output exists, not that a hook completed successfully. Cancelled or crashed review/verification hooks can leave partial artifacts behind, so auto-mode must consult hook execution outcome before treating those hooks as done.

## How

The hook registry now looks at the latest `unit-end` event for `hook/<name>` and the runtime record for terminal failed phases. A clean completed status allows normal hook completion; failed/cancelled/timeout states rerun the hook if `max_cycles` allows, otherwise auto-mode pauses and reports the failed hook.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:

- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/rule-registry.test.ts src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

Draft note: `pnpm run verify:pr` was run locally and is currently blocked by two reproduced failures outside this change:

- `doctor-scope-db-unavailable.test.ts`: `table sqlite_master may not be modified`
- `repository-registry.test.ts`: temp path mismatch between `/private/var/...` and `/var/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783080132&installation_id=134682257&pr_number=453&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F453&signature=4eea39dd3658a596ca94d4ffb6ccfeab0eba7d291c75dc3a46bf3ad275a32fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode hook orchestration and idempotency; behavior is narrower and tested, but incorrect completion signals could still pause or retry workflows incorrectly.
> 
> **Overview**
> **Post-unit hooks no longer treat an on-disk artifact as proof of success.** `RuleRegistry` now judges hook completion from the latest `unit-end` journal entry (status, `artifactVerified`, error context) and failed unit-runtime phases before skipping idempotent artifacts or dequeuing the next hook.
> 
> When a hook is judged failed, it **retries within `max_cycles`**; after that it records a consumable failure, **clears the hook queue**, and persists state so a restart does not skip the failed hook. **`postUnitPostVerification`** reads that failure and **pauses auto-mode** with a warning instead of advancing.
> 
> Tests cover failed completion with a partial artifact (no follow-up hook) and the auto-post-unit pause path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9edb9c19287ab295c0f496040ddb90abe2a0ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->