### PR TITLE
fix(browser-tools): default browser automation to playwright

### DIFF
--- a/docs/dev/ADR-024-gsd-browser-primary-browser-engine.md
+++ b/docs/dev/ADR-024-gsd-browser-primary-browser-engine.md
@@ -1,68 +1,88 @@
-# ADR-024: Make gsd-browser the Primary Browser Automation Engine
+# ADR-024: Keep Playwright as the Default Browser Automation Engine
 
 **Status:** Accepted
 **Date:** 2026-06-03
+**Updated:** 2026-06-04
 **Related:** `CONTEXT.md`, `docs/dev/ADR-008-gsd-tools-over-mcp-for-provider-parity.md`, `docs/dev/ADR-020-cloud-mcp-gateway-local-runtime.md`
 
 ## Context
 
-GSD has two browser automation paths today. Pi Providers can receive direct `browser_*` tools from the bundled `browser-tools` extension, while Claude Code and other External MCP Clients can receive `mcp__gsd-browser__browser_*` tools from `gsd-browser mcp`.
+GSD has two browser automation paths. Pi Providers receive direct `browser_*`
+tools from the bundled `browser-tools` extension, while Claude Code and other
+External MCP Clients can receive `mcp__gsd-browser__browser_*` tools from
+`gsd-browser mcp`.
 
-That split creates a confusing failure mode: GSD prompts tell agents to use `gsd-browser`, but non-Claude Pi Providers may silently execute through the legacy Playwright-backed browser tools instead. Debug and UAT failures then appear to come from Playwright even when the intended product contract is `gsd-browser`.
+The managed `gsd-browser` path gives GSD a richer browser automation surface,
+but making it the default introduced startup and availability failures in places
+where the existing Playwright-backed browser tools still worked. The product
+contract agents see should stay stable as canonical `browser_*` tools; the
+engine choice behind those tools should be an explicit runtime decision.
 
 ## Decision
 
-`gsd-browser` is the primary Browser Automation Engine for GSD. The existing `browser-tools` extension remains the Pi-facing Browser Automation Contract adapter and continues to register canonical `browser_*` tools for Pi Providers.
+Playwright is the default Browser Automation Engine for Pi Providers. The
+existing `browser-tools` extension remains the Pi-facing Browser Automation
+Contract adapter and continues to register canonical `browser_*` tools such as
+`browser_navigate`, `browser_snapshot_refs`, and `browser_assert`.
 
-Inside Pi, Providers should call canonical `browser_*` tools such as `browser_navigate`, `browser_snapshot_refs`, and `browser_assert`. Pi hides the transport detail and routes those tools through an internal MCP bridge to `gsd-browser mcp`. MCP-shaped names such as `mcp__gsd-browser__browser_navigate` remain an External MCP Client concern and a Claude Code host concern.
+`gsd-browser` remains available for External MCP Clients through `/gsd mcp init`
+and as an explicit managed-engine opt-in for Pi Providers via
+`GSD_BROWSER_ENGINE=gsd-browser`. MCP-shaped names such as
+`mcp__gsd-browser__browser_navigate` remain an External MCP Client concern and a
+Claude Code host concern.
 
-Pi owns a managed built-in `gsd-browser` engine configuration resolved from the bundled `@opengsd/gsd-browser` dependency. Project `.mcp.json` generation remains for External MCP Clients through `/gsd mcp init`; it is not required for Pi Providers to use browser automation.
+The explicit engine selector is `GSD_BROWSER_ENGINE=gsd-browser|legacy|off`.
+With no environment override, GSD uses the Playwright-backed `legacy` engine.
+`GSD_BROWSER_ENGINE=playwright` is accepted as an alias for `legacy`, and `off`
+disables Pi's Browser Automation Contract tools except for browser tools
+supplied directly by an External MCP Client or host integration.
 
-`/gsd mcp init` writes both the GSD workflow MCP server and the `gsd-browser` MCP server for External MCP Clients by default. `GSD_BROWSER_MCP_ENABLED=0` disables only the browser entry in generated external MCP config; it does not control Pi's managed Browser Automation Engine.
+Project `.mcp.json` generation remains for External MCP Clients through
+`/gsd mcp init`; it is not required for Pi Providers to use browser automation.
+`GSD_BROWSER_MCP_ENABLED=0` disables only the browser entry in generated
+external MCP config. It does not control Pi's built-in browser tools.
 
-The managed engine should have a browser-specific connection manager. It may share low-level MCP connection utilities with the generic `mcp-client` extension, but it must not expose generic `mcp_call` behavior to the model or inherit project-local trust prompts intended for arbitrary MCP servers. Its responsibility is the Browser Automation Contract: stable canonical tools, Unit/debug-scoped browser sessions, engine health, teardown, and fail-closed behavior for browser-required workflows.
-
-The first Pi-facing surface is a curated stable subset of the Browser Automation Contract, matching the browser tools GSD already depends on for debug and run-uat flows. Broader `gsd-browser` capabilities such as live viewer, recordings, auth vault, visual diff, and advanced diagnostics can be added deliberately instead of exposing the entire MCP tool surface by default.
-
-Browser evidence is artifact-first and image-optional. Tools such as `browser_screenshot` should save evidence to artifact paths and return text/structured metadata that every Provider can consume. Providers that support image tool results may also receive image blocks, but browser verification must not depend on image ingestion alone. Assertions, snapshots, console/network logs, and evidence refs remain the primary verification surface.
-
-When `gsd-browser` cannot start, browser-required Units and commands fail closed with an actionable engine error. They must not silently fall back to the legacy Playwright implementation. Legacy browser-tools behavior remains available only as an explicit compatibility fallback, not the default for new installs.
-
-The explicit engine selector is `GSD_BROWSER_ENGINE=gsd-browser|legacy|off`, defaulting to `gsd-browser`. `legacy` forces the Playwright-backed compatibility implementation, and `off` disables Pi's Browser Automation Contract tools except for browser tools supplied directly by an External MCP Client or host integration. `GSD_BROWSER_MCP_ENABLED` remains scoped to `.mcp.json` generation for External MCP Clients.
-
-Browser identity is project-scoped, while runtime browser sessions are Unit/debug-session scoped. GSD should use project identity for durable auth and state, but use distinct named `gsd-browser` sessions so parallel Units, worktrees, and debug sessions do not share one active page.
+Browser evidence is artifact-first and image-optional. Tools such as
+`browser_screenshot` should save evidence to artifact paths and return
+text/structured metadata that every Provider can consume. Assertions, snapshots,
+console/network logs, and evidence refs remain the primary verification surface.
 
 ## Consequences
 
-- GSD has one product-level Browser Automation Contract for Pi Providers and External MCP Clients.
-- `browser-tools` becomes a contract adapter rather than the name of the legacy Playwright implementation.
-- `gsd-browser mcp` is the implementation boundary inside Pi because the package is distributed as a CLI/native binary and its MCP server is the primary agent path.
-- `/gsd mcp init` remains useful, but only for MCP-capable hosts outside Pi or host integrations that expose MCP names directly; its user-facing copy should describe both workflow and browser MCP servers.
-- Doctor/onboarding should verify that `gsd-browser mcp` can start and list tools, while runtime should lazily connect only when browser automation is needed.
-- Browser evidence remains usable on Providers that cannot ingest image tool results directly.
-- Engine selection is explicit and separate from External MCP Client config generation.
+- GSD keeps one product-level Browser Automation Contract based on canonical
+  `browser_*` names.
+- Pi Providers use Playwright by default, avoiding managed `gsd-browser` startup
+  failures unless the operator explicitly opts into that engine.
+- `/gsd mcp init` remains useful for MCP-capable hosts outside Pi or host
+  integrations that expose MCP names directly.
+- The managed `gsd-browser` engine can continue to evolve without blocking the
+  default browser verification path.
+- Engine selection stays separate from External MCP Client config generation.
 
 ## Migration Order
 
-1. Add the managed `gsd-browser mcp` engine manager under `browser-tools`.
-2. Route the curated canonical `browser_*` tool subset through that engine, keeping legacy Playwright behavior behind an explicit compatibility fallback.
-3. Make debug, run-uat, and other browser-required flows fail closed when the primary engine is unavailable.
-4. Update `/gsd mcp init` copy, docs, doctor, and onboarding so users understand that `.mcp.json` is for External MCP Clients while Pi Providers use the managed engine.
+1. Keep the managed `gsd-browser mcp` engine manager under `browser-tools`.
+2. Default `resolveBrowserEngineMode()` to `legacy` while preserving explicit
+   `gsd-browser`, `playwright`, and `off` modes.
+3. Keep debug, run-uat, and other browser-required flows using canonical
+   `browser_*` tools so the prompt contract does not leak engine details.
+4. Update `/gsd mcp init` copy, docs, and prompts so users understand that
+   `.mcp.json` is for External MCP Clients while Pi Providers use built-in
+   browser tools.
 
 ## Alternatives Considered
 
+### Make `gsd-browser` the default
+
+Rejected for now. It provides richer capabilities, but current managed-engine
+startup failures can block browser verification even when Playwright succeeds.
+
 ### Expose MCP-shaped names to all Providers
 
-Rejected. It would leak transport naming into Pi prompts and tool policy, undoing the Browser Automation Contract boundary.
+Rejected. It would leak transport naming into Pi prompts and tool policy,
+undoing the Browser Automation Contract boundary.
 
-### Wrap `gsd-browser` CLI commands directly
+### Remove the managed `gsd-browser` path
 
-Rejected. CLI wrapping would duplicate schemas, response handling, batching, resources, and future MCP improvements that already exist in `gsd-browser mcp`.
-
-### Add a second Pi browser extension
-
-Rejected. A new extension would compete with `browser-tools` for the same canonical `browser_*` names and increase migration risk.
-
-### Silent fallback to legacy Playwright tools
-
-Rejected. Silent fallback hides install/runtime regressions and makes debug evidence harder to trust.
+Rejected. External MCP Clients still need it, and Pi Providers may opt into it
+when the managed engine is appropriate for their environment.

--- a/docs/dev/FILE-SYSTEM-MAP.md
+++ b/docs/dev/FILE-SYSTEM-MAP.md
@@ -15,7 +15,7 @@
 | **Auth / OAuth** | Authentication, OAuth flows, token storage |
 | **Auto Engine** | GSD autonomous execution loop, dispatch, supervision |
 | **Bg Shell** | Background process / interactive shell management |
-| **Browser Tools** | Browser Automation Contract adapter and managed gsd-browser engine integration |
+| **Browser Tools** | Browser Automation Contract adapter backed by Playwright by default, with optional managed gsd-browser integration |
 | **Build System** | Scripts for build, packaging, version management, CI |
 | **CLI** | Command-line entry points and argument parsing |
 | **CMux** | Tmux/multiplexer session integration |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -60,7 +60,7 @@ GSD workflow code must treat the active project/worktree as explicit state, not 
 | Extension | What It Provides |
 |-----------|-----------------|
 | **GSD** | Core workflow engine — auto mode, state machine, commands, dashboard |
-| **Browser Tools** | Browser Automation Contract adapter backed by managed gsd-browser by default, with explicit legacy Playwright compatibility |
+| **Browser Tools** | Browser Automation Contract adapter backed by Playwright by default, with explicit managed gsd-browser opt-in |
 | **Search the Web** | Brave Search, Tavily, or Jina page extraction |
 | **Google Search** | Gemini-powered web search with AI-synthesized answers |
 | **Context7** | Up-to-date library/framework documentation |

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -126,7 +126,7 @@ If both files exist, server names are merged and the first definition found wins
 
 Use `gsd-browser` when GSD or an external MCP client needs deterministic browser automation, versioned element refs, assertions, screenshots, visual diffs, recordings, or a live human takeover viewer.
 
-For GSD Pi Providers such as Codex and non-Claude harnesses, `@opengsd/gsd-browser` is bundled with GSD and used as the default managed browser engine. External MCP clients use a project MCP entry instead. The easiest way to write that entry is:
+For GSD Pi Providers such as Codex and non-Claude harnesses, browser tools are backed by Playwright by default. `@opengsd/gsd-browser` remains bundled for External MCP Clients and for explicit managed-engine opt-in. The easiest way to write the external MCP entry is:
 
 ```bash
 /gsd mcp init
@@ -145,7 +145,7 @@ If you prefer to maintain the MCP entry manually, add:
 }
 ```
 
-Keep this in `.gsd/mcp.json` when browser paths, vault settings, or session state are machine-local. Use `.mcp.json` only when the team should share the same server entry. Set `GSD_BROWSER_MCP_ENABLED=0` only to skip writing the external MCP entry; it does not disable GSD's managed browser engine. Use `GSD_BROWSER_ENGINE=legacy` for the Playwright compatibility engine or `GSD_BROWSER_ENGINE=off` to disable GSD-managed Pi browser tools.
+Keep this in `.gsd/mcp.json` when browser paths, vault settings, or session state are machine-local. Use `.mcp.json` only when the team should share the same server entry. Set `GSD_BROWSER_MCP_ENABLED=0` only to skip writing the external MCP entry; it does not disable Pi browser tools. Use `GSD_BROWSER_ENGINE=gsd-browser` for the managed engine, `GSD_BROWSER_ENGINE=playwright` or `legacy` for the default Playwright engine, or `GSD_BROWSER_ENGINE=off` to disable Pi browser tools.
 
 ### Example: HTTP server
 

--- a/docs/user-docs/providers.md
+++ b/docs/user-docs/providers.md
@@ -98,7 +98,7 @@ You can also trigger this manually from inside a GSD session:
 
 This writes (or updates) the `gsd-workflow` and `gsd-browser` entries in your project's `.mcp.json`. Claude Code discovers this file automatically on its next session start.
 
-GSD's own Pi Providers, including Codex and non-Claude harnesses, do not need `.mcp.json` to use browser automation. They receive canonical `browser_*` tools from GSD, and GSD routes those tools through the managed bundled `gsd-browser` engine by default.
+GSD's own Pi Providers, including Codex and non-Claude harnesses, do not need `.mcp.json` to use browser automation. They receive canonical `browser_*` tools from GSD, backed by Playwright by default. Set `GSD_BROWSER_ENGINE=gsd-browser` only when you intentionally want the managed bundled `gsd-browser` engine.
 
 **Manual setup:**
 

--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -514,9 +514,9 @@ function formatManagedBrowserError(toolName: string, error: unknown): string {
   return [
     `gsd-browser engine or tool unavailable for ${toolName}: ${message}`,
     "",
-    "GSD browser automation now uses the managed gsd-browser engine by default.",
+    "The managed gsd-browser engine is enabled for this session but is unavailable.",
     "Run /gsd doctor or reinstall dependencies so @opengsd/gsd-browser is available.",
-    "Set GSD_BROWSER_ENGINE=legacy only when you intentionally need the Playwright compatibility engine.",
+    "Unset GSD_BROWSER_ENGINE or set GSD_BROWSER_ENGINE=playwright to use the default Playwright engine.",
   ].join("\n");
 }
 

--- a/src/resources/extensions/browser-tools/engine/selection.ts
+++ b/src/resources/extensions/browser-tools/engine/selection.ts
@@ -1,6 +1,6 @@
 export type BrowserEngineMode = "gsd-browser" | "legacy" | "off";
 
-const DEFAULT_BROWSER_ENGINE: BrowserEngineMode = "gsd-browser";
+const DEFAULT_BROWSER_ENGINE: BrowserEngineMode = "legacy";
 
 export function resolveBrowserEngineMode(env: NodeJS.ProcessEnv = process.env): BrowserEngineMode {
   const raw = env.GSD_BROWSER_ENGINE?.trim();

--- a/src/resources/extensions/browser-tools/extension-manifest.json
+++ b/src/resources/extensions/browser-tools/extension-manifest.json
@@ -2,7 +2,7 @@
   "id": "browser-tools",
   "name": "Browser Tools",
   "version": "1.0.0",
-  "description": "GSD browser automation contract adapter backed by the managed gsd-browser engine",
+  "description": "GSD browser automation contract adapter backed by Playwright with optional managed gsd-browser support",
   "tier": "bundled",
   "requires": { "platform": ">=2.29.0" },
   "provides": {

--- a/src/resources/extensions/browser-tools/index.ts
+++ b/src/resources/extensions/browser-tools/index.ts
@@ -191,10 +191,9 @@ function isWarmUpDisabled(): boolean {
 }
 
 /**
- * Auto-initialize the managed gsd-browser engine when the project under
- * development is a web app, so browser UAT tools are connected and ready instead
- * of failing lazily on first use. Best-effort and non-blocking: warm-up runs in
- * the background and only surfaces a warning if it fails.
+ * Auto-initialize the managed gsd-browser engine only when explicitly selected
+ * for a web app. Best-effort and non-blocking: warm-up runs in the background
+ * and only surfaces a warning if it fails.
  */
 function maybeWarmUpManagedEngine(pi: ExtensionAPI, ctx: ExtensionContext): void {
   if (isWarmUpDisabled()) return;

--- a/src/resources/extensions/browser-tools/tests/browser-engine-selection.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/browser-engine-selection.test.mjs
@@ -11,8 +11,8 @@ const jiti = require("jiti")(__dirname, { interopDefault: true, debug: false });
 const { resolveBrowserEngineMode } = jiti("../engine/selection.ts");
 
 describe("resolveBrowserEngineMode", () => {
-  it("defaults to gsd-browser", () => {
-    assert.equal(resolveBrowserEngineMode({}), "gsd-browser");
+  it("defaults to the Playwright engine", () => {
+    assert.equal(resolveBrowserEngineMode({}), "legacy");
   });
 
   it("accepts the explicit engine modes", () => {

--- a/src/resources/extensions/browser-tools/web-app-detect.ts
+++ b/src/resources/extensions/browser-tools/web-app-detect.ts
@@ -1,14 +1,13 @@
 /**
  * web-app-detect — lightweight, synchronous heuristic for deciding whether the
- * project under development is a web app. Used to decide whether to proactively
- * warm up the managed gsd-browser engine at session start so browser UAT tools
- * are ready instead of failing lazily on first use.
+ * project under development is a web app. Used only when the optional managed
+ * gsd-browser engine is selected and can be warmed before first use.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 // Frontend frameworks / bundlers whose presence in dependencies indicates a
-// browser-facing web app worth warming the browser engine for.
+// browser-facing web app worth warming the optional managed engine for.
 const WEB_DEPENDENCY_RE =
   /^(react|react-dom|next|nuxt|vue|@vue\/|svelte|@sveltejs\/|solid-js|astro|@remix-run\/|gatsby|preact|@angular\/core|vite|@vitejs\/|@builder\.io\/qwik|@web\/dev-server|@11ty\/eleventy)/;
 

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -61,7 +61,7 @@ export const BUNDLED_SKILL_TRIGGERS: Array<{ trigger: string; skill: string }> =
   { trigger: "Core Web Vitals — fix LCP, CLS, INP; layout shifts; page experience optimization", skill: "core-web-vitals" },
   { trigger: "GitHub Actions CI/CD — write, run, and debug workflow files; live syntax and run monitoring", skill: "github-workflows" },
   { trigger: "Comprehensive web quality audit — performance, accessibility, SEO, and best-practices (Lighthouse-style)", skill: "web-quality-audit" },
-  { trigger: "gsd-browser UAT — default browser MCP/CLI for real UI verification, screenshots, assertions, console/network diagnostics", skill: "gsd-browser" },
+  { trigger: "Browser UAT — browser tools for real UI verification, screenshots, assertions, console/network diagnostics", skill: "agent-browser" },
   { trigger: "Browser automation — open sites, fill forms, click, screenshot, scrape, or test web apps programmatically", skill: "agent-browser" },
   { trigger: "Review UI code for Web Interface Guidelines compliance — UX, design, and accessibility patterns", skill: "web-design-guidelines" },
   { trigger: "UI/UX patterns reference — animations, CSS, typography, prefetching, icons (file:line findings)", skill: "userinterface-wiki" },

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -73,7 +73,7 @@ export function formatMcpInitResult(
     `Config:   ${configPath}`,
     "",
     "MCP-capable clients can now load the GSD workflow and gsd-browser MCP servers from this folder.",
-    "Pi Providers use the managed gsd-browser engine directly; this project config is for External MCP Clients.",
+    "Pi Providers use built-in browser tools directly; this project config is for External MCP Clients.",
     "Restart or reconnect any client that already has this project open.",
   ].join("\n");
 }

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -27,7 +27,7 @@ You are the UAT runner. Execute every check defined in `{{uatPath}}` as deeply a
 ### Automation rules by mode
 
 - `artifact-driven` — verify with shell commands, scripts, file reads, and artifact structure checks.
-- `browser-executable` — use gsd-browser tools to navigate to the target URL and verify expected behavior. Prefer `mcp__gsd-browser__browser_*` tools when namespaced, or direct `browser_*` tools when surfaced without a namespace. Capture screenshots as evidence. Record pass/fail with specific assertions.
+- `browser-executable` — use browser tools to navigate to the target URL and verify expected behavior. Prefer direct `browser_*` tools when available. Capture screenshots as evidence. Record pass/fail with specific assertions.
 - `runtime-executable` — execute the specified command or script. Capture stdout/stderr as evidence. Record pass/fail based on exit code and output.
 - `live-runtime` — exercise the real runtime path. Start or connect to the app/service if needed, use browser/runtime/network checks, and verify observable behavior.
 - `mixed` — run all automatable artifact-driven and live-runtime checks. Separate any remaining human-only checks explicitly.
@@ -48,7 +48,7 @@ Choose the lightest tool that proves the check honestly:
 - Run `node` / other script invocations
 - Read files and verify their contents
 - Check that expected artifacts exist and have correct structure
-- For live/runtime/UI checks, exercise the real flow with gsd-browser when applicable and inspect runtime/network/console state
+- For live/runtime/UI checks, exercise the real flow with browser tools when applicable and inspect runtime/network/console state
 - When a check cannot be honestly automated, gather the best objective evidence you can and mark it `NEEDS-HUMAN`
 
 For each check, record:

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -118,7 +118,7 @@ Templates are in `{{templatesDir}}`.
 
 **Secrets:** Use `secure_env_collect`. Never ask the user to edit `.env` files or paste secrets.
 
-**Browser verification:** Verify frontend work against a running app with gsd-browser by default. Use `browser_find`/`browser_snapshot_refs` for discovery, refs/selectors -> `browser_batch` for actions, `browser_assert` for verification, and `browser_diff` -> console/network logs -> full inspection as last resort. If tools are MCP-namespaced, prefer `mcp__gsd-browser__browser_*`. Retry only with a new hypothesis.
+**Browser verification:** Verify frontend work against a running app with browser tools by default. Use `browser_find`/`browser_snapshot_refs` for discovery, refs/selectors -> `browser_batch` for actions, `browser_assert` for verification, and `browser_diff` -> console/network logs -> full inspection as last resort. If browser tools are MCP-namespaced, use that host-provided browser surface. Retry only with a new hypothesis.
 
 **Database:** Never query `.gsd/gsd.db` directly via `sqlite3`, `better-sqlite3`, or `node -e require('better-sqlite3')`; the engine owns a single-writer WAL connection. Use `gsd_milestone_status`, `gsd_journal_query`, or other `gsd_*` tools.
 

--- a/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/run-uat.test.ts
@@ -723,7 +723,7 @@ test('(u) run-uat prompt promotes artifact-driven browser specs to browser-execu
 
       assert.match(prompt, /\*\*Detected UAT mode:\*\*\s*`browser-executable`/);
       assert.match(prompt, /uatType: "browser-executable"/);
-      assert.match(prompt, /use gsd-browser tools/i);
+      assert.match(prompt, /use browser tools/i);
       assert.match(prompt, /"browser_navigate"/);
       assert.match(prompt, /"browser_assert"/);
     } finally {

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -342,7 +342,7 @@ describe("formatMcpInitResult", () => {
     assert.match(result, /\/tmp\/project\/\.mcp\.json/);
     assert.match(result, /mcp-capable clients/i);
     assert.match(result, /workflow and gsd-browser MCP servers/i);
-    assert.match(result, /Pi Providers use the managed gsd-browser engine/i);
+    assert.match(result, /Pi Providers use built-in browser tools/i);
     assert.doesNotMatch(result, /claude code/i);
   });
 

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -83,7 +83,7 @@ test("run-uat prompt gives the complete UAT result-save presentation contract", 
   );
 });
 
-test("browser-executable UAT presentation uses direct managed browser tools", () => {
+test("browser-executable UAT presentation uses direct browser tools", () => {
   const presentation = buildRunUatPresentationForType("browser-executable");
 
   assert.equal(presentation.surface, "hybrid");
@@ -93,7 +93,7 @@ test("browser-executable UAT presentation uses direct managed browser tools", ()
   assert.ok(!presentation.presentedTools.some((toolName) => toolName.startsWith("mcp__gsd-browser__")));
 });
 
-test("live-runtime and mixed UAT presentations also surface gsd-browser tools", () => {
+test("live-runtime and mixed UAT presentations also surface browser tools", () => {
   // Regression (M001/S03): the run-uat prompt tells live-runtime and mixed to
   // drive a browser, so the runner must actually receive the browser tools and
   // a hybrid surface — otherwise live checks silently downgrade to NEEDS-HUMAN.

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -737,13 +737,13 @@ test("executeUatResultSave supplies direct browser tools for browser-executable 
       verdict: "PASS",
       checks: [{
         id: "UAT-01",
-        description: "Browser flow used managed gsd-browser tools",
+        description: "Browser flow used browser tools",
         mode: "browser",
         result: "PASS",
         evidence: [{ kind: "gsd_uat_exec", ref: evidenceId }],
         notes: "Browser check passed.",
       }],
-      notes: "UAT passed with managed browser evidence.",
+      notes: "UAT passed with browser evidence.",
     } as unknown as Parameters<typeof executeUatResultSave>[0], worktree));
 
     assert.equal(result.isError, undefined);

--- a/src/resources/extensions/gsd/tool-presentation-plan.ts
+++ b/src/resources/extensions/gsd/tool-presentation-plan.ts
@@ -124,10 +124,10 @@ export function buildRunUatCanonicalToolNames(options: { includeBrowserTools?: r
 }
 
 // UAT modes whose run-uat instructions direct the runner to exercise the live
-// app in a browser. These modes receive the gsd-browser tool surface so the
-// runner can actually launch gsd-browser instead of silently deferring browser
-// checks to a human. See run-uat.md automation rules: `browser-executable`,
-// `live-runtime`, and `mixed` are all told to drive a browser/runtime path, and
+// app in a browser. These modes receive the browser tool surface so the runner
+// can actually drive the page instead of silently deferring browser checks to a
+// human. See run-uat.md automation rules: `browser-executable`, `live-runtime`,
+// and `mixed` are all told to drive a browser/runtime path, and
 // `human-experience` is told to capture screenshots. Without this, a webpage
 // UAT classified as anything but `browser-executable` had no browser tools and
 // downgraded its live checks to NEEDS-HUMAN (M001/S03 regression).

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -346,9 +346,9 @@ export async function handleCompleteSlice(
   // ── Browser/web UAT classification gate ────────────────────────────────
   // A UAT that drives a running web UI (opening a page in a browser,
   // navigating to a page/localhost) must declare a browser-capable mode so the
-  // run-uat runner surfaces gsd-browser and actually launches it. Otherwise the
-  // browser checks get silently deferred to a human and the slice passes on
-  // static checks alone (M001/S03 regression). `browser-executable`,
+  // run-uat runner surfaces browser tools and actually launches a browser.
+  // Otherwise the browser checks get silently deferred to a human and the slice
+  // passes on static checks alone (M001/S03 regression). `browser-executable`,
   // `live-runtime`, and `mixed` all receive browser tools (see
   // BROWSER_INCLUSIVE_UAT_TYPES); only the non-browser modes are rejected here.
   //
@@ -362,11 +362,11 @@ export async function handleCompleteSlice(
   // genuinely defers verification to a human. Every other mode has a real
   // verification path: `runtime-executable` runs browser test commands like
   // `npx playwright test` via gsd_uat_exec, and live-runtime/mixed/
-  // browser-executable receive gsd-browser tools (BROWSER_INCLUSIVE_UAT_TYPES).
+  // browser-executable receive browser tools (BROWSER_INCLUSIVE_UAT_TYPES).
   const declaredUatMode = extractUatType(params.uatContent || "") ?? "artifact-driven";
   if (declaredUatMode === "artifact-driven" && hasBrowserRequiredText(params.uatContent || "")) {
     return {
-      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but declares "UAT mode: artifact-driven", which only runs static/file checks and would defer the browser work to a human. Use a mode that actually verifies the UI: "browser-executable" (interactive gsd-browser), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
+      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but declares "UAT mode: artifact-driven", which only runs static/file checks and would defer the browser work to a human. Use a mode that actually verifies the UI: "browser-executable" (interactive browser tools), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
     };
   }
 


### PR DESCRIPTION
## TL;DR

**What:** Default Pi browser automation back to the Playwright-backed browser tools while keeping managed `gsd-browser` available as an explicit opt-in.
**Why:** Managed `gsd-browser` startup/availability failures can block browser verification even when the Playwright path works.
**How:** Switch the browser engine default to `legacy`, update UAT/prompt/docs wording to stay engine-neutral, and refresh tests around the browser tool presentation.

## What

This changes the default `GSD_BROWSER_ENGINE` behavior so Pi Providers use the Playwright-backed browser tools unless `GSD_BROWSER_ENGINE=gsd-browser` is explicitly set. The canonical `browser_*` tool contract remains unchanged.

It also updates run-UAT/system prompt wording, MCP status copy, browser docs, and ADR-024 so the visible guidance says browser tools/Playwright default instead of steering users toward managed `gsd-browser` by default.

## Why

The managed `gsd-browser` path is still useful for External MCP Clients and explicit opt-in, but making it the default created a brittle browser verification path. Reverting the default lets UAT and frontend verification continue through the working Playwright implementation while preserving the optional managed engine.

## How

The engine selector now defaults to `legacy`, with `playwright` still accepted as an alias. The managed engine warm-up remains gated behind explicit `gsd-browser` selection. Browser-inclusive UAT modes still receive canonical `browser_*` tools so browser evidence is not silently deferred.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:core`
- `pnpm test:browser-tools`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts src/resources/extensions/gsd/tests/mcp-status.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/integration/run-uat.test.ts src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts`

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783215507&installation_id=134682257&pr_number=492&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F492&signature=1437d86fd474efa4c9990199130bd164b60052c91eee3d479122848bfb1ee078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default runtime behavior for all Pi browser/UAT flows; contract and opt-in paths stay the same, but teams relying on implicit managed `gsd-browser` must set `GSD_BROWSER_ENGINE=gsd-browser`.
> 
> **Overview**
> **Pi Providers now default to the Playwright-backed browser engine** instead of managed `gsd-browser`. `resolveBrowserEngineMode()` returns `legacy` when `GSD_BROWSER_ENGINE` is unset; `playwright` remains an alias, and `GSD_BROWSER_ENGINE=gsd-browser` still opts into the managed MCP engine.
> 
> The canonical **`browser_*` tool surface is unchanged**—only the default implementation behind it moves. Managed-engine **session warm-up** runs only when `gsd-browser` is explicitly selected (not on every web app at startup). Managed-engine failure copy now tells operators to unset the env var or use `playwright` for the default path.
> 
> **ADR-024**, architecture/user docs, extension manifest, and **run-UAT / system prompts** are aligned so agents and users see engine-neutral “browser tools” / Playwright-by-default guidance rather than assuming managed `gsd-browser`. **Tests** cover the new default and updated MCP init / UAT prompt wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d1992fd411bebb7284b501d51fcfa6f25cc5bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->