### PR TITLE
Fix GSD context masking for Responses payloads

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1293,17 +1293,25 @@ export function registerHooks(
     if (isAutoActive()) {
       try {
         const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+        const {
+          createObservationMask,
+          createResponsesInputObservationMask,
+          truncateContextResultMessages,
+          truncateResponsesInputResultItems,
+        } = await import("../context-masker.js");
         const prefs = loadEffectiveGSDPreferences();
         const cmConfig = prefs?.preferences.context_management;
 
         // Observation masking: replace old tool results with placeholders
         if (cmConfig?.observation_masking !== false) {
           const keepTurns = cmConfig?.observation_mask_turns ?? 8;
-          const { createObservationMask } = await import("../context-masker.js");
-          const mask = createObservationMask(keepTurns);
           const messages = payload.messages;
           if (Array.isArray(messages)) {
-            payload.messages = mask(messages);
+            payload.messages = createObservationMask(keepTurns)(messages);
+          }
+          const input = payload.input;
+          if (Array.isArray(input)) {
+            payload.input = createResponsesInputObservationMask(keepTurns)(input);
           }
         }
 
@@ -1313,23 +1321,11 @@ export function registerHooks(
         const maxChars = cmConfig?.tool_result_max_chars ?? 800;
         const msgs = payload.messages;
         if (Array.isArray(msgs)) {
-          payload.messages = msgs.map((msg: Record<string, unknown>) => {
-            // Match toolResult messages (role: "toolResult", content is array of content blocks)
-            if (msg?.role === "toolResult" && Array.isArray(msg.content)) {
-              const blocks = msg.content as Array<Record<string, unknown>>;
-              const totalLen = blocks.reduce((sum: number, b) => sum + (typeof b.text === "string" ? b.text.length : 0), 0);
-              if (totalLen > maxChars) {
-                const truncated = blocks.map(b => {
-                  if (typeof b.text === "string" && b.text.length > maxChars) {
-                    return { ...b, text: b.text.slice(0, maxChars) + "\n…[truncated]" };
-                  }
-                  return b;
-                });
-                return { ...msg, content: truncated };
-              }
-            }
-            return msg;
-          });
+          payload.messages = truncateContextResultMessages(msgs as any, maxChars);
+        }
+        const input = payload.input;
+        if (Array.isArray(input)) {
+          payload.input = truncateResponsesInputResultItems(input as any, maxChars);
         }
       } catch { /* non-fatal */ }
     }

--- a/src/resources/extensions/gsd/context-masker.ts
+++ b/src/resources/extensions/gsd/context-masker.ts
@@ -5,10 +5,17 @@
  * Reduces context bloat between compactions with zero LLM overhead.
  * Preserves message ordering, roles, and all assistant/user messages.
  *
- * Operates on the pi-ai Message[] format (post-convertToLlm, pre-provider):
+ * Operates on provider payloads after convertToLlm:
+ *
+ * pi-ai Message[] payloads:
  *   - toolResult messages: { role: "toolResult", content: TextContent[] }
  *   - bash results are already converted to: { role: "user", content: [{type:"text",text:"..."}] }
  *     and start with "Ran `" from bashExecutionToText.
+ *
+ * OpenAI/Codex Responses payloads:
+ *   - conversation items live in `input`, not `messages`
+ *   - tool results are { type: "function_call_output", output: string | content[] }
+ *   - bash results are user items with input_text content starting with "Ran `"
  */
 
 interface MaskableMessage {
@@ -20,6 +27,37 @@ interface MaskableMessage {
 
 const MASK_PLACEHOLDER = "[result masked — within summarized history]";
 const MASK_CONTENT_BLOCK = [{ type: "text" as const, text: MASK_PLACEHOLDER }];
+const RESPONSES_MASK_CONTENT_BLOCK = [{ type: "input_text" as const, text: MASK_PLACEHOLDER }];
+const TRUNCATION_MARKER = "\n…[truncated]";
+
+type TextLikeBlock = {
+  type?: string;
+  text?: unknown;
+  [key: string]: unknown;
+};
+
+interface ResponsesInputItem {
+  role?: string;
+  type?: string;
+  content?: unknown;
+  output?: unknown;
+  [key: string]: unknown;
+}
+
+function isTextLikeBlock(block: unknown): block is TextLikeBlock {
+  return Boolean(block && typeof block === "object" && "text" in block);
+}
+
+function firstTextFromContent(content: unknown): string | undefined {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return undefined;
+  const first = content.find(isTextLikeBlock);
+  return typeof first?.text === "string" ? first.text : undefined;
+}
+
+function isBashResultText(text: string | undefined): boolean {
+  return typeof text === "string" && text.startsWith("Ran `");
+}
 
 function findTurnBoundary(messages: MaskableMessage[], keepRecentTurns: number): number {
   let turnsSeen = 0;
@@ -43,10 +81,8 @@ function findTurnBoundary(messages: MaskableMessage[], keepRecentTurns: number):
  * The bashExecutionToText format always starts with "Ran `".
  */
 function isBashResultUserMessage(m: MaskableMessage): boolean {
-  if (m.role !== "user" || !Array.isArray(m.content)) return false;
-  const first = m.content[0];
-  return first && typeof first === "object" && "text" in first &&
-    typeof first.text === "string" && first.text.startsWith("Ran `");
+  if (m.role !== "user") return false;
+  return isBashResultText(firstTextFromContent(m.content));
 }
 
 function isMaskableMessage(m: MaskableMessage): boolean {
@@ -71,4 +107,115 @@ export function createObservationMask(keepRecentTurns: number = 8) {
       return m;
     });
   };
+}
+
+function isResponsesBashResultUserItem(item: ResponsesInputItem): boolean {
+  if (item.role !== "user") return false;
+  return isBashResultText(firstTextFromContent(item.content));
+}
+
+function findResponsesTurnBoundary(items: ResponsesInputItem[], keepRecentTurns: number): number {
+  let turnsSeen = 0;
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (item.role === "user" && !isResponsesBashResultUserItem(item)) {
+      turnsSeen++;
+      if (turnsSeen >= keepRecentTurns) return i;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Observation masking for OpenAI/Codex Responses API payloads.
+ *
+ * Responses payloads store the conversation under `input` instead of
+ * `messages`, with tool results as `function_call_output` items. Keep this
+ * separate from createObservationMask so each payload shape stays explicit.
+ */
+export function createResponsesInputObservationMask(keepRecentTurns: number = 8) {
+  return (items: ResponsesInputItem[]): ResponsesInputItem[] => {
+    const boundary = findResponsesTurnBoundary(items, keepRecentTurns);
+    if (boundary === 0) return items;
+
+    return items.map((item, i) => {
+      if (i >= boundary) return item;
+      if (item.type === "function_call_output") {
+        return { ...item, output: MASK_PLACEHOLDER };
+      }
+      if (isResponsesBashResultUserItem(item)) {
+        return { ...item, content: RESPONSES_MASK_CONTENT_BLOCK };
+      }
+      return item;
+    });
+  };
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars) + TRUNCATION_MARKER;
+}
+
+function truncateTextBlocks(content: unknown, maxChars: number): unknown {
+  if (typeof content === "string") {
+    return truncateText(content, maxChars);
+  }
+  if (!Array.isArray(content)) return content;
+
+  let remaining = maxChars;
+  let didTruncate = false;
+  const nextBlocks: unknown[] = [];
+
+  for (const block of content) {
+    if (!isTextLikeBlock(block) || typeof block.text !== "string") {
+      nextBlocks.push(block);
+      continue;
+    }
+
+    if (remaining <= 0) {
+      didTruncate = true;
+      continue;
+    }
+
+    const text = block.text;
+    if (text.length <= remaining) {
+      nextBlocks.push(block);
+      remaining -= text.length;
+      continue;
+    }
+
+    nextBlocks.push({ ...block, text: truncateText(text, remaining) });
+    remaining = 0;
+    didTruncate = true;
+  }
+
+  return didTruncate ? nextBlocks : content;
+}
+
+function normalizedMaxChars(maxChars: number): number {
+  return Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : 800;
+}
+
+export function truncateContextResultMessages(messages: MaskableMessage[], maxChars: number = 800): MaskableMessage[] {
+  const limit = normalizedMaxChars(maxChars);
+  return messages.map((message) => {
+    if (!isMaskableMessage(message)) return message;
+    const content = truncateTextBlocks(message.content, limit);
+    return content === message.content ? message : { ...message, content };
+  });
+}
+
+export function truncateResponsesInputResultItems(items: ResponsesInputItem[], maxChars: number = 800): ResponsesInputItem[] {
+  const limit = normalizedMaxChars(maxChars);
+  return items.map((item) => {
+    if (item.type === "function_call_output") {
+      const output = truncateTextBlocks(item.output, limit);
+      return output === item.output ? item : { ...item, output };
+    }
+    if (isResponsesBashResultUserItem(item)) {
+      const content = truncateTextBlocks(item.content, limit);
+      return content === item.content ? item : { ...item, content };
+    }
+    return item;
+  });
 }

--- a/src/resources/extensions/gsd/tests/context-masker.test.ts
+++ b/src/resources/extensions/gsd/tests/context-masker.test.ts
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createObservationMask } from "../context-masker.js";
+import {
+  createObservationMask,
+  createResponsesInputObservationMask,
+  truncateContextResultMessages,
+  truncateResponsesInputResultItems,
+} from "../context-masker.js";
 
 // These helpers produce messages in the pi-ai LLM payload format
 // (post-convertToLlm, pre-provider), which is what before_provider_request sees.
@@ -119,4 +124,54 @@ test("masks toolResult by role, not by type field", () => {
   ];
   const result = mask(messages as any);
   assert.equal((result[1].content as any)[0].text, MASK_TEXT);
+});
+
+test("truncates recent bash result user messages", () => {
+  const messages = [
+    userMsg("turn 1"),
+    bashResult("a".repeat(50)),
+    assistantMsg("response 1"),
+  ];
+  const result = truncateContextResultMessages(messages as any, 10);
+  const text = (result[1].content as any)[0].text;
+  assert.ok(text.length < (messages[1].content as any)[0].text.length);
+  assert.match(text, /…\[truncated\]/);
+});
+
+test("masks Responses API function outputs older than keepRecentTurns", () => {
+  const mask = createResponsesInputObservationMask(1);
+  const items = [
+    { role: "user", content: [{ type: "input_text", text: "turn 1" }] },
+    { type: "function_call_output", call_id: "call_1", output: "old output" },
+    { type: "message", role: "assistant", content: [{ type: "output_text", text: "response 1" }] },
+    { role: "user", content: [{ type: "input_text", text: "turn 2" }] },
+  ];
+  const result = mask(items as any);
+  assert.equal(result[1].output, MASK_TEXT);
+});
+
+test("masks Responses API bash result user items older than keepRecentTurns", () => {
+  const mask = createResponsesInputObservationMask(1);
+  const items = [
+    { role: "user", content: [{ type: "input_text", text: "turn 1" }] },
+    { role: "user", content: [{ type: "input_text", text: "Ran `npm test`\n```\nold output\n```" }] },
+    { type: "message", role: "assistant", content: [{ type: "output_text", text: "response 1" }] },
+    { role: "user", content: [{ type: "input_text", text: "turn 2" }] },
+  ];
+  const result = mask(items as any);
+  assert.equal((result[1].content as any)[0].text, MASK_TEXT);
+});
+
+test("truncates Responses API function outputs and recent bash result items", () => {
+  const items = [
+    { role: "user", content: [{ type: "input_text", text: "turn 1" }] },
+    { type: "function_call_output", call_id: "call_1", output: "b".repeat(50) },
+    { role: "user", content: [{ type: "input_text", text: "Ran `npm test`\n```\n" + "c".repeat(50) + "\n```" }] },
+  ];
+  const result = truncateResponsesInputResultItems(items as any, 12);
+
+  assert.match(result[1].output as string, /…\[truncated\]/);
+  assert.match((result[2].content as any)[0].text, /…\[truncated\]/);
+  assert.ok((result[1].output as string).length < (items[1].output as string).length);
+  assert.ok((result[2].content as any)[0].text.length < (items[2].content as any)[0].text.length);
 });


### PR DESCRIPTION
## TL;DR

**What:** Applies GSD auto-mode context masking and result truncation to both chat-style `messages` payloads and OpenAI/Codex Responses `input` payloads.
**Why:** Codex/API requests could bypass GSD context controls and still hit provider `context_length_exceeded` errors.
**How:** Adds Responses-aware masking/truncation helpers and wires the provider preflight hook to process `payload.input` as well as `payload.messages`.

## What

This updates the GSD context masker so it understands OpenAI/Codex Responses payload items, including `function_call_output` entries and bash result user items. The auto-mode `before_provider_request` hook now applies masking and truncation to both payload shapes.

The regression tests cover recent bash result truncation, old Responses function output masking, old Responses bash result masking, and Responses result truncation.

## Why

GSD is supposed to keep auto-mode context under control before provider calls. The previous hook only handled providers that send conversation history as `payload.messages`; Codex Responses sends it as `payload.input`, so large tool or bash output could still be sent verbatim and fail at the provider boundary.

## How

The patch keeps the existing message masker behavior, adds explicit Responses input helpers, and reuses a shared text truncation path for both payload formats. It keeps user and assistant messages intact while replacing or capping managed execution output.

## Validation

- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/context-masker.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run test:changed:src`
- `pnpm run verify:fast`
- `git diff --check`

## Change Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783173496&installation_id=134682257&pr_number=475&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F475&signature=17b5ab4b5aee0fe06a6df23ffaeec251c156724a3fae67fa4778afc6198cf89e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-provider request shaping for auto-mode Codex/Responses traffic; wrong masking could drop tool context, but behavior is covered by new tests and mirrors existing message-path logic.
> 
> **Overview**
> Extends GSD auto-mode **observation masking** and **tool-result truncation** so they apply to OpenAI/Codex **Responses** payloads (`payload.input`), not only chat-style `payload.messages`.
> 
> The `before_provider_request` hook now runs Responses-specific maskers for `function_call_output` and bash-style user items, and shared truncation helpers replace the inline `toolResult` logic in `register-hooks.ts`. **`context-masker.ts`** gains `createResponsesInputObservationMask`, `truncateContextResultMessages`, and `truncateResponsesInputResultItems`, with tests for Responses masking and truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5390ca711708537e5b05bd4ce663c571a136cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->