### PR TITLE
fix(gsd): make web UAT work — gate classification + repair gsd-browser launch/auto-init

### DIFF
--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -520,6 +520,25 @@ function formatManagedBrowserError(toolName: string, error: unknown): string {
   ].join("\n");
 }
 
+/**
+ * Eagerly establish the managed gsd-browser connection so browser tools are
+ * ready before first use. Best-effort: returns the error instead of throwing so
+ * callers (e.g. session-start warm-up) can surface a warning without failing the
+ * session. Connecting only spawns the gsd-browser MCP daemon; it does not launch
+ * Chrome (that happens lazily on the first navigation).
+ */
+export async function warmUpManagedGsdBrowser(
+  ctx?: ExtensionContext,
+  signal?: AbortSignal,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await getOrConnectManagedGsdBrowser(ctx, signal);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 export function registerManagedGsdBrowserTools(pi: ExtensionAPI): void {
   for (const tool of MANAGED_BROWSER_TOOLS) {
     pi.registerTool({

--- a/src/resources/extensions/browser-tools/index.ts
+++ b/src/resources/extensions/browser-tools/index.ts
@@ -1,8 +1,9 @@
 /** browser-tools — Pi Browser Automation Contract adapter. */
-import { importExtensionModule, type ExtensionAPI } from "@gsd/pi-coding-agent";
+import { importExtensionModule, type ExtensionAPI, type ExtensionContext } from "@gsd/pi-coding-agent";
 
-import { closeManagedGsdBrowser, registerManagedGsdBrowserTools } from "./engine/managed-gsd-browser.js";
+import { closeManagedGsdBrowser, registerManagedGsdBrowserTools, warmUpManagedGsdBrowser } from "./engine/managed-gsd-browser.js";
 import { resolveBrowserEngineMode, type BrowserEngineMode } from "./engine/selection.js";
+import { detectWebApp } from "./web-app-detect.js";
 
 let legacyRegistrationPromise: Promise<void> | null = null;
 let managedRegistrationPromise: Promise<void> | null = null;
@@ -184,6 +185,34 @@ async function registerBrowserTools(pi: ExtensionAPI): Promise<void> {
   }
 }
 
+function isWarmUpDisabled(): boolean {
+  const value = process.env.GSD_BROWSER_WARMUP?.trim().toLowerCase();
+  return value === "0" || value === "false" || value === "off";
+}
+
+/**
+ * Auto-initialize the managed gsd-browser engine when the project under
+ * development is a web app, so browser UAT tools are connected and ready instead
+ * of failing lazily on first use. Best-effort and non-blocking: warm-up runs in
+ * the background and only surfaces a warning if it fails.
+ */
+function maybeWarmUpManagedEngine(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  if (isWarmUpDisabled()) return;
+  if (resolveBrowserEngineMode() !== "gsd-browser") return;
+
+  const projectRoot = ctx.cwd || process.cwd();
+  if (!detectWebApp(projectRoot)) return;
+
+  void warmUpManagedGsdBrowser(ctx).then((result) => {
+    if (!result.ok && ctx.hasUI) {
+      ctx.ui.notify(
+        `gsd-browser auto-init failed: ${result.error}. Browser UAT tools will retry on first use; run /gsd doctor if this persists.`,
+        "warning",
+      );
+    }
+  });
+}
+
 async function closeActiveBrowserEngines(): Promise<void> {
   await closeManagedGsdBrowser();
   if (legacyRegistrationPromise) {
@@ -195,13 +224,16 @@ async function closeActiveBrowserEngines(): Promise<void> {
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     if (ctx.hasUI) {
-      void registerBrowserTools(pi).catch((error) => {
-        ctx.ui.notify(`browser-tools failed to load: ${error instanceof Error ? error.message : String(error)}`, "warning");
-      });
+      void registerBrowserTools(pi)
+        .then(() => maybeWarmUpManagedEngine(pi, ctx))
+        .catch((error) => {
+          ctx.ui.notify(`browser-tools failed to load: ${error instanceof Error ? error.message : String(error)}`, "warning");
+        });
       return;
     }
 
     await registerBrowserTools(pi);
+    maybeWarmUpManagedEngine(pi, ctx);
   });
 
   pi.on("session_shutdown", async () => {

--- a/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { resolveGsdBrowserMcpLaunchConfig } = await import("../../shared/gsd-browser-cli.ts");
+
+describe("resolveGsdBrowserMcpLaunchConfig identity flags", () => {
+  it("emits a non-empty --identity-key alongside --identity-scope", () => {
+    // Regression: gsd-browser exits immediately ("Connection closed") when
+    // --identity-scope is supplied without --identity-key.
+    const { args } = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {});
+
+    const scopeIndex = args.indexOf("--identity-scope");
+    const keyIndex = args.indexOf("--identity-key");
+
+    assert.ok(scopeIndex >= 0, "expected --identity-scope in args");
+    assert.ok(keyIndex >= 0, "expected --identity-key in args");
+    assert.equal(args[keyIndex + 1] && args[keyIndex + 1].length > 0, true, "identity-key must be non-empty");
+  });
+
+  it("keeps the identity-key stable across sessions for the same project", () => {
+    const a = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {}, { sessionSuffix: "pi-aaa" });
+    const b = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {}, { sessionSuffix: "pi-bbb" });
+
+    const keyOf = (cfg) => cfg.args[cfg.args.indexOf("--identity-key") + 1];
+    // Session names differ per pi process, but the persistent browser identity
+    // must not, so cookies/profile survive across sessions.
+    assert.notEqual(a.sessionName, b.sessionName);
+    assert.equal(keyOf(a), keyOf(b));
+  });
+
+  it("honors GSD_BROWSER_IDENTITY_KEY override", () => {
+    const { args } = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {
+      GSD_BROWSER_IDENTITY_KEY: "custom-key",
+    });
+    assert.equal(args[args.indexOf("--identity-key") + 1], "custom-key");
+  });
+});

--- a/src/resources/extensions/browser-tools/tests/web-app-detect.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/web-app-detect.test.mjs
@@ -1,0 +1,68 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const { detectWebApp } = await import("../web-app-detect.ts");
+
+function makeProject(files) {
+  const root = mkdtempSync(join(tmpdir(), "gsd-webapp-detect-"));
+  for (const [relPath, contents] of Object.entries(files)) {
+    const full = join(root, relPath);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return root;
+}
+
+describe("detectWebApp", () => {
+  const roots = [];
+  after(() => roots.forEach((root) => rmSync(root, { recursive: true, force: true })));
+
+  const project = (files) => {
+    const root = makeProject(files);
+    roots.push(root);
+    return root;
+  };
+
+  it("detects a React dependency", () => {
+    const root = project({ "package.json": JSON.stringify({ dependencies: { react: "^18.0.0" } }) });
+    assert.equal(detectWebApp(root), true);
+  });
+
+  it("detects a Vite/Next dev dependency", () => {
+    const root = project({ "package.json": JSON.stringify({ devDependencies: { vite: "^5.0.0" } }) });
+    assert.equal(detectWebApp(root), true);
+  });
+
+  it("detects a dev-server script", () => {
+    const root = project({ "package.json": JSON.stringify({ scripts: { dev: "next dev" } }) });
+    assert.equal(detectWebApp(root), true);
+  });
+
+  it("detects a static index.html site", () => {
+    const root = project({ "index.html": "<!doctype html>" });
+    assert.equal(detectWebApp(root), true);
+  });
+
+  it("returns false for a CLI/library package", () => {
+    const root = project({
+      "package.json": JSON.stringify({
+        dependencies: { commander: "^12.0.0" },
+        scripts: { build: "tsc", test: "node --test" },
+      }),
+    });
+    assert.equal(detectWebApp(root), false);
+  });
+
+  it("returns false when there is no package.json or index.html", () => {
+    const root = project({ "README.md": "# nothing" });
+    assert.equal(detectWebApp(root), false);
+  });
+
+  it("does not throw on malformed package.json", () => {
+    const root = project({ "package.json": "{ not valid json" });
+    assert.equal(detectWebApp(root), false);
+  });
+});

--- a/src/resources/extensions/browser-tools/web-app-detect.ts
+++ b/src/resources/extensions/browser-tools/web-app-detect.ts
@@ -1,0 +1,64 @@
+/**
+ * web-app-detect — lightweight, synchronous heuristic for deciding whether the
+ * project under development is a web app. Used to decide whether to proactively
+ * warm up the managed gsd-browser engine at session start so browser UAT tools
+ * are ready instead of failing lazily on first use.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Frontend frameworks / bundlers whose presence in dependencies indicates a
+// browser-facing web app worth warming the browser engine for.
+const WEB_DEPENDENCY_RE =
+  /^(react|react-dom|next|nuxt|vue|@vue\/|svelte|@sveltejs\/|solid-js|astro|@remix-run\/|gatsby|preact|@angular\/core|vite|@vitejs\/|@builder\.io\/qwik|@web\/dev-server|@11ty\/eleventy)/;
+
+// package.json scripts that imply a dev server / browser-facing build.
+const WEB_SCRIPT_RE = /\b(vite|next|nuxt|astro|remix|webpack(-dev-server)?|parcel|ng serve|serve\b|http-server|live-server|gatsby)\b/;
+
+interface MinimalPackageJson {
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+  peerDependencies?: Record<string, unknown>;
+  scripts?: Record<string, unknown>;
+}
+
+function readPackageJson(projectRoot: string): MinimalPackageJson | null {
+  const packageJsonPath = resolve(projectRoot, "package.json");
+  if (!existsSync(packageJsonPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as MinimalPackageJson) : null;
+  } catch {
+    return null;
+  }
+}
+
+function dependencyNames(pkg: MinimalPackageJson): string[] {
+  return [
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+  ];
+}
+
+/**
+ * Returns true when the project looks like a browser-facing web app. Conservative
+ * and dependency-free: a false negative just means lazy connection (the prior
+ * behavior); a false positive only warms an idle engine connection.
+ */
+export function detectWebApp(projectRoot: string): boolean {
+  const pkg = readPackageJson(projectRoot);
+  if (pkg) {
+    if (dependencyNames(pkg).some((name) => WEB_DEPENDENCY_RE.test(name))) return true;
+    const scriptValues = Object.values(pkg.scripts ?? {}).filter(
+      (value): value is string => typeof value === "string",
+    );
+    if (scriptValues.some((script) => WEB_SCRIPT_RE.test(script))) return true;
+  }
+
+  // No package.json signal — fall back to a top-level index.html (static sites).
+  if (existsSync(resolve(projectRoot, "index.html"))) return true;
+  if (existsSync(resolve(projectRoot, "public", "index.html"))) return true;
+
+  return false;
+}

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -35,6 +35,8 @@ import { detectStuck } from "./detect-stuck.js";
 import { runUnit } from "./run-unit.js";
 import { debugLog } from "../debug-logger.js";
 import { resolveWorktreeProjectRoot, normalizeWorktreePathForCompare } from "../worktree-root.js";
+import { buildManualValidationGuidance } from "../worktree-manager.js";
+import { relSliceFile } from "../paths.js";
 import { classifyProject } from "../detection.js";
 import { MergeConflictError } from "../git-service.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
@@ -2956,10 +2958,21 @@ export async function runFinalize(
   }
 
   if (pauseAfterUatDispatch) {
-    ctx.ui.notify(
-      "UAT requires human execution. Auto-mode will pause after this unit writes the result file.",
-      "info",
-    );
+    const pauseMid = iterData.mid;
+    const pauseSliceId = pauseMid && iterData.unitId.startsWith(`${pauseMid}/`)
+      ? iterData.unitId.slice(pauseMid.length + 1)
+      : undefined;
+    const guidance = pauseMid
+      ? buildManualValidationGuidance(s.basePath, pauseMid, {
+          uatPath: pauseSliceId
+            ? relSliceFile(s.basePath, pauseMid, pauseSliceId, "UAT")
+            : undefined,
+        })
+      : null;
+    const pauseMessage = guidance
+      ? `UAT requires human execution. Auto-mode will pause after this unit writes the result file.\n\n${guidance}`
+      : "UAT requires human execution. Auto-mode will pause after this unit writes the result file.";
+    ctx.ui.notify(pauseMessage, "info");
     await deps.pauseAuto(ctx, pi);
     debugLog("autoLoop", { phase: "exit", reason: "uat-pause" });
     clearFinalizingUnit();

--- a/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-project-config.test.ts
@@ -54,7 +54,13 @@ test("ensureProjectWorkflowMcpConfig creates .mcp.json with workflow and browser
       "--identity-scope",
       "project",
     ]);
-    assert.equal(browserArgs[mcpArgIndex + 6], projectRoot);
+    // --identity-scope requires a non-empty --identity-key or gsd-browser exits
+    // immediately ("Connection closed"); the key must be stable per project.
+    assert.equal(browserArgs[mcpArgIndex + 5], "--identity-key");
+    assert.equal(typeof browserArgs[mcpArgIndex + 6], "string");
+    assert.ok((browserArgs[mcpArgIndex + 6] ?? "").length > 0, "identity-key must be non-empty");
+    assert.equal(browserArgs[mcpArgIndex + 7], "--identity-project");
+    assert.equal(browserArgs[mcpArgIndex + 8], projectRoot);
     assert.equal((browserServer as { cwd?: string })?.cwd, projectRoot);
 
     const settings = JSON.parse(readFileSync(join(projectRoot, ".claude", "settings.local.json"), "utf-8")) as {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -836,6 +836,135 @@ test("executeUatResultSave merges canonical plan ID and read-only tools when pre
   }
 });
 
+test("executeUatResultSave surfaces the worktree validation path for NEEDS-HUMAN checks", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  const evidenceId = "uat-human-validation-evidence";
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S07", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: {
+          kind: "uat_exec",
+          milestoneId: "M001",
+          sliceId: "S07",
+          checkId: "UAT-01",
+          intent: "uat-runtime-check",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S07",
+      uatType: "human-experience",
+      verdict: "PASS",
+      checks: [
+        {
+          id: "UAT-01",
+          description: "Service boots and renders the dashboard",
+          mode: "runtime",
+          result: "PASS",
+          evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
+          notes: "Boot check passed.",
+        },
+        {
+          id: "UAT-02",
+          description: "Dashboard layout feels balanced",
+          mode: "human-follow-up",
+          result: "NEEDS-HUMAN",
+          nonAutomatable: true,
+          notes: "Open the app and eyeball the spacing.",
+        },
+      ],
+      notes: "Automatable checks passed; layout taste needs a human.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.verdict, "PASS");
+    // The reviewer needs the buried worktree checkout path, not just the file.
+    assert.equal(result.details.manualValidationPath, worktree);
+    const returnedText = (result.content[0] as { text: string }).text;
+    assert.match(returnedText, /Manual validation needed/);
+    assert.ok(returnedText.includes(worktree), "tool return should include the worktree path");
+
+    const assessment = readFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S07", "S07-ASSESSMENT.md"),
+      "utf-8",
+    );
+    assert.match(assessment, /## Manual Validation/);
+    assert.ok(assessment.includes(worktree), "assessment should include the worktree checkout path");
+    assert.match(assessment, /git worktree/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeUatResultSave omits manual-validation guidance when no human checks remain", async () => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const worktreeExecDir = join(worktree, ".gsd", "exec");
+  const evidenceId = "uat-no-human-evidence";
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S08", "complete");
+    mkdirSync(worktreeExecDir, { recursive: true });
+    writeFileSync(
+      join(worktreeExecDir, `${evidenceId}.meta.json`),
+      JSON.stringify({
+        id: evidenceId,
+        metadata: {
+          kind: "uat_exec",
+          milestoneId: "M001",
+          sliceId: "S08",
+          checkId: "UAT-01",
+          intent: "uat-artifact-check",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await inProjectDir(worktree, () => executeUatResultSave({
+      milestoneId: "M001",
+      sliceId: "S08",
+      uatType: "artifact-driven",
+      verdict: "PASS",
+      checks: [{
+        id: "UAT-01",
+        description: "Config file exists",
+        mode: "artifact",
+        result: "PASS",
+        evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
+        notes: "Artifact present.",
+      }],
+      notes: "Fully automated pass.",
+    } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.manualValidationPath, undefined);
+    const returnedText = (result.content[0] as { text: string }).text;
+    assert.equal(returnedText.includes("Manual validation needed"), false);
+
+    const assessment = readFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S08", "S08-ASSESSMENT.md"),
+      "utf-8",
+    );
+    assert.equal(assessment.includes("## Manual Validation"), false);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeUatResultSave rejects saved UAT without fresh UAT-owned evidence", async () => {
   const base = makeTmpBase();
   const worktree = join(base, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -17,8 +17,9 @@ import {
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
-import { clearPathCache, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { clearPathCache, relSliceFile, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
 import { saveFile, clearParseCache } from "../files.js";
+import { buildManualValidationGuidance, resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
@@ -1337,7 +1338,12 @@ function escapeMarkdownTableCell(value: unknown): string {
     .replace(/\r?\n/g, "<br>");
 }
 
-function renderUatAssessment(params: UatResultSaveParams, attempt: number, gateVerdict: "pass" | "flag"): string {
+function renderUatAssessment(
+  params: UatResultSaveParams,
+  attempt: number,
+  gateVerdict: "pass" | "flag",
+  basePath: string,
+): string {
   const lines = [
     "---",
     `sliceId: ${params.sliceId}`,
@@ -1372,6 +1378,27 @@ function renderUatAssessment(params: UatResultSaveParams, attempt: number, gateV
     "",
     `Aggregate UAT gate saved as ${gateVerdict}.`,
   ];
+
+  // When any check still needs a human, point them at the exact checkout to
+  // validate — critical for worktree milestones whose code sits under a hidden
+  // `.gsd/worktrees/` path the reviewer would otherwise have to hunt for.
+  const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
+  if (hasHuman) {
+    const guidance = buildManualValidationGuidance(basePath, params.milestoneId, {
+      uatPath: relSliceFile(basePath, params.milestoneId, params.sliceId, "UAT"),
+    });
+    if (guidance) {
+      lines.push(
+        "",
+        "## Manual Validation",
+        "",
+        "One or more checks are marked `NEEDS-HUMAN` and require a person to validate:",
+        "",
+        ...guidance.split("\n").map((line) => `- ${line}`),
+      );
+    }
+  }
+
   return `${lines.join("\n")}\n`;
 }
 
@@ -1424,7 +1451,7 @@ export async function executeUatResultSave(
     }
     const gateVerdict = params.verdict === "PASS" ? "pass" : "flag";
     const rationale = params.notes ?? `UAT ${params.verdict} for ${params.sliceId}.`;
-    const assessment = renderUatAssessment(params, attempt, gateVerdict);
+    const assessment = renderUatAssessment(params, attempt, gateVerdict, basePath);
     const summary = await executeSummarySave(
       {
         milestone_id: params.milestoneId,
@@ -1468,8 +1495,20 @@ export async function executeUatResultSave(
       evaluatedAt,
     });
     invalidateStateCache();
+    // Surface where to validate when checks are left for a human, so the path
+    // (often a buried worktree checkout) reaches the reviewer, not just the file.
+    const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
+    const manualGuidance = hasHuman
+      ? buildManualValidationGuidance(basePath, params.milestoneId, {
+          uatPath: relSliceFile(basePath, params.milestoneId, params.sliceId, "UAT"),
+        })
+      : null;
+    const savedText = `UAT result saved for ${params.milestoneId}/${params.sliceId}: ${params.verdict}`;
     return {
-      content: [{ type: "text", text: `UAT result saved for ${params.milestoneId}/${params.sliceId}: ${params.verdict}` }],
+      content: [{
+        type: "text",
+        text: manualGuidance ? `${savedText}\n\nManual validation needed:\n${manualGuidance}` : savedText,
+      }],
       details: {
         operation: "save_uat_result",
         milestoneId: params.milestoneId,
@@ -1479,6 +1518,9 @@ export async function executeUatResultSave(
         attempt,
         attemptPath,
         recommendedNextUnit: params.verdict === "PASS" ? null : "reactive-execute",
+        ...(hasHuman
+          ? { manualValidationPath: resolveCanonicalMilestoneRoot(basePath, params.milestoneId) }
+          : {}),
       },
     };
   } catch (err) {

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -259,6 +259,38 @@ export function resolveCanonicalMilestoneRoot(
   return wtPath;
 }
 
+/**
+ * Build human-facing guidance for manually validating a milestone's work.
+ *
+ * When a milestone runs in a git worktree, its checkout lives under the hidden
+ * `.gsd/worktrees/<MID>/` path that a human can't easily discover. The UAT
+ * pause/handoff and the saved assessment use this to tell the human exactly
+ * where to `cd` to run or inspect the app before signing off on NEEDS-HUMAN
+ * checks, rather than leaving them to hunt for a buried path.
+ *
+ * Returns null when no milestone id is available.
+ */
+export function buildManualValidationGuidance(
+  basePath: string,
+  milestoneId: string,
+  opts: { uatPath?: string } = {},
+): string | null {
+  if (!milestoneId) return null;
+  const validationRoot = resolveCanonicalMilestoneRoot(basePath, milestoneId);
+  const inWorktree = validationRoot.includes(`${sep}.gsd${sep}worktrees${sep}`);
+  const lines: string[] = [`Validate the work here: ${validationRoot}`];
+  if (inWorktree) {
+    lines.push(
+      "This milestone runs in a git worktree, so the code lives under the hidden " +
+        `\`.gsd/worktrees/\` path. Open it with: cd "${validationRoot}"`,
+    );
+  }
+  if (opts.uatPath) {
+    lines.push(`Follow the UAT checklist at: ${opts.uatPath}`);
+  }
+  return lines.join("\n");
+}
+
 // ─── Core Operations ───────────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -140,6 +140,10 @@ export function resolveGsdBrowserMcpLaunchConfig(
     : null;
   const sessionName =
     options.sessionName?.trim() || buildGsdBrowserSessionName(resolvedProjectRoot, options.sessionSuffix);
+  // Stable per-project identity key (no per-session suffix) so the browser
+  // profile/cookies persist across pi sessions for the same project. gsd-browser
+  // rejects --identity-scope unless --identity-key is also supplied.
+  const identityKey = env.GSD_BROWSER_IDENTITY_KEY?.trim() || buildGsdBrowserSessionName(resolvedProjectRoot);
   const command =
     explicitCommand
     || explicitCliPath
@@ -155,6 +159,8 @@ export function resolveGsdBrowserMcpLaunchConfig(
         sessionName,
         "--identity-scope",
         "project",
+        "--identity-key",
+        identityKey,
         "--identity-project",
         resolvedProjectRoot,
       ];


### PR DESCRIPTION
## Summary

Makes web UAT actually execute against a real browser instead of silently deferring to a human. Two halves:

**Gating (earlier commits on this branch):** classify artifact-driven UAT that contains browser requirements and route it to `browser-executable`/`mixed`/`live-runtime` so it isn't passed via static file checks alone.

**Launch repair + auto-init (this commit):** the managed gsd-browser engine never actually connected, so the gate above had nothing to run against.

## The bug

The managed engine launched the daemon with `--identity-scope project --identity-project <root>` but **no `--identity-key`**. gsd-browser rejects that combination (`--identity-scope requires --identity-key`), so the daemon exited on startup and every browser tool call failed with `MCP error -32000: Connection closed`. Broken since the managed engine landed (`dfa4fe18`).

## Changes

- **Fix launch args** — emit a stable per-project `--identity-key` (overridable via `GSD_BROWSER_IDENTITY_KEY`). Stable across pi sessions so the browser profile/cookies persist per project, matching the intent of `--identity-scope project`. Verified: connection now succeeds (62 tools listed).
- **Auto-init for web apps** — at session start, when the project looks like a web app (`detectWebApp`: framework deps / dev-server scripts / `index.html`), eagerly warm the managed engine so browser UAT tools are ready instead of failing lazily. Best-effort, non-blocking, surfaces a warning on failure, opt-out via `GSD_BROWSER_WARMUP=0`. Connecting only spawns the daemon — Chrome launches lazily on first navigation.
- **Tests** — launch-config identity-flag tests, web-app-detection tests, and updated the pinned arg-layout assertion in `mcp-project-config.test.ts`.

## Testing

- `pnpm run typecheck:extensions` — clean
- Full browser-tools suite + new tests — **72 passing**
- Reproduced the original failure and confirmed the fix connects end-to-end

## Note

A browser/Chromium binary must be present for navigation to actually run (gsd-browser launches it lazily); the connection itself no longer requires one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: surface the manual UAT validation path (commit `75b2ec6`)

The gating + launch work above makes live/mixed/human-experience UAT pause for a human. This commit makes that handoff actionable: it tells the reviewer **where** to validate — including the buried `.gsd/worktrees/<MID>/` checkout — instead of only naming a file.

- **`buildManualValidationGuidance()`** (worktree-manager) — resolves the canonical milestone root (the worktree if one exists), detects the hidden-worktree case, and returns the absolute path + a `cd "<path>"` hint + the UAT checklist path.
- **Pause/handoff** (`auto/phases.ts`) — the *"UAT requires human execution…"* notify now appends the validation path, derived from the active session base + dispatched unit (no new field threaded through the iteration pipeline).
- **Assessment + tool return** (`gsd_uat_result_save`) — adds a `## Manual Validation` section to the persisted `*-ASSESSMENT.md` and a `manualValidationPath` field to the tool result, **gated to runs that actually have `NEEDS-HUMAN` checks** so fully-automated passes stay clean.

Tests: added two cases to `workflow-tool-executors.test.ts` (path surfaces for a `human-experience` run with a `NEEDS-HUMAN` check; absent for a fully-automated `artifact-driven` pass). `tsc --noEmit` clean; full `workflow-tool-executors` suite (42) and auto-loop UAT/pause tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783205618&installation_id=134682257&pr_number=488&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F488&signature=1d6cdeb76a1f5ae4136ec29e318cb0665e58af64eb00442105da0535dd09ece7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP browser launch, session-start side effects, and UAT/auto pause messaging; behavior is guarded by env flags and covered by new tests, but browser automation remains operationally sensitive.
> 
> **Overview**
> Repairs **managed gsd-browser** so the MCP daemon can stay connected, and **pre-warms** that connection for web projects so browser UAT is ready at session start instead of failing on first tool use.
> 
> **Launch:** `resolveGsdBrowserMcpLaunchConfig` now passes a **stable per-project `--identity-key`** (optional `GSD_BROWSER_IDENTITY_KEY`) together with `--identity-scope project`, fixing immediate daemon exit / `Connection closed` when only scope was set. Session names still vary per Pi session; the identity key does not, so profiles persist.
> 
> **Warm-up:** New `warmUpManagedGsdBrowser` connects best-effort at startup. `browser-tools` calls it after registration when `detectWebApp` sees framework deps, dev-server scripts, or `index.html`, unless `GSD_BROWSER_WARMUP` is off; failures surface as a UI warning only.
> 
> **Human UAT handoff:** `buildManualValidationGuidance` points reviewers at the canonical milestone checkout (including hidden `.gsd/worktrees/` paths) and the UAT checklist. That text is added to auto-mode UAT pause notifications, `gsd_uat_result_save` responses/assessments when any check is `NEEDS-HUMAN`, and `manualValidationPath` in tool details.
> 
> Tests cover identity CLI args, web-app detection, MCP `.mcp.json` arg layout, and UAT save behavior with/without human checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b2ec69bf1e072e3c065b66dfb2ced86d979276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
