### PR TITLE
fix(issue): Auto-mode re-dispatches zero-tool-call units with no cap, wasting ~4 billed prompts per stuck unit (phases.js:2055)

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -397,6 +397,8 @@ async function validateSourceWriteWorktreeSafety(
 
 let consecutiveSessionTimeouts = 0;
 const MAX_SESSION_TIMEOUT_AUTO_RESUMES = 3;
+/** Maximum zero-tool-call retries before pausing — context exhaustion is deterministic. */
+const MAX_ZERO_TOOL_RETRIES = 1;
 
 export function resetSessionTimeoutState(): void {
   consecutiveSessionTimeouts = 0;
@@ -2711,14 +2713,27 @@ export async function runUnitPhase(
             unitId,
           });
         } else {
+          const zeroToolKey = `${unitType}/${unitId}`;
+          const attempt = (s.zeroToolRetryCount.get(zeroToolKey) ?? 0) + 1;
           debugLog("runUnitPhase", {
             phase: "zero-tool-calls",
             unitType,
             unitId,
+            attempt,
             warning: "Unit completed with 0 tool calls — likely context exhaustion, marking as failed",
           });
+          if (attempt > MAX_ZERO_TOOL_RETRIES) {
+            s.zeroToolRetryCount.delete(zeroToolKey);
+            ctx.ui.notify(
+              `${unitType} ${unitId} completed with 0 tool calls — context exhaustion, pausing auto-mode after ${MAX_ZERO_TOOL_RETRIES} retry.`,
+              "error",
+            );
+            await deps.pauseAuto(ctx, pi);
+            return { action: "break", reason: "zero-tool-calls-exhausted" };
+          }
+          s.zeroToolRetryCount.set(zeroToolKey, attempt);
           ctx.ui.notify(
-            `${unitType} ${unitId} completed with 0 tool calls — context exhaustion, will retry`,
+            `${unitType} ${unitId} completed with 0 tool calls — context exhaustion, will retry (attempt ${attempt}/${MAX_ZERO_TOOL_RETRIES})`,
             "warning",
           );
           return {
@@ -2748,6 +2763,7 @@ export async function runUnitPhase(
   if (artifactVerified) {
     s.unitDispatchCount.delete(dispatchKey);
     s.unitRecoveryCount.delete(`${unitType}/${unitId}`);
+    s.zeroToolRetryCount.delete(dispatchKey);
   }
 
   // Write phase handoff anchor after successful research/planning completion

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -176,6 +176,7 @@ export class AutoSession {
   readonly verificationRetryCount = new Map<string, number>();
   readonly verificationRetryFailureHashes = new Map<string, string>();
   readonly exhaustedVerificationUnits = new Set<string>();
+  readonly zeroToolRetryCount = new Map<string, number>();
   pausedSessionFile: string | null = null;
   pausedUnitType: string | null = null;
   pausedUnitId: string | null = null;
@@ -362,6 +363,7 @@ export class AutoSession {
     this.verificationRetryCount.clear();
     this.verificationRetryFailureHashes.clear();
     this.exhaustedVerificationUnits.clear();
+    this.zeroToolRetryCount.clear();
     this.pausedSessionFile = null;
     this.pausedUnitType = null;
     this.pausedUnitId = null;

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1118,6 +1118,7 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
     unitLifetimeDispatches: new Map<string, number>(),
     unitRecoveryCount: new Map<string, number>(),
     verificationRetryCount: new Map<string, number>(),
+    zeroToolRetryCount: new Map<string, number>(),
     gitService: null,
     lastRequestTimestamp: 0,
     autoStartTime: Date.now(),
@@ -4691,6 +4692,104 @@ test("runUnitPhase retries 0-tool units with ordinary network-related assistant 
   assert.equal(result.action, "retry");
   assert.equal((result as any).reason, "zero-tool-calls");
   assert.equal(deps.callLog.includes("pauseAuto"), false);
+});
+
+test("runUnitPhase pauses auto-mode when zero-tool-call retry is exhausted", async (t) => {
+  _resetPendingResolve();
+
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-zero-tool-exhausted-"));
+  t.after(() => {
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = {
+    ...makeMockPi(),
+    sendMessage: () => {
+      queueMicrotask(() => resolveAgentEnd(makeEvent([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Error: I'll investigate the network error handling next." },
+          ],
+        },
+      ])));
+    },
+  } as any;
+  const s = makeLoopSession({
+    basePath,
+    canonicalProjectRoot: basePath,
+    originalBasePath: basePath,
+  });
+  // Pre-seed counter at MAX_ZERO_TOOL_RETRIES so the next zero-tool turn exhausts the cap
+  s.zeroToolRetryCount.set("execute-task/M001/S01/T01", 1);
+
+  const mockLedger = {
+    version: 1,
+    projectStartedAt: Date.now(),
+    units: [] as any[],
+  };
+  const deps = makeMockDeps({
+    closeoutUnit: async () => {
+      mockLedger.units.push({
+        type: "execute-task",
+        id: "M001/S01/T01",
+        startedAt: s.currentUnit?.startedAt ?? Date.now(),
+        toolCalls: 0,
+        assistantMessages: 1,
+        tokens: { input: 100, output: 20, total: 120, cacheRead: 0, cacheWrite: 0 },
+        cost: 0.01,
+      });
+    },
+    getLedger: () => mockLedger,
+  });
+  let seq = 0;
+
+  const result = await runUnitPhase(
+    { ctx, pi, s, deps, prefs: undefined, iteration: 1, flowId: "flow-zero-tool-exhausted", nextSeq: () => ++seq },
+    {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "do work",
+      finalPrompt: "do work",
+      pauseAfterUatDispatch: false,
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Milestone" },
+        activeSlice: { id: "S01", title: "Slice" },
+        activeTask: { id: "T01", title: "Task" },
+        registry: [{ id: "M001", title: "Milestone", status: "active" }],
+        recentDecisions: [],
+        blockers: [],
+        nextAction: "",
+        progress: { milestones: { done: 0, total: 1 } },
+        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      } as any,
+      mid: "M001",
+      midTitle: "Milestone",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    { recentUnits: [{ key: "execute-task/M001/S01/T01" }], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 },
+  );
+
+  assert.equal(result.action, "break");
+  assert.equal((result as any).reason, "zero-tool-calls-exhausted");
+  assert.equal(deps.callLog.includes("pauseAuto"), true);
 });
 
 test("autoLoop pauses user-driven deep question instead of flagging 0 tool calls", async () => {


### PR DESCRIPTION
## Summary
- Capped zero-tool-call retries in `phases.ts` at `MAX_ZERO_TOOL_RETRIES=1` using a new per-unit `zeroToolRetryCount` map in `AutoSession`, pausing auto-mode on exhaustion instead of falling through to the 5-dispatch `CONSECUTIVE_SAME_UNIT_CAP`; verified with a new test asserting `action: "break"` on the second occurrence.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #472
- [#472 Auto-mode re-dispatches zero-tool-call units with no cap, wasting ~4 billed prompts per stuck unit (phases.js:2055)](https://github.com/open-gsd/gsd-pi/issues/472)

## User
- @mattiaverio

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/472-auto-mode-re-dispatches-zero-tool-call-u-1780575239`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783167608&installation_id=134682257&pr_number=473&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F473&signature=a8667b4d9fea5794901e754815a1b09c9fc7e99f095499f634de270fb8cabc0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized auto-loop recovery logic with session-scoped counters and tests; no auth, data, or API surface changes.
> 
> **Overview**
> Auto-mode no longer retries units that finish with **zero tool calls** indefinitely. **`runUnitPhase`** now tracks per-unit attempts in **`zeroToolRetryCount`** and allows at most **`MAX_ZERO_TOOL_RETRIES` (1)** retry for likely context exhaustion, then **pauses** with **`zero-tool-calls-exhausted`** instead of looping through broader dispatch caps.
> 
> **`AutoSession`** holds the counter map and clears it on **`reset()`**; successful artifact verification clears the entry for that unit. A regression test asserts pause on the second zero-tool occurrence when the counter is pre-seeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d165169d3fddc5adff479d66eccbca36169dcb51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->