### PR TITLE
fix(gsd): re-enter active worktree on cold start instead of searching

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -589,6 +589,17 @@ export function registerHooks(
     if (isAutoActive() || preserveCloseoutSurface) {
       ctx.ui.setWidget("gsd-health", undefined);
     }
+    // Cold start after /quit relaunches with cwd at the project root. When
+    // auto-mode is neither active nor paused (its own resume path re-enters the
+    // worktree with a lease check — auto.ts:3032), proactively chdir back into
+    // the active milestone's worktree so subsequent work isn't stranded at the
+    // root. Best-effort and a no-op when already inside a worktree.
+    if (!isAutoActive() && !isAutoPaused() && !preserveCloseoutSurface) {
+      try {
+        const { reenterActiveWorktreeIfNeeded } = await import("../worktree-reentry.js");
+        await reenterActiveWorktreeIfNeeded(basePath);
+      } catch { /* non-fatal */ }
+    }
   });
 
   pi.on("session_switch", async (_event, ctx) => {

--- a/src/resources/extensions/gsd/commands/handlers/auto.ts
+++ b/src/resources/extensions/gsd/commands/handlers/auto.ts
@@ -212,12 +212,12 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
     // Cold start after /quit lands at the project root, not the worktree. If the
     // active milestone has a live worktree, chdir back into it now so the agent
     // doesn't have to search for it. Best-effort; resolves to a no-op otherwise.
-    {
+    try {
       const { reenterActiveWorktreeIfNeeded } = await import("../../worktree-reentry.js");
       await reenterActiveWorktreeIfNeeded(basePath, {
         notify: (message) => ctx.ui.notify(message, "info"),
       });
-    }
+    } catch { /* non-fatal */ }
     const { hasGsdBootstrapArtifacts } = await import("../../detection.js");
     const { gsdRoot } = await import("../../paths.js");
     if (!hasGsdBootstrapArtifacts(gsdRoot(basePath))) {

--- a/src/resources/extensions/gsd/commands/handlers/auto.ts
+++ b/src/resources/extensions/gsd/commands/handlers/auto.ts
@@ -209,6 +209,15 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
   if (trimmed === "") {
     if (!(await guardRemoteSession(ctx, pi))) return true;
     const basePath = projectRoot();
+    // Cold start after /quit lands at the project root, not the worktree. If the
+    // active milestone has a live worktree, chdir back into it now so the agent
+    // doesn't have to search for it. Best-effort; resolves to a no-op otherwise.
+    {
+      const { reenterActiveWorktreeIfNeeded } = await import("../../worktree-reentry.js");
+      await reenterActiveWorktreeIfNeeded(basePath, {
+        notify: (message) => ctx.ui.notify(message, "info"),
+      });
+    }
     const { hasGsdBootstrapArtifacts } = await import("../../detection.js");
     const { gsdRoot } = await import("../../paths.js");
     if (!hasGsdBootstrapArtifacts(gsdRoot(basePath))) {

--- a/src/resources/extensions/gsd/tests/worktree-reentry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-reentry.test.ts
@@ -1,0 +1,102 @@
+/**
+ * worktree-reentry.test.ts — Unit tests for reenterActiveWorktreeIfNeeded.
+ *
+ * Covers the cold-start (/quit + relaunch) path where cwd lands at the project
+ * root instead of the active milestone's worktree. The helper should chdir back
+ * into the worktree deterministically, and no-op when it shouldn't act.
+ */
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { createAutoWorktree, _resetAutoWorktreeOriginalBaseForTests } from "../auto-worktree.ts";
+import { reenterActiveWorktreeIfNeeded } from "../worktree-reentry.ts";
+
+// Safe: all inputs below are hardcoded test strings, not user input.
+function git(subArgs: string[], cwd: string): void {
+  execFileSync("git", subArgs, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function createTempRepo(
+  t: { after: (fn: () => void) => void },
+  opts: { isolation?: "worktree" | "none" } = {},
+): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "wt-reentry-")));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(["init"], dir);
+  git(["config", "user.email", "test@test.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  if (opts.isolation === "worktree") {
+    writeFileSync(join(dir, ".gsd", "PREFERENCES.md"), "---\ngit:\n  isolation: worktree\n---\n", "utf-8");
+  }
+  const msDir = join(dir, ".gsd", "milestones", "M001");
+  mkdirSync(msDir, { recursive: true });
+  writeFileSync(join(msDir, "CONTEXT.md"), "# M001 Context\n");
+  git(["add", "."], dir);
+  git(["commit", "-m", "init"], dir);
+  git(["branch", "-M", "main"], dir);
+  return dir;
+}
+
+describe("reenterActiveWorktreeIfNeeded", () => {
+  const savedCwd = process.cwd();
+
+  beforeEach(() => {
+    _resetAutoWorktreeOriginalBaseForTests();
+    process.chdir(savedCwd);
+  });
+
+  test("re-enters the sole live worktree when sitting at the project root", async (t) => {
+    const dir = createTempRepo(t, { isolation: "worktree" });
+    t.after(() => process.chdir(savedCwd));
+
+    // createAutoWorktree chdir's INTO the worktree; simulate a cold start by
+    // returning to the project root with a clean workspace registry.
+    createAutoWorktree(dir, "M001");
+    process.chdir(dir);
+    _resetAutoWorktreeOriginalBaseForTests();
+
+    const entered = await reenterActiveWorktreeIfNeeded(dir);
+    assert.ok(entered, "re-entry returned a worktree path");
+    assert.strictEqual(realpathSync(process.cwd()), realpathSync(entered!), "cwd moved into the worktree");
+    assert.strictEqual(entered, join(dir, ".gsd", "worktrees", "M001"));
+  });
+
+  test("no-op when already inside a worktree", async (t) => {
+    const dir = createTempRepo(t, { isolation: "worktree" });
+    t.after(() => process.chdir(savedCwd));
+
+    createAutoWorktree(dir, "M001"); // leaves cwd inside the worktree
+    const cwdBefore = process.cwd();
+
+    const entered = await reenterActiveWorktreeIfNeeded(dir);
+    assert.strictEqual(entered, null, "no re-entry when already in a worktree");
+    assert.strictEqual(process.cwd(), cwdBefore, "cwd unchanged");
+  });
+
+  test("no-op when isolation is not worktree", async (t) => {
+    const dir = createTempRepo(t, { isolation: "none" });
+    t.after(() => process.chdir(savedCwd));
+    process.chdir(dir);
+
+    const entered = await reenterActiveWorktreeIfNeeded(dir);
+    assert.strictEqual(entered, null, "isolation=none never re-enters");
+    assert.strictEqual(realpathSync(process.cwd()), realpathSync(dir), "cwd stays at project root");
+  });
+
+  test("no-op when there are no worktrees", async (t) => {
+    const dir = createTempRepo(t, { isolation: "worktree" });
+    t.after(() => process.chdir(savedCwd));
+    process.chdir(dir);
+
+    const entered = await reenterActiveWorktreeIfNeeded(dir);
+    assert.strictEqual(entered, null, "nothing to re-enter");
+    assert.strictEqual(realpathSync(process.cwd()), realpathSync(dir), "cwd stays at project root");
+  });
+});

--- a/src/resources/extensions/gsd/worktree-reentry.ts
+++ b/src/resources/extensions/gsd/worktree-reentry.ts
@@ -1,0 +1,103 @@
+// Project/App: gsd-pi
+// File Purpose: Deterministically re-enter the active milestone's worktree on a
+// cold start (after /quit + relaunch). Without this, Claude Code relaunches with
+// cwd at the project root, and a bare /gsd leaves the agent there — forcing it to
+// search the filesystem ("git worktree list", branch sniffing) to find its way
+// back into the worktree. The worktree path is fully derivable from state, so we
+// resolve and chdir into it directly instead.
+
+import { readdirSync } from "node:fs";
+
+import { enterAutoWorktree, getAutoWorktreePath } from "./auto-worktree.js";
+import { getIsolationMode } from "./preferences.js";
+import { worktreesDir } from "./worktree-manager.js";
+import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
+
+interface LiveWorktree {
+  id: string;
+  path: string;
+}
+
+/**
+ * Enumerate the live (valid git) auto-worktrees under <projectRoot>/.gsd/worktrees/.
+ * Reuses getAutoWorktreePath's validation so stray directories are ignored.
+ */
+function liveMilestoneWorktrees(projectRoot: string): LiveWorktree[] {
+  let names: string[];
+  try {
+    names = readdirSync(worktreesDir(projectRoot));
+  } catch {
+    return [];
+  }
+  const live: LiveWorktree[] = [];
+  for (const id of names) {
+    const path = getAutoWorktreePath(projectRoot, id);
+    if (path) live.push({ id, path });
+  }
+  return live;
+}
+
+/**
+ * If we're sitting at the project root with worktree isolation enabled and the
+ * active milestone has a live worktree, chdir into it. No-op when already inside
+ * a worktree, when isolation is off, or when the target is ambiguous.
+ *
+ * Single live worktree → enter it (covers the common case without deriveState).
+ * Multiple live worktrees → disambiguate by the active milestone from state;
+ * if that can't be resolved unambiguously, do nothing.
+ *
+ * Best-effort: any failure resolves to a no-op so it can never block startup.
+ *
+ * @returns the worktree path entered, or null when nothing was done.
+ */
+export async function reenterActiveWorktreeIfNeeded(
+  basePath: string,
+  opts: { notify?: (message: string) => void } = {},
+): Promise<string | null> {
+  let projectRoot: string;
+  try {
+    projectRoot = resolveWorktreeProjectRoot(basePath);
+  } catch {
+    return null;
+  }
+
+  // Only worktree-isolation projects have worktrees to re-enter.
+  if (getIsolationMode(projectRoot) !== "worktree") return null;
+
+  // Already inside a worktree (warm session, or auto-mode already entered) —
+  // nothing to do.
+  let cwd: string;
+  try {
+    cwd = process.cwd();
+  } catch {
+    return null;
+  }
+  if (isGsdWorktreePath(cwd)) return null;
+
+  const live = liveMilestoneWorktrees(projectRoot);
+  if (live.length === 0) return null;
+
+  let target: LiveWorktree | null = live.length === 1 ? live[0]! : null;
+  if (!target) {
+    // Multiple live worktrees — disambiguate by the active milestone.
+    try {
+      const { deriveState } = await import("./state.js");
+      const state = await deriveState(projectRoot);
+      const activeId = state.activeMilestone?.id;
+      target = activeId ? live.find((w) => w.id === activeId) ?? null : null;
+    } catch {
+      target = null;
+    }
+  }
+  if (!target) return null;
+
+  try {
+    const entered = enterAutoWorktree(projectRoot, target.id);
+    opts.notify?.(`Resumed in worktree for ${target.id}.`);
+    return entered;
+  } catch {
+    // Worktree vanished or chdir failed — leave cwd as-is, caller falls back to
+    // the project root.
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

When a user `/quit`s and relaunches, Claude Code starts with cwd at the **project root**, not the active worktree. A bare `/gsd` then leaves the agent stranded at the root, forcing it to *discover* the worktree by searching (`git worktree list`, branch sniffing, reading multiple `.gsd` dirs) — burning turns on every restart.

## Root cause

The only deterministic worktree re-entry was auto-mode's lease-aware resume ([`auto.ts:3032`](https://github.com/open-gsd/gsd-pi/blob/main/src/resources/extensions/gsd/auto.ts#L3032)), which a bare `/gsd` never hits. The in-memory worktree pointer ([`worktree-session-state.ts`](https://github.com/open-gsd/gsd-pi/blob/main/src/resources/extensions/gsd/worktree-session-state.ts)) is module-level and wiped on restart. Nothing re-rooted the session into the worktree.

The worktree path is fully derivable — `.gsd/worktrees/<activeMilestoneId>` — so we can resolve and `chdir` into it directly instead of searching.

## Fix

- **New helper** `reenterActiveWorktreeIfNeeded()` ([`worktree-reentry.ts`](https://github.com/open-gsd/gsd-pi/blob/fix/gsd-worktree-cold-start-reentry/src/resources/extensions/gsd/worktree-reentry.ts)) reuses the existing `getAutoWorktreePath` / `enterAutoWorktree` primitives (validate + chdir + git-cache nudge). It acts **only** when:
  - isolation mode is `worktree`,
  - cwd is *not* already inside a worktree,
  - and the target is unambiguous — the sole live worktree, else disambiguated by `state.activeMilestone`.

  Fully best-effort: any failure resolves to a silent no-op so it can never block startup.
- **`session_start` hook** re-enters on cold start, gated on `!isAutoActive() && !isAutoPaused()` so it never pre-empts auto-mode's own lease-checked resume path.
- **Bare `/gsd` handler** re-enters (with a "Resumed in worktree for M001." notice) before showing the home menu — covers the exact reported symptom.

## Design note

In the multi-worktree case (parallel milestones, or stranded/unmerged ones) the helper disambiguates strictly by the active milestone and otherwise does **nothing** — never guessing, to avoid dropping the user into the wrong milestone's worktree. This mirrors the MCP server's existing `resolveSoleActiveWorktree` (null when `live.length !== 1`).

## Testing

- New `worktree-reentry.test.ts` — 4 cases: re-enters sole worktree; no-op when already inside / isolation off / no worktrees. ✅
- Existing `auto-worktree-registry` suite still passes. ✅
- `tsc --noEmit` clean. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783213056&installation_id=134682257&pr_number=489&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F489&signature=39cc731cc2b61447c20fbc3a7dde224cf9cadd2b2c4cec00b9a6a170c1b99486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort `chdir` only when isolation and target are clear; gated away from auto-mode resume and covered by focused unit tests.
> 
> **Overview**
> After `/quit` and relaunch, the session often starts at the **project root** while milestone work lives in `.gsd/worktrees/<id>`, so a bare `/gsd` left the agent to rediscover the worktree with git/search tools.
> 
> This PR adds **`reenterActiveWorktreeIfNeeded`**, which (when `git.isolation` is `worktree`, cwd is not already in a worktree, and the target is unambiguous) uses existing `getAutoWorktreePath` / `enterAutoWorktree` to `chdir` into the right tree—one live worktree, or multiple disambiguated via `state.activeMilestone`; otherwise it no-ops. Failures are silent so startup is never blocked.
> 
> It is wired on **`session_start`** (only when auto-mode is not active or paused, so auto’s lease-aware resume is not preempted) and on **bare `/gsd`** (with an optional “Resumed in worktree for …” notice). **`worktree-reentry.test.ts`** covers re-entry and the main no-op cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a045983c6cb2e38f86761fb30a462c26f3d841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->