### PR TITLE
Harden run-uat tool contract

### DIFF
--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -217,7 +217,7 @@ run-uat  (user acceptance tests)
 |--------|---------|-----------------|
 | `gate-evaluate.md` | Spawn one subagent per quality gate in parallel. Verifies `gsd_save_gate_result` called. | `subagent` × N |
 | `validate-milestone.md` | 3 parallel reviewers: (A) requirements, (B) integration, (C) acceptance. | `subagent` × 3, `gsd_validate_milestone` |
-| `run-uat.md` | Execute UAT. Modes: artifact-driven, runtime, browser, human-experience. Runs under `verification` tools policy, so Bash is limited to read-only inspection and build/test verification commands. | `gsd_summary_save(ASSESSMENT)`, verification Bash |
+| `run-uat.md` | Execute UAT. Modes: artifact-driven, runtime, browser, human-experience. Runs under `verification` tools policy with UAT-owned execution plus safe read-only/browser inspection tools. | `gsd_uat_exec`, `gsd_uat_result_save`, read-only/browser tools |
 
 `run-uat` completion verification requires a canonical verdict in the written `S##-ASSESSMENT.md` (for example `verdict: PASS | FAIL | PARTIAL`). A pre-existing assessment file without `verdict` does not satisfy artifact verification.
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -46,6 +46,7 @@ import { hasBrowserRequiredText } from "./browser-evidence.js";
 import { debugLog } from "./debug-logger.js";
 import { buildSkillActivationBlock, buildSkillDiscoveryVars } from "./skill-activation.js";
 import { findMilestoneIds } from "./milestone-ids.js";
+import { buildRunUatResultPresentation, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from "./tool-presentation-plan.js";
 
 export { buildSkillActivationBlock, buildSkillDiscoveryVars };
 
@@ -3384,6 +3385,7 @@ export async function buildRunUatPrompt(
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = resolveEffectiveUatType(uatContent);
+  const canonicalPresentation = JSON.stringify(buildRunUatResultPresentation(), null, 2);
 
   return loadPrompt("run-uat", {
     workingDirectory: base,
@@ -3392,6 +3394,8 @@ export async function buildRunUatPrompt(
     uatPath,
     uatResultPath,
     uatType,
+    toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+    canonicalPresentation,
     inlinedContext,
     skillActivation: buildSkillActivationBlock({
       base,

--- a/src/resources/extensions/gsd/auto-unit-tool-scope.ts
+++ b/src/resources/extensions/gsd/auto-unit-tool-scope.ts
@@ -1,59 +1,13 @@
 import { parseUnitId } from "./unit-id.js";
-import { RUN_UAT_WORKFLOW_TOOL_NAMES } from "./tool-presentation-plan.js";
+import {
+  AUTO_UNIT_SCOPED_TOOLS,
+  getForbiddenGsdToolReason,
+} from "./unit-tool-contracts.js";
 
-export const RUN_UAT_BROWSER_TOOL_NAMES = [
-  "browser_navigate",
-  "browser_click",
-  "browser_type",
-  "browser_fill_form",
-  "browser_click_ref",
-  "browser_fill_ref",
-  "browser_wait_for",
-  "browser_assert",
-  "browser_verify",
-  "browser_screenshot",
-  "browser_snapshot_refs",
-  "browser_find",
-  "browser_get_console_logs",
-  "browser_get_network_logs",
-  "browser_evaluate",
-  "browser_reload",
-  "browser_batch",
-  "browser_act",
-] as const;
-
-export const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = {
-  "research-milestone": ["gsd_summary_save", "gsd_decision_save"],
-  "plan-milestone": ["gsd_plan_milestone", "gsd_decision_save", "gsd_requirement_update"],
-  "discuss-milestone": [
-    "gsd_summary_save",
-    "gsd_decision_save",
-    "gsd_requirement_save",
-    "gsd_requirement_update",
-    "gsd_plan_milestone",
-    "gsd_milestone_generate_id",
-  ],
-  "discuss-slice": ["gsd_summary_save", "gsd_decision_save"],
-  "validate-milestone": ["gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
-  "complete-milestone": ["gsd_complete_milestone", "subagent"],
-  "research-slice": ["gsd_summary_save", "gsd_decision_save"],
-  "plan-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "refine-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "replan-slice": ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "complete-slice": ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice", "gsd_decision_save", "gsd_requirement_update", "subagent"],
-  "reassess-roadmap": ["gsd_reassess_roadmap"],
-  "execute-task": ["gsd_task_complete", "gsd_decision_save"],
-  "execute-task-simple": ["gsd_task_complete", "gsd_decision_save"],
-  "reactive-execute": ["gsd_task_complete", "gsd_decision_save"],
-  "run-uat": [...RUN_UAT_WORKFLOW_TOOL_NAMES, "subagent", ...RUN_UAT_BROWSER_TOOL_NAMES],
-  "gate-evaluate": ["gsd_save_gate_result"],
-  "rewrite-docs": ["gsd_summary_save", "gsd_decision_save"],
-  "workflow-preferences": ["gsd_summary_save"],
-  "discuss-project": ["gsd_summary_save", "gsd_decision_save", "gsd_requirement_save"],
-  "discuss-requirements": ["gsd_requirement_save", "gsd_summary_save"],
-  "research-decision": ["gsd_summary_save"],
-  "research-project": ["gsd_summary_save", "gsd_decision_save"],
-};
+export {
+  AUTO_UNIT_SCOPED_TOOLS,
+  RUN_UAT_BROWSER_TOOL_NAMES,
+} from "./unit-tool-contracts.js";
 
 const WORKFLOW_TOOL_ALIASES: Record<string, string> = {
   gsd_save_decision: "gsd_decision_save",
@@ -120,14 +74,18 @@ export function isWorkflowAliasTool(toolName: string): boolean {
   return Object.prototype.hasOwnProperty.call(WORKFLOW_TOOL_ALIASES, stripMcpToolPrefix(toolName));
 }
 
+function hardBlockReason(unitType: string, what: string): string {
+  return [
+    `HARD BLOCK: Tool Contract failure for unit "${unitType}" — ${what}.`,
+    "This is a mechanical phase-boundary gate. You MUST NOT proceed, retry the same call,",
+    "or route around this block; the orchestrator owns phase transitions.",
+  ].join(" ");
+}
+
 function hardBlock(unitType: string, what: string): AutoUnitToolScopeResult {
   return {
     block: true,
-    reason: [
-      `HARD BLOCK: unit "${unitType}" is constrained by auto-unit tool scope — ${what}.`,
-      "This is a mechanical phase-boundary gate. You MUST NOT proceed, retry the same call,",
-      "or route around this block; the orchestrator owns phase transitions.",
-    ].join(" "),
+    reason: hardBlockReason(unitType, what),
     displayReason: GSD_PHASE_SCOPE_DISPLAY_REASON,
   };
 }
@@ -204,6 +162,14 @@ export function shouldBlockAutoUnitToolCall(
 
   const allowedTools = allowedGsdToolsForUnit(unitType);
   if (allowedTools.includes(canonicalTool)) return { block: false };
+
+  const forbiddenReason = getForbiddenGsdToolReason(unitType, canonicalTool);
+  if (forbiddenReason) {
+    return hardBlock(
+      unitType,
+      `GSD lifecycle tool "${canonicalTool}" is not permitted; ${forbiddenReason} Fix unit-tool-contracts.ts or the ${unitType} prompt.`,
+    );
+  }
 
   return hardBlock(
     unitType,

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -427,6 +427,9 @@ export function registerDbTools(pi: ExtensionAPI): void {
     kind: StringEnum(["gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"], { description: "Evidence kind" }),
     ref: Type.String({ description: "Evidence ID, approved .gsd path, or URL" }),
     note: Type.Optional(Type.String({ description: "Short evidence note" })),
+    unitType: Type.Optional(Type.String({ description: "Unit that produced the evidence" })),
+    tool: Type.Optional(Type.String({ description: "Tool that produced the evidence" })),
+    executionId: Type.Optional(Type.String({ description: "Stable execution or artifact id" })),
   });
 
   const uatCheck = Type.Object({
@@ -440,17 +443,17 @@ export function registerDbTools(pi: ExtensionAPI): void {
   });
 
   const toolPresentationBlock = Type.Object({
-    surface: StringEnum(["provider-tools", "claude-code-sdk", "mcp", "hybrid"], { description: "Tool presentation surface" }),
+    surface: Type.Optional(StringEnum(["provider-tools", "claude-code-sdk", "mcp", "hybrid"], { description: "Tool presentation surface" })),
     model: Type.Optional(Type.Object({
       provider: Type.Optional(Type.String()),
       api: Type.Optional(Type.String()),
       id: Type.Optional(Type.String()),
     })),
-    presentedTools: Type.Array(Type.String(), { description: "Tool names actually presented to the model" }),
-    blockedTools: Type.Array(Type.Object({
+    presentedTools: Type.Optional(Type.Array(Type.String(), { description: "Tool names actually presented to the model" })),
+    blockedTools: Type.Optional(Type.Array(Type.Object({
       name: Type.String(),
       reason: Type.String(),
-    }), { description: "Tool names blocked from the model with reasons" }),
+    }), { description: "Tool names blocked from the model with reasons" })),
     aliases: Type.Optional(Type.Array(Type.Object({
       requested: Type.String(),
       canonical: Type.String(),
@@ -474,12 +477,12 @@ export function registerDbTools(pi: ExtensionAPI): void {
       "Do not use raw gsd_summary_save as a substitute for UAT results.",
     ],
     parameters: Type.Object({
-      milestoneId: Type.String({ description: "Milestone ID (e.g. M001)" }),
-      sliceId: Type.String({ description: "Slice ID (e.g. S01)" }),
-      uatType: StringEnum(["artifact-driven", "browser-executable", "runtime-executable", "live-runtime", "mixed", "human-experience"], { description: "Declared UAT mode" }),
-      verdict: StringEnum(["PASS", "FAIL", "PARTIAL"], { description: "Overall UAT verdict" }),
-      checks: Type.Array(uatCheck, { description: "Structured check results" }),
-      presentation: toolPresentationBlock,
+      milestoneId: Type.Optional(Type.String({ description: "Milestone ID (e.g. M001)" })),
+      sliceId: Type.Optional(Type.String({ description: "Slice ID (e.g. S01)" })),
+      uatType: Type.Optional(Type.String({ description: "Declared UAT mode" })),
+      verdict: Type.Optional(Type.String({ description: "Overall UAT verdict: PASS, FAIL, or PARTIAL" })),
+      checks: Type.Optional(Type.Array(uatCheck, { description: "Structured check results" })),
+      presentation: Type.Optional(toolPresentationBlock),
       notes: Type.Optional(Type.String({ description: "Overall verdict rationale" })),
       attempt: Type.Optional(Type.String({ description: "Attempt number or auto" })),
       previousAttemptId: Type.Optional(Type.String({ description: "Prior attempt ID, when retrying" })),

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -38,7 +38,7 @@ import { getGuidedUnitContext } from "../guided-unit-context.js";
 import { registerPlanMilestoneSchemaRecovery } from "./plan-milestone-schema-recovery.js";
 import { AUTO_UNIT_SCOPED_TOOLS, RUN_UAT_BROWSER_TOOL_NAMES, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
 import { filterToolsForProvider } from "../model-router.js";
-import { RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
+import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -252,7 +252,12 @@ export function buildRunUatGsdToolSet(
 ): string[] {
   const scoped = resolveScopedToolNames(
     [...activeToolNames, ...registeredToolNames],
-    [...RUN_UAT_WORKFLOW_TOOL_NAMES, "subagent", ...RUN_UAT_BROWSER_TOOL_NAMES],
+    [
+      ...RUN_UAT_WORKFLOW_TOOL_NAMES,
+      ...RUN_UAT_READ_ONLY_TOOL_NAMES,
+      "subagent",
+      ...RUN_UAT_BROWSER_TOOL_NAMES,
+    ],
   );
   return [...new Set(scoped)];
 }

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -75,24 +75,10 @@ verdict: "PASS" | "FAIL" | "PARTIAL",
 notes: "<one sentence overall verdict rationale>",
 ```
 
-Use this exact `presentation` shape in the save call so the audit can verify the run-uat tool surface without retrying missing fields one by one:
+Use this canonical `presentation` object in the save call so the audit can verify the run-uat tool surface without retrying missing fields one by one. Keep `toolPresentationPlanId` as `{{toolPresentationPlanId}}`. If browser tools were actually presented for this run, add those concrete browser tool names to `presentedTools`; otherwise reuse this object exactly:
 
-```ts
-presentation: {
-  surface: "mcp",
-  presentedTools: [
-    "gsd_uat_exec",
-    "gsd_uat_result_save",
-    "gsd_resume",
-    "gsd_milestone_status",
-    "gsd_journal_query",
-  ],
-  blockedTools: [
-    { name: "gsd_exec", reason: "forbidden during run-uat" },
-    { name: "gsd_summary_save", reason: "forbidden during run-uat" },
-    { name: "gsd_save_gate_result", reason: "forbidden during run-uat" },
-  ],
-}
+```json
+{{canonicalPresentation}}
 ```
 
 Pass `checks` with this logical shape:

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -6,7 +6,9 @@ import { ReconciliationFailedError } from "./state-reconciliation.js";
 
 export type RecoveryFailureKind =
   | "tool-schema"
+  | "tool-contract"
   | "deterministic-policy"
+  | "lifecycle-progression"
   | "stale-worker"
   | "worktree-invalid"
   | "verification-drift"
@@ -52,6 +54,14 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         exitReason: "tool-schema",
         remediation: "Fix the Unit Tool Contract or tool schema before retrying.",
       };
+    case "tool-contract":
+      return {
+        failureKind,
+        action: "stop",
+        reason: `Tool Contract failure${unitSuffix(input)}: ${message}`,
+        exitReason: "tool-contract",
+        remediation: "Fix the Unit Tool Contract or prompt so the Unit is only asked to use tools owned by its phase.",
+      };
     case "deterministic-policy":
       return {
         failureKind,
@@ -59,6 +69,14 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         reason: `Deterministic policy failure${unitSuffix(input)}: ${message}`,
         exitReason: "deterministic-policy",
         remediation: "Resolve the policy blocker; retrying the same Unit will repeat the failure.",
+      };
+    case "lifecycle-progression":
+      return {
+        failureKind,
+        action: "stop",
+        reason: `Lifecycle progression failure${unitSuffix(input)}: ${message}`,
+        exitReason: "lifecycle-progression",
+        remediation: "Route to the required owning Unit or restore the missing artifact before advancing lifecycle state.",
       };
     case "stale-worker":
       return {
@@ -118,6 +136,8 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
 }
 
 function inferFailureKind(message: string): RecoveryFailureKind {
+  if (/tool contract|auto-unit tool scope|phase-boundary gate|not permitted.*own/i.test(message)) return "tool-contract";
+  if (/lifecycle progression|required artifact|missing .*assessment|missing .*closeout|cannot legally (?:advance|progress)/i.test(message)) return "lifecycle-progression";
   if (/schema|invalid.*tool|tool.*invalid|enum/i.test(message)) return "tool-schema";
   if (/deterministic policy|policy rejection|write gate|blocked by policy/i.test(message)) return "deterministic-policy";
   if (/stale worker|stale lock|worker.*stale/i.test(message)) return "stale-worker";

--- a/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { extractUatType } from '../../files.ts';
 import { resolveSliceFile } from '../../paths.ts';
 import { buildRunUatPrompt, checkNeedsRunUat } from '../../auto-prompts.ts';
+import { buildRunUatResultPresentation, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from '../../tool-presentation-plan.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const worktreePromptsDir = join(__dirname, '../..', 'prompts');
@@ -20,6 +21,8 @@ function loadPromptFromWorktree(name: string, vars: Record<string, string> = {})
   let content = readFileSync(path, 'utf-8');
   const effectiveVars = {
     skillActivation: 'If no installed skill clearly matches this unit, skip explicit skill activation and continue with the required workflow.',
+    canonicalPresentation: JSON.stringify(buildRunUatResultPresentation(), null, 2),
+    toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
     ...vars,
   };
   for (const [key, value] of Object.entries(effectiveVars)) {

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -2,7 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.ts";
+import {
+  buildRunUatResultPresentation,
+  RUN_UAT_READ_ONLY_TOOL_NAMES,
+  RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+  RUN_UAT_WORKFLOW_TOOL_NAMES,
+} from "../tool-presentation-plan.ts";
 
 const promptsDir = join(process.cwd(), "src/resources/extensions/gsd/prompts");
 const templatesDir = join(process.cwd(), "src/resources/extensions/gsd/templates");
@@ -29,7 +34,7 @@ test("run-uat prompt branches on dynamic UAT mode and supports runtime evidence"
   assert.match(prompt, /uatType:\s*"\{\{uatType\}\}"/);
   assert.match(prompt, /gsd_uat_result_save/);
   assert.match(prompt, /presentedTools/);
-  assert.match(prompt, /blockedTools/);
+  assert.match(prompt, /\{\{canonicalPresentation\}\}/);
   assert.match(prompt, /live-runtime/);
   assert.match(prompt, /browser\/runtime\/network/i);
   assert.match(prompt, /NEEDS-HUMAN/);
@@ -51,16 +56,29 @@ test("run-uat prompt gives the complete UAT result-save presentation contract", 
   const prompt = readPrompt("run-uat");
   assert.match(prompt, /Call `gsd_uat_result_save` once after all checks are complete/);
   assert.doesNotMatch(prompt, /Call `gsd_summary_save` with `artifact_type: "ASSESSMENT"`/);
+  assert.match(prompt, /\{\{canonicalPresentation\}\}/);
+  assert.match(prompt, /\{\{toolPresentationPlanId\}\}/);
 
+  const presentation = buildRunUatResultPresentation();
+  assert.equal(presentation.toolPresentationPlanId, RUN_UAT_TOOL_PRESENTATION_PLAN_ID);
   for (const toolName of RUN_UAT_WORKFLOW_TOOL_NAMES) {
-    assert.ok(prompt.includes(`"${toolName}"`), `prompt should include required presented tool ${toolName}`);
+    assert.ok(presentation.presentedTools.includes(toolName), `presentation should include required tool ${toolName}`);
+  }
+  for (const toolName of RUN_UAT_READ_ONLY_TOOL_NAMES) {
+    assert.ok(presentation.presentedTools.includes(toolName), `presentation should include read-only tool ${toolName}`);
   }
 
   for (const toolName of ["gsd_exec", "gsd_summary_save", "gsd_save_gate_result"] as const) {
-    assert.ok(prompt.includes(`name: "${toolName}"`), `prompt should include blocked tool ${toolName}`);
+    assert.ok(
+      presentation.blockedTools.some((entry) => entry.name === toolName),
+      `presentation should include blocked tool ${toolName}`,
+    );
   }
 
-  assert.ok(prompt.includes("forbidden during run-uat"), "prompt should explain blocked run-uat tools");
+  assert.ok(
+    presentation.blockedTools.every((entry) => entry.reason === "forbidden during run-uat"),
+    "presentation should explain blocked run-uat tools",
+  );
 });
 
 test("workflow-start prompt defaults to autonomy instead of per-phase confirmation", () => {

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -123,6 +123,10 @@ test("#4782 phase 3: buildRunUatPrompt inlines UAT and keeps summary/project con
   // Project path is advertised on-demand; full project body is not inlined.
   assert.match(prompt, /\.gsd\/PROJECT\.md/);
   assert.ok(!prompt.includes("Run-UAT composer fixture project"), "run-uat should not inline full project context");
+
+  assert.match(prompt, /"toolPresentationPlanId": "run-uat\/default-v1"/);
+  assert.match(prompt, /"gsd_uat_result_save"/);
+  assert.match(prompt, /"read"/);
 });
 
 test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is missing", async (t) => {

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { classifyFailure } from "../recovery-classification.js";
 import { reconcileBeforeDispatch } from "../state-reconciliation.js";
 import { compileUnitToolContract } from "../tool-contract.js";
+import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
 import type { GSDState } from "../types.js";
 
 function makeState(overrides: Partial<GSDState> = {}): GSDState {
@@ -63,8 +64,33 @@ test("Tool Contract compiles known Unit prompt and tool policy", () => {
   assert.equal(result.ok, true);
   assert.equal(result.ok && result.contract.unitType, "execute-task");
   assert.deepEqual(result.ok && result.contract.requiredWorkflowTools, ["gsd_task_complete"]);
+  assert.deepEqual(result.ok && result.contract.forbiddenWorkflowTools, []);
   assert.equal(result.ok && result.contract.toolsPolicy.mode, "all");
   assert.ok(result.ok && result.contract.validationRules.includes("closeout-tool-present"));
+});
+
+test("Tool Contract records high-risk cross-phase tool boundaries without single-owning every tool", () => {
+  const completeSlice = compileUnitToolContract("complete-slice");
+  const runUat = compileUnitToolContract("run-uat");
+
+  assert.equal(completeSlice.ok, true);
+  assert.ok(
+    completeSlice.ok &&
+      completeSlice.contract.forbiddenWorkflowTools.some((tool) => tool.name === "gsd_uat_result_save"),
+    "complete-slice should explicitly forbid saving UAT Assessments",
+  );
+
+  assert.equal(runUat.ok, true);
+  assert.ok(
+    runUat.ok &&
+      runUat.contract.requiredWorkflowTools.includes("gsd_uat_result_save"),
+    "run-uat should own the UAT result-save tool",
+  );
+  assert.ok(
+    runUat.ok &&
+      runUat.contract.forbiddenWorkflowTools.some((tool) => tool.name === "gsd_exec"),
+    "run-uat should prefer typed UAT execution over generic gsd_exec",
+  );
 });
 
 test("Tool Contract fails closed for unknown Units", () => {
@@ -74,10 +100,20 @@ test("Tool Contract fails closed for unknown Units", () => {
   assert.equal(!result.ok && result.reason, "unknown-unit-type");
 });
 
+test("auto Unit tool scope blocks complete-slice from saving UAT Assessment", () => {
+  const result = shouldBlockAutoUnitToolCall("complete-slice", "gsd_uat_result_save");
+
+  assert.equal(result.block, true);
+  assert.match(result.reason ?? "", /Tool Contract failure/);
+  assert.match(result.reason ?? "", /Run UAT owns persisted UAT Assessment/);
+});
+
 test("Recovery Classification covers ADR-015 failure families", () => {
   const cases = [
     ["invalid tool schema enum", "tool-schema", "stop"],
+    ["Tool Contract failure: complete-slice cannot use gsd_uat_result_save", "tool-contract", "stop"],
     ["deterministic policy rejection", "deterministic-policy", "stop"],
+    ["cannot legally advance because required UAT Assessment artifact is missing", "lifecycle-progression", "stop"],
     ["stale worker lease", "stale-worker", "stop"],
     ["worktree root missing .git", "worktree-invalid", "stop"],
     ["verification drift in state snapshot", "verification-drift", "escalate"],

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -101,7 +101,7 @@ test("buildMinimalAutoGsdToolSet keeps unit-specific completion tools without al
   assert.ok(!result.includes("gsd_complete_slice"));
 });
 
-test("buildMinimalAutoGsdToolSet scopes run-uat to UAT-specific tools", () => {
+test("buildMinimalAutoGsdToolSet scopes run-uat to UAT-specific and read-only tools", () => {
   const active = ["ask_user_questions", "bash", "read", "edit", "write", "gsd_summary_save"];
   const registered = [
     ...active,
@@ -123,11 +123,11 @@ test("buildMinimalAutoGsdToolSet scopes run-uat to UAT-specific tools", () => {
   assert.ok(result.includes("gsd_resume"));
   assert.ok(result.includes("gsd_milestone_status"));
   assert.ok(result.includes("gsd_journal_query"));
+  assert.ok(result.includes("read"));
   assert.ok(result.includes("browser_navigate"), "run-uat needs browser_navigate");
   assert.ok(result.includes("browser_click"), "run-uat needs browser_click");
   assert.ok(!result.includes("ToolSearch"));
   assert.ok(!result.includes("bash"));
-  assert.ok(!result.includes("read"));
   assert.ok(!result.includes("edit"));
   assert.ok(!result.includes("write"));
   assert.ok(!result.includes("gsd_exec"));
@@ -230,9 +230,9 @@ test("buildMinimalAutoGsdToolSet preserves compatible browser add-ons for run-ua
   assert.ok(result.includes("gsd_uat_exec"));
   assert.ok(result.includes("gsd_uat_result_save"));
   assert.ok(result.includes("subagent"));
+  assert.ok(result.includes("read"));
   assert.ok(!result.includes("ToolSearch"));
   assert.ok(!result.includes("bash"));
-  assert.ok(!result.includes("read"));
   assert.ok(!result.includes("edit"));
   assert.ok(!result.includes("write"));
   assert.ok(!result.includes("gsd_exec"));
@@ -281,12 +281,12 @@ test("buildMinimalAutoGsdToolSet honors provider-compatible registered tools for
 
   assert.ok(result.includes("gsd_uat_exec"));
   assert.ok(result.includes("gsd_uat_result_save"));
+  assert.ok(result.includes("read"));
   assert.ok(result.includes("browser_navigate"));
   assert.ok(result.includes("browser_click"));
   assert.ok(!result.includes("browser_screenshot"), "provider-filtered screenshot tool must stay filtered");
   assert.ok(!result.includes("ToolSearch"));
   assert.ok(!result.includes("bash"));
-  assert.ok(!result.includes("read"));
   assert.ok(!result.includes("gsd_exec"));
   assert.ok(!result.includes("gsd_summary_save"));
   assert.ok(!result.includes("gsd_save_gate_result"));

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -705,6 +705,78 @@ test("executeUatResultSave supplies canonical presentation and normalizes verdic
   }
 });
 
+test("executeUatResultSave merges canonical plan ID and read-only tools when presentation lacks plan ID", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  const evidenceId = "uat-no-plan-id-evidence";
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S05", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: {
+          kind: "uat_exec",
+          milestoneId: "M001",
+          sliceId: "S05",
+          checkId: "UAT-01",
+          intent: "uat-artifact-check",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S05",
+      uatType: "artifact-driven",
+      verdict: "PASS",
+      checks: [{
+        id: "UAT-01",
+        description: "Presentation plan ID absent from provider call",
+        mode: "artifact",
+        result: "PASS",
+        evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
+        notes: "Canonical merge should apply even when toolPresentationPlanId is absent.",
+      }],
+      presentation: {
+        surface: "mcp",
+        presentedTools: [
+          "gsd_uat_exec",
+          "gsd_uat_result_save",
+          "gsd_resume",
+          "gsd_milestone_status",
+          "gsd_journal_query",
+        ],
+        blockedTools: [
+          { name: "gsd_exec", reason: "forbidden during run-uat" },
+          { name: "gsd_summary_save", reason: "forbidden during run-uat" },
+          { name: "gsd_save_gate_result", reason: "forbidden during run-uat" },
+        ],
+      },
+      notes: "Provider omitted toolPresentationPlanId; executor must canonicalize.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.verdict, "PASS");
+
+    const attempt = JSON.parse(readFileSync(
+      join(base, ".gsd", "uat", "M001", "S05", "attempt-1.json"),
+      "utf-8",
+    )) as { presentation?: { toolPresentationPlanId?: string; presentedTools?: string[] } };
+    assert.equal(attempt.presentation?.toolPresentationPlanId, "run-uat/default-v1");
+    assert.ok(attempt.presentation?.presentedTools?.includes("read"), "read-only tool must be merged in");
+    assert.ok(attempt.presentation?.presentedTools?.includes("gsd_uat_result_save"));
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeUatResultSave rejects saved UAT without fresh UAT-owned evidence", async () => {
   const base = makeTmpBase();
   const worktree = join(base, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -75,6 +75,11 @@ test("closeout executors reject phase escalation from the wrong active auto unit
     const milestone = await executeCompleteMilestone({} as Parameters<typeof executeCompleteMilestone>[0], "/tmp/project");
     assert.equal(milestone.isError, true);
     assert.match(String(milestone.details.error), /complete_milestone may only run from complete-milestone/);
+
+    const uat = await executeUatResultSave({} as Parameters<typeof executeUatResultSave>[0], "/tmp/project");
+    assert.equal(uat.isError, true);
+    assert.match(String(uat.details.error), /save_uat_result may only run from run-uat/);
+    assert.match(String(uat.details.error), /Tool Contract failure/);
   } finally {
     autoSession.reset();
   }
@@ -637,6 +642,106 @@ test("executeUatResultSave accepts gsd_uat_exec evidence written in a milestone 
     );
     assert.match(assessment, /Runtime path C:\\\\tmp\\\|uat evidence/);
     assert.match(assessment, /backslash \\\\ and pipe \\\|/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeUatResultSave supplies canonical presentation and normalizes verdict casing", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  const evidenceId = "uat-lowercase-verdict";
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S03", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: {
+          kind: "uat_exec",
+          milestoneId: "M001",
+          sliceId: "S03",
+          checkId: "UAT-01",
+          intent: "uat-artifact-check",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S03",
+      uatType: "artifact-driven",
+      verdict: "pass",
+      checks: [{
+        id: "UAT-01",
+        description: "Static artifact contract passes",
+        mode: "artifact",
+        result: "PASS",
+        evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
+        notes: "Artifact check passed.",
+      }],
+      notes: "UAT passed with canonical presentation supplied by the executor.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.verdict, "PASS");
+
+    const attempt = JSON.parse(readFileSync(
+      join(base, ".gsd", "uat", "M001", "S03", "attempt-1.json"),
+      "utf-8",
+    )) as { presentation?: { toolPresentationPlanId?: string; presentedTools?: string[] } };
+    assert.equal(attempt.presentation?.toolPresentationPlanId, "run-uat/default-v1");
+    assert.ok(attempt.presentation?.presentedTools?.includes("gsd_uat_result_save"));
+    assert.ok(attempt.presentation?.presentedTools?.includes("read"));
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeUatResultSave rejects saved UAT without fresh UAT-owned evidence", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  const evidenceId = "generic-exec-evidence";
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S04", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: { kind: "exec" },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S04",
+      uatType: "artifact-driven",
+      verdict: "PASS",
+      checks: [{
+        id: "UAT-01",
+        description: "Static artifact contract passes",
+        mode: "artifact",
+        result: "PASS",
+        evidence: [{ kind: "gsd_exec", ref: evidenceId }],
+        notes: "Generic evidence should not satisfy fresh UAT evidence.",
+      }],
+      notes: "UAT should not pass without fresh UAT-owned evidence.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, true);
+    assert.match(String(result.content[0]?.text), /fresh gsd_uat_exec evidence/);
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -820,6 +820,38 @@ test("executeUatResultSave rejects saved UAT without fresh UAT-owned evidence", 
   }
 });
 
+test("executeUatResultSave rejects an unrecognized uatType", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  try {
+    openTestDb(base);
+    mkdirSync(worktree, { recursive: true });
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S06", "complete");
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S06",
+      uatType: "hallucinated-mode",
+      verdict: "PASS",
+      checks: [{
+        id: "UAT-01",
+        description: "Static artifact contract passes",
+        mode: "artifact",
+        result: "PASS",
+        evidence: [{ kind: "gsd_uat_exec", ref: "some-ref" }],
+      }],
+      notes: "Should fail before evidence validation.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, true);
+    assert.match(String(result.content[0]?.text), /uatType must be one of/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeUatResultSave rejects artifact-driven PASS with human follow-up checks", async () => {
   const base = makeTmpBase();
   const worktree = join(base, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tool-contract.ts
+++ b/src/resources/extensions/gsd/tool-contract.ts
@@ -8,12 +8,14 @@ import {
   type ToolsPolicy,
 } from "./unit-context-manifest.js";
 import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
+import { getUnitToolSurfaceContract } from "./unit-tool-contracts.js";
 
 export interface UnitToolContract {
   unitType: string;
   contextMode: ContextModePolicy;
   toolsPolicy: ToolsPolicy;
   requiredWorkflowTools: readonly string[];
+  forbiddenWorkflowTools: readonly { name: string; reason: string }[];
   promptObligations: readonly string[];
   validationRules: readonly string[];
   closeoutTools: readonly string[];
@@ -30,6 +32,7 @@ export type ToolContractResult =
 
 export function compileUnitToolContract(unitType: string): ToolContractResult {
   const manifest = resolveManifest(unitType);
+  const surfaceContract = getUnitToolSurfaceContract(unitType);
   if (!manifest) {
     return {
       ok: false,
@@ -39,6 +42,8 @@ export function compileUnitToolContract(unitType: string): ToolContractResult {
   }
 
   const requiredWorkflowTools = getRequiredWorkflowToolsForAutoUnit(unitType);
+  const forbiddenWorkflowTools = Object.entries(surfaceContract?.forbiddenGsdTools ?? {})
+    .map(([name, reason]) => ({ name, reason }));
   const closeoutTools = requiredWorkflowTools.filter((tool) =>
     /^gsd_(?:task|slice|milestone|complete|validate|save|summary)/.test(tool),
   );
@@ -58,6 +63,7 @@ export function compileUnitToolContract(unitType: string): ToolContractResult {
       contextMode: manifest.contextMode,
       toolsPolicy: manifest.tools,
       requiredWorkflowTools,
+      forbiddenWorkflowTools,
       promptObligations: [
         `context-mode:${manifest.contextMode}`,
         `tools-policy:${manifest.tools.mode}`,

--- a/src/resources/extensions/gsd/tool-presentation-plan.ts
+++ b/src/resources/extensions/gsd/tool-presentation-plan.ts
@@ -1,6 +1,18 @@
 // Project/App: gsd-pi
 // File Purpose: Resolve phase-aware tool surfaces for GSD model presentations.
 
+import {
+  RUN_UAT_READ_ONLY_TOOL_NAMES,
+  RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+  RUN_UAT_WORKFLOW_TOOL_NAMES,
+} from "./unit-tool-contracts.js";
+
+export {
+  RUN_UAT_READ_ONLY_TOOL_NAMES,
+  RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+  RUN_UAT_WORKFLOW_TOOL_NAMES,
+} from "./unit-tool-contracts.js";
+
 export type ToolPresentationSurface = "provider-tools" | "claude-code-sdk" | "mcp" | "hybrid";
 
 export interface ToolPresentationModel {
@@ -19,14 +31,6 @@ export interface ToolPresentationPlan {
   aliases: Array<{ requested: string; canonical: string }>;
   diagnostics: string[];
 }
-
-export const RUN_UAT_WORKFLOW_TOOL_NAMES = [
-  "gsd_uat_exec",
-  "gsd_uat_result_save",
-  "gsd_resume",
-  "gsd_milestone_status",
-  "gsd_journal_query",
-] as const;
 
 export const RUN_UAT_FORBIDDEN_TOOL_NAMES = [
   "edit",
@@ -105,8 +109,34 @@ function addBlockedTool(
 export function buildRunUatCanonicalToolNames(options: { includeBrowserTools?: readonly string[] } = {}): string[] {
   return dedupe([
     ...RUN_UAT_WORKFLOW_TOOL_NAMES,
+    ...RUN_UAT_READ_ONLY_TOOL_NAMES,
     ...(options.includeBrowserTools ?? []),
   ]);
+}
+
+export function buildRunUatResultPresentation(options: {
+  surface?: ToolPresentationSurface;
+  includeBrowserTools?: readonly string[];
+  presentedTools?: readonly string[];
+} = {}): {
+  surface: ToolPresentationSurface;
+  presentedTools: string[];
+  blockedTools: Array<{ name: string; reason: string }>;
+  toolPresentationPlanId: string;
+} {
+  const presentedTools = options.presentedTools
+    ? dedupe(options.presentedTools)
+    : buildRunUatCanonicalToolNames({ includeBrowserTools: options.includeBrowserTools });
+  const blockedTools = RUN_UAT_FORBIDDEN_TOOL_NAMES
+    .filter((toolName) => !toolName.includes("*"))
+    .map((name) => ({ name, reason: "forbidden during run-uat" }));
+
+  return {
+    surface: options.surface ?? "mcp",
+    presentedTools,
+    blockedTools,
+    toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+  };
 }
 
 export function resolveToolPresentationPlan(options: {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -48,9 +48,11 @@ import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
 import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
 import {
+  buildRunUatResultPresentation,
   canonicalWorkflowToolName,
   parseMcpToolName,
   RUN_UAT_FORBIDDEN_TOOL_NAMES,
+  RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
 } from "../tool-presentation-plan.js";
 
@@ -90,7 +92,7 @@ function blockIfWrongAutoUnit(requiredUnitType: string, operation: string): Tool
   if (!snapshot.active || !snapshot.currentUnit) return null;
   if (snapshot.currentUnit.type === requiredUnitType) return null;
 
-  const error = `HARD BLOCK: ${operation} may only run from ${requiredUnitType}; active unit is ${snapshot.currentUnit.type}. The orchestrator owns phase transitions.`;
+  const error = `HARD BLOCK: Tool Contract failure: ${operation} may only run from ${requiredUnitType}; active unit is ${snapshot.currentUnit.type}. Fix unit-tool-contracts.ts or the active Unit prompt. The orchestrator owns phase transitions.`;
   return {
     content: [{ type: "text", text: error }],
     details: { operation, error },
@@ -449,6 +451,9 @@ export interface UatEvidenceRef {
   kind: "gsd_uat_exec" | "gsd_exec" | "screenshot" | "log" | "url" | "browser";
   ref: string;
   note?: string;
+  unitType?: string;
+  tool?: string;
+  executionId?: string;
 }
 
 export interface UatCheckResultInput {
@@ -1016,6 +1021,48 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function mergeBlockedTools(
+  current: UatPresentationInput["blockedTools"] | undefined,
+  canonical: UatPresentationInput["blockedTools"],
+): UatPresentationInput["blockedTools"] {
+  const merged = new Map<string, { name: string; reason: string }>();
+  for (const entry of [...(current ?? []), ...canonical]) {
+    merged.set(canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name), entry);
+  }
+  return [...merged.values()];
+}
+
+function mergePresentedTools(current: readonly string[] | undefined, canonical: readonly string[]): string[] {
+  return [...new Set([...(current ?? []), ...canonical])];
+}
+
+function normalizeUatResultSaveParams(params: UatResultSaveParams): UatResultSaveParams {
+  const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
+  const normalized = { ...params } as UatResultSaveParams;
+  if (typeof raw.verdict === "string") {
+    normalized.verdict = raw.verdict.toUpperCase() as UatVerdict;
+  }
+
+  const canonicalPresentation = buildRunUatResultPresentation();
+  const providedPresentation = raw.presentation as Partial<UatPresentationInput> | undefined;
+  if (!providedPresentation) {
+    normalized.presentation = canonicalPresentation;
+    return normalized;
+  }
+
+  if (providedPresentation.toolPresentationPlanId === RUN_UAT_TOOL_PRESENTATION_PLAN_ID) {
+    normalized.presentation = {
+      ...providedPresentation,
+      surface: providedPresentation.surface ?? canonicalPresentation.surface,
+      presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
+      blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
+      toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+    } as UatPresentationInput;
+  }
+
+  return normalized;
+}
+
 function ensureUatRequiredFields(params: UatResultSaveParams): string | null {
   if (!isNonEmptyString(params.milestoneId)) return "milestoneId is required";
   if (!isNonEmptyString(params.sliceId)) return "sliceId is required";
@@ -1153,6 +1200,15 @@ function validateUatChecks(basePath: string, params: UatResultSaveParams): strin
     }
   }
   return null;
+}
+
+function validateFreshUatOwnedEvidence(params: UatResultSaveParams): string | null {
+  const hasFreshUatEvidence = params.checks.some((check) =>
+    (check.evidence ?? []).some((evidence) => evidence.kind === "gsd_uat_exec")
+  );
+  return hasFreshUatEvidence
+    ? null
+    : "UAT Assessment requires at least one fresh gsd_uat_exec evidence reference from run-uat";
 }
 
 function validateUatMode(params: UatResultSaveParams): string | null {
@@ -1314,6 +1370,10 @@ export async function executeUatResultSave(
   params: UatResultSaveParams,
   basePath: string = process.cwd(),
 ): Promise<ToolExecutionResult> {
+  const unitGuard = blockIfWrongAutoUnit("run-uat", "save_uat_result");
+  if (unitGuard) return unitGuard;
+
+  params = normalizeUatResultSaveParams(params);
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) return errorResult("save_uat_result", "GSD database is not available.", "db_unavailable");
 
@@ -1323,6 +1383,8 @@ export async function executeUatResultSave(
   if (presentationError) return errorResult("save_uat_result", presentationError, "alias_tool_name");
   const checkError = validateUatChecks(basePath, params);
   if (checkError) return errorResult("save_uat_result", checkError, "invalid_evidence");
+  const freshEvidenceError = validateFreshUatOwnedEvidence(params);
+  if (freshEvidenceError) return errorResult("save_uat_result", freshEvidenceError, "missing_fresh_uat_evidence");
   const modeError = validateUatMode(params);
   if (modeError) return errorResult("save_uat_result", modeError, "uat_mode_mismatch");
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1050,15 +1050,13 @@ function normalizeUatResultSaveParams(params: UatResultSaveParams): UatResultSav
     return normalized;
   }
 
-  if (providedPresentation.toolPresentationPlanId === RUN_UAT_TOOL_PRESENTATION_PLAN_ID) {
-    normalized.presentation = {
-      ...providedPresentation,
-      surface: providedPresentation.surface ?? canonicalPresentation.surface,
-      presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
-      blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
-      toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
-    } as UatPresentationInput;
-  }
+  normalized.presentation = {
+    ...providedPresentation,
+    surface: providedPresentation.surface ?? canonicalPresentation.surface,
+    presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
+    blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
+    toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+  } as UatPresentationInput;
 
   return normalized;
 }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1067,10 +1067,22 @@ function mergeCanonicalPresentation(params: UatResultSaveParams): UatResultSaveP
   };
 }
 
+const VALID_UAT_TYPES: readonly UatType[] = [
+  "artifact-driven",
+  "browser-executable",
+  "runtime-executable",
+  "live-runtime",
+  "mixed",
+  "human-experience",
+];
+
 function ensureUatRequiredFields(params: UatResultSaveParams): string | null {
   if (!isNonEmptyString(params.milestoneId)) return "milestoneId is required";
   if (!isNonEmptyString(params.sliceId)) return "sliceId is required";
   if (!isNonEmptyString(params.uatType)) return "uatType is required";
+  if (!(VALID_UAT_TYPES as readonly string[]).includes(params.uatType)) {
+    return `uatType must be one of: ${VALID_UAT_TYPES.join(", ")}`;
+  }
   if (!["PASS", "FAIL", "PARTIAL"].includes(params.verdict)) return "verdict must be PASS, FAIL, or PARTIAL";
   if (!Array.isArray(params.checks) || params.checks.length === 0) return "checks must contain at least one UAT check";
   if (!params.presentation || !Array.isArray(params.presentation.presentedTools)) return "presentation.presentedTools is required";

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1036,29 +1036,35 @@ function mergePresentedTools(current: readonly string[] | undefined, canonical: 
   return [...new Set([...(current ?? []), ...canonical])];
 }
 
-function normalizeUatResultSaveParams(params: UatResultSaveParams): UatResultSaveParams {
+function normalizeUatVerdict(params: UatResultSaveParams): UatResultSaveParams {
   const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
-  const normalized = { ...params } as UatResultSaveParams;
   if (typeof raw.verdict === "string") {
-    normalized.verdict = raw.verdict.toUpperCase() as UatVerdict;
+    return { ...params, verdict: raw.verdict.toUpperCase() as UatVerdict };
   }
+  return params;
+}
 
+function supplyDefaultPresentation(params: UatResultSaveParams): UatResultSaveParams {
+  const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
+  if (!raw.presentation) {
+    return { ...params, presentation: buildRunUatResultPresentation() };
+  }
+  return params;
+}
+
+function mergeCanonicalPresentation(params: UatResultSaveParams): UatResultSaveParams {
   const canonicalPresentation = buildRunUatResultPresentation();
-  const providedPresentation = raw.presentation as Partial<UatPresentationInput> | undefined;
-  if (!providedPresentation) {
-    normalized.presentation = canonicalPresentation;
-    return normalized;
-  }
-
-  normalized.presentation = {
-    ...providedPresentation,
-    surface: providedPresentation.surface ?? canonicalPresentation.surface,
-    presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
-    blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
-    toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
-  } as UatPresentationInput;
-
-  return normalized;
+  const providedPresentation = params.presentation as Partial<UatPresentationInput>;
+  return {
+    ...params,
+    presentation: {
+      ...providedPresentation,
+      surface: providedPresentation.surface ?? canonicalPresentation.surface,
+      presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
+      blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
+      toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+    } as UatPresentationInput,
+  };
 }
 
 function ensureUatRequiredFields(params: UatResultSaveParams): string | null {
@@ -1371,14 +1377,23 @@ export async function executeUatResultSave(
   const unitGuard = blockIfWrongAutoUnit("run-uat", "save_uat_result");
   if (unitGuard) return unitGuard;
 
-  params = normalizeUatResultSaveParams(params);
+  // Phase 1: normalize verdict and supply the canonical presentation when none was provided.
+  params = normalizeUatVerdict(params);
+  params = supplyDefaultPresentation(params);
+
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) return errorResult("save_uat_result", "GSD database is not available.", "db_unavailable");
 
+  // Phase 2: validate the submitted presentation before the canonical merge so that
+  // presentations missing required workflow tools are rejected rather than silently patched.
   const requiredError = ensureUatRequiredFields(params);
   if (requiredError) return errorResult("save_uat_result", requiredError, "invalid_params");
   const presentationError = validateCanonicalPresentation(params);
   if (presentationError) return errorResult("save_uat_result", presentationError, "alias_tool_name");
+
+  // Phase 3: merge in the canonical plan ID and read-only audit tools so the persisted
+  // artifact always carries the full audit surface even when the provider omitted them.
+  params = mergeCanonicalPresentation(params);
   const checkError = validateUatChecks(basePath, params);
   if (checkError) return errorResult("save_uat_result", checkError, "invalid_evidence");
   const freshEvidenceError = validateFreshUatOwnedEvidence(params);

--- a/src/resources/extensions/gsd/unit-tool-contracts.ts
+++ b/src/resources/extensions/gsd/unit-tool-contracts.ts
@@ -1,0 +1,186 @@
+// Project/App: gsd-pi
+// File Purpose: Central Unit-to-tool contracts for phase-aware GSD tool surfaces.
+
+export interface UnitToolSurfaceContract {
+  allowedGsdTools: readonly string[];
+  requiredWorkflowTools: readonly string[];
+  forbiddenGsdTools?: Readonly<Record<string, string>>;
+}
+
+export const RUN_UAT_WORKFLOW_TOOL_NAMES = [
+  "gsd_uat_exec",
+  "gsd_uat_result_save",
+  "gsd_resume",
+  "gsd_milestone_status",
+  "gsd_journal_query",
+] as const;
+
+export const RUN_UAT_READ_ONLY_TOOL_NAMES = [
+  "find",
+  "glob",
+  "grep",
+  "ls",
+  "read",
+] as const;
+
+export const RUN_UAT_BROWSER_TOOL_NAMES = [
+  "browser_navigate",
+  "browser_click",
+  "browser_type",
+  "browser_fill_form",
+  "browser_click_ref",
+  "browser_fill_ref",
+  "browser_wait_for",
+  "browser_assert",
+  "browser_verify",
+  "browser_screenshot",
+  "browser_snapshot_refs",
+  "browser_find",
+  "browser_get_console_logs",
+  "browser_get_network_logs",
+  "browser_evaluate",
+  "browser_reload",
+  "browser_batch",
+  "browser_act",
+] as const;
+
+export const RUN_UAT_TOOL_PRESENTATION_PLAN_ID = "run-uat/default-v1";
+
+export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
+  "research-milestone": {
+    allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_summary_save"],
+  },
+  "plan-milestone": {
+    allowedGsdTools: ["gsd_plan_milestone", "gsd_decision_save", "gsd_requirement_update"],
+    requiredWorkflowTools: ["gsd_plan_milestone"],
+  },
+  "discuss-milestone": {
+    allowedGsdTools: [
+      "gsd_summary_save",
+      "gsd_decision_save",
+      "gsd_requirement_save",
+      "gsd_requirement_update",
+      "gsd_plan_milestone",
+      "gsd_milestone_generate_id",
+    ],
+    requiredWorkflowTools: [
+      "gsd_summary_save",
+      "gsd_requirement_save",
+      "gsd_requirement_update",
+      "gsd_plan_milestone",
+      "gsd_milestone_generate_id",
+    ],
+  },
+  "discuss-slice": {
+    allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_summary_save"],
+  },
+  "validate-milestone": {
+    allowedGsdTools: ["gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
+    requiredWorkflowTools: ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap"],
+  },
+  "complete-milestone": {
+    allowedGsdTools: ["gsd_complete_milestone", "subagent"],
+    requiredWorkflowTools: ["gsd_milestone_status", "gsd_complete_milestone"],
+  },
+  "research-slice": {
+    allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_summary_save"],
+  },
+  "plan-slice": {
+    allowedGsdTools: ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_plan_slice"],
+  },
+  "refine-slice": {
+    allowedGsdTools: ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
+    requiredWorkflowTools: [],
+  },
+  "replan-slice": {
+    allowedGsdTools: ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_replan_slice"],
+  },
+  "complete-slice": {
+    allowedGsdTools: [
+      "gsd_slice_complete",
+      "gsd_task_reopen",
+      "gsd_replan_slice",
+      "gsd_decision_save",
+      "gsd_requirement_update",
+      "subagent",
+    ],
+    requiredWorkflowTools: ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"],
+    forbiddenGsdTools: {
+      gsd_uat_result_save: "Run UAT owns persisted UAT Assessment.",
+    },
+  },
+  "reassess-roadmap": {
+    allowedGsdTools: ["gsd_reassess_roadmap"],
+    requiredWorkflowTools: ["gsd_milestone_status", "gsd_reassess_roadmap"],
+  },
+  "execute-task": {
+    allowedGsdTools: ["gsd_task_complete", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_task_complete"],
+  },
+  "execute-task-simple": {
+    allowedGsdTools: ["gsd_task_complete", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_task_complete"],
+  },
+  "reactive-execute": {
+    allowedGsdTools: ["gsd_task_complete", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_task_complete"],
+  },
+  "run-uat": {
+    allowedGsdTools: [...RUN_UAT_WORKFLOW_TOOL_NAMES, "subagent"],
+    requiredWorkflowTools: [...RUN_UAT_WORKFLOW_TOOL_NAMES],
+    forbiddenGsdTools: {
+      gsd_exec: "Use gsd_uat_exec so acceptance evidence is typed as UAT-owned.",
+      gsd_save_gate_result: "gsd_uat_result_save owns the aggregate UAT gate.",
+      gsd_summary_save: "gsd_uat_result_save owns persisted UAT Assessment writes.",
+    },
+  },
+  "gate-evaluate": {
+    allowedGsdTools: ["gsd_save_gate_result"],
+    requiredWorkflowTools: ["gsd_save_gate_result"],
+  },
+  "rewrite-docs": {
+    allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+    requiredWorkflowTools: [],
+  },
+  "workflow-preferences": {
+    allowedGsdTools: ["gsd_summary_save"],
+    requiredWorkflowTools: [],
+  },
+  "discuss-project": {
+    allowedGsdTools: ["gsd_summary_save", "gsd_decision_save", "gsd_requirement_save"],
+    requiredWorkflowTools: ["ask_user_questions", "gsd_summary_save"],
+  },
+  "discuss-requirements": {
+    allowedGsdTools: ["gsd_requirement_save", "gsd_summary_save"],
+    requiredWorkflowTools: ["ask_user_questions", "gsd_requirement_save", "gsd_summary_save"],
+  },
+  "research-decision": {
+    allowedGsdTools: ["gsd_summary_save"],
+    requiredWorkflowTools: ["ask_user_questions"],
+  },
+  "research-project": {
+    allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+    requiredWorkflowTools: [],
+  },
+};
+
+export const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = Object.fromEntries(
+  Object.entries(UNIT_TOOL_CONTRACTS).map(([unitType, contract]) => [unitType, contract.allowedGsdTools]),
+);
+
+export function getUnitToolSurfaceContract(unitType: string): UnitToolSurfaceContract | undefined {
+  return UNIT_TOOL_CONTRACTS[unitType];
+}
+
+export function getRequiredWorkflowToolsForUnit(unitType: string): string[] {
+  return [...(UNIT_TOOL_CONTRACTS[unitType]?.requiredWorkflowTools ?? [])];
+}
+
+export function getForbiddenGsdToolReason(unitType: string, toolName: string): string | undefined {
+  return UNIT_TOOL_CONTRACTS[unitType]?.forbiddenGsdTools?.[toolName];
+}

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { RUN_UAT_WORKFLOW_TOOL_NAMES } from "./tool-presentation-plan.js";
+import { getRequiredWorkflowToolsForUnit } from "./unit-tool-contracts.js";
 
 type WorkflowExecutorsModule = typeof import("./tools/workflow-tool-executors.js");
 
@@ -414,83 +414,11 @@ export function buildWorkflowMcpServers(
 }
 
 export function getRequiredWorkflowToolsForGuidedUnit(unitType: string): string[] {
-  switch (unitType) {
-    case "discuss-project":
-      return ["ask_user_questions", "gsd_summary_save"];
-    case "discuss-requirements":
-      return ["ask_user_questions", "gsd_requirement_save", "gsd_summary_save"];
-    case "research-decision":
-      return ["ask_user_questions"];
-    case "discuss-milestone":
-      return [
-        "gsd_summary_save",
-        "gsd_requirement_save",
-        "gsd_requirement_update",
-        "gsd_plan_milestone",
-        "gsd_milestone_generate_id",
-      ];
-    case "discuss-slice":
-      return ["gsd_summary_save"];
-    case "research-milestone":
-    case "research-slice":
-      return ["gsd_summary_save"];
-    case "plan-milestone":
-      return ["gsd_plan_milestone"];
-    case "plan-slice":
-      return ["gsd_plan_slice"];
-    case "execute-task":
-      return ["gsd_task_complete"];
-    case "complete-slice":
-      return ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"];
-    default:
-      return [];
-  }
+  return getRequiredWorkflowToolsForUnit(unitType);
 }
 
 export function getRequiredWorkflowToolsForAutoUnit(unitType: string): string[] {
-  switch (unitType) {
-    case "discuss-project":
-      return ["ask_user_questions", "gsd_summary_save"];
-    case "discuss-requirements":
-      return ["ask_user_questions", "gsd_requirement_save", "gsd_summary_save"];
-    case "research-decision":
-      return ["ask_user_questions"];
-    case "discuss-milestone":
-      return [
-        "gsd_summary_save",
-        "gsd_requirement_save",
-        "gsd_requirement_update",
-        "gsd_plan_milestone",
-        "gsd_milestone_generate_id",
-      ];
-    case "research-milestone":
-    case "research-slice":
-      return ["gsd_summary_save"];
-    case "run-uat":
-      return [...RUN_UAT_WORKFLOW_TOOL_NAMES];
-    case "plan-milestone":
-      return ["gsd_plan_milestone"];
-    case "plan-slice":
-      return ["gsd_plan_slice"];
-    case "execute-task":
-    case "execute-task-simple":
-    case "reactive-execute":
-      return ["gsd_task_complete"];
-    case "complete-slice":
-      return ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"];
-    case "replan-slice":
-      return ["gsd_replan_slice"];
-    case "reassess-roadmap":
-      return ["gsd_milestone_status", "gsd_reassess_roadmap"];
-    case "gate-evaluate":
-      return ["gsd_save_gate_result"];
-    case "validate-milestone":
-      return ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap"];
-    case "complete-milestone":
-      return ["gsd_milestone_status", "gsd_complete_milestone"];
-    default:
-      return [];
-  }
+  return getRequiredWorkflowToolsForUnit(unitType);
 }
 
 export function usesWorkflowMcpTransport(


### PR DESCRIPTION
## TL;DR

**What:** Hardened run-uat tool and result-save contracts so UAT failures stop as contract errors instead of provider schema overloads.
**Why:** Auto-mode was repeatedly retrying invalid UAT save calls and then aborting after schema overload, hiding the real phase-boundary bug.
**How:** Centralized run-uat tool contracts, scoped read-only/browser/UAT tools into the presentation plan, softened provider schema validation, and moved canonical validation into the executor with focused tests.

## What

This PR adds a centralized unit tool contract for run-uat, including canonical workflow, read-only, browser, and presentation-plan definitions. The run-uat prompt now consumes the canonical presentation block, and provider-facing tool schemas are permissive enough to let the GSD executor return actionable Tool Contract errors instead of provider schema overloads.

It also updates workflow MCP capability checks, run-uat tool scoping, recovery classification, prompt/schema parity tests, and UAT executor behavior around the new contract.

## Why

A run-uat unit could be prompted into invalid result-save shapes or wrong-phase tool presentation, causing repeated provider-level validation failures. The real problem was deterministic orchestration contract drift, not product UAT failure.

This makes the phase boundary explicit and keeps retries from being spent on calls that the unit contract can reject deterministically.

## How

- Add `unit-tool-contracts.ts` as the source of truth for run-uat tools and presentation.
- Reuse those constants across tool scoping, workflow MCP requirements, prompt rendering, and presentation validation.
- Let `gsd_uat_result_save` accept provider-loose arguments while the executor enforces verdict normalization, canonical presentation, valid `uatType`, and fresh UAT evidence.
- Add recovery categories for Tool Contract and lifecycle progression failures.
- Cover prompt parity, schema optionality, token tool gating, runtime invariants, package MCP behavior, and UAT executor behavior.

## Validation

- [x] `pnpm run verify:fast`
- [x] `pnpm run build:core`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test packages/mcp-server/src/workflow-tools.test.ts`
- [x] `pnpm run test:compile && pnpm run test:packages:compiled`
- [x] PR CI: `fast-gates`, `build`, and `windows-portability`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.
