### PR TITLE
Add gsd-browser release notices

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "gsd:web": "pnpm run build:contracts && pnpm run build:pi && pnpm run copy-resources && node scripts/build-web-if-stale.cjs && node scripts/dev-cli.js --web",
     "gsd:web:stop": "node scripts/dev-cli.js web stop",
     "gsd:web:stop:all": "node scripts/dev-cli.js web stop all",
+    "update:gsd-browser": "node scripts/update-gsd-browser-local.mjs",
     "postinstall": "node scripts/install.js",
     "pi:install-global": "node scripts/install-pi-global.js",
     "pi:uninstall-global": "node scripts/uninstall-pi-global.js",

--- a/scripts/__tests__/update-gsd-browser-local.test.mjs
+++ b/scripts/__tests__/update-gsd-browser-local.test.mjs
@@ -1,0 +1,119 @@
+// Project/App: gsd-pi
+// File Purpose: Fast-gate coverage for the local gsd-browser update helper.
+
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+import {
+  expandHome,
+  parseArgs,
+  resolveCargoBinaryPath,
+  resolveInstalledGsdBrowserBinaryPath,
+  updateInstalledGsdBrowser,
+} from "../update-gsd-browser-local.mjs";
+
+function makeFakeSource(root, profile = "debug") {
+  const sourceRoot = join(root, "gsd-browser");
+  mkdirSync(join(sourceRoot, "npm"), { recursive: true });
+  mkdirSync(join(sourceRoot, "target", profile), { recursive: true });
+  writeFileSync(join(sourceRoot, "Cargo.toml"), "[workspace]\n");
+  writeFileSync(
+    join(sourceRoot, "npm", "package.json"),
+    `${JSON.stringify({ name: "@opengsd/gsd-browser", version: "9.9.9" }, null, 2)}\n`,
+  );
+
+  const binaryPath = resolveCargoBinaryPath(sourceRoot, profile, "darwin");
+  writeFileSync(binaryPath, "#!/usr/bin/env sh\necho gsd-browser 9.9.9\n");
+  chmodSync(binaryPath, 0o755);
+  return { sourceRoot, binaryPath };
+}
+
+test("expandHome resolves only leading home markers", () => {
+  assert.equal(expandHome("~/github/open-gsd", "/Users/dev"), "/Users/dev/github/open-gsd");
+  assert.equal(expandHome("~", "/Users/dev"), "/Users/dev");
+  assert.equal(expandHome("/tmp/~literal", "/Users/dev"), "/tmp/~literal");
+});
+
+test("parseArgs accepts explicit source and build flags", () => {
+  const source = resolve("/tmp/gsd-browser");
+  const options = parseArgs(["--source", source, "--debug", "--skip-build", "--no-verify"], {});
+
+  assert.equal(options.sourceRoot, source);
+  assert.equal(options.profile, "debug");
+  assert.equal(options.skipBuild, true);
+  assert.equal(options.verify, false);
+});
+
+test("parseArgs accepts positional source", () => {
+  const source = resolve("/tmp/positional-gsd-browser");
+  const options = parseArgs([source, "--release"], {});
+
+  assert.equal(options.sourceRoot, source);
+  assert.equal(options.profile, "release");
+});
+
+test("parseArgs ignores pnpm's forwarded argument separator", () => {
+  const options = parseArgs(["--", "--help"], {});
+
+  assert.equal(options.help, true);
+});
+
+test("updateInstalledGsdBrowser copies an existing local build into the installed package", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-browser-update-"));
+
+  try {
+    const { sourceRoot, binaryPath } = makeFakeSource(tmp);
+    const packageDir = join(tmp, "installed-package");
+    mkdirSync(join(packageDir, "bin"), { recursive: true });
+    writeFileSync(join(packageDir, "bin", "gsd-browser"), "#!/usr/bin/env node\n");
+
+    const result = updateInstalledGsdBrowser({
+      sourceRoot,
+      packageDir,
+      sourceBinaryPath: binaryPath,
+      profile: "debug",
+      platform: "darwin",
+      skipBuild: true,
+      verify: false,
+    });
+
+    const installedBinary = resolveInstalledGsdBrowserBinaryPath(packageDir, "darwin");
+    assert.equal(result.targetBinaryPath, installedBinary);
+    assert.equal(existsSync(installedBinary), true);
+    assert.equal(readFileSync(installedBinary, "utf8"), readFileSync(binaryPath, "utf8"));
+    assert.equal(result.npmVersion, "9.9.9");
+    assert.ok(result.bytes > 0);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("updateInstalledGsdBrowser rejects the wrong npm package", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-browser-update-wrong-package-"));
+
+  try {
+    const { sourceRoot, binaryPath } = makeFakeSource(tmp);
+    writeFileSync(
+      join(sourceRoot, "npm", "package.json"),
+      `${JSON.stringify({ name: "@opengsd/not-browser", version: "1.0.0" }, null, 2)}\n`,
+    );
+
+    assert.throws(
+      () => updateInstalledGsdBrowser({
+        sourceRoot,
+        packageDir: join(tmp, "installed-package"),
+        sourceBinaryPath: binaryPath,
+        profile: "debug",
+        platform: "darwin",
+        skipBuild: true,
+        verify: false,
+      }),
+      /Expected .*@opengsd\/gsd-browser/,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/scripts/update-gsd-browser-local.mjs
+++ b/scripts/update-gsd-browser-local.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// Project/App: gsd-pi
+// File Purpose: Refresh the installed @opengsd/gsd-browser binary from a local checkout.
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, statSync, chmodSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const DEFAULT_GSD_BROWSER_SOURCE = "~/github/open-gsd/gsd-browser";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const PACKAGE_NAME = "@opengsd/gsd-browser";
+
+function usage() {
+  return [
+    "Usage: pnpm run update:gsd-browser -- [options] [source]",
+    "",
+    "Build gsd-browser from a local checkout and copy the native binary into",
+    "this repo's installed @opengsd/gsd-browser package.",
+    "",
+    "Options:",
+    `  --source <path>   Source checkout (default: ${DEFAULT_GSD_BROWSER_SOURCE})`,
+    "  --debug           Use target/debug instead of target/release",
+    "  --release         Use target/release (default)",
+    "  --skip-build      Reuse the existing Cargo build output",
+    "  --no-verify       Skip running the copied binary with --version",
+    "  -h, --help        Show this help",
+  ].join("\n");
+}
+
+export function expandHome(input, home = homedir()) {
+  if (input === "~") return home;
+  if (input.startsWith("~/")) return join(home, input.slice(2));
+  return input;
+}
+
+function isTruthy(value) {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function parseArgs(argv = process.argv.slice(2), env = process.env) {
+  const options = {
+    sourceRoot: expandHome(env.GSD_BROWSER_SOURCE || DEFAULT_GSD_BROWSER_SOURCE),
+    profile: env.GSD_BROWSER_BUILD_PROFILE === "debug" ? "debug" : "release",
+    root: REPO_ROOT,
+    skipBuild: isTruthy(env.GSD_BROWSER_SKIP_BUILD || ""),
+    verify: env.GSD_BROWSER_VERIFY !== "0",
+    help: false,
+  };
+
+  let positionalSourceSeen = false;
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      options.help = true;
+      continue;
+    }
+    if (arg === "--source" || arg === "--repo") {
+      const value = argv[++index];
+      if (!value) throw new Error(`${arg} requires a path`);
+      options.sourceRoot = expandHome(value);
+      continue;
+    }
+    if (arg.startsWith("--source=")) {
+      options.sourceRoot = expandHome(arg.slice("--source=".length));
+      continue;
+    }
+    if (arg === "--debug") {
+      options.profile = "debug";
+      continue;
+    }
+    if (arg === "--release") {
+      options.profile = "release";
+      continue;
+    }
+    if (arg === "--skip-build") {
+      options.skipBuild = true;
+      continue;
+    }
+    if (arg === "--no-verify") {
+      options.verify = false;
+      continue;
+    }
+    if (!arg.startsWith("-") && !positionalSourceSeen) {
+      positionalSourceSeen = true;
+      options.sourceRoot = expandHome(arg);
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return {
+    ...options,
+    sourceRoot: resolve(options.sourceRoot),
+  };
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+export function resolveCargoBinaryPath(sourceRoot, profile = "release", platform = process.platform) {
+  const binaryName = platform === "win32" ? "gsd-browser.exe" : "gsd-browser";
+  return join(sourceRoot, "target", profile, binaryName);
+}
+
+export function resolveInstalledGsdBrowserPackageDir(root = REPO_ROOT) {
+  const requireFromRoot = createRequire(join(root, "package.json"));
+  return dirname(requireFromRoot.resolve(`${PACKAGE_NAME}/package.json`));
+}
+
+export function resolveInstalledGsdBrowserBinaryPath(packageDir, platform = process.platform) {
+  const binaryName = platform === "win32" ? "gsd-browser.exe" : "gsd-browser-bin";
+  return join(packageDir, "bin", binaryName);
+}
+
+function assertSourceCheckout(sourceRoot) {
+  const cargoManifestPath = join(sourceRoot, "Cargo.toml");
+  const npmPackageJsonPath = join(sourceRoot, "npm", "package.json");
+  if (!existsSync(cargoManifestPath)) {
+    throw new Error(`Missing Cargo manifest: ${cargoManifestPath}`);
+  }
+  if (!existsSync(npmPackageJsonPath)) {
+    throw new Error(`Missing npm package manifest: ${npmPackageJsonPath}`);
+  }
+
+  const npmPackage = readJson(npmPackageJsonPath);
+  if (npmPackage.name !== PACKAGE_NAME) {
+    throw new Error(`Expected ${npmPackageJsonPath} to be ${PACKAGE_NAME}`);
+  }
+
+  return {
+    cargoManifestPath,
+    npmVersion: npmPackage.version || "0.0.0",
+  };
+}
+
+function runCargoBuild(sourceRoot, cargoManifestPath, profile) {
+  const args = ["build", "--manifest-path", cargoManifestPath, "--package", "gsd-browser"];
+  if (profile === "release") args.push("--release");
+  execFileSync("cargo", args, {
+    cwd: sourceRoot,
+    stdio: "inherit",
+  });
+}
+
+function copyBrowserBinary(sourceBinaryPath, targetBinaryPath, platform) {
+  if (!existsSync(sourceBinaryPath)) {
+    throw new Error(`Built gsd-browser binary not found: ${sourceBinaryPath}`);
+  }
+
+  mkdirSync(dirname(targetBinaryPath), { recursive: true });
+  copyFileSync(sourceBinaryPath, targetBinaryPath);
+  if (platform !== "win32") chmodSync(targetBinaryPath, 0o755);
+
+  const launcherPath = join(dirname(targetBinaryPath), "gsd-browser");
+  if (platform !== "win32" && existsSync(launcherPath)) chmodSync(launcherPath, 0o755);
+
+  return statSync(targetBinaryPath).size;
+}
+
+function verifyBrowserBinary(targetBinaryPath) {
+  return execFileSync(targetBinaryPath, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+export function updateInstalledGsdBrowser(options = {}) {
+  const sourceRoot = resolve(expandHome(options.sourceRoot || DEFAULT_GSD_BROWSER_SOURCE));
+  const profile = options.profile || "release";
+  const platform = options.platform || process.platform;
+  const { cargoManifestPath, npmVersion } = assertSourceCheckout(sourceRoot);
+
+  if (!options.skipBuild) {
+    runCargoBuild(sourceRoot, cargoManifestPath, profile);
+  }
+
+  const packageDir = options.packageDir || resolveInstalledGsdBrowserPackageDir(options.root || REPO_ROOT);
+  const sourceBinaryPath = options.sourceBinaryPath || resolveCargoBinaryPath(sourceRoot, profile, platform);
+  const targetBinaryPath = resolveInstalledGsdBrowserBinaryPath(packageDir, platform);
+  const bytes = copyBrowserBinary(sourceBinaryPath, targetBinaryPath, platform);
+  const versionOutput = options.verify === false ? "" : verifyBrowserBinary(targetBinaryPath);
+
+  return {
+    sourceRoot,
+    profile,
+    packageDir,
+    sourceBinaryPath,
+    targetBinaryPath,
+    npmVersion,
+    versionOutput,
+    bytes,
+  };
+}
+
+function main() {
+  const options = parseArgs();
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  process.stdout.write(`Updating ${PACKAGE_NAME} from ${options.sourceRoot}\n`);
+  process.stdout.write(`Profile: ${options.profile}${options.skipBuild ? " (skip build)" : ""}\n`);
+
+  const result = updateInstalledGsdBrowser(options);
+  process.stdout.write(`Copied ${result.bytes} bytes to ${result.targetBinaryPath}\n`);
+  if (result.versionOutput) {
+    process.stdout.write(`Verified: ${result.versionOutput}\n`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { loadStoredEnvKeys } from './wizard.js'
 import { migratePiCredentials } from './pi-migration.js'
 import { shouldRunOnboarding, runOnboarding } from './onboarding.js'
 import chalk from 'chalk'
-import { checkForUpdates } from './update-check.js'
+import { checkForGsdBrowserUpdates, checkForUpdates } from './update-check.js'
 import { shouldBypassManagedResourceMismatchGate } from './cli-policy.js'
 import { shouldRedirectAutoToHeadless } from './cli-auto-routing.js'
 import { printHelp, printSubcommandHelp } from './help-text.js'
@@ -246,7 +246,7 @@ function ensureRtkBootstrap(): Promise<void> {
 // actually upgrade out of the broken state. See shouldBypassManagedResourceMismatchGate.
 if (shouldBypassManagedResourceMismatchGate(cliFlags.messages[0])) {
   const { runUpdate } = await import('./update-cmd.js')
-  await runUpdate()
+  await runUpdate({ target: cliFlags.messages[1] })
   process.exit(0)
 }
 
@@ -616,6 +616,7 @@ if (!isPrintMode && shouldRunOnboarding(authStorage, settingsManager.getDefaultP
 // available (using cached data or a background fetch) without blocking the TUI.
 if (!isPrintMode) {
   checkForUpdates().catch(() => {})
+  checkForGsdBrowserUpdates().catch(() => {})
 }
 
 // Warn if terminal is too narrow for readable output

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -22,19 +22,23 @@ const SUBCOMMAND_HELP: Record<string, string> = {
   ].join('\n'),
 
   update: [
-    'Usage: gsd update',
+    'Usage: gsd update [browser]',
     '',
-    'Update GSD to the latest version.',
+    'Update GSD to the latest version, or update browser automation only.',
     '',
-    'Equivalent to: npm install -g @opengsd/gsd-pi@latest',
+    'Examples:',
+    '  gsd update',
+    '  gsd update browser',
   ].join('\n'),
 
   upgrade: [
-    'Usage: gsd upgrade',
+    'Usage: gsd upgrade [browser]',
     '',
-    'Upgrade GSD to the latest @opengsd package.',
+    'Alias for update. Upgrade GSD, or upgrade browser automation only.',
     '',
-    'Equivalent to: npm install -g @opengsd/gsd-pi@latest',
+    'Examples:',
+    '  gsd upgrade',
+    '  gsd upgrade browser',
   ].join('\n'),
 
   sessions: [

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -7,6 +7,7 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { existsSync, readFileSync, mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join, resolve as resolvePath, sep } from "node:path";
 import { homedir } from "node:os";
 import { deriveState } from "./state.js";
@@ -37,7 +38,10 @@ import {
   scopeGsdWorkflowToolsForDispatch,
 } from "./bootstrap/register-hooks.js";
 
+const GSD_PI_PACKAGE = "@opengsd/gsd-pi";
+const GSD_BROWSER_PACKAGE = "@opengsd/gsd-browser";
 const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/@opengsd%2fgsd-pi/latest";
+const BROWSER_UPDATE_REGISTRY_URL = "https://registry.npmjs.org/@opengsd%2fgsd-browser/latest";
 const UPDATE_FETCH_TIMEOUT_MS = 5000;
 
 // Detects a bun-installed gsd via `process.argv[1]`. Mirrors isBunInstall in
@@ -62,12 +66,12 @@ function resolveInstallCommand(pkg: string): string {
   return `npm install -g ${pkg}`;
 }
 
-async function fetchLatestVersionForCommand(): Promise<string | null> {
+async function fetchLatestVersionForCommand(registryUrl: string = UPDATE_REGISTRY_URL): Promise<string | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), UPDATE_FETCH_TIMEOUT_MS);
 
   try {
-    const res = await fetch(UPDATE_REGISTRY_URL, { signal: controller.signal });
+    const res = await fetch(registryUrl, { signal: controller.signal });
     if (!res.ok) return null;
     const data = (await res.json()) as { version?: string };
     const latest = typeof data.version === "string" ? data.version.trim().replace(/^v/, "") : "";
@@ -76,6 +80,19 @@ async function fetchLatestVersionForCommand(): Promise<string | null> {
     return null;
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+function resolveInstalledPackageVersionForCommand(packageName: string): string | null {
+  try {
+    const requireFromHere = createRequire(import.meta.url);
+    const packageJsonPath = requireFromHere.resolve(`${packageName}/package.json`);
+    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.trim().length > 0
+      ? pkg.version.trim().replace(/^v/, "")
+      : null;
+  } catch {
+    return null;
   }
 }
 
@@ -473,26 +490,41 @@ function compareSemverLocal(a: string, b: string): number {
   return 0
 }
 
-export async function handleUpdate(ctx: ExtensionCommandContext): Promise<void> {
+function formatCommandVersion(version: string | null): string {
+  return version ? `v${version}` : "unknown";
+}
+
+export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Promise<void> {
   const { execSync } = await import("node:child_process");
 
-  const NPM_PACKAGE = "@opengsd/gsd-pi";
-  const current = process.env.GSD_VERSION || "0.0.0";
+  const target = args.trim();
+  const browserUpdate = target === "browser" || target === "gsd-browser";
+  if (target && !browserUpdate) {
+    ctx.ui.notify("Usage: /gsd update [browser]", "warning");
+    return;
+  }
 
-  ctx.ui.notify(`Current version: v${current}\nChecking npm registry...`, "info");
+  const NPM_PACKAGE = browserUpdate ? GSD_BROWSER_PACKAGE : GSD_PI_PACKAGE;
+  const registryUrl = browserUpdate ? BROWSER_UPDATE_REGISTRY_URL : UPDATE_REGISTRY_URL;
+  const current = browserUpdate
+    ? resolveInstalledPackageVersionForCommand(GSD_BROWSER_PACKAGE)
+    : process.env.GSD_VERSION || "0.0.0";
+  const label = browserUpdate ? "gsd-browser version" : "version";
 
-  const latest = await fetchLatestVersionForCommand();
+  ctx.ui.notify(`Current ${label}: ${formatCommandVersion(current)}\nChecking npm registry...`, "info");
+
+  const latest = await fetchLatestVersionForCommand(registryUrl);
   if (!latest) {
     ctx.ui.notify("Failed to reach npm registry. Check your network connection.", "error");
     return;
   }
 
-  if (compareSemverLocal(latest, current) <= 0) {
-    ctx.ui.notify(`Already up to date (v${current}).`, "info");
+  if (current && compareSemverLocal(latest, current) <= 0) {
+    ctx.ui.notify(`Already up to date (${formatCommandVersion(current)}).`, "info");
     return;
   }
 
-  ctx.ui.notify(`Updating: v${current} → v${latest}...`, "info");
+  ctx.ui.notify(`Updating: ${formatCommandVersion(current)} → v${latest}...`, "info");
 
   const installCmd = resolveInstallCommand(`${NPM_PACKAGE}@latest`);
   try {
@@ -500,7 +532,9 @@ export async function handleUpdate(ctx: ExtensionCommandContext): Promise<void> 
       stdio: ["ignore", "pipe", "ignore"],
     });
     ctx.ui.notify(
-      `Updated to v${latest}. Restart your GSD session to use the new version.`,
+      browserUpdate
+        ? `Updated gsd-browser to v${latest}. Restart your GSD session to use the new browser automation version.`
+        : `Updated to v${latest}. Restart your GSD session to use the new version.`,
       "info",
     );
   } catch {

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -7,6 +7,7 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { existsSync, readFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { join, resolve as resolvePath, sep } from "node:path";
 import { homedir } from "node:os";
@@ -494,6 +495,30 @@ function formatCommandVersion(version: string | null): string {
   return version ? `v${version}` : "unknown";
 }
 
+function pickHigherVersionForCommand(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return compareSemverLocal(a, b) >= 0 ? a : b;
+}
+
+// Mirrors resolveGsdBrowserPathVersion in src/update-check.ts — duplicated because
+// tsconfig.resources.json rootDir prevents importing from src/.
+function resolveGsdBrowserPathVersionForCommand(env: NodeJS.ProcessEnv = process.env): string | null {
+  const explicit = env.GSD_BROWSER_PATH_VERSION?.trim();
+  if (explicit) return explicit.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
+  try {
+    const out = execFileSync("gsd-browser", ["--version"], {
+      encoding: "utf-8",
+      env,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    });
+    return out.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Promise<void> {
   const { execSync } = await import("node:child_process");
 
@@ -506,8 +531,11 @@ export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Pro
 
   const NPM_PACKAGE = browserUpdate ? GSD_BROWSER_PACKAGE : GSD_PI_PACKAGE;
   const registryUrl = browserUpdate ? BROWSER_UPDATE_REGISTRY_URL : UPDATE_REGISTRY_URL;
-  const current = browserUpdate
+  const bundledVersion = browserUpdate
     ? resolveInstalledPackageVersionForCommand(GSD_BROWSER_PACKAGE)
+    : null;
+  const current = browserUpdate
+    ? pickHigherVersionForCommand(bundledVersion, resolveGsdBrowserPathVersionForCommand())
     : process.env.GSD_VERSION || "0.0.0";
   const label = browserUpdate ? "gsd-browser version" : "version";
 
@@ -531,9 +559,12 @@ export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Pro
     execSync(installCmd, {
       stdio: ["ignore", "pipe", "ignore"],
     });
+    const newPathVersion = browserUpdate ? resolveGsdBrowserPathVersionForCommand() : null;
+    const pathReady = !browserUpdate || (!!newPathVersion && compareSemverLocal(newPathVersion, latest) >= 0);
     ctx.ui.notify(
       browserUpdate
-        ? `Updated gsd-browser to v${latest}. Restart your GSD session to use the new browser automation version.`
+        ? `Updated gsd-browser to v${latest}. Restart your GSD session to use the new browser automation version.` +
+          (pathReady ? "" : "\nNote: Ensure the npm global bin directory is on your PATH so MCP automation uses the updated binary.")
         : `Updated to v${latest}. Restart your GSD session to use the new version.`,
       "info",
     );

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -282,8 +282,8 @@ Examples:
     await handleInspect(ctx);
     return true;
   }
-  if (trimmed === "update" || trimmed === "upgrade") {
-    await handleUpdate(ctx);
+  if (trimmed === "update" || trimmed.startsWith("update ") || trimmed === "upgrade" || trimmed.startsWith("upgrade ")) {
+    await handleUpdate(ctx, trimmed.replace(/^(?:update|upgrade)\s*/, "").trim());
     return true;
   }
   if (trimmed === "fast" || trimmed.startsWith("fast ")) {

--- a/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  buildProjectBrowserMcpServerConfig,
   ensureClaudeCodeMcpJsonServerEnabled,
   ensureProjectWorkflowMcpConfig,
   GSD_BROWSER_MCP_SERVER_NAME,
@@ -155,6 +156,37 @@ test("ensureProjectWorkflowMcpConfig can disable the default browser MCP server"
       enabledMcpjsonServers?: string[];
     };
     assert.deepEqual(settings.enabledMcpjsonServers, [GSD_WORKFLOW_MCP_SERVER_NAME]);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildProjectBrowserMcpServerConfig prefers newer gsd-browser on PATH", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-browser-"));
+
+  try {
+    const config = buildProjectBrowserMcpServerConfig(projectRoot, {
+      GSD_BROWSER_PATH_VERSION: "99.0.0",
+    });
+
+    assert.equal(config?.command, "gsd-browser");
+    assert.equal(config?.args?.[0], "mcp");
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildProjectBrowserMcpServerConfig keeps bundled browser when PATH version is older", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-browser-"));
+
+  try {
+    const config = buildProjectBrowserMcpServerConfig(projectRoot, {
+      GSD_BROWSER_PATH_VERSION: "0.0.1",
+    });
+
+    assert.equal(config?.command, process.execPath);
+    assert.match(config?.args?.[0] ?? "", /@opengsd[\/\\]gsd-browser[\/\\]bin[\/\\]gsd-browser/);
+    assert.equal(config?.args?.[1], "mcp");
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,6 +37,57 @@ function sanitizeSessionSegment(value: string): string {
     .replace(/[^a-zA-Z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 40);
+}
+
+function compareSemverLocal(a: string, b: string): number {
+  const left = a.split(".").map(Number);
+  const right = b.split(".").map(Number);
+  for (let index = 0; index < Math.max(left.length, right.length); index++) {
+    const leftValue = left[index] || 0;
+    const rightValue = right[index] || 0;
+    if (leftValue > rightValue) return 1;
+    if (leftValue < rightValue) return -1;
+  }
+  return 0;
+}
+
+function parseGsdBrowserVersion(output: string): string | null {
+  return output.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
+}
+
+function resolveBundledGsdBrowserPackageVersion(): string | null {
+  try {
+    const requireFromHere = createRequire(import.meta.url);
+    const packageJsonPath = requireFromHere.resolve("@opengsd/gsd-browser/package.json");
+    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version?: unknown };
+    return typeof pkg.version === "string" ? parseGsdBrowserVersion(pkg.version) : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolvePathGsdBrowserVersion(env: NodeJS.ProcessEnv): string | null {
+  const explicit = env.GSD_BROWSER_PATH_VERSION?.trim();
+  if (explicit) return parseGsdBrowserVersion(explicit);
+
+  try {
+    return parseGsdBrowserVersion(execFileSync("gsd-browser", ["--version"], {
+      encoding: "utf-8",
+      env,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+function shouldPreferPathGsdBrowser(env: NodeJS.ProcessEnv): boolean {
+  const pathVersion = resolvePathGsdBrowserVersion(env);
+  if (!pathVersion) return false;
+
+  const bundledVersion = resolveBundledGsdBrowserPackageVersion();
+  return !bundledVersion || compareSemverLocal(pathVersion, bundledVersion) > 0;
 }
 
 export function resolveBundledGsdBrowserCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
@@ -82,12 +134,16 @@ export function resolveGsdBrowserMcpLaunchConfig(
   const explicitEnv = parseJsonEnv<Record<string, string>>(env, "GSD_BROWSER_MCP_ENV");
   const explicitCommand = env.GSD_BROWSER_MCP_COMMAND?.trim();
   const explicitCliPath = env.GSD_BROWSER_CLI_PATH?.trim() || env.GSD_BROWSER_BIN_PATH?.trim();
-  const bundledCliPath = !explicitCommand && !explicitCliPath ? resolveBundledGsdBrowserCliPath(env) : null;
+  const preferPathCli = !explicitCommand && !explicitCliPath && shouldPreferPathGsdBrowser(env);
+  const bundledCliPath = !explicitCommand && !explicitCliPath && !preferPathCli
+    ? resolveBundledGsdBrowserCliPath(env)
+    : null;
   const sessionName =
     options.sessionName?.trim() || buildGsdBrowserSessionName(resolvedProjectRoot, options.sessionSuffix);
   const command =
     explicitCommand
     || explicitCliPath
+    || (preferPathCli ? "gsd-browser" : undefined)
     || (bundledCliPath ? process.execPath : undefined)
     || "gsd-browser";
   const args = Array.isArray(explicitArgs) && explicitArgs.length > 0

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -5,7 +5,15 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createServer } from 'node:http'
 
-import { compareSemver, readUpdateCache, writeUpdateCache, checkForUpdates, fetchLatestVersionFromRegistry } from '../update-check.js'
+import {
+  compareSemver,
+  readUpdateCache,
+  writeUpdateCache,
+  checkForGsdBrowserUpdates,
+  checkForUpdates,
+  fetchLatestVersionFromRegistry,
+  GSD_BROWSER_PACKAGE_NAME,
+} from '../update-check.js'
 
 // ---------------------------------------------------------------------------
 // compareSemver
@@ -206,6 +214,36 @@ test('checkForUpdates writes cache after successful fetch', async (t) => {
   assert.ok(cache, 'cache should exist after fetch')
   assert.equal(cache!.latestVersion, '5.0.0')
   assert.ok(cache!.lastCheck > 0)
+})
+
+test('checkForGsdBrowserUpdates checks and caches the browser package independently', async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-browser-update-'))
+  const cachePath = join(tmp, '.update-check-gsd-browser')
+  const registry = await startMockRegistry({ version: '0.1.99' })
+  t.after(async () => {
+    await registry.close()
+    rmSync(tmp, { recursive: true, force: true })
+  });
+
+  let reportedPackage = ''
+  let reportedLatest = ''
+
+  await checkForGsdBrowserUpdates({
+    currentVersion: '0.1.27',
+    cachePath,
+    registryUrl: registry.url,
+    checkIntervalMs: 0,
+    fetchTimeoutMs: 5000,
+    onUpdate: (_current, latest, packageName) => {
+      reportedLatest = latest
+      reportedPackage = packageName
+    },
+  })
+
+  assert.equal(reportedPackage, GSD_BROWSER_PACKAGE_NAME)
+  assert.equal(reportedLatest, '0.1.99')
+  assert.equal(readUpdateCache(cachePath), null, 'default GSD cache reader must ignore browser cache entries')
+  assert.equal(readUpdateCache(cachePath, GSD_BROWSER_PACKAGE_NAME)?.latestVersion, '0.1.99')
 })
 
 test('checkForUpdates uses cache and skips fetch when checked recently', async (t) => {

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 
 import { runUpdate } from "../update-cmd.ts";
 import { handleUpdate } from "../resources/extensions/gsd/commands-handlers.ts";
+import { GSD_BROWSER_PACKAGE_NAME, resolveInstalledPackageVersion } from "../update-check.js";
 
 test("update-cmd prints latest version before comparison (#3445)", async (t) => {
   const originalFetch = globalThis.fetch;
@@ -82,6 +83,31 @@ test("update-cmd refreshes managed resources when already up to date (#52)", asy
   const manifest = JSON.parse(readFileSync(join(fakeAgentDir, "managed-resources.json"), "utf-8"));
   assert.equal(manifest.gsdVersion, "1.0.1");
   assert.equal(manifest.packageName, "@opengsd/gsd-pi");
+});
+
+test("update-cmd supports browser-only update checks", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalStdoutWrite = process.stdout.write;
+  const writes: string[] = [];
+  const browserVersion = resolveInstalledPackageVersion(GSD_BROWSER_PACKAGE_NAME) ?? "0.1.27";
+
+  try {
+    globalThis.fetch = async () => Response.json({ version: browserVersion });
+    (process.stdout as any).write = (chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    };
+
+    await runUpdate({ target: "browser" });
+  } finally {
+    globalThis.fetch = originalFetch;
+    (process.stdout as any).write = originalStdoutWrite;
+  }
+
+  const output = writes.join("");
+  assert.match(output, /Current gsd-browser version:/);
+  assert.match(output, /Latest gsd-browser version:/);
+  assert.match(output, /gsd-browser is already up to date/);
 });
 
 test("update-check exports resolveInstallCommand (#4145)", async () => {
@@ -209,6 +235,33 @@ test("/gsd update handler fetches latest version through the registry endpoint (
   }
 
   assert.deepEqual(fetchUrls, ["https://registry.npmjs.org/@opengsd%2fgsd-pi/latest"]);
+  assert.ok(notifications.some((notification) => notification.message.includes("Already up to date")));
+});
+
+test("/gsd update browser handler fetches latest gsd-browser version", async () => {
+  const originalFetch = globalThis.fetch;
+  const fetchUrls: string[] = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+  const browserVersion = resolveInstalledPackageVersion(GSD_BROWSER_PACKAGE_NAME) ?? "0.1.27";
+
+  try {
+    globalThis.fetch = async (input) => {
+      fetchUrls.push(String(input));
+      return Response.json({ version: browserVersion });
+    };
+
+    await handleUpdate({
+      ui: {
+        notify(message: string, level: string) {
+          notifications.push({ message, level });
+        },
+      },
+    } as any, "browser");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(fetchUrls, ["https://registry.npmjs.org/@opengsd%2fgsd-browser/latest"]);
   assert.ok(notifications.some((notification) => notification.message.includes("Already up to date")));
 });
 

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 
 import { runUpdate } from "../update-cmd.ts";
 import { handleUpdate } from "../resources/extensions/gsd/commands-handlers.ts";
-import { GSD_BROWSER_PACKAGE_NAME, resolveInstalledPackageVersion } from "../update-check.js";
+import { GSD_BROWSER_PACKAGE_NAME, GSD_BROWSER_REGISTRY_URL, resolveInstalledPackageVersion } from "../update-check.js";
 
 test("update-cmd prints latest version before comparison (#3445)", async (t) => {
   const originalFetch = globalThis.fetch;
@@ -448,6 +448,74 @@ test("isBunInstall returns true when running under Bun runtime (#4145)", async (
     }
     process.argv[1] = origArgv1;
   }
+});
+
+test("runBrowserUpdate uses PATH version as current when it is newer than bundled", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalStdoutWrite = process.stdout.write;
+  const originalBrowserPathVersion = process.env.GSD_BROWSER_PATH_VERSION;
+  const writes: string[] = [];
+
+  t.after(() => {
+    if (originalBrowserPathVersion === undefined) {
+      delete process.env.GSD_BROWSER_PATH_VERSION;
+    } else {
+      process.env.GSD_BROWSER_PATH_VERSION = originalBrowserPathVersion;
+    }
+  });
+
+  try {
+    // PATH has 99.0.0 and registry reports the same — should be "up to date"
+    process.env.GSD_BROWSER_PATH_VERSION = "99.0.0";
+    globalThis.fetch = async (input) => {
+      assert.equal(String(input), GSD_BROWSER_REGISTRY_URL);
+      return Response.json({ version: "99.0.0" });
+    };
+    (process.stdout as any).write = (chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    };
+
+    await runUpdate({ target: "browser" });
+  } finally {
+    globalThis.fetch = originalFetch;
+    (process.stdout as any).write = originalStdoutWrite;
+  }
+
+  const output = writes.join("");
+  assert.match(output, /Current gsd-browser version:.*99\.0\.0/);
+  assert.match(output, /gsd-browser is already up to date/);
+});
+
+test("/gsd update browser uses PATH version as current when it is newer than bundled", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalBrowserPathVersion = process.env.GSD_BROWSER_PATH_VERSION;
+  const notifications: Array<{ message: string; level: string }> = [];
+
+  t.after(() => {
+    if (originalBrowserPathVersion === undefined) {
+      delete process.env.GSD_BROWSER_PATH_VERSION;
+    } else {
+      process.env.GSD_BROWSER_PATH_VERSION = originalBrowserPathVersion;
+    }
+  });
+
+  try {
+    process.env.GSD_BROWSER_PATH_VERSION = "99.0.0";
+    globalThis.fetch = async () => Response.json({ version: "99.0.0" });
+
+    await handleUpdate({
+      ui: {
+        notify(message: string, level: string) {
+          notifications.push({ message, level });
+        },
+      },
+    } as any, "browser");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.ok(notifications.some((n) => n.message.includes("Already up to date")));
 });
 
 test("isPnpmInstall detects pnpm user agent, exec path, and PNPM_HOME", async () => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -2,17 +2,23 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { dirname, join, resolve as resolvePath, sep } from 'node:path'
 import { homedir } from 'node:os'
+import { createRequire } from 'node:module'
 import chalk from 'chalk'
 import { appRoot } from './app-paths.js'
 import { isPnpmInstall } from './resources/shared/package-manager-detection.js'
 
 export { isPnpmInstall }
 
+export const GSD_PI_PACKAGE_NAME = '@opengsd/gsd-pi'
+export const GSD_BROWSER_PACKAGE_NAME = '@opengsd/gsd-browser'
+
 const CACHE_FILE = join(appRoot, '.update-check')
-const NPM_PACKAGE_NAME = '@opengsd/gsd-pi'
+const GSD_BROWSER_CACHE_FILE = join(appRoot, '.update-check-gsd-browser')
+const NPM_PACKAGE_NAME = GSD_PI_PACKAGE_NAME
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24 hours
 const FETCH_TIMEOUT_MS = 5000
-const DEFAULT_REGISTRY_URL = `https://registry.npmjs.org/@opengsd%2fgsd-pi/latest`
+export const DEFAULT_REGISTRY_URL = `https://registry.npmjs.org/@opengsd%2fgsd-pi/latest`
+export const GSD_BROWSER_REGISTRY_URL = `https://registry.npmjs.org/@opengsd%2fgsd-browser/latest`
 
 interface UpdateCheckCache {
   lastCheck: number
@@ -65,6 +71,17 @@ function normalizeLatestVersion(version: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null
 }
 
+export function resolveInstalledPackageVersion(packageName: string): string | null {
+  try {
+    const requireFromHere = createRequire(import.meta.url)
+    const packageJsonPath = requireFromHere.resolve(`${packageName}/package.json`)
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown }
+    return normalizeLatestVersion(pkg.version)
+  } catch {
+    return null
+  }
+}
+
 export async function fetchLatestVersionFromRegistry(
   registryUrl: string = DEFAULT_REGISTRY_URL,
   fetchTimeoutMs: number = FETCH_TIMEOUT_MS,
@@ -115,8 +132,16 @@ export function resolveInstallCommand(
   return `npm install -g ${pkg}`
 }
 
-function printUpdateBanner(current: string, latest: string): void {
-  const installCmd = resolveInstallCommand('@opengsd/gsd-pi@latest')
+function printUpdateBanner(current: string, latest: string, packageName: string = GSD_PI_PACKAGE_NAME): void {
+  if (packageName === GSD_BROWSER_PACKAGE_NAME) {
+    process.stderr.write(
+      `  ${chalk.yellow('gsd-browser update available:')} ${chalk.dim(`v${current}`)} → ${chalk.bold(`v${latest}`)}\n` +
+      `  ${chalk.dim('Run')} gsd update browser ${chalk.dim('to upgrade browser automation')}\n\n`,
+    )
+    return
+  }
+
+  const installCmd = resolveInstallCommand(`${GSD_PI_PACKAGE_NAME}@latest`)
   process.stderr.write(
     `  ${chalk.yellow('Update available:')} ${chalk.dim(`v${current}`)} → ${chalk.bold(`v${latest}`)}\n` +
     `  ${chalk.dim('Run')} ${installCmd} ${chalk.dim('or')} /gsd upgrade ${chalk.dim('to upgrade')}\n\n`,
@@ -124,12 +149,28 @@ function printUpdateBanner(current: string, latest: string): void {
 }
 
 export interface UpdateCheckOptions {
+  packageName?: string
   currentVersion?: string
   cachePath?: string
   registryUrl?: string
   checkIntervalMs?: number
   fetchTimeoutMs?: number
-  onUpdate?: (current: string, latest: string) => void
+  onUpdate?: (current: string, latest: string, packageName: string) => void
+}
+
+function defaultCurrentVersion(packageName: string): string | null {
+  if (packageName === GSD_PI_PACKAGE_NAME) {
+    return process.env.GSD_VERSION || '0.0.0'
+  }
+  return resolveInstalledPackageVersion(packageName)
+}
+
+function defaultCachePath(packageName: string): string {
+  return packageName === GSD_BROWSER_PACKAGE_NAME ? GSD_BROWSER_CACHE_FILE : CACHE_FILE
+}
+
+function defaultRegistryUrl(packageName: string): string {
+  return packageName === GSD_BROWSER_PACKAGE_NAME ? GSD_BROWSER_REGISTRY_URL : DEFAULT_REGISTRY_URL
 }
 
 /**
@@ -137,18 +178,21 @@ export interface UpdateCheckOptions {
  * caches the result, and prints a banner if a newer version is available.
  */
 export async function checkForUpdates(options: UpdateCheckOptions = {}): Promise<void> {
-  const currentVersion = options.currentVersion || process.env.GSD_VERSION || '0.0.0'
-  const cachePath = options.cachePath || CACHE_FILE
-  const registryUrl = options.registryUrl || DEFAULT_REGISTRY_URL
+  const packageName = options.packageName || GSD_PI_PACKAGE_NAME
+  const currentVersion = options.currentVersion || defaultCurrentVersion(packageName)
+  if (!currentVersion) return
+
+  const cachePath = options.cachePath || defaultCachePath(packageName)
+  const registryUrl = options.registryUrl || defaultRegistryUrl(packageName)
   const checkIntervalMs = options.checkIntervalMs ?? CHECK_INTERVAL_MS
   const fetchTimeoutMs = options.fetchTimeoutMs ?? FETCH_TIMEOUT_MS
   const onUpdate = options.onUpdate || printUpdateBanner
 
   // Check cache — skip network if checked recently
-  const cache = readUpdateCache(cachePath)
+  const cache = readUpdateCache(cachePath, packageName)
   if (cache && Date.now() - cache.lastCheck < checkIntervalMs) {
     if (compareSemver(cache.latestVersion, currentVersion) > 0) {
-      onUpdate(currentVersion, cache.latestVersion)
+      onUpdate(currentVersion, cache.latestVersion, packageName)
     }
     return
   }
@@ -157,14 +201,21 @@ export async function checkForUpdates(options: UpdateCheckOptions = {}): Promise
     const latestVersion = await fetchLatestVersionFromRegistry(registryUrl, fetchTimeoutMs)
     if (!latestVersion) return
 
-    writeUpdateCache({ lastCheck: Date.now(), latestVersion }, cachePath)
+    writeUpdateCache({ lastCheck: Date.now(), latestVersion }, cachePath, packageName)
 
     if (compareSemver(latestVersion, currentVersion) > 0) {
-      onUpdate(currentVersion, latestVersion)
+      onUpdate(currentVersion, latestVersion, packageName)
     }
   } catch {
     // Network error or timeout — silently ignore, don't block startup
   }
+}
+
+export async function checkForGsdBrowserUpdates(options: UpdateCheckOptions = {}): Promise<void> {
+  await checkForUpdates({
+    ...options,
+    packageName: GSD_BROWSER_PACKAGE_NAME,
+  })
 }
 
 const PROMPT_TIMEOUT_MS = 30_000

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 import { dirname, join, resolve as resolvePath, sep } from 'node:path'
 import { homedir } from 'node:os'
 import { createRequire } from 'node:module'
@@ -82,6 +82,33 @@ export function resolveInstalledPackageVersion(packageName: string): string | nu
   }
 }
 
+/**
+ * Resolves the gsd-browser version from PATH (via `gsd-browser --version`).
+ * Respects GSD_BROWSER_PATH_VERSION env override for testing.
+ * Returns null if gsd-browser is not on PATH or times out.
+ */
+export function resolveGsdBrowserPathVersion(env: NodeJS.ProcessEnv = process.env): string | null {
+  const explicit = env.GSD_BROWSER_PATH_VERSION?.trim()
+  if (explicit) return explicit.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null
+  try {
+    const out = execFileSync('gsd-browser', ['--version'], {
+      encoding: 'utf-8',
+      env,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    })
+    return out.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null
+  } catch {
+    return null
+  }
+}
+
+export function pickHigherVersion(a: string | null, b: string | null): string | null {
+  if (!a) return b
+  if (!b) return a
+  return compareSemver(a, b) >= 0 ? a : b
+}
+
 export async function fetchLatestVersionFromRegistry(
   registryUrl: string = DEFAULT_REGISTRY_URL,
   fetchTimeoutMs: number = FETCH_TIMEOUT_MS,
@@ -162,7 +189,11 @@ function defaultCurrentVersion(packageName: string): string | null {
   if (packageName === GSD_PI_PACKAGE_NAME) {
     return process.env.GSD_VERSION || '0.0.0'
   }
-  return resolveInstalledPackageVersion(packageName)
+  const bundled = resolveInstalledPackageVersion(packageName)
+  if (packageName === GSD_BROWSER_PACKAGE_NAME) {
+    return pickHigherVersion(bundled, resolveGsdBrowserPathVersion())
+  }
+  return bundled
 }
 
 function defaultCachePath(packageName: string): string {

--- a/src/update-cmd.ts
+++ b/src/update-cmd.ts
@@ -1,16 +1,77 @@
 import { execSync } from 'node:child_process'
 import { agentDir as defaultAgentDir } from './app-paths.js'
 import { initResources } from './resource-loader.js'
-import { compareSemver, fetchLatestVersionFromRegistry, resolveInstallCommand } from './update-check.js'
+import {
+  compareSemver,
+  fetchLatestVersionFromRegistry,
+  GSD_BROWSER_PACKAGE_NAME,
+  GSD_BROWSER_REGISTRY_URL,
+  GSD_PI_PACKAGE_NAME,
+  resolveInstallCommand,
+  resolveInstalledPackageVersion,
+} from './update-check.js'
 
-const NPM_PACKAGE = '@opengsd/gsd-pi'
+const NPM_PACKAGE = GSD_PI_PACKAGE_NAME
 
 interface RunUpdateOptions {
   agentDir?: string
   skillsDir?: string
+  target?: string
+}
+
+function formatCurrentVersion(version: string | null): string {
+  return version ? `v${version}` : 'unknown'
+}
+
+async function runBrowserUpdate(): Promise<void> {
+  const current = resolveInstalledPackageVersion(GSD_BROWSER_PACKAGE_NAME)
+  const bold = '\x1b[1m'
+  const dim = '\x1b[2m'
+  const green = '\x1b[32m'
+  const yellow = '\x1b[33m'
+  const reset = '\x1b[0m'
+
+  process.stdout.write(`${dim}Current gsd-browser version:${reset} ${formatCurrentVersion(current)}\n`)
+  process.stdout.write(`${dim}Checking npm registry...${reset}\n`)
+
+  const latest = await fetchLatestVersionFromRegistry(GSD_BROWSER_REGISTRY_URL)
+  if (!latest) {
+    process.stderr.write(`${yellow}Failed to reach npm registry.${reset}\n`)
+    process.exit(1)
+  }
+
+  process.stdout.write(`${dim}Latest gsd-browser version:${reset}  v${latest}\n`)
+
+  if (current && compareSemver(latest, current) <= 0) {
+    process.stdout.write(`${green}gsd-browser is already up to date.${reset}\n`)
+    return
+  }
+
+  process.stdout.write(`${dim}Updating gsd-browser:${reset} ${formatCurrentVersion(current)} → ${bold}v${latest}${reset}\n`)
+
+  const installCmd = resolveInstallCommand(`${GSD_BROWSER_PACKAGE_NAME}@latest`)
+  try {
+    execSync(installCmd, {
+      stdio: 'inherit',
+    })
+    process.stdout.write(`\n${green}${bold}Updated gsd-browser to v${latest}${reset}\n`)
+  } catch {
+    process.stderr.write(`\n${yellow}gsd-browser update failed. Try manually: ${installCmd}${reset}\n`)
+    process.exit(1)
+  }
 }
 
 export async function runUpdate(options: RunUpdateOptions = {}): Promise<void> {
+  if (options.target === 'browser' || options.target === 'gsd-browser') {
+    await runBrowserUpdate()
+    return
+  }
+  if (options.target) {
+    process.stderr.write(`Unknown update target: ${options.target}\n`)
+    process.stderr.write('Usage: gsd update [browser]\n')
+    process.exit(1)
+  }
+
   const current = process.env.GSD_VERSION || '0.0.0'
   const bold = '\x1b[1m'
   const dim = '\x1b[2m'

--- a/src/update-cmd.ts
+++ b/src/update-cmd.ts
@@ -7,6 +7,8 @@ import {
   GSD_BROWSER_PACKAGE_NAME,
   GSD_BROWSER_REGISTRY_URL,
   GSD_PI_PACKAGE_NAME,
+  pickHigherVersion,
+  resolveGsdBrowserPathVersion,
   resolveInstallCommand,
   resolveInstalledPackageVersion,
 } from './update-check.js'
@@ -24,7 +26,8 @@ function formatCurrentVersion(version: string | null): string {
 }
 
 async function runBrowserUpdate(): Promise<void> {
-  const current = resolveInstalledPackageVersion(GSD_BROWSER_PACKAGE_NAME)
+  const bundled = resolveInstalledPackageVersion(GSD_BROWSER_PACKAGE_NAME)
+  const current = pickHigherVersion(bundled, resolveGsdBrowserPathVersion())
   const bold = '\x1b[1m'
   const dim = '\x1b[2m'
   const green = '\x1b[32m'
@@ -55,6 +58,14 @@ async function runBrowserUpdate(): Promise<void> {
       stdio: 'inherit',
     })
     process.stdout.write(`\n${green}${bold}Updated gsd-browser to v${latest}${reset}\n`)
+    // Verify the new version is reachable via PATH (MCP prefers PATH binary when newer)
+    const newPathVersion = resolveGsdBrowserPathVersion()
+    if (!newPathVersion || compareSemver(newPathVersion, latest) < 0) {
+      process.stdout.write(
+        `${yellow}Note:${reset} ${dim}Ensure the npm global bin directory is on your PATH` +
+        ` so MCP automation uses the updated binary.${reset}\n`,
+      )
+    }
   } catch {
     process.stderr.write(`\n${yellow}gsd-browser update failed. Try manually: ${installCmd}${reset}\n`)
     process.exit(1)


### PR DESCRIPTION
## TL;DR
Adds a gsd-browser update path so gsd-pi can notify users when @opengsd/gsd-browser has a newer npm release and let them run `gsd update browser`.

## What
- Add passive @opengsd/gsd-browser registry checks with a separate cache and startup banner.
- Add `gsd update browser` and `/gsd update browser` handlers.
- Compare browser updates against the newer of the bundled package version and PATH `gsd-browser` version.
- Prefer a newer PATH `gsd-browser` binary for project MCP config while keeping the bundled fallback.
- Add `pnpm run update:gsd-browser` to refresh the installed browser binary from `~/github/open-gsd/gsd-browser` during local development.
- Cover update checks, update commands, MCP browser resolution, and helper script behavior.

## Why
Keep gsd-pi users aware of newer browser automation releases without requiring a full gsd-pi release.

## How
Targeted update-check plumbing, update command routing, browser MCP binary selection, and focused tests.

## Requirements
- [x] Conventional commits included.
- [x] Focused tests added/updated.
- [x] `node --test scripts/__tests__/update-gsd-browser-local.test.mjs`
- [x] `pnpm run update:gsd-browser -- --help && node_modules/.bin/gsd-browser --version`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/update-check.test.ts src/tests/update-cmd-diagnostics.test.ts src/resources/extensions/gsd/tests/mcp-project-config.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run test:changed:src`
- [x] `node --test "scripts/__tests__/*.mjs" "scripts/__tests__/*.cjs"`
- [x] PR CI green: fast-gates and build passed.
- [ ] Full `pnpm run verify:merge`
