### PR TITLE
fix(issue): Auto-mode loops to per-unit cost cap on MCP -32602 tool-validation errors (not classified as deterministic)

### DIFF
--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -94,7 +94,7 @@ export function clearInFlightTools(): void {
  * from the tool handler. When these errors occur, retrying the same unit will
  * produce the same failure, so the retry loop must be broken.
  */
-const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation error|Invalid arguments for tool|MCP error -32602|No such tool available|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
 const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -881,7 +881,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       sliceTitle: Type.String({ description: "Title of the slice" }),
       oneLiner: Type.String({ description: "One-line summary of what the slice accomplished" }),
       narrative: Type.String({ description: "Detailed narrative of what happened across all tasks" }),
-      verification: Type.String({ description: "What was verified across all tasks" }),
+      verification: Type.Optional(Type.String({ description: "What was verified across all tasks — if omitted, summary records verification as passed without detail." })),
       uatContent: Type.String({ description: "UAT test content (markdown body)" }),
       // ── Enrichment metadata (optional — defaults to empty) ────────────
       deviations: Type.Optional(Type.String({ description: "Deviations from the slice plan, or 'None.'" })),

--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -20,6 +20,7 @@ import {
   insertMilestone,
   insertSlice,
   insertTask,
+  setSliceSummaryMd,
 } from '../gsd-db.ts';
 import { handleCompleteSlice } from '../tools/complete-slice.ts';
 import type { CompleteSliceParams } from '../types.ts';
@@ -152,5 +153,46 @@ describe('complete-slice verification gate (#3580)', () => {
         `clean inputs should not be rejected by the BLOCKED_SIGNALS gate, got: ${result.error}`,
       );
     }
+  });
+
+  test('backfills prior verification narrative when verification is omitted on re-completion', async () => {
+    // Seed full_summary_md with a prior verification narrative (simulates a
+    // previous completion where the verification text was recorded).
+    const priorVerification = 'All 12 API integration tests pass — zero regressions detected.';
+    const priorSummary = [
+      '---',
+      'verification_result: passed',
+      '---',
+      '',
+      '# S01: Test Slice',
+      '',
+      '## What Happened',
+      '',
+      'narrative goes here',
+      '',
+      '## Verification',
+      '',
+      priorVerification,
+      '',
+      '## Requirements Advanced',
+      '',
+    ].join('\n');
+    setSliceSummaryMd('M001', 'S01', priorSummary, '');
+
+    // Complete slice without providing verification — handler must backfill
+    // from the existing summary rather than writing an empty section.
+    const result = await handleCompleteSlice(
+      makeParams({ verification: undefined }),
+      basePath,
+    );
+
+    assert.ok(!('error' in result), `expected success, got: ${'error' in result ? (result as { error: string }).error : ''}`);
+
+    const { summaryPath } = result as { summaryPath: string };
+    const written = fs.readFileSync(summaryPath, 'utf8');
+    assert.ok(
+      written.includes(priorVerification),
+      `prior verification narrative must be preserved when verification is omitted; got:\n${written}`,
+    );
   });
 });

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -102,6 +102,25 @@ describe("#2883: isToolInvocationError classification", () => {
     );
   });
 
+  test("detects MCP -32602 Input validation error (wire format)", () => {
+    assert.equal(
+      isToolInvocationError("MCP error -32602: Input validation error: Invalid arguments for tool gsd_slice_complete [path: verification, expected string, invalid_type]"),
+      true,
+    );
+  });
+
+  test("detects standalone 'Input validation error' prefix", () => {
+    assert.equal(isToolInvocationError("Input validation error: expected string"), true);
+  });
+
+  test("detects 'Invalid arguments for tool' prefix", () => {
+    assert.equal(isToolInvocationError("Invalid arguments for tool gsd_slice_complete"), true);
+  });
+
+  test("detects 'No such tool available' error", () => {
+    assert.equal(isToolInvocationError("No such tool available: mcp__gsd-workflow__memory_query"), true);
+  });
+
   test("detects ESM export-link errors", () => {
     assert.equal(
       isToolInvocationError("The requested module '../paths.js' does not provide an export named 'gsdProjectionRoot'"),

--- a/src/resources/extensions/gsd/tests/tool-param-optionality.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-param-optionality.test.ts
@@ -101,12 +101,18 @@ test("gsd_slice_complete — enrichment arrays are optional", () => {
     "sliceTitle",
     "oneLiner",
     "narrative",
-    "verification",
     "uatContent",
   ];
   for (const field of coreRequired) {
     assert.ok(required.has(field), `core field "${field}" must be required`);
   }
+
+  // verification is intentionally optional — models that omit it avoid -32602;
+  // the summary records verification as passed without detail in that case.
+  assert.ok(
+    !required.has("verification"),
+    "verification must be optional — omitting it avoids -32602; summary records verification as passed without detail",
+  );
 
   // Enrichment/metadata arrays MUST be optional
   const enrichmentFields = [

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -217,7 +217,7 @@ ${params.narrative}
 
 ## Verification
 
-${params.verification}
+${params.verification ?? ""}
 
 ## Requirements Advanced
 

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -440,6 +440,19 @@ export async function handleCompleteSlice(
       const parsed = parseRequirementSection(existingSummaryMd, "Requirements Invalidated or Re-scoped", "what");
       if (parsed.length > 0) effectiveParams.requirementsInvalidated = parsed as Array<{ id: string; what: string }>;
     }
+    if (effectiveParams.verification === undefined) {
+      const headingLine = "## Verification\n\n";
+      const start = existingSummaryMd.indexOf(headingLine);
+      if (start !== -1) {
+        const contentStart = start + headingLine.length;
+        const nextHeading = existingSummaryMd.indexOf("\n\n## ", contentStart);
+        const prior = nextHeading === -1
+          ? existingSummaryMd.slice(contentStart)
+          : existingSummaryMd.slice(contentStart, nextHeading);
+        const trimmed = prior.trim();
+        if (trimmed) effectiveParams.verification = trimmed;
+      }
+    }
   }
 
   // Render summary markdown

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -707,7 +707,8 @@ export interface CompleteSliceParams {
   sliceTitle: string;
   oneLiner: string;
   narrative: string;
-  verification: string;
+  /** @optional — if omitted, verification section is left blank in summary */
+  verification?: string;
   uatContent: string;
   /** @optional — defaults to [] when omitted by models with limited tool-calling */
   keyFiles?: string[];


### PR DESCRIPTION
## Summary
- Added MCP `-32602`/`Input validation error`/`Invalid arguments for tool`/`No such tool available` patterns to `TOOL_INVOCATION_ERROR_RE` so deterministic closeout failures pause auto-mode immediately, and made `gsd_slice_complete.verification` optional to prevent the asymmetric schema from triggering the error in the first place.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #461
- [#461 Auto-mode loops to per-unit cost cap on MCP -32602 tool-validation errors (not classified as deterministic)](https://github.com/open-gsd/gsd-pi/issues/461)

## User
- @OfficialDelta

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/461-auto-mode-loops-to-per-unit-cost-cap-on--1780503217`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783095717&installation_id=134682257&pr_number=462&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F462&signature=a55c4b54277877ef39828ac19455ffea7c91715218b38ad8440c33af25a46cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode pause/retry behavior and the slice-complete tool contract; impact is limited by tests but affects workflow closeout paths.
> 
> **Overview**
> Stops **auto-mode** from retrying the same unit until the per-unit cost cap when closeout fails with **MCP `-32602` / input validation** errors, and removes a common trigger by making **`gsd_slice_complete.verification` optional**.
> 
> `isToolInvocationError` now treats wire-format messages like **`MCP error -32602`**, **`Input validation error`**, **`Invalid arguments for tool`**, and **`No such tool available`** as deterministic invocation failures (same retry-loop break as truncated JSON / module errors). The **`gsd_slice_complete`** tool schema and **`CompleteSliceParams`** no longer require `verification`; on re-completion, **`handleCompleteSlice`** can **backfill** the Verification section from existing slice summary markdown instead of clearing it.
> 
> Tests cover the new classifier patterns, schema optionality, and verification backfill on omitted re-completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c67bfd3b9699abbfdb23a42b9bd9e2c0373c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->