### PR TITLE
fix(gsd): block split-brain milestone closeout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,6 +15,7 @@
 - **Needs Attention**: a finding that requires human review before progression or completion continues.
 - **First-visible response latency**: the user-perceived delay from submitting a prompt to seeing the first assistant output. Distinct from total completion time, Unit duration, or tool execution duration.
 - **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves a durable final closeout surface visible in the live terminal, not merely scrollback or a cleared progress area.
+- **Closeout Consistency Gate**: the preventive rule that finalization, merge, and all-complete stop paths require canonical DB state to prove the closeout is complete before they proceed. Distinct from State Reconciliation, which detects and repairs drift before dispatch.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.
 - **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.

--- a/docs/dev/ADR-025-closeout-consistency-gate.md
+++ b/docs/dev/ADR-025-closeout-consistency-gate.md
@@ -1,0 +1,9 @@
+# Closeout Consistency Gate
+
+Closeout finalization, worktree merge, and all-complete stop paths must prove canonical DB closeout after any deterministic reconciliation attempt. Markdown summaries and projections may explain or support recovery, but they cannot authorize destructive closeout actions when the canonical DB still shows open milestones, slices, tasks, or quality gates.
+
+In worktree mode, the canonical DB for this gate is the project-root DB after worktree DB reconciliation, not the worktree DB alone. If reconciliation fails or the project-root DB still shows open closeout state, the gate fails closed even when the worktree DB or markdown artifacts look complete.
+
+Failures surface as Needs Attention with a `closeout-consistency-blocked` recovery reason after at most one deterministic reconciliation attempt. They must not enter generic provider retry handling or be reported as ordinary git merge failures.
+
+This intentionally rejects permissive recovery from success-looking artifacts in favor of failing closed before merge or all-complete notification. The trade-off is that rare transient DB lag may require an explicit retry or recovery step, but the runtime will not silently merge or stop from a split-brain state.

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -96,6 +96,10 @@ import { probeGitConflictState } from "./git-conflict-state.js";
 import { runTurnGitAction } from "./git-service.js";
 import { parseUnitId } from "./unit-id.js";
 import { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
+import {
+  checkCloseoutConsistencyGate,
+  formatCloseoutConsistencyBlock,
+} from "./closeout-consistency-gate.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -1634,6 +1638,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
             unitId: mid,
             prompt: await buildCompleteMilestonePrompt(mid, midTitle, basePath),
           };
+        }
+        if (milestone) {
+          const closeoutGate = checkCloseoutConsistencyGate(mid, { refreshFromDisk: true });
+          if (!closeoutGate.ok) {
+            return {
+              action: "stop",
+              reason: formatCloseoutConsistencyBlock(closeoutGate),
+              level: "warning",
+            };
+          }
         }
       }
       return {

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -54,6 +54,7 @@ import { isGsdWorktreePath } from "./worktree-root.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
+import { checkCloseoutConsistencyGate } from "./closeout-consistency-gate.js";
 
 // Re-export so existing consumers of auto-recovery.ts keep working.
 export { resolveExpectedArtifactPath, diagnoseExpectedArtifact };
@@ -626,9 +627,8 @@ export function verifyExpectedArtifact(
     if (summaryOutcome === "failure") return false;
     const { milestone: mid } = parseUnitId(unitId);
     if (mid && isDbAvailable()) {
-      const dbMilestone = getMilestone(mid);
-      if (!dbMilestone) return false;
-      if (!isClosedStatus(dbMilestone.status) && summaryOutcome !== "success") return false;
+      const closeoutGate = checkCloseoutConsistencyGate(mid, { refreshFromDisk: true });
+      if (!closeoutGate.ok) return false;
     }
     if (hasImplementationArtifacts(base, mid) === "absent") return false;
   }

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -83,6 +83,11 @@ import {
   nativeWorktreeList,
   nativeLsFiles,
 } from "./native-git-bridge.js";
+import {
+  CLOSEOUT_CONSISTENCY_BLOCKED_REASON,
+  checkCloseoutConsistencyGate,
+  formatCloseoutConsistencyBlock,
+} from "./closeout-consistency-gate.js";
 import { gsdHome } from "./gsd-home.js";
 import { type MilestoneScope, type GsdWorkspace, createWorkspace } from "./workspace.js";
 import {
@@ -1771,16 +1776,29 @@ export function mergeMilestoneToMain(
   // symlink layout) — ATTACHing a WAL-mode file to itself corrupts the
   // database (#2823).
   if (isDbAvailable()) {
+    const contract = resolveGsdPathContract(worktreeCwd, originalBasePath_);
+    const worktreeDbPath = join(contract.worktreeGsd ?? join(worktreeCwd, ".gsd"), "gsd.db");
+    const mainDbPath = contract.projectDb;
     try {
-      const contract = resolveGsdPathContract(worktreeCwd, originalBasePath_);
-      const worktreeDbPath = join(contract.worktreeGsd ?? join(worktreeCwd, ".gsd"), "gsd.db");
-      const mainDbPath = contract.projectDb;
+      const activeDbPath = getDbPath();
+      if (activeDbPath && _shouldReconcileWorktreeDb(activeDbPath, mainDbPath)) {
+        closeDatabase();
+        if (!openDatabase(mainDbPath)) {
+          throw new Error(`cannot open project DB at ${mainDbPath}`);
+        }
+      }
       if (_shouldReconcileWorktreeDb(worktreeDbPath, mainDbPath)) {
         reconcileWorktreeDb(mainDbPath, worktreeDbPath);
       }
     } catch (err) {
-      /* non-fatal */
-      logError("worktree", `DB reconciliation failed: ${err instanceof Error ? err.message : String(err)}`);
+      const message = `DB reconciliation failed before milestone ${milestoneId} merge: ${err instanceof Error ? err.message : String(err)}`;
+      logError("worktree", message);
+      throw new GSDError(GSD_GIT_ERROR, `${message}. Recovery reason: ${CLOSEOUT_CONSISTENCY_BLOCKED_REASON}.`);
+    }
+
+    const closeoutGate = checkCloseoutConsistencyGate(milestoneId);
+    if (!closeoutGate.ok) {
+      throw new GSDError(GSD_GIT_ERROR, formatCloseoutConsistencyBlock(closeoutGate));
     }
   }
 

--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -1,0 +1,137 @@
+// Project/App: gsd-pi
+// File Purpose: Shared DB-backed guard for milestone closeout finalization.
+
+import {
+  getDbPath,
+  getLatestAssessmentByScope,
+  getMilestone,
+  getMilestoneSlices,
+  getPendingGates,
+  getSliceTasks,
+  isDbAvailable,
+  refreshOpenDatabaseFromDisk,
+} from "./gsd-db.js";
+import { isClosedStatus } from "./status-guards.js";
+
+export const CLOSEOUT_CONSISTENCY_BLOCKED_REASON = "closeout-consistency-blocked";
+
+export type CloseoutConsistencyFailureReason =
+  | "db-unavailable"
+  | "db-refresh-failed"
+  | "milestone-missing"
+  | "milestone-open"
+  | "validation-not-pass"
+  | "slice-missing"
+  | "slice-open"
+  | "task-open"
+  | "quality-gate-pending";
+
+export type CloseoutConsistencyResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: CloseoutConsistencyFailureReason;
+      recoveryReason: typeof CLOSEOUT_CONSISTENCY_BLOCKED_REASON;
+      message: string;
+    };
+
+export interface CloseoutConsistencyOptions {
+  refreshFromDisk?: boolean;
+}
+
+function blocked(reason: CloseoutConsistencyFailureReason, message: string): CloseoutConsistencyResult {
+  return {
+    ok: false,
+    reason,
+    recoveryReason: CLOSEOUT_CONSISTENCY_BLOCKED_REASON,
+    message,
+  };
+}
+
+function isFileBackedDbPath(path: string | null): boolean {
+  return Boolean(path && path !== ":memory:");
+}
+
+export function checkCloseoutConsistencyGate(
+  milestoneId: string,
+  options: CloseoutConsistencyOptions = {},
+): CloseoutConsistencyResult {
+  if (!isDbAvailable()) {
+    return blocked(
+      "db-unavailable",
+      `Closeout consistency blocked for ${milestoneId}: canonical DB is unavailable.`,
+    );
+  }
+
+  if (options.refreshFromDisk && isFileBackedDbPath(getDbPath()) && !refreshOpenDatabaseFromDisk()) {
+    return blocked(
+      "db-refresh-failed",
+      `Closeout consistency blocked for ${milestoneId}: canonical DB refresh failed.`,
+    );
+  }
+
+  const milestone = getMilestone(milestoneId);
+  if (!milestone) {
+    return blocked(
+      "milestone-missing",
+      `Closeout consistency blocked for ${milestoneId}: milestone is missing from canonical DB.`,
+    );
+  }
+  if (!isClosedStatus(milestone.status)) {
+    return blocked(
+      "milestone-open",
+      `Closeout consistency blocked for ${milestoneId}: canonical DB milestone status is "${milestone.status}".`,
+    );
+  }
+
+  if (milestone.status !== "skipped") {
+    const validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
+    if (validation?.status !== "pass") {
+      return blocked(
+        "validation-not-pass",
+        `Closeout consistency blocked for ${milestoneId}: latest milestone validation is "${validation?.status ?? "absent"}".`,
+      );
+    }
+  }
+
+  const slices = getMilestoneSlices(milestoneId);
+  if (slices.length === 0 && milestone.status !== "skipped") {
+    return blocked(
+      "slice-missing",
+      `Closeout consistency blocked for ${milestoneId}: no slices exist in canonical DB.`,
+    );
+  }
+
+  for (const slice of slices) {
+    if (!isClosedStatus(slice.status)) {
+      return blocked(
+        "slice-open",
+        `Closeout consistency blocked for ${milestoneId}: slice ${slice.id} status is "${slice.status}".`,
+      );
+    }
+
+    for (const task of getSliceTasks(milestoneId, slice.id)) {
+      if (!isClosedStatus(task.status)) {
+        return blocked(
+          "task-open",
+          `Closeout consistency blocked for ${milestoneId}: task ${slice.id}/${task.id} status is "${task.status}".`,
+        );
+      }
+    }
+
+    const pendingGate = getPendingGates(milestoneId, slice.id)[0];
+    if (pendingGate) {
+      return blocked(
+        "quality-gate-pending",
+        `Closeout consistency blocked for ${milestoneId}: quality gate ${pendingGate.gate_id} is still pending for ${slice.id}.`,
+      );
+    }
+  }
+
+  return { ok: true };
+}
+
+export function formatCloseoutConsistencyBlock(result: CloseoutConsistencyResult): string {
+  if (result.ok) return "";
+  return `${result.message} Recovery reason: ${result.recoveryReason}. Resolve the canonical DB state and run /gsd auto to retry.`;
+}

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -16,6 +16,7 @@ import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 import { logWarning } from "./workflow-logger.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 import { buildCompleteMilestonePrompt } from "./auto-prompts.js";
+import { checkCloseoutConsistencyGate } from "./closeout-consistency-gate.js";
 import type { DispatchAction, DispatchContext } from "./auto-dispatch.js";
 import {
   commitPendingMilestoneCloseoutChanges,
@@ -37,7 +38,8 @@ export async function isMilestoneCloseoutSettled(mid: string, basePath: string):
     if (isDbAvailable()) {
       const milestone = getMilestone(mid);
       if (milestone && isClosedStatus(milestone.status)) {
-        if (verifyExpectedArtifact("complete-milestone", mid, basePath)) {
+        const closeoutGate = checkCloseoutConsistencyGate(mid, { refreshFromDisk: true });
+        if (closeoutGate.ok && verifyExpectedArtifact("complete-milestone", mid, basePath)) {
           return true;
         }
       }

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1558,6 +1558,14 @@ test("verifyExpectedArtifact complete-milestone passes when DB milestone is comp
 
     openDatabase(join(base, ".gsd", "gsd.db"));
     insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Done Slice", status: "complete" });
+    insertAssessment({
+      path: "milestones/M001/M001-VALIDATION.md",
+      milestoneId: "M001",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
+    });
 
     const result = verifyExpectedArtifact("complete-milestone", "M001", base);
     assert.equal(result, true, "complete-milestone should pass when DB status is complete");
@@ -1566,7 +1574,7 @@ test("verifyExpectedArtifact complete-milestone passes when DB milestone is comp
   }
 });
 
-test("verifyExpectedArtifact complete-milestone tolerates transient DB lag when SUMMARY is canonical success (#4658)", () => {
+test("verifyExpectedArtifact complete-milestone rejects success SUMMARY when DB milestone is still open (#4658)", () => {
   const base = makeGitBase();
   try {
     execFileSync("git", ["checkout", "-b", "feat/ms-db-lag-success"], { cwd: base, stdio: "ignore" });
@@ -1591,7 +1599,7 @@ test("verifyExpectedArtifact complete-milestone tolerates transient DB lag when 
     insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
 
     const result = verifyExpectedArtifact("complete-milestone", "M001", base);
-    assert.equal(result, true, "canonical success SUMMARY should pass verification during transient DB lag");
+    assert.equal(result, false, "success SUMMARY must not overrule an open DB milestone");
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/commands-dispatcher-unmerged-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-dispatcher-unmerged-milestone.test.ts
@@ -9,6 +9,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { handleGSDCommand } from "../commands/dispatcher.ts";
 import {
   closeDatabase,
+  insertAssessment,
   insertMilestone,
   insertSlice,
   openDatabase,
@@ -106,6 +107,13 @@ function seedRegisteredCompletedWorktreeWithoutRoadmap(base: string): void {
     title: "Live Text Search",
     status: "complete",
   });
+  insertAssessment({
+    path: "milestones/M008/M008-VALIDATION.md",
+    milestoneId: "M008",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
   writeFileSync(
     join(base, ".gsd", "PREFERENCES.md"),
     "---\ngit:\n  isolation: worktree\n---\n",
@@ -124,6 +132,19 @@ function seedRegisteredCompletedWorktree(base: string): void {
   mkdirSync(join(base, ".gsd"), { recursive: true });
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M008", title: "Live Text Search", status: "complete" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M008",
+    title: "Live Text Search",
+    status: "complete",
+  });
+  insertAssessment({
+    path: "milestones/M008/M008-VALIDATION.md",
+    milestoneId: "M008",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
   writeWorktreePreferencesAndRoadmap(base);
 
   const worktreePath = join(base, ".gsd", "worktrees", "M008");

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -14,7 +14,7 @@ import { execFileSync } from "node:child_process";
 
 import { DISPATCH_RULES, resolveDispatch, type DispatchContext } from "../auto-dispatch.ts";
 import { AutoSession } from "../auto/session.ts";
-import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
+import { closeDatabase, insertAssessment, insertGateRow, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 
 function makeBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-complete-dispatch-"));
@@ -225,6 +225,14 @@ describe("complete phase dispatch guard (#5683)", () => {
     base = makeBase();
     openDatabase(join(base, ".gsd", "gsd.db"));
     insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+    insertAssessment({
+      path: "milestones/M001/M001-VALIDATION.md",
+      milestoneId: "M001",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
+    });
 
     const ctx = buildDispatchCtx(base);
     ctx.state.phase = "complete";
@@ -233,6 +241,37 @@ describe("complete phase dispatch guard (#5683)", () => {
 
     assert.equal(result?.action, "stop");
     assert.equal(result?.reason, "All milestones complete.");
+  });
+
+  test("blocks terminal stop when closed milestone still has pending gates", async () => {
+    base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+    insertAssessment({
+      path: "milestones/M001/M001-VALIDATION.md",
+      milestoneId: "M001",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
+    });
+    insertGateRow({
+      milestoneId: "M001",
+      sliceId: "S01",
+      gateId: "Q3",
+      scope: "slice",
+      status: "pending",
+    });
+
+    const ctx = buildDispatchCtx(base);
+    ctx.state.phase = "complete";
+
+    const result = await rule.match(ctx);
+
+    assert.equal(result?.action, "stop");
+    assert.equal(result?.level, "warning");
+    assert.match(result?.reason ?? "", /closeout-consistency-blocked/);
+    assert.match(result?.reason ?? "", /quality gate Q3 is still pending/);
   });
 });
 

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -29,6 +29,7 @@ import { nativeMergeSquash } from "../../native-git-bridge.ts";
 import { drainLogs, setStderrLoggingEnabled } from "../../workflow-logger.ts";
 import {
   closeDatabase,
+  insertAssessment,
   insertMilestone,
   insertSlice,
   insertTask,
@@ -207,6 +208,13 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
         });
       }
     }
+    insertAssessment({
+      path: "milestones/M020/M020-VALIDATION.md",
+      milestoneId: "M020",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
+    });
 
     const roadmap = makeRoadmap("M020", "Backend foundation", [
       { id: "S01", title: "Core API" },

--- a/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
@@ -41,6 +41,7 @@ import {
 import {
   openDatabase,
   closeDatabase,
+  insertAssessment,
   insertMilestone,
   insertSlice,
   updateMilestoneStatus,
@@ -346,6 +347,13 @@ test("mergeCompletedMilestone — synthesizes roadmap from DB when projection is
       milestoneId: "M010",
       title: "Search Bar",
       status: "complete",
+    });
+    insertAssessment({
+      path: "milestones/M010/M010-VALIDATION.md",
+      milestoneId: "M010",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
     });
 
     createMilestoneBranch(repo, "M010", [
@@ -671,6 +679,14 @@ function setupCanonicalDbWithWorktree(basePath: string, mid: string): void {
   const dbPath = join(basePath, ".gsd", "gsd.db");
   openDatabase(dbPath);
   insertMilestone({ id: mid, title: `Milestone ${mid}`, status: "complete" });
+  insertSlice({ id: "S01", milestoneId: mid, title: "Done Slice", status: "complete" });
+  insertAssessment({
+    path: `milestones/${mid}/${mid}-VALIDATION.md`,
+    milestoneId: mid,
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
   updateMilestoneStatus(mid, "complete", new Date().toISOString());
   closeDatabase();
 }

--- a/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
@@ -1,0 +1,63 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for DB-backed closeout consistency before merge.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { mergeMilestoneToMain } from "../auto-worktree.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function createRepo(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "merge-closeout-gate-")));
+  git(["init"], dir);
+  git(["config", "user.email", "test@test.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  git(["add", "."], dir);
+  git(["commit", "-m", "init"], dir);
+  git(["branch", "-M", "main"], dir);
+
+  git(["checkout", "-b", "milestone/M001"], dir);
+  writeFileSync(join(dir, "feature.ts"), "export const feature = true;\n");
+  git(["add", "feature.ts"], dir);
+  git(["commit", "-m", "feat: milestone work"], dir);
+  git(["checkout", "main"], dir);
+  return dir;
+}
+
+test("mergeMilestoneToMain blocks when project DB closeout is still open", () => {
+  const savedCwd = process.cwd();
+  const repo = createRepo();
+  try {
+    assert.equal(openDatabase(join(repo, ".gsd", "gsd.db")), true);
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+
+    const mainHeadBefore = git(["rev-parse", "main"], repo);
+    process.chdir(repo);
+
+    assert.throws(
+      () => mergeMilestoneToMain(repo, "M001", "# M001\n- [x] **S01: Done**\n"),
+      /closeout-consistency-blocked/,
+    );
+
+    assert.equal(git(["rev-parse", "main"], repo), mainHeadBefore);
+    assert.equal(git(["branch", "--show-current"], repo), "main");
+  } finally {
+    closeDatabase();
+    process.chdir(savedCwd);
+    if (existsSync(repo)) rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/merge-db-cycle.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-db-cycle.test.ts
@@ -15,7 +15,7 @@ import { delimiter, join } from "node:path";
 import { execFileSync } from "node:child_process";
 
 import { mergeMilestoneToMain } from "../auto-worktree.ts";
-import { closeDatabase, openDatabase } from "../gsd-db.ts";
+import { closeDatabase, insertAssessment, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 import { GIT_NO_PROMPT_ENV } from "../git-constants.js";
 import { _clearGsdRootCache } from "../paths.ts";
 import { _resetServiceCache } from "../worktree.ts";
@@ -145,6 +145,15 @@ test("mergeMilestoneToMain keeps the Windows DB cycle closed through squash merg
 
     withPlatform("win32", () => {
       assert.equal(openDatabase(join(repo, ".gsd", "gsd.db")), true);
+      insertMilestone({ id: "M001", title: "Windows DB cycle", status: "complete" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Done Slice", status: "complete" });
+      insertAssessment({
+        path: "milestones/M001/M001-VALIDATION.md",
+        milestoneId: "M001",
+        status: "pass",
+        scope: "milestone-validation",
+        fullContent: "verdict: pass",
+      });
       assert.equal(existsSync(join(repo, ".gsd", "gsd.db-shm")), true);
 
       process.env.PATH = `${bin}${delimiter}${originalPath}`;

--- a/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { openDatabase, insertMilestone, closeDatabase } from "../gsd-db.js";
+import { openDatabase, insertAssessment, insertMilestone, insertSlice, closeDatabase } from "../gsd-db.js";
 import {
   isMilestoneCloseoutSettled,
   evaluateCompleteMilestoneDispatch,
@@ -39,6 +39,14 @@ test("isMilestoneCloseoutSettled requires DB closed and summary artifact", async
   mkdirSync(join(base, ".gsd"), { recursive: true });
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Done", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Done Slice", status: "complete" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
   const milestoneDir = join(base, ".gsd", "milestones", "M001");
   mkdirSync(milestoneDir, { recursive: true });
   writeFileSync(join(milestoneDir, "M001-SUMMARY.md"), "# Milestone Summary\n");


### PR DESCRIPTION
## TL;DR

**What:** Adds a DB-backed Closeout Consistency Gate before milestone closeout verification, terminal stop, and worktree merge paths.
**Why:** Prevents split-brain closeout where success-looking summaries or projections can mask open canonical DB state.
**How:** Centralizes the closeout proof, fails closed with `closeout-consistency-blocked`, and covers artifact verification, dispatch, merge, and regression tests.

## What

This change adds a shared closeout consistency guard for GSD milestone finalization paths. The guard requires the canonical DB to prove that the milestone is closed, slices and tasks are closed, latest milestone validation passed, and no quality gates remain pending.

It wires that guard into complete-milestone artifact verification, milestone closeout settling, the complete-phase terminal stop rule, and worktree merge. It also documents the rule in `CONTEXT.md` and ADR-025.

## Why

A project can drift into a split-brain state where markdown summaries or projections look complete while the canonical DB still has open milestones, slices, tasks, or gates. In that state, auto-mode should pause for recovery instead of merging or declaring all work complete.

## How

The new `closeout-consistency-gate` module returns a structured block reason and recovery message. Merge now treats DB reconciliation failure as fatal for closeout, verifies the project-root DB after reconciliation, and reports `closeout-consistency-blocked` instead of continuing into squash merge side effects.

Artifact verification no longer allows a success-looking SUMMARY to overrule an open DB milestone. Tests cover the rejected transient-lag behavior, pending quality gates blocking terminal stop, and merge blocking when the project DB milestone is still open.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts src/resources/extensions/gsd/tests/merge-db-cycle.test.ts src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783125862&installation_id=134682257&pr_number=466&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F466&signature=e9461201a01edb76787dffd8f561715ab145a60c56caed4b8d84892966be7630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes critical closeout, worktree merge, and auto-dispatch stop paths; incorrect gate logic could block legitimate merges or still allow unsafe closeout if DB checks are wrong.
> 
> **Overview**
> Introduces a shared **Closeout Consistency Gate** so milestone finalization, merge, and “all complete” stops require the **canonical DB** to show a fully closed milestone—not just success-looking markdown.
> 
> A new `closeout-consistency-gate` module checks closed milestone status, passing milestone validation, closed slices/tasks, and no pending quality gates (with optional disk refresh). Failures use recovery reason `closeout-consistency-blocked` and block progression instead of generic retries or merge errors.
> 
> **Wiring:** `verifyExpectedArtifact` and `isMilestoneCloseoutSettled` use the gate for `complete-milestone`; the `complete → stop` dispatch rule stops with a warning when the DB is inconsistent; `mergeMilestoneToMain` treats DB reconciliation failure as fatal and runs the gate on the project-root DB before squash merge.
> 
> **Behavior change:** A canonical success **SUMMARY** no longer passes verification when the DB milestone is still open (transient-lag tolerance removed).
> 
> **Docs:** `CONTEXT.md` glossary entry and **ADR-025** document fail-closed closeout vs state reconciliation. Tests cover open DB at merge, pending gates blocking terminal stop, and updated merge/dispatch fixtures with validation + slice rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58c63ccc70fcb917fc37074d6dfe32a0612c247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->