### PR TITLE
Add planner handoff after planning

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -15,6 +15,7 @@
 | `/gsd discuss` | Discuss architecture and decisions (stop auto-mode first with `/gsd stop`) |
 | `/gsd status` | Open workflow visualizer |
 | `/gsd widget` | Cycle dashboard widget: full / small / min / off |
+| `/gsd planner [MID]` | Launch `gsd-planner` to review or customize a planned milestone before implementation |
 | `/gsd notifications` | View, filter, and clear persistent notification history |
 | `/gsd queue` | Queue and reorder future milestones (`pending`, `queued`, and legacy `planned`; safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -17,7 +17,18 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, insertAssessment, setSliceSketchFlag, transaction, getAssessment } from "./gsd-db.js";
+import {
+  isDbAvailable,
+  getMilestoneSlices,
+  getPendingGates,
+  markAllGatesOmitted,
+  getMilestone,
+  insertAssessment,
+  setSliceSketchFlag,
+  transaction,
+  getAssessment,
+  getSliceTasks,
+} from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -104,6 +115,12 @@ import {
   checkCloseoutConsistencyGate,
   formatCloseoutConsistencyBlock,
 } from "./closeout-consistency-gate.js";
+import {
+  formatPlannerHandoffPauseReason,
+  hasPlannerHandoffBeenOffered,
+  markPlannerHandoffOffered,
+  PLANNER_HANDOFF_RULE_NAME,
+} from "./planner-handoff.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -406,6 +423,43 @@ function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
     }
   }
   return hasImplementationArtifacts(basePath, mid) === "present";
+}
+
+function isBeforeFirstImplementationTask(mid: string): boolean {
+  if (!isDbAvailable()) return true;
+  for (const slice of getMilestoneSlices(mid)) {
+    const tasks = getSliceTasks(mid, slice.id);
+    if (tasks.some(task => isClosedStatus(task.status))) return false;
+  }
+  return true;
+}
+
+function hasRoadmapLevelPlan(basePath: string, mid: string): boolean {
+  if (isDbAvailable() && getMilestoneSlices(mid).length > 0) return true;
+  const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
+  return !!(roadmapFile && existsSync(roadmapFile));
+}
+
+function isPlannerHandoffBoundary(state: GSDState): boolean {
+  if (state.phase !== "planning") return false;
+  if (!state.activeSlice || state.activeTask) return false;
+  const nextAction = state.nextAction ?? "";
+  return (
+    /^Plan slice \S+/.test(nextAction) ||
+    /^Slice \S+ has no DB tasks\./.test(nextAction)
+  );
+}
+
+function shouldOfferPlannerHandoff(basePath: string, mid: string, state: GSDState): boolean {
+  if (process.env.GSD_HEADLESS) return false;
+  if (!isPlannerHandoffBoundary(state)) return false;
+  if (!state.activeMilestone || state.activeMilestone.id !== mid) return false;
+  if (!hasRoadmapLevelPlan(basePath, mid)) return false;
+  if (hasMilestonePassedDiscuss(basePath, mid)) return false;
+  if (hasPlannerHandoffBeenOffered(basePath, mid)) return false;
+  if (!isBeforeFirstImplementationTask(mid)) return false;
+  if (hasImplementationArtifacts(basePath, mid) === "present") return false;
+  return true;
 }
 
 /**
@@ -1018,6 +1072,18 @@ export const DISPATCH_RULES: DispatchRule[] = [
       return {
         action: "stop" as const,
         reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
+        level: "warning" as const,
+      };
+    },
+  },
+  {
+    name: PLANNER_HANDOFF_RULE_NAME,
+    match: async ({ state, mid, basePath }) => {
+      if (!shouldOfferPlannerHandoff(basePath, mid, state)) return null;
+      markPlannerHandoffOffered(basePath, mid);
+      return {
+        action: "stop" as const,
+        reason: formatPlannerHandoffPauseReason(mid),
         level: "warning" as const,
       };
     },

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|planner|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -25,6 +25,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "status", desc: "Open the status dashboard" },
   { cmd: "widget", desc: "Cycle widget: full → small → min → off" },
   { cmd: "visualize", desc: "Open 10-tab workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)" },
+  { cmd: "planner", desc: "Launch gsd-planner to review or customize the current plan before implementation" },
   { cmd: "brief", desc: "Generate a visual HTML brief: diagram, plan, diff review, recap, table, or slides" },
   { cmd: "queue", desc: "Queue and reorder future milestones" },
   { cmd: "quick", desc: "Execute a quick task without full planning overhead" },
@@ -323,6 +324,10 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "--open", desc: "Open a browser chart saved to .gsd/reports/" },
     { cmd: "--text", desc: "Plain-text breakdown" },
     { cmd: "--json", desc: "Machine-readable JSON output" },
+  ],
+  planner: [
+    { cmd: "--dry-run", desc: "Print the gsd-planner command without launching it" },
+    { cmd: "M001", desc: "Launch planner for a specific milestone ID" },
   ],
   backlog: [
     { cmd: "add", desc: "Add item to backlog" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -14,6 +14,13 @@ import { projectRoot } from "../context.js";
 import { formattedShortcutPair } from "../../shortcut-defs.js";
 import { getVisualBriefOutputDir } from "../../../visual-brief/artifact-policy.js";
 import { buildVisualBriefPrompt, parseVisualBriefArgs, VISUAL_BRIEF_USAGE } from "../../../visual-brief/prompts.js";
+import {
+  buildGsdPlannerSpawnPlan,
+  formatGsdPlannerCommand,
+  formatPlannerLaunchUnavailable,
+  launchGsdPlanner,
+  markPlannerHandoffOffered,
+} from "../../planner-handoff.js";
 
 export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
   const summaryLines = [
@@ -29,6 +36,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     `  /gsd status         Status dashboard  (${formattedShortcutPair("dashboard")})`,
     `  /gsd parallel watch Parallel monitor  (${formattedShortcutPair("parallel")})`,
     `  /gsd notifications  Notification history  (${formattedShortcutPair("notifications")})`,
+    "  /gsd planner        Launch gsd-planner to review the current plan",
     "  /gsd visualize      Workflow visualizer",
     "  /gsd report         Generate all HTML reports and open browser",
     "  /gsd brief <mode>   Visual HTML brief (diagram, plan, diff, recap, table, slides)",
@@ -72,6 +80,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd stop           Stop auto-mode gracefully",
     "  /gsd pause          Pause auto-mode (preserves state, /gsd auto to resume)",
     "  /gsd discuss        Start guided milestone/slice discussion",
+    "  /gsd planner        Launch gsd-planner to customize a planned milestone before implementation",
     "  /gsd new-milestone  Create milestone from headless context (used by gsd headless)",
     "  /gsd new-project    Bootstrap a new project (use --deep for staged project-level discovery)",
     "  /gsd quick          Execute a quick task without full planning overhead",
@@ -83,6 +92,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "VISIBILITY",
     `  /gsd status         Status dashboard  (${formattedShortcutPair("dashboard")})`,
     `  /gsd parallel watch Open parallel worker monitor  (${formattedShortcutPair("parallel")})`,
+    "  /gsd planner        Launch gsd-planner for plan review/customization  [Mxxx] [--dry-run]",
     "  /gsd widget         Cycle status widget  [full|small|min|off]",
     "  /gsd visualize      Workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)",
     "  /gsd brief <mode>   Generate a visual HTML brief  [diagram|plan|diff|recap|table|slides] [topic] [--slides]",
@@ -463,6 +473,68 @@ async function handleModel(trimmedArgs: string, ctx: ExtensionCommandContext, pi
   ctx.ui.notify(`Model: ${targetModel.provider}/${targetModel.id}`, "info");
 }
 
+function parsePlannerArgs(args: string): { dryRun: boolean; milestoneId: string | null; extraArgs: string[] } {
+  const parts = args.trim().split(/\s+/).filter(Boolean);
+  let dryRun = false;
+  let milestoneId: string | null = null;
+  const extraArgs: string[] = [];
+
+  for (const part of parts) {
+    if (part === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (!milestoneId && /^M\d+(?:-[a-z0-9]{6})?$/i.test(part)) {
+      milestoneId = part.toUpperCase();
+      continue;
+    }
+    extraArgs.push(part);
+  }
+
+  return { dryRun, milestoneId, extraArgs };
+}
+
+async function handlePlanner(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const basePath = projectRoot();
+  const parsed = parsePlannerArgs(args);
+  let milestoneId = parsed.milestoneId;
+  if (!milestoneId) {
+    const state = await deriveState(basePath);
+    milestoneId = state.activeMilestone?.id ?? null;
+  }
+  const plan = buildGsdPlannerSpawnPlan({
+    basePath,
+    milestoneId,
+    extraArgs: parsed.extraArgs,
+  });
+
+  if (parsed.dryRun) {
+    ctx.ui.notify(formatGsdPlannerCommand(plan), "info");
+    return;
+  }
+
+  const result = await launchGsdPlanner({
+    basePath,
+    milestoneId,
+    extraArgs: parsed.extraArgs,
+  });
+
+  if (result.status === "failed") {
+    ctx.ui.notify(formatPlannerLaunchUnavailable(result.plan, result.error), "warning");
+    return;
+  }
+
+  if (milestoneId) {
+    markPlannerHandoffOffered(basePath, milestoneId, "command");
+  }
+  ctx.ui.notify(
+    milestoneId
+      ? `Launched gsd-planner for ${milestoneId}. Run /gsd auto when you are ready to continue.`
+      : "Launched gsd-planner. Run /gsd auto when you are ready to continue.",
+    "info",
+  );
+}
+
 export async function handleCoreCommand(
   trimmed: string,
   ctx: ExtensionCommandContext,
@@ -478,6 +550,10 @@ export async function handleCoreCommand(
   }
   if (trimmed === "visualize") {
     await handleVisualize(ctx);
+    return true;
+  }
+  if (trimmed === "planner" || trimmed.startsWith("planner ")) {
+    await handlePlanner(trimmed.replace(/^planner\s*/, "").trim(), ctx);
     return true;
   }
   if (trimmed === "brief" || trimmed.startsWith("brief ")) {

--- a/src/resources/extensions/gsd/planner-handoff.ts
+++ b/src/resources/extensions/gsd/planner-handoff.ts
@@ -1,0 +1,149 @@
+// Project/App: gsd-pi
+// File Purpose: Optional gsd-planner handoff after milestone planning.
+
+import { spawn as spawnChild, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { gsdRoot } from "./paths.js";
+
+export const PLANNER_HANDOFF_RULE_NAME = "planning review handoff -> gsd-planner";
+export const GSD_PLANNER_COMMAND = "gsd-planner";
+
+export interface GsdPlannerSpawnPlan {
+  command: string;
+  args: string[];
+  cwd: string;
+}
+
+export interface GsdPlannerLaunchInput {
+  basePath: string;
+  milestoneId?: string | null;
+  extraArgs?: string[];
+}
+
+export type GsdPlannerLaunchResult =
+  | { status: "launched"; plan: GsdPlannerSpawnPlan }
+  | { status: "failed"; plan: GsdPlannerSpawnPlan; error: Error };
+
+type SpawnLike = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+export interface GsdPlannerLaunchDeps {
+  spawn?: SpawnLike;
+}
+
+function handoffDir(basePath: string): string {
+  return join(gsdRoot(basePath), "runtime", "planner-handoffs");
+}
+
+function safeMilestoneFileSegment(milestoneId: string): string {
+  return milestoneId.replace(/[^A-Za-z0-9._-]/g, "_") || "unknown";
+}
+
+function handoffMarkerPath(basePath: string, milestoneId: string): string {
+  return join(handoffDir(basePath), `${safeMilestoneFileSegment(milestoneId)}.json`);
+}
+
+export function hasPlannerHandoffBeenOffered(basePath: string, milestoneId: string): boolean {
+  return existsSync(handoffMarkerPath(basePath, milestoneId));
+}
+
+export function markPlannerHandoffOffered(
+  basePath: string,
+  milestoneId: string,
+  source: "auto" | "command" = "auto",
+): void {
+  mkdirSync(handoffDir(basePath), { recursive: true });
+  writeFileSync(
+    handoffMarkerPath(basePath, milestoneId),
+    JSON.stringify({
+      milestoneId,
+      source,
+      offeredAt: new Date().toISOString(),
+    }, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+export function buildGsdPlannerSpawnPlan(input: GsdPlannerLaunchInput): GsdPlannerSpawnPlan {
+  const args = ["--project", input.basePath];
+  const milestoneId = input.milestoneId?.trim();
+  if (milestoneId) args.push("--milestone", milestoneId);
+  args.push(...(input.extraArgs ?? []));
+  return {
+    command: GSD_PLANNER_COMMAND,
+    args,
+    cwd: input.basePath,
+  };
+}
+
+function quoteArg(arg: string): string {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(arg) ? arg : JSON.stringify(arg);
+}
+
+export function formatGsdPlannerCommand(plan: GsdPlannerSpawnPlan): string {
+  return [plan.command, ...plan.args].map(quoteArg).join(" ");
+}
+
+export async function launchGsdPlanner(
+  input: GsdPlannerLaunchInput,
+  deps: GsdPlannerLaunchDeps = {},
+): Promise<GsdPlannerLaunchResult> {
+  const plan = buildGsdPlannerSpawnPlan(input);
+  const spawn = deps.spawn ?? spawnChild;
+
+  let child: ChildProcess;
+  try {
+    child = spawn(plan.command, plan.args, {
+      cwd: plan.cwd,
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  } catch (err) {
+    return {
+      status: "failed",
+      plan,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: GsdPlannerLaunchResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    child.once("error", (err) => {
+      settle({
+        status: "failed",
+        plan,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    });
+    child.once("spawn", () => {
+      child.unref();
+      settle({ status: "launched", plan });
+    });
+  });
+}
+
+export function formatPlannerHandoffPauseReason(milestoneId: string): string {
+  return [
+    `Milestone ${milestoneId} is planned. Review or customize the plan before implementation if needed.`,
+    `Run /gsd planner to launch ${GSD_PLANNER_COMMAND}, or run /gsd auto to continue without planner changes.`,
+  ].join(" ");
+}
+
+export function formatPlannerLaunchUnavailable(plan: GsdPlannerSpawnPlan, error: Error): string {
+  return [
+    `Could not launch ${GSD_PLANNER_COMMAND}: ${error.message}`,
+    `Install ${GSD_PLANNER_COMMAND} or run it manually: ${formatGsdPlannerCommand(plan)}`,
+  ].join("\n");
+}

--- a/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 
 import { DISPATCH_RULES } from "../auto-dispatch.ts";
 import type { DispatchContext, DispatchAction } from "../auto-dispatch.ts";
+import { PLANNER_HANDOFF_RULE_NAME } from "../planner-handoff.ts";
 import type { GSDState } from "../types.ts";
 
 // ─── State helpers ────────────────────────────────────────────────────────
@@ -216,6 +217,29 @@ test("dispatch-rule-coverage: planning with active slice and skip_research → p
   );
 });
 
+test("dispatch-rule-coverage: planning boundary → planner handoff", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-planner-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
+  writeMilestoneFile(tmp, "M001", "ROADMAP", "# Roadmap\n");
+
+  const state = makeState({
+    phase: "planning",
+    activeSlice: { id: "S01", title: "First Slice" },
+    nextAction: "Plan slice S01 (First Slice).",
+  });
+  const match = await findFirstMatch(makeCtx(tmp, state));
+  assertMatch(
+    match,
+    { ruleName: PLANNER_HANDOFF_RULE_NAME, action: "stop" },
+    "planning boundary → planner handoff",
+  );
+  if (match?.result.action === "stop") {
+    assert.match(match.result.reason, /\/gsd planner/);
+  }
+});
+
 test("dispatch-rule-coverage: executing with task plan present → execute-task", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-exec-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
@@ -350,7 +374,7 @@ test("dispatch-rule-coverage: rule registry has the expected size", () => {
   // intentionally.
   assert.equal(
     DISPATCH_RULES.length,
-    29,
+    30,
     `DISPATCH_RULES length changed (got ${DISPATCH_RULES.length}). ` +
       "If you added a rule, add a state stub to dispatch-rule-coverage.test.ts " +
       "and update this expected count.",

--- a/src/resources/extensions/gsd/tests/planner-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/planner-handoff.test.ts
@@ -1,0 +1,178 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { GSD_COMMAND_DESCRIPTION, getGsdArgumentCompletions } from "../commands/catalog.ts";
+import { handleCoreCommand } from "../commands/handlers/core.ts";
+import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import {
+  buildGsdPlannerSpawnPlan,
+  formatGsdPlannerCommand,
+  hasPlannerHandoffBeenOffered,
+  markPlannerHandoffOffered,
+  PLANNER_HANDOFF_RULE_NAME,
+} from "../planner-handoff.ts";
+import { closeDatabase, isDbAvailable } from "../gsd-db.ts";
+import type { GSDState } from "../types.ts";
+
+function writeRoadmap(basePath: string, milestoneId: string): void {
+  const milestoneDir = join(basePath, ".gsd", "milestones", milestoneId);
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, `${milestoneId}-ROADMAP.md`),
+    [
+      `# ${milestoneId}: Planner Handoff`,
+      "",
+      "**Vision:** Review the plan before implementation.",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First Slice** `risk:low` `depends:[]`",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function buildState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Planner Handoff" },
+    activeSlice: { id: "S01", title: "First Slice" },
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Plan slice S01 (First Slice).",
+    registry: [],
+    ...overrides,
+  };
+}
+
+function buildCtx(basePath: string, state: GSDState = buildState()): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Planner Handoff",
+    state,
+    prefs: undefined,
+  };
+}
+
+function findPlannerRule() {
+  const rule = DISPATCH_RULES.find(candidate => candidate.name === PLANNER_HANDOFF_RULE_NAME);
+  if (!rule) throw new Error(`missing dispatch rule: ${PLANNER_HANDOFF_RULE_NAME}`);
+  return rule;
+}
+
+describe("planner handoff command catalog", () => {
+  test("/gsd planner appears in description and completions", () => {
+    assert.match(GSD_COMMAND_DESCRIPTION, /planner/);
+    const completions = getGsdArgumentCompletions("pla");
+    const entry = completions.find(completion => completion.value === "planner");
+
+    assert.ok(entry, "planner should appear in top-level completions");
+    assert.match(entry.description, /customize/i);
+  });
+
+  test("planner nested completions expose dry-run", () => {
+    const completions = getGsdArgumentCompletions("planner --");
+
+    assert.ok(
+      completions.some(completion => completion.value === "planner --dry-run"),
+      "planner should suggest --dry-run",
+    );
+  });
+});
+
+describe("planner handoff command handler", () => {
+  test("/gsd planner dry-run prints the launch command", async () => {
+    const notifications: Array<{ message: string; level?: string }> = [];
+    const ctx = {
+      ui: {
+        notify(message: string, level?: string) {
+          notifications.push({ message, level });
+        },
+      },
+    };
+
+    const handled = await handleCoreCommand("planner M001 --dry-run --inspect", ctx as any);
+
+    assert.equal(handled, true);
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0]?.level, "info");
+    assert.match(notifications[0]?.message ?? "", /^gsd-planner --project /);
+    assert.match(notifications[0]?.message ?? "", / --milestone M001 /);
+    assert.match(notifications[0]?.message ?? "", / --inspect$/);
+  });
+});
+
+describe("planner handoff launcher", () => {
+  test("builds gsd-planner command with project and milestone context", () => {
+    const plan = buildGsdPlannerSpawnPlan({
+      basePath: "/tmp/project with spaces",
+      milestoneId: "M001",
+      extraArgs: ["--inspect"],
+    });
+
+    assert.deepEqual(plan, {
+      command: "gsd-planner",
+      args: ["--project", "/tmp/project with spaces", "--milestone", "M001", "--inspect"],
+      cwd: "/tmp/project with spaces",
+    });
+    assert.equal(
+      formatGsdPlannerCommand(plan),
+      'gsd-planner --project "/tmp/project with spaces" --milestone M001 --inspect',
+    );
+  });
+
+  test("records one-shot handoff markers per milestone", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "gsd-planner-marker-"));
+    try {
+      assert.equal(hasPlannerHandoffBeenOffered(basePath, "M001"), false);
+      markPlannerHandoffOffered(basePath, "M001");
+      assert.equal(hasPlannerHandoffBeenOffered(basePath, "M001"), true);
+      assert.equal(hasPlannerHandoffBeenOffered(basePath, "M002"), false);
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("planner handoff dispatch rule", () => {
+  test("pauses once after roadmap planning before plan-slice dispatch", async () => {
+    if (isDbAvailable()) closeDatabase();
+    const basePath = mkdtempSync(join(tmpdir(), "gsd-planner-dispatch-"));
+    try {
+      writeRoadmap(basePath, "M001");
+      const rule = findPlannerRule();
+
+      const first = await rule.match(buildCtx(basePath));
+      assert.ok(first, "planner handoff should match the first time");
+      assert.equal(first!.action, "stop");
+      if (first!.action === "stop") {
+        assert.equal(first!.level, "warning");
+        assert.match(first!.reason, /\/gsd planner/);
+        assert.match(first!.reason, /\/gsd auto/);
+      }
+
+      const second = await rule.match(buildCtx(basePath));
+      assert.equal(second, null, "handoff marker should make the pause one-shot");
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("rule is ordered before plan-slice and execute-task dispatch", () => {
+    const plannerIdx = DISPATCH_RULES.findIndex(rule => rule.name === PLANNER_HANDOFF_RULE_NAME);
+    const planSliceIdx = DISPATCH_RULES.findIndex(rule => rule.name.startsWith("planning → plan-slice"));
+    const executeTaskIdx = DISPATCH_RULES.findIndex(rule => rule.name.startsWith("executing → execute-task"));
+
+    assert.ok(plannerIdx >= 0, "planner handoff rule must be registered");
+    assert.ok(planSliceIdx >= 0, "plan-slice rule must be registered");
+    assert.ok(executeTaskIdx >= 0, "execute-task rule must be registered");
+    assert.ok(plannerIdx < planSliceIdx, "planner handoff must preempt plan-slice");
+    assert.ok(plannerIdx < executeTaskIdx, "planner handoff must preempt execute-task");
+  });
+});

--- a/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
@@ -32,6 +32,7 @@ import {
 import { deriveStateFromDb } from "../state.ts";
 import { _clearGsdRootCache } from "../paths.ts";
 import { invalidateAllCaches } from "../cache.ts";
+import { markPlannerHandoffOffered } from "../planner-handoff.ts";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -172,6 +173,7 @@ test("#4551: dispatch rule injects failure context and clears session field", as
 
   const state = await deriveStateFromDb(base);
   assert.equal(state.phase, "planning", "state must be in planning phase");
+  markPlannerHandoffOffered(base, "M001", "command");
 
   const session = new AutoSession();
   session.basePath = base;
@@ -232,6 +234,7 @@ test("#4551: dispatch rule does NOT inject stale failure for a different slice",
   invalidateAllCaches();
 
   const state = await deriveStateFromDb(base);
+  markPlannerHandoffOffered(base, "M001", "command");
 
   const session = new AutoSession();
   session.basePath = base;


### PR DESCRIPTION
## TL;DR

**What:** Adds an optional `gsd-planner` handoff after milestone planning.
**Why:** Users need a chance to review and customize a plan before GSD begins creating or implementing it.
**How:** Adds a one-shot auto-mode pause, a `/gsd planner` launcher command, command docs/completions, and focused tests.

## What

This adds a planning review handoff for GSD milestones:

- Auto-mode now pauses once after roadmap-level planning is available and before plan-slice or task execution dispatches.
- The pause tells users to run `/gsd planner` to launch `gsd-planner`, or `/gsd auto` to continue without planner changes.
- `/gsd planner [MID] [--dry-run]` launches `gsd-planner` with project and milestone context.
- Command help, completions, and user docs include the new planner command.
- Focused tests cover command exposure, dry-run routing, launch command formatting, one-shot markers, and dispatch rule ordering.

## Why

Planning currently moves directly into creation/implementation once the roadmap is available. This gives users an explicit review point where they can customize or modify the generated plan first.

Closes #474

## How

The handoff uses a lightweight marker under `.gsd/runtime/planner-handoffs/` so auto-mode offers the planner option once per milestone and does not loop if the user chooses to continue. The dispatch rule is placed before plan-slice and execute-task rules so the handoff happens before implementation work begins.

The launcher builds `gsd-planner --project <path> --milestone <MID>` and runs it detached. If the binary is unavailable, the command surfaces the exact manual command to run.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/planner-handoff.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`
- `git diff --check`

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783197338&installation_id=134682257&pr_number=483&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F483&signature=7456ac9e386280f205b87f838e021478a74fff83bb45e57666b7a08526ca691d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive workflow pause and external process spawn; no auth, data, or payment paths touched. Main risk is auto-mode stopping unexpectedly until the user resumes or uses the planner.
> 
> **Overview**
> Adds an optional **plan review checkpoint** between milestone roadmap planning and slice/task implementation.
> 
> **Auto-mode** gains a one-shot pause when planning is ready to move into `plan-slice` (roadmap present, no closed tasks or implementation artifacts yet). The pause message points users to **`/gsd planner`** to open **`gsd-planner`**, or **`/gsd auto`** to skip review. A marker under `.gsd/runtime/planner-handoffs/` ensures the offer happens once per milestone (skipped in headless mode).
> 
> **`/gsd planner [MID] [--dry-run]`** builds and launches `gsd-planner --project … [--milestone …]` detached; dry-run prints the command, and failed spawns show the manual command. Help text, command catalog/completions, and user docs document the new command.
> 
> Tests cover dispatch rule ordering, one-shot markers, command routing, and pre-exec gate tests that mark the handoff so they still reach `plan-slice`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8849763b8e2dc41fee62ab2ce522ba9ceccb996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->