### PR TITLE
fix(gsd): launch gsd-browser for live/mixed UAT and gate web UAT classification

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -212,6 +212,29 @@ describe('complete-slice verification gate (#3580)', () => {
     }
   });
 
+  test('allows an artifact-driven UAT whose "navigate" step targets a file, not a browser', async () => {
+    // Bugbot regression: a bare "navigate to <file/API>" must not trip the gate
+    // just because it contains the word "navigate".
+    const body = [
+      '## UAT Type',
+      '- UAT mode: artifact-driven',
+      '',
+      '## Test Cases',
+      '1. Navigate to the generated report file and confirm the schema section exists.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /browser-capable mode/i,
+        `non-web "navigate" must not trip the browser gate, got: ${result.error}`,
+      );
+    }
+  });
+
   test('allows a browser UAT when it is declared browser-executable', async () => {
     const body = BROWSER_UAT_BODY.replace('artifact-driven', 'browser-executable');
     const result = await handleCompleteSlice(

--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -155,6 +155,93 @@ describe('complete-slice verification gate (#3580)', () => {
     }
   });
 
+  // ── Browser/web UAT classification gate (M001/S03 regression) ──────────
+  const BROWSER_UAT_BODY = [
+    '## UAT Type',
+    '- UAT mode: artifact-driven',
+    '',
+    '## Smoke Test',
+    '1. Open the page in a browser and perform add/edit/complete/delete once.',
+  ].join('\n');
+
+  test('rejects an artifact-driven UAT that drives a browser (open the page in a browser)', async () => {
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: BROWSER_UAT_BODY }),
+      basePath,
+    );
+    assert.ok('error' in result, 'expected handler to reject a browser UAT mislabeled artifact-driven');
+    assert.match((result as { error: string }).error, /browser-capable mode|browser-executable/i);
+  });
+
+  test('rejects a runtime-executable UAT that navigates to a localhost URL', async () => {
+    const body = [
+      '## UAT Type',
+      '- UAT mode: runtime-executable',
+      '',
+      '## Test Cases',
+      '1. Navigate to http://localhost:3000 and verify the dashboard renders.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    assert.ok('error' in result, 'expected handler to reject a browser UAT mislabeled runtime-executable');
+    assert.match((result as { error: string }).error, /browser-capable mode|browser-executable/i);
+  });
+
+  test('allows an artifact-driven UAT that only disclaims browser coverage (no false positive)', async () => {
+    // S01-style: genuinely artifact-driven persistence scaffolding that merely
+    // mentions "cross-browser" / "browser-level" in a Not-Proven disclaimer.
+    const body = [
+      '## UAT Type',
+      '- UAT mode: artifact-driven',
+      '',
+      '## Not Proven By This UAT',
+      '- Interactive browser-level CRUD and real cross-browser localStorage behavior.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /browser-capable mode/i,
+        `disclaimer-only mention must not trip the browser gate, got: ${result.error}`,
+      );
+    }
+  });
+
+  test('allows a browser UAT when it is declared browser-executable', async () => {
+    const body = BROWSER_UAT_BODY.replace('artifact-driven', 'browser-executable');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /browser-capable mode/i,
+        `browser-executable UAT must pass the browser gate, got: ${result.error}`,
+      );
+    }
+  });
+
+  test('allows a browser UAT when it is declared mixed (mixed receives browser tools)', async () => {
+    const body = BROWSER_UAT_BODY.replace('artifact-driven', 'mixed (artifact-driven + browser)');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /browser-capable mode/i,
+        `mixed UAT must pass the browser gate, got: ${result.error}`,
+      );
+    }
+  });
+
   test('backfills prior verification narrative when verification is omitted on re-completion', async () => {
     // Seed full_summary_md with a prior verification narrative (simulates a
     // previous completion where the verification text was recorded).

--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -170,23 +170,31 @@ describe('complete-slice verification gate (#3580)', () => {
       basePath,
     );
     assert.ok('error' in result, 'expected handler to reject a browser UAT mislabeled artifact-driven');
-    assert.match((result as { error: string }).error, /browser-capable mode|browser-executable/i);
+    assert.match((result as { error: string }).error, /requires browser verification/i);
   });
 
-  test('rejects a runtime-executable UAT that navigates to a localhost URL', async () => {
+  test('allows a runtime-executable UAT that runs a browser test command (playwright)', async () => {
+    // Bugbot regression: runtime-executable legitimately drives a browser via a
+    // command captured by gsd_uat_exec — it must not be pushed to gsd-browser.
     const body = [
       '## UAT Type',
       '- UAT mode: runtime-executable',
       '',
       '## Test Cases',
-      '1. Navigate to http://localhost:3000 and verify the dashboard renders.',
+      '1. Run `npx playwright test` and confirm a passing exit code; capture a screenshot artifact.',
+      '2. Hit http://localhost:3000/health and assert a 200 response.',
     ].join('\n');
     const result = await handleCompleteSlice(
       makeParams({ uatContent: body }),
       basePath,
     );
-    assert.ok('error' in result, 'expected handler to reject a browser UAT mislabeled runtime-executable');
-    assert.match((result as { error: string }).error, /browser-capable mode|browser-executable/i);
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /artifact-driven|browser-capable|browser verification/i,
+        `runtime-executable command UATs must not be gated, got: ${result.error}`,
+      );
+    }
   });
 
   test('allows an artifact-driven UAT that only disclaims browser coverage (no false positive)', async () => {
@@ -206,7 +214,7 @@ describe('complete-slice verification gate (#3580)', () => {
     if ('error' in result) {
       assert.doesNotMatch(
         result.error,
-        /browser-capable mode/i,
+        /requires browser verification/i,
         `disclaimer-only mention must not trip the browser gate, got: ${result.error}`,
       );
     }
@@ -229,7 +237,7 @@ describe('complete-slice verification gate (#3580)', () => {
     if ('error' in result) {
       assert.doesNotMatch(
         result.error,
-        /browser-capable mode/i,
+        /requires browser verification/i,
         `non-web "navigate" must not trip the browser gate, got: ${result.error}`,
       );
     }
@@ -244,7 +252,7 @@ describe('complete-slice verification gate (#3580)', () => {
     if ('error' in result) {
       assert.doesNotMatch(
         result.error,
-        /browser-capable mode/i,
+        /requires browser verification/i,
         `browser-executable UAT must pass the browser gate, got: ${result.error}`,
       );
     }
@@ -259,7 +267,7 @@ describe('complete-slice verification gate (#3580)', () => {
     if ('error' in result) {
       assert.doesNotMatch(
         result.error,
-        /browser-capable mode/i,
+        /requires browser verification/i,
         `mixed UAT must pass the browser gate, got: ${result.error}`,
       );
     }

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -93,6 +93,33 @@ test("browser-executable UAT presentation uses direct managed browser tools", ()
   assert.ok(!presentation.presentedTools.some((toolName) => toolName.startsWith("mcp__gsd-browser__")));
 });
 
+test("live-runtime and mixed UAT presentations also surface gsd-browser tools", () => {
+  // Regression (M001/S03): the run-uat prompt tells live-runtime and mixed to
+  // drive a browser, so the runner must actually receive the browser tools and
+  // a hybrid surface — otherwise live checks silently downgrade to NEEDS-HUMAN.
+  for (const uatType of ["live-runtime", "mixed", "human-experience"] as const) {
+    const presentation = buildRunUatPresentationForType(uatType);
+    assert.equal(presentation.surface, "hybrid", `${uatType} should use the hybrid surface`);
+    for (const toolName of RUN_UAT_BROWSER_TOOL_NAMES) {
+      assert.ok(
+        presentation.presentedTools.includes(toolName),
+        `${uatType} presentation should include browser tool ${toolName}`,
+      );
+    }
+  }
+});
+
+test("artifact-driven and runtime-executable UAT presentations stay browser-free", () => {
+  for (const uatType of ["artifact-driven", "runtime-executable"] as const) {
+    const presentation = buildRunUatPresentationForType(uatType);
+    assert.equal(presentation.surface, "mcp", `${uatType} should use the mcp surface`);
+    assert.ok(
+      !RUN_UAT_BROWSER_TOOL_NAMES.some((toolName) => presentation.presentedTools.includes(toolName)),
+      `${uatType} presentation should not include browser tools`,
+    );
+  }
+});
+
 test("workflow-start prompt defaults to autonomy instead of per-phase confirmation", () => {
   const prompt = readPrompt("workflow-start");
   assert.match(prompt, /Keep moving by default/i);

--- a/src/resources/extensions/gsd/tool-presentation-plan.ts
+++ b/src/resources/extensions/gsd/tool-presentation-plan.ts
@@ -123,12 +123,31 @@ export function buildRunUatCanonicalToolNames(options: { includeBrowserTools?: r
   ]);
 }
 
+// UAT modes whose run-uat instructions direct the runner to exercise the live
+// app in a browser. These modes receive the gsd-browser tool surface so the
+// runner can actually launch gsd-browser instead of silently deferring browser
+// checks to a human. See run-uat.md automation rules: `browser-executable`,
+// `live-runtime`, and `mixed` are all told to drive a browser/runtime path, and
+// `human-experience` is told to capture screenshots. Without this, a webpage
+// UAT classified as anything but `browser-executable` had no browser tools and
+// downgraded its live checks to NEEDS-HUMAN (M001/S03 regression).
+export const BROWSER_INCLUSIVE_UAT_TYPES: readonly string[] = [
+  "browser-executable",
+  "live-runtime",
+  "mixed",
+  "human-experience",
+];
+
+function uatTypeIncludesBrowser(uatType: string | undefined): boolean {
+  return uatType !== undefined && BROWSER_INCLUSIVE_UAT_TYPES.includes(uatType);
+}
+
 export function runUatBrowserToolsForType(uatType: string | undefined): readonly string[] {
-  return uatType === "browser-executable" ? RUN_UAT_BROWSER_TOOL_NAMES : [];
+  return uatTypeIncludesBrowser(uatType) ? RUN_UAT_BROWSER_TOOL_NAMES : [];
 }
 
 export function runUatPresentationSurfaceForType(uatType: string | undefined): ToolPresentationSurface {
-  return uatType === "browser-executable" ? "hybrid" : "mcp";
+  return uatTypeIncludesBrowser(uatType) ? "hybrid" : "mcp";
 }
 
 export function buildRunUatPresentationForType(

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -35,6 +35,7 @@ import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../path
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache, extractUatType } from "../files.js";
+import { hasBrowserRequiredText } from "../browser-evidence.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb } from "../markdown-renderer.js";
 import { parseRoadmap } from "../parsers-legacy.js";
@@ -344,19 +345,22 @@ export async function handleCompleteSlice(
 
   // ── Browser/web UAT classification gate ────────────────────────────────
   // A UAT that drives a running web UI (opening a page in a browser,
-  // navigating a URL, or hitting localhost) must declare a browser-capable
-  // mode so the run-uat runner surfaces gsd-browser and actually launches it.
-  // Otherwise the browser checks get silently deferred to a human and the slice
-  // passes on static checks alone (M001/S03 regression). `browser-executable`,
+  // navigating to a page/localhost) must declare a browser-capable mode so the
+  // run-uat runner surfaces gsd-browser and actually launches it. Otherwise the
+  // browser checks get silently deferred to a human and the slice passes on
+  // static checks alone (M001/S03 regression). `browser-executable`,
   // `live-runtime`, and `mixed` all receive browser tools (see
   // BROWSER_INCLUSIVE_UAT_TYPES); only the non-browser modes are rejected here.
-  const BROWSER_UAT_SIGNALS =
-    /\b(?:in (?:a|the|your|one|any)\s+(?:modern\s+)?browser|open(?:ing)?\s+(?:the\s+)?(?:page|app|site)\b|navigat\w*\s+to\b|gsd-browser|https?:\/\/localhost|localhost:\d)\b/i;
+  //
+  // Reuse the canonical hasBrowserRequiredText detector (also used by dispatch
+  // and milestone validation): it skips Not-Proven/Out-of-Scope disclaimer
+  // sections and only treats verbs like navigate/open as web when they sit next
+  // to browser/page/localhost — avoiding false positives on CLI/file/API steps.
   const NON_BROWSER_UAT_MODES = new Set(["artifact-driven", "runtime-executable"]);
   const declaredUatMode = extractUatType(params.uatContent || "") ?? "artifact-driven";
-  if (NON_BROWSER_UAT_MODES.has(declaredUatMode) && BROWSER_UAT_SIGNALS.test(params.uatContent || "")) {
+  if (NON_BROWSER_UAT_MODES.has(declaredUatMode) && hasBrowserRequiredText(params.uatContent || "")) {
     return {
-      error: `UAT describes browser/web interaction (opening a page in a browser, navigating a URL, or hitting localhost) but declares non-browser mode "${declaredUatMode}". A webpage/site/app UAT must use a browser-capable mode so gsd-browser launches automatically — set "UAT mode: browser-executable" (or a browser-inclusive "mixed"/"live-runtime") and include at least one concrete browser check. Re-author the UAT Type section and complete the slice again.`,
+      error: `UAT describes browser/web interaction (opening a page in a browser, navigating to a page or localhost) but declares non-browser mode "${declaredUatMode}". A webpage/site/app UAT must use a browser-capable mode so gsd-browser launches automatically — set "UAT mode: browser-executable" (or a browser-inclusive "mixed"/"live-runtime") and include at least one concrete browser check. Re-author the UAT Type section and complete the slice again.`,
     };
   }
 

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -356,11 +356,17 @@ export async function handleCompleteSlice(
   // and milestone validation): it skips Not-Proven/Out-of-Scope disclaimer
   // sections and only treats verbs like navigate/open as web when they sit next
   // to browser/page/localhost — avoiding false positives on CLI/file/API steps.
-  const NON_BROWSER_UAT_MODES = new Set(["artifact-driven", "runtime-executable"]);
+  //
+  // Only `artifact-driven` is gated. It is the one mode that performs no
+  // execution at all (static/file checks), so a browser-requiring UAT under it
+  // genuinely defers verification to a human. Every other mode has a real
+  // verification path: `runtime-executable` runs browser test commands like
+  // `npx playwright test` via gsd_uat_exec, and live-runtime/mixed/
+  // browser-executable receive gsd-browser tools (BROWSER_INCLUSIVE_UAT_TYPES).
   const declaredUatMode = extractUatType(params.uatContent || "") ?? "artifact-driven";
-  if (NON_BROWSER_UAT_MODES.has(declaredUatMode) && hasBrowserRequiredText(params.uatContent || "")) {
+  if (declaredUatMode === "artifact-driven" && hasBrowserRequiredText(params.uatContent || "")) {
     return {
-      error: `UAT describes browser/web interaction (opening a page in a browser, navigating to a page or localhost) but declares non-browser mode "${declaredUatMode}". A webpage/site/app UAT must use a browser-capable mode so gsd-browser launches automatically — set "UAT mode: browser-executable" (or a browser-inclusive "mixed"/"live-runtime") and include at least one concrete browser check. Re-author the UAT Type section and complete the slice again.`,
+      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but declares "UAT mode: artifact-driven", which only runs static/file checks and would defer the browser work to a human. Use a mode that actually verifies the UI: "browser-executable" (interactive gsd-browser), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
     };
   }
 

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -34,7 +34,7 @@ import { getGatesForTurn } from "../gate-registry.js";
 import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
-import { saveFile, clearParseCache } from "../files.js";
+import { saveFile, clearParseCache, extractUatType } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb } from "../markdown-renderer.js";
 import { parseRoadmap } from "../parsers-legacy.js";
@@ -340,6 +340,24 @@ export async function handleCompleteSlice(
   const BLOCKED_SIGNALS = /\b(status:\s*blocked|verification_result:\s*failed|slice is blocked|cannot complete|verification failed)\b/i;
   if (BLOCKED_SIGNALS.test(params.verification || "") || BLOCKED_SIGNALS.test(params.uatContent || "")) {
     return { error: `slice verification indicates blocked/failed state — do not complete a slice that has not passed verification. Address the blockers and re-verify first.` };
+  }
+
+  // ── Browser/web UAT classification gate ────────────────────────────────
+  // A UAT that drives a running web UI (opening a page in a browser,
+  // navigating a URL, or hitting localhost) must declare a browser-capable
+  // mode so the run-uat runner surfaces gsd-browser and actually launches it.
+  // Otherwise the browser checks get silently deferred to a human and the slice
+  // passes on static checks alone (M001/S03 regression). `browser-executable`,
+  // `live-runtime`, and `mixed` all receive browser tools (see
+  // BROWSER_INCLUSIVE_UAT_TYPES); only the non-browser modes are rejected here.
+  const BROWSER_UAT_SIGNALS =
+    /\b(?:in (?:a|the|your|one|any)\s+(?:modern\s+)?browser|open(?:ing)?\s+(?:the\s+)?(?:page|app|site)\b|navigat\w*\s+to\b|gsd-browser|https?:\/\/localhost|localhost:\d)\b/i;
+  const NON_BROWSER_UAT_MODES = new Set(["artifact-driven", "runtime-executable"]);
+  const declaredUatMode = extractUatType(params.uatContent || "") ?? "artifact-driven";
+  if (NON_BROWSER_UAT_MODES.has(declaredUatMode) && BROWSER_UAT_SIGNALS.test(params.uatContent || "")) {
+    return {
+      error: `UAT describes browser/web interaction (opening a page in a browser, navigating a URL, or hitting localhost) but declares non-browser mode "${declaredUatMode}". A webpage/site/app UAT must use a browser-capable mode so gsd-browser launches automatically — set "UAT mode: browser-executable" (or a browser-inclusive "mixed"/"live-runtime") and include at least one concrete browser check. Re-author the UAT Type section and complete the slice again.`,
+    };
   }
 
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───


### PR DESCRIPTION
## Linked issue

Closes #486

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Surface gsd-browser tools for browser-driving UAT modes and reject web UATs that declare a non-browser mode.
**Why:** A webpage UAT (M001/S03) passed without ever launching gsd-browser because only `browser-executable` UATs received the browser tools.
**How:** Broaden the run-uat browser tool surface to all browser-driving modes, plus a slice-complete classification gate.

## What

- `tool-presentation-plan.ts` — `runUatBrowserToolsForType` / `runUatPresentationSurfaceForType` now surface the gsd-browser tool set and the `hybrid` surface for every UAT mode the run-uat prompt directs to a browser, via a new `BROWSER_INCLUSIVE_UAT_TYPES` constant (`browser-executable`, `live-runtime`, `mixed`, `human-experience`). `artifact-driven`/`runtime-executable` stay browser-free.
- `tools/complete-slice.ts` — new classification gate alongside the existing `BLOCKED_SIGNALS` guard: rejects a UAT that drives a browser (opens a page, navigates a URL, hits localhost) but declares `artifact-driven`/`runtime-executable`, with an actionable message to use `browser-executable` (or a browser-inclusive `mixed`/`live-runtime`).
- Tests in `prompt-contracts.test.ts` and `complete-slice-verification-gate.test.ts`.

## Why

In `M001/S03` a `mixed`-classified webpage UAT reported "no browser tools configured", downgraded its live browser checks to `NEEDS-HUMAN`, and still returned `PASS` — so the browser smoke test never ran (not by gsd-browser, not by a human). Milestone validation later flagged the missing evidence and blocked the milestone. The run-uat prompt *tells* `mixed`/`live-runtime` to drive a browser, but the tool surface withheld the tools from those modes.

## How

Two complementary layers:

1. **Runtime surface** — any mode the prompt sends to a browser now actually receives the browser tools + hybrid surface, so the runner launches gsd-browser instead of deferring to a human.
2. **Classification gate** — a web/UI slice can no longer be silently mislabeled as a non-browser mode at authoring time. The detector is tuned to imperative test-step phrases ("open the page in a browser", "navigate to", localhost), so a "Not Proven By This UAT" disclaimer mentioning "cross-browser" does not false-positive (explicit regression test).

Combined: if a UAT is a webpage/site/app, gsd-browser runs.

Not changed here: `mixed`/`live-runtime` can still technically PASS with a `NEEDS-HUMAN` browser check. Now that the tools are actually available, tightening `validateUatMode` for those modes is a reasonable follow-up.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

New/updated tests:
- `prompt-contracts.test.ts` — asserts `live-runtime`/`mixed`/`human-experience` get browser tools + hybrid surface; `artifact-driven`/`runtime-executable` stay browser-free.
- `complete-slice-verification-gate.test.ts` — 5 new cases: reject browser-driving `artifact-driven`/`runtime-executable` UATs; allow `browser-executable`, `mixed`, and disclaimer-only `artifact-driven`.

All 67 prompt-contract + 12 gate tests pass locally.

## AI disclosure

- [x] This PR includes AI-assisted code (Claude Code; verified by running the affected unit tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783203022&installation_id=134682257&pr_number=487&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F487&signature=8cd322f8f17b0749d116c99b09c4f504d7cf859f65a8c97413e60625d2e0f20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow verification and tool-presentation changes are covered by new unit tests; no auth, data, or public API surface changes.
> 
> **Overview**
> Fixes a regression where **run-uat** could tell the runner to use a browser for modes like `live-runtime` and `mixed`, but only **`browser-executable`** actually received **gsd-browser** tools and a **hybrid** surface—so live checks often became **NEEDS-HUMAN** while the slice still completed.
> 
> **`tool-presentation-plan.ts`** introduces **`BROWSER_INCLUSIVE_UAT_TYPES`** (`browser-executable`, `live-runtime`, `mixed`, `human-experience`) so those modes get browser tools and **hybrid**; **`artifact-driven`** / **`runtime-executable`** stay on **mcp** without browser tools.
> 
> **`complete-slice.ts`** adds a gate: **`artifact-driven`** UAT whose body **`hasBrowserRequiredText`** detects as web UI work is rejected with guidance to pick a browser-capable mode (reusing the shared detector to avoid disclaimer/file-navigation false positives).
> 
> Tests lock presentation contracts and gate accept/reject cases (playwright **runtime-executable**, disclaimers, file **navigate**, **mixed** / **browser-executable**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f0f19b3183dd3020308a8adc61e26f6479eef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->