### PR TITLE
fix(gsd): project prior-milestone summaries into worktrees

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -97,6 +97,50 @@ test("projectRootToWorktree forwards root PROJECT.md into isolated worktrees", (
   }
 });
 
+test("projectRootToWorktree projects prior-milestone slice/task SUMMARY.md, not just top-level files", () => {
+  // Regression: a worktree opened for the CURRENT milestone (M002) must also
+  // receive the full subtree of OTHER, already-completed milestones (M001) so
+  // their per-slice/per-task SUMMARY.md exist on the worktree filesystem.
+  // Previously only top-level *.md/*.json were projected for other milestones,
+  // leaving the stale-render detector to flag M001's summaries as "complete in
+  // DB but missing on disk".
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const worktree = join(dir, ".gsd", "worktrees", "M002");
+    mkdirSync(join(worktree, ".gsd"), { recursive: true });
+
+    // Current milestone (M002) — what the worktree is working on.
+    mkdirSync(join(dir, ".gsd", "milestones", "M002"), { recursive: true });
+    writeFileSync(join(dir, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002\n");
+
+    // Prior, completed milestone (M001) with nested slice + task summaries.
+    const m001TaskDir = join(dir, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+    mkdirSync(m001TaskDir, { recursive: true });
+    writeFileSync(join(dir, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n");
+    writeFileSync(
+      join(dir, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+      "# S01 Summary\n",
+    );
+    writeFileSync(join(m001TaskDir, "T01-SUMMARY.md"), "# T01 Summary\n");
+
+    const workspace = createWorkspace(worktree);
+    const scope = scopeMilestone(workspace, "M002");
+    new WorktreeStateProjection().projectRootToWorktree(scope);
+
+    const wtGsd = join(worktree, ".gsd");
+    assert.ok(
+      existsSync(join(wtGsd, "milestones", "M001", "slices", "S01", "S01-SUMMARY.md")),
+      "prior-milestone slice SUMMARY.md is projected into the worktree",
+    );
+    assert.ok(
+      existsSync(join(wtGsd, "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md")),
+      "prior-milestone task SUMMARY.md is projected into the worktree",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 // ─── projectWorktreeToRoot — Module contract ────────────────────────────────
 
 test("projectWorktreeToRoot exists and accepts a MilestoneScope", () => {

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -123,36 +123,29 @@ function forceOverwriteAssessmentsWithVerdict(
   }
 }
 
-function syncTopLevelMilestoneArtifacts(
+function syncOtherMilestoneArtifacts(
   srcMilestonesDir: string,
   dstMilestonesDir: string,
+  currentMilestoneId: string,
 ): void {
   if (!existsSync(srcMilestonesDir)) return;
 
   try {
     for (const milestoneEntry of readdirSync(srcMilestonesDir, { withFileTypes: true })) {
       if (!milestoneEntry.isDirectory()) continue;
+      // The current milestone is already fully projected by the caller's
+      // additive safeCopyRecursive; skip it here to avoid redundant work.
+      if (milestoneEntry.name === currentMilestoneId) continue;
       const srcMilestoneDir = join(srcMilestonesDir, milestoneEntry.name);
       const dstMilestoneDir = join(dstMilestonesDir, milestoneEntry.name);
 
-      try {
-        mkdirSync(dstMilestoneDir, { recursive: true });
-        for (const fileEntry of readdirSync(srcMilestoneDir, { withFileTypes: true })) {
-          if (!fileEntry.isFile()) continue;
-          if (!fileEntry.name.endsWith(".md") && !fileEntry.name.endsWith(".json")) continue;
-
-          safeCopy(
-            join(srcMilestoneDir, fileEntry.name),
-            join(dstMilestoneDir, fileEntry.name),
-            { force: false },
-          );
-        }
-      } catch (err) {
-        logWarning(
-          "worktree",
-          `milestone top-level artifact sync failed (${milestoneEntry.name}): ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      // Additively project the entire milestone subtree (force:false), not just
+      // top-level files. Prior completed milestones keep their per-slice and
+      // per-task SUMMARY.md / UAT.md on disk so the worktree's stale-render
+      // detector doesn't flag them as missing (DB has summary, disk doesn't).
+      // force:false preserves any worktree-local files (#1886 invariant) and
+      // only fills in files absent from the worktree projection.
+      safeCopyRecursive(srcMilestoneDir, dstMilestoneDir, { force: false });
     }
   } catch (err) {
     logWarning(
@@ -248,9 +241,16 @@ export function _projectRootToWorktreeImpl(
     { force: false },
   );
 
-  // Additively project missing top-level milestone files for all milestones
-  // so worktree-bound units can verify future-milestone context artifacts.
-  syncTopLevelMilestoneArtifacts(join(prGsd, "milestones"), join(wtGsd, "milestones"));
+  // Additively project the full subtree of every OTHER milestone so
+  // worktree-bound units can read prior-milestone context artifacts and so
+  // completed milestones retain their per-slice/per-task SUMMARY.md and
+  // UAT.md on the worktree filesystem (otherwise the stale-render detector
+  // flags them as "complete in DB but missing on disk").
+  syncOtherMilestoneArtifacts(
+    join(prGsd, "milestones"),
+    join(wtGsd, "milestones"),
+    milestoneId,
+  );
 
   // Force-sync ASSESSMENT files that have a verdict from project root (#2821).
   // The additive-only copy above preserves worktree-local files, but


### PR DESCRIPTION
## Linked issue

<!-- ⚠️ No issue linked yet — please add one before merge (repo policy closes PRs without a linked issue). -->

Closes #

- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Auto-worktrees now project prior completed milestones' per-slice/per-task `SUMMARY.md`/`UAT.md` onto the worktree filesystem.
**Why:** Without them the stale-render detector flagged completed milestones as "complete with summary in DB but missing on disk."
**How:** Replace the top-level-only milestone artifact sync with an additive full-subtree recursive copy.

## What

`src/resources/extensions/gsd/worktree-state-projection.ts`: replaced `syncTopLevelMilestoneArtifacts` (copied only top-level `*.md`/`*.json` for non-current milestones) with `syncOtherMilestoneArtifacts`, which additively projects each *other* milestone's full subtree via `safeCopyRecursive(..., { force: false })`. The current milestone is skipped because the caller already copies it recursively just above.

Added a regression test in `worktree-state-projection.test.ts` asserting a worktree opened for M002 receives M001's nested slice and task `SUMMARY.md` files.

## Why

`.gsd/` is gitignored, so a freshly-created auto-worktree starts with an empty `.gsd/`. On dispatch, projection fully copied only the *current* milestone; for every other milestone it copied just top-level files and never recursed into `slices/`. Completed prior milestones therefore had their summaries in the canonical DB but no `SUMMARY.md` on the worktree disk, producing output like:

```
markdown-renderer: detected 14 stale render(s):
  - .../worktrees/M002/.gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md: T01 is complete with summary in DB but SUMMARY.md missing on disk
  ...
```

The DB was never wrong — only the worktree's on-disk projection was incomplete.

## How

`syncOtherMilestoneArtifacts` recurse-copies each non-current milestone directory with `force: false`. `force: false` preserves any worktree-local files (the #1886 additive-copy invariant) and only fills in files absent from the worktree projection, so there is no regression to the separate ASSESSMENT verdict force-overwrite path. For not-yet-started future milestones the project root has only top-level files, so behavior is unchanged there.

Note: `reconcileBeforeDispatch` → `repairStaleRenders` already re-renders missing summaries from the DB before each dispatch, so existing live worktrees self-heal regardless; this change fixes the projection up front so the detector stops firing in the first place.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — `tsc --noEmit --project tsconfig.extensions.json` clean; worktree projection test suites green (incl. new regression case)
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code <!-- Claude Code (Opus 4.8); typecheck + projection test suites run locally -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250530&installation_id=134682257&pr_number=500&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F500&signature=9e922ef90bf9200428e67263b8ac734d3146d14ace1e0ea16e8f065a01d1ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive `force: false` copy in GSD worktree projection only; current-milestone and ASSESSMENT force-sync paths are unchanged, with a targeted regression test.
> 
> **Overview**
> **Fixes incomplete auto-worktree projection** so non-current milestones copy their full `slices/` / `tasks/` tree (e.g. per-slice and per-task `SUMMARY.md` / `UAT.md`), not only top-level milestone `*.md` / `*.json`.
> 
> `projectRootToWorktree` now calls **`syncOtherMilestoneArtifacts`**, which skips the active milestone (already copied recursively) and additively mirrors each other milestone with `safeCopyRecursive(..., { force: false })`, preserving worktree-local files (#1886). That stops the stale-render detector from reporting prior completed work as “summary in DB but missing on disk” on fresh worktrees.
> 
> A **regression test** asserts an M002 worktree receives M001 nested `S01-SUMMARY.md` and `T01-SUMMARY.md` after projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99bcd199c928c43ae59b2ee35a199953fbe46b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->