### PR TITLE
Hide model-facing GSD gate prompts in tool UI

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -118,6 +118,35 @@ describe("ToolExecutionComponent", () => {
 		assert.match(rendered, /boom/);
 	});
 
+	test("generic failed tools render displayReason instead of model-facing policy text", () => {
+		const modelFacingReason = [
+			'HARD BLOCK: unit "discuss-requirements" is constrained by auto-unit tool scope.',
+			'GSD lifecycle tool "gsd_milestone_status" is not permitted.',
+			"This is a mechanical phase-boundary gate. You MUST NOT proceed, retry the same call, or route around this block.",
+		].join(" ");
+		const rendered = renderTool(
+			"gsd_milestone_status",
+			{ milestoneId: "M001" },
+			{
+				content: [
+					{
+						type: "text",
+						text: modelFacingReason,
+					},
+				],
+				isError: true,
+				details: {
+					displayReason: "This GSD phase only allows its scoped workflow tools.",
+				},
+			},
+		);
+
+		assert.match(rendered, /This GSD phase only allows its scoped workflow tools/);
+		assert.doesNotMatch(rendered, /HARD BLOCK/);
+		assert.doesNotMatch(rendered, /phase-boundary gate/);
+		assert.doesNotMatch(rendered, /MUST NOT proceed/);
+	});
+
 	test("collapses successful low-signal tool cards by default", () => {
 		const rendered = renderToolCollapsed(
 			"mcp__demo__noop",

--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -20,6 +20,7 @@ import type { ToolDefinition, ToolRenderContext } from "@gsd/pi-coding-agent/cor
 import { computeEditDiff, type EditDiffError, type EditDiffResult } from "@gsd/pi-coding-agent/core/tools/edit-diff.js";
 import { allTools } from "@gsd/pi-coding-agent/core/tools/index.js";
 import { getReadTuiMaxDisplayLines } from "@gsd/pi-coding-agent/core/tools/read.js";
+import { getDisplayReason } from "@gsd/pi-coding-agent/core/tools/render-utils.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@gsd/pi-coding-agent/core/tools/truncate.js";
 import { convertToPng } from "@gsd/pi-coding-agent/utils/image-convert.js";
 import { sanitizeBinaryOutput } from "@gsd/pi-coding-agent/utils/shell.js";
@@ -1089,6 +1090,11 @@ export class ToolExecutionComponent extends Container {
 
 	private getTextOutput(): string {
 		if (!this.result) return "";
+
+		const displayReason = this.result.isError ? getDisplayReason(this.result.details) : undefined;
+		if (displayReason) {
+			return sanitizeBinaryOutput(stripAnsi(displayReason)).replace(/\r/g, "");
+		}
 
 		const textBlocks = this.result.content?.filter((c: any) => c.type === "text") || [];
 		const imageBlocks = this.result.content?.filter((c: any) => c.type === "image") || [];

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -747,9 +747,10 @@ async function prepareToolCall(
 				};
 			}
 			if (beforeResult?.block) {
+				const reason = beforeResult.reason || "Tool execution was blocked";
 				return {
 					kind: "immediate",
-					result: createErrorToolResult(beforeResult.reason || "Tool execution was blocked"),
+					result: createErrorToolResult(reason, beforeResult.displayReason),
 					isError: true,
 				};
 			}
@@ -858,10 +859,10 @@ async function finalizeExecutedToolCall(
 	};
 }
 
-function createErrorToolResult(message: string): AgentToolResult<any> {
+function createErrorToolResult(message: string, displayReason?: string): AgentToolResult<any> {
 	return {
 		content: [{ type: "text", text: message }],
-		details: {},
+		details: displayReason ? { displayReason } : {},
 	};
 }
 

--- a/packages/pi-agent-core/src/harness/agent-harness.ts
+++ b/packages/pi-agent-core/src/harness/agent-harness.ts
@@ -420,7 +420,9 @@ export class AgentHarness<
 					toolName: toolCall.name,
 					input: args as Record<string, unknown>,
 				});
-				return result ? { block: result.block, reason: result.reason } : undefined;
+				return result
+					? { block: result.block, reason: result.reason, displayReason: result.displayReason }
+					: undefined;
 			},
 			afterToolCall: async ({ toolCall, args, result, isError }) => {
 				const patch = await this.emitHook({

--- a/packages/pi-agent-core/src/harness/types.ts
+++ b/packages/pi-agent-core/src/harness/types.ts
@@ -662,6 +662,7 @@ export interface BeforeProviderPayloadResult {
 export interface ToolCallResult {
 	block?: boolean;
 	reason?: string;
+	displayReason?: string;
 }
 
 export interface ToolResultPatch {

--- a/packages/pi-agent-core/src/types.ts
+++ b/packages/pi-agent-core/src/types.ts
@@ -50,11 +50,13 @@ export type AgentToolCall = Extract<AssistantMessage["content"][number], { type:
  * Result returned from `beforeToolCall`.
  *
  * Returning `{ block: true }` prevents the tool from executing. The loop emits an error tool result instead.
- * `reason` becomes the text shown in that error result. If omitted, a default blocked message is used.
+ * `reason` becomes the model-facing error result text. If omitted, a default blocked message is used.
+ * `displayReason` optionally replaces `reason` in UI renderers without changing what the model receives.
  */
 export interface BeforeToolCallResult {
 	block?: boolean;
 	reason?: string;
+	displayReason?: string;
 }
 
 /**

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -369,6 +369,75 @@ describe("agentLoop with AgentMessage", () => {
 		expect(executed).toEqual([123]);
 	});
 
+	it("should preserve blocked tool reason for the model and displayReason for UI", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("tool should have been blocked");
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("echo something");
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			beforeToolCall: async () => ({
+				block: true,
+				reason: "HARD BLOCK: call ask_user_questions before writing context.",
+				displayReason: "Depth check required before writing milestone context.",
+			}),
+		};
+
+		let callIndex = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+						"toolUse",
+					);
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage([{ type: "text", text: "done" }]);
+					stream.push({ type: "done", reason: "stop", message });
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const blockedResult = events.find(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end" && event.toolCallId === "tool-1",
+		);
+		expect(blockedResult?.isError).toBe(true);
+		expect(blockedResult?.result.content[0]?.text).toBe(
+			"HARD BLOCK: call ask_user_questions before writing context.",
+		);
+		expect(blockedResult?.result.details?.displayReason).toBe(
+			"Depth check required before writing milestone context.",
+		);
+	});
+
 	it("should prepare tool arguments for validation", async () => {
 		const replaceSchema = Type.Object({ oldText: Type.String(), newText: Type.String() });
 		const toolSchema = Type.Object({ edits: Type.Array(replaceSchema) });

--- a/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
@@ -1026,7 +1026,10 @@ export type BeforeProviderRequestEventResult = unknown;
 export interface ToolCallEventResult {
 	/** Block tool execution. To modify arguments, mutate `event.input` in place instead. */
 	block?: boolean;
+	/** Model-facing reason returned to the agent as the blocked tool result. */
 	reason?: string;
+	/** Optional UI-facing summary for renderers; the model still receives `reason`. */
+	displayReason?: string;
 }
 
 /** Result from user_bash event handler */

--- a/packages/pi-coding-agent/src/core/tools/bash.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash.ts
@@ -17,7 +17,7 @@ import {
 } from "../../utils/shell.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { OutputAccumulator } from "./output-accumulator.js";
-import { getTextOutput, invalidArgText, str } from "./render-utils.js";
+import { getDisplayReason, getTextOutput, invalidArgText, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult } from "./truncate.js";
 
@@ -188,7 +188,7 @@ function rebuildBashResultRenderComponent(
 	component: BashResultRenderComponent,
 	result: {
 		content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
-		details?: BashToolDetails;
+		details?: BashToolDetails & { displayReason?: string };
 	},
 	options: ToolRenderResultOptions,
 	showImages: boolean,
@@ -198,7 +198,7 @@ function rebuildBashResultRenderComponent(
 	const state = component.state;
 	component.clear();
 
-	let output = getTextOutput(result as any, showImages).trim();
+	let output = getDisplayReason(result.details) ?? getTextOutput(result as any, showImages).trim();
 	const truncation = result.details?.truncation;
 	const fullOutputPath = result.details?.fullOutputPath;
 	if (!options.isPartial && truncation?.truncated && fullOutputPath && output.endsWith("]")) {

--- a/packages/pi-coding-agent/src/core/tools/edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/edit.ts
@@ -20,7 +20,7 @@ import {
 } from "./edit-diff.js";
 import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { resolveToCwd } from "./path-utils.js";
-import { invalidArgText, shortenPath, str } from "./render-utils.js";
+import { getDisplayReason, invalidArgText, shortenPath, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 type EditPreview = EditDiffResult | EditDiffError;
@@ -210,10 +210,11 @@ function formatEditResult(
 	const previewDiff = preview && !("error" in preview) ? preview.diff : undefined;
 	const previewError = preview && "error" in preview ? preview.error : undefined;
 	if (isError) {
-		const errorText = result.content
+		const contentErrorText = result.content
 			.filter((c) => c.type === "text")
 			.map((c) => c.text || "")
 			.join("\n");
+		const errorText = getDisplayReason(result.details) ?? contentErrorText;
 		if (!errorText || errorText === previewError) {
 			return undefined;
 		}

--- a/packages/pi-coding-agent/src/core/tools/render-utils.ts
+++ b/packages/pi-coding-agent/src/core/tools/render-utils.ts
@@ -59,6 +59,12 @@ export type ToolRenderResultLike<TDetails> = {
 	details: TDetails;
 };
 
+export function getDisplayReason(details: unknown): string | undefined {
+	if (!details || typeof details !== "object") return undefined;
+	const value = (details as { displayReason?: unknown }).displayReason;
+	return typeof value === "string" && value ? value : undefined;
+}
+
 export function invalidArgText(theme: { fg: (name: any, text: string) => string }): string {
 	return theme.fg("error", "[invalid arg]");
 }

--- a/packages/pi-coding-agent/src/core/tools/write.ts
+++ b/packages/pi-coding-agent/src/core/tools/write.ts
@@ -8,7 +8,7 @@ import { getLanguageFromPath, highlightCode } from "../../theme/theme.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { resolveToCwd } from "./path-utils.js";
-import { invalidArgText, normalizeDisplayText, replaceTabs, shortenPath, str } from "./render-utils.js";
+import { getDisplayReason, invalidArgText, normalizeDisplayText, replaceTabs, shortenPath, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const writeSchema = Type.Object({
@@ -162,16 +162,21 @@ function formatWriteCall(
 }
 
 function formatWriteResult(
-	result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean },
+	result: {
+		content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+		details?: unknown;
+		isError?: boolean;
+	},
 	theme: typeof import("../../theme/theme.js").theme,
 ): string | undefined {
 	if (!result.isError) {
 		return undefined;
 	}
-	const output = result.content
+	const contentOutput = result.content
 		.filter((c) => c.type === "text")
 		.map((c) => c.text || "")
 		.join("\n");
+	const output = getDisplayReason(result.details) ?? contentOutput;
 	if (!output) {
 		return undefined;
 	}

--- a/packages/pi-coding-agent/test/tool-display-reason.test.ts
+++ b/packages/pi-coding-agent/test/tool-display-reason.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { createWriteToolDefinition } from "../src/core/tools/write.ts";
+import { initTheme, theme } from "../src/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+describe("tool displayReason rendering", () => {
+	test("write errors render displayReason instead of model-facing policy text", () => {
+		initTheme("dark");
+		const tool = createWriteToolDefinition(process.cwd());
+		const component = tool.renderResult?.(
+			{
+				content: [{
+					type: "text",
+					text: "HARD BLOCK: Cannot write to milestone CONTEXT.md without depth verification.",
+				}],
+				details: { displayReason: "Depth check required before writing milestone context." },
+			},
+			{ expanded: false, isPartial: false },
+			theme,
+			{ isError: true } as any,
+		);
+
+		const rendered = stripAnsi(component?.render(120).join("\n") ?? "");
+		expect(rendered).toContain("Depth check required before writing milestone context.");
+		expect(rendered).not.toContain("HARD BLOCK");
+		expect(rendered).not.toContain("ask_user_questions");
+	});
+});

--- a/src/resources/extensions/gsd/auto-unit-tool-scope.ts
+++ b/src/resources/extensions/gsd/auto-unit-tool-scope.ts
@@ -97,6 +97,14 @@ const SCOPED_GSD_LIFECYCLE_TOOLS = new Set(
     .map(canonicalWorkflowToolName),
 );
 
+export const GSD_PHASE_SCOPE_DISPLAY_REASON = "This GSD phase only allows its scoped workflow tools.";
+
+type AutoUnitToolScopeResult = {
+  block: boolean;
+  reason?: string;
+  displayReason?: string;
+};
+
 function stripMcpToolPrefix(toolName: string): string {
   if (!toolName.startsWith("mcp__")) return toolName;
   const toolSeparator = toolName.indexOf("__", "mcp__".length);
@@ -112,12 +120,16 @@ export function isWorkflowAliasTool(toolName: string): boolean {
   return Object.prototype.hasOwnProperty.call(WORKFLOW_TOOL_ALIASES, stripMcpToolPrefix(toolName));
 }
 
-function hardBlockReason(unitType: string, what: string): string {
-  return [
-    `HARD BLOCK: unit "${unitType}" is constrained by auto-unit tool scope — ${what}.`,
-    "This is a mechanical phase-boundary gate. You MUST NOT proceed, retry the same call,",
-    "or route around this block; the orchestrator owns phase transitions.",
-  ].join(" ");
+function hardBlock(unitType: string, what: string): AutoUnitToolScopeResult {
+  return {
+    block: true,
+    reason: [
+      `HARD BLOCK: unit "${unitType}" is constrained by auto-unit tool scope — ${what}.`,
+      "This is a mechanical phase-boundary gate. You MUST NOT proceed, retry the same call,",
+      "or route around this block; the orchestrator owns phase transitions.",
+    ].join(" "),
+    displayReason: GSD_PHASE_SCOPE_DISPLAY_REASON,
+  };
 }
 
 function allowedGsdToolsForUnit(unitType: string): string[] {
@@ -144,7 +156,7 @@ function shouldBlockTaskCompletionScope(
   unitId: string | undefined,
   toolName: string,
   input: unknown,
-): { block: boolean; reason?: string } {
+): AutoUnitToolScopeResult {
   if (!EXECUTE_TASK_UNIT_TYPES.has(unitType)) return { block: false };
   if (canonicalWorkflowToolName(toolName) !== "gsd_task_complete") return { block: false };
   if (!unitId) return { block: false };
@@ -165,13 +177,10 @@ function shouldBlockTaskCompletionScope(
     return { block: false };
   }
 
-  return {
-    block: true,
-    reason: hardBlockReason(
-      unitType,
-      `gsd_task_complete may only complete the active task ${expected.milestone}/${expected.slice}/${expected.task}; requested ${actualMilestone}/${actualSlice}/${actualTask}`,
-    ),
-  };
+  return hardBlock(
+    unitType,
+    `gsd_task_complete may only complete the active task ${expected.milestone}/${expected.slice}/${expected.task}; requested ${actualMilestone}/${actualSlice}/${actualTask}`,
+  );
 }
 
 export function shouldBlockAutoUnitToolCall(
@@ -179,15 +188,12 @@ export function shouldBlockAutoUnitToolCall(
   toolName: string,
   input?: unknown,
   unitId?: string,
-): { block: boolean; reason?: string } {
+): AutoUnitToolScopeResult {
   const scopedTools = AUTO_UNIT_SCOPED_TOOLS[unitType];
   if (!scopedTools) return { block: false };
 
   if (isNativeWorkflowTool(toolName)) {
-    return {
-      block: true,
-      reason: hardBlockReason(unitType, "native Workflow is not permitted inside a dispatched GSD auto-mode unit"),
-    };
+    return hardBlock(unitType, "native Workflow is not permitted inside a dispatched GSD auto-mode unit");
   }
 
   const taskScope = shouldBlockTaskCompletionScope(unitType, unitId, toolName, input);
@@ -199,11 +205,8 @@ export function shouldBlockAutoUnitToolCall(
   const allowedTools = allowedGsdToolsForUnit(unitType);
   if (allowedTools.includes(canonicalTool)) return { block: false };
 
-  return {
-    block: true,
-    reason: hardBlockReason(
-      unitType,
-      `GSD lifecycle tool "${canonicalTool}" is not permitted; allowed GSD tools: ${allowedTools.length > 0 ? allowedTools.join(", ") : "(none)"}`,
-    ),
-  };
+  return hardBlock(
+    unitType,
+    `GSD lifecycle tool "${canonicalTool}" is not permitted; allowed GSD tools: ${allowedTools.length > 0 ? allowedTools.join(", ") : "(none)"}`,
+  );
 }

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -78,6 +78,9 @@ function readDetails(result: any): any {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- result shape varies by tool
 function formatToolErrorText(result: any, details: any): string {
+  if (typeof details?.displayReason === "string" && details.displayReason) {
+    return details.displayReason;
+  }
   const message = details?.error
     ?? result?.content?.find((entry: { type?: string; text?: string }) => entry.type === "text")?.text
     ?? "unknown";

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -480,22 +480,30 @@ function isContextDraftSummarySave(toolName: string, input: unknown): boolean {
   return (input as { artifact_type?: unknown }).artifact_type === "CONTEXT-DRAFT";
 }
 
+function withDepthGateDisplayReason<T extends { block: boolean; reason?: string }>(
+  result: T,
+  displayReason = "Depth confirmation is waiting for your answer.",
+): T & { displayReason?: string } {
+  if (!result.block) return result;
+  return { ...result, displayReason };
+}
+
 function shouldBlockDeferredApprovalTool(
   toolName: string,
   input: unknown,
   basePath: string,
-): { block: boolean; reason?: string } {
+): { block: boolean; reason?: string; displayReason?: string } {
   if (deferredApprovalGate?.basePath !== basePath) return { block: false };
   if (toolName === "ask_user_questions") return { block: false };
   if (isContextDraftSummarySave(toolName, input)) return { block: false };
-  return {
+  return withDepthGateDisplayReason({
     block: true,
     reason: [
       `HARD BLOCK: Approval question "${deferredApprovalGate.gateId}" has been shown to the user.`,
       `Only CONTEXT-DRAFT persistence may finish in this same assistant turn.`,
       `Wait for the user's answer before calling additional tools.`,
     ].join(" "),
-  };
+  });
 }
 
 export function resolveNotificationStoreBasePath(basePath: string): string {
@@ -917,7 +925,7 @@ export function registerHooks(
               "Depth confirmation is waiting for your answer — pausing auto-mode.",
             );
           }
-          return bashGuard;
+          return withDepthGateDisplayReason(bashGuard);
         }
       } else {
         const gateGuard = shouldBlockPendingGate(
@@ -935,7 +943,7 @@ export function registerHooks(
               "Depth confirmation is waiting for your answer — pausing auto-mode.",
             );
           }
-          return gateGuard;
+          return withDepthGateDisplayReason(gateGuard);
         }
       }
     }
@@ -1040,7 +1048,9 @@ export function registerHooks(
       isQueuePhaseActive(discussionBasePath),
       discussionBasePath,
     );
-    if (result.block) return result;
+    if (result.block) {
+      return withDepthGateDisplayReason(result, "Depth check required before writing milestone context.");
+    }
   });
 
   // ── Safety harness: evidence collection + destructive command blocking ──

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -4,7 +4,7 @@ import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { minimatch } from "minimatch";
 
-import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
+import { GSD_PHASE_SCOPE_DISPLAY_REASON, shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
 import { getIsolationMode } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
@@ -772,6 +772,20 @@ function blockReason(unitType: string, mode: string, what: string): string {
   ].join(" ");
 }
 
+function planningBlock(unitType: string, mode: string, what: string): PlanningUnitBlockResult {
+  return {
+    block: true,
+    reason: blockReason(unitType, mode, what),
+    displayReason: GSD_PHASE_SCOPE_DISPLAY_REASON,
+  };
+}
+
+type PlanningUnitBlockResult = {
+  block: boolean;
+  reason?: string;
+  displayReason?: string;
+};
+
 /**
  * Planning-unit tool-policy enforcement. Returns { block } per the policy
  * resolved from the active unit's manifest:
@@ -812,7 +826,7 @@ export function shouldBlockPlanningUnit(
   agentClasses?: readonly string[],
   toolInput?: unknown,
   unitId?: string,
-): { block: boolean; reason?: string } {
+): PlanningUnitBlockResult {
   const tool = canonicalToolName(toolName);
   const autoScopeGuard = shouldBlockAutoUnitToolCall(unitType, toolName, toolInput, unitId);
   if (autoScopeGuard.block) return autoScopeGuard;
@@ -825,10 +839,10 @@ export function shouldBlockPlanningUnit(
     if (PLANNING_SAFE_TOOLS.has(tool)) return { block: false };
     if (tool.startsWith("gsd_")) return { block: false };
     if (PLANNING_WRITE_TOOLS.has(tool) || tool === "bash" || PLANNING_SUBAGENT_TOOLS.has(tool)) {
-      return { block: true, reason: blockReason(unitType, policy.mode, `${tool} is not permitted (read-only)`) };
+      return planningBlock(unitType, policy.mode, `${tool} is not permitted (read-only)`);
     }
     // Unknown tool in read-only mode — block by default.
-    return { block: true, reason: blockReason(unitType, policy.mode, `tool "${tool}" is not on the read-only allowlist`) };
+    return planningBlock(unitType, policy.mode, `tool "${tool}" is not on the read-only allowlist`);
   }
 
   // planning / planning-dispatch / docs / verification modes share the same surface for safe tools, bash, and subagent.
@@ -846,14 +860,11 @@ export function shouldBlockPlanningUnit(
       // instead of silently bypassing the gate.
       if (agentClasses === undefined) {
         warnMissingControlledDispatchAgentClasses(unitType, policy.mode, tool);
-        return {
-          block: true,
-          reason: blockReason(
-            unitType,
-            policy.mode,
-            `subagent dispatch blocked: stale caller did not supply agent identities for "${tool}"; update extractSubagentAgentClasses to handle this input shape`,
-          ),
-        };
+        return planningBlock(
+          unitType,
+          policy.mode,
+          `subagent dispatch blocked: stale caller did not supply agent identities for "${tool}"; update extractSubagentAgentClasses to handle this input shape`,
+        );
       }
       // agentClasses was explicitly provided but resolved to an empty list (for
       // example, a bare tool call with no agent field). Pass through; no agents
@@ -863,57 +874,45 @@ export function shouldBlockPlanningUnit(
       }
       const globallyDisallowed = requested.find(a => !isReadOnlySpecialist(a));
       if (globallyDisallowed) {
-        return {
-          block: true,
-          reason: blockReason(
-            unitType,
-            policy.mode,
-            `subagent dispatch of "${globallyDisallowed}" not permitted; only read-only specialists (${allowedPlanningDispatchAgentsList()}) may be dispatched from ${policy.mode} units`,
-          ),
-        };
+        return planningBlock(
+          unitType,
+          policy.mode,
+          `subagent dispatch of "${globallyDisallowed}" not permitted; only read-only specialists (${allowedPlanningDispatchAgentsList()}) may be dispatched from ${policy.mode} units`,
+        );
       }
       const disallowedByPolicy = requested.find(a => !allowed.has(a));
       if (disallowedByPolicy) {
-        return {
-          block: true,
-          reason: blockReason(
-            unitType,
-            policy.mode,
-            `subagent dispatch of "${disallowedByPolicy}" not permitted by ToolsPolicy.allowedSubagents; permitted agents for this unit: ${allowedSubagents.join(", ")}`,
-          ),
-        };
+        return planningBlock(
+          unitType,
+          policy.mode,
+          `subagent dispatch of "${disallowedByPolicy}" not permitted by ToolsPolicy.allowedSubagents; permitted agents for this unit: ${allowedSubagents.join(", ")}`,
+        );
       }
       return { block: false };
     }
-    return { block: true, reason: blockReason(unitType, policy.mode, `subagent dispatch is not permitted in planning units`) };
+    return planningBlock(unitType, policy.mode, "subagent dispatch is not permitted in planning units");
   }
 
   if (tool === "bash") {
     if (policy.mode === "verification") {
       if (BASH_VERIFICATION_RE.test(pathOrCommand) || BASH_READ_ONLY_RE.test(pathOrCommand)) return { block: false };
-      return {
-        block: true,
-        reason: blockReason(
-          unitType,
-          policy.mode,
-          `bash is restricted to build/test verification commands (npm run build, npm test, etc.); cannot run "${pathOrCommand.slice(0, 80)}${pathOrCommand.length > 80 ? "…" : ""}"`,
-        ),
-      };
-    }
-    if (BASH_READ_ONLY_RE.test(pathOrCommand)) return { block: false };
-    return {
-      block: true,
-      reason: blockReason(
+      return planningBlock(
         unitType,
         policy.mode,
-        `bash is restricted to read-only commands (cat/grep/git log/etc); cannot run "${pathOrCommand.slice(0, 80)}${pathOrCommand.length > 80 ? "…" : ""}"`,
-      ),
-    };
+        `bash is restricted to build/test verification commands (npm run build, npm test, etc.); cannot run "${pathOrCommand.slice(0, 80)}${pathOrCommand.length > 80 ? "…" : ""}"`,
+      );
+    }
+    if (BASH_READ_ONLY_RE.test(pathOrCommand)) return { block: false };
+    return planningBlock(
+      unitType,
+      policy.mode,
+      `bash is restricted to read-only commands (cat/grep/git log/etc); cannot run "${pathOrCommand.slice(0, 80)}${pathOrCommand.length > 80 ? "…" : ""}"`,
+    );
   }
 
   if (PLANNING_WRITE_TOOLS.has(tool)) {
     if (!pathOrCommand) {
-      return { block: true, reason: blockReason(unitType, policy.mode, `${tool} called with empty path`) };
+      return planningBlock(unitType, policy.mode, `${tool} called with empty path`);
     }
     const absPath = isAbsolute(pathOrCommand) ? pathOrCommand : resolve(basePath, pathOrCommand);
 
@@ -925,14 +924,11 @@ export function shouldBlockPlanningUnit(
       return { block: false };
     }
 
-    return {
-      block: true,
-      reason: blockReason(
-        unitType,
-        policy.mode,
-        `cannot ${tool} "${pathOrCommand}" — writes are restricted to .gsd/${policy.mode === "docs" ? " and " + policy.allowedPathGlobs.join(", ") : ""}`,
-      ),
-    };
+    return planningBlock(
+      unitType,
+      policy.mode,
+      `cannot ${tool} "${pathOrCommand}" — writes are restricted to .gsd/${policy.mode === "docs" ? " and " + policy.allowedPathGlobs.join(", ") : ""}`,
+    );
   }
 
   // Unknown tool name — pass through. Other layers (queue, pending-gate,

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -70,6 +70,50 @@ test("register-hooks hard-blocks destructive bash commands outside auto-mode", a
   assert.match(block?.reason ?? "", /IaC apply\/destroy/);
 });
 
+test("register-hooks keeps depth-gate reason model-facing and adds displayReason", async (t) => {
+  const dir = makeTempDir("display-reason");
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  resetWriteGateState(dir);
+
+  t.after(() => {
+    try {
+      resetWriteGateState(dir);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  let block: any;
+  for (const handler of handlers.get("tool_call") ?? []) {
+    const result = await handler({
+      toolName: "write",
+      input: {
+        path: join(dir, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+        content: "# M001 Context\n",
+      },
+    });
+    if (result?.block) block = result;
+  }
+
+  assert.equal(block?.block, true);
+  assert.match(block?.reason ?? "", /HARD BLOCK: Cannot write to milestone CONTEXT\.md/);
+  assert.match(block?.reason ?? "", /ask_user_questions/);
+  assert.equal(block?.displayReason, "Depth check required before writing milestone context.");
+});
+
 test("register-hooks unlocks milestone depth verification from question id without guided-flow state (#4047)", async (t) => {
   const dir = makeTempDir("manual");
   const originalCwd = process.cwd();

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -1409,6 +1409,10 @@ test("executeSummarySave blocks final root artifacts while approval gate is pend
 
     assert.equal(result.isError, true);
     assert.equal(result.details.error, "root_artifact_write_blocked");
+    assert.equal(
+      result.details.displayReason,
+      "Approval confirmation required before saving final project setup artifacts.",
+    );
     assert.match(result.content[0].text, /has not been confirmed/);
     assert.equal(existsSync(join(base, ".gsd", "REQUIREMENTS.md")), false);
 
@@ -1451,6 +1455,10 @@ test("executeSummarySave requires verified root approval in deep mode", async ()
 
     assert.equal(blocked.isError, true);
     assert.equal(blocked.details.error, "root_artifact_write_blocked");
+    assert.equal(
+      blocked.details.displayReason,
+      "Approval confirmation required before saving final project setup artifacts.",
+    );
     assert.match(blocked.content[0].text, /fail-closed/);
     assert.equal(existsSync(join(base, ".gsd", "PROJECT.md")), false);
 
@@ -1667,6 +1675,10 @@ test("executeSummarySave CONTEXT HARD BLOCK clears after write-gate state file i
       content: "# Context\n\ncontent",
     }, base));
     assert.equal(blocked.isError, true, "should be blocked without depth verification");
+    assert.equal(
+      blocked.details.displayReason,
+      "Depth check required before writing milestone context.",
+    );
     assert.match(
       blocked.content[0].text,
       /HARD BLOCK/,

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -9,6 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { join, sep } from 'node:path';
 
+import { GSD_PHASE_SCOPE_DISPLAY_REASON } from '../auto-unit-tool-scope.ts';
 import { ALLOWED_PLANNING_DISPATCH_AGENTS, shouldBlockPlanningUnit } from '../bootstrap/write-gate.ts';
 import { extractSubagentAgentClasses } from '../bootstrap/subagent-input.ts';
 import { isDeterministicPolicyError } from '../auto-tool-tracking.ts';
@@ -63,6 +64,19 @@ test('planning-unit: deterministic block reason is suitable for retry short-circ
   assert.match(r.reason!, /HARD BLOCK/);
   assert.match(r.reason!, /tools-policy/);
   assert.strictEqual(isDeterministicPolicyError(r.reason!), true);
+});
+
+test('planning-unit: blocked tool-policy calls include UI-safe display reason', () => {
+  const r = shouldBlockPlanningUnit(
+    'edit',
+    'src/main.ts',
+    BASE,
+    'discuss-milestone',
+    PLANNING,
+  );
+  assert.strictEqual(r.block, true);
+  assert.match(r.reason!, /HARD BLOCK/);
+  assert.strictEqual(r.displayReason, GSD_PHASE_SCOPE_DISPLAY_REASON);
 });
 
 test('planning-unit: blocks write to user source via relative path', () => {
@@ -367,6 +381,7 @@ test('auto-unit scope: execute-task allows only its task completion lifecycle to
   assert.strictEqual(blocked.block, true);
   assert.match(blocked.reason!, /HARD BLOCK/);
   assert.match(blocked.reason!, /gsd_save_gate_result/);
+  assert.strictEqual(blocked.displayReason, GSD_PHASE_SCOPE_DISPLAY_REASON);
   assert.strictEqual(isDeterministicPolicyError(blocked.reason!), true);
 });
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -178,7 +178,11 @@ export async function executeSummarySave(
   if (rootArtifactGuard.block) {
     return {
       content: [{ type: "text", text: `Error saving artifact: ${rootArtifactGuard.reason ?? "root artifact write blocked"}` }],
-      details: { operation: "save_summary", error: "root_artifact_write_blocked" },
+      details: {
+        operation: "save_summary",
+        error: "root_artifact_write_blocked",
+        displayReason: "Approval confirmation required before saving final project setup artifacts.",
+      },
       isError: true,
     };
   }
@@ -191,9 +195,13 @@ export async function executeSummarySave(
   if (contextGuard.block) {
     return {
       content: [{ type: "text", text: `Error saving artifact: ${contextGuard.reason ?? "context write blocked"}` }],
-      details: { operation: "save_summary", error: "context_write_blocked" },
-    isError: true,
-      };
+      details: {
+        operation: "save_summary",
+        error: "context_write_blocked",
+        displayReason: "Depth check required before writing milestone context.",
+      },
+      isError: true,
+    };
   }
   try {
     let relativePath: string;


### PR DESCRIPTION
## TL;DR

**What:** Adds a UI-only display reason channel for blocked tool calls and uses it across GSD gate renderers.
**Why:** Mechanical hard-block prompts need to guide the model without dumping internal instructions into the terminal UI.
**How:** Carries `displayReason` through agent-core tool results, prefers it in renderers, and adds GSD-specific display summaries plus regression tests.

## What

This updates the tool-call block contract so hooks can return a model-facing `reason` and a separate UI-facing `displayReason`. The agent loop preserves the full reason in the tool result content while storing the short display reason in result details.

Renderer paths for write, edit, bash, database-backed GSD tools, and generic terminal tool cards now prefer `displayReason` for failed results. GSD depth, approval, context, planning-policy, and auto-unit phase-boundary blocks now supply concise display text while keeping the hard-block instruction intact for the model.

## Why

Users were seeing internal hard-block prompts such as depth-verification and phase-boundary instructions rendered directly in the terminal. Those prompts are useful control text for the model, but they are noisy and confusing as user-facing UI output.

## How

The implementation splits blocked tool text into two channels: `reason` for model-visible tool result content, and optional `displayReason` for renderers. Existing renderers read the display reason from result details, and the GSD gates attach short summaries for depth verification, approval waits, milestone context writes, and scoped workflow phase blocks.

## Validation

- `pnpm run build:agent-modes`
- `pnpm run typecheck:extensions`
- `pnpm --filter @gsd/pi-agent-core exec vitest --run test/agent-loop.test.ts`
- `pnpm --filter @gsd/pi-coding-agent exec vitest --run test/tool-display-reason.test.ts`
- `pnpm --filter @gsd/agent-modes test -- src/modes/interactive/components/__tests__/tool-execution.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts`
- `pnpm run verify:fast`
- `git diff --check`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783123849&installation_id=134682257&pr_number=464&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F464&signature=a8571816bcb2513f0232d14f310a366fc4b8144f2e71ae6be6e040fdfa81f99d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contract and display-only path; model-facing tool content unchanged. Risk is mainly inconsistent adoption if a blocker omits displayReason.
> 
> **Overview**
> Blocked and failed tool calls can now carry a **UI-only** `displayReason` alongside the existing model-facing `reason`. The agent loop still puts full policy text (e.g. HARD BLOCK instructions) in tool result **content** for the model, but stores the short summary in `details.displayReason` when hooks or executors supply it.
> 
> **Agent core and harness** thread `displayReason` through `beforeToolCall`, blocked-tool error results, and extension `tool_call` event types. **Renderers** (`getDisplayReason` in pi-coding-agent, interactive tool cards, write/edit/bash, GSD DB tool errors) prefer `displayReason` for error display when present.
> 
> **GSD gates** attach user-friendly copy for phase/tool-scope blocks, depth checks before milestone context writes, deferred approval waits, and blocked root/context artifact saves—without changing what the model is told to do.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cab50eeb16478e3c28950860fb888e9ab5ed8b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->