### PR TITLE
fix(auto): run-latency quick wins — stalled-tool timeout, resume thrash, skill bloat, switch noise

### DIFF
--- a/packages/pi-ai/src/providers/transform-messages.ts
+++ b/packages/pi-ai/src/providers/transform-messages.ts
@@ -281,7 +281,14 @@ export function transformMessagesWithReport<TApi extends Api>(
 	// If the conversation ends with unresolved tool calls, synthesize results now.
 	insertSyntheticToolResults();
 
-	if (hasReportChanges(report)) {
+	// Only surface a provider-switch report when the source and target APIs
+	// actually differ. Within-API transforms — most notably synthetic
+	// tool-result backfills inserted when a same-provider conversation ends on
+	// an unresolved tool call — are not cross-provider data loss and must not be
+	// reported as a "provider switch". Callers that omit `sourceApi` default
+	// `fromApi` to the target api, so without this guard every such call emits a
+	// spurious same→same report that floods telemetry and buries real switches.
+	if (hasReportChanges(report) && report.fromApi !== report.toApi) {
 		notifyProviderSwitchObserver(report);
 	}
 

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -147,6 +147,15 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
   const softTimeoutMs = supervisionTimeouts.softTimeoutMs;
   const idleTimeoutMs = supervisionTimeouts.idleTimeoutMs;
   const hardTimeoutMs = supervisionTimeouts.hardTimeoutMs;
+  // A single hung tool gets its own short budget, NOT the general idle window:
+  // a long-but-progressing session is not idle, but a tool stuck for minutes
+  // is. Falls back to the idle window only if misconfigured to zero. The
+  // hung-tool budget is intentionally not scaled by task estimate — a stuck
+  // tool call is stuck regardless of how long the overall task should take.
+  const stalledToolTimeoutMs =
+    (supervisor.stalled_tool_timeout_minutes ?? 0) > 0
+      ? supervisor.stalled_tool_timeout_minutes! * 60 * 1000
+      : idleTimeoutMs;
 
   // ── 1. Soft timeout warning ──
   s.wrapupWarningHandle = setTimeout(() => {
@@ -189,10 +198,13 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
       };
       const runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
       if (!runtime) return;
-      if (Date.now() - runtime.lastProgressAt < idleTimeoutMs) return;
 
-      // Agent has tool calls currently executing — not idle, just waiting.
-      // But only suppress recovery if the tool started recently.
+      // In-flight tool handling runs on its own dedicated hung-tool budget,
+      // independent of the general idle gate below, so a genuinely stuck tool
+      // is caught in minutes instead of waiting out the (typically much longer)
+      // idle window (#2527, follow-up). A tool actively executing within budget
+      // is real progress, so refreshing lastProgressAt here also keeps the idle
+      // gate from firing during legitimate long-running tool calls.
       let stalledToolDetected = false;
       if (getInFlightToolCount() > 0) {
         // User-interactive tools (ask_user_questions, secure_env_collect) block
@@ -206,24 +218,28 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
         }
         const oldestStart = getOldestInFlightToolStart()!;
         const toolAgeMs = Date.now() - oldestStart;
-        if (toolAgeMs < idleTimeoutMs) {
+        if (toolAgeMs < stalledToolTimeoutMs) {
           writeUnitRuntimeRecord(s.basePath, unitType, unitId, s.currentUnit.startedAt, {
             lastProgressAt: Date.now(),
             lastProgressKind: "tool-in-flight",
           });
           return;
         }
-        // Tool has been in-flight longer than idle timeout — treat as hung.
-        // Clear the stale entries so subsequent ticks don't re-detect them,
-        // and set the flag so the filesystem-activity check below does not
-        // override the stall verdict (#2527).
+        // Tool has been in-flight longer than the hung-tool budget — treat as
+        // hung. Clear the stale entries so subsequent ticks don't re-detect
+        // them, and set the flag so the idle gate and filesystem-activity check
+        // below do not override the stall verdict (#2527).
         stalledToolDetected = true;
         clearInFlightTools();
         ctx.ui.notify(
-          `Stalled tool detected: a tool has been in-flight for ${Math.round(toolAgeMs / 60000)}min. Treating as hung — attempting idle recovery.`,
+          `Stalled tool detected: a tool has been in-flight for ${Math.round(toolAgeMs / 60000)}min (budget ${Math.round(stalledToolTimeoutMs / 60000)}min). Treating as hung — attempting idle recovery.`,
           "warning",
         );
       }
+
+      // No hung tool — apply the general idle gate. A unit that has made
+      // meaningful progress within the idle window is not idle yet.
+      if (!stalledToolDetected && Date.now() - runtime.lastProgressAt < idleTimeoutMs) return;
 
       // Check if the agent is producing work on disk.
       // Skip this when a stalled tool was just detected — filesystem changes

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -542,8 +542,26 @@ function handlePausedSessionResumeRecovery(
 ): { skippedReplay: boolean } {
   if (!state.pausedSessionFile) return { skippedReplay: false };
 
-  const pausedRecoveryUnitType = state.currentUnit?.type ?? state.pausedUnitType ?? "unknown";
-  const pausedRecoveryUnitId = state.currentUnit?.id ?? state.pausedUnitId ?? "unknown";
+  const pausedRecoveryUnitType = state.currentUnit?.type ?? state.pausedUnitType ?? null;
+  const pausedRecoveryUnitId = state.currentUnit?.id ?? state.pausedUnitId ?? null;
+
+  // When the paused-session metadata never captured the unit identity (the
+  // pause happened between units, or the worker died before currentUnit was
+  // set), we have nothing to verify against and nothing correct to target. A
+  // replay synthesized with an "unknown" unit re-injects an unbounded,
+  // mis-identified tool-call blob into the fresh resume context — exactly the
+  // thrash that turns one stuck unit into several. Disk state has already been
+  // rebuilt (rebuildState + doctor) before this runs, so skip the replay and
+  // let the normal dispatcher recompute the next unit from disk.
+  if (!pausedRecoveryUnitType || !pausedRecoveryUnitId) {
+    state.pausedSessionFile = null;
+    state.pausedUnitType = null;
+    state.pausedUnitId = null;
+    state.pendingCrashRecovery = null;
+    notify("Paused session had no recorded unit identity. Skipping tool-call replay and resuming from disk state.");
+    return { skippedReplay: true };
+  }
+
   const completedPausedUnit = verifyExpectedArtifact(
     pausedRecoveryUnitType,
     pausedRecoveryUnitId,

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -139,6 +139,7 @@ function collectConfigSections(): ConfigSection[] {
     if (sup.model) supRows.push({ label: "Model", value: sup.model });
     supRows.push({ label: "Soft timeout", value: `${sup.soft_timeout_minutes}m` });
     supRows.push({ label: "Idle timeout", value: `${sup.idle_timeout_minutes}m` });
+    supRows.push({ label: "Stalled tool timeout", value: `${sup.stalled_tool_timeout_minutes}m` });
     supRows.push({ label: "Hard timeout", value: `${sup.hard_timeout_minutes}m` });
     sections.push({ title: "Auto Supervisor", rows: supRows });
   }

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -372,6 +372,7 @@ export function resolveAutoSupervisorConfig(): AutoSupervisorConfig {
     soft_timeout_minutes: configured.soft_timeout_minutes ?? 20,
     idle_timeout_minutes: configured.idle_timeout_minutes ?? 10,
     hard_timeout_minutes: configured.hard_timeout_minutes ?? 30,
+    stalled_tool_timeout_minutes: configured.stalled_tool_timeout_minutes ?? 5,
     ...(configured.model ? { model: configured.model } : {}),
   };
 }

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -256,6 +256,14 @@ export interface AutoSupervisorConfig {
   soft_timeout_minutes?: number;
   idle_timeout_minutes?: number;
   hard_timeout_minutes?: number;
+  /**
+   * Dedicated budget for a single in-flight tool call before it is treated as
+   * hung. Distinct from `idle_timeout_minutes`: a genuinely stuck tool should
+   * be recovered in minutes rather than waiting out the full idle window. A
+   * long-but-progressing session is not idle, so it must not share the hung-tool
+   * threshold.
+   */
+  stalled_tool_timeout_minutes?: number;
 }
 
 export interface RemoteQuestionsConfig {

--- a/src/resources/extensions/gsd/skill-manifest.ts
+++ b/src/resources/extensions/gsd/skill-manifest.ts
@@ -117,6 +117,18 @@ const UNIT_TYPE_SKILL_MANIFEST: Record<string, string[]> = {
     "review",
     "accessibility",
   ],
+  // Slice closeout — the "closer" role: verify assembled task work, write the
+  // downstream-ready summary + UAT, optionally drive reviewer/security/tester
+  // subagents. Predictable skill set, mirrors `complete-milestone`.
+  "complete-slice": [
+    "verify-before-complete",
+    "test",
+    "review",
+    "security-review",
+    "write-docs",
+    "observability",
+    "handoff",
+  ],
   // `execute-task` intentionally omitted — implementation hot path covers a
   // wide surface of technologies; wildcard fallback preserves today's
   // behavior until per-task skill hints can be derived from task-plan

--- a/src/resources/extensions/gsd/tests/auto-supervisor.test.mjs
+++ b/src/resources/extensions/gsd/tests/auto-supervisor.test.mjs
@@ -20,6 +20,10 @@ test('resolveAutoSupervisorConfig provides safe timeout defaults', () => {
     assert.equal(supervisor.soft_timeout_minutes, 20);
     assert.equal(supervisor.idle_timeout_minutes, 10);
     assert.equal(supervisor.hard_timeout_minutes, 30);
+    // A single hung tool gets its own short budget, well below the idle window,
+    // so a genuinely stuck tool is recovered in minutes instead of waiting out
+    // the full idle timeout.
+    assert.equal(supervisor.stalled_tool_timeout_minutes, 5);
   } finally {
     if (previousGsdHome === undefined) {
       delete process.env.GSD_HOME;

--- a/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
@@ -226,6 +226,33 @@ test("direct /gsd auto skips paused-session replay when recovered unit already c
   }
 });
 
+test("paused-session resume skips replay when unit identity was never recorded", () => {
+  const base = makeTmpBase();
+  try {
+    // No currentUnit and no persisted unit type/id — identity is unknown. The
+    // old code fell back to the literal "unknown" unit, which can neither be
+    // verified nor correctly targeted, and synthesized a full tool-call replay
+    // (the thrash that turns one stuck unit into several). The fix skips the
+    // replay and resumes from rebuilt disk state instead.
+    const state = {
+      pausedSessionFile: join(base, ".gsd", "activity", "paused-session.jsonl"),
+      currentUnit: null,
+      pausedUnitType: null,
+      pausedUnitId: null,
+      pendingCrashRecovery: "stale-recovery-prompt",
+    };
+
+    const result = _handlePausedSessionResumeRecoveryForTest(base, state);
+    assert.equal(result.skippedReplay, true);
+    assert.equal(state.pausedSessionFile, null);
+    assert.equal(state.pendingCrashRecovery, null, "must not synthesize a replay for an unknown unit");
+    assert.equal(state.pausedUnitType, null);
+    assert.equal(state.pausedUnitId, null);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("interrupted-session source preserves raw lock and excludes same-pid from running classification", async () => {
   const source = await import(`node:fs/promises`).then((fs) =>
     fs.readFile(new URL("../interrupted-session.ts", import.meta.url), "utf-8")

--- a/src/resources/extensions/gsd/tests/provider-switch-observer.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-switch-observer.test.ts
@@ -210,6 +210,61 @@ test("end-to-end: audit event is emitted when an auto trace is active", async ()
   }
 });
 
+test("same-API transform with changes does not fire the observer (no real provider switch)", async () => {
+  const { basePath, cleanup } = withTempBasePath();
+  try {
+    initNotificationStore(basePath);
+    installProviderSwitchObserver();
+
+    // Target api === source api. The conversation ends on an unresolved tool
+    // call, so a synthetic tool result IS backfilled (a non-empty report) — but
+    // this is a within-provider normalization, not a cross-provider switch.
+    // `sourceApi` is omitted (the common case), so fromApi defaults to the
+    // target api and equals toApi. The observer must stay silent.
+    const sameApiModel = {
+      id: "gpt-5",
+      name: "GPT-5",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    } as Parameters<typeof transformMessagesWithReport>[1];
+
+    const messages = [
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "toolCall" as const, id: "call_orphan_1", name: "bash", arguments: {} },
+        ],
+        api: "openai-responses",
+        provider: "openai",
+        model: "gpt-5",
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        stopReason: "stop" as const,
+        timestamp: Date.now(),
+      },
+    ];
+
+    transformMessagesWithReport(
+      messages as Parameters<typeof transformMessagesWithReport>[0],
+      sameApiModel,
+    );
+
+    assert.equal(getProviderSwitchStats().totalSwitches, 0, "same→same transform must not count as a provider switch");
+    assert.equal(
+      readNotifications(basePath).filter((n) => n.message.includes("Provider switch")).length,
+      0,
+      "same→same transform must not emit a provider-switch notification",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test("empty report does not bump counter or emit a notification", async () => {
   const { basePath, cleanup } = withTempBasePath();
   try {

--- a/src/resources/extensions/gsd/tests/skill-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-manifest.test.ts
@@ -3,8 +3,8 @@
 // Focused tests for `resolveSkillManifest` and `filterSkillsByManifest`.
 // Covers the wildcard semantics, the newly seeded unit-type entries
 // (complete-milestone, validate-milestone, reassess-roadmap, research-slice,
-// plan-slice, refine-slice, replan-slice, run-uat), and the deliberate
-// wildcard fallback for the execute-task hot path (RFC #4779).
+// plan-slice, refine-slice, replan-slice, run-uat, complete-slice), and the
+// deliberate wildcard fallback for the execute-task hot path (RFC #4779).
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -23,6 +23,7 @@ const NEWLY_WIRED_UNIT_TYPES = [
   "refine-slice",
   "replan-slice",
   "run-uat",
+  "complete-slice",
 ] as const;
 
 test("resolveSkillManifest returns null for undefined unit type (wildcard)", () => {
@@ -65,7 +66,7 @@ test("resolveSkillManifest: slice-level manifests include decompose-into-slices"
 });
 
 test("resolveSkillManifest: validation / completion flows include verify-before-complete", () => {
-  for (const unitType of ["complete-milestone", "validate-milestone", "run-uat"] as const) {
+  for (const unitType of ["complete-milestone", "validate-milestone", "run-uat", "complete-slice"] as const) {
     const allowlist = resolveSkillManifest(unitType);
     assert.ok(
       allowlist?.includes("verify-before-complete"),


### PR DESCRIPTION
## TL;DR

**What:** Four targeted engine fixes that remove avoidable latency from auto-mode runs — a dedicated hung-tool timeout, a resume-replay guard, slice-closeout skill trimming, and suppression of bogus provider-switch warnings.
**Why:** Diagnosing a slow run in `test-apps/456` (a trivial single-file app) surfaced these as concrete, independently-fixable latency/noise sinks.
**How:** Each is a small, localized change with its own regression test; the two larger architectural levers are intentionally deferred.

## What

- **R2 — Dedicated hung-tool timeout.** Adds `auto_supervisor.stalled_tool_timeout_minutes` (default **5**) and evaluates the in-flight-tool check on its own budget, independent of the general idle gate. Files: `auto-timers.ts`, `preferences-types.ts`, `preferences-models.ts`, `config-overlay.ts`.
- **R5 — Resume replay guard.** When a paused-session resume has no recorded unit identity, skip the full tool-call replay and resume from rebuilt disk state. File: `auto.ts`.
- **R7 — Slice-closeout skill allowlist.** `complete-slice` gets a focused closeout allowlist instead of the full ~49-skill catalog. File: `skill-manifest.ts` (the `unit-context-manifest` policy auto-derives). `execute-task` deliberately left wildcard per RFC #4779.
- **R8 — Provider-switch noise.** Only notify the provider-switch observer on a genuine cross-API switch. File: `packages/pi-ai/src/providers/transform-messages.ts`.
- Tests: `auto-supervisor.test.mjs`, `interrupted-session-auto.test.ts`, `provider-switch-observer.test.ts`, `skill-manifest.test.ts`.

## Why

A small milestone in `test-apps/456` ran far slower than it should. Diagnosis isolated several engine-level causes, of which these four are the low-risk quick wins:

- The idle watchdog reused `idle_timeout_minutes` to judge a single in-flight tool as hung, so a stuck tool ran out the full idle window (~58 min observed) before recovery fired (**R2**).
- On resume with no recorded unit identity, recovery fell back to a literal `"unknown"` unit — unverifiable and un-targetable — then synthesized a full tool-call replay that re-injected an unbounded blob into the fresh context and re-overflowed it (**R5**).
- `complete-slice` injected the full skill catalog into every closeout (**R7**).
- Callers omitting `sourceApi` defaulted `fromApi` to the target api, so within-provider synthetic tool-result backfills fired as `Provider switch X → X` warnings — 88% of notifications in the sample run, burying real signals (**R8**).

The two deeper levers (auto-advance between phases; retry-ceiling + context compaction on resume) are intentionally **out of scope** here and tracked for follow-up.

## How

- **R2:** In `startUnitSupervision`, the in-flight-tool branch now uses `stalledToolTimeoutMs` and runs before the general idle gate, so a hung tool is caught in minutes while a tool progressing within budget still counts as real progress. New config field is additive with a default; setting it to `0` falls back to the idle window.
- **R5:** `handlePausedSessionResumeRecovery` returns early (skipping replay) when neither the live unit nor persisted paused-unit identity is present; disk state has already been rebuilt by `rebuildState` + doctor before this point.
- **R7:** Adds a `complete-slice` entry to `UNIT_TYPE_SKILL_MANIFEST`; `unit-context-manifest` derives its skills policy from the resolver, so both stay consistent (covered by existing test #4782).
- **R8:** Guards `notifyProviderSwitchObserver` on `report.fromApi !== report.toApi`. Existing cross-API observer tests are unaffected; a new test covers the same-API suppression path.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` / `refactor` / `docs` / `chore`

## Breaking changes

None. R2 adds one **optional** preference (`auto_supervisor.stalled_tool_timeout_minutes`, default 5) — fully backward-compatible. R8 changes notification behavior only (suppresses non-actionable same→same warnings); no public API, CLI, or file-format change.

## Notes

- Touches auto-mode (`auto-timers.ts`, `auto.ts`) — flagging per the RFC-for-core-systems guideline; these are localized bug fixes rather than architectural changes, but happy to convert to an issue/ADR first if maintainers prefer.
- Bundled as one cohesive "run-latency quick wins" set from a single diagnosis; can split into per-fix PRs on request.
- This PR is AI-assisted (Claude Code). Changes were built, tested, and smoke-run against a source-dev runtime before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto supervision, resume recovery, and pi-ai message transform notification paths; behavior is well-tested but affects long-running auto sessions and provider telemetry.
> 
> **Overview**
> Four targeted **auto-mode latency** fixes: hung tools, resume thrash, closeout prompt bloat, and provider-switch telemetry noise.
> 
> **Hung tools** get a dedicated **`stalled_tool_timeout_minutes`** (default **5m**, separate from idle). The idle watchdog judges in-flight tools on that budget, refreshes progress for tools still within budget, and only then applies the general idle gate—so stuck tools recover in minutes instead of riding the full idle window.
> 
> **Paused resume** no longer falls back to an `"unknown"` unit when pause metadata lacks unit identity; it **skips tool-call replay** and continues from rebuilt disk state after doctor/rebuild.
> 
> **`complete-slice`** now uses a focused **skill allowlist** (like milestone closeout) instead of the full catalog; **`execute-task`** stays wildcard per RFC #4779.
> 
> **`transformMessages`** only notifies the provider-switch observer when **`fromApi !== toApi`**, so same-provider synthetic tool-result backfills no longer flood telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336c2a9ab26dfe04d9dda480f557d410efd0ba8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->