### PR TITLE
fix(gsd): present browser tools for executable UAT

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -46,7 +46,7 @@ import { hasBrowserRequiredText } from "./browser-evidence.js";
 import { debugLog } from "./debug-logger.js";
 import { buildSkillActivationBlock, buildSkillDiscoveryVars } from "./skill-activation.js";
 import { findMilestoneIds } from "./milestone-ids.js";
-import { buildRunUatResultPresentation, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from "./tool-presentation-plan.js";
+import { buildRunUatPresentationForType, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from "./tool-presentation-plan.js";
 
 export { buildSkillActivationBlock, buildSkillDiscoveryVars };
 
@@ -3385,7 +3385,7 @@ export async function buildRunUatPrompt(
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = resolveEffectiveUatType(uatContent);
-  const canonicalPresentation = JSON.stringify(buildRunUatResultPresentation(), null, 2);
+  const canonicalPresentation = JSON.stringify(buildRunUatPresentationForType(uatType), null, 2);
 
   return loadPrompt("run-uat", {
     workingDirectory: base,

--- a/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
@@ -724,6 +724,8 @@ test('(u) run-uat prompt promotes artifact-driven browser specs to browser-execu
       assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`browser-executable`/);
       assert.match(prompt, /uatType: "browser-executable"/);
       assert.match(prompt, /use gsd-browser tools/i);
+      assert.match(prompt, /"browser_navigate"/);
+      assert.match(prompt, /"browser_assert"/);
     } finally {
       cleanup(base);
     }
@@ -741,6 +743,7 @@ test('(v) run-uat prompt keeps deferred browser work artifact-driven', async () 
       assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`artifact-driven`/);
       assert.match(prompt, /uatType: "artifact-driven"/);
       assert.doesNotMatch(prompt, /uatType: "browser-executable"/);
+      assert.doesNotMatch(prompt, /"browser_navigate"/);
     } finally {
       cleanup(base);
     }

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  RUN_UAT_BROWSER_TOOL_NAMES,
   buildRunUatResultPresentation,
+  buildRunUatPresentationForType,
   RUN_UAT_READ_ONLY_TOOL_NAMES,
   RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
@@ -79,6 +81,16 @@ test("run-uat prompt gives the complete UAT result-save presentation contract", 
     presentation.blockedTools.every((entry) => entry.reason === "forbidden during run-uat"),
     "presentation should explain blocked run-uat tools",
   );
+});
+
+test("browser-executable UAT presentation uses direct managed browser tools", () => {
+  const presentation = buildRunUatPresentationForType("browser-executable");
+
+  assert.equal(presentation.surface, "hybrid");
+  for (const toolName of RUN_UAT_BROWSER_TOOL_NAMES) {
+    assert.ok(presentation.presentedTools.includes(toolName), `presentation should include browser tool ${toolName}`);
+  }
+  assert.ok(!presentation.presentedTools.some((toolName) => toolName.startsWith("mcp__gsd-browser__")));
 });
 
 test("workflow-start prompt defaults to autonomy instead of per-phase confirmation", () => {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -705,6 +705,65 @@ test("executeUatResultSave supplies canonical presentation and normalizes verdic
   }
 });
 
+test("executeUatResultSave supplies direct browser tools for browser-executable UAT", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  const evidenceId = "uat-direct-browser-evidence";
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S06", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: {
+          kind: "uat_exec",
+          milestoneId: "M001",
+          sliceId: "S06",
+          checkId: "UAT-01",
+          intent: "uat-browser-check",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S06",
+      uatType: "browser-executable",
+      verdict: "PASS",
+      checks: [{
+        id: "UAT-01",
+        description: "Browser flow used managed gsd-browser tools",
+        mode: "browser",
+        result: "PASS",
+        evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
+        notes: "Browser check passed.",
+      }],
+      notes: "UAT passed with managed browser evidence.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, undefined);
+    const attempt = JSON.parse(readFileSync(
+      join(base, ".gsd", "uat", "M001", "S06", "attempt-1.json"),
+      "utf-8",
+    )) as { presentation?: { presentedTools?: string[] } };
+
+    assert.ok(attempt.presentation?.presentedTools?.includes("browser_navigate"));
+    assert.ok(attempt.presentation?.presentedTools?.includes("browser_assert"));
+    assert.equal(
+      attempt.presentation?.presentedTools?.some((toolName) => toolName.startsWith("mcp__gsd-browser__")),
+      false,
+    );
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeUatResultSave merges canonical plan ID and read-only tools when presentation lacks plan ID", async () => {
   const base = makeTmpBase();
   const worktree = join(base, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tool-presentation-plan.ts
+++ b/src/resources/extensions/gsd/tool-presentation-plan.ts
@@ -2,12 +2,14 @@
 // File Purpose: Resolve phase-aware tool surfaces for GSD model presentations.
 
 import {
+  RUN_UAT_BROWSER_TOOL_NAMES,
   RUN_UAT_READ_ONLY_TOOL_NAMES,
   RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
 } from "./unit-tool-contracts.js";
 
 export {
+  RUN_UAT_BROWSER_TOOL_NAMES,
   RUN_UAT_READ_ONLY_TOOL_NAMES,
   RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
@@ -30,6 +32,13 @@ export interface ToolPresentationPlan {
   blockedToolNames: Array<{ name: string; reason: string }>;
   aliases: Array<{ requested: string; canonical: string }>;
   diagnostics: string[];
+}
+
+export interface RunUatResultPresentation {
+  surface: ToolPresentationSurface;
+  presentedTools: string[];
+  blockedTools: Array<{ name: string; reason: string }>;
+  toolPresentationPlanId: string;
 }
 
 export const RUN_UAT_FORBIDDEN_TOOL_NAMES = [
@@ -114,16 +123,33 @@ export function buildRunUatCanonicalToolNames(options: { includeBrowserTools?: r
   ]);
 }
 
+export function runUatBrowserToolsForType(uatType: string | undefined): readonly string[] {
+  return uatType === "browser-executable" ? RUN_UAT_BROWSER_TOOL_NAMES : [];
+}
+
+export function runUatPresentationSurfaceForType(uatType: string | undefined): ToolPresentationSurface {
+  return uatType === "browser-executable" ? "hybrid" : "mcp";
+}
+
+export function buildRunUatPresentationForType(
+  uatType: string | undefined,
+  options: {
+    surface?: ToolPresentationSurface;
+    presentedTools?: readonly string[];
+  } = {},
+): RunUatResultPresentation {
+  return buildRunUatResultPresentation({
+    ...options,
+    surface: options.surface ?? runUatPresentationSurfaceForType(uatType),
+    includeBrowserTools: runUatBrowserToolsForType(uatType),
+  });
+}
+
 export function buildRunUatResultPresentation(options: {
   surface?: ToolPresentationSurface;
   includeBrowserTools?: readonly string[];
   presentedTools?: readonly string[];
-} = {}): {
-  surface: ToolPresentationSurface;
-  presentedTools: string[];
-  blockedTools: Array<{ name: string; reason: string }>;
-  toolPresentationPlanId: string;
-} {
+} = {}): RunUatResultPresentation {
   const presentedTools = options.presentedTools
     ? dedupe(options.presentedTools)
     : buildRunUatCanonicalToolNames({ includeBrowserTools: options.includeBrowserTools });

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -48,7 +48,7 @@ import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
 import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
 import {
-  buildRunUatResultPresentation,
+  buildRunUatPresentationForType,
   canonicalWorkflowToolName,
   parseMcpToolName,
   RUN_UAT_FORBIDDEN_TOOL_NAMES,
@@ -1047,13 +1047,13 @@ function normalizeUatVerdict(params: UatResultSaveParams): UatResultSaveParams {
 function supplyDefaultPresentation(params: UatResultSaveParams): UatResultSaveParams {
   const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
   if (!raw.presentation) {
-    return { ...params, presentation: buildRunUatResultPresentation() };
+    return { ...params, presentation: buildRunUatPresentationForType(params.uatType) };
   }
   return params;
 }
 
 function mergeCanonicalPresentation(params: UatResultSaveParams): UatResultSaveParams {
-  const canonicalPresentation = buildRunUatResultPresentation();
+  const canonicalPresentation = buildRunUatPresentationForType(params.uatType);
   const providedPresentation = params.presentation as Partial<UatPresentationInput>;
   return {
     ...params,


### PR DESCRIPTION
## TL;DR

**What:** Browser-executable UAT now presents direct managed browser tools in the run-uat prompt and saved UAT presentation contract.
**Why:** Browser UAT was being steered toward workflow/MCP-only tooling instead of the direct browser tool surface available to Codex/API.
**How:** The UAT presentation plan now derives browser tools and a hybrid surface from the effective UAT type, and result-save canonicalization uses the same type-aware presentation.

## What

- Adds type-aware run-uat presentation helpers for browser-executable UAT.
- Injects direct browser tools such as `browser_navigate` and `browser_assert` into browser-executable prompt contracts.
- Persists the same canonical browser tool presentation through `gsd_uat_result_save`.
- Adds regression coverage for prompt composition and result-save normalization.

## Why

Browser-executable UAT needs to use the managed browser tool surface when that surface is available. Without the browser tools in the canonical presentation, UAT can drift into artifact-only or MCP-discovery behavior even when the requested UAT mode is explicitly browser executable.

## How

The presentation plan now maps `browser-executable` UAT to a `hybrid` surface and includes `RUN_UAT_BROWSER_TOOL_NAMES`. Prompt generation and result-save canonicalization both call the type-aware helper so the prompt contract and persisted UAT attempt stay aligned.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Testing

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/integration/run-uat.test.ts src/resources/extensions/gsd/tests/token-tool-gating.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

## Breaking changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to UAT presentation and prompt/result-save wiring; behavior change is limited to browser-executable mode with added test coverage.
> 
> **Overview**
> **Browser-executable UAT** now gets a **type-aware tool presentation** so run-uat prompts and saved UAT attempts advertise **direct managed browser tools** (`browser_navigate`, `browser_assert`, etc.) on a **`hybrid`** surface instead of a generic plan that omitted them or pushed MCP-only discovery.
> 
> `buildRunUatPresentationForType` derives browser tool names and surface from the effective UAT type; **`buildRunUatPrompt`** and **`gsd_uat_result_save`** canonicalization both use it so the **prompt contract** and **persisted attempt presentation** stay aligned. **Artifact-driven** UAT is unchanged and still omits browser tools in the canonical JSON.
> 
> Regression tests cover prompt composition, presentation contracts, and result-save normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8252b35f88653214f99cffd970b30d19219dfd66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->