### PR TITLE
Refactor GSD UAT policy and run records

### DIFF
--- a/docs/dev/uat-process.md
+++ b/docs/dev/uat-process.md
@@ -1,0 +1,42 @@
+# UAT Process
+
+This document names the current UAT contract so prompt, dispatch, browser tooling, and milestone validation do not drift apart.
+
+## Pipeline Order
+
+1. `complete-slice` persists the slice summary and UAT spec. It rejects specs that declare `artifact-driven` while requiring browser-observable checks.
+2. `run-uat` runs after slice completion. It classifies the UAT spec through `src/resources/extensions/gsd/uat-policy.ts`, presents the matching tool surface, records typed evidence, and saves one `S##-ASSESSMENT.md` plus a typed attempt record through `gsd_uat_result_save`.
+3. `validate-milestone` runs after all slices close. It dispatches three reviewers in parallel: requirements coverage, cross-slice integration, and assessment/acceptance evidence. It consumes UAT assessments; it is not the UAT producer.
+4. `complete-milestone` runs only after validation records a passing milestone verdict.
+
+## UAT Mode Policy
+
+`uat-policy.ts` is the source of truth for:
+
+- Declared and effective UAT mode classification.
+- Artifact-driven specs that must be escalated to browser-backed UAT.
+- Which UAT modes receive browser tools.
+- Which modes may produce `PARTIAL`.
+- Result-save requirements such as runtime evidence for `runtime-executable` and browser evidence for `browser-executable`.
+- Dispatch-time browser tool support checks when an active tool snapshot is available.
+
+## Browser And Playwright
+
+GSD exposes a product-level Browser Automation Contract with canonical `browser_*` tool names. Per ADR-024, Playwright-backed browser tools are the default Pi Provider path. `gsd-browser` remains available for External MCP Clients and explicit managed-engine opt-in.
+
+`browser-executable`, `live-runtime`, `mixed`, and `human-experience` UAT modes require browser tools when the active tool snapshot is known. If no browser tool is present, dispatch stops before burning a UAT retry attempt. A UAT that uses a Playwright command should be declared `runtime-executable` and should record runtime evidence through `gsd_uat_exec`.
+
+## Current Guardrails
+
+- `complete-slice` blocks browser-required specs mislabeled as `artifact-driven`.
+- `run-uat` requires `gsd_uat_result_save` and rejects forbidden summary/gate write substitutes.
+- `src/resources/extensions/gsd/uat-run.ts` owns `gsd_uat_result_save` lifecycle preparation, run IDs, attempt metadata, worktree capture, and assessment rendering.
+- `gsd_uat_result_save` validates objective evidence, fresh UAT-owned exec evidence, canonical tool presentation, and mode-specific evidence before saving the assessment and attempt artifact.
+- Manual handoff text includes the real worktree path when checks are left as `NEEDS-HUMAN`.
+- Milestone validation downgrades a pass to `needs-attention` when browser-observable acceptance criteria lack persisted browser/runtime evidence.
+
+## Next Deepening Opportunities
+
+- Persist each milestone reviewer output separately before aggregating the final validation verdict.
+- Promote file-backed UAT attempt records into DB-indexed run records if queue inspection needs SQL access.
+- Bind browser PASS evidence to concrete browser tool calls, browser artifacts, or explicit runtime-executable Playwright evidence.

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -205,21 +205,24 @@ guided-resume-task  (if task was interrupted)
 
 ```
 gate-evaluate  (parallel gate subagents)
+
+complete-slice  (writes the slice summary and UAT spec)
          │
          ▼
-validate-milestone  (3 parallel reviewers)
+run-uat  (per-slice user acceptance assessment)
          │
          ▼
-run-uat  (user acceptance tests)
+validate-milestone  (3 parallel reviewers after all slices close)
 ```
 
 | Prompt | Purpose | Key Tools Called |
 |--------|---------|-----------------|
 | `gate-evaluate.md` | Spawn one subagent per quality gate in parallel. Verifies `gsd_save_gate_result` called. | `subagent` × N |
 | `validate-milestone.md` | 3 parallel reviewers: (A) requirements, (B) integration, (C) acceptance. | `subagent` × 3, `gsd_validate_milestone` |
-| `run-uat.md` | Execute UAT. Modes: artifact-driven, runtime, browser, human-experience. Runs under `verification` tools policy with UAT-owned execution plus safe read-only/browser inspection tools. | `gsd_uat_exec`, `gsd_uat_result_save`, read-only/browser tools |
+| `run-uat.md` | Execute UAT. Modes: artifact-driven, browser-executable, runtime-executable, live-runtime, mixed, human-experience. Runs under `verification` tools policy with UAT-owned execution plus safe read-only/browser inspection tools. | `gsd_uat_exec`, `gsd_uat_result_save`, read-only/browser tools |
 
 `run-uat` completion verification requires a canonical verdict in the written `S##-ASSESSMENT.md` (for example `verdict: PASS | FAIL | PARTIAL`). A pre-existing assessment file without `verdict` does not satisfy artifact verification.
+`src/resources/extensions/gsd/uat-policy.ts` is the shared policy source for UAT mode classification, browser-tool requirements, dispatch decisions, and result-save mode validation.
 
 ### 5f. Completion Flow
 
@@ -317,11 +320,11 @@ STATE.md
               ├── [gate]  gate-evaluate ────────────► N× subagent
               │              │ writes gate results
               │              │
+              ├── [sl]    complete-slice
+              │              │ writes S##-SUMMARY.md and S##-UAT.md
+              │              │
               ├── [sl]    run-uat
               │              │ writes S##-ASSESSMENT.md
-              │              │
-              ├── [sl]    complete-slice
-              │              │ writes S##-SUMMARY.md
               │              │
               ├── [ms]    reassess-roadmap
               │              │ updates M##-ROADMAP.md

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,9 +14,9 @@
 
 import type { GSDState } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
-import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
+import { getUatBrowserToolSupportError, type UatType } from "./uat-policy.js";
 import {
   isDbAvailable,
   getMilestoneSlices,
@@ -688,6 +688,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
       );
       if (transportError) {
         return { action: "stop" as const, reason: transportError, level: "warning" as const };
+      }
+      const browserToolError = getUatBrowserToolSupportError({
+        uatType,
+        activeTools,
+        milestoneId: mid,
+        sliceId,
+      });
+      if (browserToolError) {
+        return { action: "stop" as const, reason: browserToolError, level: "warning" as const };
       }
 
       // Cap run-uat dispatch attempts to prevent infinite replay (#3624).

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -10,8 +10,8 @@
  */
 
 import { loadFile, parseContinue, parseSummary, loadActiveOverrides, formatOverridesSection, parseTaskPlanFile } from "./files.js";
-import type { Override, UatType } from "./files.js";
-import { hasVerdict, getUatType, extractVerdict } from "./verdict-parser.js";
+import type { Override } from "./files.js";
+import { hasVerdict, extractVerdict } from "./verdict-parser.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import {
   resolveMilestoneFile, resolveSliceFile, resolveSlicePath,
@@ -42,11 +42,11 @@ import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
 import { classifyProject, type ProjectClassification } from "./detection.js";
-import { hasBrowserRequiredText } from "./browser-evidence.js";
 import { debugLog } from "./debug-logger.js";
 import { buildSkillActivationBlock, buildSkillDiscoveryVars } from "./skill-activation.js";
 import { findMilestoneIds } from "./milestone-ids.js";
 import { buildRunUatPresentationForType, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from "./tool-presentation-plan.js";
+import { resolveEffectiveUatType, shouldDispatchUatForContent, type UatType } from "./uat-policy.js";
 
 export { buildSkillActivationBlock, buildSkillDiscoveryVars };
 
@@ -284,19 +284,6 @@ function prependContextModeToBlock(
   if (!contextMode) return block;
   if (!block.trim()) return contextMode;
   return `${contextMode}\n\n${block}`;
-}
-
-function resolveEffectiveUatType(content: string): UatType {
-  const uatType = getUatType(content);
-  if (uatType === "artifact-driven" && hasBrowserRequiredText(content)) {
-    return "browser-executable";
-  }
-  return uatType;
-}
-
-function shouldDispatchUatForContent(content: string, prefs: GSDPreferences | undefined): boolean {
-  const uatType = resolveEffectiveUatType(content);
-  return !!prefs?.uat_dispatch || uatType !== "artifact-driven" || hasBrowserRequiredText(content);
 }
 
 // ─── Executor Constraints ─────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -109,22 +109,12 @@ test("checkEngineHealth treats explicit reopen as authoritative when dispatch ti
       worker_id, host, pid, started_at, version, last_heartbeat_at, status, project_root_realpath
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run("worker-1", "localhost", 1, "2026-01-01T00:00:00.000Z", "test", "2026-01-01T00:00:00.000Z", "stopped", base);
-  db.exec("PRAGMA writable_schema = ON");
   db.prepare(
-    `UPDATE sqlite_schema
-     SET sql = replace(sql, 'started_at TEXT NOT NULL', 'started_at TEXT')
-     WHERE type = 'table' AND name = 'unit_dispatches'`,
-  ).run();
-  db.exec("PRAGMA writable_schema = OFF");
-  closeDatabase();
-  openDatabase(join(gsdDir, "gsd.db"));
-  const reopenedDb = _getAdapter()!;
-  reopenedDb.prepare(
     `INSERT INTO unit_dispatches (
       trace_id, worker_id, milestone_lease_token, milestone_id,
       unit_type, unit_id, status, attempt_n, started_at, ended_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run("trace-1", "worker-1", 1, "M001", "complete-milestone", "M001", "completed", 1, null, null);
+  ).run("trace-1", "worker-1", 1, "M001", "complete-milestone", "M001", "completed", 1, "", "");
   appendEvent(base, {
     cmd: "reopen-milestone",
     params: { milestoneId: "M001" },

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../bootstrap/register-hooks.ts";
 import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.ts";
 import { UNIT_TOOL_CONTRACTS } from "../unit-tool-contracts.ts";
+import { uatTypeIncludesBrowser } from "../uat-policy.ts";
 
 const promptsDir = join(process.cwd(), "src/resources/extensions/gsd/prompts");
 const templatesDir = join(process.cwd(), "src/resources/extensions/gsd/templates");
@@ -183,6 +184,7 @@ test("live-runtime and mixed UAT presentations also surface browser tools", () =
   // drive a browser, so the runner must actually receive the browser tools and
   // a hybrid surface — otherwise live checks silently downgrade to NEEDS-HUMAN.
   for (const uatType of ["live-runtime", "mixed", "human-experience"] as const) {
+    assert.equal(uatTypeIncludesBrowser(uatType), true, `${uatType} policy should include browser tools`);
     const presentation = buildRunUatPresentationForType(uatType);
     assert.equal(presentation.surface, "hybrid", `${uatType} should use the hybrid surface`);
     for (const toolName of RUN_UAT_BROWSER_TOOL_NAMES) {
@@ -196,6 +198,7 @@ test("live-runtime and mixed UAT presentations also surface browser tools", () =
 
 test("artifact-driven and runtime-executable UAT presentations stay browser-free", () => {
   for (const uatType of ["artifact-driven", "runtime-executable"] as const) {
+    assert.equal(uatTypeIncludesBrowser(uatType), false, `${uatType} policy should stay browser-free`);
     const presentation = buildRunUatPresentationForType(uatType);
     assert.equal(presentation.surface, "mcp", `${uatType} should use the mcp surface`);
     assert.ok(

--- a/src/resources/extensions/gsd/tests/repository-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/repository-registry.test.ts
@@ -2,7 +2,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -117,7 +117,7 @@ test("repository registry keeps project root anchored to .gsd project in monorep
 });
 
 test("repository registry uses external-state worktree checkout as project root", (t) => {
-  const base = mkdtempSync(join(tmpdir(), "gsd-repo-registry-external-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-repo-registry-external-")));
   t.after(() => rmSync(base, { recursive: true, force: true }));
   const worktree = join(base, ".gsd", "projects", "abc123", "worktrees", "M001");
   mkdirSync(worktree, { recursive: true });

--- a/src/resources/extensions/gsd/tests/uat-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-policy.test.ts
@@ -1,0 +1,170 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifyUatContent,
+  getDeclaredUatType,
+  getUatBrowserToolSupportError,
+  hasUatBrowserToolSurface,
+  isPartialEligibleUatType,
+  resolveEffectiveUatType,
+  shouldDispatchUatForContent,
+  shouldEscalateArtifactUatToBrowser,
+  uatTypeIncludesBrowser,
+  validateUatModePolicy,
+} from "../uat-policy.ts";
+
+describe("uat-policy", () => {
+  it("defaults missing UAT mode to artifact-driven", () => {
+    assert.equal(getDeclaredUatType("# UAT\n\nCheck generated files."), "artifact-driven");
+  });
+
+  it("escalates artifact-driven UAT to browser-executable when the spec requires browser work", () => {
+    const content = [
+      "## UAT Type",
+      "- UAT mode: artifact-driven",
+      "",
+      "## Test",
+      "Open the page in a browser and verify the submit button is visible.",
+    ].join("\n");
+
+    assert.equal(shouldEscalateArtifactUatToBrowser(content), true);
+    assert.equal(resolveEffectiveUatType(content), "browser-executable");
+    assert.equal(shouldDispatchUatForContent(content, undefined), true);
+    assert.deepEqual(classifyUatContent(content), {
+      declaredType: "artifact-driven",
+      effectiveType: "browser-executable",
+      browserRequired: true,
+      shouldDispatchByDefault: true,
+    });
+  });
+
+  it("does not escalate disclaimer-only browser mentions", () => {
+    const content = [
+      "## UAT Type",
+      "- UAT mode: artifact-driven",
+      "",
+      "## Not Proven By This UAT",
+      "- No live browser session was run in this artifact check.",
+    ].join("\n");
+
+    assert.equal(shouldEscalateArtifactUatToBrowser(content), false);
+    assert.equal(resolveEffectiveUatType(content), "artifact-driven");
+    assert.equal(shouldDispatchUatForContent(content, undefined), false);
+  });
+
+  it("centralizes which UAT modes receive browser tools", () => {
+    for (const uatType of ["browser-executable", "live-runtime", "mixed", "human-experience"] as const) {
+      assert.equal(uatTypeIncludesBrowser(uatType), true, `${uatType} should include browser tools`);
+    }
+
+    for (const uatType of ["artifact-driven", "runtime-executable"] as const) {
+      assert.equal(uatTypeIncludesBrowser(uatType), false, `${uatType} should not include browser tools`);
+    }
+  });
+
+  it("detects direct and MCP-shaped browser tool surfaces", () => {
+    assert.equal(hasUatBrowserToolSurface(["read", "browser_navigate"]), true);
+    assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-browser__browser_navigate"]), true);
+    assert.equal(hasUatBrowserToolSurface(["read", "gsd_uat_exec"]), false);
+    assert.equal(hasUatBrowserToolSurface(undefined), false);
+  });
+
+  it("reports missing browser tools only for browser-backed UAT with a known tool snapshot", () => {
+    assert.equal(
+      getUatBrowserToolSupportError({
+        uatType: "artifact-driven",
+        activeTools: ["read", "gsd_uat_exec"],
+        milestoneId: "M001",
+        sliceId: "S01",
+      }),
+      null,
+    );
+    assert.equal(
+      getUatBrowserToolSupportError({
+        uatType: "browser-executable",
+        activeTools: undefined,
+        milestoneId: "M001",
+        sliceId: "S01",
+      }),
+      null,
+    );
+
+    const error = getUatBrowserToolSupportError({
+      uatType: "browser-executable",
+      activeTools: ["read", "gsd_uat_exec"],
+      milestoneId: "M001",
+      sliceId: "S01",
+    });
+    assert.match(error ?? "", /Cannot dispatch browser-backed run-uat for M001\/S01/);
+  });
+
+  it("centralizes partial verdict eligibility", () => {
+    assert.equal(isPartialEligibleUatType("mixed"), true);
+    assert.equal(isPartialEligibleUatType("human-experience"), true);
+    assert.equal(isPartialEligibleUatType("live-runtime"), true);
+    assert.equal(isPartialEligibleUatType("artifact-driven"), false);
+    assert.equal(isPartialEligibleUatType("browser-executable"), false);
+    assert.equal(isPartialEligibleUatType("runtime-executable"), false);
+  });
+
+  it("requires runtime evidence for runtime-executable UAT", () => {
+    assert.equal(
+      validateUatModePolicy({
+        uatType: "runtime-executable",
+        verdict: "PASS",
+        checks: [{ mode: "artifact", result: "PASS" }],
+      }),
+      "runtime-executable UAT requires runtime evidence",
+    );
+
+    assert.equal(
+      validateUatModePolicy({
+        uatType: "runtime-executable",
+        verdict: "PASS",
+        checks: [{ mode: "runtime", result: "PASS" }],
+      }),
+      null,
+    );
+  });
+
+  it("requires browser evidence for browser-executable UAT", () => {
+    assert.equal(
+      validateUatModePolicy({
+        uatType: "browser-executable",
+        verdict: "PASS",
+        checks: [{ mode: "runtime", result: "PASS" }],
+      }),
+      "browser-executable UAT requires browser evidence",
+    );
+
+    assert.equal(
+      validateUatModePolicy({
+        uatType: "browser-executable",
+        verdict: "PASS",
+        checks: [{ mode: "browser", result: "PASS" }],
+      }),
+      null,
+    );
+  });
+
+  it("allows live-runtime evidence through either runtime or browser checks", () => {
+    assert.equal(
+      validateUatModePolicy({
+        uatType: "live-runtime",
+        verdict: "PASS",
+        checks: [{ mode: "artifact", result: "PASS" }],
+      }),
+      "live-runtime UAT requires runtime or browser evidence",
+    );
+
+    assert.equal(
+      validateUatModePolicy({
+        uatType: "live-runtime",
+        verdict: "PASS",
+        checks: [{ mode: "browser", result: "PASS" }],
+      }),
+      null,
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -631,14 +631,32 @@ test("executeUatResultSave accepts gsd_uat_exec evidence written in a milestone 
     assert.equal(result.isError, undefined);
     assert.equal(result.details.operation, "save_uat_result");
     assert.equal(result.details.verdict, "PASS");
+    assert.equal(result.details.runId, "uat:M001:S02:attempt-1");
+    assert.equal(result.details.worktreeRoot, worktree);
+    assert.equal(result.details.browserToolsPresented, false);
     assert.ok(
       existsSync(join(base, ".gsd", "uat", "M001", "S02", "attempt-1.json")),
       "attempt JSON should be persisted under the authoritative project .gsd",
     );
+    const attempt = JSON.parse(readFileSync(
+      join(base, ".gsd", "uat", "M001", "S02", "attempt-1.json"),
+      "utf-8",
+    )) as {
+      runId?: string;
+      worktreeRoot?: string;
+      browserToolsPresented?: boolean;
+      modePolicy?: { requiredAnyModes?: string[] };
+    };
+    assert.equal(attempt.runId, "uat:M001:S02:attempt-1");
+    assert.equal(attempt.worktreeRoot, worktree);
+    assert.equal(attempt.browserToolsPresented, false);
+    assert.deepEqual(attempt.modePolicy?.requiredAnyModes, ["runtime"]);
     const assessment = readFileSync(
       join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-ASSESSMENT.md"),
       "utf-8",
     );
+    assert.match(assessment, /runId: uat:M001:S02:attempt-1/);
+    assert.ok(assessment.includes(`worktreeRoot: ${worktree}`));
     assert.match(assessment, /Runtime path C:\\\\tmp\\\|uat evidence/);
     assert.match(assessment, /backslash \\\\ and pipe \\\|/);
   } finally {
@@ -749,8 +767,10 @@ test("executeUatResultSave supplies direct browser tools for browser-executable 
     const attempt = JSON.parse(readFileSync(
       join(base, ".gsd", "uat", "M001", "S06", "attempt-1.json"),
       "utf-8",
-    )) as { presentation?: { presentedTools?: string[] } };
+    )) as { browserToolsPresented?: boolean; presentation?: { presentedTools?: string[] } };
 
+    assert.equal(result.details.browserToolsPresented, true);
+    assert.equal(attempt.browserToolsPresented, true);
     assert.ok(attempt.presentation?.presentedTools?.includes("browser_navigate"));
     assert.ok(attempt.presentation?.presentedTools?.includes("browser_assert"));
     assert.equal(

--- a/src/resources/extensions/gsd/tool-presentation-plan.ts
+++ b/src/resources/extensions/gsd/tool-presentation-plan.ts
@@ -7,6 +7,7 @@ import {
   RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
 } from "./unit-tool-contracts.js";
+import { uatTypeIncludesBrowser } from "./uat-policy.js";
 
 export {
   RUN_UAT_BROWSER_TOOL_NAMES,
@@ -131,17 +132,6 @@ export function buildRunUatCanonicalToolNames(options: { includeBrowserTools?: r
 // `human-experience` is told to capture screenshots. Without this, a webpage
 // UAT classified as anything but `browser-executable` had no browser tools and
 // downgraded its live checks to NEEDS-HUMAN (M001/S03 regression).
-export const BROWSER_INCLUSIVE_UAT_TYPES: readonly string[] = [
-  "browser-executable",
-  "live-runtime",
-  "mixed",
-  "human-experience",
-];
-
-function uatTypeIncludesBrowser(uatType: string | undefined): boolean {
-  return uatType !== undefined && BROWSER_INCLUSIVE_UAT_TYPES.includes(uatType);
-}
-
 export function runUatBrowserToolsForType(uatType: string | undefined): readonly string[] {
   return uatTypeIncludesBrowser(uatType) ? RUN_UAT_BROWSER_TOOL_NAMES : [];
 }

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -34,8 +34,8 @@ import { getGatesForTurn } from "../gate-registry.js";
 import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
-import { saveFile, clearParseCache, extractUatType } from "../files.js";
-import { hasBrowserRequiredText } from "../browser-evidence.js";
+import { saveFile, clearParseCache } from "../files.js";
+import { getDeclaredUatType, shouldEscalateArtifactUatToBrowser } from "../uat-policy.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb } from "../markdown-renderer.js";
 import { parseRoadmap } from "../parsers-legacy.js";
@@ -350,7 +350,7 @@ export async function handleCompleteSlice(
   // Otherwise the browser checks get silently deferred to a human and the slice
   // passes on static checks alone (M001/S03 regression). `browser-executable`,
   // `live-runtime`, and `mixed` all receive browser tools (see
-  // BROWSER_INCLUSIVE_UAT_TYPES); only the non-browser modes are rejected here.
+  // UAT_MODE_POLICIES); only the non-browser modes are rejected here.
   //
   // Reuse the canonical hasBrowserRequiredText detector (also used by dispatch
   // and milestone validation): it skips Not-Proven/Out-of-Scope disclaimer
@@ -362,9 +362,10 @@ export async function handleCompleteSlice(
   // genuinely defers verification to a human. Every other mode has a real
   // verification path: `runtime-executable` runs browser test commands like
   // `npx playwright test` via gsd_uat_exec, and live-runtime/mixed/
-  // browser-executable receive browser tools (BROWSER_INCLUSIVE_UAT_TYPES).
-  const declaredUatMode = extractUatType(params.uatContent || "") ?? "artifact-driven";
-  if (declaredUatMode === "artifact-driven" && hasBrowserRequiredText(params.uatContent || "")) {
+  // browser-executable receive browser tools (UAT_MODE_POLICIES).
+  const uatContent = params.uatContent || "";
+  const declaredUatMode = getDeclaredUatType(uatContent);
+  if (shouldEscalateArtifactUatToBrowser(uatContent)) {
     return {
       error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but declares "UAT mode: artifact-driven", which only runs static/file checks and would defer the browser work to a human. Use a mode that actually verifies the UI: "browser-executable" (interactive browser tools), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
     };

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -17,11 +17,10 @@ import {
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
-import { clearPathCache, relSliceFile, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { clearPathCache, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
 import { saveFile, clearParseCache } from "../files.js";
-import { buildManualValidationGuidance, resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
-import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
-import { isAbsolute, join, resolve } from "node:path";
+import { unlinkSync } from "node:fs";
+import { join } from "node:path";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
 import { handleCompleteMilestone } from "./complete-milestone.js";
 import { handleCompleteTask } from "./complete-task.js";
@@ -50,13 +49,15 @@ import { parseProject } from "../schemas/parsers.js";
 import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
 import { renderPlanFromDb } from "../markdown-renderer.js";
 import {
-  buildRunUatPresentationForType,
-  canonicalWorkflowToolName,
-  parseMcpToolName,
-  RUN_UAT_FORBIDDEN_TOOL_NAMES,
-  RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
-  RUN_UAT_WORKFLOW_TOOL_NAMES,
-} from "../tool-presentation-plan.js";
+  prepareUatRun,
+  saveUatAttemptArtifact,
+  type UatResultSaveParams,
+} from "../uat-run.js";
+export type {
+  UatCheckResultInput,
+  UatEvidenceRef,
+  UatPresentationInput,
+} from "../uat-run.js";
 
 export const SUPPORTED_SUMMARY_ARTIFACT_TYPES = [
   "SUMMARY",
@@ -438,58 +439,7 @@ export interface SaveGateResultParams {
   findings?: string;
 }
 
-export type UatType =
-  | "artifact-driven"
-  | "browser-executable"
-  | "runtime-executable"
-  | "live-runtime"
-  | "mixed"
-  | "human-experience";
-
-export type UatVerdict = "PASS" | "FAIL" | "PARTIAL";
-export type UatCheckResult = "PASS" | "FAIL" | "NEEDS-HUMAN";
-
-export interface UatEvidenceRef {
-  kind: "gsd_uat_exec" | "gsd_exec" | "screenshot" | "log" | "url" | "browser";
-  ref: string;
-  note?: string;
-  unitType?: string;
-  tool?: string;
-  executionId?: string;
-}
-
-export interface UatCheckResultInput {
-  id: string;
-  description: string;
-  mode: "artifact" | "runtime" | "browser" | "human-follow-up";
-  result: UatCheckResult;
-  evidence?: UatEvidenceRef[];
-  notes?: string;
-  nonAutomatable?: boolean;
-}
-
-export interface UatPresentationInput {
-  surface: "provider-tools" | "claude-code-sdk" | "mcp" | "hybrid";
-  model?: { provider?: string; api?: string; id?: string };
-  presentedTools: string[];
-  blockedTools: Array<{ name: string; reason: string }>;
-  aliases?: Array<{ requested: string; canonical: string }>;
-  fallbackToolsUsed?: string[];
-  toolPresentationPlanId?: string;
-  notes?: string;
-}
-
-export interface UatResultSaveParams {
-  milestoneId: string;
-  sliceId: string;
-  uatType: UatType;
-  verdict: UatVerdict;
-  checks: UatCheckResultInput[];
-  presentation: UatPresentationInput;
-  notes?: string;
-  attempt?: number | string | "auto";
-  previousAttemptId?: string;
-}
+export type { UatResultSaveParams };
 
 export async function executeTaskComplete(
   params: TaskCompleteParams,
@@ -1020,397 +970,6 @@ function errorResult(operation: string, message: string, error: string): ToolExe
   };
 }
 
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function mergeBlockedTools(
-  current: UatPresentationInput["blockedTools"] | undefined,
-  canonical: UatPresentationInput["blockedTools"],
-): UatPresentationInput["blockedTools"] {
-  const merged = new Map<string, { name: string; reason: string }>();
-  for (const entry of [...(current ?? []), ...canonical]) {
-    merged.set(canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name), entry);
-  }
-  return [...merged.values()];
-}
-
-function mergePresentedTools(current: readonly string[] | undefined, canonical: readonly string[]): string[] {
-  return [...new Set([...(current ?? []), ...canonical])];
-}
-
-function normalizeUatVerdict(params: UatResultSaveParams): UatResultSaveParams {
-  const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
-  if (typeof raw.verdict === "string") {
-    return { ...params, verdict: raw.verdict.toUpperCase() as UatVerdict };
-  }
-  return params;
-}
-
-function supplyDefaultPresentation(params: UatResultSaveParams): UatResultSaveParams {
-  const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
-  if (!raw.presentation) {
-    return { ...params, presentation: buildRunUatPresentationForType(params.uatType) };
-  }
-  return params;
-}
-
-function mergeCanonicalPresentation(params: UatResultSaveParams): UatResultSaveParams {
-  const canonicalPresentation = buildRunUatPresentationForType(params.uatType);
-  const providedPresentation = params.presentation as Partial<UatPresentationInput>;
-  return {
-    ...params,
-    presentation: {
-      ...providedPresentation,
-      surface: providedPresentation.surface ?? canonicalPresentation.surface,
-      presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
-      blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
-      toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
-    } as UatPresentationInput,
-  };
-}
-
-const VALID_UAT_TYPES: readonly UatType[] = [
-  "artifact-driven",
-  "browser-executable",
-  "runtime-executable",
-  "live-runtime",
-  "mixed",
-  "human-experience",
-];
-
-function ensureUatRequiredFields(params: UatResultSaveParams): string | null {
-  if (!isNonEmptyString(params.milestoneId)) return "milestoneId is required";
-  if (!isNonEmptyString(params.sliceId)) return "sliceId is required";
-  if (!isNonEmptyString(params.uatType)) return "uatType is required";
-  if (!(VALID_UAT_TYPES as readonly string[]).includes(params.uatType)) {
-    return `uatType must be one of: ${VALID_UAT_TYPES.join(", ")}`;
-  }
-  if (!["PASS", "FAIL", "PARTIAL"].includes(params.verdict)) return "verdict must be PASS, FAIL, or PARTIAL";
-  if (!Array.isArray(params.checks) || params.checks.length === 0) return "checks must contain at least one UAT check";
-  if (!params.presentation || !Array.isArray(params.presentation.presentedTools)) return "presentation.presentedTools is required";
-  if (!Array.isArray(params.presentation.blockedTools)) return "presentation.blockedTools is required";
-  return null;
-}
-
-function approvedEvidenceRoots(basePath: string): string[] {
-  const contract = resolveGsdPathContract(basePath);
-  return [contract.worktreeGsd, contract.projectGsd].filter((root): root is string => typeof root === "string");
-}
-
-function approvedBrowserArtifactRoots(basePath: string): string[] {
-  const contract = resolveGsdPathContract(basePath);
-  const roots = [contract.workRoot, contract.projectRoot].map((root) => join(root, ".artifacts", "browser"));
-  return [...new Set(roots)];
-}
-
-function pathStartsWithin(parent: string, target: string): boolean {
-  const normalizedParent = parent.replace(/\\/g, "/").replace(/\/+$/, "");
-  const normalizedTarget = target.replace(/\\/g, "/").replace(/\/+$/, "");
-  return normalizedTarget === normalizedParent || normalizedTarget.startsWith(`${normalizedParent}/`);
-}
-
-function pushUnique(paths: string[], candidate: string): void {
-  if (!paths.includes(candidate)) paths.push(candidate);
-}
-
-function execMetaPathCandidates(basePath: string, ref: string): string[] {
-  const trimmed = ref.trim();
-  const candidates: string[] = [];
-  const execDirs = approvedEvidenceRoots(basePath).map((root) => join(root, "exec"));
-  const normalizedRef = trimmed.replace(/\\/g, "/");
-  const pathLike = normalizedRef.endsWith(".meta.json") || normalizedRef.includes("/.gsd/exec/");
-
-  if (pathLike) {
-    const rawPath = isAbsolute(trimmed) ? resolve(trimmed) : resolve(basePath, trimmed);
-    pushUnique(candidates, rawPath);
-
-    const relativeExecMarker = ".gsd/exec/";
-    const markerIndex = normalizedRef.indexOf(relativeExecMarker);
-    if (markerIndex >= 0) {
-      const execRelative = normalizedRef.slice(markerIndex + relativeExecMarker.length);
-      for (const execDir of execDirs) {
-        pushUnique(candidates, join(execDir, execRelative));
-      }
-    }
-
-    return candidates.filter((candidate) =>
-      execDirs.some((execDir) => pathStartsWithin(execDir, candidate))
-    );
-  }
-
-  for (const execDir of execDirs) {
-    pushUnique(candidates, join(execDir, `${trimmed}.meta.json`));
-  }
-  return candidates;
-}
-
-function resolveExecMetaPath(basePath: string, ref: string): string | null {
-  for (const candidate of execMetaPathCandidates(basePath, ref)) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-function evidencePathIsApproved(basePath: string, ref: string): boolean {
-  const normalizedRef = ref.replace(/\\/g, "/");
-  if (normalizedRef.startsWith(".gsd/exec/") || normalizedRef.startsWith(".gsd/uat/")) return true;
-  if (normalizedRef.startsWith(".artifacts/browser/")) {
-    const resolvedRef = resolve(basePath, ref);
-    return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, resolvedRef));
-  }
-  const gsdEvidenceApproved = approvedEvidenceRoots(basePath).some((root) => {
-    return pathStartsWithin(join(root, "exec"), ref) || pathStartsWithin(join(root, "uat"), ref);
-  });
-  if (gsdEvidenceApproved) return true;
-  return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, ref));
-}
-
-function validateEvidenceRef(basePath: string, evidence: UatEvidenceRef): string | null {
-  if (!isNonEmptyString(evidence.ref)) return "evidence.ref is required";
-  if (evidence.kind === "gsd_uat_exec" || evidence.kind === "gsd_exec") {
-    const path = resolveExecMetaPath(basePath, evidence.ref.trim());
-    if (!path) return `missing gsd_exec metadata for evidence id "${evidence.ref}"`;
-    if (evidence.kind === "gsd_uat_exec") {
-      try {
-        const meta = JSON.parse(readFileSync(path, "utf-8")) as { metadata?: { kind?: unknown } };
-        if (meta.metadata?.kind !== "uat_exec") return `evidence id "${evidence.ref}" is not typed as uat_exec`;
-      } catch {
-        return `invalid gsd_exec metadata JSON for evidence id "${evidence.ref}"`;
-      }
-    }
-    return null;
-  }
-  if (evidence.kind === "url") {
-    try {
-      const parsed = new URL(evidence.ref);
-      return parsed.protocol === "http:" || parsed.protocol === "https:"
-        ? null
-        : `invalid URL evidence ref "${evidence.ref}"`;
-    } catch {
-      return `invalid URL evidence ref "${evidence.ref}"`;
-    }
-  }
-  return evidencePathIsApproved(basePath, evidence.ref)
-    ? null
-    : `evidence ref "${evidence.ref}" is outside approved evidence locations`;
-}
-
-function validateUatChecks(basePath: string, params: UatResultSaveParams): string | null {
-  for (const check of params.checks) {
-    if (!isNonEmptyString(check.id)) return "every check must have a non-empty id";
-    if (!isNonEmptyString(check.description)) return `check ${check.id} must have a description`;
-    if (!["artifact", "runtime", "browser", "human-follow-up"].includes(check.mode)) {
-      return `check ${check.id} has invalid mode "${check.mode}"`;
-    }
-    if (!["PASS", "FAIL", "NEEDS-HUMAN"].includes(check.result)) {
-      return `check ${check.id} has invalid result "${check.result}"`;
-    }
-    if (check.result === "PASS" || check.result === "FAIL") {
-      if (!Array.isArray(check.evidence) || check.evidence.length === 0) {
-        return `check ${check.id} is ${check.result} but has no objective evidence`;
-      }
-      for (const evidence of check.evidence) {
-        const error = validateEvidenceRef(basePath, evidence);
-        if (error) return `check ${check.id}: ${error}`;
-      }
-    } else if (!isNonEmptyString(check.notes)) {
-      return `check ${check.id} is NEEDS-HUMAN but has no manual instruction or reason`;
-    }
-  }
-  return null;
-}
-
-function validateFreshUatOwnedEvidence(params: UatResultSaveParams): string | null {
-  const hasFreshUatEvidence = params.checks.some((check) =>
-    (check.evidence ?? []).some((evidence) => evidence.kind === "gsd_uat_exec")
-  );
-  return hasFreshUatEvidence
-    ? null
-    : "UAT Assessment requires at least one fresh gsd_uat_exec evidence reference from run-uat";
-}
-
-function validateUatMode(params: UatResultSaveParams): string | null {
-  const modes = new Set(params.checks.map((check) => check.mode));
-  const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
-  if (params.uatType === "artifact-driven" && hasHuman && params.verdict === "PASS") {
-    return "artifact-driven UAT cannot PASS with human-only checks";
-  }
-  if (
-    hasHuman &&
-    params.verdict === "PASS" &&
-    !["human-experience", "mixed", "live-runtime"].includes(params.uatType) &&
-    !params.checks.every((check) => check.result !== "NEEDS-HUMAN" || check.nonAutomatable === true)
-  ) {
-    return "NEEDS-HUMAN checks can only coexist with PASS for human-experience, mixed, live-runtime, or explicitly non-automatable checks";
-  }
-  if (params.uatType === "runtime-executable" && !modes.has("runtime")) {
-    return "runtime-executable UAT requires at least one runtime check";
-  }
-  if (params.uatType === "browser-executable" && !modes.has("browser")) {
-    return "browser-executable UAT requires at least one browser check";
-  }
-  if (params.uatType === "live-runtime" && !modes.has("runtime") && !modes.has("browser")) {
-    return "live-runtime UAT requires runtime or browser evidence";
-  }
-  return null;
-}
-
-function quoteToolNames(toolNames: readonly string[]): string {
-  return toolNames.map((toolName) => `"${toolName}"`).join(", ");
-}
-
-function validateCanonicalPresentation(params: UatResultSaveParams): string | null {
-  const aliasHints: Record<string, string> = {
-    gsd_save_summary: "gsd_summary_save",
-    gsd_complete_task: "gsd_task_complete",
-    gsd_complete_slice: "gsd_slice_complete",
-    gsd_milestone_complete: "gsd_complete_milestone",
-  };
-  const errors: string[] = [];
-  for (const toolName of params.presentation.presentedTools) {
-    const baseName = parseMcpToolName(toolName)?.tool ?? toolName;
-    const canonical = aliasHints[baseName];
-    if (canonical) errors.push(`presentation tool "${toolName}" uses an alias; use canonical "${canonical}"`);
-  }
-
-  const presentedCanonical = new Set(
-    params.presentation.presentedTools.map((toolName) =>
-      canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName)
-    ),
-  );
-  const missingRequiredTools = RUN_UAT_WORKFLOW_TOOL_NAMES.filter(
-    (requiredTool) => !presentedCanonical.has(requiredTool),
-  );
-  if (missingRequiredTools.length === 1) {
-    errors.push(`presentation is missing required UAT tool "${missingRequiredTools[0]}"`);
-  } else if (missingRequiredTools.length > 1) {
-    errors.push(`presentation is missing required UAT tools ${quoteToolNames(missingRequiredTools)}`);
-  }
-
-  const forbiddenCanonical = new Set(
-    RUN_UAT_FORBIDDEN_TOOL_NAMES
-      .filter((toolName) => !toolName.includes("*"))
-      .map((toolName) => canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName)),
-  );
-  const forbiddenPresentedTools: string[] = [];
-  for (const toolName of params.presentation.presentedTools) {
-    const canonical = canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName);
-    if (toolName === "mcp__gsd-workflow__*" || forbiddenCanonical.has(canonical)) {
-      forbiddenPresentedTools.push(toolName);
-    }
-  }
-  if (forbiddenPresentedTools.length === 1) {
-    errors.push(`presentation includes forbidden run-uat tool "${forbiddenPresentedTools[0]}"`);
-  } else if (forbiddenPresentedTools.length > 1) {
-    errors.push(`presentation includes forbidden run-uat tools ${quoteToolNames(forbiddenPresentedTools)}`);
-  }
-
-  const blockedCanonical = new Set(
-    params.presentation.blockedTools.map((entry) =>
-      canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name)
-    ),
-  );
-  const missingBlockedTools = ["gsd_exec", "gsd_summary_save", "gsd_save_gate_result"].filter(
-    (blockedTool) => !blockedCanonical.has(blockedTool),
-  );
-  if (missingBlockedTools.length === 1) {
-    errors.push(`presentation must record "${missingBlockedTools[0]}" as blocked during run-uat`);
-  } else if (missingBlockedTools.length > 1) {
-    errors.push(`presentation must record ${quoteToolNames(missingBlockedTools)} as blocked during run-uat`);
-  }
-  return errors.length > 0 ? errors.join("; ") : null;
-}
-
-function nextUatAttempt(basePath: string, milestoneId: string, sliceId: string): number {
-  const contract = resolveGsdPathContract(basePath);
-  const dir = join(contract.projectGsd, "uat", milestoneId, sliceId);
-  if (!existsSync(dir)) return 1;
-  let max = 0;
-  for (const entry of readdirSync(dir)) {
-    const match = /^attempt-(\d+)\.json$/.exec(entry);
-    if (match) max = Math.max(max, Number(match[1]));
-  }
-  return max + 1;
-}
-
-function escapeMarkdownTableCell(value: unknown): string {
-  return String(value ?? "")
-    .replace(/[\\|]/g, (char) => `\\${char}`)
-    .replace(/\r?\n/g, "<br>");
-}
-
-function renderUatAssessment(
-  params: UatResultSaveParams,
-  attempt: number,
-  gateVerdict: "pass" | "flag",
-  basePath: string,
-): string {
-  const lines = [
-    "---",
-    `sliceId: ${params.sliceId}`,
-    `uatType: ${params.uatType}`,
-    `verdict: ${params.verdict}`,
-    `attempt: ${attempt}`,
-    `date: ${new Date().toISOString()}`,
-    "---",
-    "",
-    `# UAT Result - ${params.sliceId}`,
-    "",
-    "## Checks",
-    "",
-    "| Check | Mode | Result | Evidence | Notes |",
-    "|-------|------|--------|----------|-------|",
-    ...params.checks.map((check) => {
-      const evidence = (check.evidence ?? []).map((entry) => `${entry.kind}:${entry.ref}`).join("<br>") || "-";
-      return `| ${escapeMarkdownTableCell(check.description)} | ${escapeMarkdownTableCell(check.mode)} | ${escapeMarkdownTableCell(check.result)} | ${escapeMarkdownTableCell(evidence)} | ${escapeMarkdownTableCell(check.notes)} |`;
-    }),
-    "",
-    "## Overall Verdict",
-    "",
-    `${params.verdict} - ${params.notes ?? "UAT result saved."}`,
-    "",
-    "## Tool Presentation",
-    "",
-    "```json",
-    JSON.stringify(params.presentation, null, 2),
-    "```",
-    "",
-    "## Gate",
-    "",
-    `Aggregate UAT gate saved as ${gateVerdict}.`,
-  ];
-
-  // When any check still needs a human, point them at the exact checkout to
-  // validate — critical for worktree milestones whose code sits under a hidden
-  // `.gsd/worktrees/` path the reviewer would otherwise have to hunt for.
-  const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
-  if (hasHuman) {
-    const guidance = buildManualValidationGuidance(basePath, params.milestoneId, {
-      uatPath: relSliceFile(basePath, params.milestoneId, params.sliceId, "UAT"),
-    });
-    if (guidance) {
-      lines.push(
-        "",
-        "## Manual Validation",
-        "",
-        "One or more checks are marked `NEEDS-HUMAN` and require a person to validate:",
-        "",
-        ...guidance.split("\n").map((line) => `- ${line}`),
-      );
-    }
-  }
-
-  return `${lines.join("\n")}\n`;
-}
-
-async function saveUatAttemptArtifact(basePath: string, params: UatResultSaveParams, attempt: number): Promise<string> {
-  const contract = resolveGsdPathContract(basePath);
-  const relativePath = `uat/${params.milestoneId}/${params.sliceId}/attempt-${attempt}.json`;
-  await saveFile(join(contract.projectGsd, relativePath), `${JSON.stringify({ ...params, attempt }, null, 2)}\n`);
-  return relativePath;
-}
-
 export async function executeUatResultSave(
   params: UatResultSaveParams,
   basePath: string = process.cwd(),
@@ -1418,110 +977,78 @@ export async function executeUatResultSave(
   const unitGuard = blockIfWrongAutoUnit("run-uat", "save_uat_result");
   if (unitGuard) return unitGuard;
 
-  // Phase 1: normalize verdict and supply the canonical presentation when none was provided.
-  params = normalizeUatVerdict(params);
-  params = supplyDefaultPresentation(params);
-
   const dbAvailable = await ensureDbOpen(basePath);
   if (!dbAvailable) return errorResult("save_uat_result", "GSD database is not available.", "db_unavailable");
 
-  // Phase 2: validate the submitted presentation before the canonical merge so that
-  // presentations missing required workflow tools are rejected rather than silently patched.
-  const requiredError = ensureUatRequiredFields(params);
-  if (requiredError) return errorResult("save_uat_result", requiredError, "invalid_params");
-  const presentationError = validateCanonicalPresentation(params);
-  if (presentationError) return errorResult("save_uat_result", presentationError, "alias_tool_name");
-
-  // Phase 3: merge in the canonical plan ID and read-only audit tools so the persisted
-  // artifact always carries the full audit surface even when the provider omitted them.
-  params = mergeCanonicalPresentation(params);
-  const checkError = validateUatChecks(basePath, params);
-  if (checkError) return errorResult("save_uat_result", checkError, "invalid_evidence");
-  const freshEvidenceError = validateFreshUatOwnedEvidence(params);
-  if (freshEvidenceError) return errorResult("save_uat_result", freshEvidenceError, "missing_fresh_uat_evidence");
-  const modeError = validateUatMode(params);
-  if (modeError) return errorResult("save_uat_result", modeError, "uat_mode_mismatch");
+  const prepared = prepareUatRun(basePath, params);
+  if (!prepared.ok) {
+    return errorResult("save_uat_result", prepared.error.message, prepared.error.code);
+  }
+  const { run } = prepared;
 
   try {
-    const attempt = params.attempt === "auto" || params.attempt === undefined
-      ? nextUatAttempt(basePath, params.milestoneId, params.sliceId)
-      : typeof params.attempt === "string"
-        ? Number.parseInt(params.attempt, 10)
-        : params.attempt;
-    if (!Number.isInteger(attempt) || attempt < 1) {
-      return errorResult("save_uat_result", "attempt must be a positive integer or auto", "invalid_attempt");
-    }
-    const gateVerdict = params.verdict === "PASS" ? "pass" : "flag";
-    const rationale = params.notes ?? `UAT ${params.verdict} for ${params.sliceId}.`;
-    const assessment = renderUatAssessment(params, attempt, gateVerdict, basePath);
     const summary = await executeSummarySave(
       {
-        milestone_id: params.milestoneId,
-        slice_id: params.sliceId,
+        milestone_id: run.params.milestoneId,
+        slice_id: run.params.sliceId,
         artifact_type: "ASSESSMENT",
-        content: assessment,
+        content: run.assessment,
       },
       basePath,
     );
     if (summary.isError) return summary;
-    const attemptPath = await saveUatAttemptArtifact(basePath, params, attempt);
-    const evaluatedAt = new Date().toISOString();
+    const attemptPath = await saveUatAttemptArtifact(basePath, run);
     upsertQualityGate({
-      milestoneId: params.milestoneId,
-      sliceId: params.sliceId,
+      milestoneId: run.params.milestoneId,
+      sliceId: run.params.sliceId,
       gateId: "UAT",
       scope: "slice",
       taskId: "",
       status: "complete",
-      verdict: gateVerdict,
-      rationale,
-      findings: assessment,
-      evaluatedAt,
+      verdict: run.gateVerdict,
+      rationale: run.rationale,
+      findings: run.assessment,
+      evaluatedAt: run.evaluatedAt,
     });
     insertGateRun({
-      traceId: `uat:${params.milestoneId}:${params.sliceId}`,
-      turnId: `uat:${params.sliceId}:attempt-${attempt}`,
+      traceId: `uat:${run.params.milestoneId}:${run.params.sliceId}`,
+      turnId: run.runId,
       gateId: "UAT",
       gateType: "uat",
       unitType: "run-uat",
-      unitId: `run-uat:${params.milestoneId}/${params.sliceId}`,
-      milestoneId: params.milestoneId,
-      sliceId: params.sliceId,
-      outcome: params.verdict === "PASS" ? "pass" : "fail",
-      failureClass: params.verdict === "PASS" ? "none" : "verification",
-      rationale,
-      findings: assessment,
-      attempt,
-      maxAttempts: attempt,
-      retryable: params.verdict !== "PASS",
-      evaluatedAt,
+      unitId: `run-uat:${run.params.milestoneId}/${run.params.sliceId}`,
+      milestoneId: run.params.milestoneId,
+      sliceId: run.params.sliceId,
+      outcome: run.gateOutcome,
+      failureClass: run.params.verdict === "PASS" ? "none" : "verification",
+      rationale: run.rationale,
+      findings: run.assessment,
+      attempt: run.attempt,
+      maxAttempts: run.attempt,
+      retryable: run.params.verdict !== "PASS",
+      evaluatedAt: run.evaluatedAt,
     });
     invalidateStateCache();
-    // Surface where to validate when checks are left for a human, so the path
-    // (often a buried worktree checkout) reaches the reviewer, not just the file.
-    const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
-    const manualGuidance = hasHuman
-      ? buildManualValidationGuidance(basePath, params.milestoneId, {
-          uatPath: relSliceFile(basePath, params.milestoneId, params.sliceId, "UAT"),
-        })
-      : null;
-    const savedText = `UAT result saved for ${params.milestoneId}/${params.sliceId}: ${params.verdict}`;
+    const savedText = `UAT result saved for ${run.params.milestoneId}/${run.params.sliceId}: ${run.params.verdict}`;
     return {
       content: [{
         type: "text",
-        text: manualGuidance ? `${savedText}\n\nManual validation needed:\n${manualGuidance}` : savedText,
+        text: run.manualGuidance ? `${savedText}\n\nManual validation needed:\n${run.manualGuidance}` : savedText,
       }],
       details: {
         operation: "save_uat_result",
-        milestoneId: params.milestoneId,
-        sliceId: params.sliceId,
-        verdict: params.verdict,
-        gateVerdict,
-        attempt,
+        milestoneId: run.params.milestoneId,
+        sliceId: run.params.sliceId,
+        verdict: run.params.verdict,
+        gateVerdict: run.gateVerdict,
+        attempt: run.attempt,
         attemptPath,
-        recommendedNextUnit: params.verdict === "PASS" ? null : "reactive-execute",
-        ...(hasHuman
-          ? { manualValidationPath: resolveCanonicalMilestoneRoot(basePath, params.milestoneId) }
+        runId: run.runId,
+        worktreeRoot: run.worktreeRoot,
+        browserToolsPresented: run.browserToolsPresented,
+        recommendedNextUnit: run.params.verdict === "PASS" ? null : "reactive-execute",
+        ...(run.hasHuman
+          ? { manualValidationPath: run.worktreeRoot }
           : {}),
       },
     };

--- a/src/resources/extensions/gsd/uat-policy.ts
+++ b/src/resources/extensions/gsd/uat-policy.ts
@@ -1,0 +1,191 @@
+// Project/App: gsd-pi
+// File Purpose: Central UAT mode policy for dispatch, tool presentation, and result validation.
+
+import { extractUatType } from "./files.js";
+import type { UatType } from "./files.js";
+import { hasBrowserRequiredText } from "./browser-evidence.js";
+
+export type { UatType } from "./files.js";
+
+export type UatVerdict = "PASS" | "FAIL" | "PARTIAL";
+export type UatCheckResult = "PASS" | "FAIL" | "NEEDS-HUMAN";
+export type UatCheckMode = "artifact" | "runtime" | "browser" | "human-follow-up";
+
+export interface UatPolicyCheck {
+  mode: UatCheckMode;
+  result: UatCheckResult;
+  nonAutomatable?: boolean;
+}
+
+export interface UatModePolicy {
+  browserTools: boolean;
+  partialEligible: boolean;
+  passWithHumanFollowUp: boolean;
+  requiredAnyModes: readonly UatCheckMode[];
+}
+
+export interface UatContentPolicy {
+  declaredType: UatType;
+  effectiveType: UatType;
+  browserRequired: boolean;
+  shouldDispatchByDefault: boolean;
+}
+
+export const UAT_TYPES: readonly UatType[] = [
+  "artifact-driven",
+  "browser-executable",
+  "runtime-executable",
+  "live-runtime",
+  "mixed",
+  "human-experience",
+] as const;
+
+export const UAT_MODE_POLICIES: Readonly<Record<UatType, UatModePolicy>> = {
+  "artifact-driven": {
+    browserTools: false,
+    partialEligible: false,
+    passWithHumanFollowUp: false,
+    requiredAnyModes: [],
+  },
+  "browser-executable": {
+    browserTools: true,
+    partialEligible: false,
+    passWithHumanFollowUp: false,
+    requiredAnyModes: ["browser"],
+  },
+  "runtime-executable": {
+    browserTools: false,
+    partialEligible: false,
+    passWithHumanFollowUp: false,
+    requiredAnyModes: ["runtime"],
+  },
+  "live-runtime": {
+    browserTools: true,
+    partialEligible: true,
+    passWithHumanFollowUp: true,
+    requiredAnyModes: ["runtime", "browser"],
+  },
+  mixed: {
+    browserTools: true,
+    partialEligible: true,
+    passWithHumanFollowUp: true,
+    requiredAnyModes: [],
+  },
+  "human-experience": {
+    browserTools: true,
+    partialEligible: true,
+    passWithHumanFollowUp: true,
+    requiredAnyModes: [],
+  },
+};
+
+export function isUatType(value: unknown): value is UatType {
+  return typeof value === "string" && (UAT_TYPES as readonly string[]).includes(value);
+}
+
+export function getDeclaredUatType(content: string): UatType {
+  return extractUatType(content) ?? "artifact-driven";
+}
+
+export function classifyUatContent(content: string): UatContentPolicy {
+  const declaredType = getDeclaredUatType(content);
+  const browserRequired = hasBrowserRequiredText(content);
+  const effectiveType = declaredType === "artifact-driven" && browserRequired
+    ? "browser-executable"
+    : declaredType;
+
+  return {
+    declaredType,
+    effectiveType,
+    browserRequired,
+    shouldDispatchByDefault: effectiveType !== "artifact-driven" || browserRequired,
+  };
+}
+
+export function shouldEscalateArtifactUatToBrowser(content: string): boolean {
+  const policy = classifyUatContent(content);
+  return policy.declaredType === "artifact-driven" && policy.browserRequired;
+}
+
+export function resolveEffectiveUatType(content: string): UatType {
+  return classifyUatContent(content).effectiveType;
+}
+
+export function shouldDispatchUatForContent(
+  content: string,
+  prefs: { uat_dispatch?: boolean } | undefined,
+): boolean {
+  return !!prefs?.uat_dispatch || classifyUatContent(content).shouldDispatchByDefault;
+}
+
+export function uatTypeIncludesBrowser(uatType: string | undefined): boolean {
+  return isUatType(uatType) && UAT_MODE_POLICIES[uatType].browserTools;
+}
+
+function canonicalPresentedToolName(toolName: string): string {
+  if (!toolName.startsWith("mcp__")) return toolName;
+  const toolSeparator = toolName.indexOf("__", "mcp__".length);
+  return toolSeparator >= 0 ? toolName.slice(toolSeparator + 2) : toolName;
+}
+
+export function isUatBrowserToolName(toolName: string): boolean {
+  return canonicalPresentedToolName(toolName).startsWith("browser_");
+}
+
+export function hasUatBrowserToolSurface(activeTools: readonly string[] | undefined): boolean {
+  return Array.isArray(activeTools) && activeTools.some(isUatBrowserToolName);
+}
+
+export function getUatBrowserToolSupportError(options: {
+  uatType: UatType;
+  activeTools: readonly string[] | undefined;
+  milestoneId: string;
+  sliceId: string;
+}): string | null {
+  if (!uatTypeIncludesBrowser(options.uatType)) return null;
+  if (!Array.isArray(options.activeTools)) return null;
+  if (hasUatBrowserToolSurface(options.activeTools)) return null;
+
+  return `Cannot dispatch browser-backed run-uat for ${options.milestoneId}/${options.sliceId}: UAT mode "${options.uatType}" requires browser tools, but the active tool surface has none. Enable browser tools or change the UAT to a runtime-executable Playwright command, then rerun /gsd auto.`;
+}
+
+export function isPartialEligibleUatType(uatType: UatType | undefined): boolean {
+  return !!uatType && UAT_MODE_POLICIES[uatType].partialEligible;
+}
+
+function modeList(modes: readonly UatCheckMode[]): string {
+  if (modes.length === 1) return modes[0]!;
+  return modes.slice(0, -1).join(", ") + " or " + modes[modes.length - 1]!;
+}
+
+export function validateUatModePolicy(params: {
+  uatType: UatType;
+  verdict: UatVerdict;
+  checks: readonly UatPolicyCheck[];
+}): string | null {
+  const policy = UAT_MODE_POLICIES[params.uatType];
+  const modes = new Set(params.checks.map((check) => check.mode));
+  const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
+
+  if (params.uatType === "artifact-driven" && hasHuman && params.verdict === "PASS") {
+    return "artifact-driven UAT cannot PASS with human-only checks";
+  }
+
+  if (
+    hasHuman &&
+    params.verdict === "PASS" &&
+    !policy.passWithHumanFollowUp &&
+    !params.checks.every((check) => check.result !== "NEEDS-HUMAN" || check.nonAutomatable === true)
+  ) {
+    return "NEEDS-HUMAN checks can only coexist with PASS for human-experience, mixed, live-runtime, or explicitly non-automatable checks";
+  }
+
+  if (
+    policy.requiredAnyModes.length > 0 &&
+    !policy.requiredAnyModes.some((mode) => modes.has(mode))
+  ) {
+    return `${params.uatType} UAT requires ${modeList(policy.requiredAnyModes)} evidence`;
+  }
+
+  return null;
+}

--- a/src/resources/extensions/gsd/uat-run.ts
+++ b/src/resources/extensions/gsd/uat-run.ts
@@ -1,0 +1,550 @@
+// Project/App: gsd-pi
+// File Purpose: Owns the durable UAT run lifecycle behind gsd_uat_result_save.
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+
+import {
+  hasUatBrowserToolSurface,
+  isUatType,
+  UAT_MODE_POLICIES,
+  UAT_TYPES,
+  validateUatModePolicy,
+  type UatCheckMode,
+  type UatCheckResult,
+  type UatType,
+  type UatVerdict,
+} from "./uat-policy.js";
+import {
+  buildRunUatPresentationForType,
+  canonicalWorkflowToolName,
+  parseMcpToolName,
+  RUN_UAT_FORBIDDEN_TOOL_NAMES,
+  RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+  RUN_UAT_WORKFLOW_TOOL_NAMES,
+} from "./tool-presentation-plan.js";
+import { saveFile } from "./files.js";
+import { relSliceFile, resolveGsdPathContract } from "./paths.js";
+import { buildManualValidationGuidance, resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+
+export interface UatEvidenceRef {
+  kind: "gsd_uat_exec" | "gsd_exec" | "screenshot" | "log" | "url" | "browser";
+  ref: string;
+  note?: string;
+  unitType?: string;
+  tool?: string;
+  executionId?: string;
+}
+
+export interface UatCheckResultInput {
+  id: string;
+  description: string;
+  mode: UatCheckMode;
+  result: UatCheckResult;
+  evidence?: UatEvidenceRef[];
+  notes?: string;
+  nonAutomatable?: boolean;
+}
+
+export interface UatPresentationInput {
+  surface: "provider-tools" | "claude-code-sdk" | "mcp" | "hybrid";
+  model?: { provider?: string; api?: string; id?: string };
+  presentedTools: string[];
+  blockedTools: Array<{ name: string; reason: string }>;
+  aliases?: Array<{ requested: string; canonical: string }>;
+  fallbackToolsUsed?: string[];
+  toolPresentationPlanId?: string;
+  notes?: string;
+}
+
+export interface UatResultSaveParams {
+  milestoneId: string;
+  sliceId: string;
+  uatType: UatType;
+  verdict: UatVerdict;
+  checks: UatCheckResultInput[];
+  presentation: UatPresentationInput;
+  notes?: string;
+  attempt?: number | string | "auto";
+  previousAttemptId?: string;
+}
+
+export interface PreparedUatRun {
+  params: UatResultSaveParams;
+  runId: string;
+  attempt: number;
+  gateVerdict: "pass" | "flag";
+  gateOutcome: "pass" | "fail";
+  rationale: string;
+  assessment: string;
+  evaluatedAt: string;
+  hasHuman: boolean;
+  manualGuidance: string | null;
+  worktreeRoot: string;
+  browserToolsPresented: boolean;
+}
+
+export interface UatRunValidationError {
+  code: string;
+  message: string;
+}
+
+export type PrepareUatRunResult =
+  | { ok: true; run: PreparedUatRun }
+  | { ok: false; error: UatRunValidationError };
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function mergeBlockedTools(
+  current: UatPresentationInput["blockedTools"] | undefined,
+  canonical: UatPresentationInput["blockedTools"],
+): UatPresentationInput["blockedTools"] {
+  const merged = new Map<string, { name: string; reason: string }>();
+  for (const entry of [...(current ?? []), ...canonical]) {
+    merged.set(canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name), entry);
+  }
+  return [...merged.values()];
+}
+
+function mergePresentedTools(current: readonly string[] | undefined, canonical: readonly string[]): string[] {
+  return [...new Set([...(current ?? []), ...canonical])];
+}
+
+function normalizeUatVerdict(params: UatResultSaveParams): UatResultSaveParams {
+  const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
+  if (typeof raw.verdict === "string") {
+    return { ...params, verdict: raw.verdict.toUpperCase() as UatVerdict };
+  }
+  return params;
+}
+
+function supplyDefaultPresentation(params: UatResultSaveParams): UatResultSaveParams {
+  const raw = params as Partial<UatResultSaveParams> & Record<string, unknown>;
+  if (!raw.presentation) {
+    return { ...params, presentation: buildRunUatPresentationForType(params.uatType) };
+  }
+  return params;
+}
+
+function mergeCanonicalPresentation(params: UatResultSaveParams): UatResultSaveParams {
+  const canonicalPresentation = buildRunUatPresentationForType(params.uatType);
+  const providedPresentation = params.presentation as Partial<UatPresentationInput>;
+  return {
+    ...params,
+    presentation: {
+      ...providedPresentation,
+      surface: providedPresentation.surface ?? canonicalPresentation.surface,
+      presentedTools: mergePresentedTools(providedPresentation.presentedTools, canonicalPresentation.presentedTools),
+      blockedTools: mergeBlockedTools(providedPresentation.blockedTools, canonicalPresentation.blockedTools),
+      toolPresentationPlanId: RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
+    } as UatPresentationInput,
+  };
+}
+
+function ensureUatRequiredFields(params: UatResultSaveParams): string | null {
+  if (!isNonEmptyString(params.milestoneId)) return "milestoneId is required";
+  if (!isNonEmptyString(params.sliceId)) return "sliceId is required";
+  if (!isNonEmptyString(params.uatType)) return "uatType is required";
+  if (!isUatType(params.uatType)) {
+    return `uatType must be one of: ${UAT_TYPES.join(", ")}`;
+  }
+  if (!["PASS", "FAIL", "PARTIAL"].includes(params.verdict)) return "verdict must be PASS, FAIL, or PARTIAL";
+  if (!Array.isArray(params.checks) || params.checks.length === 0) return "checks must contain at least one UAT check";
+  if (!params.presentation || !Array.isArray(params.presentation.presentedTools)) return "presentation.presentedTools is required";
+  if (!Array.isArray(params.presentation.blockedTools)) return "presentation.blockedTools is required";
+  return null;
+}
+
+function approvedEvidenceRoots(basePath: string): string[] {
+  const contract = resolveGsdPathContract(basePath);
+  return [contract.worktreeGsd, contract.projectGsd].filter((root): root is string => typeof root === "string");
+}
+
+function approvedBrowserArtifactRoots(basePath: string): string[] {
+  const contract = resolveGsdPathContract(basePath);
+  const roots = [contract.workRoot, contract.projectRoot].map((root) => join(root, ".artifacts", "browser"));
+  return [...new Set(roots)];
+}
+
+function pathStartsWithin(parent: string, target: string): boolean {
+  const normalizedParent = parent.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalizedTarget = target.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalizedTarget === normalizedParent || normalizedTarget.startsWith(`${normalizedParent}/`);
+}
+
+function pushUnique(paths: string[], candidate: string): void {
+  if (!paths.includes(candidate)) paths.push(candidate);
+}
+
+function execMetaPathCandidates(basePath: string, ref: string): string[] {
+  const trimmed = ref.trim();
+  const candidates: string[] = [];
+  const execDirs = approvedEvidenceRoots(basePath).map((root) => join(root, "exec"));
+  const normalizedRef = trimmed.replace(/\\/g, "/");
+  const pathLike = normalizedRef.endsWith(".meta.json") || normalizedRef.includes("/.gsd/exec/");
+
+  if (pathLike) {
+    const rawPath = isAbsolute(trimmed) ? resolve(trimmed) : resolve(basePath, trimmed);
+    pushUnique(candidates, rawPath);
+
+    const relativeExecMarker = ".gsd/exec/";
+    const markerIndex = normalizedRef.indexOf(relativeExecMarker);
+    if (markerIndex >= 0) {
+      const execRelative = normalizedRef.slice(markerIndex + relativeExecMarker.length);
+      for (const execDir of execDirs) {
+        pushUnique(candidates, join(execDir, execRelative));
+      }
+    }
+
+    return candidates.filter((candidate) =>
+      execDirs.some((execDir) => pathStartsWithin(execDir, candidate))
+    );
+  }
+
+  for (const execDir of execDirs) {
+    pushUnique(candidates, join(execDir, `${trimmed}.meta.json`));
+  }
+  return candidates;
+}
+
+function resolveExecMetaPath(basePath: string, ref: string): string | null {
+  for (const candidate of execMetaPathCandidates(basePath, ref)) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function evidencePathIsApproved(basePath: string, ref: string): boolean {
+  const normalizedRef = ref.replace(/\\/g, "/");
+  if (normalizedRef.startsWith(".gsd/exec/") || normalizedRef.startsWith(".gsd/uat/")) return true;
+  if (normalizedRef.startsWith(".artifacts/browser/")) {
+    const resolvedRef = resolve(basePath, ref);
+    return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, resolvedRef));
+  }
+  const gsdEvidenceApproved = approvedEvidenceRoots(basePath).some((root) => {
+    return pathStartsWithin(join(root, "exec"), ref) || pathStartsWithin(join(root, "uat"), ref);
+  });
+  if (gsdEvidenceApproved) return true;
+  return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, ref));
+}
+
+function validateEvidenceRef(basePath: string, evidence: UatEvidenceRef): string | null {
+  if (!isNonEmptyString(evidence.ref)) return "evidence.ref is required";
+  if (evidence.kind === "gsd_uat_exec" || evidence.kind === "gsd_exec") {
+    const path = resolveExecMetaPath(basePath, evidence.ref.trim());
+    if (!path) return `missing gsd_exec metadata for evidence id "${evidence.ref}"`;
+    if (evidence.kind === "gsd_uat_exec") {
+      try {
+        const meta = JSON.parse(readFileSync(path, "utf-8")) as { metadata?: { kind?: unknown } };
+        if (meta.metadata?.kind !== "uat_exec") return `evidence id "${evidence.ref}" is not typed as uat_exec`;
+      } catch {
+        return `invalid gsd_exec metadata JSON for evidence id "${evidence.ref}"`;
+      }
+    }
+    return null;
+  }
+  if (evidence.kind === "url") {
+    try {
+      const parsed = new URL(evidence.ref);
+      return parsed.protocol === "http:" || parsed.protocol === "https:"
+        ? null
+        : `invalid URL evidence ref "${evidence.ref}"`;
+    } catch {
+      return `invalid URL evidence ref "${evidence.ref}"`;
+    }
+  }
+  return evidencePathIsApproved(basePath, evidence.ref)
+    ? null
+    : `evidence ref "${evidence.ref}" is outside approved evidence locations`;
+}
+
+function validateUatChecks(basePath: string, params: UatResultSaveParams): string | null {
+  for (const check of params.checks) {
+    if (!isNonEmptyString(check.id)) return "every check must have a non-empty id";
+    if (!isNonEmptyString(check.description)) return `check ${check.id} must have a description`;
+    if (!["artifact", "runtime", "browser", "human-follow-up"].includes(check.mode)) {
+      return `check ${check.id} has invalid mode "${check.mode}"`;
+    }
+    if (!["PASS", "FAIL", "NEEDS-HUMAN"].includes(check.result)) {
+      return `check ${check.id} has invalid result "${check.result}"`;
+    }
+    if (check.result === "PASS" || check.result === "FAIL") {
+      if (!Array.isArray(check.evidence) || check.evidence.length === 0) {
+        return `check ${check.id} is ${check.result} but has no objective evidence`;
+      }
+      for (const evidence of check.evidence) {
+        const error = validateEvidenceRef(basePath, evidence);
+        if (error) return `check ${check.id}: ${error}`;
+      }
+    } else if (!isNonEmptyString(check.notes)) {
+      return `check ${check.id} is NEEDS-HUMAN but has no manual instruction or reason`;
+    }
+  }
+  return null;
+}
+
+function validateFreshUatOwnedEvidence(params: UatResultSaveParams): string | null {
+  const hasFreshUatEvidence = params.checks.some((check) =>
+    (check.evidence ?? []).some((evidence) => evidence.kind === "gsd_uat_exec")
+  );
+  return hasFreshUatEvidence
+    ? null
+    : "UAT Assessment requires at least one fresh gsd_uat_exec evidence reference from run-uat";
+}
+
+function quoteToolNames(toolNames: readonly string[]): string {
+  return toolNames.map((toolName) => `"${toolName}"`).join(", ");
+}
+
+function validateCanonicalPresentation(params: UatResultSaveParams): string | null {
+  const aliasHints: Record<string, string> = {
+    gsd_save_summary: "gsd_summary_save",
+    gsd_complete_task: "gsd_task_complete",
+    gsd_complete_slice: "gsd_slice_complete",
+    gsd_milestone_complete: "gsd_complete_milestone",
+  };
+  const errors: string[] = [];
+  for (const toolName of params.presentation.presentedTools) {
+    const baseName = parseMcpToolName(toolName)?.tool ?? toolName;
+    const canonical = aliasHints[baseName];
+    if (canonical) errors.push(`presentation tool "${toolName}" uses an alias; use canonical "${canonical}"`);
+  }
+
+  const presentedCanonical = new Set(
+    params.presentation.presentedTools.map((toolName) =>
+      canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName)
+    ),
+  );
+  const missingRequiredTools = RUN_UAT_WORKFLOW_TOOL_NAMES.filter(
+    (requiredTool) => !presentedCanonical.has(requiredTool),
+  );
+  if (missingRequiredTools.length === 1) {
+    errors.push(`presentation is missing required UAT tool "${missingRequiredTools[0]}"`);
+  } else if (missingRequiredTools.length > 1) {
+    errors.push(`presentation is missing required UAT tools ${quoteToolNames(missingRequiredTools)}`);
+  }
+
+  const forbiddenCanonical = new Set(
+    RUN_UAT_FORBIDDEN_TOOL_NAMES
+      .filter((toolName) => !toolName.includes("*"))
+      .map((toolName) => canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName)),
+  );
+  const forbiddenPresentedTools: string[] = [];
+  for (const toolName of params.presentation.presentedTools) {
+    const canonical = canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName);
+    if (toolName === "mcp__gsd-workflow__*" || forbiddenCanonical.has(canonical)) {
+      forbiddenPresentedTools.push(toolName);
+    }
+  }
+  if (forbiddenPresentedTools.length === 1) {
+    errors.push(`presentation includes forbidden run-uat tool "${forbiddenPresentedTools[0]}"`);
+  } else if (forbiddenPresentedTools.length > 1) {
+    errors.push(`presentation includes forbidden run-uat tools ${quoteToolNames(forbiddenPresentedTools)}`);
+  }
+
+  const blockedCanonical = new Set(
+    params.presentation.blockedTools.map((entry) =>
+      canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name)
+    ),
+  );
+  const missingBlockedTools = ["gsd_exec", "gsd_summary_save", "gsd_save_gate_result"].filter(
+    (blockedTool) => !blockedCanonical.has(blockedTool),
+  );
+  if (missingBlockedTools.length === 1) {
+    errors.push(`presentation must record "${missingBlockedTools[0]}" as blocked during run-uat`);
+  } else if (missingBlockedTools.length > 1) {
+    errors.push(`presentation must record ${quoteToolNames(missingBlockedTools)} as blocked during run-uat`);
+  }
+  return errors.length > 0 ? errors.join("; ") : null;
+}
+
+function nextUatAttempt(basePath: string, milestoneId: string, sliceId: string): number {
+  const contract = resolveGsdPathContract(basePath);
+  const dir = join(contract.projectGsd, "uat", milestoneId, sliceId);
+  if (!existsSync(dir)) return 1;
+  let max = 0;
+  for (const entry of readdirSync(dir)) {
+    const match = /^attempt-(\d+)\.json$/.exec(entry);
+    if (match) max = Math.max(max, Number(match[1]));
+  }
+  return max + 1;
+}
+
+function resolveUatAttempt(basePath: string, params: UatResultSaveParams): number | UatRunValidationError {
+  if (params.attempt === "auto" || params.attempt === undefined) {
+    return nextUatAttempt(basePath, params.milestoneId, params.sliceId);
+  }
+
+  const attempt = typeof params.attempt === "string"
+    ? Number.parseInt(params.attempt, 10)
+    : params.attempt;
+  if (!Number.isInteger(attempt) || attempt < 1) {
+    return {
+      code: "invalid_attempt",
+      message: "attempt must be a positive integer or auto",
+    };
+  }
+  return attempt;
+}
+
+function escapeMarkdownTableCell(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[\\|]/g, (char) => `\\${char}`)
+    .replace(/\r?\n/g, "<br>");
+}
+
+interface UatAssessmentContext {
+  attempt: number;
+  gateVerdict: "pass" | "flag";
+  runId: string;
+  worktreeRoot: string;
+  evaluatedAt: string;
+  manualGuidance: string | null;
+}
+
+function renderCheckRow(check: UatCheckResultInput): string {
+  const evidence = (check.evidence ?? []).map((entry) => `${entry.kind}:${entry.ref}`).join("<br>") || "-";
+  return `| ${escapeMarkdownTableCell(check.description)} | ${escapeMarkdownTableCell(check.mode)} | ${escapeMarkdownTableCell(check.result)} | ${escapeMarkdownTableCell(evidence)} | ${escapeMarkdownTableCell(check.notes)} |`;
+}
+
+function renderUatAssessment(params: UatResultSaveParams, run: UatAssessmentContext): string {
+  const lines = [
+    "---",
+    `sliceId: ${params.sliceId}`,
+    `uatType: ${params.uatType}`,
+    `verdict: ${params.verdict}`,
+    `attempt: ${run.attempt}`,
+    `runId: ${run.runId}`,
+    `worktreeRoot: ${run.worktreeRoot}`,
+    `date: ${run.evaluatedAt}`,
+    "---",
+    "",
+    `# UAT Result - ${params.sliceId}`,
+    "",
+    "## Checks",
+    "",
+    "| Check | Mode | Result | Evidence | Notes |",
+    "|-------|------|--------|----------|-------|",
+    ...params.checks.map(renderCheckRow),
+    "",
+    "## Overall Verdict",
+    "",
+    `${params.verdict} - ${params.notes ?? "UAT result saved."}`,
+    "",
+    "## Tool Presentation",
+    "",
+    "```json",
+    JSON.stringify(params.presentation, null, 2),
+    "```",
+    "",
+    "## Gate",
+    "",
+    `Aggregate UAT gate saved as ${run.gateVerdict}.`,
+  ];
+
+  if (run.manualGuidance) {
+    lines.push(
+      "",
+      "## Manual Validation",
+      "",
+      "One or more checks are marked `NEEDS-HUMAN` and require a person to validate:",
+      "",
+      ...run.manualGuidance.split("\n").map((line) => `- ${line}`),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function prepareUatRun(basePath: string, rawParams: UatResultSaveParams): PrepareUatRunResult {
+  let params = normalizeUatVerdict(rawParams);
+  params = supplyDefaultPresentation(params);
+
+  const requiredError = ensureUatRequiredFields(params);
+  if (requiredError) return { ok: false, error: { code: "invalid_params", message: requiredError } };
+
+  const presentationError = validateCanonicalPresentation(params);
+  if (presentationError) return { ok: false, error: { code: "alias_tool_name", message: presentationError } };
+
+  params = mergeCanonicalPresentation(params);
+
+  const checkError = validateUatChecks(basePath, params);
+  if (checkError) return { ok: false, error: { code: "invalid_evidence", message: checkError } };
+
+  const freshEvidenceError = validateFreshUatOwnedEvidence(params);
+  if (freshEvidenceError) {
+    return { ok: false, error: { code: "missing_fresh_uat_evidence", message: freshEvidenceError } };
+  }
+
+  const modeError = validateUatModePolicy(params);
+  if (modeError) return { ok: false, error: { code: "uat_mode_mismatch", message: modeError } };
+
+  const attempt = resolveUatAttempt(basePath, params);
+  if (typeof attempt !== "number") return { ok: false, error: attempt };
+
+  const gateVerdict = params.verdict === "PASS" ? "pass" : "flag";
+  const gateOutcome = params.verdict === "PASS" ? "pass" : "fail";
+  const rationale = params.notes ?? `UAT ${params.verdict} for ${params.sliceId}.`;
+  const evaluatedAt = new Date().toISOString();
+  const runId = `uat:${params.milestoneId}:${params.sliceId}:attempt-${attempt}`;
+  const worktreeRoot = resolveCanonicalMilestoneRoot(basePath, params.milestoneId);
+  const hasHuman = params.checks.some((check) => check.result === "NEEDS-HUMAN");
+  const manualGuidance = hasHuman
+    ? buildManualValidationGuidance(basePath, params.milestoneId, {
+        uatPath: relSliceFile(basePath, params.milestoneId, params.sliceId, "UAT"),
+      })
+    : null;
+  const browserToolsPresented = hasUatBrowserToolSurface(params.presentation.presentedTools);
+  const assessment = renderUatAssessment(params, {
+    attempt,
+    gateVerdict,
+    runId,
+    worktreeRoot,
+    evaluatedAt,
+    manualGuidance,
+  });
+
+  return {
+    ok: true,
+    run: {
+      params,
+      runId,
+      attempt,
+      gateVerdict,
+      gateOutcome,
+      rationale,
+      assessment,
+      evaluatedAt,
+      hasHuman,
+      manualGuidance,
+      worktreeRoot,
+      browserToolsPresented,
+    },
+  };
+}
+
+export async function saveUatAttemptArtifact(basePath: string, run: PreparedUatRun): Promise<string> {
+  const contract = resolveGsdPathContract(basePath);
+  const relativePath = `uat/${run.params.milestoneId}/${run.params.sliceId}/attempt-${run.attempt}.json`;
+  const payload = {
+    runId: run.runId,
+    attempt: run.attempt,
+    milestoneId: run.params.milestoneId,
+    sliceId: run.params.sliceId,
+    uatType: run.params.uatType,
+    verdict: run.params.verdict,
+    gateVerdict: run.gateVerdict,
+    evaluatedAt: run.evaluatedAt,
+    worktreeRoot: run.worktreeRoot,
+    browserToolsPresented: run.browserToolsPresented,
+    modePolicy: UAT_MODE_POLICIES[run.params.uatType],
+    checks: run.params.checks,
+    presentation: run.params.presentation,
+    notes: run.params.notes,
+    previousAttemptId: run.params.previousAttemptId,
+  };
+  await saveFile(join(contract.projectGsd, relativePath), `${JSON.stringify(payload, null, 2)}\n`);
+  return relativePath;
+}

--- a/src/resources/extensions/gsd/verdict-parser.ts
+++ b/src/resources/extensions/gsd/verdict-parser.ts
@@ -5,10 +5,9 @@
  * (e.g. `passed` → `pass`) are applied consistently across the codebase.
  */
 
-import { extractUatType } from "./files.js";
-import type { UatType } from "./files.js";
 import { splitFrontmatter, parseFrontmatterMap } from "../shared/frontmatter.js";
 import { parse as parseYaml } from "yaml";
+import { getDeclaredUatType, isPartialEligibleUatType, type UatType } from "./uat-policy.js";
 
 function normalizeVerdict(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -103,12 +102,6 @@ export const UAT_ACCEPTABLE_VERDICTS: readonly string[] = ["pass", "passed"];
  * UAT types whose results may legitimately produce a `partial` verdict
  * when all automatable checks pass but human-only checks remain.
  */
-const PARTIAL_ELIGIBLE_UAT_TYPES: readonly UatType[] = [
-  "mixed",
-  "human-experience",
-  "live-runtime",
-];
-
 /**
  * Check whether a verdict is acceptable for a given UAT type.
  *
@@ -117,7 +110,7 @@ const PARTIAL_ELIGIBLE_UAT_TYPES: readonly UatType[] = [
  */
 export function isAcceptableUatVerdict(verdict: string, uatType: UatType | undefined): boolean {
   if (UAT_ACCEPTABLE_VERDICTS.includes(verdict)) return true;
-  if (verdict === "partial" && uatType && (PARTIAL_ELIGIBLE_UAT_TYPES as readonly string[]).includes(uatType)) {
+  if (verdict === "partial" && isPartialEligibleUatType(uatType)) {
     return true;
   }
   return false;
@@ -147,5 +140,5 @@ export function isValidMilestoneVerdict(verdict: string): verdict is ValidationV
  * the codebase when a UAT file lacks an explicit `## UAT Type` section.
  */
 export function getUatType(content: string): UatType {
-  return extractUatType(content) ?? "artifact-driven";
+  return getDeclaredUatType(content);
 }


### PR DESCRIPTION
## TL;DR

**What:** Centralizes GSD UAT mode policy and moves UAT attempt/result preparation into a dedicated run-record module.
**Why:** The UAT, browser-tool, Playwright/runtime, and milestone-validation paths had drifted across prompts, dispatch, result-save, and docs.
**How:** Adds shared UAT policy and run lifecycle modules, wires dispatch/result-save through them, documents the canonical process, and expands regression coverage.

## What

This PR adds a shared UAT policy source for mode classification, browser-tool requirements, dispatch decisions, partial verdict eligibility, and result-save evidence validation. It also extracts the UAT result-save lifecycle out of the large workflow executor into a dedicated run-record module that prepares canonical presentation metadata, run IDs, attempt artifacts, worktree capture, and assessment rendering.

It updates the prompt/process docs to reflect the actual order: slice completion writes the UAT spec, `run-uat` produces the per-slice assessment and attempt record, and milestone validation then runs the three parallel reviewers against completed slice evidence.

The PR also includes two small test robustness fixes surfaced while running the full merge gate: one avoids SQLite defensive-mode schema mutation, and one normalizes macOS temp realpaths in repository-registry assertions.

## Why

UAT mode behavior was split across prompt wording, dispatch helpers, tool-presentation plans, verdict parsing, and result-save validation. That made browser-backed UAT easy to advertise without proving browser-tool support and made milestone validation rely on late prose-level evidence checks.

Centralizing the policy makes the browser and runtime requirements explicit before dispatch and keeps result-save validation aligned with the same contract.

## How

- Adds `uat-policy.ts` as the shared UAT mode contract.
- Adds `uat-run.ts` to prepare and persist UAT run records and rendered assessments.
- Wires `complete-slice`, `auto-prompts`, `auto-dispatch`, `tool-presentation-plan`, `verdict-parser`, and `workflow-tool-executors` through the shared policy/run modules.
- Adds focused policy coverage and extends workflow executor tests for run IDs, worktree roots, mode policy metadata, and browser-tool presentation tracking.
- Updates `docs/dev/uat-process.md` and `docs/prompt-map.md` with the canonical UAT and validation order.

## Validation

- `pnpm run verify:merge`
- Focused UAT/prompt/workflow tests during development
- `git diff --check`

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783252767&installation_id=134682257&pr_number=501&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F501&signature=94326d5296fd16312eded5ee0fdfa5df6da591a9212111ef5e78bab9647699b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quality-gate dispatch, slice completion validation, and UAT result persistence—behavior changes (browser preflight, shared mode rules) affect auto-mode progression but are covered by new policy and executor tests.
> 
> **Overview**
> Introduces **`uat-policy.ts`** as the single contract for UAT modes (classification, artifact→browser escalation, browser-tool surfaces, partial verdicts, and mode-specific evidence rules) and **`uat-run.ts`** to own `gsd_uat_result_save` preparation—validation, canonical presentation merge, **runId**, **worktreeRoot**, **browserToolsPresented**, assessment rendering, and structured attempt JSON.
> 
> **Dispatch** now calls `getUatBrowserToolSupportError` before `run-uat` when an active tool snapshot exists, so browser-backed UAT stops early instead of burning retry attempts. **complete-slice**, **auto-prompts**, **tool-presentation-plan**, and **verdict-parser** route through the shared policy instead of duplicated helpers.
> 
> **`executeUatResultSave`** shrinks to delegating to `prepareUatRun` / `saveUatAttemptArtifact`; assessments and attempt records gain explicit run/worktree metadata.
> 
> Docs add **`docs/dev/uat-process.md`** and update **`prompt-map.md`** (quality-gate order: complete-slice → run-uat → validate-milestone; expanded UAT mode list). Tests add **`uat-policy.test.ts`**, tighten prompt-contract assertions, and include minor DB/registry test fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbef45f70815940a8450be52b11ac8201511e5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->