### PR TITLE
[codex] Align quality gate evaluation contracts

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -20,8 +20,8 @@ import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
 import {
   isDbAvailable,
   getMilestoneSlices,
-  getPendingGates,
-  markAllGatesOmitted,
+  getPendingGatesForTurn,
+  markPendingGatesOmittedForTurn,
   getMilestone,
   insertAssessment,
   setSliceSketchFlag,
@@ -1264,11 +1264,11 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Gate evaluation is opt-in via preferences
       const gateConfig = prefs?.gate_evaluation;
       if (!gateConfig?.enabled) {
-        markAllGatesOmitted(mid, sid);
+        markPendingGatesOmittedForTurn(mid, sid, "gate-evaluate");
         return { action: "skip" };
       }
 
-      const pending = getPendingGates(mid, sid, "slice");
+      const pending = getPendingGatesForTurn(mid, sid, "gate-evaluate");
       if (pending.length === 0) return { action: "skip" };
 
       return {

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -15,7 +15,25 @@ import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, getMilestoneSlices, getLatestAssessmentByScope, updateMilestoneStatus, refreshOpenDatabaseFromDisk, getCompletedMilestoneTaskFileHints, getMilestoneCommitAttributionShas, recordMilestoneCommitAttribution, transaction } from "./gsd-db.js";
+import {
+  isDbAvailable,
+  getTask,
+  getSlice,
+  getSliceTasks,
+  getPendingGatesForTurn,
+  updateTaskStatus,
+  updateSliceStatus,
+  insertSlice,
+  getMilestone,
+  getMilestoneSlices,
+  getLatestAssessmentByScope,
+  updateMilestoneStatus,
+  refreshOpenDatabaseFromDisk,
+  getCompletedMilestoneTaskFileHints,
+  getMilestoneCommitAttributionShas,
+  recordMilestoneCommitAttribution,
+  transaction,
+} from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -390,8 +408,9 @@ export function verifyExpectedArtifact(
     if (gateIds.length === 0) return true;
 
     try {
-      const pending = getPendingGates(mid, sid, "slice");
-      const pendingIds = new Set(pending.map((g: any) => g.gate_id));
+      if (!isDbAvailable()) return false;
+      const pending = getPendingGatesForTurn(mid, sid, "gate-evaluate");
+      const pendingIds = new Set<string>(pending.map((g) => g.gate_id));
       // All dispatched gates must no longer be pending
       for (const gid of gateIds) {
         if (pendingIds.has(gid)) return false;

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1285,7 +1285,7 @@ async function configureHooks(ctx: ExtensionCommandContext, prefs: Record<string
   if (geEnabled !== undefined) ge.enabled = geEnabled;
   const currentSliceGates = Array.isArray(ge.slice_gates) ? ge.slice_gates as string[] : [];
   const sgInput = await ctx.ui.input(
-    `Slice gates to evaluate (comma-separated, blank keeps)${currentSliceGates.length ? ` (current: ${currentSliceGates.join(", ")})` : " (default: Q3,Q4)"}:`,
+    `Gate-evaluate slice gates (Q3,Q4; comma-separated, blank keeps)${currentSliceGates.length ? ` (current: ${currentSliceGates.join(", ")})` : " (default: Q3,Q4)"}:`,
     currentSliceGates.join(", "),
   );
   if (sgInput !== null && sgInput !== undefined) {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -2364,12 +2364,13 @@ export function saveGateResult(g: {
   findings: string;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  currentDb.prepare(
+  const evaluatedAt = new Date().toISOString();
+  const result = currentDb.prepare(
     `UPDATE quality_gates
      SET status = 'complete', verdict = :verdict, rationale = :rationale,
          findings = :findings, evaluated_at = :evaluated_at
      WHERE milestone_id = :mid AND slice_id = :sid AND gate_id = :gid
-       AND task_id = :tid`,
+       AND (task_id = :tid OR (:tid = '' AND task_id IS NULL))`,
   ).run({
     ":mid": g.milestoneId,
     ":sid": g.sliceId,
@@ -2378,8 +2379,15 @@ export function saveGateResult(g: {
     ":verdict": g.verdict,
     ":rationale": g.rationale,
     ":findings": g.findings,
-    ":evaluated_at": new Date().toISOString(),
-  });
+    ":evaluated_at": evaluatedAt,
+  }) as { changes?: number };
+
+  if ((result.changes ?? 0) === 0) {
+    throw new GSDError(
+      GSD_STALE_STATE,
+      `quality gate row not found for ${g.milestoneId}/${g.sliceId}/${g.gateId}${g.taskId ? `/${g.taskId}` : ""}`,
+    );
+  }
 
   const outcome =
     g.verdict === "pass"
@@ -2402,7 +2410,7 @@ export function saveGateResult(g: {
     attempt: 1,
     maxAttempts: 1,
     retryable: false,
-    evaluatedAt: new Date().toISOString(),
+    evaluatedAt,
   });
 }
 
@@ -2436,6 +2444,30 @@ export function markAllGatesOmitted(milestoneId: string, sliceId: string): void 
     ":sid": sliceId,
     ":now": new Date().toISOString(),
   });
+}
+
+export function markPendingGatesOmittedForTurn(
+  milestoneId: string,
+  sliceId: string,
+  turn: OwnerTurn,
+): void {
+  if (!currentDb) return;
+  const gateIds = [...getGateIdsForTurn(turn)];
+  if (gateIds.length === 0) return;
+  const placeholders = gateIds.map((_, i) => `:gid${i}`).join(",");
+  const params: Record<string, unknown> = {
+    ":mid": milestoneId,
+    ":sid": sliceId,
+    ":now": new Date().toISOString(),
+  };
+  gateIds.forEach((id, index) => {
+    params[`:gid${index}`] = id;
+  });
+  currentDb.prepare(
+    `UPDATE quality_gates SET status = 'complete', verdict = 'omitted', evaluated_at = :now
+     WHERE milestone_id = :mid AND slice_id = :sid AND status = 'pending'
+       AND gate_id IN (${placeholders})`,
+  ).run(params);
 }
 
 export function getPendingSliceGateCount(milestoneId: string, sliceId: string): number {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -12,6 +12,7 @@ import type { DynamicRoutingConfig } from "./model-router.js";
 import { isAbsolute } from "node:path";
 import { VALID_BRANCH_NAME } from "./git-service.js";
 import { normalizeStringArray } from "../shared/format-utils.js";
+import { getGateIdsForTurn } from "./gate-registry.js";
 
 import {
   KNOWN_PREFERENCE_KEYS,
@@ -37,6 +38,7 @@ const VALID_POST_UNIT_HOOK_ON_BLOCK_ACTIONS = new Set([
   "queue-slice",
   "pause",
 ]);
+const VALID_GATE_EVALUATE_SLICE_GATES = new Set<string>(getGateIdsForTurn("gate-evaluate"));
 
 export function validatePreferences(preferences: GSDPreferences): {
   preferences: GSDPreferences;
@@ -907,7 +909,14 @@ export function validatePreferences(preferences: GSDPreferences): {
       }
       if (ge.slice_gates !== undefined) {
         if (Array.isArray(ge.slice_gates) && ge.slice_gates.every((g: unknown) => typeof g === "string")) {
-          validGe.slice_gates = ge.slice_gates;
+          const invalid = ge.slice_gates.filter((g) => !VALID_GATE_EVALUATE_SLICE_GATES.has(g));
+          if (invalid.length === 0) {
+            validGe.slice_gates = ge.slice_gates;
+          } else {
+            errors.push(
+              `gate_evaluation.slice_gates must contain only gate-evaluate slice gates: ${[...VALID_GATE_EVALUATE_SLICE_GATES].join(", ")}`,
+            );
+          }
         } else {
           errors.push("gate_evaluation.slice_gates must be an array of strings");
         }

--- a/src/resources/extensions/gsd/prompts/gate-evaluate.md
+++ b/src/resources/extensions/gsd/prompts/gate-evaluate.md
@@ -38,7 +38,7 @@ You are evaluating **quality gates in parallel** for this slice. Each gate is an
 3. **Verify each gate wrote its result** by checking that `gsd_save_gate_result` was called for each gate ID.
    - Call it **directly** — do **not** use `ToolSearch` (it is not available in GSD).
    - Inside Claude Code use the active MCP-scoped workflow name for `gsd_save_gate_result`; otherwise use `gsd_save_gate_result`.
-   - Always pass all required fields (camelCase): `milestoneId`, `sliceId`, `gateId`, `verdict`, `rationale`. Never call with an empty `{}` object.
+   - Always pass all required fields (camelCase): `milestoneId`, `sliceId`, `gateId`, `verdict`, `rationale`, and `findings` (empty string if none). Never call with an empty `{}` object.
 4. **Report the batch outcome** — which gates passed, which flagged concerns, and which were omitted as not applicable.
 
 Gate agents may return `verdict: "omitted"` if the gate question is not applicable to this slice (e.g., no auth surface for Q3, no existing requirements touched for Q4). This is expected for simple slices.

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -9,7 +9,7 @@ import { randomUUID } from "node:crypto";
 
 import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, diagnoseWorktreeIntegrityFailure, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact, writeReactiveExecuteBlocker } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getTask } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getTask, saveGateResult } from "../gsd-db.ts";
 import { readEvents } from "../workflow-events.ts";
 import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
@@ -1611,6 +1611,27 @@ test("verifyExpectedArtifact checks pending gate-evaluate artifacts without ESM 
   const verified = verifyExpectedArtifact("gate-evaluate", "M001/S01/gates+Q3", base);
 
   assert.equal(verified, false, "pending gates should keep gate-evaluate unverified");
+});
+
+test("verifyExpectedArtifact fails closed for gate-evaluate when the DB is unavailable", () => {
+  const base = makeTmpProject();
+  closeDatabase();
+
+  const verified = verifyExpectedArtifact("gate-evaluate", "M001/S01/gates+Q3", base);
+
+  assert.equal(verified, false, "gate-evaluate must verify against the DB-backed gate rows");
+});
+
+test("verifyExpectedArtifact ignores complete-slice gates in stale gate-evaluate unit ids", () => {
+  const base = makeTmpProject();
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q8", scope: "slice" });
+  saveGateResult({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", verdict: "pass", rationale: "OK", findings: "" });
+  saveGateResult({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", verdict: "pass", rationale: "OK", findings: "" });
+
+  const verified = verifyExpectedArtifact("gate-evaluate", "M001/S01/gates+Q3,Q4,Q8", base);
+
+  assert.equal(verified, true, "pending Q8 belongs to complete-slice and must not keep gate-evaluate unverified");
 });
 
 // ─── #4414 regressions ────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/gate-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-dispatch.test.ts
@@ -19,10 +19,12 @@ import {
   saveGateResult,
   markAllGatesOmitted,
   getPendingSliceGateCount,
+  getGateResults,
 } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
 import { renderPlanFromDb } from "../markdown-renderer.ts";
 import { invalidateAllCaches } from "../cache.ts";
+import { DISPATCH_RULES } from "../auto-dispatch.ts";
 
 function setupTestProject(): { tmpDir: string; dbPath: string } {
   const tmpDir = mkdtempSync(join(tmpdir(), "gate-dispatch-"));
@@ -212,5 +214,67 @@ describe("evaluating-gates phase", () => {
       "executing",
       `pending Q8 must not stall evaluating-gates — got phase=${state.phase}`,
     );
+  });
+
+  test("gate-evaluate dispatch id includes only gate-evaluate-owned gates", async () => {
+    planSlice(tmpDir);
+    await renderPlanFromDb(tmpDir, "M001", "S01");
+
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q8", scope: "slice" });
+
+    invalidateStateCache();
+    const state = await deriveState(tmpDir);
+    assert.equal(state.phase, "evaluating-gates");
+
+    const rule = DISPATCH_RULES.find((candidate) => candidate.name === "evaluating-gates → gate-evaluate");
+    assert.ok(rule, "gate-evaluate dispatch rule must exist");
+
+    const result = await rule.match({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state,
+      prefs: { gate_evaluation: { enabled: true } },
+    });
+
+    assert.ok(result);
+    assert.equal(result.action, "dispatch");
+    if (result.action !== "dispatch") throw new Error("expected gate-evaluate dispatch");
+    assert.equal(result.unitId, "M001/S01/gates+Q3,Q4");
+    assert.doesNotMatch(result.prompt, /\*\*Q8\*\*/);
+  });
+
+  test("disabled gate evaluation only omits gate-evaluate-owned gates", async () => {
+    planSlice(tmpDir);
+    await renderPlanFromDb(tmpDir, "M001", "S01");
+
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q8", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q5", scope: "task", taskId: "T01" });
+
+    invalidateStateCache();
+    const state = await deriveState(tmpDir);
+    assert.equal(state.phase, "evaluating-gates");
+
+    const rule = DISPATCH_RULES.find((candidate) => candidate.name === "evaluating-gates → gate-evaluate");
+    assert.ok(rule, "gate-evaluate dispatch rule must exist");
+
+    const result = await rule.match({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state,
+      prefs: { gate_evaluation: { enabled: false } },
+    });
+
+    assert.equal(result?.action, "skip");
+    const byId = new Map(getGateResults("M001", "S01").map((gate) => [gate.gate_id, gate]));
+    assert.equal(byId.get("Q3")?.verdict, "omitted");
+    assert.equal(byId.get("Q4")?.verdict, "omitted");
+    assert.equal(byId.get("Q8")?.status, "pending");
+    assert.equal(byId.get("Q5")?.status, "pending");
   });
 });

--- a/src/resources/extensions/gsd/tests/gate-storage.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-storage.test.ts
@@ -83,6 +83,21 @@ describe("quality_gates CRUD", () => {
     assert.ok(results[0].evaluated_at);
   });
 
+  test("saveGateResult throws when the gate row does not exist", () => {
+    assert.throws(
+      () => saveGateResult({
+        milestoneId: "M001",
+        sliceId: "S01",
+        gateId: "Q3",
+        verdict: "pass",
+        rationale: "No row exists.",
+        findings: "",
+      }),
+      /quality gate row not found/,
+    );
+    assert.equal(getGateResults("M001", "S01").length, 0);
+  });
+
   test("getPendingGates filters by scope", () => {
     insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
     insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q5", scope: "task", taskId: "T01" });

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -133,6 +133,36 @@ test('handlePlanSlice persists explicit slice/task target repositories', async (
   }
 });
 
+test('handlePlanSlice honors configured gate-evaluation gate sets', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    writeFileSync(
+      join(base, '.gsd', 'PREFERENCES.md'),
+      [
+        '---',
+        'gate_evaluation:',
+        '  enabled: true',
+        '  slice_gates:',
+        '    - Q3',
+        '  task_gates: false',
+        '---',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    const gateIds = getGateResults('M001', 'S02').map((gate) => gate.gate_id).sort();
+    assert.deepEqual(gateIds, ['Q3', 'Q8']);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice rejects unknown target repositories', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -467,6 +467,20 @@ test("notification fields validate correctly", () => {
   assert.equal(preferences.notifications?.on_complete, false);
 });
 
+test("gate_evaluation slice_gates only accepts gate-evaluate-owned gates", () => {
+  const valid = validatePreferences({
+    gate_evaluation: { enabled: true, slice_gates: ["Q3", "Q4"], task_gates: false },
+  });
+  assert.equal(valid.errors.length, 0);
+  assert.deepEqual(valid.preferences.gate_evaluation?.slice_gates, ["Q3", "Q4"]);
+  assert.equal(valid.preferences.gate_evaluation?.task_gates, false);
+
+  const invalid = validatePreferences({
+    gate_evaluation: { enabled: true, slice_gates: ["Q3", "Q8"] },
+  });
+  assert.ok(invalid.errors.some((error) => error.includes("gate_evaluation.slice_gates")));
+});
+
 test("cmux fields validate correctly", () => {
   const { preferences, errors } = validatePreferences({
     cmux: {

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -659,6 +659,12 @@ test("parallel subagent prompts forbid serialized tasks arrays", () => {
   }
 });
 
+test("gate-evaluate prompt requires gate result findings field", () => {
+  const prompt = readPrompt("gate-evaluate");
+  assert.match(prompt, /`findings`/);
+  assert.match(prompt, /empty string if none/i);
+});
+
 // ─── Project-shape classifier + 3-or-4-options-with-Other-hatch contract ──
 
 test("guided-discuss-project classifies project shape and persists the verdict to PROJECT.md", () => {

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -85,6 +85,12 @@ test("#4782 phase 1: no manifest has the same artifact key in inline AND excerpt
   }
 });
 
+test("gate-evaluate manifest matches its prompt builder context", () => {
+  assert.deepEqual(UNIT_MANIFESTS["gate-evaluate"].artifacts.inline, ["slice-plan"]);
+  assert.deepEqual(UNIT_MANIFESTS["gate-evaluate"].artifacts.excerpt, []);
+  assert.deepEqual(UNIT_MANIFESTS["gate-evaluate"].artifacts.onDemand, []);
+});
+
 test("#4782 phase 1: every manifest has a positive maxSystemPromptChars", () => {
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
     assert.ok(
@@ -432,7 +438,7 @@ test('Unit Tool Contract exposes subagent dispatch permissions', () => {
   });
   assert.deepEqual(resolveSubagentPermissionContract("gate-evaluate"), {
     allowed: true,
-    allowedSubagents: ["reviewer", "security", "tester"],
+    allowedSubagents: ["tester"],
     toolsMode: "planning-dispatch",
   });
   assert.deepEqual(resolveSubagentPermissionContract("run-uat"), {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -9,7 +9,6 @@ import {
   openDatabase,
   closeDatabase,
   _getAdapter,
-  insertGateRow,
   insertAssessment,
   upsertRequirement,
   getAllMilestones,
@@ -1447,12 +1446,25 @@ test("executeSaveGateResult validates inputs and persists verdicts", async () =>
     openTestDb(base);
     seedMilestone("M005", "Milestone Five");
     seedSlice("M005", "S05", "pending");
-    insertGateRow({
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "gate.ts"), "export const gate = true;\n", "utf-8");
+    await inProjectDir(base, () => executePlanSlice({
       milestoneId: "M005",
       sliceId: "S05",
-      gateId: "Q3",
-      scope: "slice",
-    });
+      goal: "Plan gate save projection.",
+      tasks: [
+        {
+          taskId: "T01",
+          title: "Add gate fixture",
+          description: "Create a fixture touched by gate evaluation.",
+          estimate: "10m",
+          files: ["src/gate.ts"],
+          verify: "node --test",
+          inputs: [],
+          expectedOutput: ["src/gate.ts"],
+        },
+      ],
+    }, base));
 
     const result = await inProjectDir(base, () => executeSaveGateResult({
       milestoneId: "M005",
@@ -1471,6 +1483,33 @@ test("executeSaveGateResult validates inputs and persists verdicts", async () =>
     assert.equal(row?.status, "complete");
     assert.equal(row?.verdict, "pass");
     assert.equal(row?.rationale, "Looks good.");
+    const planPath = join(base, ".gsd", "milestones", "M005", "slices", "S05", "S05-PLAN.md");
+    assert.match(readFileSync(planPath, "utf-8"), /No issues found\./);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSaveGateResult fails when no canonical gate row is updated", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M005", "Milestone Five");
+    seedSlice("M005", "S05", "pending");
+
+    const result = await inProjectDir(base, () => executeSaveGateResult({
+      milestoneId: "M005",
+      sliceId: "S05",
+      gateId: "Q3",
+      verdict: "pass",
+      rationale: "Looks good.",
+      findings: "No issues found.",
+    }, base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details.operation, "save_gate_result");
+    assert.match(String(result.details.error), /quality gate row not found/);
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -3,6 +3,7 @@ import { join, relative } from "node:path";
 import { clearParseCache } from "../files.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
 import { isNonEmptyString, validateStringArray } from "../validation.js";
+import { getGateIdsForTurn } from "../gate-registry.js";
 import {
   transaction,
   getMilestone,
@@ -17,7 +18,7 @@ import {
   deleteTask,
   deleteArtifactByPath,
 } from "../gsd-db.js";
-import type { GateId } from "../types.js";
+import type { GateEvaluationConfig, GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
 import { renderPlanFromDb } from "../markdown-renderer.js";
 import { renderAllProjections } from "../workflow-projections.js";
@@ -163,9 +164,27 @@ function validateParams(params: PlanSliceParams): PlanSliceParams {
   };
 }
 
-function loadRepositoryRegistry(basePath: string): RepositoryRegistry {
+function loadPlanningContext(basePath: string): {
+  repositoryRegistry: RepositoryRegistry;
+  gateEvaluation?: GateEvaluationConfig;
+} {
   const loaded = loadEffectiveGSDPreferences(basePath);
-  return createRepositoryRegistryFromPreferences(basePath, loaded?.preferences);
+  return {
+    repositoryRegistry: createRepositoryRegistryFromPreferences(basePath, loaded?.preferences),
+    gateEvaluation: loaded?.preferences?.gate_evaluation,
+  };
+}
+
+function resolveGateEvaluateSliceGates(config: GateEvaluationConfig | undefined): GateId[] {
+  const ownedGateIds = [...getGateIdsForTurn("gate-evaluate")];
+  if (!config?.slice_gates?.length) return ownedGateIds;
+  const owned = new Set<string>(ownedGateIds);
+  return config.slice_gates.filter((gateId): gateId is GateId => owned.has(gateId));
+}
+
+function resolveTaskGates(config: GateEvaluationConfig | undefined): GateId[] {
+  if (config?.task_gates === false) return [];
+  return [...getGateIdsForTurn("execute-task")];
 }
 
 function validateReferencedRepositories(
@@ -265,8 +284,11 @@ export async function handlePlanSlice(
   }
 
   let repositoryRegistry: RepositoryRegistry;
+  let gateEvaluation: GateEvaluationConfig | undefined;
   try {
-    repositoryRegistry = loadRepositoryRegistry(basePath);
+    const context = loadPlanningContext(basePath);
+    repositoryRegistry = context.repositoryRegistry;
+    gateEvaluation = context.gateEvaluation;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { error: `validation failed: ${message}` };
@@ -384,11 +406,11 @@ export async function handlePlanSlice(
 
       // Seed quality gate rows inside the transaction — all-or-nothing with
       // the plan data so a crash can't leave orphaned gates without tasks.
-      const sliceGates: GateId[] = ["Q3", "Q4"];
+      const sliceGates = resolveGateEvaluateSliceGates(gateEvaluation);
       for (const gid of sliceGates) {
         insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "slice" });
       }
-      const taskGates: GateId[] = ["Q5", "Q6", "Q7"];
+      const taskGates = resolveTaskGates(gateEvaluation);
       for (const task of params.tasks) {
         for (const gid of taskGates) {
           insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "task", taskId: task.taskId });

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -48,6 +48,7 @@ import { invalidateStateCache } from "../state.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
 import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
+import { renderPlanFromDb } from "../markdown-renderer.js";
 import {
   buildRunUatPresentationForType,
   canonicalWorkflowToolName,
@@ -994,6 +995,7 @@ export async function executeSaveGateResult(
       rationale: params.rationale,
       findings: params.findings ?? "",
     });
+    await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
     invalidateStateCache();
     return {
       content: [{ type: "text", text: `Gate ${params.gateId} result saved: verdict=${params.verdict}` }],

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -317,11 +317,10 @@ const TOOLS_PLANNING_DISPATCH_RECON: ToolsPolicy = {
   mode: "planning-dispatch",
   allowedSubagents: ["scout", "planner"],
 };
-// Like TOOLS_PLANNING_DISPATCH_RECON, but for closeout units that fan out
-// verification work to review-tier specialists.
+// Like TOOLS_PLANNING_DISPATCH_RECON, but for gate-evaluate's tester fanout.
 const TOOLS_PLANNING_DISPATCH_REVIEW: ToolsPolicy = {
   mode: "planning-dispatch",
-  allowedSubagents: ["reviewer", "security", "tester"],
+  allowedSubagents: ["tester"],
 };
 const TOOLS_DOCS: ToolsPolicy = {
   mode: "docs",
@@ -626,7 +625,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     // plan and report via the DB-backed gate-result tool.
     tools: TOOLS_PLANNING_DISPATCH_REVIEW,
     artifacts: {
-      inline: ["slice-plan", "prior-task-summaries"],
+      inline: ["slice-plan"],
       excerpt: [],
       onDemand: [],
     },


### PR DESCRIPTION
## TL;DR

**What:** Align quality gate evaluation ownership, persistence, prompts, and tests around the gate registry.
**Why:** Slice-scoped gates were being treated as a single bucket, which let Q8 leak into `gate-evaluate` and allowed stale or ignored gate-result state.
**How:** Route gate dispatch/recovery through owner-turn filters, honor gate-evaluation preferences at planning time, fail stale gate result saves, refresh projections after saves, and lock the contracts with focused tests.

## What

This PR tightens the GSD quality gate contract across dispatch, planning, persistence, prompts, and manifest tests:

- `gate-evaluate` now dispatches and verifies only the gates it owns, Q3 and Q4.
- Disabled gate evaluation only omits pending `gate-evaluate` gates instead of clearing unrelated slice/task gates.
- `gate_evaluation.slice_gates` is validated against gate-evaluate-owned slice gates, and `plan-slice` now honors both configured slice gates and disabled task gates.
- `gsd_save_gate_result` now fails when no canonical `quality_gates` row is updated, records a gate run only after a real update, and rerenders the slice plan projection after saving.
- The gate-evaluate prompt and unit context manifest now match the runtime contract, including the required `findings` field and the actual inline artifact set.

## Why

The gate registry already defines ownership by workflow turn, but several callers still treated all slice-scoped quality gates as equivalent. That caused three alignment problems:

- Q8, which belongs to `complete-slice`, could appear in stale gate-evaluate unit ids or pending checks.
- Gate-evaluation preferences accepted values that plan-slice either ignored or applied too broadly.
- Gate result saves could report success without proving that a canonical quality gate row was updated.

Those mismatches made the contract harder to reason about and risked hiding or misrouting gate work.

## How

The fix makes owner-turn ownership the boundary everywhere gate-evaluate participates:

- Dispatch and recovery use `getPendingGatesForTurn(..., "gate-evaluate")` rather than slice scope alone.
- A new turn-specific omit helper closes only pending gates owned by the disabled turn.
- Planning resolves configured gate-evaluate slice gates from the registry and keeps Q8 seeded for complete-slice.
- Persistence treats missing gate rows as stale state and updates the rendered plan after successful saves.
- Tests cover dispatch ids, disabled evaluation, DB-unavailable recovery, stale Q8 unit ids, preference validation, prompt requirements, manifest context, projection refresh, and stale save failures.

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

None expected. This does tighten validation so `gate_evaluation.slice_gates` may only contain gate-evaluate-owned slice gates, currently Q3 and Q4.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/plan-slice.test.ts src/resources/extensions/gsd/tests/preferences.test.ts src/resources/extensions/gsd/tests/gate-dispatch.test.ts src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- `pnpm run build:core`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250141&installation_id=134682257&pr_number=499&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F499&signature=cc225f4c739082d2e66eba88ab8c0adc57fce8b544f1ed69075085f341fb266b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workflow dispatch, DB gate updates, and preference validation (stricter `slice_gates`); mistakes could misroute gates or block saves, but behavior is heavily test-covered.
> 
> **Overview**
> **Aligns `gate-evaluate` with gate-registry ownership** so only Q3/Q4 are dispatched, verified, and omitted when evaluation is disabled—Q8 and task gates (Q5–Q7) stay pending for their owning turns.
> 
> Dispatch and recovery now use `getPendingGatesForTurn(..., "gate-evaluate")` and `markPendingGatesOmittedForTurn` instead of treating all slice-scoped gates the same. **Planning** seeds gates from preferences: configurable `slice_gates` (validated to Q3/Q4 only) and optional task gates via `getGateIdsForTurn`; Q8 remains seeded for `complete-slice`.
> 
> **Persistence** tightens `saveGateResult` (match NULL `task_id`, throw if no row updates, single `evaluatedAt`) and **rerenders the slice plan** after `gsd_save_gate_result`. The gate-evaluate prompt requires `findings`; the unit manifest allows only **tester** subagents and inlines **slice-plan** only.
> 
> Tests cover dispatch unit IDs, disabled evaluation scope, DB-unavailable recovery, stale Q8 in unit ids, preference validation, and projection refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1493b58d79a770d02a111cd4c02f5087f2712d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->