### PR TITLE
[codex] Align GSD phase tool contracts with prompts

### DIFF
--- a/src/resources/extensions/gsd/prompts/plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/plan-milestone.md
@@ -14,7 +14,7 @@ All relevant context is preloaded below. Start immediately without re-reading th
 
 ## Already Planned? Soft Brake
 
-If `{{outputPath}}` exists with at least one slice line (e.g. `- [ ] **S01:`) AND `gsd_query` reports slice rows for this milestone, a prior `gsd_plan_milestone` call already persisted the plan. Do **not** re-call it; its UPSERT could overwrite existing planning. Skip to the ready phrase.
+If `{{outputPath}}` exists with at least one slice line (e.g. `- [ ] **S01:`) AND `gsd_milestone_status` reports slice rows for this milestone, a prior `gsd_plan_milestone` call already persisted the plan. Do **not** re-call it; its UPSERT could overwrite existing planning. Skip to the ready phrase.
 
 If only the file or only DB rows exist, the prior write was incomplete; plan normally so the tool reconciles both.
 

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -140,7 +140,7 @@ function makeCtx(
 test("vacuous-truth (a): unit type with empty workflow-required tools → dispatch succeeds", async () => {
   const env = makeTempProject();
   try {
-    // `refine-slice` is not in the getRequiredWorkflowToolsForAutoUnit switch
+    // `rewrite-docs` has no required workflow tools
     // → returns []. Exercises the empty-requiredTools branch in
     // applyModelPolicyFilter (existing test used
     // gate-evaluate which has non-empty required tools and never hit this path).
@@ -162,7 +162,7 @@ test("vacuous-truth (a): unit type with empty workflow-required tools → dispat
     const result = await selectAndApplyModel(
       makeCtx(availableModels),
       pi as any,
-      "refine-slice",
+      "rewrite-docs",
       "x1",
       env.dir,
       undefined,
@@ -309,8 +309,8 @@ test("genuinely-impossible (a): pi-native required tool incompatible with candid
 test("genuinely-impossible (b): cross-provider routing disabled + provider mismatch → typed error", async () => {
   const env = makeTempProject();
   try {
-    // Use plan-slice (workflow-required: ["gsd_plan_slice"]) but pretend no
-    // candidate model can carry it.  The simplest way: provide a model whose
+    // Use plan-slice but pretend no candidate model can carry its required
+    // workflow tools. The simplest way: provide a model whose
     // api is a fictitious "no-tools" string — `filterToolsForProvider` returns
     // every tool as filtered for an unknown api with toolCalling=false, OR we
     // can pick a real api that also denies the tool.  We use an api that

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -10,6 +10,13 @@ import {
   RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
 } from "../tool-presentation-plan.ts";
+import {
+  buildMinimalAutoGsdToolSet,
+  MINIMAL_AUTO_BASE_TOOL_NAMES,
+  MINIMAL_GSD_TOOL_NAMES,
+} from "../bootstrap/register-hooks.ts";
+import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.ts";
+import { UNIT_TOOL_CONTRACTS } from "../unit-tool-contracts.ts";
 
 const promptsDir = join(process.cwd(), "src/resources/extensions/gsd/prompts");
 const templatesDir = join(process.cwd(), "src/resources/extensions/gsd/templates");
@@ -21,6 +28,84 @@ function readPrompt(name: string): string {
 function readTemplate(name: string): string {
   return readFileSync(join(templatesDir, `${name}.md`), "utf-8");
 }
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const registeredPhaseToolNames = [
+  ...new Set([
+    ...MINIMAL_AUTO_BASE_TOOL_NAMES,
+    ...MINIMAL_GSD_TOOL_NAMES,
+    ...Object.values(UNIT_TOOL_CONTRACTS).flatMap((contract) => contract.allowedGsdTools),
+  ]),
+];
+
+const PHASE_PROMPT_TOOL_CALLS: Record<string, readonly string[]> = {
+  "research-milestone": ["gsd_summary_save"],
+  "plan-milestone": [
+    "gsd_milestone_status",
+    "gsd_plan_milestone",
+    "gsd_plan_slice",
+    "gsd_decision_save",
+  ],
+  "research-slice": ["gsd_summary_save"],
+  "plan-slice": ["gsd_reassess_roadmap", "gsd_plan_slice", "gsd_decision_save"],
+  "refine-slice": ["gsd_plan_slice", "gsd_decision_save"],
+  "replan-slice": ["gsd_replan_slice"],
+  "execute-task": ["gsd_task_complete"],
+  "reactive-execute": ["gsd_summary_save"],
+  "complete-slice": [
+    "gsd_exec",
+    "gsd_task_reopen",
+    "gsd_replan_slice",
+    "gsd_requirement_update",
+    "capture_thought",
+    "gsd_slice_complete",
+    "gsd_summary_save",
+  ],
+  "reassess-roadmap": ["gsd_milestone_status", "gsd_reassess_roadmap"],
+  "validate-milestone": ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap"],
+  "run-uat": ["gsd_uat_exec", "gsd_uat_result_save"],
+  "gate-evaluate": ["gsd_save_gate_result"],
+  "complete-milestone": [
+    "gsd_milestone_status",
+    "gsd_requirement_update",
+    "gsd_summary_save",
+    "capture_thought",
+    "gsd_complete_milestone",
+  ],
+};
+
+test("auto phase prompt tool calls are available in scoped tool surfaces", () => {
+  for (const [unitType, promptTools] of Object.entries(PHASE_PROMPT_TOOL_CALLS)) {
+    const prompt = readPrompt(unitType);
+    const activeTools = buildMinimalAutoGsdToolSet(
+      registeredPhaseToolNames,
+      unitType,
+      registeredPhaseToolNames,
+    );
+
+    for (const toolName of promptTools) {
+      assert.match(
+        prompt,
+        new RegExp(`\\b${escapeRegExp(toolName)}\\b`),
+        `${unitType} prompt should mention ${toolName}`,
+      );
+      assert.ok(
+        activeTools.includes(toolName),
+        `${unitType} prompt mentions ${toolName}, but scoped tools are ${activeTools.join(", ")}`,
+      );
+
+      const scopeResult = shouldBlockAutoUnitToolCall(unitType, toolName);
+      assert.equal(
+        scopeResult.block,
+        false,
+        `${unitType} phase gate blocked ${toolName}: ${scopeResult.reason ?? "unknown reason"}`,
+      );
+    }
+  }
+});
 
 test("reactive-execute prompt keeps task summaries with subagents and avoids batch commits", () => {
   const prompt = readPrompt("reactive-execute");

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -108,6 +108,26 @@ test("auto Unit tool scope blocks complete-slice from saving UAT Assessment", ()
   assert.match(result.reason ?? "", /Run UAT owns persisted UAT Assessment/);
 });
 
+test("auto Unit tool scope allows plan-slice to reassess invalid roadmap assumptions", () => {
+  const result = shouldBlockAutoUnitToolCall("plan-slice", "gsd_reassess_roadmap");
+
+  assert.equal(result.block, false);
+});
+
+test("auto Unit tool scope allows status/read helpers named by closeout prompts", () => {
+  for (const unitType of ["plan-milestone", "validate-milestone", "complete-milestone", "reassess-roadmap"]) {
+    const result = shouldBlockAutoUnitToolCall(unitType, "gsd_milestone_status");
+    assert.equal(result.block, false, `${unitType} should be able to call gsd_milestone_status`);
+  }
+});
+
+test("auto Unit tool scope blocks stale per-task planner in slice planning phases", () => {
+  for (const unitType of ["plan-slice", "refine-slice", "replan-slice"]) {
+    const result = shouldBlockAutoUnitToolCall(unitType, "gsd_plan_task");
+    assert.equal(result.block, true, `${unitType} should not call stale gsd_plan_task`);
+  }
+});
+
 test("Recovery Classification covers ADR-015 failure families", () => {
   const cases = [
     ["invalid tool schema enum", "tool-schema", "stop"],

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -48,10 +48,50 @@ test("auto execute-task requires canonical task completion tool", () => {
   assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("execute-task"), ["gsd_task_complete"]);
 });
 
+test("plan-slice requires planning and roadmap reassessment tools", () => {
+  const expected = ["gsd_plan_slice", "gsd_reassess_roadmap"];
+  assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("plan-slice"), expected);
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("plan-slice"), expected);
+});
+
+test("plan-milestone requires status, roadmap, and single-slice planning tools", () => {
+  const expected = ["gsd_milestone_status", "gsd_plan_milestone", "gsd_plan_slice"];
+  assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("plan-milestone"), expected);
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("plan-milestone"), expected);
+});
+
+test("refine-slice requires canonical slice planning tool", () => {
+  assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("refine-slice"), ["gsd_plan_slice"]);
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("refine-slice"), ["gsd_plan_slice"]);
+});
+
 test("complete-slice requires closeout and execution handoff tools", () => {
-  const expected = ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"];
+  const expected = [
+    "gsd_slice_complete",
+    "gsd_task_reopen",
+    "gsd_replan_slice",
+    "gsd_requirement_update",
+    "gsd_summary_save",
+  ];
   assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("complete-slice"), expected);
   assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("complete-slice"), expected);
+});
+
+test("complete-milestone requires status, requirement, project refresh, and closeout tools", () => {
+  const expected = [
+    "gsd_milestone_status",
+    "gsd_requirement_update",
+    "gsd_summary_save",
+    "gsd_complete_milestone",
+  ];
+  assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("complete-milestone"), expected);
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("complete-milestone"), expected);
+});
+
+test("reactive-execute requires task completion and failed-task summary tools", () => {
+  const expected = ["gsd_task_complete", "gsd_summary_save"];
+  assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("reactive-execute"), expected);
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("reactive-execute"), expected);
 });
 
 test("workflow MCP capability surface includes native legacy gsd aliases", () => {
@@ -679,7 +719,7 @@ test("transport compatibility ignores API-backed providers", () => {
 test("transport compatibility now allows plan-slice over workflow MCP surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
-    ["gsd_plan_slice"],
+    getRequiredWorkflowToolsForAutoUnit("plan-slice"),
     {
       projectRoot: "/tmp/project",
       env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
@@ -696,7 +736,7 @@ test("transport compatibility now allows plan-slice over workflow MCP surface", 
 test("transport compatibility now allows complete-slice over workflow MCP surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
-    ["gsd_complete_slice"],
+    getRequiredWorkflowToolsForAutoUnit("complete-slice"),
     {
       projectRoot: "/tmp/project",
       env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
@@ -747,7 +787,7 @@ test("transport compatibility now allows gate-evaluate over workflow MCP surface
 test("transport compatibility now allows validate-milestone over workflow MCP surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
-    ["gsd_milestone_status", "gsd_validate_milestone"],
+    getRequiredWorkflowToolsForAutoUnit("validate-milestone"),
     {
       projectRoot: "/tmp/project",
       env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
@@ -764,7 +804,7 @@ test("transport compatibility now allows validate-milestone over workflow MCP su
 test("transport compatibility now allows complete-milestone over workflow MCP surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
-    ["gsd_milestone_status", "gsd_complete_milestone"],
+    getRequiredWorkflowToolsForAutoUnit("complete-milestone"),
     {
       projectRoot: "/tmp/project",
       env: { GSD_WORKFLOW_MCP_COMMAND: "node" },

--- a/src/resources/extensions/gsd/unit-tool-contracts.ts
+++ b/src/resources/extensions/gsd/unit-tool-contracts.ts
@@ -52,8 +52,14 @@ export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
     requiredWorkflowTools: ["gsd_summary_save"],
   },
   "plan-milestone": {
-    allowedGsdTools: ["gsd_plan_milestone", "gsd_decision_save", "gsd_requirement_update"],
-    requiredWorkflowTools: ["gsd_plan_milestone"],
+    allowedGsdTools: [
+      "gsd_milestone_status",
+      "gsd_plan_milestone",
+      "gsd_plan_slice",
+      "gsd_decision_save",
+      "gsd_requirement_update",
+    ],
+    requiredWorkflowTools: ["gsd_milestone_status", "gsd_plan_milestone", "gsd_plan_slice"],
   },
   "discuss-milestone": {
     allowedGsdTools: [
@@ -77,27 +83,38 @@ export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
     requiredWorkflowTools: ["gsd_summary_save"],
   },
   "validate-milestone": {
-    allowedGsdTools: ["gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
+    allowedGsdTools: ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
     requiredWorkflowTools: ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap"],
   },
   "complete-milestone": {
-    allowedGsdTools: ["gsd_complete_milestone", "subagent"],
-    requiredWorkflowTools: ["gsd_milestone_status", "gsd_complete_milestone"],
+    allowedGsdTools: [
+      "gsd_milestone_status",
+      "gsd_requirement_update",
+      "gsd_summary_save",
+      "gsd_complete_milestone",
+      "subagent",
+    ],
+    requiredWorkflowTools: [
+      "gsd_milestone_status",
+      "gsd_requirement_update",
+      "gsd_summary_save",
+      "gsd_complete_milestone",
+    ],
   },
   "research-slice": {
     allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
     requiredWorkflowTools: ["gsd_summary_save"],
   },
   "plan-slice": {
-    allowedGsdTools: ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
-    requiredWorkflowTools: ["gsd_plan_slice"],
+    allowedGsdTools: ["gsd_plan_slice", "gsd_reassess_roadmap", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_plan_slice", "gsd_reassess_roadmap"],
   },
   "refine-slice": {
-    allowedGsdTools: ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
-    requiredWorkflowTools: [],
+    allowedGsdTools: ["gsd_plan_slice", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_plan_slice"],
   },
   "replan-slice": {
-    allowedGsdTools: ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
+    allowedGsdTools: ["gsd_replan_slice", "gsd_decision_save"],
     requiredWorkflowTools: ["gsd_replan_slice"],
   },
   "complete-slice": {
@@ -107,15 +124,22 @@ export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
       "gsd_replan_slice",
       "gsd_decision_save",
       "gsd_requirement_update",
+      "gsd_summary_save",
       "subagent",
     ],
-    requiredWorkflowTools: ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"],
+    requiredWorkflowTools: [
+      "gsd_slice_complete",
+      "gsd_task_reopen",
+      "gsd_replan_slice",
+      "gsd_requirement_update",
+      "gsd_summary_save",
+    ],
     forbiddenGsdTools: {
       gsd_uat_result_save: "Run UAT owns persisted UAT Assessment.",
     },
   },
   "reassess-roadmap": {
-    allowedGsdTools: ["gsd_reassess_roadmap"],
+    allowedGsdTools: ["gsd_milestone_status", "gsd_reassess_roadmap"],
     requiredWorkflowTools: ["gsd_milestone_status", "gsd_reassess_roadmap"],
   },
   "execute-task": {
@@ -127,8 +151,8 @@ export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
     requiredWorkflowTools: ["gsd_task_complete"],
   },
   "reactive-execute": {
-    allowedGsdTools: ["gsd_task_complete", "gsd_decision_save"],
-    requiredWorkflowTools: ["gsd_task_complete"],
+    allowedGsdTools: ["gsd_task_complete", "gsd_summary_save", "gsd_decision_save"],
+    requiredWorkflowTools: ["gsd_task_complete", "gsd_summary_save"],
   },
   "run-uat": {
     allowedGsdTools: [...RUN_UAT_WORKFLOW_TOOL_NAMES, "subagent"],


### PR DESCRIPTION
## TL;DR

**What:** Align GSD phase-scoped tool contracts with the tools named by their prompts.
**Why:** Some phases instructed agents to call tools that were omitted from the scoped phase surface or MCP requirement list.
**How:** Update the central unit tool contract, fix a stale prompt tool reference, and add regression coverage that checks prompt mentions against scoped tool availability and phase-gate behavior.

## What

This updates the GSD unit tool contracts for planning, validation, reassessment, closeout, and reactive execution phases so their allowed and required workflow tools match the prompt instructions. It also changes the plan-milestone soft brake from the stale `gsd_query` reference to `gsd_milestone_status`.

The tests now include a phase prompt/tool audit that verifies each curated auto-phase prompt tool call is present in the prompt, available in the scoped active tool set, and allowed by the phase gate.

## Why

The phase gate can block scoped lifecycle tools even when the prompt tells the agent to use them. That created real drift between prompt instructions, native tool scoping, and workflow MCP presentation. The mismatch was broader than roadmap reassessment alone.

## How

- Add missing scoped tools for plan-milestone, complete-slice, complete-milestone, validate-milestone, reassess-roadmap, plan-slice, refine-slice, and reactive-execute.
- Remove stale `gsd_plan_task` exposure from slice-planning phases that explicitly route task persistence through `gsd_plan_slice` or `gsd_replan_slice`.
- Add regression tests for prompt/tool alignment, workflow MCP required tools, and phase-gate allow/block behavior.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts src/resources/extensions/gsd/tests/workflow-mcp.test.ts src/resources/extensions/gsd/tests/token-tool-gating.test.ts src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run test:changed:src`
- `pnpm run verify:fast`

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783221716&installation_id=134682257&pr_number=495&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F495&signature=e2a3bb6f0fc6bd1c05d45938f8ffa202de5ec7f51a2fad051123ae751d0a4372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools auto phases may call and which workflow tools MCP/model policy require—incorrect alignment could block legitimate agent actions or allow wrong tools, but scope is GSD extension lifecycle tooling with strong test coverage.
> 
> **Overview**
> Aligns **GSD auto-phase tool contracts** with what phase prompts tell agents to call, so scoped surfaces, phase gates, and workflow MCP requirements stop disagreeing with instructions.
> 
> **`unit-tool-contracts.ts`** expands **allowed** and **requiredWorkflowTools** for planning and closeout phases (e.g. `gsd_milestone_status` on plan/validate/reassess/complete-milestone; `gsd_reassess_roadmap` on plan-slice; richer complete-slice / complete-milestone / reactive-execute sets). It **drops `gsd_plan_task`** from plan/refine/replan-slice in favor of slice-level planners, and gives **refine-slice** a non-empty required set (`gsd_plan_slice`).
> 
> **`plan-milestone.md`** fixes the “already planned” soft brake to use **`gsd_milestone_status`** instead of stale **`gsd_query`**.
> 
> **Tests** add a **prompt ↔ scoped tools ↔ phase gate** audit (`PHASE_PROMPT_TOOL_CALLS`), workflow MCP required-tool parity, runtime scope allow/block cases, and small fixes in auto-model-selection tests (e.g. vacuous-truth unit → `rewrite-docs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b0584ac143852cb2b6bce96ae498b2c1c4d3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->