### PR TITLE
fix(issue): [Bug]: Failed to run provider setup

### DIFF
--- a/scripts/install/handoff.js
+++ b/scripts/install/handoff.js
@@ -22,10 +22,21 @@ export function resolveGsdBin({ isLocal, cwd = process.cwd() }) {
   return join(binDir, 'gsd')
 }
 
+// On Windows, .cmd shims cannot be executed directly by spawnSync without a
+// shell. Use `cmd /c <bin> <args>` to avoid both ENOENT failures and the
+// Node 22 DEP0190 deprecation triggered by `shell: true` with args.
+function buildSpawnInvocation(bin, args) {
+  if (process.platform === 'win32') {
+    return { cmd: 'cmd', args: ['/c', bin, ...args] }
+  }
+  return { cmd: bin, args }
+}
+
 export function runConfigHandoff({ bin, nonInteractive }) {
   if (nonInteractive) return { skipped: true }
 
-  const result = spawnSync(bin, ['config'], {
+  const inv = buildSpawnInvocation(bin, ['config'])
+  const result = spawnSync(inv.cmd, inv.args, {
     stdio: 'inherit',
     timeout: 600_000,
     env: { ...process.env, [GSD_SUPPRESS_LOGO_ENV]: '1' },
@@ -52,7 +63,8 @@ export async function promptLaunch({ bin, clack: p, nonInteractive }) {
 
   if (p.isCancel(launch) || !launch) return false
 
-  const result = spawnSync(bin, [], {
+  const inv = buildSpawnInvocation(bin, [])
+  const result = spawnSync(inv.cmd, inv.args, {
     stdio: 'inherit',
   })
 
@@ -64,7 +76,8 @@ export async function promptLaunch({ bin, clack: p, nonInteractive }) {
 }
 
 export function verifyInstall(bin) {
-  const result = spawnSync(bin, ['--version'], {
+  const inv = buildSpawnInvocation(bin, ['--version'])
+  const result = spawnSync(inv.cmd, inv.args, {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 10_000,

--- a/src/tests/installer-handoff.test.ts
+++ b/src/tests/installer-handoff.test.ts
@@ -15,7 +15,7 @@ test('runConfigHandoff suppresses duplicate logo in gsd config subprocess', () =
     'utf-8',
   )
   assert.match(source, /GSD_SUPPRESS_LOGO/)
-  assert.match(source, /spawnSync\(bin, \['config'\], \{[\s\S]*env: \{ \.\.\.process\.env, \[GSD_SUPPRESS_LOGO_ENV\]: '1' \}/)
+  assert.match(source, /buildSpawnInvocation\(bin, \['config'\]\)[\s\S]*env: \{ \.\.\.process\.env, \[GSD_SUPPRESS_LOGO_ENV\]: '1' \}/)
 })
 
 test('promptLaunch does not time out the interactive agent session', () => {


### PR DESCRIPTION
## Summary
- Added a `buildSpawnInvocation` Windows `.cmd` shim wrapper to `handoff.js` (mirroring the existing pattern in `claude-cli-check.ts`) so `runConfigHandoff`/`promptLaunch`/`verifyInstall` invoke `cmd /c <bin> <args>` on Windows instead of failing with ENOENT; updated the corresponding test regex; all 5 handoff tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #484
- [#484 [Bug]: Failed to run provider setup](https://github.com/open-gsd/gsd-pi/issues/484)

## User
- @razllivan

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/484-bug-failed-to-run-provider-setup-1780607038`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to installer handoff subprocess spawning on Windows; non-Windows behavior is unchanged and no auth or data paths are touched.
> 
> **Overview**
> Fixes Windows installer handoffs where **`spawnSync` directly on `gsd.cmd`** failed with ENOENT during provider setup, launch, and version verification.
> 
> Adds **`buildSpawnInvocation`** in `handoff.js` so on Windows subprocesses run as **`cmd /c <bin> <args>`** instead of relying on `shell: true` (which avoids Node 22 DEP0190). **`runConfigHandoff`**, **`promptLaunch`**, and **`verifyInstall`** all route through this helper; logo suppression for `gsd config` is unchanged. The installer-handoff source test now asserts the wrapper is used for the config spawn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741659a0c55215c6d2448a0fedab90b424f8f1d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783199290&installation_id=134682257&pr_number=485&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F485&signature=b9b68e89471c9fd2a776de158199fc35964522ab1f5704f7632e04267e9b9611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->