### PR TITLE
test(gsd): add zero-tool retry state to session mocks

### DIFF
--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -129,6 +129,7 @@ function makeLoopSession(overrides?: Record<string, unknown>) {
     unitLifetimeDispatches: new Map<string, number>(),
     unitRecoveryCount: new Map<string, number>(),
     verificationRetryCount: new Map<string, number>(),
+    zeroToolRetryCount: new Map<string, number>(),
     gitService: null,
     autoStartTime: Date.now(),
     activeEngineId: null,

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -200,6 +200,7 @@ function makeSession() {
     unitLifetimeDispatches: new Map<string, number>(),
     unitRecoveryCount: new Map<string, number>(),
     verificationRetryCount: new Map<string, number>(),
+    zeroToolRetryCount: new Map<string, number>(),
     gitService: null,
     autoStartTime: Date.now(),
     cmdCtx: {

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -852,9 +852,8 @@ test("transport compatibility still blocks units whose MCP tools are not exposed
 });
 
 test("discuss-milestone guided flow does not abort when all required tools are on MCP surface (regression #469)", () => {
-  // Before the fix, activeTools being non-empty caused uniqueRequired to be filtered
-  // against the pi host tool list instead of MCP_WORKFLOW_TOOL_SURFACE, making every
-  // surface tool appear missing and aborting the guided flow with a false error.
+  // Guided flow starts the workflow MCP server as part of dispatch, so the
+  // parent session active-tool list is not authoritative for MCP tools.
   const discussMilestoneTools = [
     "gsd_summary_save",
     "gsd_requirement_save",
@@ -872,7 +871,6 @@ test("discuss-milestone guided flow does not abort when all required tools are o
       unitType: "discuss-milestone",
       authMode: "externalCli",
       baseUrl: "local://claude-code",
-      activeTools: ["ScheduleWakeup", "ToolSearch", "bash", "read", "write"],
     },
   );
 


### PR DESCRIPTION
## TL;DR

**What:** Keeps GSD auto-session test mocks and workflow-MCP regression coverage aligned with current runtime contracts.
**Why:** PR #473 added `zeroToolRetryCount`, and the merged workflow-MCP tests also needed to reflect the guided-flow dispatch path after the active-tool preflight tightening.
**How:** Adds the missing retry map to hand-rolled session mocks and updates the discuss-milestone regression test to rely on the configured workflow MCP launch surface instead of a parent-session active-tool fixture.

## What

Updated the session helper objects in `custom-engine-loop-integration.test.ts` and `journal-integration.test.ts` so they include `zeroToolRetryCount`.

Updated the discuss-milestone workflow-MCP regression test so it matches guided flow's actual compatibility check: guided flow starts workflow MCP as part of dispatch, so the parent session active-tool list is not authoritative for MCP-surface tools.

## Why

PR #473 clears `zeroToolRetryCount` on successful artifact verification. A couple of integration tests use plain object session mocks instead of `AutoSession`, so those mocks must track the same field or the auto-loop can throw and retry instead of completing.

After the run-uat active-tool preflight tightened, the #469 guided-flow regression test was still passing a parent active-tool fixture directly into the helper. The production guided-flow caller no longer does that, because workflow MCP tools are launched for the dispatched turn.

## How

The mock fix mirrors the production session shape by adding `new Map<string, number>()` for `zeroToolRetryCount` alongside the existing dispatch, recovery, and verification counters.

The workflow-MCP test fix preserves the auto-mode coverage that rejects genuinely tool-starved active sessions, while keeping the guided-flow regression focused on the launch-configured workflow MCP surface.

## Verification

- `pnpm run verify:fast`
- `pnpm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=spec --test-name-pattern "discuss-milestone guided flow does not abort" --test dist-test/src/resources/extensions/gsd/tests/workflow-mcp.test.js`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/workflow-mcp.test.js`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.js dist-test/src/resources/extensions/gsd/tests/journal-integration.test.js`

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers and one regression test assertion; no production runtime behavior is modified in this diff.
> 
> **Overview**
> Keeps GSD auto-loop integration test session mocks in sync with production **`AutoSession`** by adding **`zeroToolRetryCount`** (`Map<string, number>`) next to the other per-unit counters, so successful paths that clear that map no longer throw on plain-object mocks.
> 
> Updates the **`discuss-milestone`** workflow MCP regression test: it no longer passes a parent **`activeTools`** list that omits workflow tools, and the comment states guided flow starts the workflow MCP server during dispatch, so the parent session tool list should not gate MCP tool availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6d78f4bdf93db6050750b495e5f2b48a29082d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->