### PR TITLE
feat(browser-tools): use managed gsd-browser engine

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@
 - **Worktree State Projection module**: module that owns the direction-and-rules of state file flow between project root and auto-worktree. Encodes the bug-hardened invariants (additive milestone copy, ASSESSMENT verdict overwrite, completed-units forward-sync, WAL/SHM cleanup) that `syncProjectRootToWorktree` and `syncStateToProjectRoot` carry today.
 - **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, runtime, and reconciliation-drift failures to a Recovery decision.
 - **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, and pre-dispatch validation aligned.
+- **Provider**: a model execution path inside the Pi/GSD agent loop, selected for a session or Unit and subject to GSD's tool and capability contracts.
+- **External MCP Client**: an AI client outside the Pi/GSD agent loop that connects to project MCP servers and owns discovery, startup, and presentation of those servers.
+- **Browser Automation Contract**: the GSD capability contract for real browser inspection, interaction, assertions, screenshots, and runtime evidence. The contract is distinct from the transport that exposes it.
+- **Browser Automation Engine**: the runtime implementation that satisfies the Browser Automation Contract for Pi/GSD Providers.
 - **Cloud MCP Gateway**: a cloud-hosted MCP endpoint that mirrors the GSD MCP tool surface and routes calls to a connected Local GSD Runtime. It stores routing metadata only, not source files or `.gsd` artifacts.
 - **Local GSD Runtime**: a user-controlled daemon process that owns project files, `.gsd` state, provider credentials, git worktrees, and actual GSD execution while maintaining an outbound connection to the Cloud MCP Gateway.
 - **Device Token**: a revocable credential issued during cloud pairing that authorizes one Local GSD Runtime to connect to the Cloud MCP Gateway for a single user account.

--- a/docs/dev/ADR-024-gsd-browser-primary-browser-engine.md
+++ b/docs/dev/ADR-024-gsd-browser-primary-browser-engine.md
@@ -1,0 +1,68 @@
+# ADR-024: Make gsd-browser the Primary Browser Automation Engine
+
+**Status:** Accepted
+**Date:** 2026-06-03
+**Related:** `CONTEXT.md`, `docs/dev/ADR-008-gsd-tools-over-mcp-for-provider-parity.md`, `docs/dev/ADR-020-cloud-mcp-gateway-local-runtime.md`
+
+## Context
+
+GSD has two browser automation paths today. Pi Providers can receive direct `browser_*` tools from the bundled `browser-tools` extension, while Claude Code and other External MCP Clients can receive `mcp__gsd-browser__browser_*` tools from `gsd-browser mcp`.
+
+That split creates a confusing failure mode: GSD prompts tell agents to use `gsd-browser`, but non-Claude Pi Providers may silently execute through the legacy Playwright-backed browser tools instead. Debug and UAT failures then appear to come from Playwright even when the intended product contract is `gsd-browser`.
+
+## Decision
+
+`gsd-browser` is the primary Browser Automation Engine for GSD. The existing `browser-tools` extension remains the Pi-facing Browser Automation Contract adapter and continues to register canonical `browser_*` tools for Pi Providers.
+
+Inside Pi, Providers should call canonical `browser_*` tools such as `browser_navigate`, `browser_snapshot_refs`, and `browser_assert`. Pi hides the transport detail and routes those tools through an internal MCP bridge to `gsd-browser mcp`. MCP-shaped names such as `mcp__gsd-browser__browser_navigate` remain an External MCP Client concern and a Claude Code host concern.
+
+Pi owns a managed built-in `gsd-browser` engine configuration resolved from the bundled `@opengsd/gsd-browser` dependency. Project `.mcp.json` generation remains for External MCP Clients through `/gsd mcp init`; it is not required for Pi Providers to use browser automation.
+
+`/gsd mcp init` writes both the GSD workflow MCP server and the `gsd-browser` MCP server for External MCP Clients by default. `GSD_BROWSER_MCP_ENABLED=0` disables only the browser entry in generated external MCP config; it does not control Pi's managed Browser Automation Engine.
+
+The managed engine should have a browser-specific connection manager. It may share low-level MCP connection utilities with the generic `mcp-client` extension, but it must not expose generic `mcp_call` behavior to the model or inherit project-local trust prompts intended for arbitrary MCP servers. Its responsibility is the Browser Automation Contract: stable canonical tools, Unit/debug-scoped browser sessions, engine health, teardown, and fail-closed behavior for browser-required workflows.
+
+The first Pi-facing surface is a curated stable subset of the Browser Automation Contract, matching the browser tools GSD already depends on for debug and run-uat flows. Broader `gsd-browser` capabilities such as live viewer, recordings, auth vault, visual diff, and advanced diagnostics can be added deliberately instead of exposing the entire MCP tool surface by default.
+
+Browser evidence is artifact-first and image-optional. Tools such as `browser_screenshot` should save evidence to artifact paths and return text/structured metadata that every Provider can consume. Providers that support image tool results may also receive image blocks, but browser verification must not depend on image ingestion alone. Assertions, snapshots, console/network logs, and evidence refs remain the primary verification surface.
+
+When `gsd-browser` cannot start, browser-required Units and commands fail closed with an actionable engine error. They must not silently fall back to the legacy Playwright implementation. Legacy browser-tools behavior remains available only as an explicit compatibility fallback, not the default for new installs.
+
+The explicit engine selector is `GSD_BROWSER_ENGINE=gsd-browser|legacy|off`, defaulting to `gsd-browser`. `legacy` forces the Playwright-backed compatibility implementation, and `off` disables Pi's Browser Automation Contract tools except for browser tools supplied directly by an External MCP Client or host integration. `GSD_BROWSER_MCP_ENABLED` remains scoped to `.mcp.json` generation for External MCP Clients.
+
+Browser identity is project-scoped, while runtime browser sessions are Unit/debug-session scoped. GSD should use project identity for durable auth and state, but use distinct named `gsd-browser` sessions so parallel Units, worktrees, and debug sessions do not share one active page.
+
+## Consequences
+
+- GSD has one product-level Browser Automation Contract for Pi Providers and External MCP Clients.
+- `browser-tools` becomes a contract adapter rather than the name of the legacy Playwright implementation.
+- `gsd-browser mcp` is the implementation boundary inside Pi because the package is distributed as a CLI/native binary and its MCP server is the primary agent path.
+- `/gsd mcp init` remains useful, but only for MCP-capable hosts outside Pi or host integrations that expose MCP names directly; its user-facing copy should describe both workflow and browser MCP servers.
+- Doctor/onboarding should verify that `gsd-browser mcp` can start and list tools, while runtime should lazily connect only when browser automation is needed.
+- Browser evidence remains usable on Providers that cannot ingest image tool results directly.
+- Engine selection is explicit and separate from External MCP Client config generation.
+
+## Migration Order
+
+1. Add the managed `gsd-browser mcp` engine manager under `browser-tools`.
+2. Route the curated canonical `browser_*` tool subset through that engine, keeping legacy Playwright behavior behind an explicit compatibility fallback.
+3. Make debug, run-uat, and other browser-required flows fail closed when the primary engine is unavailable.
+4. Update `/gsd mcp init` copy, docs, doctor, and onboarding so users understand that `.mcp.json` is for External MCP Clients while Pi Providers use the managed engine.
+
+## Alternatives Considered
+
+### Expose MCP-shaped names to all Providers
+
+Rejected. It would leak transport naming into Pi prompts and tool policy, undoing the Browser Automation Contract boundary.
+
+### Wrap `gsd-browser` CLI commands directly
+
+Rejected. CLI wrapping would duplicate schemas, response handling, batching, resources, and future MCP improvements that already exist in `gsd-browser mcp`.
+
+### Add a second Pi browser extension
+
+Rejected. A new extension would compete with `browser-tools` for the same canonical `browser_*` names and increase migration risk.
+
+### Silent fallback to legacy Playwright tools
+
+Rejected. Silent fallback hides install/runtime regressions and makes debug evidence harder to trust.

--- a/docs/dev/FILE-SYSTEM-MAP.md
+++ b/docs/dev/FILE-SYSTEM-MAP.md
@@ -15,7 +15,7 @@
 | **Auth / OAuth** | Authentication, OAuth flows, token storage |
 | **Auto Engine** | GSD autonomous execution loop, dispatch, supervision |
 | **Bg Shell** | Background process / interactive shell management |
-| **Browser Tools** | Playwright-based browser automation extension |
+| **Browser Tools** | Browser Automation Contract adapter and managed gsd-browser engine integration |
 | **Build System** | Scripts for build, packaging, version management, CI |
 | **CLI** | Command-line entry points and argument parsing |
 | **CMux** | Tmux/multiplexer session integration |
@@ -575,7 +575,7 @@
 | bg-shell/interaction.ts | Bg Shell | Interactive process communication |
 | bg-shell/output-formatter.ts | Bg Shell | Process output formatting |
 | bg-shell/overlay.ts | Bg Shell, TUI Components | Terminal overlay for process monitoring |
-| browser-tools/index.ts | Browser Tools | Playwright-based browser automation extension |
+| browser-tools/index.ts | Browser Tools | Browser Automation Contract adapter registration |
 | browser-tools/core.ts | Browser Tools | Core Playwright instance management |
 | browser-tools/lifecycle.ts | Browser Tools | Browser session lifecycle |
 | browser-tools/capture.ts | Browser Tools | Screenshot and media capture |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -60,7 +60,7 @@ GSD workflow code must treat the active project/worktree as explicit state, not 
 | Extension | What It Provides |
 |-----------|-----------------|
 | **GSD** | Core workflow engine — auto mode, state machine, commands, dashboard |
-| **Browser Tools** | Playwright-based browser automation — navigation, forms, screenshots, PDF export, device emulation, visual regression, structured data extraction, route mocking, accessibility tree inspection, and semantic actions |
+| **Browser Tools** | Browser Automation Contract adapter backed by managed gsd-browser by default, with explicit legacy Playwright compatibility |
 | **Search the Web** | Brave Search, Tavily, or Jina page extraction |
 | **Google Search** | Gemini-powered web search with AI-synthesized answers |
 | **Context7** | Up-to-date library/framework documentation |

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -126,27 +126,26 @@ If both files exist, server names are merged and the first definition found wins
 
 Use `gsd-browser` when GSD or an external MCP client needs deterministic browser automation, versioned element refs, assertions, screenshots, visual diffs, recordings, or a live human takeover viewer.
 
-Install the companion CLI first:
+For GSD Pi Providers such as Codex and non-Claude harnesses, `@opengsd/gsd-browser` is bundled with GSD and used as the default managed browser engine. External MCP clients use a project MCP entry instead. The easiest way to write that entry is:
 
 ```bash
-npm install -g @opengsd/gsd-browser
+/gsd mcp init
 ```
 
-Then add a local MCP server entry:
+If you prefer to maintain the MCP entry manually, add:
 
 ```json
 {
   "mcpServers": {
     "gsd-browser": {
-      "type": "stdio",
       "command": "gsd-browser",
-      "args": ["mcp"]
+      "args": ["mcp", "--session", "gsd-my-project", "--identity-scope", "project", "--identity-project", "/path/to/project"]
     }
   }
 }
 ```
 
-Keep this in `.gsd/mcp.json` when browser paths, vault settings, or session state are machine-local. Use `.mcp.json` only when the team should share the same server entry.
+Keep this in `.gsd/mcp.json` when browser paths, vault settings, or session state are machine-local. Use `.mcp.json` only when the team should share the same server entry. Set `GSD_BROWSER_MCP_ENABLED=0` only to skip writing the external MCP entry; it does not disable GSD's managed browser engine. Use `GSD_BROWSER_ENGINE=legacy` for the Playwright compatibility engine or `GSD_BROWSER_ENGINE=off` to disable GSD-managed Pi browser tools.
 
 ### Example: HTTP server
 

--- a/docs/user-docs/providers.md
+++ b/docs/user-docs/providers.md
@@ -88,7 +88,7 @@ If you already have a Claude Pro or Max subscription and want to use GSD's plann
 
 **Automatic setup (recommended):**
 
-When GSD detects a Claude Code model during startup, it automatically writes a `.mcp.json` file in your project root with the GSD workflow MCP server configured. No manual steps needed — just start GSD once with Claude Code as the provider and the config is created for you.
+When GSD detects a Claude Code model during startup, it automatically writes a `.mcp.json` file in your project root with the GSD workflow and `gsd-browser` MCP servers configured. No manual steps needed — just start GSD once with Claude Code as the provider and the config is created for you.
 
 You can also trigger this manually from inside a GSD session:
 
@@ -96,7 +96,9 @@ You can also trigger this manually from inside a GSD session:
 /gsd mcp init
 ```
 
-This writes (or updates) the `gsd-workflow` entry in your project's `.mcp.json`. Claude Code discovers this file automatically on its next session start.
+This writes (or updates) the `gsd-workflow` and `gsd-browser` entries in your project's `.mcp.json`. Claude Code discovers this file automatically on its next session start.
+
+GSD's own Pi Providers, including Codex and non-Claude harnesses, do not need `.mcp.json` to use browser automation. They receive canonical `browser_*` tools from GSD, and GSD routes those tools through the managed bundled `gsd-browser` engine by default.
 
 **Manual setup:**
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "prototype:tui-widget": "pnpm run build:pi-tui && pnpm run build:pi-coding-agent && node --experimental-strip-types packages/gsd-agent-modes/scripts/run-widget-prototype.mjs",
     "test:smoke": "node --experimental-strip-types tests/smoke/run.ts",
     "test:live": "node scripts/with-env.mjs GSD_LIVE_TESTS=1 -- node --experimental-strip-types tests/live/run.ts",
-    "test:browser-tools": "node --test src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs",
+    "test:browser-tools": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs src/resources/extensions/browser-tools/tests/browser-engine-selection.test.mjs src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs",
     "test:native": "pnpm --filter @gsd/native run test",
     "test:secret-scan": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/secret-scan.test.ts",
     "secret-scan": "node scripts/secret-scan.mjs",

--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -1,0 +1,579 @@
+import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Type, type TSchema } from "@sinclair/typebox";
+
+import { resolveGsdBrowserMcpLaunchConfig, type GsdBrowserMcpLaunchConfig } from "../../shared/gsd-browser-cli.js";
+import { buildMcpChildEnv } from "../../mcp-client/manager.js";
+
+type ManagedBrowserToolResult = AgentToolResult<ManagedBrowserToolDetails> & { isError?: boolean };
+
+interface ManagedBrowserToolDetails {
+  engine: "gsd-browser";
+  server: string;
+  tool: string;
+  mcpTool: string;
+  sessionName?: string;
+  projectRoot?: string;
+  truncated?: boolean;
+  outputLines?: number;
+  outputBytes?: number;
+  structuredContent?: unknown;
+  mcpIsError?: boolean;
+  error?: string;
+}
+
+interface ManagedConnection {
+  client: Client;
+  transport: StdioClientTransport;
+  launch: GsdBrowserMcpLaunchConfig;
+}
+
+interface McpContentItem {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  [key: string]: unknown;
+}
+
+interface ManagedBrowserToolSpec {
+  name: string;
+  mcpTools?: string[];
+  label: string;
+  description: string;
+  parameters: TSchema;
+  promptGuidelines?: string[];
+  compatibility?: { producesImages?: boolean };
+}
+
+const connections = new Map<string, ManagedConnection>();
+const pendingConnections = new Map<string, Promise<ManagedConnection>>();
+const DEFAULT_MAX_LINES = 2_000;
+const DEFAULT_MAX_BYTES = 50 * 1024;
+
+const AssertionCheck = Type.Object({
+  kind: Type.String({ description: "Assertion kind, e.g. url_contains, text_visible, selector_visible, no_console_errors, no_failed_requests." }),
+  selector: Type.Optional(Type.String()),
+  text: Type.Optional(Type.String()),
+  value: Type.Optional(Type.String()),
+  checked: Type.Optional(Type.Boolean()),
+  sinceActionId: Type.Optional(Type.Number()),
+}, { additionalProperties: true });
+
+const BatchStep = Type.Object({
+  action: Type.String({ description: "Step action, e.g. navigate, click, type, wait_for, assert, click_ref, fill_ref." }),
+  selector: Type.Optional(Type.String()),
+  text: Type.Optional(Type.String()),
+  url: Type.Optional(Type.String()),
+  key: Type.Optional(Type.String()),
+  condition: Type.Optional(Type.String()),
+  value: Type.Optional(Type.String()),
+  threshold: Type.Optional(Type.String()),
+  timeout: Type.Optional(Type.Number()),
+  clearFirst: Type.Optional(Type.Boolean()),
+  submit: Type.Optional(Type.Boolean()),
+  ref: Type.Optional(Type.String()),
+  checks: Type.Optional(Type.Array(AssertionCheck)),
+}, { additionalProperties: true });
+
+export const MANAGED_GSD_BROWSER_TOOL_NAMES = [
+  "browser_navigate",
+  "browser_click",
+  "browser_type",
+  "browser_fill_form",
+  "browser_click_ref",
+  "browser_fill_ref",
+  "browser_wait_for",
+  "browser_assert",
+  "browser_verify",
+  "browser_screenshot",
+  "browser_snapshot_refs",
+  "browser_find",
+  "browser_get_console_logs",
+  "browser_get_network_logs",
+  "browser_evaluate",
+  "browser_reload",
+  "browser_batch",
+  "browser_act",
+] as const;
+
+const MANAGED_BROWSER_TOOLS: ManagedBrowserToolSpec[] = [
+  {
+    name: "browser_navigate",
+    label: "Browser Navigate",
+    description: "Navigate the managed gsd-browser session to a URL and return page state. Use for local web app verification and UAT evidence.",
+    parameters: Type.Object({
+      url: Type.String({ description: "URL to navigate to, e.g. http://localhost:3000." }),
+      screenshot: Type.Optional(Type.Boolean({ description: "Capture screenshot evidence when supported." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_click",
+    label: "Browser Click",
+    description: "Click an element in the managed gsd-browser session by selector or coordinates.",
+    parameters: Type.Object({
+      selector: Type.Optional(Type.String({ description: "CSS selector to click." })),
+      x: Type.Optional(Type.Number({ description: "X coordinate to click." })),
+      y: Type.Optional(Type.Number({ description: "Y coordinate to click." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_type",
+    label: "Browser Type",
+    description: "Type or fill text into an input in the managed gsd-browser session.",
+    parameters: Type.Object({
+      selector: Type.Optional(Type.String({ description: "CSS selector of the input to type into." })),
+      text: Type.String({ description: "Text to enter." }),
+      clearFirst: Type.Optional(Type.Boolean({ description: "Clear existing text first." })),
+      submit: Type.Optional(Type.Boolean({ description: "Press Enter after typing." })),
+      slowly: Type.Optional(Type.Boolean({ description: "Type character by character." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_fill_form",
+    label: "Browser Fill Form",
+    description: "Fill a form in the managed gsd-browser session using field labels, names, placeholders, or aria labels.",
+    parameters: Type.Object({
+      selector: Type.Optional(Type.String({ description: "CSS selector targeting the form." })),
+      values: Type.Record(Type.String(), Type.String(), { description: "Field identifier to value mapping." }),
+      submit: Type.Optional(Type.Boolean({ description: "Submit the form after filling." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_click_ref",
+    label: "Browser Click Ref",
+    description: "Click a versioned ref from the latest gsd-browser snapshot.",
+    parameters: Type.Object({
+      ref: Type.String({ description: "Versioned ref, e.g. @v3:e2." }),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_fill_ref",
+    label: "Browser Fill Ref",
+    description: "Fill text into an input-like versioned ref from the latest gsd-browser snapshot.",
+    parameters: Type.Object({
+      ref: Type.String({ description: "Versioned ref, e.g. @v3:e1." }),
+      text: Type.String({ description: "Text to enter." }),
+      clearFirst: Type.Optional(Type.Boolean({ description: "Clear existing text first." })),
+      submit: Type.Optional(Type.Boolean({ description: "Press Enter after filling." })),
+      slowly: Type.Optional(Type.Boolean({ description: "Type character by character." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_wait_for",
+    label: "Browser Wait For",
+    description: "Wait for a browser condition such as network idle, selector visibility, text visibility, or URL change.",
+    parameters: Type.Object({
+      condition: Type.String({ description: "Condition, e.g. network_idle, selector_visible, text_visible, url_contains." }),
+      value: Type.Optional(Type.String({ description: "Selector, text, URL substring, or delay value depending on condition." })),
+      threshold: Type.Optional(Type.String({ description: "Threshold expression for count-based conditions." })),
+      timeout: Type.Optional(Type.Number({ description: "Maximum milliseconds to wait." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_assert",
+    label: "Browser Assert",
+    description: "Run explicit browser assertions and return structured PASS/FAIL evidence.",
+    promptGuidelines: [
+      "Prefer browser_assert for final browser verification instead of inferring success from summaries.",
+      "Use checks for URL, text, selector state, value, and browser diagnostics whenever those signals are available.",
+    ],
+    parameters: Type.Object({
+      checks: Type.Array(AssertionCheck),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_verify",
+    label: "Browser Verify",
+    description: "Run a structured browser verification flow and return evidence from the managed gsd-browser session.",
+    parameters: Type.Object({
+      url: Type.String({ description: "URL to verify." }),
+      checks: Type.Array(Type.Object({
+        description: Type.String({ description: "What this check verifies." }),
+        selector: Type.Optional(Type.String()),
+        expectedText: Type.Optional(Type.String()),
+        expectedVisible: Type.Optional(Type.Boolean()),
+        screenshot: Type.Optional(Type.Boolean()),
+      }, { additionalProperties: true })),
+      timeout: Type.Optional(Type.Number({ description: "Navigation timeout in milliseconds." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_screenshot",
+    label: "Browser Screenshot",
+    description: "Capture browser screenshot evidence from the managed gsd-browser session.",
+    compatibility: { producesImages: true },
+    parameters: Type.Object({
+      fullPage: Type.Optional(Type.Boolean({ description: "Capture the full scrollable page." })),
+      selector: Type.Optional(Type.String({ description: "CSS selector to crop." })),
+      quality: Type.Optional(Type.Number({ description: "JPEG quality when supported." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_snapshot_refs",
+    mcpTools: ["browser_snapshot", "browser_snapshot_refs"],
+    label: "Browser Snapshot Refs",
+    description: "Capture a compact gsd-browser snapshot with versioned refs for reliable interaction.",
+    parameters: Type.Object({
+      selector: Type.Optional(Type.String({ description: "Optional CSS selector scope." })),
+      interactiveOnly: Type.Optional(Type.Boolean({ description: "Compatibility flag; use mode for gsd-browser filtering." })),
+      limit: Type.Optional(Type.Number({ description: "Maximum elements to include." })),
+      mode: Type.Optional(Type.String({ description: "Snapshot mode: interactive, form, dialog, navigation, errors, headings, visible_only." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_find",
+    mcpTools: ["browser_find_element", "browser_find"],
+    label: "Browser Find",
+    description: "Find elements by text, role, or selector in the managed gsd-browser session.",
+    parameters: Type.Object({
+      text: Type.Optional(Type.String({ description: "Visible text to find." })),
+      role: Type.Optional(Type.String({ description: "ARIA role to filter by." })),
+      selector: Type.Optional(Type.String({ description: "CSS selector to scope or match." })),
+      limit: Type.Optional(Type.Number({ description: "Maximum results to return." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_get_console_logs",
+    mcpTools: ["browser_console", "browser_get_console_logs"],
+    label: "Browser Console Logs",
+    description: "Return buffered console logs and JavaScript errors from the managed gsd-browser session.",
+    parameters: Type.Object({
+      clear: Type.Optional(Type.Boolean({ description: "Clear the buffer after reading logs." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_get_network_logs",
+    mcpTools: ["browser_network", "browser_get_network_logs"],
+    label: "Browser Network Logs",
+    description: "Return buffered network requests and responses from the managed gsd-browser session.",
+    parameters: Type.Object({
+      clear: Type.Optional(Type.Boolean({ description: "Clear the buffer after reading logs." })),
+      filter: Type.Optional(Type.String({ description: "Filter, e.g. all, errors, fetch-xhr." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_evaluate",
+    mcpTools: ["browser_eval", "browser_evaluate"],
+    label: "Browser Evaluate",
+    description: "Evaluate a JavaScript expression in the managed gsd-browser page context.",
+    parameters: Type.Object({
+      expression: Type.String({ description: "JavaScript expression to evaluate." }),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_reload",
+    label: "Browser Reload",
+    description: "Reload the current page in the managed gsd-browser session.",
+    parameters: Type.Object({}, { additionalProperties: true }),
+  },
+  {
+    name: "browser_batch",
+    label: "Browser Batch",
+    description: "Execute multiple explicit browser steps through the managed gsd-browser session in one call.",
+    promptGuidelines: [
+      "Use browser_batch for obvious low-risk sequences like navigate, snapshot, click, type, wait, assert.",
+      "Keep browser_batch steps explicit; do not use it as a speculative planner.",
+    ],
+    parameters: Type.Object({
+      steps: Type.Array(BatchStep),
+      stopOnFailure: Type.Optional(Type.Boolean({ description: "Stop after the first failing step." })),
+      finalSummaryOnly: Type.Optional(Type.Boolean({ description: "Return only the compact final summary." })),
+    }, { additionalProperties: true }),
+  },
+  {
+    name: "browser_act",
+    label: "Browser Act",
+    description: "Execute a semantic browser action through gsd-browser, such as primary_cta, submit_form, or close_dialog.",
+    parameters: Type.Object({
+      intent: Type.String({ description: "Semantic intent, e.g. submit_form, close_dialog, primary_cta, search_field, accept_cookies." }),
+      scope: Type.Optional(Type.String({ description: "CSS selector to narrow the search area." })),
+    }, { additionalProperties: true }),
+  },
+];
+
+function resolveProjectRoot(ctx?: ExtensionContext): string {
+  return ctx?.cwd || process.cwd();
+}
+
+function resolveManagedSessionSuffix(ctx?: ExtensionContext): string {
+  const explicit = process.env.GSD_BROWSER_SESSION_SUFFIX?.trim() || process.env.GSD_BROWSER_SESSION_ID?.trim();
+  if (explicit) return explicit;
+
+  try {
+    const sessionId = ctx?.sessionManager?.getSessionId?.();
+    if (sessionId) return `pi-${sessionId.slice(0, 12)}`;
+  } catch {
+    // Fall back to pid below when session metadata is unavailable.
+  }
+
+  return `pi-${process.pid}`;
+}
+
+function buildConnectionKey(launch: GsdBrowserMcpLaunchConfig): string {
+  return JSON.stringify({
+    command: launch.command,
+    args: launch.args,
+    cwd: launch.cwd,
+    env: launch.env ?? {},
+  });
+}
+
+async function connectManagedGsdBrowser(
+  launch: GsdBrowserMcpLaunchConfig,
+  signal?: AbortSignal,
+): Promise<ManagedConnection> {
+  const client = new Client({ name: "gsd-pi-browser-tools", version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: launch.command,
+    args: launch.args,
+    env: buildMcpChildEnv(launch.env),
+    cwd: launch.cwd,
+    stderr: "pipe",
+  });
+
+  try {
+    await client.connect(transport, { signal, timeout: 30000 });
+    return { client, transport, launch };
+  } catch (error) {
+    try {
+      await transport.close();
+    } catch {
+      // Best-effort cleanup after a failed or aborted connection attempt.
+    }
+    try {
+      await client.close();
+    } catch {
+      // Best-effort cleanup after a failed or aborted connection attempt.
+    }
+    throw error;
+  }
+}
+
+async function getOrConnectManagedGsdBrowser(
+  ctx?: ExtensionContext,
+  signal?: AbortSignal,
+): Promise<ManagedConnection> {
+  const launch = resolveGsdBrowserMcpLaunchConfig(resolveProjectRoot(ctx), process.env, {
+    sessionSuffix: resolveManagedSessionSuffix(ctx),
+  });
+  const key = buildConnectionKey(launch);
+  const existing = connections.get(key);
+  if (existing) return existing;
+
+  const pending = pendingConnections.get(key);
+  if (pending) return pending;
+
+  const connectionPromise = connectManagedGsdBrowser(launch, signal);
+  pendingConnections.set(key, connectionPromise);
+  try {
+    const connection = await connectionPromise;
+    connections.set(key, connection);
+    return connection;
+  } finally {
+    pendingConnections.delete(key);
+  }
+}
+
+function isUnknownMcpToolError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /unknown tool|tool .*not found|tool not found|not registered|does not exist/i.test(message);
+}
+
+function normalizeManagedArgs(piToolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (piToolName === "browser_snapshot_refs") {
+    const { interactiveOnly: _interactiveOnly, ...snapshotArgs } = args;
+    return snapshotArgs;
+  }
+  return args;
+}
+
+function serializeMcpContent(
+  contentItems: McpContentItem[],
+): { content: ManagedBrowserToolResult["content"]; truncated: boolean; outputLines: number; outputBytes: number } {
+  const imageItems: Array<{ type: "image"; data: string; mimeType: string }> = [];
+  const textParts: string[] = [];
+
+  for (const item of contentItems) {
+    if (item.type === "text") {
+      textParts.push(item.text ?? "");
+      continue;
+    }
+    if (item.type === "image" && typeof item.data === "string" && typeof item.mimeType === "string") {
+      imageItems.push({ type: "image", data: item.data, mimeType: item.mimeType });
+      textParts.push(`[image evidence: ${item.mimeType}]`);
+      continue;
+    }
+    textParts.push(JSON.stringify(item));
+  }
+
+  const rawText = textParts.filter((part) => part.length > 0).join("\n");
+  const truncation = truncateHeadText(rawText, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+  let finalText = truncation.content;
+  if (truncation.truncated) {
+    finalText += `\n\n[Output truncated: ${truncation.outputLines}/${truncation.totalLines} lines (${formatByteSize(truncation.outputBytes)} of ${formatByteSize(truncation.totalBytes)})]`;
+  }
+
+  let content: ManagedBrowserToolResult["content"];
+  if (finalText) {
+    content = [{ type: "text", text: finalText }, ...imageItems];
+  } else if (imageItems.length > 0) {
+    content = imageItems;
+  } else {
+    content = [{ type: "text", text: "gsd-browser returned no content." }];
+  }
+
+  return {
+    content,
+    truncated: truncation.truncated,
+    outputLines: truncation.outputLines,
+    outputBytes: truncation.outputBytes,
+  };
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function truncateHeadText(
+  text: string,
+  options: { maxLines: number; maxBytes: number },
+): { content: string; truncated: boolean; outputLines: number; totalLines: number; outputBytes: number; totalBytes: number } {
+  const totalBytes = Buffer.byteLength(text, "utf-8");
+  const allLines = text.split(/\r?\n/);
+  const totalLines = text.length === 0 ? 0 : allLines.length;
+  let content = allLines.slice(0, options.maxLines).join("\n");
+
+  while (Buffer.byteLength(content, "utf-8") > options.maxBytes && content.length > 0) {
+    content = content.slice(0, Math.max(0, content.length - 1024));
+  }
+
+  const outputBytes = Buffer.byteLength(content, "utf-8");
+  const outputLines = content.length === 0 ? 0 : content.split(/\r?\n/).length;
+  return {
+    content,
+    truncated: outputLines < totalLines || outputBytes < totalBytes,
+    outputLines,
+    totalLines,
+    outputBytes,
+    totalBytes,
+  };
+}
+
+async function callManagedGsdBrowserTool(
+  piToolName: string,
+  mcpTools: string[],
+  args: Record<string, unknown>,
+  options: { signal?: AbortSignal; ctx?: ExtensionContext },
+): Promise<ManagedBrowserToolResult> {
+  const connection = await getOrConnectManagedGsdBrowser(options.ctx, options.signal);
+  const normalizedArgs = normalizeManagedArgs(piToolName, args);
+  let lastError: unknown;
+
+  for (const mcpTool of mcpTools) {
+    try {
+      const result = await connection.client.callTool(
+        { name: mcpTool, arguments: normalizedArgs },
+        undefined,
+        { signal: options.signal, timeout: 60000 },
+      );
+      const contentItems = Array.isArray(result.content) ? result.content as McpContentItem[] : [];
+      const serialized = serializeMcpContent(contentItems);
+
+      return {
+        content: serialized.content,
+        details: {
+          engine: "gsd-browser",
+          server: connection.launch.serverName,
+          tool: piToolName,
+          mcpTool,
+          sessionName: connection.launch.sessionName,
+          projectRoot: connection.launch.projectRoot,
+          truncated: serialized.truncated,
+          outputLines: serialized.outputLines,
+          outputBytes: serialized.outputBytes,
+          structuredContent: (result as { structuredContent?: unknown }).structuredContent,
+          mcpIsError: Boolean((result as { isError?: boolean }).isError),
+        },
+        isError: Boolean((result as { isError?: boolean }).isError),
+      };
+    } catch (error) {
+      lastError = error;
+      if (!isUnknownMcpToolError(error)) break;
+    }
+  }
+
+  throw lastError;
+}
+
+function formatManagedBrowserError(toolName: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return [
+    `gsd-browser engine or tool unavailable for ${toolName}: ${message}`,
+    "",
+    "GSD browser automation now uses the managed gsd-browser engine by default.",
+    "Run /gsd doctor or reinstall dependencies so @opengsd/gsd-browser is available.",
+    "Set GSD_BROWSER_ENGINE=legacy only when you intentionally need the Playwright compatibility engine.",
+  ].join("\n");
+}
+
+export function registerManagedGsdBrowserTools(pi: ExtensionAPI): void {
+  for (const tool of MANAGED_BROWSER_TOOLS) {
+    pi.registerTool({
+      name: tool.name,
+      label: tool.label,
+      description: tool.description,
+      ...(tool.promptGuidelines ? { promptGuidelines: tool.promptGuidelines } : {}),
+      ...(tool.compatibility ? { compatibility: tool.compatibility } : {}),
+      parameters: tool.parameters,
+      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+        try {
+          return await callManagedGsdBrowserTool(
+            tool.name,
+            tool.mcpTools ?? [tool.name],
+            params as Record<string, unknown>,
+            { signal, ctx },
+          );
+        } catch (error) {
+          const message = formatManagedBrowserError(tool.name, error);
+          return {
+            content: [{ type: "text", text: message }],
+            details: {
+              engine: "gsd-browser",
+              server: "gsd-browser",
+              tool: tool.name,
+              mcpTool: tool.mcpTools?.[0] ?? tool.name,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            isError: true,
+          };
+        }
+      },
+    });
+  }
+}
+
+export async function closeManagedGsdBrowser(): Promise<void> {
+  const closing = Array.from(connections.entries()).map(async ([key, connection]) => {
+    try {
+      await connection.client.close();
+    } catch {
+      // Best-effort cleanup.
+    }
+    try {
+      await connection.transport.close();
+    } catch {
+      // Best-effort cleanup.
+    }
+    connections.delete(key);
+  });
+  await Promise.allSettled(closing);
+  pendingConnections.clear();
+}
+
+export async function _resetManagedGsdBrowserForTest(): Promise<void> {
+  await closeManagedGsdBrowser();
+}

--- a/src/resources/extensions/browser-tools/engine/selection.ts
+++ b/src/resources/extensions/browser-tools/engine/selection.ts
@@ -1,0 +1,19 @@
+export type BrowserEngineMode = "gsd-browser" | "legacy" | "off";
+
+const DEFAULT_BROWSER_ENGINE: BrowserEngineMode = "gsd-browser";
+
+export function resolveBrowserEngineMode(env: NodeJS.ProcessEnv = process.env): BrowserEngineMode {
+  const raw = env.GSD_BROWSER_ENGINE?.trim();
+  if (!raw) return DEFAULT_BROWSER_ENGINE;
+
+  const normalized = raw.toLowerCase();
+  if (normalized === "gsd-browser" || normalized === "gsd_browser" || normalized === "gsdbrowser") {
+    return "gsd-browser";
+  }
+  if (normalized === "legacy" || normalized === "playwright") return "legacy";
+  if (normalized === "off" || normalized === "none" || normalized === "disabled" || normalized === "0" || normalized === "false") {
+    return "off";
+  }
+
+  throw new Error(`Invalid GSD_BROWSER_ENGINE="${raw}". Expected "gsd-browser", "legacy", or "off".`);
+}

--- a/src/resources/extensions/browser-tools/extension-manifest.json
+++ b/src/resources/extensions/browser-tools/extension-manifest.json
@@ -2,7 +2,7 @@
   "id": "browser-tools",
   "name": "Browser Tools",
   "version": "1.0.0",
-  "description": "Playwright-based web automation, screenshots, and analysis",
+  "description": "GSD browser automation contract adapter backed by the managed gsd-browser engine",
   "tier": "bundled",
   "requires": { "platform": ">=2.29.0" },
   "provides": {
@@ -32,6 +32,6 @@
     "hooks": ["session_start", "session_shutdown"]
   },
   "dependencies": {
-    "runtime": ["playwright"]
+    "runtime": ["@opengsd/gsd-browser"]
   }
 }

--- a/src/resources/extensions/browser-tools/index.ts
+++ b/src/resources/extensions/browser-tools/index.ts
@@ -1,11 +1,16 @@
-/** browser-tools — pi extension: full browser interaction via Playwright. */
+/** browser-tools — Pi Browser Automation Contract adapter. */
 import { importExtensionModule, type ExtensionAPI } from "@gsd/pi-coding-agent";
 
-let registrationPromise: Promise<void> | null = null;
+import { closeManagedGsdBrowser, registerManagedGsdBrowserTools } from "./engine/managed-gsd-browser.js";
+import { resolveBrowserEngineMode, type BrowserEngineMode } from "./engine/selection.js";
 
-async function registerBrowserTools(pi: ExtensionAPI): Promise<void> {
-  if (!registrationPromise) {
-    registrationPromise = (async () => {
+let legacyRegistrationPromise: Promise<void> | null = null;
+let managedRegistrationPromise: Promise<void> | null = null;
+let registeredEngine: Exclude<BrowserEngineMode, "off"> | null = null;
+
+async function registerLegacyBrowserTools(pi: ExtensionAPI): Promise<void> {
+  if (!legacyRegistrationPromise) {
+    legacyRegistrationPromise = (async () => {
       const [
         lifecycle,
         capture,
@@ -136,12 +141,55 @@ async function registerBrowserTools(pi: ExtensionAPI): Promise<void> {
       injectionDetection.registerInjectionDetectionTools(pi, deps);
       verify.registerVerifyTools(pi, deps);
     })().catch((error) => {
-      registrationPromise = null;
+      legacyRegistrationPromise = null;
       throw error;
     });
   }
 
-  return registrationPromise;
+  return legacyRegistrationPromise;
+}
+
+async function registerBrowserTools(pi: ExtensionAPI): Promise<void> {
+  const engine = resolveBrowserEngineMode();
+  if (engine === "off") return;
+  if (registeredEngine && registeredEngine !== engine) {
+    throw new Error(
+      `Browser tools already registered with GSD_BROWSER_ENGINE=${registeredEngine}. Restart GSD before switching to ${engine}.`,
+    );
+  }
+
+  let registration: Promise<void>;
+  if (engine === "legacy") {
+    registration = registerLegacyBrowserTools(pi);
+  } else if (!managedRegistrationPromise) {
+    managedRegistrationPromise = Promise.resolve()
+      .then(() => {
+        registerManagedGsdBrowserTools(pi);
+      })
+      .catch((error) => {
+        managedRegistrationPromise = null;
+        throw error;
+      });
+    registration = managedRegistrationPromise;
+  } else {
+    registration = managedRegistrationPromise;
+  }
+
+  registeredEngine = engine;
+  try {
+    await registration;
+  } catch (error) {
+    if (registeredEngine === engine) registeredEngine = null;
+    throw error;
+  }
+}
+
+async function closeActiveBrowserEngines(): Promise<void> {
+  await closeManagedGsdBrowser();
+  if (legacyRegistrationPromise) {
+    const { closeBrowser } = await importExtensionModule<typeof import("./lifecycle.js")>(import.meta.url, "./lifecycle.js");
+    await closeBrowser();
+  }
 }
 
 export default function (pi: ExtensionAPI) {
@@ -157,7 +205,10 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
-    const { closeBrowser } = await importExtensionModule<typeof import("./lifecycle.js")>(import.meta.url, "./lifecycle.js");
-    await closeBrowser();
+    await closeActiveBrowserEngines();
+  });
+
+  pi.on("session_switch", async () => {
+    await closeActiveBrowserEngines();
   });
 }

--- a/src/resources/extensions/browser-tools/package.json
+++ b/src/resources/extensions/browser-tools/package.json
@@ -4,16 +4,20 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --test tests/*.test.mjs"
+    "test": "node --import ../gsd/tests/resolve-ts.mjs --experimental-strip-types --test tests/*.test.mjs"
   },
   "pi": {
     "extensions": ["./index.ts"]
   },
   "peerDependencies": {
+    "@opengsd/gsd-browser": ">=0.1.27",
     "playwright": ">=1.40.0",
     "sharp": ">=0.33.0"
   },
   "peerDependenciesMeta": {
+    "@opengsd/gsd-browser": {
+      "optional": true
+    },
     "playwright": {
       "optional": true
     },

--- a/src/resources/extensions/browser-tools/tests/browser-engine-selection.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/browser-engine-selection.test.mjs
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const jiti = require("jiti")(__dirname, { interopDefault: true, debug: false });
+
+const { resolveBrowserEngineMode } = jiti("../engine/selection.ts");
+
+describe("resolveBrowserEngineMode", () => {
+  it("defaults to gsd-browser", () => {
+    assert.equal(resolveBrowserEngineMode({}), "gsd-browser");
+  });
+
+  it("accepts the explicit engine modes", () => {
+    assert.equal(resolveBrowserEngineMode({ GSD_BROWSER_ENGINE: "gsd-browser" }), "gsd-browser");
+    assert.equal(resolveBrowserEngineMode({ GSD_BROWSER_ENGINE: "legacy" }), "legacy");
+    assert.equal(resolveBrowserEngineMode({ GSD_BROWSER_ENGINE: "off" }), "off");
+  });
+
+  it("accepts compatibility aliases", () => {
+    assert.equal(resolveBrowserEngineMode({ GSD_BROWSER_ENGINE: "playwright" }), "legacy");
+    assert.equal(resolveBrowserEngineMode({ GSD_BROWSER_ENGINE: "false" }), "off");
+  });
+
+  it("rejects unknown engine modes", () => {
+    assert.throws(
+      () => resolveBrowserEngineMode({ GSD_BROWSER_ENGINE: "surprise" }),
+      /Expected "gsd-browser", "legacy", or "off"/,
+    );
+  });
+});

--- a/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  MANAGED_GSD_BROWSER_TOOL_NAMES,
+  registerManagedGsdBrowserTools,
+} = await import("../engine/managed-gsd-browser.ts");
+
+describe("registerManagedGsdBrowserTools", () => {
+  it("registers the curated Pi browser contract", () => {
+    const tools = [];
+    registerManagedGsdBrowserTools({
+      registerTool(tool) {
+        tools.push(tool);
+      },
+    });
+
+    assert.deepEqual(tools.map((tool) => tool.name), [...MANAGED_GSD_BROWSER_TOOL_NAMES]);
+    assert.equal(new Set(tools.map((tool) => tool.name)).size, tools.length);
+  });
+
+  it("keeps screenshots marked as image-producing evidence", () => {
+    const tools = [];
+    registerManagedGsdBrowserTools({
+      registerTool(tool) {
+        tools.push(tool);
+      },
+    });
+
+    const screenshot = tools.find((tool) => tool.name === "browser_screenshot");
+    assert.equal(screenshot?.compatibility?.producesImages, true);
+  });
+});

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -72,7 +72,8 @@ export function formatMcpInitResult(
     `Project: ${targetPath}`,
     `Config:   ${configPath}`,
     "",
-    "MCP-capable clients can now load the GSD workflow MCP server from this folder.",
+    "MCP-capable clients can now load the GSD workflow and gsd-browser MCP servers from this folder.",
+    "Pi Providers use the managed gsd-browser engine directly; this project config is for External MCP Clients.",
     "Restart or reconnect any client that already has this project open.",
   ].join("\n");
 }

--- a/src/resources/extensions/gsd/mcp-project-config.ts
+++ b/src/resources/extensions/gsd/mcp-project-config.ts
@@ -1,14 +1,17 @@
-import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { basename, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  GSD_BROWSER_MCP_SERVER_NAME,
+  resolveBundledGsdBrowserCliPath,
+  resolveGsdBrowserMcpLaunchConfig,
+} from "../shared/gsd-browser-cli.js";
 import { assertSafeDirectory } from "./validate-directory.js";
 import { detectWorkflowMcpLaunchConfig } from "./workflow-mcp.js";
 
 export const GSD_WORKFLOW_MCP_SERVER_NAME = "gsd-workflow";
-export const GSD_BROWSER_MCP_SERVER_NAME = "gsd-browser";
+export { GSD_BROWSER_MCP_SERVER_NAME, resolveBundledGsdBrowserCliPath };
 
 export interface ProjectMcpServerConfig {
   command?: string;
@@ -59,31 +62,6 @@ export function resolveBundledGsdCliPath(env: NodeJS.ProcessEnv = process.env): 
   return null;
 }
 
-export function resolveBundledGsdBrowserCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
-  const explicit = env.GSD_BROWSER_CLI_PATH?.trim() || env.GSD_BROWSER_BIN_PATH?.trim();
-  if (explicit) return explicit;
-
-  try {
-    const requireFromHere = createRequire(import.meta.url);
-    const packageJsonPath = requireFromHere.resolve("@opengsd/gsd-browser/package.json");
-    const candidate = resolve(packageJsonPath, "..", "bin", "gsd-browser");
-    if (existsSync(candidate)) return candidate;
-  } catch {
-    // Fall through to path candidates for source/dist layouts.
-  }
-
-  const candidates = [
-    resolve(fileURLToPath(new URL("../../../../node_modules/@opengsd/gsd-browser/bin/gsd-browser", import.meta.url))),
-    resolve(fileURLToPath(new URL("../../../../node_modules/.bin/gsd-browser", import.meta.url))),
-  ];
-
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
-  }
-
-  return null;
-}
-
 export function buildProjectWorkflowMcpServerConfig(
   projectRoot: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -119,29 +97,10 @@ function buildProjectWorkflowMcpServerSpec(
   };
 }
 
-function parseJsonEnv<T>(env: NodeJS.ProcessEnv, name: string): T | undefined {
-  const raw = env[name];
-  if (!raw) return undefined;
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    throw new Error(`Invalid JSON in ${name}`);
-  }
-}
-
 function isEnvDisabled(value: string | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
   return normalized === "0" || normalized === "false" || normalized === "off";
-}
-
-function buildBrowserSessionName(projectRoot: string): string {
-  const resolvedProjectRoot = resolve(projectRoot);
-  const base = basename(resolvedProjectRoot)
-    .replace(/[^a-zA-Z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "") || "project";
-  const hash = createHash("sha1").update(resolvedProjectRoot).digest("hex").slice(0, 8);
-  return `gsd-${base}-${hash}`;
 }
 
 export function buildProjectBrowserMcpServerConfig(
@@ -157,39 +116,15 @@ function buildProjectBrowserMcpServerSpec(
 ): ProjectMcpServerSpec | null {
   if (isEnvDisabled(env.GSD_BROWSER_MCP_ENABLED)) return null;
 
-  const resolvedProjectRoot = resolve(projectRoot);
-  const serverName = env.GSD_BROWSER_MCP_NAME?.trim() || GSD_BROWSER_MCP_SERVER_NAME;
-  const explicitArgs = parseJsonEnv<unknown>(env, "GSD_BROWSER_MCP_ARGS");
-  const explicitEnv = parseJsonEnv<Record<string, string>>(env, "GSD_BROWSER_MCP_ENV");
-  const explicitCommand = env.GSD_BROWSER_MCP_COMMAND?.trim();
-  const explicitCliPath = env.GSD_BROWSER_CLI_PATH?.trim() || env.GSD_BROWSER_BIN_PATH?.trim();
-  const bundledCliPath = !explicitCommand && !explicitCliPath ? resolveBundledGsdBrowserCliPath(env) : null;
-  const command =
-    explicitCommand
-    || explicitCliPath
-    || (bundledCliPath ? process.execPath : undefined)
-    || "gsd-browser";
-  const args = Array.isArray(explicitArgs) && explicitArgs.length > 0
-    ? explicitArgs.map(String)
-    : [
-        ...(bundledCliPath ? [bundledCliPath] : []),
-        "mcp",
-        "--session",
-        buildBrowserSessionName(resolvedProjectRoot),
-        "--identity-scope",
-        "project",
-        "--identity-project",
-        resolvedProjectRoot,
-      ];
-  const cwd = env.GSD_BROWSER_MCP_CWD?.trim() || resolvedProjectRoot;
+  const launch = resolveGsdBrowserMcpLaunchConfig(projectRoot, env);
 
   return {
-    serverName,
+    serverName: launch.serverName,
     server: {
-      command,
-      args,
-      cwd,
-      ...(explicitEnv ? { env: explicitEnv } : {}),
+      command: launch.command,
+      args: launch.args,
+      cwd: launch.cwd,
+      ...(launch.env ? { env: launch.env } : {}),
     },
   };
 }

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -341,6 +341,8 @@ describe("formatMcpInitResult", () => {
     assert.match(result, /created project mcp config/i);
     assert.match(result, /\/tmp\/project\/\.mcp\.json/);
     assert.match(result, /mcp-capable clients/i);
+    assert.match(result, /workflow and gsd-browser MCP servers/i);
+    assert.match(result, /Pi Providers use the managed gsd-browser engine/i);
     assert.doesNotMatch(result, /claude code/i);
   });
 

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -1,0 +1,116 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { basename, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const GSD_BROWSER_MCP_SERVER_NAME = "gsd-browser";
+
+export interface GsdBrowserMcpLaunchConfig {
+  serverName: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+  projectRoot: string;
+  sessionName: string;
+}
+
+export interface GsdBrowserMcpLaunchOptions {
+  sessionName?: string;
+  sessionSuffix?: string;
+}
+
+function parseJsonEnv<T>(env: NodeJS.ProcessEnv, name: string): T | undefined {
+  const raw = env[name];
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new Error(`Invalid JSON in ${name}`);
+  }
+}
+
+function sanitizeSessionSegment(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+export function resolveBundledGsdBrowserCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const explicit = env.GSD_BROWSER_CLI_PATH?.trim() || env.GSD_BROWSER_BIN_PATH?.trim();
+  if (explicit) return explicit;
+
+  try {
+    const requireFromHere = createRequire(import.meta.url);
+    const packageJsonPath = requireFromHere.resolve("@opengsd/gsd-browser/package.json");
+    const candidate = resolve(packageJsonPath, "..", "bin", "gsd-browser");
+    if (existsSync(candidate)) return candidate;
+  } catch {
+    // Fall through to path candidates for source/dist layouts.
+  }
+
+  const candidates = [
+    resolve(fileURLToPath(new URL("../../../../node_modules/@opengsd/gsd-browser/bin/gsd-browser", import.meta.url))),
+    resolve(fileURLToPath(new URL("../../../../node_modules/.bin/gsd-browser", import.meta.url))),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+export function buildGsdBrowserSessionName(projectRoot: string, suffix?: string): string {
+  const resolvedProjectRoot = resolve(projectRoot);
+  const base = sanitizeSessionSegment(basename(resolvedProjectRoot)) || "project";
+  const hash = createHash("sha1").update(resolvedProjectRoot).digest("hex").slice(0, 8);
+  const cleanSuffix = suffix ? sanitizeSessionSegment(suffix) : "";
+  return cleanSuffix ? `gsd-${base}-${hash}-${cleanSuffix}` : `gsd-${base}-${hash}`;
+}
+
+export function resolveGsdBrowserMcpLaunchConfig(
+  projectRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+  options: GsdBrowserMcpLaunchOptions = {},
+): GsdBrowserMcpLaunchConfig {
+  const resolvedProjectRoot = resolve(projectRoot);
+  const serverName = env.GSD_BROWSER_MCP_NAME?.trim() || GSD_BROWSER_MCP_SERVER_NAME;
+  const explicitArgs = parseJsonEnv<unknown>(env, "GSD_BROWSER_MCP_ARGS");
+  const explicitEnv = parseJsonEnv<Record<string, string>>(env, "GSD_BROWSER_MCP_ENV");
+  const explicitCommand = env.GSD_BROWSER_MCP_COMMAND?.trim();
+  const explicitCliPath = env.GSD_BROWSER_CLI_PATH?.trim() || env.GSD_BROWSER_BIN_PATH?.trim();
+  const bundledCliPath = !explicitCommand && !explicitCliPath ? resolveBundledGsdBrowserCliPath(env) : null;
+  const sessionName =
+    options.sessionName?.trim() || buildGsdBrowserSessionName(resolvedProjectRoot, options.sessionSuffix);
+  const command =
+    explicitCommand
+    || explicitCliPath
+    || (bundledCliPath ? process.execPath : undefined)
+    || "gsd-browser";
+  const args = Array.isArray(explicitArgs) && explicitArgs.length > 0
+    ? explicitArgs.map(String)
+    : [
+        ...(bundledCliPath ? [bundledCliPath] : []),
+        "mcp",
+        "--session",
+        sessionName,
+        "--identity-scope",
+        "project",
+        "--identity-project",
+        resolvedProjectRoot,
+      ];
+  const cwd = env.GSD_BROWSER_MCP_CWD?.trim() || resolvedProjectRoot;
+
+  return {
+    serverName,
+    command,
+    args,
+    cwd,
+    ...(explicitEnv ? { env: explicitEnv } : {}),
+    projectRoot: resolvedProjectRoot,
+    sessionName,
+  };
+}


### PR DESCRIPTION
## TL;DR

**What:** Routes the Pi Browser Automation Contract through a managed `gsd-browser mcp` engine by default while keeping the Playwright implementation behind `GSD_BROWSER_ENGINE=legacy`.
**Why:** GSD should not tell agents to use `gsd-browser` while non-Claude Pi Providers silently execute through the legacy Playwright path.
**How:** Adds a browser-specific managed MCP bridge, a `GSD_BROWSER_ENGINE` selector, shared `gsd-browser` launch resolution, docs/ADR updates, and targeted tests for registration and MCP init copy.

## What

- Adds a managed `gsd-browser` engine under `browser-tools` that registers the curated canonical `browser_*` Pi tool subset.
- Keeps legacy Playwright browser tools available only via `GSD_BROWSER_ENGINE=legacy`; `GSD_BROWSER_ENGINE=off` disables GSD-managed Pi browser tools.
- Extracts shared bundled `@opengsd/gsd-browser` CLI resolution for both `/gsd mcp init` and the managed Pi engine.
- Updates `/gsd mcp init` copy and user/docs architecture language to separate Pi Providers from External MCP Clients.
- Adds ADR-024 documenting `gsd-browser` as the primary Browser Automation Engine.

## Why

The existing split made browser failures confusing: Pi Providers could receive `browser_*` tools from the legacy Playwright implementation while prompts and docs pointed to `gsd-browser`. That made `/gsd-debug`, UAT, and other browser-required flows look like Playwright problems even when the intended product boundary was `gsd-browser`.

## How

- `browser-tools/index.ts` now selects the engine once per process with `GSD_BROWSER_ENGINE=gsd-browser|legacy|off`.
- The managed engine lazily starts `gsd-browser mcp` with project identity and a Pi/session-derived named session, then forwards canonical Pi tool calls to the MCP tool surface.
- Compatibility aliases preserve existing Pi-facing names such as `browser_snapshot_refs`, `browser_get_console_logs`, and `browser_get_network_logs` while the MCP server can expose modern names such as `browser_snapshot`, `browser_console`, and `browser_network`.
- `.mcp.json` generation remains scoped to External MCP Clients; `GSD_BROWSER_MCP_ENABLED=0` only disables that generated external browser MCP entry.

## Verification

- `pnpm run build:pi`
- `pnpm run build:rpc-client && pnpm run build:mcp-server`
- `pnpm run typecheck:extensions`
- `pnpm run test:browser-tools`
- `pnpm run test:changed:src`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/mcp-status.test.ts src/resources/extensions/gsd/tests/mcp-project-config.test.ts`

## Change type checklist

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

This changes the default Pi browser engine from the legacy Playwright implementation to managed `gsd-browser`. The compatibility path remains available with `GSD_BROWSER_ENGINE=legacy`, and `GSD_BROWSER_ENGINE=off` disables GSD-managed Pi browser tools.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783093369&installation_id=134682257&pr_number=459&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F459&signature=5dda512b18e58528ca9d71d6785d3cc4c08d9f0c23487b11aded237f273ab274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default browser execution path for Pi Providers and debug/UAT flows; misconfiguration or a broken bundled `gsd-browser` install will surface as engine errors until `legacy` is set or dependencies are fixed.
> 
> **Overview**
> **Pi Providers now default to a managed `gsd-browser` engine** instead of silently using Playwright for canonical `browser_*` tools. The `browser-tools` extension selects an engine via `GSD_BROWSER_ENGINE` (`gsd-browser` | `legacy` | `off`); the default path registers a curated tool subset that forwards to `gsd-browser mcp` over an internal stdio MCP bridge, with project-scoped identity and Pi/session-scoped session names. **Legacy Playwright remains only when explicitly requested** (`legacy` / `playwright`); engine failures return actionable errors rather than falling back.
> 
> Shared **`resolveGsdBrowserMcpLaunchConfig`** (and bundled CLI resolution) now backs both the managed Pi engine and **`/gsd mcp init`** project config. User-facing copy and docs clarify that **`.mcp.json` is for External MCP Clients**; `GSD_BROWSER_MCP_ENABLED` only toggles the external browser MCP entry, not Pi’s managed engine.
> 
> **ADR-024**, glossary updates, and tests cover engine selection, managed tool registration, and MCP init messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa4fe18cc1e6f4e082c4b3ec287fa6957727775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->