### PR TITLE
fix(issue): Guided flow under claude-code falsely aborts: workflow-MCP surface tools re-validated against pi.getActiveTools()

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -850,6 +850,34 @@ test("transport compatibility still blocks units whose MCP tools are not exposed
   assert.match(error ?? "", /currently exposes only/);
 });
 
+test("discuss-milestone guided flow does not abort when all required tools are on MCP surface (regression #469)", () => {
+  // Before the fix, activeTools being non-empty caused uniqueRequired to be filtered
+  // against the pi host tool list instead of MCP_WORKFLOW_TOOL_SURFACE, making every
+  // surface tool appear missing and aborting the guided flow with a false error.
+  const discussMilestoneTools = [
+    "gsd_summary_save",
+    "gsd_requirement_save",
+    "gsd_requirement_update",
+    "gsd_plan_milestone",
+    "gsd_milestone_generate_id",
+  ];
+  const error = getWorkflowTransportSupportError(
+    "claude-code",
+    discussMilestoneTools,
+    {
+      projectRoot: "/tmp/project",
+      env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
+      surface: "guided flow",
+      unitType: "discuss-milestone",
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      activeTools: ["ScheduleWakeup", "ToolSearch", "bash", "read", "write"],
+    },
+  );
+
+  assert.equal(error, null);
+});
+
 test("transport compatibility accepts MCP-namespaced runtime tools", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",


### PR DESCRIPTION
## Summary
- Added regression test for discuss-milestone guided-flow false-abort (issue #469); the underlying `piRuntimeRequired` fix was already applied in workflow-mcp.ts, so only the dedicated test was missing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #469
- [#469 Guided flow under claude-code falsely aborts: workflow-MCP surface tools re-validated against pi.getActiveTools()](https://github.com/open-gsd/gsd-pi/issues/469)

## User
- @mashpie

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/469-guided-flow-under-claude-code-falsely-ab-1780572840`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783165454&installation_id=134682257&pr_number=471&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F471&signature=d9f0778e711ce45230bae5504bb47368c64a831e0e6d5368ddc32c72b03feae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modified in this PR.
> 
> **Overview**
> Adds a **regression test** for issue **#469**: when **claude-code** runs the **discuss-milestone** guided flow with a non-empty `activeTools` list from the pi host, `getWorkflowTransportSupportError` must return **no error** if every required tool is on the workflow MCP surface.
> 
> The test encodes the bug where required tools were checked against `pi.getActiveTools()` instead of `MCP_WORKFLOW_TOOL_SURFACE`, so MCP-only tools looked missing and the guided flow aborted falsely. **No production code changes** in this diff—the behavior fix is assumed to already exist in `workflow-mcp.ts`; this PR only locks it in with the new case in `workflow-mcp.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14fa674d0dc1b1205193235e5581a3eee3b2a713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->