### PR TITLE
fix(gsd): harden drift reconciliation single-writer + projection invariant

### DIFF
--- a/src/headless-recover.ts
+++ b/src/headless-recover.ts
@@ -50,14 +50,20 @@ async function loadExtensionModules() {
   const dbModule = await jiti.import(gsdExtensionPath('gsd-db.ts'), {}) as any
   const importerModule = await jiti.import(gsdExtensionPath('md-importer.ts'), {}) as any
   const dynamicToolsModule = await jiti.import(gsdExtensionPath('bootstrap/dynamic-tools.ts'), {}) as any
+  const migrationCheckModule = await jiti.import(gsdExtensionPath('migration-auto-check.ts'), {}) as any
+  const rendererModule = await jiti.import(gsdExtensionPath('markdown-renderer.ts'), {}) as any
+  type Counts = { milestones: number; slices: number; tasks: number }
   return {
     ensureDbOpen: dynamicToolsModule.ensureDbOpen as (basePath: string) => Promise<boolean>,
     isDbAvailable: dbModule.isDbAvailable as () => boolean,
     clearEngineHierarchy: dbModule.clearEngineHierarchy as () => void,
     transaction: dbModule.transaction as <T>(fn: () => T) => T,
-    migrateHierarchyToDb: importerModule.migrateHierarchyToDb as (basePath: string) =>
-      { milestones: number; slices: number; tasks: number },
+    backupDatabaseSnapshot: dbModule.backupDatabaseSnapshot as (label: string) => string | null,
+    migrateHierarchyToDb: importerModule.migrateHierarchyToDb as (basePath: string) => Counts,
     invalidateStateCache: stateModule.invalidateStateCache as () => void,
+    countDbHierarchy: migrationCheckModule.countDbHierarchy as () => Counts,
+    countMarkdownHierarchy: migrationCheckModule.countMarkdownHierarchy as (basePath: string) => Counts,
+    renderAllFromDb: rendererModule.renderAllFromDb as (basePath: string) => Promise<unknown>,
   }
 }
 
@@ -87,6 +93,29 @@ export async function handleRecover(basePath: string): Promise<RecoverResult> {
     return { exitCode: 1 }
   }
 
+  // Refuse a destructive recover that would delete authoritative DB rows the
+  // markdown lacks, unless explicitly allowed. The DB is the source of truth;
+  // re-projecting via rebuild is almost always what's wanted instead.
+  const markdown = modules.countMarkdownHierarchy(basePath)
+  const beforeDb = modules.countDbHierarchy()
+  const dataLoss =
+    beforeDb.milestones > markdown.milestones ||
+    beforeDb.slices > markdown.slices ||
+    beforeDb.tasks > markdown.tasks
+  const allowDataLoss = process.env.GSD_RECOVER_ALLOW_DATA_LOSS === '1'
+  if (dataLoss && !allowDataLoss) {
+    process.stderr.write(
+      `[headless] recover refused: DB holds ${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T ` +
+        `but markdown only ${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T; ` +
+        `recover would delete the extra rows. Set GSD_RECOVER_ALLOW_DATA_LOSS=1 to override, ` +
+        `or run a DB-to-markdown rebuild instead.\n`,
+    )
+    return { exitCode: 1 }
+  }
+
+  // Snapshot the DB before the destructive clear so recover is reversible.
+  const backupPath = modules.backupDatabaseSnapshot('pre-recover')
+
   let counts: { milestones: number; slices: number; tasks: number }
   try {
     counts = modules.transaction(() => {
@@ -100,6 +129,28 @@ export async function handleRecover(basePath: string): Promise<RecoverResult> {
   }
 
   modules.invalidateStateCache()
+
+  // Re-project markdown from the freshly imported DB so disk and DB agree.
+  try {
+    await modules.renderAllFromDb(basePath)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`[headless] recover: re-render after import failed: ${msg}\n`)
+  }
+
+  if (
+    counts.milestones < markdown.milestones ||
+    counts.slices < markdown.slices ||
+    counts.tasks < markdown.tasks
+  ) {
+    process.stderr.write(
+      `[headless] recover: imported fewer rows than markdown contained ` +
+        `(${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T on disk); some markdown may have failed to parse\n`,
+    )
+  }
+  if (backupPath) {
+    process.stderr.write(`[headless] recover: pre-recover snapshot saved to ${backupPath}\n`)
+  }
 
   process.stderr.write(
     `gsd-recover: recovered ${counts.milestones}M/${counts.slices}S/${counts.tasks}T hierarchy\n`,

--- a/src/headless-recover.ts
+++ b/src/headless-recover.ts
@@ -63,7 +63,9 @@ async function loadExtensionModules() {
     invalidateStateCache: stateModule.invalidateStateCache as () => void,
     countDbHierarchy: migrationCheckModule.countDbHierarchy as () => Counts,
     countMarkdownHierarchy: migrationCheckModule.countMarkdownHierarchy as (basePath: string) => Counts,
-    renderAllFromDb: rendererModule.renderAllFromDb as (basePath: string) => Promise<unknown>,
+    recoverWouldDeleteDbRows: migrationCheckModule.recoverWouldDeleteDbRows as (basePath: string) => boolean,
+    renderAllFromDb: rendererModule.renderAllFromDb as (basePath: string) =>
+      Promise<{ rendered: number; skipped: number; errors: string[] }>,
   }
 }
 
@@ -95,19 +97,18 @@ export async function handleRecover(basePath: string): Promise<RecoverResult> {
 
   // Refuse a destructive recover that would delete authoritative DB rows the
   // markdown lacks, unless explicitly allowed. The DB is the source of truth;
-  // re-projecting via rebuild is almost always what's wanted instead.
+  // re-projecting via rebuild is almost always what's wanted instead. The
+  // check is identity-based, so it also catches equal-count divergence (DB S99
+  // vs markdown S01) that a cardinality-only comparison would miss.
   const markdown = modules.countMarkdownHierarchy(basePath)
   const beforeDb = modules.countDbHierarchy()
-  const dataLoss =
-    beforeDb.milestones > markdown.milestones ||
-    beforeDb.slices > markdown.slices ||
-    beforeDb.tasks > markdown.tasks
+  const dataLoss = modules.recoverWouldDeleteDbRows(basePath)
   const allowDataLoss = process.env.GSD_RECOVER_ALLOW_DATA_LOSS === '1'
   if (dataLoss && !allowDataLoss) {
     process.stderr.write(
-      `[headless] recover refused: DB holds ${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T ` +
-        `but markdown only ${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T; ` +
-        `recover would delete the extra rows. Set GSD_RECOVER_ALLOW_DATA_LOSS=1 to override, ` +
+      `[headless] recover refused: the DB (${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T) ` +
+        `holds rows the markdown (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) lacks; ` +
+        `recover would delete them. Set GSD_RECOVER_ALLOW_DATA_LOSS=1 to override, ` +
         `or run a DB-to-markdown rebuild instead.\n`,
     )
     return { exitCode: 1 }
@@ -131,11 +132,25 @@ export async function handleRecover(basePath: string): Promise<RecoverResult> {
   modules.invalidateStateCache()
 
   // Re-project markdown from the freshly imported DB so disk and DB agree.
+  // renderAllFromDb resolves even when individual artifacts fail, so inspect
+  // its error list — a silent projection failure must surface, not pass as a
+  // clean recover.
+  let projectionErrors = 0
   try {
-    await modules.renderAllFromDb(basePath)
+    const renderResult = await modules.renderAllFromDb(basePath)
+    projectionErrors = renderResult.errors.length
+    if (projectionErrors > 0) {
+      process.stderr.write(
+        `[headless] recover: ${projectionErrors} markdown projection(s) failed to render — markdown may be stale:\n`,
+      )
+      for (const e of renderResult.errors.slice(0, 10)) {
+        process.stderr.write(`  - ${e}\n`)
+      }
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(`[headless] recover: re-render after import failed: ${msg}\n`)
+    projectionErrors = 1
   }
 
   if (
@@ -153,7 +168,8 @@ export async function handleRecover(basePath: string): Promise<RecoverResult> {
   }
 
   process.stderr.write(
-    `gsd-recover: recovered ${counts.milestones}M/${counts.slices}S/${counts.tasks}T hierarchy\n`,
+    `gsd-recover: recovered ${counts.milestones}M/${counts.slices}S/${counts.tasks}T hierarchy` +
+      `${projectionErrors > 0 ? ` (${projectionErrors} projection error(s) — run rebuild markdown)` : ''}\n`,
   )
   return { exitCode: 0 }
 }

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -542,9 +542,26 @@ async function confirmRecover(
       "Import markdown into the DB?",
       `${warningText}\n\nContinue only if the DB is lost or corrupt and markdown is the source you intend to import.`,
     );
-    if (confirmed) return true;
-    ctx.ui.notify("gsd recover cancelled. No database changes made.", "info");
-    return false;
+    if (!confirmed) {
+      ctx.ui.notify("gsd recover cancelled. No database changes made.", "info");
+      return false;
+    }
+    // Data loss requires a second, explicit acknowledgement — the interactive
+    // equivalent of the --allow-data-loss opt-in the non-interactive paths
+    // demand. A single generic "yes" must not silently delete DB rows.
+    if (dataLoss) {
+      const acknowledged = await ctx.ui.confirm(
+        "Permanently delete DB rows the markdown lacks?",
+        "This recover will DELETE authoritative DB rows the markdown does not contain. " +
+          "A snapshot is saved to .gsd/backups/ first, but /gsd rebuild markdown is usually " +
+          "what you want. Proceed with the deletion?",
+      );
+      if (!acknowledged) {
+        ctx.ui.notify("gsd recover cancelled. No database changes made.", "info");
+        return false;
+      }
+    }
+    return true;
   }
 
   ctx.ui.notify(

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -481,6 +481,8 @@ export async function handleCleanupProjects(args: string, ctx: ExtensionCommandC
   ctx.ui.notify(lines.join("\n"), "info");
 }
 
+type HierarchyCounts = { milestones: number; slices: number; tasks: number };
+
 function recoverConfirmed(args: string): boolean {
   return args
     .split(/\s+/)
@@ -488,19 +490,66 @@ function recoverConfirmed(args: string): boolean {
     .some((part) => part === "--confirm" || part === "--yes" || part === "confirm");
 }
 
-async function confirmRecover(ctx: ExtensionCommandContext, args: string): Promise<boolean> {
-  if (recoverConfirmed(args)) return true;
+function recoverAllowsDataLoss(args: string): boolean {
+  return args
+    .split(/\s+/)
+    .map((part) => part.trim().toLowerCase())
+    .some((part) => part === "--allow-data-loss" || part === "--force");
+}
 
+/** True when the DB holds more rows than markdown — recover would delete them. */
+function recoverWouldLoseData(markdown: HierarchyCounts, beforeDb: HierarchyCounts): boolean {
+  return (
+    beforeDb.milestones > markdown.milestones ||
+    beforeDb.slices > markdown.slices ||
+    beforeDb.tasks > markdown.tasks
+  );
+}
+
+async function confirmRecover(
+  ctx: ExtensionCommandContext,
+  args: string,
+  markdown: HierarchyCounts,
+  beforeDb: HierarchyCounts,
+  dataLoss: boolean,
+): Promise<boolean> {
   const warning = [
     "gsd recover imports markdown into the database.",
     "It clears and reconstructs milestone, slice, and task hierarchy rows from rendered markdown.",
     "Use /gsd rebuild markdown for normal DB-to-markdown realignment.",
-  ].join("\n");
+    "",
+    `  Markdown on disk: ${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T`,
+    `  Current DB:       ${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T`,
+  ];
+  if (dataLoss) {
+    warning.push(
+      "",
+      "⚠ The DB holds more rows than the markdown. Recover will permanently DELETE the",
+      "  rows that markdown lacks. A snapshot is written to .gsd/backups/ first, but if",
+      "  the DB is the source of truth you almost certainly want /gsd rebuild markdown.",
+    );
+  }
+  const warningText = warning.join("\n");
+
+  if (recoverConfirmed(args)) {
+    // Non-interactive --confirm still refuses a data-loss recover unless the
+    // caller explicitly opts in with --allow-data-loss / --force.
+    if (dataLoss && !recoverAllowsDataLoss(args)) {
+      ctx.ui.notify(
+        `${warningText}\n\nRefusing: this would delete authoritative DB rows. Re-run with ` +
+          `/gsd recover --confirm --allow-data-loss to proceed, or use /gsd rebuild markdown ` +
+          `to re-project markdown from the DB instead.`,
+        "error",
+      );
+      return false;
+    }
+    return true;
+  }
 
   if (typeof ctx.ui.confirm === "function") {
     const confirmed = await ctx.ui.confirm(
       "Import markdown into the DB?",
-      `${warning}\n\nContinue only if the DB is lost or corrupt and markdown is the source you intend to import.`,
+      `${warningText}\n\nContinue only if the DB is lost or corrupt and markdown is the source you intend to import.`,
     );
     if (confirmed) return true;
     ctx.ui.notify("gsd recover cancelled. No database changes made.", "info");
@@ -508,7 +557,7 @@ async function confirmRecover(ctx: ExtensionCommandContext, args: string): Promi
   }
 
   ctx.ui.notify(
-    `${warning}\n\nNo database changes made. Re-run /gsd recover --confirm to proceed.`,
+    `${warningText}\n\nNo database changes made. Re-run /gsd recover --confirm to proceed.`,
     "warning",
   );
   return false;
@@ -524,18 +573,29 @@ async function confirmRecover(ctx: ExtensionCommandContext, args: string): Promi
  * Prints counts of recovered items and the resulting project phase.
  */
 export async function handleRecover(ctx: ExtensionCommandContext, basePath: string, args = ""): Promise<void> {
-  const { isDbAvailable: dbAvailable, clearEngineHierarchy, transaction: dbTransaction } = await import("./gsd-db.js");
+  const { isDbAvailable: dbAvailable, clearEngineHierarchy, transaction: dbTransaction, backupDatabaseSnapshot } = await import("./gsd-db.js");
   const { migrateHierarchyToDb } = await import("./md-importer.js");
   const { invalidateStateCache } = await import("./state.js");
+  const { countDbHierarchy, countMarkdownHierarchy } = await import("./migration-auto-check.js");
+  const { renderAllFromDb } = await import("./markdown-renderer.js");
 
   if (!dbAvailable()) {
     ctx.ui.notify("gsd recover: No database open. Run a GSD command first to initialize the DB.", "error");
     return;
   }
 
-  if (!(await confirmRecover(ctx, args))) return;
+  // Compare markdown-on-disk against the live DB so the confirmation prompt can
+  // surface exactly what recover will overwrite (and refuse silent data loss).
+  const markdown = countMarkdownHierarchy(basePath);
+  const beforeDb = countDbHierarchy();
+  const dataLoss = recoverWouldLoseData(markdown, beforeDb);
+
+  if (!(await confirmRecover(ctx, args, markdown, beforeDb, dataLoss))) return;
 
   try {
+    // 0. Snapshot the DB before the destructive clear so recover is reversible.
+    const backupPath = backupDatabaseSnapshot("pre-recover");
+
     // 1. Delete + re-populate inside a single transaction for atomicity.
     //    clearEngineHierarchy() uses transaction() internally but transaction()
     //    is re-entrant, so wrapping in dbTransaction() keeps the whole
@@ -545,8 +605,13 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
       return migrateHierarchyToDb(basePath);
     });
 
-    // 3. Invalidate state cache so deriveState() picks up fresh DB data
+    // 2. Invalidate state cache so deriveState() picks up fresh DB data
     invalidateStateCache();
+
+    // 3. Re-project markdown from the freshly imported DB so disk and DB agree
+    //    immediately (otherwise the markdown still reflects the pre-import state
+    //    and the next startup check would flag fresh drift).
+    await renderAllFromDb(basePath);
 
     // 4. Derive state to verify sanity
     const state = await deriveState(basePath);
@@ -560,6 +625,23 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
       ``,
       `  Phase:      ${state.phase}`,
     ];
+    // Post-import verification: markdown that failed to parse imports as fewer
+    // rows than countMarkdownHierarchy saw on disk. Surface the shortfall.
+    if (
+      counts.milestones < markdown.milestones ||
+      counts.slices < markdown.slices ||
+      counts.tasks < markdown.tasks
+    ) {
+      lines.push(
+        ``,
+        `  ⚠ Imported fewer rows than markdown contained ` +
+          `(${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T on disk). ` +
+          `Some markdown may have failed to parse — review before continuing.`,
+      );
+    }
+    if (backupPath) {
+      lines.push(``, `  Backup:     ${backupPath}`);
+    }
     if (state.activeMilestone) {
       lines.push(`  Active:     ${state.activeMilestone.id}: ${state.activeMilestone.title}`);
     }

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -497,15 +497,6 @@ function recoverAllowsDataLoss(args: string): boolean {
     .some((part) => part === "--allow-data-loss" || part === "--force");
 }
 
-/** True when the DB holds more rows than markdown — recover would delete them. */
-function recoverWouldLoseData(markdown: HierarchyCounts, beforeDb: HierarchyCounts): boolean {
-  return (
-    beforeDb.milestones > markdown.milestones ||
-    beforeDb.slices > markdown.slices ||
-    beforeDb.tasks > markdown.tasks
-  );
-}
-
 async function confirmRecover(
   ctx: ExtensionCommandContext,
   args: string,
@@ -524,9 +515,9 @@ async function confirmRecover(
   if (dataLoss) {
     warning.push(
       "",
-      "⚠ The DB holds more rows than the markdown. Recover will permanently DELETE the",
-      "  rows that markdown lacks. A snapshot is written to .gsd/backups/ first, but if",
-      "  the DB is the source of truth you almost certainly want /gsd rebuild markdown.",
+      "⚠ The DB holds rows the markdown lacks. Recover will permanently DELETE",
+      "  those rows. A snapshot is written to .gsd/backups/ first, but if the DB",
+      "  is the source of truth you almost certainly want /gsd rebuild markdown.",
     );
   }
   const warningText = warning.join("\n");
@@ -576,7 +567,7 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
   const { isDbAvailable: dbAvailable, clearEngineHierarchy, transaction: dbTransaction, backupDatabaseSnapshot } = await import("./gsd-db.js");
   const { migrateHierarchyToDb } = await import("./md-importer.js");
   const { invalidateStateCache } = await import("./state.js");
-  const { countDbHierarchy, countMarkdownHierarchy } = await import("./migration-auto-check.js");
+  const { countDbHierarchy, countMarkdownHierarchy, recoverWouldDeleteDbRows } = await import("./migration-auto-check.js");
   const { renderAllFromDb } = await import("./markdown-renderer.js");
 
   if (!dbAvailable()) {
@@ -586,9 +577,11 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
 
   // Compare markdown-on-disk against the live DB so the confirmation prompt can
   // surface exactly what recover will overwrite (and refuse silent data loss).
+  // The data-loss check is identity-based, not count-based: it flags any DB row
+  // markdown lacks, including equal-count divergence (DB S99 vs markdown S01).
   const markdown = countMarkdownHierarchy(basePath);
   const beforeDb = countDbHierarchy();
-  const dataLoss = recoverWouldLoseData(markdown, beforeDb);
+  const dataLoss = recoverWouldDeleteDbRows(basePath);
 
   if (!(await confirmRecover(ctx, args, markdown, beforeDb, dataLoss))) return;
 
@@ -610,8 +603,10 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
 
     // 3. Re-project markdown from the freshly imported DB so disk and DB agree
     //    immediately (otherwise the markdown still reflects the pre-import state
-    //    and the next startup check would flag fresh drift).
-    await renderAllFromDb(basePath);
+    //    and the next startup check would flag fresh drift). renderAllFromDb
+    //    swallows per-artifact failures into its result, so inspect them — a
+    //    silent projection failure must not be reported as a clean success.
+    const renderResult = await renderAllFromDb(basePath);
 
     // 4. Derive state to verify sanity
     const state = await deriveState(basePath);
@@ -652,10 +647,27 @@ export async function handleRecover(ctx: ExtensionCommandContext, basePath: stri
       lines.push(`  Task:       ${state.activeTask.id}: ${state.activeTask.title}`);
     }
 
+    // Surface markdown projection failures: renderAllFromDb resolves even when
+    // individual artifacts fail to render, so a clean exit here would otherwise
+    // hide a stale/partial projection.
+    const renderFailed = renderResult.errors.length > 0;
+    if (renderFailed) {
+      lines.push(
+        ``,
+        `  ⚠ ${renderResult.errors.length} markdown projection(s) failed to render — ` +
+          `markdown may be stale. Re-run /gsd rebuild markdown.`,
+      );
+      for (const e of renderResult.errors.slice(0, 5)) lines.push(`    - ${e}`);
+      if (renderResult.errors.length > 5) {
+        lines.push(`    …and ${renderResult.errors.length - 5} more`);
+      }
+    }
+
     process.stderr.write(
-      `gsd-recover: recovered ${counts.milestones}M/${counts.slices}S/${counts.tasks}T hierarchy\n`,
+      `gsd-recover: recovered ${counts.milestones}M/${counts.slices}S/${counts.tasks}T hierarchy` +
+        `${renderFailed ? ` (${renderResult.errors.length} projection errors)` : ""}\n`,
     );
-    ctx.ui.notify(lines.join("\n"), "success");
+    ctx.ui.notify(lines.join("\n"), renderFailed ? "warning" : "success");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logWarning("command", `recover failed: ${msg}`);

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -452,6 +452,44 @@ export function _resetDecisionSaveLock(): void {
   _decisionSaveLock = Promise.resolve();
 }
 
+/**
+ * Re-project root DECISIONS.md from the authoritative decision records, with no
+ * new decision being added. Mirrors the projection saveDecisionToDb performs
+ * after a save, but over the full set — so a DB → markdown re-projection
+ * (recover, rebuild, reconcile) re-derives DECISIONS.md and never leaves it
+ * showing a stale subset (e.g. after a worktree merge that accepted one
+ * branch's DECISIONS.md while the DB holds the union of both branches'
+ * decisions). DB stays the single source of truth; this only writes markdown.
+ */
+export async function regenerateDecisionsMarkdown(basePath: string): Promise<void> {
+  const { getAllDecisionsFromMemories } = await import('./context-store.js');
+  const allDecisions: Decision[] = getAllDecisionsFromMemories();
+
+  const filePath = resolveGsdRootFile(basePath, 'DECISIONS');
+  let existingContent: string | null = null;
+  if (existsSync(filePath)) {
+    existingContent = readFileSync(filePath, 'utf-8');
+  }
+
+  // Nothing to project: no decisions in the DB and no file to normalize.
+  if (allDecisions.length === 0 && existingContent === null) return;
+
+  let md: string;
+  if (existingContent && !isDecisionsTableFormat(existingContent)) {
+    // Preserve freeform content; refresh only the appended decisions table.
+    const marker = '---\n\n## Decisions Table';
+    const markerIdx = existingContent.indexOf(marker);
+    const freeformPart = markerIdx >= 0
+      ? existingContent.substring(0, markerIdx).trimEnd()
+      : existingContent.trimEnd();
+    md = freeformPart + '\n' + generateDecisionsAppendBlock(allDecisions);
+  } else {
+    md = generateDecisionsMd(allDecisions);
+  }
+
+  await saveFile(filePath, md);
+}
+
 // ─── Save Decision to DB + Regenerate Markdown ────────────────────────────
 
 export interface SaveDecisionFields {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -25,7 +25,7 @@
 import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
 import { existsSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type { Decision, Requirement, GateRow, GateId, GateScope, GateStatus, GateVerdict } from "./types.js";
 import { GSDError, GSD_STALE_STATE } from "./errors.js";
 import type { GsdWorkspace, MilestoneScope } from "./workspace.js";
@@ -758,6 +758,28 @@ export function checkpointDatabase(): void {
   try {
     currentDb.exec('PRAGMA wal_checkpoint(TRUNCATE)');
   } catch (e) { logWarning("db", `WAL checkpoint failed: ${(e as Error).message}`); }
+}
+
+/**
+ * Copy the live database file to `.gsd/backups/<label>-<timestamp>.db` so a
+ * destructive operation (e.g. recover, which clears the hierarchy tables) is
+ * reversible. Checkpoints the WAL first so the snapshot is complete. Returns
+ * the backup path, or null if no DB is open or the copy failed.
+ */
+export function backupDatabaseSnapshot(label: string): string | null {
+  if (!currentPath) return null;
+  try {
+    checkpointDatabase();
+    const backupsDir = join(dirname(currentPath), "backups");
+    mkdirSync(backupsDir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const dest = join(backupsDir, `${label}-${stamp}.db`);
+    copyFileSync(currentPath, dest);
+    return dest;
+  } catch (e) {
+    logWarning("db", `database snapshot failed: ${(e as Error).message}`);
+    return null;
+  }
 }
 
 const _transactionRunner = createDbTransactionRunner();

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -21,7 +21,6 @@ import {
   getSliceTasks,
   getTask,
   getSlice,
-  getArtifact,
   insertArtifact,
   getGateResults,
 } from "./gsd-db.js";
@@ -107,22 +106,6 @@ function sanitizeInlineRoadmapText(value: string | null | undefined): string {
     .replace(/[|`]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-}
-
-/**
- * Load artifact content from the DB. Markdown projections are not authoritative
- * during runtime; when the artifact row is missing, callers regenerate from DB
- * rows instead of patching disk fallback content and storing it back.
- */
-function loadArtifactContent(
-  artifactPath: string,
-): string | null {
-  const artifact = getArtifact(artifactPath);
-  if (artifact && artifact.full_content) {
-    return artifact.full_content;
-  }
-
-  return null;
 }
 
 function resolveRoadmapProjectionPath(basePath: string, milestoneId: string): string {
@@ -510,8 +493,14 @@ export async function renderRoadmapCheckboxes(
 /**
  * Render plan checkbox states from DB.
  *
- * For each task in the slice, sets [x] if status === 'done',
- * [ ] otherwise. Bidirectional.
+ * Compatibility wrapper for legacy callers that used to patch plan checkboxes
+ * in-place. Plans are now fully regenerated from DB rows (mirroring
+ * renderRoadmapCheckboxes) so the projection always reflects the complete
+ * current task set and statuses. The previous regex-patch approach reused the
+ * cached PLAN artifact as the render input, which silently dropped tasks added
+ * to the DB after the artifact was first written — producing a lossy
+ * projection (the 4S/0T-vs-5S/13T drift class). The artifacts table is an
+ * output sink, never a render input.
  *
  * @returns true if the plan was written, false on skip/error
  */
@@ -528,48 +517,7 @@ export async function renderPlanCheckboxes(
     return false;
   }
 
-  const absPath = resolveSliceFile(basePath, milestoneId, sliceId, "PLAN");
-  const artifactPath = absPath ? toArtifactPath(absPath, basePath) : null;
-
-  let content: string | null = null;
-  if (artifactPath) {
-    content = loadArtifactContent(artifactPath);
-  }
-
-  if (!content) {
-    await renderPlanFromDb(basePath, milestoneId, sliceId);
-    return true;
-  }
-
-  // Apply checkbox patches for each task
-  let updated = content;
-  for (const task of tasks) {
-    const isDone = isClosedStatus(task.status);
-    const tid = task.id;
-
-    if (isDone) {
-      // Set [x]
-      updated = updated.replace(
-        new RegExp(`^(\\s*-\\s+)\\[ \\]\\s+\\*\\*${tid}:`, "m"),
-        `$1[x] **${tid}:`,
-      );
-    } else {
-      // Set [ ]
-      updated = updated.replace(
-        new RegExp(`^(\\s*-\\s+)\\[x\\]\\s+\\*\\*${tid}:`, "mi"),
-        `$1[ ] **${tid}:`,
-      );
-    }
-  }
-
-  if (!absPath) return false;
-
-  await writeAndStore(absPath, artifactPath!, updated, {
-    artifact_type: "PLAN",
-    milestone_id: milestoneId,
-    slice_id: sliceId,
-  });
-
+  await renderPlanFromDb(basePath, milestoneId, sliceId);
   return true;
 }
 
@@ -747,6 +695,18 @@ export async function renderAllFromDb(basePath: string): Promise<RenderAllResult
     }
   }
 
+  // Re-project root DECISIONS.md from the authoritative decision records so a
+  // full DB → markdown re-projection (recover, rebuild) also heals decisions
+  // drift — e.g. a worktree merge that accepted one branch's DECISIONS.md while
+  // the DB holds the union of both branches' decisions.
+  try {
+    const { regenerateDecisionsMarkdown } = await import("./db-writer.js");
+    await regenerateDecisionsMarkdown(basePath);
+    result.rendered++;
+  } catch (err) {
+    result.errors.push(`decisions: ${(err as Error).message}`);
+  }
+
   return result;
 }
 
@@ -832,7 +792,16 @@ export function detectStaleRenders(basePath: string): StaleEntry[] {
           for (const task of tasks) {
             const isDoneInDb = isClosedStatus(task.status);
             const planTask = parsed.tasks.find((t: { id: string }) => t.id === task.id);
-            if (!planTask) continue;
+            if (!planTask) {
+              // DB has a task the plan markdown lacks: the projection is
+              // lossy (e.g. tasks added after the PLAN artifact was first
+              // written). Flag it so the plan is re-rendered from DB rows.
+              stale.push({
+                path: planPath,
+                reason: `${task.id} exists in DB but is missing in plan`,
+              });
+              continue;
+            }
 
             if (isDoneInDb && !planTask.done) {
               stale.push({

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -4,7 +4,7 @@
 //
 // Exports: parseDecisionsTable, parseRequirementsSections, migrateFromMarkdown
 
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { Decision, Requirement } from './types.js';
 import {
@@ -16,6 +16,7 @@ import {
   insertTask,
   openDatabase,
   transaction,
+  updateMilestoneStatus,
   updateSliceStatus,
   _getAdapter,
 } from './gsd-db.js';
@@ -37,6 +38,27 @@ import { logWarning } from './workflow-logger.js';
 // ─── DECISIONS.md Parser ───────────────────────────────────────────────────
 
 const VALID_MADE_BY = new Set(['human', 'agent', 'collaborative']);
+
+const IMPORT_COMPLETE_STATUSES = new Set(['complete', 'done']);
+
+/**
+ * Completion timestamp for an entity imported as complete: the SUMMARY.md mtime
+ * when one exists (deterministic, matches the completion drift handler), else
+ * the import time. Crucially this never returns null, so a complete entity is
+ * never left with completed_at=null — which would otherwise be permanent,
+ * undetectable drift when no SUMMARY file is present.
+ */
+function importCompletionTimestamp(summaryPath: string | null): string {
+  if (summaryPath && existsSync(summaryPath)) {
+    try {
+      return statSync(summaryPath).mtime.toISOString();
+    } catch (err) {
+      // Fall through to import time.
+      logWarning('projection', `summary mtime read failed for ${summaryPath}: ${(err as Error).message}`);
+    }
+  }
+  return new Date().toISOString();
+}
 
 /**
  * Parse a DECISIONS.md markdown table into Decision objects (without seq).
@@ -587,6 +609,14 @@ export function migrateHierarchyToDb(basePath: string): {
         boundaryMapMarkdown: boundaryMapSection,
       },
     });
+    // insertMilestone never sets completed_at; backfill it now for milestones
+    // imported as complete so the DB is internally coherent immediately after
+    // import (rather than relying on a later reconciliation pass that can't even
+    // see the drift when no SUMMARY file exists).
+    if (IMPORT_COMPLETE_STATUSES.has(milestoneStatus)) {
+      const summaryPath = resolveMilestoneFile(basePath, milestoneId, 'SUMMARY');
+      updateMilestoneStatus(milestoneId, milestoneStatus, importCompletionTimestamp(summaryPath));
+    }
     counts.milestones++;
 
     // Parse roadmap for slices
@@ -614,10 +644,22 @@ export function migrateHierarchyToDb(basePath: string): {
         depends: sliceEntry.depends,
         demo: sliceEntry.demo,
         sequence: si + 1, // Preserve roadmap parse order (#3356)
+        isSketch: sliceEntry.isSketch ?? false, // ADR-011: preserve the `[sketch]` flag on re-import
         planning: {
           goal: plan?.goal ?? '',
         },
       });
+      // insertSlice never sets completed_at; backfill it for slices imported as
+      // complete (same rationale as milestones above).
+      if (IMPORT_COMPLETE_STATUSES.has(sliceStatus)) {
+        const sliceSummary = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'SUMMARY');
+        updateSliceStatus(
+          milestoneId,
+          sliceEntry.id,
+          sliceStatus,
+          importCompletionTimestamp(sliceSummary),
+        );
+      }
       counts.slices++;
 
       // Insert tasks from parsed plan
@@ -674,7 +716,12 @@ export function migrateHierarchyToDb(basePath: string): {
         });
         if (allTasksDone && hasSliceSummary) {
           if (_getAdapter()) {
-            updateSliceStatus(milestoneId, sliceEntry.id, 'complete');
+            updateSliceStatus(
+              milestoneId,
+              sliceEntry.id,
+              'complete',
+              importCompletionTimestamp(sliceSummaryPath),
+            );
             process.stderr.write(
               `gsd-migrate: ${milestoneId}/${sliceEntry.id} all tasks + slice summary complete — upgrading slice to complete\n`,
             );

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -23,7 +23,7 @@ export interface HierarchyCounts {
 
 export interface MigrationAutoCheckResult {
   action: "none" | "recovery-required";
-  reason: "no-markdown" | "in-sync" | "db-empty" | "count-mismatch";
+  reason: "no-markdown" | "in-sync" | "db-empty" | "count-mismatch" | "markdown-missing";
   markdown: HierarchyCounts;
   beforeDb: HierarchyCounts;
   afterDb: HierarchyCounts;
@@ -31,71 +31,115 @@ export interface MigrationAutoCheckResult {
   message?: string;
 }
 
+interface HierarchyScan {
+  counts: HierarchyCounts;
+  // Fully-qualified identities: milestone "M001", slice "M001/S01",
+  // task "M001/S01/T01". Used to detect drift the cardinalities miss (a
+  // deleted+added pair nets to the same counts but is real divergence).
+  milestones: Set<string>;
+  slices: Set<string>;
+  tasks: Set<string>;
+}
+
 function zeroCounts(): HierarchyCounts {
   return { milestones: 0, slices: 0, tasks: 0 };
+}
+
+function emptyScan(): HierarchyScan {
+  return { counts: zeroCounts(), milestones: new Set(), slices: new Set(), tasks: new Set() };
 }
 
 function sameCounts(a: HierarchyCounts, b: HierarchyCounts): boolean {
   return a.milestones === b.milestones && a.slices === b.slices && a.tasks === b.tasks;
 }
 
-export function countMarkdownHierarchy(basePath: string): HierarchyCounts {
-  const root = milestonesDir(basePath);
-  if (!existsSync(root)) return zeroCounts();
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) if (!b.has(value)) return false;
+  return true;
+}
 
-  const counts = zeroCounts();
+function scanIdentitiesMatch(a: HierarchyScan, b: HierarchyScan): boolean {
+  return (
+    setsEqual(a.milestones, b.milestones) &&
+    setsEqual(a.slices, b.slices) &&
+    setsEqual(a.tasks, b.tasks)
+  );
+}
+
+export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
+  const root = milestonesDir(basePath);
+  if (!existsSync(root)) return emptyScan();
+
+  const scan = emptyScan();
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     if (!entry.isDirectory() || !/^M\d+/.test(entry.name)) continue;
-    counts.milestones++;
+    scan.counts.milestones++;
+    scan.milestones.add(entry.name);
 
     const roadmapPath = resolveMilestoneFile(basePath, entry.name, "ROADMAP");
     if (!roadmapPath || !existsSync(roadmapPath)) continue;
 
     const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
-    counts.slices += roadmap.slices.length;
+    scan.counts.slices += roadmap.slices.length;
 
     for (const slice of roadmap.slices) {
+      scan.slices.add(`${entry.name}/${slice.id}`);
       const planPath = resolveSliceFile(basePath, entry.name, slice.id, "PLAN");
       if (!planPath || !existsSync(planPath)) continue;
       const plan = parsePlan(readFileSync(planPath, "utf-8"));
-      counts.tasks += plan.tasks.length;
+      scan.counts.tasks += plan.tasks.length;
+      for (const task of plan.tasks) {
+        scan.tasks.add(`${entry.name}/${slice.id}/${task.id}`);
+      }
     }
   }
 
-  return counts;
+  return scan;
+}
+
+export function scanDbHierarchy(): HierarchyScan {
+  if (!isDbAvailable()) return emptyScan();
+  const scan = emptyScan();
+  const milestones = getAllMilestones();
+  scan.counts.milestones = milestones.length;
+
+  for (const milestone of milestones) {
+    scan.milestones.add(milestone.id);
+    const slices = getMilestoneSlices(milestone.id);
+    scan.counts.slices += slices.length;
+    for (const slice of slices) {
+      scan.slices.add(`${milestone.id}/${slice.id}`);
+      const tasks = getSliceTasks(milestone.id, slice.id);
+      scan.counts.tasks += tasks.length;
+      for (const task of tasks) {
+        scan.tasks.add(`${milestone.id}/${slice.id}/${task.id}`);
+      }
+    }
+  }
+
+  return scan;
+}
+
+export function countMarkdownHierarchy(basePath: string): HierarchyCounts {
+  return scanMarkdownHierarchy(basePath).counts;
 }
 
 export function countDbHierarchy(): HierarchyCounts {
-  if (!isDbAvailable()) return zeroCounts();
-  const counts = zeroCounts();
-  const milestones = getAllMilestones();
-  counts.milestones = milestones.length;
-
-  for (const milestone of milestones) {
-    const slices = getMilestoneSlices(milestone.id);
-    counts.slices += slices.length;
-    for (const slice of slices) {
-      counts.tasks += getSliceTasks(milestone.id, slice.id).length;
-    }
-  }
-
-  return counts;
+  return scanDbHierarchy().counts;
 }
 
 export async function checkMarkdownHierarchyAgainstDb(
   basePath: string,
 ): Promise<MigrationAutoCheckResult> {
-  const markdown = countMarkdownHierarchy(basePath);
-  if (sameCounts(markdown, zeroCounts())) {
-    return {
-      action: "none",
-      reason: "no-markdown",
-      markdown,
-      beforeDb: zeroCounts(),
-      afterDb: zeroCounts(),
-    };
-  }
+  const markdownScan = scanMarkdownHierarchy(basePath);
+  const markdown = markdownScan.counts;
 
+  // Always open the DB before deciding. An empty markdown tree does NOT imply
+  // an empty project — the DB may hold authoritative rows whose markdown was
+  // lost, which is itself recoverable drift. The previous early return here
+  // skipped the DB entirely and silently hid a populated-DB/empty-markdown
+  // project.
   const opened = await ensureDbOpen(basePath);
   if (!opened || !isDbAvailable()) {
     throw new Error(`failed to open or create the GSD database at ${basePath}`);
@@ -106,12 +150,63 @@ export async function checkMarkdownHierarchyAgainstDb(
   // warn from a stale long-lived SQLite handle.
   refreshOpenDatabaseFromDisk();
 
-  const beforeDb = countDbHierarchy();
-  if (sameCounts(markdown, beforeDb)) {
+  const dbScan = scanDbHierarchy();
+  const beforeDb = dbScan.counts;
+
+  const markdownEmpty = sameCounts(markdown, zeroCounts());
+  const dbEmpty = sameCounts(beforeDb, zeroCounts());
+
+  // Genuinely empty project: nothing on disk, nothing in the DB.
+  if (markdownEmpty && dbEmpty) {
+    return { action: "none", reason: "no-markdown", markdown, beforeDb, afterDb: beforeDb };
+  }
+
+  // In sync only when both cardinalities AND identities agree. Identity
+  // comparison catches drift the counts miss (e.g. a slice deleted from the DB
+  // and a different one added nets to the same count but is real divergence,
+  // and a missing PLAN.md vs DB tasks shows up as a task-identity gap).
+  if (sameCounts(markdown, beforeDb) && scanIdentitiesMatch(markdownScan, dbScan)) {
     return { action: "none", reason: "in-sync", markdown, beforeDb, afterDb: beforeDb };
   }
 
-  const reason = sameCounts(beforeDb, zeroCounts()) ? "db-empty" : "count-mismatch";
+  // Choose the SAFE repair direction. Recover imports markdown → DB and DELETES
+  // DB rows markdown lacks, so it must never be recommended when the DB is the
+  // richer side. When the DB holds rows markdown is missing, the correct repair
+  // is to re-project markdown from the DB (rebuild), never recover.
+  const dbRicher =
+    beforeDb.milestones > markdown.milestones ||
+    beforeDb.slices > markdown.slices ||
+    beforeDb.tasks > markdown.tasks;
+  const markdownRicher =
+    markdown.milestones > beforeDb.milestones ||
+    markdown.slices > beforeDb.slices ||
+    markdown.tasks > beforeDb.tasks;
+
+  const countsLine =
+    `Markdown planning artifacts (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) ` +
+    `do not match the authoritative DB (${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T). `;
+
+  // DB is the source of truth and holds more than markdown (or markdown is
+  // entirely missing): re-project from the DB. Recover here would destroy data.
+  if (dbRicher && !markdownRicher) {
+    return {
+      action: "recovery-required",
+      reason: markdownEmpty ? "markdown-missing" : "count-mismatch",
+      markdown,
+      beforeDb,
+      afterDb: beforeDb,
+      recoveryCommand: "/gsd rebuild markdown",
+      message:
+        countsLine +
+        "The DB holds rows the markdown lacks, so the markdown projection is stale. " +
+        "Run `/gsd rebuild markdown` to re-project from the authoritative DB. " +
+        "Do NOT run `/gsd recover --confirm` here — it would delete the extra DB rows.",
+    };
+  }
+
+  // DB is empty (or markdown is strictly richer): markdown is the surviving
+  // source to import.
+  const reason = dbEmpty ? "db-empty" : "count-mismatch";
   return {
     action: "recovery-required",
     reason,
@@ -120,8 +215,7 @@ export async function checkMarkdownHierarchyAgainstDb(
     afterDb: beforeDb,
     recoveryCommand: "/gsd recover --confirm",
     message:
-      `Markdown planning artifacts (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) ` +
-      `do not match the authoritative DB (${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T). ` +
+      countsLine +
       "Runtime startup will not import markdown automatically; run `/gsd recover --confirm` if markdown should repopulate the database.",
   };
 }

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -67,6 +67,31 @@ function scanIdentitiesMatch(a: HierarchyScan, b: HierarchyScan): boolean {
   );
 }
 
+/** True if any element of `a` is absent from `b`. */
+function hasExtra(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  for (const value of a) if (!b.has(value)) return true;
+  return false;
+}
+
+function scanHasExtraIdentities(a: HierarchyScan, b: HierarchyScan): boolean {
+  return (
+    hasExtra(a.milestones, b.milestones) ||
+    hasExtra(a.slices, b.slices) ||
+    hasExtra(a.tasks, b.tasks)
+  );
+}
+
+/**
+ * True when the DB holds any milestone/slice/task identity the markdown lacks —
+ * i.e. a `/gsd recover --confirm` (markdown → DB) would DELETE authoritative DB
+ * rows. This is identity-based, so it catches equal-count divergence (e.g. DB
+ * slice `S99` vs markdown `S01`) that a cardinality-only check misses. Used by
+ * the recover data-loss guard.
+ */
+export function recoverWouldDeleteDbRows(basePath: string): boolean {
+  return scanHasExtraIdentities(scanDbHierarchy(), scanMarkdownHierarchy(basePath));
+}
+
 export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
   const root = milestonesDir(basePath);
   if (!existsSync(root)) return emptyScan();
@@ -169,26 +194,21 @@ export async function checkMarkdownHierarchyAgainstDb(
     return { action: "none", reason: "in-sync", markdown, beforeDb, afterDb: beforeDb };
   }
 
-  // Choose the SAFE repair direction. Recover imports markdown → DB and DELETES
-  // DB rows markdown lacks, so it must never be recommended when the DB is the
-  // richer side. When the DB holds rows markdown is missing, the correct repair
-  // is to re-project markdown from the DB (rebuild), never recover.
-  const dbRicher =
-    beforeDb.milestones > markdown.milestones ||
-    beforeDb.slices > markdown.slices ||
-    beforeDb.tasks > markdown.tasks;
-  const markdownRicher =
-    markdown.milestones > beforeDb.milestones ||
-    markdown.slices > beforeDb.slices ||
-    markdown.tasks > beforeDb.tasks;
+  // Choose the SAFE repair direction by IDENTITY, not cardinality. Recover
+  // imports markdown → DB and DELETES any DB row markdown lacks, so it must
+  // never be recommended when the DB holds identities the markdown is missing —
+  // including equal-count divergence (DB `S99` vs markdown `S01`), which a
+  // count-only check would wrongly route to recover. Whenever the DB holds rows
+  // markdown lacks, the correct repair is to re-project from the DB (rebuild).
+  const dbHasExtra = scanHasExtraIdentities(dbScan, markdownScan);
 
   const countsLine =
     `Markdown planning artifacts (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) ` +
     `do not match the authoritative DB (${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T). `;
 
-  // DB is the source of truth and holds more than markdown (or markdown is
+  // The DB holds rows markdown lacks (richer, identity-diverged, or markdown
   // entirely missing): re-project from the DB. Recover here would destroy data.
-  if (dbRicher && !markdownRicher) {
+  if (dbHasExtra) {
     return {
       action: "recovery-required",
       reason: markdownEmpty ? "markdown-missing" : "count-mismatch",

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -99,23 +99,29 @@ export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
   const scan = emptyScan();
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     if (!entry.isDirectory() || !/^M\d+/.test(entry.name)) continue;
+    // Use the CANONICAL milestone id (e.g. "M001" or "M001-a1b2c3"), matching
+    // scanDbHierarchy's milestone.id — not the raw directory name, which may
+    // carry a legacy descriptor (e.g. "M001-some-descriptor"). The canonical id
+    // both keys the identity sets AND resolves files correctly: resolveFile's
+    // prefix/legacy-pattern matching handles the descriptor dir either way.
+    const milestoneId = entry.name.match(/^(M\d+(?:-[a-z0-9]{6})?)/)?.[1] ?? entry.name;
     scan.counts.milestones++;
-    scan.milestones.add(entry.name);
+    scan.milestones.add(milestoneId);
 
-    const roadmapPath = resolveMilestoneFile(basePath, entry.name, "ROADMAP");
+    const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
     if (!roadmapPath || !existsSync(roadmapPath)) continue;
 
     const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
     scan.counts.slices += roadmap.slices.length;
 
     for (const slice of roadmap.slices) {
-      scan.slices.add(`${entry.name}/${slice.id}`);
-      const planPath = resolveSliceFile(basePath, entry.name, slice.id, "PLAN");
+      scan.slices.add(`${milestoneId}/${slice.id}`);
+      const planPath = resolveSliceFile(basePath, milestoneId, slice.id, "PLAN");
       if (!planPath || !existsSync(planPath)) continue;
       const plan = parsePlan(readFileSync(planPath, "utf-8"));
       scan.counts.tasks += plan.tasks.length;
       for (const task of plan.tasks) {
-        scan.tasks.add(`${entry.name}/${slice.id}/${task.id}`);
+        scan.tasks.add(`${milestoneId}/${slice.id}/${task.id}`);
       }
     }
   }

--- a/src/resources/extensions/gsd/parsers-legacy.ts
+++ b/src/resources/extensions/gsd/parsers-legacy.ts
@@ -60,11 +60,31 @@ export function parseRoadmap(content: string): Roadmap {
   return cachedParse(content, 'roadmap', _parseRoadmapImpl);
 }
 
+/**
+ * ADR-011: the roadmap renderer writes a `[sketch]` badge for sketch slices,
+ * but the native parser does not surface it. Re-scan the markdown and set
+ * isSketch on the matching slice so the flag survives a markdown → DB re-import
+ * (e.g. /gsd recover) instead of being silently dropped.
+ */
+function applySketchFlags(roadmap: Roadmap, content: string): void {
+  const sketchIds = new Set<string>();
+  for (const line of content.split("\n")) {
+    if (!/\[sketch\]/i.test(line)) continue;
+    const m = line.match(/\*\*([\w.]+):/);
+    if (m) sketchIds.add(m[1]!);
+  }
+  if (sketchIds.size === 0) return;
+  for (const slice of roadmap.slices) {
+    if (sketchIds.has(slice.id)) slice.isSketch = true;
+  }
+}
+
 function _parseRoadmapImpl(content: string): Roadmap {
   const stopTimer = debugTime("parse-roadmap");
   // Try native parser first for better performance
   const nativeResult = nativeParseRoadmap(content);
   if (nativeResult) {
+    applySketchFlags(nativeResult, content);
     stopTimer({ native: true, slices: nativeResult.slices.length, boundaryEntries: nativeResult.boundaryMap.length });
     debugCount("parseRoadmapCalls");
     return nativeResult;

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -193,7 +193,12 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
         ? expandDependencies(depsMatch[1]!.split(",").map(s => s.trim()))
         : [];
 
-      currentSlice = { id, title, risk, depends, done, demo: "" };
+      // ADR-011: the renderer writes a `[sketch]` badge for sketch slices.
+      // Parse it back so the is_sketch flag survives a markdown → DB re-import
+      // (e.g. /gsd recover); otherwise the flag was silently lost.
+      const isSketch = /\[sketch\]/i.test(rest);
+
+      currentSlice = { id, title, risk, depends, done, demo: "", isSketch };
       continue;
     }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
@@ -9,6 +9,7 @@
 import { existsSync, statSync } from "node:fs";
 
 import {
+  getAllMilestones,
   getMilestone,
   getMilestoneSlices,
   getSliceTasks,
@@ -41,17 +42,30 @@ function summaryMtimeIso(path: string): string | null {
 }
 
 export function detectMissingCompletionTimestampDrift(
-  state: GSDState,
+  _state: GSDState,
   ctx: DriftContext,
 ): CompletionTimestampDrift[] {
   if (!isDbAvailable()) return [];
-  const mid = state.activeMilestone?.id;
-  if (!mid) return [];
 
-  const milestone = getMilestone(mid);
-  if (!milestone) return [];
-
+  // Scan every milestone, not just the active one. Markdown artifacts exist on
+  // disk for all milestones, so a user can manually complete a queued/parked
+  // milestone (edit the roadmap + drop a SUMMARY) and leave completed_at=null
+  // in the DB. Gating on the active milestone left that drift unrepaired until
+  // the milestone happened to become active.
   const drifts: CompletionTimestampDrift[] = [];
+  for (const { id: mid } of getAllMilestones()) {
+    collectMilestoneCompletionDrift(mid, ctx, drifts);
+  }
+  return drifts;
+}
+
+function collectMilestoneCompletionDrift(
+  mid: string,
+  ctx: DriftContext,
+  drifts: CompletionTimestampDrift[],
+): void {
+  const milestone = getMilestone(mid);
+  if (!milestone) return;
 
   // Milestone-level
   if (
@@ -105,8 +119,6 @@ export function detectMissingCompletionTimestampDrift(
       }
     }
   }
-
-  return drifts;
 }
 
 export function repairMissingCompletionTimestamp(

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -106,7 +106,13 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: plan path missing milestone/slice segments: ${record.renderPath}`,
       );
     }
-    await renderPlanCheckboxes(basePath, pathMatch[1], pathMatch[2]);
+    const wrote = await renderPlanCheckboxes(basePath, pathMatch[1], pathMatch[2]);
+    if (!wrote) {
+      throw new Error(
+        `stale-render drift: plan re-render wrote nothing for ${pathMatch[1]}/${pathMatch[2]} ` +
+          `(${record.renderPath}); slice has no tasks or its path is unresolvable`,
+      );
+    }
     return;
   }
 
@@ -120,7 +126,14 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: task summary path/reason malformed: ${record.renderPath} reason=${reason}`,
       );
     }
-    await renderTaskSummary(basePath, pathMatch[1], pathMatch[2], taskMatch[1]);
+    const wrote = await renderTaskSummary(basePath, pathMatch[1], pathMatch[2], taskMatch[1]);
+    if (!wrote) {
+      throw new Error(
+        `stale-render drift: task summary re-render wrote nothing for ` +
+          `${pathMatch[1]}/${pathMatch[2]}/${taskMatch[1]} (${record.renderPath}); ` +
+          `task has no summary in DB or its slice path is unresolvable`,
+      );
+    }
     return;
   }
 
@@ -139,7 +152,14 @@ async function repairStaleRenderFromBasePath(
     if (slice?.full_uat_md && !existsSync(uatPath)) {
       setSliceSummaryMd(milestoneId, sliceId, slice.full_summary_md ?? "", "");
     }
-    await renderSliceSummary(basePath, milestoneId, sliceId);
+    const wrote = await renderSliceSummary(basePath, milestoneId, sliceId);
+    if (!wrote) {
+      throw new Error(
+        `stale-render drift: slice summary re-render wrote nothing for ` +
+          `${milestoneId}/${sliceId} (${record.renderPath}); slice has no summary/UAT ` +
+          `in DB or its path is unresolvable`,
+      );
+    }
     return;
   }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -61,6 +61,14 @@ function isRepairableStaleRenderReason(reason: string): boolean {
   );
 }
 
+function canonicalizeMilestoneId(dirSegment: string): string {
+  if (getMilestone(dirSegment)) return dirSegment;
+  // Descriptor layout: e.g. M001-old → M001; M001-a1b2c3 → M001
+  const canonical = dirSegment.match(/^(M\d+(?:-[a-z0-9]{6})?)/i)?.[1];
+  if (canonical && getMilestone(canonical)) return canonical;
+  return canonical ?? dirSegment;
+}
+
 function resolveRoadmapMilestoneIdFromPath(normPath: string): string {
   const milestoneMatch = normPath.match(/milestones\/([^/]+)\//);
   if (!milestoneMatch) {
@@ -106,10 +114,11 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: plan path missing milestone/slice segments: ${record.renderPath}`,
       );
     }
-    const wrote = await renderPlanCheckboxes(basePath, pathMatch[1], pathMatch[2]);
+    const milestoneId = canonicalizeMilestoneId(pathMatch[1]);
+    const wrote = await renderPlanCheckboxes(basePath, milestoneId, pathMatch[2]);
     if (!wrote) {
       throw new Error(
-        `stale-render drift: plan re-render wrote nothing for ${pathMatch[1]}/${pathMatch[2]} ` +
+        `stale-render drift: plan re-render wrote nothing for ${milestoneId}/${pathMatch[2]} ` +
           `(${record.renderPath}); slice has no tasks or its path is unresolvable`,
       );
     }
@@ -126,11 +135,12 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: task summary path/reason malformed: ${record.renderPath} reason=${reason}`,
       );
     }
-    const wrote = await renderTaskSummary(basePath, pathMatch[1], pathMatch[2], taskMatch[1]);
+    const milestoneId = canonicalizeMilestoneId(pathMatch[1]);
+    const wrote = await renderTaskSummary(basePath, milestoneId, pathMatch[2], taskMatch[1]);
     if (!wrote) {
       throw new Error(
         `stale-render drift: task summary re-render wrote nothing for ` +
-          `${pathMatch[1]}/${pathMatch[2]}/${taskMatch[1]} (${record.renderPath}); ` +
+          `${milestoneId}/${pathMatch[2]}/${taskMatch[1]} (${record.renderPath}); ` +
           `task has no summary in DB or its slice path is unresolvable`,
       );
     }
@@ -144,7 +154,7 @@ async function repairStaleRenderFromBasePath(
         `stale-render drift: slice summary path missing milestone/slice segments: ${record.renderPath}`,
       );
     }
-    const milestoneId = pathMatch[1];
+    const milestoneId = canonicalizeMilestoneId(pathMatch[1]);
     const sliceId = pathMatch[2];
     const slice = getSlice(milestoneId, sliceId);
     const uatPath = join(dirname(record.renderPath), buildSliceFileName(sliceId, "UAT"));
@@ -172,7 +182,7 @@ async function repairStaleRenderFromBasePath(
     }
     // When UAT.md is removed from disk, mirror that intent by clearing stale
     // persisted UAT content instead of rehydrating it back onto disk.
-    const milestoneId = pathMatch[1];
+    const milestoneId = canonicalizeMilestoneId(pathMatch[1]);
     const sliceId = pathMatch[2];
     const slice = getSlice(milestoneId, sliceId);
     if (!slice) {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-worker.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-worker.ts
@@ -10,6 +10,11 @@ import {
   readSessionLockData,
   removeStaleSessionLock,
 } from "../../session-lock.js";
+import { clearStaleWorkerLock } from "../../crash-recovery.js";
+import { findStaleWorkerForProject } from "../../db/auto-workers.js";
+import { isDbAvailable } from "../../gsd-db.js";
+import { normalizeRealPath } from "../../paths.js";
+import { logWarning } from "../../workflow-logger.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
@@ -20,23 +25,46 @@ export function detectStaleWorkerDrift(
   ctx: DriftContext,
 ): StaleWorkerDrift[] {
   const data = readSessionLockData(ctx.basePath);
-  if (!data) return [];
-  if (typeof data.pid !== "number") return [];
-  if (isSessionLockProcessAlive(data)) return [];
+  if (data && typeof data.pid === "number") {
+    return isSessionLockProcessAlive(data)
+      ? []
+      : [{ kind: "stale-worker", lockPath: effectiveLockFile(), pid: data.pid }];
+  }
 
-  return [
-    {
-      kind: "stale-worker",
-      lockPath: effectiveLockFile(),
-      pid: data.pid,
-    },
-  ];
+  // The lock file is missing or unparseable. It is not the only source of
+  // truth: a crashed worker can leave a workers row 'active' with held leases
+  // and in-flight dispatches even when its lock file is gone. Fall back to the
+  // DB worker registry so that state is still detected and repaired.
+  if (isDbAvailable()) {
+    try {
+      const stale = findStaleWorkerForProject(normalizeRealPath(ctx.basePath));
+      if (stale && typeof stale.pid === "number") {
+        return [{ kind: "stale-worker", lockPath: effectiveLockFile(), pid: stale.pid }];
+      }
+    } catch (err) {
+      // Best-effort: detection must never throw and abort the reconcile cycle.
+      logWarning(
+        "reconcile",
+        `stale-worker DB fallback detection failed: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  return [];
 }
 
 export function repairStaleWorker(_record: StaleWorkerDrift, ctx: DriftContext): void {
   // removeStaleSessionLock is idempotent: it re-reads lock state and is a
   // no-op when the lock is held by an alive process. Safe under cap=2 retry.
   removeStaleSessionLock(ctx.basePath);
+
+  // Removing the lock file alone leaves the DB-side worker state dangling: the
+  // dead worker's milestone_leases stay 'held' and its unit_dispatches stay
+  // 'running'/'claimed', blocking new claims until the lease TTL expires.
+  // clearStaleWorkerLock cancels those dispatches, releases the leases, and
+  // marks the worker stopping — the same cleanup the startup crash-recovery
+  // path performs. It is DB-gated, idempotent, and best-effort.
+  clearStaleWorkerLock(ctx.basePath);
 }
 
 export const staleWorkerHandler: DriftHandler<StaleWorkerDrift> = {

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -7,6 +7,8 @@ import {
   invalidateStateCache as defaultInvalidate,
 } from "../state.js";
 import { clearParseCache as defaultClearParseCache } from "../files.js";
+import { clearPathCache } from "../paths.js";
+import { logWarning } from "../workflow-logger.js";
 import type { GSDState } from "../types.js";
 
 import {
@@ -68,18 +70,24 @@ export async function reconcileBeforeDispatch(
     const stateSnapshot = await deps.deriveState(basePath, deps.deriveStateOptions);
     const ctx: DriftContext = { basePath, state: stateSnapshot };
 
-    const drift = await detectAllDrift(stateSnapshot, ctx, registry, pass);
+    const detection = await detectAllDrift(stateSnapshot, ctx, registry);
+    const drift = detection.records;
     if (drift.length === 0) {
       return {
         ok: true,
         stateSnapshot,
         repaired,
-        blockers: stateSnapshot.blockers ?? [],
+        blockers: [
+          ...new Set([
+            ...(stateSnapshot.blockers ?? []),
+            ...detection.detectBlockers,
+          ]),
+        ],
       };
     }
 
     const failures: ReconciliationFailureDetail[] = [];
-    const blockers: string[] = [];
+    const blockers: string[] = [...detection.detectBlockers];
     let repairedThisPass = false;
     for (const record of drift) {
       const handler = registry.find((h) => h.kind === record.kind);
@@ -107,7 +115,11 @@ export async function reconcileBeforeDispatch(
     }
 
     if (repairedThisPass) {
+      // A repair may have mutated on-disk structure (e.g. quarantined a slice
+      // dir). Clear both the parse cache and the path/dir cache centrally so
+      // later passes and any subsequent repair see fresh filesystem state.
       clearParseCache();
+      clearPathCache();
     }
     if (blockers.length > 0) {
       let blockerState = stateSnapshot;
@@ -132,10 +144,11 @@ export async function reconcileBeforeDispatch(
   deps.invalidateStateCache();
   const finalState = await deps.deriveState(basePath, deps.deriveStateOptions);
   const finalCtx: DriftContext = { basePath, state: finalState };
-  const persistent = await detectAllDrift(finalState, finalCtx, registry);
+  const finalDetection = await detectAllDrift(finalState, finalCtx, registry);
+  const persistent = finalDetection.records;
 
   if (persistent.length > 0) {
-    const blockers: string[] = [];
+    const blockers: string[] = [...finalDetection.detectBlockers];
     const unblockedPersistent: DriftRecord[] = [];
     for (const record of persistent) {
       const handler = registry.find((h) => h.kind === record.kind);
@@ -161,28 +174,45 @@ export async function reconcileBeforeDispatch(
     ok: true,
     stateSnapshot: finalState,
     repaired,
-    blockers: finalState.blockers ?? [],
+    blockers: [
+      ...new Set([
+        ...(finalState.blockers ?? []),
+        ...finalDetection.detectBlockers,
+      ]),
+    ],
   };
 }
 
+interface DetectionOutcome {
+  records: DriftRecord[];
+  /** One blocker string per handler whose detect() threw. */
+  detectBlockers: string[];
+}
+
+/**
+ * Run every detector. A single detector throwing (e.g. a transient file read
+ * error) must NOT abort the whole cycle and hide every later handler's drift —
+ * it is collected as a blocker so dispatch is still gated, while the remaining
+ * detectors run and their drift gets repaired (graceful degradation, ADR-017).
+ */
 async function detectAllDrift(
   state: GSDState,
   ctx: DriftContext,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry: ReadonlyArray<DriftHandler<any>>,
-  pass?: number,
-): Promise<DriftRecord[]> {
-  const collected: DriftRecord[] = [];
+): Promise<DetectionOutcome> {
+  const records: DriftRecord[] = [];
+  const detectBlockers: string[] = [];
   for (const handler of registry) {
     try {
       const detected = await handler.detect(state, ctx);
-      collected.push(...detected);
+      records.push(...detected);
     } catch (cause) {
-      throw new ReconciliationFailedError({
-        failures: [{ drift: { kind: handler.kind } as DriftRecord, cause }],
-        pass,
-      });
+      const message = cause instanceof Error ? cause.message : String(cause);
+      const blocker = `Drift detection failed for "${handler.kind}": ${message}`;
+      logWarning("reconcile", blocker);
+      detectBlockers.push(blocker);
     }
   }
-  return collected;
+  return { records, detectBlockers };
 }

--- a/src/resources/extensions/gsd/state-reconciliation/spawn-gate.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/spawn-gate.ts
@@ -21,10 +21,10 @@ export interface SpawnGateDeps extends Partial<ReconciliationDeps> {
 }
 
 /**
- * Run reconciliation before spawning workers. Returns ok=true when the run
- * completed without throwing (blockers ride along but don't fail the gate —
- * spawn callers can choose how to handle them). On
- * ReconciliationFailedError, returns ok=false with the error message so the
+ * Run reconciliation before spawning workers. Returns ok=true only when the run
+ * completed without throwing AND surfaced no blockers; any blocker fails the
+ * gate (ok=false, reason carries the first blocker) so callers must not spawn.
+ * On ReconciliationFailedError, returns ok=false with the error message so the
  * caller can surface it to the user without re-throwing.
  *
  * Other unexpected errors propagate; they are not part of the drift

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -534,4 +534,43 @@ describe('gsd-recover', async () => {
       cleanup(base);
     }
   });
+
+  test('handleRecover interactive data-loss requires a second explicit acknowledgement', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
+
+      // First confirm (proceed?) = yes; second confirm (delete rows?) = no.
+      let call = 0;
+      const { ctx, notes } = makeCtx(async () => { call += 1; return call === 1; });
+      await handleRecover(ctx, base, '');
+
+      assert.ok(getMilestone('M999'), 'declining the data-loss ack preserves DB rows');
+      assert.equal(getMilestone('M001'), null, 'markdown not imported when data-loss ack declined');
+      assert.match(notes.at(-1)?.message ?? '', /cancelled/);
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('handleRecover interactive proceeds when the data-loss deletion is acknowledged', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
+
+      const { ctx } = makeCtx(async () => true); // both confirms accepted
+      await handleRecover(ctx, base, '');
+
+      assert.equal(getMilestone('M999'), null, 'acknowledged data-loss recover clears old rows');
+      assert.ok(getMilestone('M001'), 'acknowledged data-loss recover imports markdown');
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
 });

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -502,11 +502,33 @@ describe('gsd-recover', async () => {
       insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
 
       const { ctx, notes } = makeCtx();
-      await handleRecover(ctx, base, '--confirm');
+      // M999 is in the DB but not in the markdown, so recover would delete it:
+      // a data-loss recover now requires explicit --allow-data-loss.
+      await handleRecover(ctx, base, '--confirm --allow-data-loss');
 
       assert.equal(getMilestone('M999'), null, 'confirmed recover clears old hierarchy rows');
       assert.ok(getMilestone('M001'), 'confirmed recover imports markdown hierarchy');
       assert.equal(notes.at(-1)?.kind, 'success');
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('handleRecover refuses to delete DB rows markdown lacks without --allow-data-loss', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M999', title: 'Existing DB State', status: 'active' });
+
+      const { ctx, notes } = makeCtx();
+      await handleRecover(ctx, base, '--confirm');
+
+      // --confirm alone must NOT clear authoritative DB rows the markdown lacks.
+      assert.ok(getMilestone('M999'), 'data-loss recover is refused, DB row preserved');
+      assert.equal(getMilestone('M001'), null, 'markdown not imported on refusal');
+      assert.equal(notes.at(-1)?.kind, 'error');
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -393,6 +393,48 @@ test('── markdown-renderer: renderPlanCheckboxes round-trip ──', async (
   }
 });
 
+test('── markdown-renderer: renderPlanCheckboxes re-renders DB tasks added after the plan artifact ──', async () => {
+  // Regression for the lossy-projection root cause: renderPlanCheckboxes used to
+  // patch the cached PLAN artifact in place, silently dropping tasks added to
+  // the DB after the artifact was first written (the 4S/0T-vs-5S/13T drift).
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    scaffoldDirs(tmpDir, 'M001', ['S01']);
+    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice', status: 'pending' });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'First task', status: 'pending' });
+
+    // PLAN.md on disk reflects an earlier state with only T01.
+    const planPath = path.join(tmpDir, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'S01-PLAN.md');
+    fs.writeFileSync(planPath, makePlanContent('S01', [{ id: 'T01', title: 'First task', done: false }]));
+    clearAllCaches();
+
+    // Two more tasks are written to the DB after the artifact already exists.
+    insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', title: 'Second task', status: 'done' });
+    insertTask({ id: 'T03', sliceId: 'S01', milestoneId: 'M001', title: 'Third task', status: 'pending' });
+
+    const ok = await renderPlanCheckboxes(tmpDir, 'M001', 'S01');
+    assert.ok(ok, 'renderPlanCheckboxes returns true');
+
+    const parsed = parsePlan(fs.readFileSync(planPath, 'utf-8'));
+    clearAllCaches();
+    assert.deepStrictEqual(
+      parsed.tasks.map(t => t.id).sort(),
+      ['T01', 'T02', 'T03'],
+      'full re-render must include tasks added after the artifact was written',
+    );
+    assert.ok(parsed.tasks.find(t => t.id === 'T02')!.done, 'T02 reflects done status from DB');
+    assert.ok(!parsed.tasks.find(t => t.id === 'T03')!.done, 'T03 reflects pending status from DB');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 test('── markdown-renderer: renderPlanCheckboxes bidirectional ──', async () => {
   const tmpDir = makeTmpDir();
   const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -151,6 +151,57 @@ test("migration auto-check leaves matching DB hierarchy alone", async () => {
   }
 });
 
+test("migration auto-check flags a populated DB with missing markdown and points at rebuild (not recover)", async () => {
+  const base = makeBase();
+  try {
+    // A project with no milestone markdown: simulate lost/empty projections
+    // over a populated DB. The previous early return treated all-zero markdown
+    // as 'no project' and never even opened the DB, silently hiding the rows.
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    assert.deepEqual(countMarkdownHierarchy(base), { milestones: 0, slices: 0, tasks: 0 });
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "recovery-required");
+    assert.equal(result.reason, "markdown-missing");
+    // The DB is the richer side, so recover (md → DB) would DELETE rows. The
+    // safe repair is to re-project from the DB.
+    assert.equal(result.recoveryCommand, "/gsd rebuild markdown");
+    assert.match(result.message ?? "", /rebuild markdown/);
+    assert.match(result.message ?? "", /Do NOT run/);
+    // The check must not mutate the DB.
+    assert.equal(getAllMilestones().length, 1);
+    assert.equal(getSliceTasks("M001", "S01").length, 1);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check detects identity drift even when counts match", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01
+    assert.equal(await ensureDbOpen(base), true);
+    // Same cardinalities (1M/1S/1T) but a DIFFERENT slice identity (S99 vs S01).
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S99", milestoneId: "M001", title: "Other Slice", status: "pending", risk: "medium", depends: [], demo: "d", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S99", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    // Counts are equal on both sides, so the old count-only comparison reported
+    // 'in-sync'. Identity comparison must catch the divergence instead.
+    assert.equal(result.action, "recovery-required");
+    assert.notEqual(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+    assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("migration auto-check refreshes a stale open DB handle before comparing", async () => {
   const base = makeBase();
   try {

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -223,6 +223,33 @@ test("recoverWouldDeleteDbRows flags identity drift the markdown lacks (even at 
   }
 });
 
+test("migration auto-check canonicalizes a legacy descriptor milestone dir (no false drift)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // creates .gsd/milestones/M001
+    // Rename the dir to a legacy descriptor form while the DB id stays "M001".
+    // scanMarkdownHierarchy must canonicalize "M001-old" → "M001" so the
+    // identity sets line up with scanDbHierarchy (which uses milestone.id).
+    const milestonesRoot = join(base, ".gsd", "milestones");
+    renameSync(join(milestonesRoot, "M001"), join(milestonesRoot, "M001-old"));
+
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    // Must be in-sync: the raw dir name "M001-old" would otherwise mismatch the
+    // DB id "M001" and be flagged as false drift.
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+    assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("migration auto-check refreshes a stale open DB handle before comparing", async () => {
   const base = makeBase();
   try {

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -197,6 +197,27 @@ test("migration auto-check detects identity drift even when counts match", async
     assert.notEqual(result.reason, "in-sync");
     assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
     assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+    // The DB holds S99 (which markdown lacks), so recover would DELETE it. Even
+    // at equal counts the safe recommendation must be rebuild, not recover.
+    assert.equal(result.recoveryCommand, "/gsd rebuild markdown");
+    assert.match(result.message ?? "", /Do NOT run/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("recoverWouldDeleteDbRows flags identity drift the markdown lacks (even at equal counts)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01
+    assert.equal(await ensureDbOpen(base), true);
+    // DB row identity (S99) differs from markdown (S01) at the same count.
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S99", milestoneId: "M001", title: "Other Slice", status: "pending", risk: "medium", depends: [], demo: "d", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S99", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+    const { recoverWouldDeleteDbRows } = await import("../migration-auto-check.ts");
+    assert.equal(recoverWouldDeleteDbRows(base), true, "DB S99 is absent from markdown — recover would delete it");
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -152,35 +152,50 @@ test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shap
   );
 });
 
-test("ADR-017 (#5700): detector failure throws ReconciliationFailedError with shape", async () => {
-  const handler: DriftHandler = {
-    kind: "stale-sketch-flag",
+test("ADR-017 (#5700): a detector failure degrades to a blocker without aborting other handlers", async () => {
+  // A single detector throwing (e.g. a transient file read error) must NOT
+  // abort the whole cycle and hide every later handler's drift. It is collected
+  // as a blocker (so dispatch is still gated) while the remaining detectors run
+  // and their drift is repaired — graceful degradation, not fail-fast.
+  const throwingHandler: DriftHandler = {
+    kind: "stale-render",
     detect: () => {
       throw new Error("simulated detect failure");
     },
     repair: () => {
-      /* detect fails before repair */
+      /* never reached: detect throws */
     },
   };
 
-  await assert.rejects(
-    () =>
-      reconcileBeforeDispatch("/project", {
-        invalidateStateCache: () => {},
-        deriveState: async () => makeState(),
-        registry: [handler],
-      }),
-    (err: unknown) => {
-      assert.ok(err instanceof ReconciliationFailedError, "must be ReconciliationFailedError");
-      assert.equal(err.failures.length, 1);
-      assert.equal(err.failures[0]?.drift.kind, "stale-sketch-flag");
-      assert.ok(err.failures[0]?.cause instanceof Error);
-      assert.equal((err.failures[0]?.cause as Error).message, "simulated detect failure");
-      assert.equal(err.pass, 0);
-      assert.equal(err.detectionFailures.length, 0);
-      assert.equal(err.persistentDrift.length, 0);
-      return true;
+  let repairCount = 0;
+  const workingHandler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () =>
+      repairCount === 0
+        ? [{ kind: "stale-sketch-flag", mid: "M001", sid: "S02" }]
+        : [],
+    repair: () => {
+      repairCount++;
     },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [throwingHandler, workingHandler],
+  });
+
+  assert.equal(result.ok, true, "cycle must not abort on a single detector failure");
+  // The working handler (registered AFTER the thrower) still detected + repaired.
+  assert.equal(repairCount, 1, "later handler must still run despite earlier detect failure");
+  assert.equal(result.repaired.length, 1);
+  assert.equal(result.repaired[0]?.kind, "stale-sketch-flag");
+  // The detector failure surfaces as a blocker so dispatch is still gated.
+  assert.ok(
+    result.blockers.some(
+      (b) => b.includes("stale-render") && b.includes("simulated detect failure"),
+    ),
+    "detect failure must surface as a blocker",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -761,6 +761,46 @@ test("ADR-017 (#5702): missing UAT.md clears stale full_uat_md from DB", async (
   );
 });
 
+test("ADR-017 (#5702): stale-render plan repair works with descriptor-layout milestone dir", async (t) => {
+  // Regression for bugbot finding: repairStaleRenderFromBasePath was passing the
+  // raw dir segment (e.g. M001-DESCRIPTOR) straight to renderPlanCheckboxes, which
+  // queries the DB as getSliceTasks("M001-DESCRIPTOR", …) → empty → throws.
+  // After the fix it calls canonicalizeMilestoneId() first.
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-descriptor-"));
+  // Use a descriptor-style directory name (M001-DESCRIPTOR → DB milestone M001)
+  const milestoneDir = "M001-DESCRIPTOR";
+  const sliceDir = join(base, ".gsd", "milestones", milestoneDir, "slices", "S01");
+  mkdirSync(join(sliceDir, "tasks"), { recursive: true });
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmTreeQuiet(base);
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  clearRendererCaches();
+  // DB uses the canonical ID (M001), directory uses the descriptor name.
+  insertMilestone({ id: "M001", title: "Descriptor Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task One", status: "done" });
+
+  const planPath = join(sliceDir, "S01-PLAN.md");
+  writeFileSync(planPath, makeStalePlanContent("S01", [
+    { id: "T01", title: "Task One", done: false },
+  ]));
+  clearRendererCaches();
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true, "reconcile should succeed with descriptor-layout milestone dir");
+  const renderRepaired = result.repaired.find((d) => d.kind === "stale-render");
+  assert.ok(renderRepaired, "stale-render drift should be repaired");
+  const repairedContent = readFileSync(planPath, "utf-8");
+  assert.match(repairedContent, /\[x\][^\n]*T01:/, "T01 checkbox should be checked after repair");
+});
+
 // ─── #5703: stale-worker drift ───────────────────────────────────────────────
 
 const DEAD_PID = 999_999_999; // far above any realistic system PID; process.kill(pid, 0) → ESRCH

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -35,6 +35,7 @@ export interface RoadmapSliceEntry {
   depends: string[]; // e.g. ["S01", "S02"]
   done: boolean;
   demo: string; // the "After this:" sentence
+  isSketch?: boolean; // ADR-011: true when the roadmap shows the `[sketch]` badge
 }
 
 export interface BoundaryMapEntry {

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -546,6 +546,15 @@ export async function regenerateIfMissing(
     return false;
   }
 
+  // A sketch slice (or any slice not yet planned into tasks) legitimately has
+  // no PLAN.md to project. renderPlanFromDb throws on a zero-task slice, so
+  // skip cleanly here rather than logging a spurious failure. The PLAN.md will
+  // be created once the slice is refined and its first task is written through
+  // the single writer.
+  if (fileType === "PLAN" && getSliceTasks(milestoneId, sliceId).length === 0) {
+    return false;
+  }
+
   // Regenerate the missing file. Each renderer may swallow its own errors
   // (e.g. renderStateProjection), so confirm the file actually exists on
   // disk before reporting success — true must mean "file is there now".


### PR DESCRIPTION
## Summary

A deep audit of the drift-reconciliation subsystem (44-agent workflow → 27 adversarially-verified findings) surfaced ways the core invariant could break: **the DB is authoritative, markdown is a projection, and `/gsd recover --confirm` is the only sanctioned markdown→DB import.** The single-writer arm was sound; every bug was on the **projection** arm. This PR fixes all 27.

## What changed (by area)

- **Projection (`markdown-renderer`)** — `renderPlanCheckboxes` now full-renders from the DB instead of regex-patching the cached PLAN artifact, which silently dropped tasks added after the artifact was first written (the `4S/0T`-vs-`5S/13T` drift class). `detectStaleRenders` flags DB-only tasks; `renderAllFromDb` re-projects `DECISIONS.md`.
- **Count-check (`migration-auto-check`) — CRITICAL** — opens the DB *before* the empty-markdown early return (a populated DB with missing markdown was silently hidden), compares hierarchy **identities** not just counts, and recommends the **safe** command: `rebuild` when the DB is richer, `recover` only when markdown is.
- **Recover (interactive + headless) — CRITICAL** — shows the DB↔markdown delta, refuses to delete DB rows without `--allow-data-loss` / `GSD_RECOVER_ALLOW_DATA_LOSS=1`, snapshots to `.gsd/backups/` first, and re-projects + verifies after import.
- **Reconcile loop** — a single detector throwing now degrades to a blocker instead of aborting the whole cycle; stale-render repairs throw on a failed write instead of reporting false success; cache clearing centralized.
- **Stale-worker** — repair releases `milestone_leases` and cancels `unit_dispatches` for the dead worker (was leaking held leases); DB-registry fallback when the lock file is missing/unparseable.
- **Completion** — scans all milestones (not just the active one); the importer backfills `completed_at` for milestones/slices imported as complete.
- **Sketch flag** round-trips through markdown → DB re-import.
- **spawn-gate** JSDoc corrected to match code (blockers fail the gate).

## Tests

- New regression tests: projection-lossy root cause (tasks added after the artifact survive re-render) + the two critical count-check cases (populated-DB/missing-markdown → points at rebuild not recover; identity drift with matching counts).
- Typecheck clean; targeted reconciliation/projection suites + full `pnpm test:unit` pass.

> Note: two pre-existing, unrelated failures on `main` (`doctor-scope-db-unavailable`, `repository-registry`) are **not** touched by this PR — they fail on the baseline without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783255920&installation_id=134682257&pr_number=502&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F502&signature=2da443bcebc322c119b5fc82c101b2fe132eeb6e12378abb49622dbc6121f0ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches destructive recover, hierarchy import/export, reconciliation before worker spawn, and coordination cleanup—bugs could delete or mis-project authoritative DB state or block dispatch incorrectly.
> 
> **Overview**
> Hardens the **DB authoritative / markdown projection** invariant across recover, startup drift checks, reconciliation, and rendering.
> 
> **Recover (interactive + headless)** now compares DB vs markdown **by identity** (not just counts), refuses runs that would delete DB-only rows unless `GSD_RECOVER_ALLOW_DATA_LOSS=1` / `--allow-data-loss`, snapshots to `.gsd/backups/` first, re-projects via `renderAllFromDb` after import, and surfaces projection/import shortfalls instead of reporting a clean success.
> 
> **`migration-auto-check`** always opens the DB (no silent skip on empty markdown), treats identity mismatch as drift, and recommends **`/gsd rebuild markdown`** when the DB is richer—**`/gsd recover`** only when markdown is the surviving source.
> 
> **Projection fixes:** `renderPlanCheckboxes` full-renders plans from DB rows (fixes lossy regex patches); stale detection flags DB tasks missing from plans; `renderAllFromDb` also re-projects **`DECISIONS.md`** via `regenerateDecisionsMarkdown`.
> 
> **Reconcile loop:** one failing detector becomes a **blocker** instead of aborting the cycle; repairs clear path + parse caches; stale-render repairs fail loudly on no-op writes; stale-worker repair also clears DB leases/dispatches with a registry fallback.
> 
> **Importer / drift:** backfills `completed_at` on complete imports, preserves **`[sketch]`** through parse/re-import, completion drift scans **all** milestones, and descriptor milestone dirs are canonicalized in scans/repairs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad69d8a111d060ab8b599f2fc0359c80a0f9506a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->