### PR TITLE
feat(gsd): add post-unit hook criticality gates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,14 @@
 - **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; unit-execution failure recovery is classified by the Recovery Classification module.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
+- **Post-Unit Hook**: a configured follow-up evaluation that runs after a Unit completes. It may be advisory or may act as a Post-Unit Gate.
+- **Advisory Post-Unit Hook**: a Post-Unit Hook whose outcome may be recorded but is not required for Unit progression.
+- **Post-Unit Gate**: a Post-Unit Hook whose successful completion is required before Unit progression continues.
+- **Post-Unit Gate Enforcement**: the orchestration rule that decides whether a Post-Unit Gate permits, delays, or stops Unit progression.
+- **Post-Unit Hook Outcome**: the recorded result of a Post-Unit Hook, including whether it allows progress or calls for rework or remediation.
+- **Rework**: corrective work that revisits the Unit that produced an unsatisfactory result.
+- **Remediation**: corrective workflow work scheduled beyond the triggering Unit to address a finding before downstream completion or progression.
+- **Needs Attention**: a finding that requires human review before progression or completion continues.
 - **First-visible response latency**: the user-perceived delay from submitting a prompt to seeing the first assistant output. Distinct from total completion time, Unit duration, or tool execution duration.
 - **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves a durable final closeout surface visible in the live terminal, not merely scrollback or a cleared progress area.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.

--- a/docs/dev/ADR-022-post-unit-gate-enforcement.md
+++ b/docs/dev/ADR-022-post-unit-gate-enforcement.md
@@ -1,0 +1,24 @@
+# ADR-022: Post-Unit Gate Enforcement Belongs to Orchestration
+
+**Status:** Accepted
+**Date:** 2026-06-03
+
+Post-Unit Gates block Unit progression, so gate enforcement belongs to Auto Orchestration and post-unit finalization rather than the hook registry. The registry should identify configured Post-Unit Hooks, preserve hook state, and provide active hook metadata; it should not decide whether auto-mode may advance.
+
+Failed, cancelled, timed-out, or unverified gate execution should flow through Recovery Classification so runtime failures produce the same retry, pause, or remediation behavior as other Unit failures. This keeps progression decisions in the orchestration layer while still allowing Advisory Post-Unit Hooks to record outcomes without blocking advancement.
+
+Gate success requires both clean hook execution and verified required output. Artifact existence is evidence that output exists, not proof that the gate completed successfully.
+
+Rework may default to retrying the trigger Unit for compatibility with existing `retry_on` behavior. The routing action is named `retry-unit` because hooks can fire after task, slice, milestone, and UAT Units; `retry-task` is only a task-level compatibility alias.
+
+Remediation that creates new workflow work must be routed explicitly. Without an explicit route, orchestration pauses instead of mutating the task or slice graph.
+
+Task-level remediation stays inside the current slice. Work that changes slice boundaries or crosses slice scope must be routed as slice-level remediation.
+
+Slice-level remediation uses the existing reassess-roadmap mutation path instead of introducing a second roadmap mutation surface.
+
+Scheduled remediation is deduped by hook name, trigger Unit, and a stable finding fingerprint so reruns, resumes, and artifact reprocessing do not create duplicate tasks or slices.
+
+Status surfaces such as `/gsd status` should show the blocking gate name, trigger Unit, verdict or execution failure, scheduled remediation, and next recovery action using user-facing commands.
+
+Gate reruns use the configured hook cycle budget for the trigger Unit. Once that budget is exhausted, orchestration pauses with the gate name, trigger Unit, and recovery context instead of continuing progression or looping indefinitely.

--- a/docs/dev/ADR-023-post-unit-hook-outcome-artifacts.md
+++ b/docs/dev/ADR-023-post-unit-hook-outcome-artifacts.md
@@ -1,0 +1,22 @@
+# ADR-023: Post-Unit Hook Outcomes Live in Artifact Frontmatter
+
+**Status:** Accepted
+**Date:** 2026-06-03
+
+Post-Unit Hook Outcomes use YAML frontmatter on the configured hook artifact as the canonical machine-readable contract. The artifact body remains human-readable review, verification, or diagnostic prose, while frontmatter records the verdict, severity, and required work needed for orchestration decisions.
+
+Hook-authored verdicts describe the finding. Hook execution state is recorded separately by the runtime, so a cancelled, timed-out, or failed hook is not represented by a `failed` verdict in the artifact.
+
+An `advisory` verdict records a finding without required work. Even for a Post-Unit Gate, a cleanly completed advisory outcome permits Unit progression.
+
+`needs-attention` pauses for human review. Automated scheduling is reserved for rework and remediation outcomes whose required work is explicit enough for orchestration to route.
+
+Severity is informational metadata for display and triage. Routing is driven by verdict and explicit block routing, not by severity thresholds.
+
+Post-Unit Gates require a durable outcome source, such as a configured artifact. Missing required output is a gate failure; Advisory Post-Unit Hooks may still omit durable artifacts.
+
+Configuration validation rejects a Post-Unit Gate that lacks a durable outcome source. Silent downgrade to advisory behavior would hide a user-requested gate.
+
+For Advisory Post-Unit Hooks, artifact existence may remain an idempotency signal even when the artifact has no outcome frontmatter. The stricter outcome-frontmatter requirement applies to Post-Unit Gates because they make progression decisions.
+
+This keeps the hook's human output and machine outcome together and follows existing GSD artifact patterns such as milestone validation and UAT assessment verdicts. Legacy `retry_on` sentinel files remain supported as a compatibility signal that maps to trigger-Unit rework, but sentinel existence is not the canonical outcome contract for new Post-Unit Gates.

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -58,6 +58,7 @@ import {
   consumeHookFailure,
   isRetryPending,
   consumeRetryTrigger,
+  consumeGateBlock,
   persistHookState,
   resolveHookArtifactPath,
 } from "./post-unit-hooks.js";
@@ -2228,11 +2229,11 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   // ── Post-unit hooks ──
   if (s.currentUnit && !s.stepMode) {
     const hookUnit = checkPostUnitHooks(s.currentUnit.type, s.currentUnit.id, s.basePath);
+    persistHookState(s.basePath);
     if (hookUnit) {
       if (s.currentUnit) {
         await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt, buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id));
       }
-      persistHookState(s.basePath);
 
       return enqueueSidecar(
         s, ctx,
@@ -2255,8 +2256,9 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
     if (isRetryPending()) {
       const trigger = consumeRetryTrigger();
       if (trigger) {
+        persistHookState(s.basePath);
         ctx.ui.notify(
-          `Hook requested retry of ${trigger.unitType} ${trigger.unitId} — resetting task state.`,
+          `Hook requested retry of ${trigger.unitType} ${trigger.unitId} — resetting trigger unit state.`,
           "info",
         );
 
@@ -2309,6 +2311,19 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
         // Fall through to normal dispatch — deriveState will re-derive the unit
       }
+    }
+
+    const gateBlock = consumeGateBlock();
+    if (gateBlock) {
+      persistHookState(s.basePath);
+      const verdict = gateBlock.verdict ? ` verdict=${gateBlock.verdict};` : "";
+      const artifact = gateBlock.artifact ? ` artifact=${gateBlock.artifact};` : "";
+      const message =
+        `Post-unit gate "${gateBlock.hookName}" blocked ${gateBlock.triggerUnitType} ${gateBlock.triggerUnitId}:` +
+        `${verdict}${artifact} ${gateBlock.reason}. Run /gsd status to inspect, then /gsd auto after recovery.`;
+      ctx.ui.notify(message, "warning");
+      await pauseAuto(ctx, pi);
+      return "stopped";
     }
   }
 

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -305,9 +305,17 @@ This config sets a parent workspace with two child repositories. The implicit `p
   - `max_cycles`: number — max times this hook fires per trigger (default: 1, max: 10).
   - `model`: string — optional model override.
   - `artifact`: string — expected output file name (relative to task/slice dir). Hook is skipped if file already exists (idempotent).
+  - `criticality`: `"advisory"` or `"blocking"` — advisory preserves current best-effort behavior; blocking requires clean hook completion plus a valid outcome verdict before auto-mode advances. Default: `"advisory"`.
   - `retry_on`: string — if this file is produced instead of the artifact, re-run the trigger unit then re-run hooks.
+  - `on_block`: object — optional routing for blocking findings:
+    - `action`: `"retry-unit"`, `"retry-task"`, `"queue-task"`, `"queue-slice"`, or `"pause"`.
+    - `artifact`: string — optional compatibility artifact for retry routing.
   - `agent`: string — agent definition file to use for hook execution.
   - `enabled`: boolean — toggle without removing (default: `true`).
+
+  Blocking hook artifacts must begin with YAML frontmatter containing either `verdict` or `outcome.verdict`.
+  Supported verdicts are `pass`, `advisory`, `needs-rework`, `needs-remediation`, and `needs-attention`.
+  `pass` and `advisory` continue; `needs-rework` retries the trigger unit when routed with `retry-unit`/`retry-task`; `needs-remediation` and `needs-attention` pause with recovery guidance.
 
 - `pre_dispatch_hooks`: array — hooks that fire before a unit is dispatched. Each entry has:
   - `name`: string — unique hook identifier.

--- a/src/resources/extensions/gsd/post-unit-hooks.ts
+++ b/src/resources/extensions/gsd/post-unit-hooks.ts
@@ -9,6 +9,7 @@ import type {
   HookDispatchResult,
   PreDispatchResult,
   HookStatusEntry,
+  PostUnitGateBlock,
 } from "./types.js";
 import { getOrCreateRegistry, resolveHookArtifactPath } from "./rule-registry.js";
 
@@ -33,12 +34,20 @@ export function isRetryPending(): boolean {
   return getOrCreateRegistry().isRetryPending();
 }
 
-export function consumeRetryTrigger(): { unitType: string; unitId: string; retryArtifact: string } | null {
+export function consumeRetryTrigger(): { unitType: string; unitId: string; retryArtifact?: string } | null {
   return getOrCreateRegistry().consumeRetryTrigger();
 }
 
 export function consumeHookFailure(): { hookName: string; unitType: string; unitId: string; reason: string } | null {
   return getOrCreateRegistry().consumeHookFailure();
+}
+
+export function isGateBlockPending(): boolean {
+  return getOrCreateRegistry().isGateBlockPending();
+}
+
+export function consumeGateBlock(): PostUnitGateBlock | null {
+  return getOrCreateRegistry().consumeGateBlock();
 }
 
 export function resetHookState(): void {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -29,6 +29,14 @@ const VALID_UOK_TURN_ACTIONS = new Set<"commit" | "snapshot" | "status-only">([
   "snapshot",
   "status-only",
 ]);
+const VALID_POST_UNIT_HOOK_CRITICALITIES = new Set(["advisory", "blocking"]);
+const VALID_POST_UNIT_HOOK_ON_BLOCK_ACTIONS = new Set([
+  "retry-unit",
+  "retry-task",
+  "queue-task",
+  "queue-slice",
+  "pause",
+]);
 
 export function validatePreferences(preferences: GSDPreferences): {
   preferences: GSDPreferences;
@@ -486,8 +494,36 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (typeof hook.artifact === "string" && hook.artifact.trim()) {
         validHook.artifact = hook.artifact.trim();
       }
+      if (hook.criticality !== undefined) {
+        const criticality = typeof hook.criticality === "string" ? hook.criticality.trim() : "";
+        if (VALID_POST_UNIT_HOOK_CRITICALITIES.has(criticality)) {
+          validHook.criticality = criticality as PostUnitHookConfig["criticality"];
+        } else {
+          errors.push(`post_unit_hooks "${name}" invalid criticality: ${String(hook.criticality)}`);
+        }
+      }
       if (typeof hook.retry_on === "string" && hook.retry_on.trim()) {
         validHook.retry_on = hook.retry_on.trim();
+      }
+      if (hook.on_block !== undefined) {
+        if (!hook.on_block || typeof hook.on_block !== "object") {
+          errors.push(`post_unit_hooks "${name}" on_block must be an object`);
+        } else {
+          const onBlock = hook.on_block as unknown as Record<string, unknown>;
+          const action = typeof onBlock.action === "string" ? onBlock.action.trim() : "";
+          if (!VALID_POST_UNIT_HOOK_ON_BLOCK_ACTIONS.has(action)) {
+            errors.push(`post_unit_hooks "${name}" invalid on_block action: ${String(onBlock.action)}`);
+          } else {
+            validHook.on_block = { action: action as NonNullable<PostUnitHookConfig["on_block"]>["action"] };
+            if (typeof onBlock.artifact === "string" && onBlock.artifact.trim()) {
+              validHook.on_block.artifact = onBlock.artifact.trim();
+            }
+          }
+        }
+      }
+      if (validHook.criticality === "blocking" && !validHook.artifact) {
+        errors.push(`post_unit_hooks "${name}" criticality blocking requires artifact`);
+        continue;
       }
       if (typeof hook.agent === "string" && hook.agent.trim()) {
         validHook.agent = hook.agent.trim();

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -17,6 +17,8 @@ import type {
   HookExecutionState,
   PersistedHookState,
   HookStatusEntry,
+  PostUnitGateBlock,
+  PostUnitHookOutcomeVerdict,
 } from "./types.js";
 import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
@@ -24,6 +26,7 @@ import { join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
 import { queryJournal, type JournalEntry } from "./journal.js";
 import { readUnitRuntimeRecord, type UnitRuntimePhase } from "./unit-runtime.js";
+import { extractFrontmatterVerdict } from "./verdict-parser.js";
 
 // ─── Artifact Path Resolution ──────────────────────────────────────────────
 
@@ -77,6 +80,38 @@ type HookCompletionAssessment =
   | { outcome: "failed"; reason: string }
   | { outcome: "unknown" };
 
+const HOOK_OUTCOME_VERDICTS = new Set<PostUnitHookOutcomeVerdict>([
+  "pass",
+  "advisory",
+  "needs-rework",
+  "needs-remediation",
+  "needs-attention",
+]);
+
+interface HookTriggerRef {
+  triggerUnitType: string;
+  triggerUnitId: string;
+}
+
+interface GateOutcome {
+  verdict?: PostUnitHookOutcomeVerdict | "failed";
+  artifact?: string;
+  artifactPath?: string;
+  reason?: string;
+}
+
+function isBlockingHook(config: PostUnitHookConfig | undefined): boolean {
+  return config?.criticality === "blocking";
+}
+
+function hookMaxCycles(config: PostUnitHookConfig): number {
+  return config.max_cycles ?? 1;
+}
+
+function hookCycleKey(config: PostUnitHookConfig, trigger: HookTriggerRef): string {
+  return `${config.name}/${trigger.triggerUnitType}/${trigger.triggerUnitId}`;
+}
+
 export class RuleRegistry {
   /** Static dispatch rules provided at construction time. */
   private readonly dispatchRules: UnifiedRule[];
@@ -88,11 +123,13 @@ export class RuleRegistry {
     config: PostUnitHookConfig;
     triggerUnitType: string;
     triggerUnitId: string;
+    forceRun?: boolean;
   }> = [];
   cycleCounts: Map<string, number> = new Map();
   retryPending: boolean = false;
-  retryTrigger: { unitType: string; unitId: string; retryArtifact: string } | null = null;
+  retryTrigger: { unitType: string; unitId: string; retryArtifact?: string } | null = null;
   hookFailure: HookFailureState | null = null;
+  gateBlockPending: PostUnitGateBlock | null = null;
 
   constructor(dispatchRules: UnifiedRule[]) {
     this.dispatchRules = dispatchRules;
@@ -121,6 +158,7 @@ export class RuleRegistry {
           artifact: hook.artifact,
           retry_on: hook.retry_on,
           max_cycles: hook.max_cycles,
+          criticality: hook.criticality,
         },
       });
     }
@@ -176,7 +214,10 @@ export class RuleRegistry {
   ): HookDispatchResult | null {
     // If we just completed a hook unit, handle its result
     if (this.activeHook) {
-      return this._handleHookCompletion(basePath);
+      const observedCleanExecution =
+        completedUnitType === `hook/${this.activeHook.hookName}` &&
+        completedUnitId === this.activeHook.triggerUnitId;
+      return this._handleHookCompletion(basePath, observedCleanExecution);
     }
 
     // Don't trigger hooks for other hook units (prevent hook-on-hook chains)
@@ -208,10 +249,11 @@ export class RuleRegistry {
   private _dequeueNextHook(basePath: string): HookDispatchResult | null {
     while (this.hookQueue.length > 0) {
       const entry = this.hookQueue.shift()!;
-      const { config, triggerUnitType, triggerUnitId } = entry;
+      const { config, triggerUnitType, triggerUnitId, forceRun } = entry;
 
-      // Check idempotency — if artifact already exists, skip
-      if (config.artifact) {
+      // Advisory hooks preserve existing idempotency: any configured artifact
+      // means the hook already ran. Blocking gates must verify outcome first.
+      if (config.artifact && !forceRun) {
         const artifactPath = resolveHookArtifactPath(basePath, triggerUnitId, config.artifact);
         if (existsSync(artifactPath)) {
           const completion = this._assessConfiguredHookCompletion(basePath, config.name, triggerUnitId);
@@ -222,19 +264,36 @@ export class RuleRegistry {
                 hookName: config.name,
                 triggerUnitType,
                 triggerUnitId,
-                cycle: this.cycleCounts.get(`${config.name}/${triggerUnitType}/${triggerUnitId}`) ?? 0,
+                cycle: this.cycleCounts.get(hookCycleKey(config, { triggerUnitType, triggerUnitId })) ?? 0,
                 pendingRetry: false,
               },
               config,
               completion.reason,
             );
           }
-          continue;
+          if (!isBlockingHook(config)) continue;
+          const decision = this._handleExistingBlockingArtifact(config, { triggerUnitType, triggerUnitId }, basePath);
+          if (decision === "skip") continue;
+          return decision;
         }
       }
 
       const dispatch = this._startHook(config, triggerUnitType, triggerUnitId);
       if (dispatch) return dispatch;
+      if (isBlockingHook(config)) {
+        const cycleKey = hookCycleKey(config, { triggerUnitType, triggerUnitId });
+        const maxCycles = hookMaxCycles(config);
+        const currentCycle = this.cycleCounts.get(cycleKey) ?? 0;
+        if (currentCycle >= maxCycles) {
+          this._setGateBlock(config, { triggerUnitType, triggerUnitId }, {
+            action: "pause",
+            reason: `gate cycle budget exhausted before ${config.name} produced a passing outcome`,
+            cycle: currentCycle,
+            maxCycles,
+          });
+          return null;
+        }
+      }
     }
 
     // No more hooks — clear active state
@@ -242,10 +301,14 @@ export class RuleRegistry {
     return null;
   }
 
-  private _handleHookCompletion(basePath: string): HookDispatchResult | null {
+  private _handleHookCompletion(basePath: string, observedCleanExecution: boolean): HookDispatchResult | null {
     const hook = this.activeHook!;
     const hooks = resolvePostUnitHooks(basePath);
     const config = hooks.find(h => h.name === hook.hookName);
+    if (!config) {
+      this.activeHook = null;
+      return this._dequeueNextHook(basePath);
+    }
 
     const completion = this._assessHookCompletion(basePath, hook);
     if (completion.outcome === "failed") {
@@ -253,25 +316,27 @@ export class RuleRegistry {
     }
 
     // Check if retry was requested via retry_on artifact
-    if (config?.retry_on) {
+    if (config.retry_on) {
       const retryArtifactPath = resolveHookArtifactPath(basePath, hook.triggerUnitId, config.retry_on);
       if (existsSync(retryArtifactPath)) {
-        const cycleKey = `${config.name}/${hook.triggerUnitType}/${hook.triggerUnitId}`;
-        const currentCycle = this.cycleCounts.get(cycleKey) ?? 1;
-        const maxCycles = config.max_cycles ?? 1;
-
-        if (currentCycle < maxCycles) {
+        if (this._requestTriggerRetry(config, hook, config.retry_on)) {
+          return null;
+        }
+        if (isBlockingHook(config)) {
+          this._setGateBlock(config, hook, {
+            action: "pause",
+            reason: `gate cycle budget exhausted after ${config.retry_on} requested rework`,
+            retryArtifact: config.retry_on,
+          });
           this.activeHook = null;
           this.hookQueue = [];
-          this.retryPending = true;
-          this.retryTrigger = {
-            unitType: hook.triggerUnitType,
-            unitId: hook.triggerUnitId,
-            retryArtifact: config.retry_on,
-          };
           return null;
         }
       }
+    }
+
+    if (isBlockingHook(config)) {
+      return this._handleBlockingGateCompletion(config, hook, basePath, observedCleanExecution);
     }
 
     // Hook completed normally — try next hook in queue
@@ -402,6 +467,255 @@ export class RuleRegistry {
     return null;
   }
 
+  private _handleExistingBlockingArtifact(
+    config: PostUnitHookConfig,
+    trigger: HookTriggerRef,
+    basePath: string,
+  ): "skip" | HookDispatchResult | null {
+    const outcome = this._readGateOutcome(config, trigger, basePath);
+    switch (outcome.verdict) {
+      case "pass":
+      case "advisory":
+        return "skip";
+      case "needs-rework":
+        return this._routeNeedsRework(config, trigger, outcome);
+      case "needs-remediation":
+      case "needs-attention":
+        this._pauseForGate(config, trigger, outcome, `gate reported ${outcome.verdict}`);
+        return null;
+      case "failed":
+      case undefined:
+        return this._rerunGateOrBlock(config, trigger, basePath, {
+          reason: outcome.reason ?? `gate artifact reported verdict=${outcome.verdict}`,
+          outcome,
+        });
+    }
+    return this._rerunGateOrBlock(config, trigger, basePath, {
+      reason: `gate artifact reported unsupported verdict=${String(outcome.verdict)}`,
+      outcome,
+    });
+  }
+
+  private _handleBlockingGateCompletion(
+    config: PostUnitHookConfig,
+    hook: HookExecutionState,
+    basePath: string,
+    observedCleanExecution: boolean,
+  ): HookDispatchResult | null {
+    if (!observedCleanExecution) {
+      return this._rerunGateOrBlock(config, hook, basePath, {
+        reason: `hook/${config.name} did not complete cleanly before the trigger unit resumed`,
+      });
+    }
+
+    const outcome = this._readGateOutcome(config, hook, basePath);
+    switch (outcome.verdict) {
+      case "pass":
+      case "advisory":
+        this.activeHook = null;
+        return this._dequeueNextHook(basePath);
+      case "needs-rework":
+        return this._routeNeedsRework(config, hook, outcome);
+      case "needs-remediation":
+      case "needs-attention":
+        return this._pauseForGate(config, hook, outcome, `gate reported ${outcome.verdict}`);
+      case "failed":
+      case undefined:
+        return this._rerunGateOrBlock(config, hook, basePath, {
+          reason: outcome.reason ?? `gate artifact reported verdict=${outcome.verdict}`,
+          outcome,
+        });
+    }
+    return this._rerunGateOrBlock(config, hook, basePath, {
+      reason: `gate artifact reported unsupported verdict=${String(outcome.verdict)}`,
+      outcome,
+    });
+  }
+
+  private _routeNeedsRework(
+    config: PostUnitHookConfig,
+    trigger: HookTriggerRef,
+    outcome: GateOutcome,
+  ): null {
+    const action = config.on_block?.action ?? "retry-unit";
+    if (action === "retry-task" || action === "retry-unit") {
+      if (this._requestTriggerRetry(config, trigger, config.on_block?.artifact)) {
+        return null;
+      }
+      this._setGateBlock(config, trigger, {
+        action: "pause",
+        reason: "gate cycle budget exhausted after needs-rework",
+        outcome,
+        retryArtifact: config.on_block?.artifact,
+      });
+      this.activeHook = null;
+      this.hookQueue = [];
+      return null;
+    }
+    return this._pauseForGate(config, trigger, outcome, `gate reported needs-rework; configured on_block action is ${action}`);
+  }
+
+  private _pauseForGate(
+    config: PostUnitHookConfig,
+    trigger: HookTriggerRef,
+    outcome: GateOutcome,
+    reason: string,
+  ): null {
+    this._setGateBlock(config, trigger, {
+      action: config.on_block?.action ?? "pause",
+      reason,
+      outcome,
+      retryArtifact: config.on_block?.artifact,
+    });
+    this.activeHook = null;
+    this.hookQueue = [];
+    return null;
+  }
+
+  private _requestTriggerRetry(
+    config: PostUnitHookConfig,
+    hook: HookTriggerRef,
+    retryArtifact?: string,
+  ): boolean {
+    const cycleKey = hookCycleKey(config, hook);
+    const currentCycle = this.cycleCounts.get(cycleKey) ?? 1;
+    const maxCycles = hookMaxCycles(config);
+    if (currentCycle >= maxCycles) return false;
+
+    this.activeHook = null;
+    this.hookQueue = [];
+    this.retryPending = true;
+    this.retryTrigger = {
+      unitType: hook.triggerUnitType,
+      unitId: hook.triggerUnitId,
+    };
+    if (retryArtifact !== undefined) {
+      this.retryTrigger.retryArtifact = retryArtifact;
+    }
+    return true;
+  }
+
+  private _rerunGateOrBlock(
+    config: PostUnitHookConfig,
+    trigger: HookTriggerRef,
+    basePath: string,
+    opts: {
+      reason: string;
+      outcome?: GateOutcome;
+    },
+  ): HookDispatchResult | null {
+    const cycleKey = hookCycleKey(config, trigger);
+    const currentCycle = this.cycleCounts.get(cycleKey) ?? 0;
+    const maxCycles = hookMaxCycles(config);
+    if (currentCycle < maxCycles) {
+      this.activeHook = null;
+      this.hookQueue.unshift({
+        config,
+        triggerUnitType: trigger.triggerUnitType,
+        triggerUnitId: trigger.triggerUnitId,
+        forceRun: true,
+      });
+      return this._dequeueNextHook(basePath);
+    }
+
+    this._setGateBlock(config, trigger, {
+      action: "pause",
+      reason: `${opts.reason}; gate cycle budget exhausted`,
+      outcome: opts.outcome,
+      cycle: currentCycle,
+      maxCycles,
+    });
+    this.activeHook = null;
+    this.hookQueue = [];
+    return null;
+  }
+
+  private _readGateOutcome(
+    config: PostUnitHookConfig,
+    trigger: HookTriggerRef,
+    basePath: string,
+  ): GateOutcome {
+    if (!config.artifact) {
+      return { reason: "blocking gate has no configured artifact" };
+    }
+    const artifactPath = resolveHookArtifactPath(basePath, trigger.triggerUnitId, config.artifact);
+    if (!existsSync(artifactPath)) {
+      return {
+        artifact: config.artifact,
+        artifactPath,
+        reason: `missing required gate artifact ${config.artifact}`,
+      };
+    }
+    let content = "";
+    try {
+      content = readFileSync(artifactPath, "utf-8");
+    } catch (e) {
+      return {
+        artifact: config.artifact,
+        artifactPath,
+        reason: `could not read gate artifact ${config.artifact}: ${(e as Error).message}`,
+      };
+    }
+
+    const rawVerdict = extractFrontmatterVerdict(content);
+    if (!rawVerdict) {
+      return {
+        artifact: config.artifact,
+        artifactPath,
+        reason: `gate artifact ${config.artifact} is missing frontmatter verdict`,
+      };
+    }
+    if (rawVerdict === "failed") {
+      return {
+        artifact: config.artifact,
+        artifactPath,
+        verdict: "failed",
+        reason: `gate artifact ${config.artifact} reported verdict=failed`,
+      };
+    }
+    if (!HOOK_OUTCOME_VERDICTS.has(rawVerdict as PostUnitHookOutcomeVerdict)) {
+      return {
+        artifact: config.artifact,
+        artifactPath,
+        reason: `gate artifact ${config.artifact} has unsupported verdict=${rawVerdict}`,
+      };
+    }
+    return {
+      artifact: config.artifact,
+      artifactPath,
+      verdict: rawVerdict as PostUnitHookOutcomeVerdict,
+    };
+  }
+
+  private _setGateBlock(
+    config: PostUnitHookConfig,
+    trigger: HookTriggerRef,
+    opts: {
+      action: PostUnitGateBlock["action"];
+      reason: string;
+      outcome?: GateOutcome;
+      cycle?: number;
+      maxCycles?: number;
+      retryArtifact?: string;
+    },
+  ): void {
+    const cycleKey = hookCycleKey(config, trigger);
+    const cycle = opts.cycle ?? this.cycleCounts.get(cycleKey) ?? 0;
+    this.gateBlockPending = {
+      hookName: config.name,
+      triggerUnitType: trigger.triggerUnitType,
+      triggerUnitId: trigger.triggerUnitId,
+      artifact: opts.outcome?.artifact ?? config.artifact,
+      artifactPath: opts.outcome?.artifactPath,
+      verdict: opts.outcome?.verdict,
+      action: opts.action,
+      reason: opts.reason,
+      cycle,
+      maxCycles: opts.maxCycles ?? hookMaxCycles(config),
+      retryArtifact: opts.retryArtifact,
+    };
+  }
+
   // ── Pre-dispatch hook evaluation (sync, all-matching with compose) ──
 
   /**
@@ -493,11 +807,15 @@ export class RuleRegistry {
     return failure;
   }
 
+  isGateBlockPending(): boolean {
+    return this.gateBlockPending !== null;
+  }
+
   /**
    * Returns the trigger unit info for a pending retry, or null.
    * Clears the retry state after reading.
    */
-  consumeRetryTrigger(): { unitType: string; unitId: string; retryArtifact: string } | null {
+  consumeRetryTrigger(): { unitType: string; unitId: string; retryArtifact?: string } | null {
     if (!this.retryPending || !this.retryTrigger) return null;
     const trigger = { ...this.retryTrigger };
     this.retryPending = false;
@@ -505,7 +823,18 @@ export class RuleRegistry {
     return trigger;
   }
 
-  /** Clear all mutable state (activeHook, hookQueue, cycleCounts, retryPending, retryTrigger). */
+  /**
+   * Returns a pending post-unit gate block, or null.
+   * Clears the block state after reading.
+   */
+  consumeGateBlock(): PostUnitGateBlock | null {
+    if (!this.gateBlockPending) return null;
+    const block = { ...this.gateBlockPending };
+    this.gateBlockPending = null;
+    return block;
+  }
+
+  /** Clear all mutable hook lifecycle state. */
   resetState(): void {
     this.activeHook = null;
     this.hookQueue = [];
@@ -513,6 +842,7 @@ export class RuleRegistry {
     this.retryPending = false;
     this.retryTrigger = null;
     this.hookFailure = null;
+    this.gateBlockPending = null;
   }
 
   // ── Persistence ─────────────────────────────────────────────────────
@@ -521,10 +851,17 @@ export class RuleRegistry {
     return join(basePath, ".gsd", HOOK_STATE_FILE);
   }
 
-  /** Persist current hook cycle counts to disk. */
+  /** Persist current hook state to disk. */
   persistState(basePath: string): void {
     const state: PersistedHookState = {
       cycleCounts: Object.fromEntries(this.cycleCounts),
+      activeHook: this.activeHook ? { ...this.activeHook } : null,
+      hookQueue: this.hookQueue.map(entry => ({
+        hookName: entry.config.name,
+        triggerUnitType: entry.triggerUnitType,
+        triggerUnitId: entry.triggerUnitId,
+        forceRun: entry.forceRun,
+      })),
       savedAt: new Date().toISOString(),
     };
     try {
@@ -536,7 +873,7 @@ export class RuleRegistry {
     }
   }
 
-  /** Restore hook cycle counts from disk after a crash/restart. */
+  /** Restore hook state from disk after a crash/restart. */
   restoreState(basePath: string): void {
     try {
       const filePath = this._hookStatePath(basePath);
@@ -548,6 +885,24 @@ export class RuleRegistry {
         for (const [key, value] of Object.entries(state.cycleCounts)) {
           if (typeof value === "number") {
             this.cycleCounts.set(key, value);
+          }
+        }
+      }
+      this.activeHook = state.activeHook && typeof state.activeHook === "object"
+        ? { ...state.activeHook }
+        : null;
+      this.hookQueue = [];
+      if (Array.isArray(state.hookQueue)) {
+        const hooks = resolvePostUnitHooks(basePath);
+        for (const entry of state.hookQueue) {
+          const config = hooks.find(h => h.name === entry.hookName);
+          if (config) {
+            this.hookQueue.push({
+              config,
+              triggerUnitType: entry.triggerUnitType,
+              triggerUnitId: entry.triggerUnitId,
+              forceRun: entry.forceRun,
+            });
           }
         }
       }
@@ -563,7 +918,7 @@ export class RuleRegistry {
       if (existsSync(filePath)) {
         writeFileSync(
           filePath,
-          JSON.stringify({ cycleCounts: {}, savedAt: new Date().toISOString() }, null, 2),
+          JSON.stringify({ cycleCounts: {}, activeHook: null, hookQueue: [], savedAt: new Date().toISOString() }, null, 2),
           "utf-8",
         );
       }
@@ -591,6 +946,7 @@ export class RuleRegistry {
         type: "post",
         enabled: hook.enabled !== false,
         targets: hook.after,
+        criticality: hook.criticality ?? "advisory",
         activeCycles,
       });
     }
@@ -680,9 +1036,10 @@ export class RuleRegistry {
       lines.push("Post-Unit Hooks (run after unit completes):");
       for (const hook of postHooks) {
         const status = hook.enabled ? "enabled" : "disabled";
+        const criticality = hook.criticality ?? "advisory";
         const cycles = Object.keys(hook.activeCycles).length;
         const cycleInfo = cycles > 0 ? ` (${cycles} active cycle${cycles === 1 ? "" : "s"})` : "";
-        lines.push(`  ${hook.name} [${status}] → after: ${hook.targets.join(", ")}${cycleInfo}`);
+        lines.push(`  ${hook.name} [${status}, ${criticality}] → after: ${hook.targets.join(", ")}${cycleInfo}`);
       }
       lines.push("");
     }

--- a/src/resources/extensions/gsd/rule-types.ts
+++ b/src/resources/extensions/gsd/rule-types.ts
@@ -32,6 +32,8 @@ export interface RuleLifecycle {
   retry_on?: string;
   /** Max times this hook can fire for the same trigger unit. */
   max_cycles?: number;
+  /** Whether this hook is advisory or blocking. */
+  criticality?: PostUnitHookConfig["criticality"];
   /** Idempotency key pattern for this hook. */
   idempotency_key?: string;
 }

--- a/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
@@ -11,6 +11,7 @@ import {
   resetHookState,
   isRetryPending,
   consumeRetryTrigger,
+  consumeGateBlock,
   resolveHookArtifactPath,
   runPreDispatchHooks,
   persistHookState,
@@ -20,6 +21,7 @@ import {
   formatHookStatus,
   triggerHookManually,
 } from "../post-unit-hooks.ts";
+import { invalidateAllCaches } from "../cache.ts";
 
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
 
@@ -27,6 +29,11 @@ function createFixtureBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-hook-test-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
   return base;
+}
+
+function writeHookPreferences(base: string, hookYaml: string): void {
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), `---\npost_unit_hooks:\n${hookYaml}\n---\n`, "utf-8");
+  invalidateAllCaches();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -102,6 +109,156 @@ test('consumeRetryTrigger clears state', () => {
   resetHookState();
   assert.deepStrictEqual(consumeRetryTrigger(), null, "no trigger initially");
   assert.ok(!isRetryPending(), "no retry initially");
+});
+
+test('Advisory hook keeps artifact idempotency without verdict frontmatter', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: docs-hint
+    after:
+      - execute-task
+    prompt: Review docs
+    artifact: DOCS-HINT.md
+`);
+    writeFileSync(resolveHookArtifactPath(base, "M001/S01/T01", "DOCS-HINT.md"), "plain advisory note", "utf-8");
+
+    const result = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.deepStrictEqual(result, null, "existing advisory artifact remains idempotent");
+    assert.deepStrictEqual(consumeGateBlock(), null, "advisory hook does not create gate block");
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Blocking hook skips only after passing frontmatter verdict', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: security-review
+    after:
+      - execute-task
+    prompt: Review security
+    artifact: SECURITY-REVIEW.md
+    criticality: blocking
+`);
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01/T01", "SECURITY-REVIEW.md"),
+      "---\nverdict: pass\n---\n\nNo blocking findings.\n",
+      "utf-8",
+    );
+
+    const result = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.deepStrictEqual(result, null, "passing gate artifact is idempotent");
+    assert.deepStrictEqual(consumeGateBlock(), null, "passing gate does not block");
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Blocking hook reruns invalid artifact once then blocks at cycle budget', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: security-review
+    after:
+      - execute-task
+    prompt: Review security
+    artifact: SECURITY-REVIEW.md
+    criticality: blocking
+`);
+    writeFileSync(resolveHookArtifactPath(base, "M001/S01/T01", "SECURITY-REVIEW.md"), "partial output", "utf-8");
+
+    const dispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(dispatch, "invalid gate artifact dispatches the blocking hook");
+    assert.equal(dispatch.unitType, "hook/security-review");
+
+    const afterHook = checkPostUnitHooks("hook/security-review", "M001/S01/T01", base);
+    assert.deepStrictEqual(afterHook, null, "no further hook dispatch after max_cycles=1");
+    const block = consumeGateBlock();
+    assert.ok(block, "gate block is recorded");
+    assert.equal(block.hookName, "security-review");
+    assert.match(block.reason, /missing frontmatter verdict/);
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Blocking hook restored from disk does not trust artifact without clean hook completion', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: security-review
+    after:
+      - execute-task
+    prompt: Review security
+    artifact: SECURITY-REVIEW.md
+    criticality: blocking
+    max_cycles: 2
+`);
+    const firstDispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(firstDispatch, "gate dispatches first cycle");
+    persistHookState(base);
+
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01/T01", "SECURITY-REVIEW.md"),
+      "---\noutcome:\n  verdict: pass\n---\n",
+      "utf-8",
+    );
+
+    resetHookState();
+    restoreHookState(base);
+
+    const resumed = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(resumed, "persisted active gate reruns when clean hook completion was not observed");
+    assert.equal(resumed.unitType, "hook/security-review");
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Blocking hook needs-rework verdict requests trigger unit retry', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: review-arbiter
+    after:
+      - execute-task
+    prompt: Review task
+    artifact: REVIEW-DEBATE.md
+    criticality: blocking
+    max_cycles: 2
+    on_block:
+      action: retry-unit
+`);
+    const dispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(dispatch, "gate dispatches");
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW-DEBATE.md"),
+      "---\nverdict: needs-rework\n---\n\nRework required.\n",
+      "utf-8",
+    );
+
+    const afterHook = checkPostUnitHooks("hook/review-arbiter", "M001/S01/T01", base);
+    assert.deepStrictEqual(afterHook, null, "needs-rework routes via retry signal");
+    assert.ok(isRetryPending(), "retry is pending");
+    assert.deepStrictEqual(consumeRetryTrigger(), {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 // ─── Variable substitution in prompts ──────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
@@ -49,6 +49,23 @@ post_unit_hooks:
   writeFileSync(join(basePath, ".gsd", "PREFERENCES.md"), content, "utf-8");
 }
 
+function writeBlockingPreferences(basePath: string): void {
+  const content = `---
+post_unit_hooks:
+  - name: review-arbiter
+    after:
+      - execute-task
+    prompt: Review {taskId}
+    agent: arbiter
+    artifact: REVIEW-DEBATE.md
+    criticality: blocking
+    max_cycles: 2
+    enabled: true
+---
+`;
+  writeFileSync(join(basePath, ".gsd", "PREFERENCES.md"), content, "utf-8");
+}
+
 test("post-unit retry_on marks trigger unit as retry in orchestrator before redispatch", async () => {
   const originalCwd = process.cwd();
   const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-retry-"));
@@ -177,6 +194,74 @@ test("failed post-unit hook pauses auto-mode even when its artifact exists", asy
       notifications.some(message => message.includes("Post-unit hook review-arbiter failed")),
       "pause notification should explain the failed hook",
     );
+  } finally {
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("post-unit blocking gate pauses auto-mode on needs-attention verdict", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-gate-"));
+  const taskDir = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+  mkdirSync(taskDir, { recursive: true });
+
+  try {
+    process.chdir(base);
+    _clearGsdRootCache();
+    invalidateAllCaches();
+    resetHookState();
+    writeBlockingPreferences(base);
+
+    const hookDispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(hookDispatch, "hook should dispatch for execute-task");
+
+    const artifactPath = resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW-DEBATE.md");
+    writeFileSync(artifactPath, "---\nverdict: needs-attention\n---\n\nManual review required.\n", "utf-8");
+
+    const pauseAuto = mock.fn(async () => {});
+    const s = new AutoSession();
+    s.basePath = base;
+    s.active = true;
+    s.currentUnit = { type: "hook/review-arbiter", id: "M001/S01/T01", startedAt: Date.now() };
+    s.orchestration = {
+      start: async () => ({ kind: "started" }),
+      advance: async () => ({ kind: "stopped", reason: "unused" }),
+      completeActiveUnit: async () => {},
+      retryActiveUnit: async () => {},
+      resume: async () => ({ kind: "resumed" }),
+      stop: async (reason: string) => ({ kind: "stopped", reason }),
+      getStatus: () => ({ phase: "running", transitionCount: 0 }),
+    };
+
+    const notifications: string[] = [];
+    const pctx: PostUnitContext = {
+      s,
+      ctx: {
+        ui: {
+          notify: (message: string) => { notifications.push(message); },
+          setStatus: () => {},
+          setWidget: () => {},
+          setFooter: () => {},
+        },
+        model: { id: "test-model" },
+      } as any,
+      pi: { sendMessage: async () => {}, setModel: async () => true } as any,
+      buildSnapshotOpts: () => ({}),
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto,
+      updateProgressWidget: () => {},
+    };
+
+    const result = await postUnitPostVerification(pctx);
+    assert.equal(result, "stopped");
+    assert.equal(pauseAuto.mock.callCount(), 1);
+    assert.match(notifications.join("\n"), /Post-unit gate "review-arbiter" blocked execute-task M001\/S01\/T01/);
+    assert.match(notifications.join("\n"), /\/gsd status/);
   } finally {
     process.chdir(originalCwd);
     resetHookState();

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -561,6 +561,35 @@ test("post-unit hook max_cycles clamping via validatePreferences", () => {
   assert.equal(p4.post_unit_hooks![0].max_cycles, 3, "valid value passes through");
 });
 
+test("post-unit hook criticality and on_block validation", () => {
+  const base = { name: "h", after: ["execute-task"], prompt: "do something", artifact: "REVIEW.md" };
+
+  const { preferences, errors } = validatePreferences({
+    post_unit_hooks: [{
+      ...base,
+      criticality: "blocking",
+      on_block: { action: "retry-unit", artifact: "NEEDS-REWORK.md" },
+    }],
+  } as any);
+  assert.equal(errors.length, 0);
+  assert.equal(preferences.post_unit_hooks![0].criticality, "blocking");
+  assert.deepEqual(preferences.post_unit_hooks![0].on_block, {
+    action: "retry-unit",
+    artifact: "NEEDS-REWORK.md",
+  });
+
+  const missingArtifact = validatePreferences({
+    post_unit_hooks: [{ name: "blocking", after: ["execute-task"], prompt: "do something", criticality: "blocking" }],
+  } as any);
+  assert.match(missingArtifact.errors.join("\n"), /criticality blocking requires artifact/);
+  assert.equal(missingArtifact.preferences.post_unit_hooks, undefined);
+
+  const invalidAction = validatePreferences({
+    post_unit_hooks: [{ ...base, on_block: { action: "teleport" } }],
+  } as any);
+  assert.match(invalidAction.errors.join("\n"), /invalid on_block action/);
+});
+
 test("pre-dispatch hook action validation via validatePreferences", () => {
   const base = { name: "h", before: ["execute-task"] };
 

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -270,6 +270,29 @@ export interface GSDActiveUnit {
 
 // ─── Post-Unit Hook Types ─────────────────────────────────────────────────
 
+export type PostUnitHookCriticality = "advisory" | "blocking";
+
+export type PostUnitHookOutcomeVerdict =
+  | "pass"
+  | "advisory"
+  | "needs-rework"
+  | "needs-remediation"
+  | "needs-attention";
+
+export type PostUnitHookOnBlockAction =
+  | "retry-unit"
+  | "retry-task"
+  | "queue-task"
+  | "queue-slice"
+  | "pause";
+
+export interface PostUnitHookOnBlockConfig {
+  /** Routing action for blocking hook findings. */
+  action: PostUnitHookOnBlockAction;
+  /** Optional artifact used by compatibility retry routing. */
+  artifact?: string;
+}
+
 export interface PostUnitHookConfig {
   /** Unique hook identifier — used in idempotency keys and logging. */
   name: string;
@@ -283,8 +306,12 @@ export interface PostUnitHookConfig {
   model?: string;
   /** Expected output file name (relative to task/slice dir). Used for idempotency — skip if exists. */
   artifact?: string;
+  /** Whether the hook is advisory or blocks unit advancement. Default advisory. */
+  criticality?: PostUnitHookCriticality;
   /** If this file is produced instead of artifact, re-run the trigger unit then re-run hooks. */
   retry_on?: string;
+  /** Optional routing for blocking findings. */
+  on_block?: PostUnitHookOnBlockConfig;
   /** Agent definition file to use. */
   agent?: string;
   /** Set false to disable without removing config. Default true. */
@@ -315,6 +342,31 @@ export interface HookDispatchResult {
   unitType: string;
   /** The trigger unit's ID, reused for the hook. */
   unitId: string;
+}
+
+export interface PostUnitGateBlock {
+  /** Blocking hook name. */
+  hookName: string;
+  /** The unit type that triggered the gate. */
+  triggerUnitType: string;
+  /** The unit ID that triggered the gate. */
+  triggerUnitId: string;
+  /** Gate artifact name, when configured. */
+  artifact?: string;
+  /** Absolute path to the gate artifact, when known. */
+  artifactPath?: string;
+  /** Parsed blocking verdict, when present. */
+  verdict?: PostUnitHookOutcomeVerdict | "failed";
+  /** Configured routing action that caused the pause. */
+  action: PostUnitHookOnBlockAction;
+  /** Human-readable pause reason. */
+  reason: string;
+  /** Current hook cycle count. */
+  cycle: number;
+  /** Configured max cycle count. */
+  maxCycles: number;
+  /** Optional compatibility retry artifact. */
+  retryArtifact?: string;
 }
 
 // ─── Budget & Notification Types ──────────────────────────────────────────
@@ -452,6 +504,15 @@ export interface PreDispatchResult {
 export interface PersistedHookState {
   /** Cycle counts keyed as "hookName/triggerUnitType/triggerUnitId". */
   cycleCounts: Record<string, number>;
+  /** In-flight hook, persisted so blocking gates cannot be skipped after resume. */
+  activeHook?: HookExecutionState | null;
+  /** Remaining hook queue by hook name and trigger unit. */
+  hookQueue?: Array<{
+    hookName: string;
+    triggerUnitType: string;
+    triggerUnitId: string;
+    forceRun?: boolean;
+  }>;
   /** Timestamp of last state save. */
   savedAt: string;
 }
@@ -465,6 +526,8 @@ export interface HookStatusEntry {
   enabled: boolean;
   /** What unit types it targets. */
   targets: string[];
+  /** Whether this post-unit hook is advisory or blocking. */
+  criticality?: PostUnitHookCriticality;
   /** Current cycle counts for active triggers. */
   activeCycles: Record<string, number>;
 }

--- a/src/resources/extensions/gsd/verdict-parser.ts
+++ b/src/resources/extensions/gsd/verdict-parser.ts
@@ -7,8 +7,59 @@
 
 import { extractUatType } from "./files.js";
 import type { UatType } from "./files.js";
+import { splitFrontmatter, parseFrontmatterMap } from "../shared/frontmatter.js";
+import { parse as parseYaml } from "yaml";
+
+function normalizeVerdict(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  let verdict = value.trim().toLowerCase();
+  if (!verdict) return undefined;
+  if (verdict === "passed") verdict = "pass";
+  return verdict;
+}
+
+function getCaseInsensitive(obj: Record<string, unknown>, key: string): unknown {
+  const lowerKey = key.toLowerCase();
+  for (const [candidate, value] of Object.entries(obj)) {
+    if (candidate.toLowerCase() === lowerKey) return value;
+  }
+  return undefined;
+}
 
 // ── Verdict extraction ──────────────────────────────────────────────────
+
+/**
+ * Extract and normalize the frontmatter `verdict` value.
+ *
+ * Supports both top-level `verdict` and the hook outcome shape
+ * `outcome.verdict`. Returns `undefined` when frontmatter is absent or has no
+ * verdict field.
+ */
+export function extractFrontmatterVerdict(content: string): string | undefined {
+  const [frontmatterLines] = splitFrontmatter(content);
+  if (!frontmatterLines) return undefined;
+
+  try {
+    const parsed = parseYaml(frontmatterLines.join("\n")) as unknown;
+    if (parsed && typeof parsed === "object") {
+      const root = parsed as Record<string, unknown>;
+      const topLevel = normalizeVerdict(getCaseInsensitive(root, "verdict"));
+      if (topLevel) return topLevel;
+      const outcome = getCaseInsensitive(root, "outcome");
+      if (outcome && typeof outcome === "object") {
+        const nested = normalizeVerdict(getCaseInsensitive(outcome as Record<string, unknown>, "verdict"));
+        if (nested) return nested;
+      }
+    }
+  } catch {
+    // Fall through to the permissive parser used by legacy frontmatter paths.
+  }
+
+  const frontmatter = parseFrontmatterMap(frontmatterLines);
+  const topLevel = normalizeVerdict(getCaseInsensitive(frontmatter, "verdict"));
+  if (topLevel) return topLevel;
+  return undefined;
+}
 
 /**
  * Extract and normalize the `verdict` value from YAML frontmatter.
@@ -21,24 +72,14 @@ import type { UatType } from "./files.js";
  */
 export function extractVerdict(content: string): string | undefined {
   // Primary: YAML frontmatter verdict (canonical format)
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (fmMatch) {
-    const verdictMatch = fmMatch[1].match(/verdict:\s*([\w-]+)/i);
-    if (verdictMatch) {
-      let v = verdictMatch[1].toLowerCase();
-      if (v === "passed") v = "pass";
-      return v;
-    }
-    return undefined;
-  }
+  const [frontmatterLines] = splitFrontmatter(content);
+  if (frontmatterLines) return extractFrontmatterVerdict(content);
 
   // Fallback: detect verdict in markdown body (LLM manual writes, #2960).
   // Matches patterns like: **Verdict:** PASS, **Verdict:** ✅ PASS, **Verdict** needs-remediation
   const bodyMatch = content.match(/\*\*Verdict:?\*\*\s*(?:✅\s*)?(\w[\w-]*)/i);
   if (bodyMatch) {
-    let v = bodyMatch[1].toLowerCase();
-    if (v === "passed") v = "pass";
-    return v;
+    return normalizeVerdict(bodyMatch[1]);
   }
 
   return undefined;


### PR DESCRIPTION
## TL;DR

**What:** Adds first-class post-unit hook criticality, blocking gate enforcement, and hook outcome verdict parsing.
**Why:** Post-unit hooks currently behave like advisory sidecars even when workflows need them to block advancement or route rework.
**How:** Validates new hook config, preserves advisory behavior, enforces blocking gates through artifact frontmatter verdicts, and pauses or retries through the existing post-unit orchestration bridge.

## What

- Adds optional `criticality` and `on_block` fields for `post_unit_hooks`.
- Adds blocking gate handling for `pass`, `advisory`, `needs-rework`, `needs-remediation`, `needs-attention`, and failed/missing verdict outcomes.
- Persists active hook state so interrupted blocking gates cannot be skipped only because an artifact exists.
- Updates GSD glossary, preferences docs, and ADRs for post-unit gate enforcement and hook outcome artifacts.
- Adds regression coverage for advisory compatibility, blocking gate reruns, restored in-flight gates, retry routing, and auto-mode pause behavior.

## Why

Post-unit hooks can represent very different workflow concerns, from optional documentation hints to required security or correctness reviews. Without typed criticality and outcome handling, auto-mode can treat required governance hooks like passive artifacts.

Closes #451.

## How

- Defaults omitted `criticality` to advisory behavior for compatibility.
- Requires blocking gates to declare a durable artifact and read machine-verdicts from frontmatter.
- Treats clean `pass` and `advisory` outcomes as progression-safe.
- Routes `needs-rework` through the existing trigger-unit retry path when configured for `retry-unit` or `retry-task`.
- Pauses for `needs-remediation`, `needs-attention`, missing/invalid gate output, failed hook execution, or exhausted gate cycle budgets.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None. The new hook fields are optional and advisory remains the default behavior.

## Validation

- `pnpm run build:pi`
- `pnpm run build:rpc-client && pnpm run build:mcp-server`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-unit-hooks.test.ts src/resources/extensions/gsd/tests/preferences.test.ts src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts`
- `pnpm run test:changed:src`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783082547&installation_id=134682257&pr_number=455&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F455&signature=189f6ab0ff4299fe09edda530b71c1e83728afba20d0d84fad3d494871df0207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode progression and post-unit orchestration when hooks are configured as blocking; default advisory behavior is unchanged but misconfigured gates or verdict parsing can pause runs until recovery.
> 
> **Overview**
> This PR adds **blocking post-unit gates** on top of existing advisory hooks. Hooks can set `criticality: advisory | blocking` and optional `on_block` routing; blocking hooks must declare an `artifact`, and progression depends on **YAML frontmatter verdicts** (`pass`, `advisory`, `needs-rework`, `needs-remediation`, `needs-attention`) parsed via shared `extractFrontmatterVerdict`.
> 
> **`RuleRegistry`** now enforces gates: advisory hooks still skip when an artifact exists without verdict; blocking hooks re-read outcomes, rerun within `max_cycles` when output is missing/invalid or hook completion wasn’t observed, route `needs-rework` through trigger-unit retry (`retry-unit` / `retry-task`), and record a **gate block** for pause paths. **Hook state persistence** expands to `activeHook` and `hookQueue` so resumed runs can’t bypass an in-flight gate.
> 
> **Auto post-unit** persists hook state earlier, handles gate blocks with `/gsd status` guidance, and tightens retry messaging. Preferences validation, types, docs, ADRs, and tests cover advisory compatibility, blocking idempotency, cycle exhaustion, restore-after-crash, and orchestrator pause on `needs-attention`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438d0018f17a81500565ab9562514f1b850c43ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->