### PR TITLE
Remove planner command surface

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -15,7 +15,6 @@
 | `/gsd discuss` | Discuss architecture and decisions (stop auto-mode first with `/gsd stop`) |
 | `/gsd status` | Open workflow visualizer |
 | `/gsd widget` | Cycle dashboard widget: full / small / min / off |
-| `/gsd planner [MID]` | Launch `gsd-planner` to review or customize a planned milestone before implementation |
 | `/gsd notifications` | View, filter, and clear persistent notification history |
 | `/gsd queue` | Queue and reorder future milestones (`pending`, `queued`, and legacy `planned`; safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -27,7 +27,6 @@ import {
   setSliceSketchFlag,
   transaction,
   getAssessment,
-  getSliceTasks,
 } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
@@ -115,12 +114,6 @@ import {
   checkCloseoutConsistencyGate,
   formatCloseoutConsistencyBlock,
 } from "./closeout-consistency-gate.js";
-import {
-  formatPlannerHandoffPauseReason,
-  hasPlannerHandoffBeenOffered,
-  markPlannerHandoffOffered,
-  PLANNER_HANDOFF_RULE_NAME,
-} from "./planner-handoff.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -423,43 +416,6 @@ function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
     }
   }
   return hasImplementationArtifacts(basePath, mid) === "present";
-}
-
-function isBeforeFirstImplementationTask(mid: string): boolean {
-  if (!isDbAvailable()) return true;
-  for (const slice of getMilestoneSlices(mid)) {
-    const tasks = getSliceTasks(mid, slice.id);
-    if (tasks.some(task => isClosedStatus(task.status))) return false;
-  }
-  return true;
-}
-
-function hasRoadmapLevelPlan(basePath: string, mid: string): boolean {
-  if (isDbAvailable() && getMilestoneSlices(mid).length > 0) return true;
-  const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
-  return !!(roadmapFile && existsSync(roadmapFile));
-}
-
-function isPlannerHandoffBoundary(state: GSDState): boolean {
-  if (state.phase !== "planning") return false;
-  if (!state.activeSlice || state.activeTask) return false;
-  const nextAction = state.nextAction ?? "";
-  return (
-    /^Plan slice \S+/.test(nextAction) ||
-    /^Slice \S+ has no DB tasks\./.test(nextAction)
-  );
-}
-
-function shouldOfferPlannerHandoff(basePath: string, mid: string, state: GSDState): boolean {
-  if (process.env.GSD_HEADLESS) return false;
-  if (!isPlannerHandoffBoundary(state)) return false;
-  if (!state.activeMilestone || state.activeMilestone.id !== mid) return false;
-  if (!hasRoadmapLevelPlan(basePath, mid)) return false;
-  if (hasMilestonePassedDiscuss(basePath, mid)) return false;
-  if (hasPlannerHandoffBeenOffered(basePath, mid)) return false;
-  if (!isBeforeFirstImplementationTask(mid)) return false;
-  if (hasImplementationArtifacts(basePath, mid) === "present") return false;
-  return true;
 }
 
 /**
@@ -1072,18 +1028,6 @@ export const DISPATCH_RULES: DispatchRule[] = [
       return {
         action: "stop" as const,
         reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
-        level: "warning" as const,
-      };
-    },
-  },
-  {
-    name: PLANNER_HANDOFF_RULE_NAME,
-    match: async ({ state, mid, basePath }) => {
-      if (!shouldOfferPlannerHandoff(basePath, mid, state)) return null;
-      markPlannerHandoffOffered(basePath, mid);
-      return {
-        action: "stop" as const,
-        reason: formatPlannerHandoffPauseReason(mid),
         level: "warning" as const,
       };
     },

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|planner|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -25,7 +25,6 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "status", desc: "Open the status dashboard" },
   { cmd: "widget", desc: "Cycle widget: full → small → min → off" },
   { cmd: "visualize", desc: "Open 10-tab workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)" },
-  { cmd: "planner", desc: "Launch gsd-planner to review or customize the current plan before implementation" },
   { cmd: "brief", desc: "Generate a visual HTML brief: diagram, plan, diff review, recap, table, or slides" },
   { cmd: "queue", desc: "Queue and reorder future milestones" },
   { cmd: "quick", desc: "Execute a quick task without full planning overhead" },
@@ -324,10 +323,6 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "--open", desc: "Open a browser chart saved to .gsd/reports/" },
     { cmd: "--text", desc: "Plain-text breakdown" },
     { cmd: "--json", desc: "Machine-readable JSON output" },
-  ],
-  planner: [
-    { cmd: "--dry-run", desc: "Print the gsd-planner command without launching it" },
-    { cmd: "M001", desc: "Launch planner for a specific milestone ID" },
   ],
   backlog: [
     { cmd: "add", desc: "Add item to backlog" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -14,13 +14,6 @@ import { projectRoot } from "../context.js";
 import { formattedShortcutPair } from "../../shortcut-defs.js";
 import { getVisualBriefOutputDir } from "../../../visual-brief/artifact-policy.js";
 import { buildVisualBriefPrompt, parseVisualBriefArgs, VISUAL_BRIEF_USAGE } from "../../../visual-brief/prompts.js";
-import {
-  buildGsdPlannerSpawnPlan,
-  formatGsdPlannerCommand,
-  formatPlannerLaunchUnavailable,
-  launchGsdPlanner,
-  markPlannerHandoffOffered,
-} from "../../planner-handoff.js";
 
 export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
   const summaryLines = [
@@ -36,7 +29,6 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     `  /gsd status         Status dashboard  (${formattedShortcutPair("dashboard")})`,
     `  /gsd parallel watch Parallel monitor  (${formattedShortcutPair("parallel")})`,
     `  /gsd notifications  Notification history  (${formattedShortcutPair("notifications")})`,
-    "  /gsd planner        Launch gsd-planner to review the current plan",
     "  /gsd visualize      Workflow visualizer",
     "  /gsd report         Generate all HTML reports and open browser",
     "  /gsd brief <mode>   Visual HTML brief (diagram, plan, diff, recap, table, slides)",
@@ -80,7 +72,6 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd stop           Stop auto-mode gracefully",
     "  /gsd pause          Pause auto-mode (preserves state, /gsd auto to resume)",
     "  /gsd discuss        Start guided milestone/slice discussion",
-    "  /gsd planner        Launch gsd-planner to customize a planned milestone before implementation",
     "  /gsd new-milestone  Create milestone from headless context (used by gsd headless)",
     "  /gsd new-project    Bootstrap a new project (use --deep for staged project-level discovery)",
     "  /gsd quick          Execute a quick task without full planning overhead",
@@ -92,7 +83,6 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "VISIBILITY",
     `  /gsd status         Status dashboard  (${formattedShortcutPair("dashboard")})`,
     `  /gsd parallel watch Open parallel worker monitor  (${formattedShortcutPair("parallel")})`,
-    "  /gsd planner        Launch gsd-planner for plan review/customization  [Mxxx] [--dry-run]",
     "  /gsd widget         Cycle status widget  [full|small|min|off]",
     "  /gsd visualize      Workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export)",
     "  /gsd brief <mode>   Generate a visual HTML brief  [diagram|plan|diff|recap|table|slides] [topic] [--slides]",
@@ -473,68 +463,6 @@ async function handleModel(trimmedArgs: string, ctx: ExtensionCommandContext, pi
   ctx.ui.notify(`Model: ${targetModel.provider}/${targetModel.id}`, "info");
 }
 
-function parsePlannerArgs(args: string): { dryRun: boolean; milestoneId: string | null; extraArgs: string[] } {
-  const parts = args.trim().split(/\s+/).filter(Boolean);
-  let dryRun = false;
-  let milestoneId: string | null = null;
-  const extraArgs: string[] = [];
-
-  for (const part of parts) {
-    if (part === "--dry-run") {
-      dryRun = true;
-      continue;
-    }
-    if (!milestoneId && /^M\d+(?:-[a-z0-9]{6})?$/i.test(part)) {
-      milestoneId = part.toUpperCase();
-      continue;
-    }
-    extraArgs.push(part);
-  }
-
-  return { dryRun, milestoneId, extraArgs };
-}
-
-async function handlePlanner(args: string, ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
-  const parsed = parsePlannerArgs(args);
-  let milestoneId = parsed.milestoneId;
-  if (!milestoneId) {
-    const state = await deriveState(basePath);
-    milestoneId = state.activeMilestone?.id ?? null;
-  }
-  const plan = buildGsdPlannerSpawnPlan({
-    basePath,
-    milestoneId,
-    extraArgs: parsed.extraArgs,
-  });
-
-  if (parsed.dryRun) {
-    ctx.ui.notify(formatGsdPlannerCommand(plan), "info");
-    return;
-  }
-
-  const result = await launchGsdPlanner({
-    basePath,
-    milestoneId,
-    extraArgs: parsed.extraArgs,
-  });
-
-  if (result.status === "failed") {
-    ctx.ui.notify(formatPlannerLaunchUnavailable(result.plan, result.error), "warning");
-    return;
-  }
-
-  if (milestoneId) {
-    markPlannerHandoffOffered(basePath, milestoneId, "command");
-  }
-  ctx.ui.notify(
-    milestoneId
-      ? `Launched gsd-planner for ${milestoneId}. Run /gsd auto when you are ready to continue.`
-      : "Launched gsd-planner. Run /gsd auto when you are ready to continue.",
-    "info",
-  );
-}
-
 export async function handleCoreCommand(
   trimmed: string,
   ctx: ExtensionCommandContext,
@@ -550,10 +478,6 @@ export async function handleCoreCommand(
   }
   if (trimmed === "visualize") {
     await handleVisualize(ctx);
-    return true;
-  }
-  if (trimmed === "planner" || trimmed.startsWith("planner ")) {
-    await handlePlanner(trimmed.replace(/^planner\s*/, "").trim(), ctx);
     return true;
   }
   if (trimmed === "brief" || trimmed.startsWith("brief ")) {

--- a/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
@@ -14,7 +14,6 @@ import { tmpdir } from "node:os";
 
 import { DISPATCH_RULES } from "../auto-dispatch.ts";
 import type { DispatchContext, DispatchAction } from "../auto-dispatch.ts";
-import { PLANNER_HANDOFF_RULE_NAME } from "../planner-handoff.ts";
 import type { GSDState } from "../types.ts";
 
 // ─── State helpers ────────────────────────────────────────────────────────
@@ -217,8 +216,8 @@ test("dispatch-rule-coverage: planning with active slice and skip_research → p
   );
 });
 
-test("dispatch-rule-coverage: planning boundary → planner handoff", async (t) => {
-  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-planner-"));
+test("dispatch-rule-coverage: planning boundary without planner handoff → research-slice", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-planning-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
 
   writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
@@ -232,12 +231,13 @@ test("dispatch-rule-coverage: planning boundary → planner handoff", async (t) 
   const match = await findFirstMatch(makeCtx(tmp, state));
   assertMatch(
     match,
-    { ruleName: PLANNER_HANDOFF_RULE_NAME, action: "stop" },
-    "planning boundary → planner handoff",
+    {
+      ruleName: "planning (no research, not S01) → research-slice",
+      action: "dispatch",
+      unitType: "research-slice",
+    },
+    "planning boundary without planner handoff",
   );
-  if (match?.result.action === "stop") {
-    assert.match(match.result.reason, /\/gsd planner/);
-  }
 });
 
 test("dispatch-rule-coverage: executing with task plan present → execute-task", async (t) => {
@@ -374,7 +374,7 @@ test("dispatch-rule-coverage: rule registry has the expected size", () => {
   // intentionally.
   assert.equal(
     DISPATCH_RULES.length,
-    30,
+    29,
     `DISPATCH_RULES length changed (got ${DISPATCH_RULES.length}). ` +
       "If you added a rule, add a state stub to dispatch-rule-coverage.test.ts " +
       "and update this expected count.",

--- a/src/resources/extensions/gsd/tests/planner-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/planner-handoff.test.ts
@@ -1,12 +1,12 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { GSD_COMMAND_DESCRIPTION, getGsdArgumentCompletions } from "../commands/catalog.ts";
+import { GSD_COMMAND_DESCRIPTION, getGsdArgumentCompletions, TOP_LEVEL_SUBCOMMANDS } from "../commands/catalog.ts";
 import { handleCoreCommand } from "../commands/handlers/core.ts";
-import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import { DISPATCH_RULES } from "../auto-dispatch.ts";
 import {
   buildGsdPlannerSpawnPlan,
   formatGsdPlannerCommand,
@@ -14,80 +14,34 @@ import {
   markPlannerHandoffOffered,
   PLANNER_HANDOFF_RULE_NAME,
 } from "../planner-handoff.ts";
-import { closeDatabase, isDbAvailable } from "../gsd-db.ts";
-import type { GSDState } from "../types.ts";
-
-function writeRoadmap(basePath: string, milestoneId: string): void {
-  const milestoneDir = join(basePath, ".gsd", "milestones", milestoneId);
-  mkdirSync(milestoneDir, { recursive: true });
-  writeFileSync(
-    join(milestoneDir, `${milestoneId}-ROADMAP.md`),
-    [
-      `# ${milestoneId}: Planner Handoff`,
-      "",
-      "**Vision:** Review the plan before implementation.",
-      "",
-      "## Slices",
-      "",
-      "- [ ] **S01: First Slice** `risk:low` `depends:[]`",
-      "",
-    ].join("\n"),
-    "utf-8",
-  );
-}
-
-function buildState(overrides: Partial<GSDState> = {}): GSDState {
-  return {
-    activeMilestone: { id: "M001", title: "Planner Handoff" },
-    activeSlice: { id: "S01", title: "First Slice" },
-    activeTask: null,
-    phase: "planning",
-    recentDecisions: [],
-    blockers: [],
-    nextAction: "Plan slice S01 (First Slice).",
-    registry: [],
-    ...overrides,
-  };
-}
-
-function buildCtx(basePath: string, state: GSDState = buildState()): DispatchContext {
-  return {
-    basePath,
-    mid: "M001",
-    midTitle: "Planner Handoff",
-    state,
-    prefs: undefined,
-  };
-}
-
-function findPlannerRule() {
-  const rule = DISPATCH_RULES.find(candidate => candidate.name === PLANNER_HANDOFF_RULE_NAME);
-  if (!rule) throw new Error(`missing dispatch rule: ${PLANNER_HANDOFF_RULE_NAME}`);
-  return rule;
-}
 
 describe("planner handoff command catalog", () => {
-  test("/gsd planner appears in description and completions", () => {
-    assert.match(GSD_COMMAND_DESCRIPTION, /planner/);
+  test("/gsd planner is hidden from description and completions", () => {
+    assert.doesNotMatch(GSD_COMMAND_DESCRIPTION, /\|planner(?:\||$)/);
+    assert.equal(
+      TOP_LEVEL_SUBCOMMANDS.some((command) => command.cmd === "planner"),
+      false,
+      "planner should not appear in top-level commands",
+    );
+
     const completions = getGsdArgumentCompletions("pla");
-    const entry = completions.find(completion => completion.value === "planner");
 
-    assert.ok(entry, "planner should appear in top-level completions");
-    assert.match(entry.description, /customize/i);
-  });
+    assert.equal(
+      completions.some((completion) => completion.value === "planner"),
+      false,
+      "planner should not appear in top-level completions",
+    );
 
-  test("planner nested completions expose dry-run", () => {
-    const completions = getGsdArgumentCompletions("planner --");
-
-    assert.ok(
-      completions.some(completion => completion.value === "planner --dry-run"),
-      "planner should suggest --dry-run",
+    assert.deepEqual(
+      getGsdArgumentCompletions("planner --"),
+      [],
+      "planner should not expose nested completions",
     );
   });
 });
 
 describe("planner handoff command handler", () => {
-  test("/gsd planner dry-run prints the launch command", async () => {
+  test("/gsd planner falls through to the unknown-command path", async () => {
     const notifications: Array<{ message: string; level?: string }> = [];
     const ctx = {
       ui: {
@@ -99,12 +53,8 @@ describe("planner handoff command handler", () => {
 
     const handled = await handleCoreCommand("planner M001 --dry-run --inspect", ctx as any);
 
-    assert.equal(handled, true);
-    assert.equal(notifications.length, 1);
-    assert.equal(notifications[0]?.level, "info");
-    assert.match(notifications[0]?.message ?? "", /^gsd-planner --project /);
-    assert.match(notifications[0]?.message ?? "", / --milestone M001 /);
-    assert.match(notifications[0]?.message ?? "", / --inspect$/);
+    assert.equal(handled, false);
+    assert.deepEqual(notifications, []);
   });
 });
 
@@ -141,38 +91,10 @@ describe("planner handoff launcher", () => {
 });
 
 describe("planner handoff dispatch rule", () => {
-  test("pauses once after roadmap planning before plan-slice dispatch", async () => {
-    if (isDbAvailable()) closeDatabase();
-    const basePath = mkdtempSync(join(tmpdir(), "gsd-planner-dispatch-"));
-    try {
-      writeRoadmap(basePath, "M001");
-      const rule = findPlannerRule();
-
-      const first = await rule.match(buildCtx(basePath));
-      assert.ok(first, "planner handoff should match the first time");
-      assert.equal(first!.action, "stop");
-      if (first!.action === "stop") {
-        assert.equal(first!.level, "warning");
-        assert.match(first!.reason, /\/gsd planner/);
-        assert.match(first!.reason, /\/gsd auto/);
-      }
-
-      const second = await rule.match(buildCtx(basePath));
-      assert.equal(second, null, "handoff marker should make the pause one-shot");
-    } finally {
-      rmSync(basePath, { recursive: true, force: true });
-    }
-  });
-
-  test("rule is ordered before plan-slice and execute-task dispatch", () => {
-    const plannerIdx = DISPATCH_RULES.findIndex(rule => rule.name === PLANNER_HANDOFF_RULE_NAME);
-    const planSliceIdx = DISPATCH_RULES.findIndex(rule => rule.name.startsWith("planning → plan-slice"));
-    const executeTaskIdx = DISPATCH_RULES.findIndex(rule => rule.name.startsWith("executing → execute-task"));
-
-    assert.ok(plannerIdx >= 0, "planner handoff rule must be registered");
-    assert.ok(planSliceIdx >= 0, "plan-slice rule must be registered");
-    assert.ok(executeTaskIdx >= 0, "execute-task rule must be registered");
-    assert.ok(plannerIdx < planSliceIdx, "planner handoff must preempt plan-slice");
-    assert.ok(plannerIdx < executeTaskIdx, "planner handoff must preempt execute-task");
+  test("rule is not registered while /gsd planner is disabled", () => {
+    assert.equal(
+      DISPATCH_RULES.some((rule) => rule.name === PLANNER_HANDOFF_RULE_NAME),
+      false,
+    );
   });
 });

--- a/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
@@ -32,7 +32,6 @@ import {
 import { deriveStateFromDb } from "../state.ts";
 import { _clearGsdRootCache } from "../paths.ts";
 import { invalidateAllCaches } from "../cache.ts";
-import { markPlannerHandoffOffered } from "../planner-handoff.ts";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -173,7 +172,6 @@ test("#4551: dispatch rule injects failure context and clears session field", as
 
   const state = await deriveStateFromDb(base);
   assert.equal(state.phase, "planning", "state must be in planning phase");
-  markPlannerHandoffOffered(base, "M001", "command");
 
   const session = new AutoSession();
   session.basePath = base;
@@ -234,7 +232,6 @@ test("#4551: dispatch rule does NOT inject stale failure for a different slice",
   invalidateAllCaches();
 
   const state = await deriveStateFromDb(base);
-  markPlannerHandoffOffered(base, "M001", "command");
 
   const session = new AutoSession();
   session.basePath = base;


### PR DESCRIPTION
## TL;DR

**What:** Temporarily removes the `/gsd planner` command surface and automatic planner handoff pause.
**Why:** The planner path needs more work, and the next release should not expose or pause on it.
**How:** Removes the command registration/help/docs/handler path and unregisters the auto-dispatch handoff rule while keeping the dormant planner helper available for future rework.

## What

- Removed `/gsd planner` from command descriptions, top-level completions, nested completions, help text, and user docs.
- Removed the `/gsd planner` command handler.
- Removed the auto-dispatch rule that stopped after planning and told users to run `/gsd planner`.
- Updated regression coverage so the command stays hidden and planning-boundary dispatch continues to normal planning behavior.

## Why

The planner launch flow is not ready for the release. Keeping the command and auto handoff in the shipped surface would expose a path that currently needs more product work and could block users at the planning boundary.

## How

The release-facing command and dispatch surfaces are disabled, but `planner-handoff.ts` remains in place so the implementation can be reworked and restored later without rebuilding the helper from scratch.

## Validation

- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/planner-handoff.test.ts src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`
- `node scripts/verify-changed-src-tests.mjs --files ...`

## Change Type

- [x] `fix` — Bug fix
- [x] `test` — Updating tests
- [x] `docs` — Documentation update
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

Temporarily removes the `/gsd planner` CLI command and the automatic planner handoff pause from the release surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783224060&installation_id=134682257&pr_number=496&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F496&signature=f09a072634a396f0877770d89bf9127bf63e6bbb1ad6f075c5426df996bf70dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for anyone relying on `/gsd planner` or the planning-boundary pause; auto-mode behavior at that boundary changes to continue dispatch instead of stopping.
> 
> **Overview**
> **Removes the shipped `/gsd planner` surface and the auto-mode pause that pointed users at it**, so the release no longer exposes or blocks on the unfinished `gsd-planner` flow.
> 
> The command is dropped from user docs, `GSD_COMMAND_DESCRIPTION`, top-level completions, nested `planner` completions, and help text in `core.ts`. The `handlePlanner` handler and its routing in `handleCoreCommand` are removed, so `/gsd planner` is no longer handled and falls through as unknown.
> 
> In **auto-dispatch**, the `PLANNER_HANDOFF` rule and helpers (`shouldOfferPlannerHandoff`, `isBeforeFirstImplementationTask`, etc.) are removed. At the planning boundary after roadmap work, auto-mode **continues into normal planning** (e.g. `research-slice`) instead of stopping with a message to run `/gsd planner`. `DISPATCH_RULES` count goes from 30 to 29.
> 
> **`planner-handoff.ts` stays** (spawn plan, markers, launch helpers) for later rework; tests now assert the command stays hidden, the handler is not registered, and dispatch coverage matches the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6867d9c4e264a2c8878f82e9de223f24964c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->