### PR TITLE
fix(gsd): preserve closeout UI during session reroot

### DIFF
--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -42,6 +42,10 @@ export function isAutoPaused(): boolean {
   return autoSession.paused;
 }
 
+export function isAutoCompletionStopInProgress(): boolean {
+  return autoSession.completionStopInProgress;
+}
+
 export function markToolStart(toolCallId: string, toolName?: string): void {
   markTrackedToolStart(toolCallId, autoSession.active, toolName);
 }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -17,7 +17,7 @@ import { canonicalToolName, clearDiscussionFlowState, isDepthConfirmationAnswer,
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
-import { clearToolInvocationError, getAutoRuntimeSnapshot, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto-runtime-state.js";
+import { clearToolInvocationError, getAutoRuntimeSnapshot, isAutoActive, isAutoCompletionStopInProgress, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto-runtime-state.js";
 
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { maybePauseAutoForApprovalGate, resetPendingGatePauseGuard } from "./pending-gate-pause.js";
@@ -535,8 +535,9 @@ export function registerHooks(
 
   pi.on("session_start", async (_event, ctx) => {
     const basePath = contextBasePath(ctx);
+    const preserveCloseoutSurface = isAutoCompletionStopInProgress();
     initSessionNotifications(ctx);
-    if (!isAutoActive()) {
+    if (!isAutoActive() && !preserveCloseoutSurface) {
       const { initHealthWidget } = await import("../health-widget.js");
       initHealthWidget(ctx);
     }
@@ -556,15 +557,18 @@ export function registerHooks(
       const prefs = loadEffectiveGSDPreferences(basePath);
       process.env.GSD_SHOW_TOKEN_COST = prefs?.preferences.show_token_cost ? "1" : "";
     } catch { /* non-fatal */ }
-    await installWelcomeHeader(ctx);
+    if (!preserveCloseoutSurface) {
+      await installWelcomeHeader(ctx);
+    }
     await loadToolApiKeysForSession();
-    if (isAutoActive()) {
+    if (isAutoActive() || preserveCloseoutSurface) {
       ctx.ui.setWidget("gsd-health", undefined);
     }
   });
 
   pi.on("session_switch", async (_event, ctx) => {
     const basePath = contextBasePath(ctx);
+    const preserveCloseoutSurface = isAutoCompletionStopInProgress();
     initSessionNotifications(ctx);
     resetWriteGateState(basePath);
     resetToolCallLoopGuard();
@@ -576,7 +580,7 @@ export function registerHooks(
     await applyCompactionThresholdOverride(ctx);
     await prepareWorkflowMcpForHookContext(ctx, basePath);
     await loadToolApiKeysForSession();
-    if (!isAutoActive()) {
+    if (!isAutoActive() && !preserveCloseoutSurface) {
       ctx.ui.setWidget("gsd-progress", undefined);
       ctx.ui.setWidget("gsd-outcome", undefined);
       const { initHealthWidget } = await import("../health-widget.js");

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -298,6 +298,106 @@ test("session_start installs the welcome screen as the TUI header", async (t) =>
   assert.deepEqual(header.render(123), ["welcome 9.9.9-test none 123"]);
 });
 
+test("session hooks preserve closeout-boundary UI during completion reroot", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-closeout-session-hooks-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  mkdirSync(join(dir, "dist"), { recursive: true });
+  const tempGsdHome = join(dir, "home");
+  mkdirSync(tempGsdHome, { recursive: true });
+  writeFileSync(
+    join(dir, "dist", "welcome-screen.js"),
+    "export function buildWelcomeScreenLines() { return ['welcome header']; }\n",
+    "utf-8",
+  );
+
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const originalGsdPkgRoot = process.env.GSD_PKG_ROOT;
+  process.chdir(dir);
+  process.env.GSD_HOME = tempGsdHome;
+  process.env.GSD_PKG_ROOT = dir;
+  autoSession.reset();
+  autoSession.completionStopInProgress = true;
+  t.after(() => {
+    autoSession.reset();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    if (originalGsdPkgRoot === undefined) delete process.env.GSD_PKG_ROOT;
+    else process.env.GSD_PKG_ROOT = originalGsdPkgRoot;
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<void> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const sessionStart = handlers.get("session_start");
+  const sessionSwitch = handlers.get("session_switch");
+  assert.ok(sessionStart, "session_start handler must be registered");
+  assert.ok(sessionSwitch, "session_switch handler must be registered");
+
+  const widgetCalls: Array<{ key: string; value: unknown }> = [];
+  let headerInstallCount = 0;
+  const ctx = {
+    hasUI: true,
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setFooter: () => {},
+      setHeader: () => {
+        headerInstallCount++;
+      },
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: (key: string, value: unknown) => {
+        widgetCalls.push({ key, value });
+      },
+    },
+    sessionManager: { getSessionId: () => null },
+    model: null,
+    setCompactionThresholdOverride: () => {},
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => false,
+    },
+  };
+
+  await sessionStart!({}, ctx);
+  assert.equal(
+    headerInstallCount,
+    0,
+    "completion reroot session_start must not reinstall the welcome/project-console header",
+  );
+  assert.ok(
+    widgetCalls.some((call) => call.key === "gsd-health" && call.value === undefined),
+    "completion reroot session_start should hide the ambient health widget",
+  );
+
+  widgetCalls.length = 0;
+  await sessionSwitch!({ reason: "reroot" }, ctx);
+  assert.deepEqual(
+    widgetCalls
+      .filter((call) => call.key === "gsd-progress" || call.key === "gsd-outcome")
+      .map((call) => [call.key, call.value]),
+    [],
+    "completion reroot session_switch must not clear the preserved closeout surface",
+  );
+  assert.ok(
+    widgetCalls.some((call) => call.key === "gsd-health" && call.value === undefined),
+    "completion reroot session_switch should keep the ambient health widget hidden",
+  );
+});
+
 test("session_start and session_switch apply disabled model provider policy from current preferences", async (t) => {
   const dir = join(
     tmpdir(),


### PR DESCRIPTION
## TL;DR

**What:** Preserve the terminal closeout surface when completion stop re-roots the command session.
**Why:** A session event during completion cleanup could replace the final closeout transcript with the startup Project Console surface.
**How:** Treat closeout-boundary preservation as an active UI state in session hooks, and add a regression test for the reroot path.

## What

- Adds an auto-runtime accessor for the closeout completion-stop flag.
- Guards GSD `session_start` and `session_switch` hooks so preserved closeout UI does not reinstall the welcome header or clear final widgets.
- Adds a regression test that fails if completion reroot replaces the closeout surface with the project console or clears `gsd-progress` / `gsd-outcome`.

## Why

Foreground closeout-boundary stops are supposed to leave the final closeout report visible. The stop path already avoided installing the completion roll-up widget, but the follow-up command-session reroot could still trigger session hooks that restored startup UI. That pushed the final closeout surface out of the live terminal.

## How

The session hooks now check whether a closeout completion stop is in progress. When it is, they skip the welcome/health replacement path and keep ambient health hidden, matching active auto-mode behavior for the duration of the preserved closeout surface.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `pnpm run build:core`
- `pnpm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/session-start-footer.test.ts src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
- `pnpm run test:changed:src`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783105134&installation_id=134682257&pr_number=463&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F463&signature=2f96c83c04121434243337a0dc36c5ab335870ffb34de1fd1969cc3c60a8feb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI lifecycle only; no auth, data, or workflow execution changes beyond skipping header/widget resets during an existing completion-stop flag.
> 
> **Overview**
> Prevents **completion-stop session reroot** from replacing the terminal **closeout report** with the normal startup **Project Console** surface.
> 
> Adds **`isAutoCompletionStopInProgress()`** and uses it in **`session_start`** / **`session_switch`**: while that flag is set, hooks **skip** reinstalling the welcome header and ambient health widget init, **keep** `gsd-health` hidden like active auto-mode, and **do not clear** `gsd-progress` / `gsd-outcome` on switch. A **regression test** covers the reroot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5b4c1d4d46e762186ceb8a245fb2ecaca5e1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->