### PR TITLE
fix(gsd): restore gsd-browser skill trigger

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -61,7 +61,7 @@ export const BUNDLED_SKILL_TRIGGERS: Array<{ trigger: string; skill: string }> =
   { trigger: "Core Web Vitals — fix LCP, CLS, INP; layout shifts; page experience optimization", skill: "core-web-vitals" },
   { trigger: "GitHub Actions CI/CD — write, run, and debug workflow files; live syntax and run monitoring", skill: "github-workflows" },
   { trigger: "Comprehensive web quality audit — performance, accessibility, SEO, and best-practices (Lighthouse-style)", skill: "web-quality-audit" },
-  { trigger: "Browser UAT — browser tools for real UI verification, screenshots, assertions, console/network diagnostics", skill: "agent-browser" },
+  { trigger: "gsd-browser opt-in and External MCP UAT — screenshots, assertions, console/network diagnostics", skill: "gsd-browser" },
   { trigger: "Browser automation — open sites, fill forms, click, screenshot, scrape, or test web apps programmatically", skill: "agent-browser" },
   { trigger: "Review UI code for Web Interface Guidelines compliance — UX, design, and accessibility patterns", skill: "web-design-guidelines" },
   { trigger: "UI/UX patterns reference — animations, CSS, typography, prefetching, icons (file:line findings)", skill: "userinterface-wiki" },

--- a/src/resources/extensions/gsd/tests/bundled-skill-triggers.test.ts
+++ b/src/resources/extensions/gsd/tests/bundled-skill-triggers.test.ts
@@ -76,3 +76,12 @@ test('BUNDLED_SKILL_TRIGGERS: skill ids are unique', () => {
     seen.add(skill);
   }
 });
+
+test('BUNDLED_SKILL_TRIGGERS: gsd-browser and agent-browser stay distinct', () => {
+  const gsdBrowser = BUNDLED_SKILL_TRIGGERS.find(entry => entry.skill === 'gsd-browser');
+  const agentBrowser = BUNDLED_SKILL_TRIGGERS.find(entry => entry.skill === 'agent-browser');
+
+  assert.ok(gsdBrowser, 'gsd-browser trigger should be registered');
+  assert.ok(agentBrowser, 'agent-browser trigger should be registered');
+  assert.notStrictEqual(gsdBrowser.trigger, agentBrowser.trigger);
+});


### PR DESCRIPTION
## TL;DR

**What:** Restore the bundled `gsd-browser` skill trigger while keeping Playwright as the default browser engine.
**Why:** PR #492 changed the trigger to `agent-browser`, which broke the bundled-skill registry contract and duplicated the `agent-browser` skill id.
**How:** Keep a separate `gsd-browser` trigger for explicit opt-in / External MCP UAT and leave the generic browser automation trigger mapped to `agent-browser`.

## What

This updates the bundled skill trigger registry so `gsd-browser` remains registered and skill ids stay unique.

## Why

CI failed in `BUNDLED_SKILL_TRIGGERS: PR #5060 previously-unexposed skills are present` and `skill ids are unique` after PR #492 merged. This restores the expected registry shape without changing the Playwright-default browser engine behavior.

## How

The `gsd-browser` trigger text now describes opt-in and External MCP UAT usage. The general browser automation trigger remains assigned to `agent-browser`.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/bundled-skill-triggers.test.ts`
- `git diff --check`

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783216037&installation_id=134682257&pr_number=493&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F493&signature=1455378517a490b1c7ce889ffe133dfbcd0237bc24109930c9783b6382983db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and test-only changes to bundled skill trigger metadata; no runtime browser engine or auth changes.
> 
> **Overview**
> **Restores the bundled `gsd-browser` skill trigger** in `BUNDLED_SKILL_TRIGGERS` after it was incorrectly pointed at `agent-browser`, which duplicated the skill id and broke CI checks for PR #5060 skills and unique ids.
> 
> The registry now has **two separate entries**: `gsd-browser` for opt-in / External MCP UAT (screenshots, assertions, console/network diagnostics), and `agent-browser` for general programmatic browser automation. Playwright-default engine behavior is unchanged.
> 
> A new regression test asserts both skills are registered and use **different trigger text**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb6ab6196b81db562dd80c8270082b7d2e6a9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->