### PR TITLE
fix(gsd): track DB recovery evidence surfaces

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -50,7 +50,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 
 ## 2. Schema Version History
 
-Current version: **V28**
+Current version: **V29**
 
 | Version | What Changed |
 |---------|-------------|
@@ -82,6 +82,7 @@ Current version: **V28**
 | V26 | milestone_commit_attributions |
 | V27 | artifacts.content_hash (SHA-256 of full_content, computed on every insertArtifact) |
 | V28 | memories.last_hit_at; incrementMemoryHitCount sets it; queryMemoriesRanked applies time-decay (1.0 → 0.7 floor over 90 days) |
+| V29 | slices.target_repositories and tasks.target_repositories for multi-repository planning |
 
 ---
 
@@ -112,7 +113,6 @@ made_by        TEXT NOT NULL DEFAULT 'agent'     ← V4
 source         TEXT NOT NULL DEFAULT 'discussion' ← V16
 superseded_by  TEXT DEFAULT NULL
 ```
-- Index: `idx_memories_active` (superseded_by)
 - View: `active_decisions` WHERE superseded_by IS NULL
 
 ---
@@ -196,6 +196,7 @@ success_criteria     TEXT NOT NULL DEFAULT ''           ← V8
 proof_level          TEXT NOT NULL DEFAULT ''           ← V8
 integration_closure  TEXT NOT NULL DEFAULT ''           ← V8
 observability_impact TEXT NOT NULL DEFAULT ''           ← V8
+target_repositories TEXT NOT NULL DEFAULT '[]'          ← V29, JSON
 sequence             INTEGER DEFAULT 0                  ← V9
 replan_triggered_at  TEXT DEFAULT NULL                  ← V10
 is_sketch            INTEGER NOT NULL DEFAULT 0         ← V16
@@ -239,6 +240,7 @@ inputs                      TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
 expected_output             TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
 observability_impact        TEXT NOT NULL DEFAULT ''           ← V8
 full_plan_md                TEXT NOT NULL DEFAULT ''           ← V11
+target_repositories         TEXT NOT NULL DEFAULT '[]'         ← V29, JSON
 sequence                    INTEGER DEFAULT 0                  ← V9
 PRIMARY KEY (milestone_id, slice_id, id)
 FOREIGN KEY (milestone_id, slice_id) → slices(milestone_id, id)
@@ -662,6 +664,23 @@ runtime_kv  (soft state KV)
 
 ---
 
+## 4b. Recovery And Worktree Merge Surfaces
+
+`.gsd/state-manifest.json` snapshots DB-backed correctness state: requirements,
+artifacts, milestones, slices, tasks, decisions, replan history, assessments,
+quality gates, verification evidence, and milestone commit attributions. Restore
+rebuilds decision mirror memories from the restored decisions and preserves
+optional rows when reading older manifests that predate the extended arrays.
+
+`reconcileWorktreeDb` merges hidden-worktree correctness rows back into the main
+DB, including hierarchy, requirements, artifacts, memories, replan history,
+assessments, quality gates, slice dependencies, verification evidence, gate
+runs, and milestone commit attributions. Runtime-only/audit substrates such as
+`runtime_kv`, `turn_git_transactions`, `audit_events`, and `audit_turn_index`
+remain outside manifest restore.
+
+---
+
 ## 5. Complete gsd_* Tool → Table Map
 
 | Tool | Tables READ | Tables WRITTEN | Disk Artifacts |
@@ -676,8 +695,9 @@ runtime_kv  (soft state KV)
 | `gsd_plan_task` | slices, tasks | tasks | T##-PLAN.md |
 | `gsd_task_complete` | tasks, slices | tasks, verification_evidence | T##-SUMMARY.md; toggles checkbox in S##-PLAN.md |
 | `gsd_slice_complete` | tasks, slices | slices, tasks (cascade skipped) | S##-SUMMARY.md, S##-UAT.md; toggles checkpoint in ROADMAP.md |
+| `gsd_uat_result_save` | slices, artifacts | artifacts, assessments, quality_gates, gate_runs | S##-ASSESSMENT.md; UAT attempt JSON |
 | `gsd_complete_milestone` | milestones, slices, tasks | milestones | M##-SUMMARY.md |
-| `gsd_validate_milestone` | milestones, slices, tasks | assessments | VALIDATION.md |
+| `gsd_validate_milestone` | milestones, slices, tasks | assessments, quality_gates, gate_runs | VALIDATION.md |
 | `gsd_reassess_roadmap` | milestones, slices | milestones, slices, assessments | ROADMAP.md, ASSESSMENT.md |
 | `gsd_replan_slice` | slices, tasks | slices, tasks, replan_history, quality_gates | S##-PLAN.md, S##-REPLAN.md |
 | `gsd_skip_slice` | slices, tasks | slices, tasks | STATE.md (via rebuildState) |

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -23,6 +23,7 @@ import {
   getPendingGatesForTurn,
   markPendingGatesOmittedForTurn,
   getMilestone,
+  insertArtifact,
   insertAssessment,
   setSliceSketchFlag,
   transaction,
@@ -439,6 +440,53 @@ export function findMissingSummaries(basePath: string, mid: string): string[] {
     .map(s => s.id);
 }
 
+function stringField(row: Record<string, unknown> | null, key: string): string | null {
+  const value = row?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function stripGsdPrefix(path: string): string {
+  return path.startsWith(".gsd/") ? path.slice(".gsd/".length) : path;
+}
+
+function persistSliceAssessmentBackfill(
+  assessmentRelPath: string,
+  mid: string,
+  sliceId: string,
+  content: string,
+): void {
+  const artifactPath = stripGsdPrefix(assessmentRelPath);
+  const existingAssessment =
+    getAssessment(assessmentRelPath) ??
+    getAssessment(artifactPath);
+  const scope = stringField(existingAssessment, "scope") ?? "run-uat";
+  const status = stringField(existingAssessment, "status") ??
+    extractVerdict(content)?.toLowerCase() ??
+    "unknown";
+
+  transaction(() => {
+    insertArtifact({
+      path: artifactPath,
+      artifact_type: "ASSESSMENT",
+      milestone_id: mid,
+      slice_id: sliceId,
+      task_id: null,
+      full_content: content,
+    });
+    if (!getAssessment(assessmentRelPath)) {
+      insertAssessment({
+        path: assessmentRelPath,
+        milestoneId: mid,
+        sliceId,
+        taskId: null,
+        status,
+        scope,
+        fullContent: content,
+      });
+    }
+  });
+}
+
 function backfillMissingAssessmentsFromSummaries(basePath: string, mid: string): void {
   const completedSliceIds = new Set<string>();
   if (isDbAvailable()) {
@@ -467,11 +515,12 @@ function backfillMissingAssessmentsFromSummaries(basePath: string, mid: string):
     const slicePath = resolveSlicePath(basePath, mid, sliceId);
     const assessmentPath = resolveSliceFile(basePath, mid, sliceId, "ASSESSMENT")
       ?? (slicePath ? join(slicePath, buildSliceFileName(sliceId, "ASSESSMENT")) : null);
-    if (!assessmentPath || existsSync(assessmentPath)) continue;
+    if (!assessmentPath) continue;
 
-    mkdirSync(dirname(assessmentPath), { recursive: true });
+    const assessmentRelPath = relSliceFile(basePath, mid, sliceId, "ASSESSMENT");
     const now = new Date().toISOString();
-    const content = [
+    const didCreateAssessment = !existsSync(assessmentPath);
+    const content = didCreateAssessment ? [
       "---",
       `sliceId: ${sliceId}`,
       "verdict: PASS",
@@ -483,8 +532,20 @@ function backfillMissingAssessmentsFromSummaries(basePath: string, mid: string):
       "Auto-created during milestone validation because this completed slice had a SUMMARY but no ASSESSMENT artifact.",
       "No additional reassessment changes were detected in this backfill step.",
       "",
-    ].join("\n");
-    writeFileSync(assessmentPath, content, "utf-8");
+    ].join("\n") : readFileSync(assessmentPath, "utf-8");
+
+    if (isDbAvailable()) {
+      try {
+        persistSliceAssessmentBackfill(assessmentRelPath, mid, sliceId, content);
+      } catch (err) {
+        logWarning("dispatch", `failed to backfill assessment DB rows for ${mid}/${sliceId}: ${(err as Error).message}`);
+      }
+    }
+
+    if (didCreateAssessment) {
+      mkdirSync(dirname(assessmentPath), { recursive: true });
+      writeFileSync(assessmentPath, content, "utf-8");
+    }
   }
 }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1260,14 +1260,14 @@ export function insertTask(t: {
       milestone_id, slice_id, id, title, status, one_liner, narrative,
       verification_result, duration, completed_at, blocker_discovered,
       deviations, known_issues, key_files, key_decisions, full_summary_md,
-      description, estimate, files, verify, inputs, expected_output, observability_impact, sequence
-      , target_repositories
+      description, estimate, files, verify, inputs, expected_output,
+      observability_impact, full_plan_md, target_repositories, sequence
     ) VALUES (
       :milestone_id, :slice_id, :id, :title, :status, :one_liner, :narrative,
       :verification_result, :duration, :completed_at, :blocker_discovered,
       :deviations, :known_issues, :key_files, :key_decisions, :full_summary_md,
-      :description, :estimate, :files, :verify, :inputs, :expected_output, :observability_impact, :sequence
-      , :target_repositories
+      :description, :estimate, :files, :verify, :inputs, :expected_output,
+      :observability_impact, :full_plan_md, :target_repositories, :sequence
     )
     ON CONFLICT(milestone_id, slice_id, id) DO UPDATE SET
       title = CASE WHEN NULLIF(:title, '') IS NOT NULL THEN :title ELSE tasks.title END,
@@ -1290,6 +1290,7 @@ export function insertTask(t: {
       inputs = CASE WHEN NULLIF(:inputs, '[]') IS NOT NULL THEN :inputs ELSE tasks.inputs END,
       expected_output = CASE WHEN NULLIF(:expected_output, '[]') IS NOT NULL THEN :expected_output ELSE tasks.expected_output END,
       observability_impact = CASE WHEN NULLIF(:observability_impact, '') IS NOT NULL THEN :observability_impact ELSE tasks.observability_impact END,
+      full_plan_md = CASE WHEN NULLIF(:full_plan_md, '') IS NOT NULL THEN :full_plan_md ELSE tasks.full_plan_md END,
       sequence = :sequence,
       target_repositories = CASE
         WHEN :raw_target_repositories IS NOT NULL THEN :target_repositories
@@ -1319,6 +1320,7 @@ export function insertTask(t: {
     ":inputs": JSON.stringify(t.planning?.inputs ?? []),
     ":expected_output": JSON.stringify(t.planning?.expectedOutput ?? []),
     ":observability_impact": t.planning?.observabilityImpact ?? "",
+    ":full_plan_md": t.planning?.fullPlanMd ?? "",
     ":sequence": t.sequence ?? 0,
     ":target_repositories": JSON.stringify(t.planning?.targetRepositories ?? []),
     ":raw_target_repositories":
@@ -1855,7 +1857,13 @@ export interface ReconcileResult {
   slices: number;
   tasks: number;
   memories: number;
+  replan_history: number;
+  assessments: number;
+  quality_gates: number;
+  slice_dependencies: number;
   verification_evidence: number;
+  gate_runs: number;
+  milestone_commit_attributions: number;
   conflicts: string[];
 }
 
@@ -1863,7 +1871,23 @@ export function reconcileWorktreeDb(
   mainDbPath: string,
   worktreeDbPath: string,
 ): ReconcileResult {
-  const zero: ReconcileResult = { decisions: 0, requirements: 0, artifacts: 0, milestones: 0, slices: 0, tasks: 0, memories: 0, verification_evidence: 0, conflicts: [] };
+  const zero: ReconcileResult = {
+    decisions: 0,
+    requirements: 0,
+    artifacts: 0,
+    milestones: 0,
+    slices: 0,
+    tasks: 0,
+    memories: 0,
+    replan_history: 0,
+    assessments: 0,
+    quality_gates: 0,
+    slice_dependencies: 0,
+    verification_evidence: 0,
+    gate_runs: 0,
+    milestone_commit_attributions: 0,
+    conflicts: [],
+  };
   if (!existsSync(worktreeDbPath)) return zero;
   // Guard: bail when both paths resolve to the same physical file.
   // ATTACHing a WAL-mode DB to itself corrupts the WAL (#2823).
@@ -1889,224 +1913,398 @@ export function reconcileWorktreeDb(
   try {
     adapter.exec(`ATTACH DATABASE '${worktreeDbPath}' AS wt`);
     try {
-      const wtInfo = adapter.prepare("PRAGMA wt.table_info('decisions')").all();
+      function countChanges(result: unknown): number {
+        return typeof result === "object" && result !== null ? ((result as { changes?: number }).changes ?? 0) : 0;
+      }
+
+      function wtTableInfo(tableName: string): Array<Record<string, unknown>> {
+        return adapter.prepare(`PRAGMA wt.table_info('${tableName}')`).all() as Array<Record<string, unknown>>;
+      }
+
+      const wtInfo = wtTableInfo("decisions");
+      const hasWtDecisions = wtInfo.length > 0;
       const hasMadeBy = wtInfo.some((col) => col["name"] === "made_by");
       // ADR-011: worktree may predate schema v16/v17. For missing columns we
       // fall through to the main DB's existing value (not a literal default)
       // so reconcile never silently clears state the main tree has recorded.
       const hasDecisionSource = wtInfo.some((col) => col["name"] === "source");
-      const wtMilestoneInfo = adapter.prepare("PRAGMA wt.table_info('milestones')").all();
+      const wtRequirementInfo = wtTableInfo("requirements");
+      const hasWtRequirements = wtRequirementInfo.length > 0;
+      const wtMilestoneInfo = wtTableInfo("milestones");
+      const hasWtMilestones = wtMilestoneInfo.length > 0;
       const hasMilestoneSequence = wtMilestoneInfo.some((col) => col["name"] === "sequence");
-      const wtSliceInfo = adapter.prepare("PRAGMA wt.table_info('slices')").all();
+      const wtSliceInfo = wtTableInfo("slices");
+      const hasWtSlices = wtSliceInfo.length > 0;
       const hasIsSketch = wtSliceInfo.some((col) => col["name"] === "is_sketch");
       const hasSketchScope = wtSliceInfo.some((col) => col["name"] === "sketch_scope");
       const hasSliceTargetRepositories = wtSliceInfo.some((col) => col["name"] === "target_repositories");
-      const wtTaskInfo = adapter.prepare("PRAGMA wt.table_info('tasks')").all();
+      const wtTaskInfo = wtTableInfo("tasks");
+      const hasWtTasks = wtTaskInfo.length > 0;
       const hasTaskTargetRepositories = wtTaskInfo.some((col) => col["name"] === "target_repositories");
       const hasBlockerSource = wtTaskInfo.some((col) => col["name"] === "blocker_source");
       const hasEscalationPending = wtTaskInfo.some((col) => col["name"] === "escalation_pending");
       const hasEscalationAwaiting = wtTaskInfo.some((col) => col["name"] === "escalation_awaiting_review");
       const hasEscalationArtifact = wtTaskInfo.some((col) => col["name"] === "escalation_artifact_path");
       const hasEscalationOverride = wtTaskInfo.some((col) => col["name"] === "escalation_override_applied_at");
-      const wtArtifactInfo = adapter.prepare("PRAGMA wt.table_info('artifacts')").all();
-      const hasArtifactContentHash = wtArtifactInfo.some((col) => col["name"] === "content_hash");
-      const wtMemoryInfo = adapter.prepare("PRAGMA wt.table_info('memories')").all();
+      const wtArtifactInfo = wtTableInfo("artifacts");
+      const hasWtArtifacts = wtArtifactInfo.length > 0;
+      const wtMemoryInfo = wtTableInfo("memories");
+      const hasWtMemories = wtMemoryInfo.length > 0;
       const hasMemoryScope = wtMemoryInfo.some((col) => col["name"] === "scope");
       const hasMemoryTags = wtMemoryInfo.some((col) => col["name"] === "tags");
       const hasMemoryStructuredFields = wtMemoryInfo.some((col) => col["name"] === "structured_fields");
       const hasMemoryLastHitAt = wtMemoryInfo.some((col) => col["name"] === "last_hit_at");
+      const hasWtReplanHistory = wtTableInfo("replan_history").length > 0;
+      const hasWtAssessments = wtTableInfo("assessments").length > 0;
+      const hasWtQualityGates = wtTableInfo("quality_gates").length > 0;
+      const hasWtSliceDependencies = wtTableInfo("slice_dependencies").length > 0;
+      const hasWtVerificationEvidence = wtTableInfo("verification_evidence").length > 0;
+      const hasWtGateRuns = wtTableInfo("gate_runs").length > 0;
+      const hasWtMilestoneCommitAttributions = wtTableInfo("milestone_commit_attributions").length > 0;
 
-      const decConf = adapter.prepare(
-        `SELECT m.id FROM decisions m INNER JOIN wt.decisions w ON m.id = w.id WHERE m.decision != w.decision OR m.choice != w.choice OR m.rationale != w.rationale OR ${
-          hasMadeBy ? "m.made_by != w.made_by" : "'agent' != 'agent'"
-        } OR m.superseded_by IS NOT w.superseded_by`,
-      ).all();
-      for (const row of decConf) conflicts.push(`decision ${(row as Record<string, unknown>)["id"]}: modified in both`);
-
-      const reqConf = adapter.prepare(
-        `SELECT m.id FROM requirements m INNER JOIN wt.requirements w ON m.id = w.id WHERE m.description != w.description OR m.status != w.status OR m.notes != w.notes OR m.superseded_by IS NOT w.superseded_by`,
-      ).all();
-      for (const row of reqConf) conflicts.push(`requirement ${(row as Record<string, unknown>)["id"]}: modified in both`);
-
-      const merged: Omit<ReconcileResult, "conflicts"> = { decisions: 0, requirements: 0, artifacts: 0, milestones: 0, slices: 0, tasks: 0, memories: 0, verification_evidence: 0 };
-
-      function countChanges(result: unknown): number {
-        return typeof result === "object" && result !== null ? ((result as { changes?: number }).changes ?? 0) : 0;
+      if (hasWtDecisions) {
+        const decConf = adapter.prepare(
+          `SELECT m.id FROM decisions m INNER JOIN wt.decisions w ON m.id = w.id WHERE m.decision != w.decision OR m.choice != w.choice OR m.rationale != w.rationale OR ${
+            hasMadeBy ? "m.made_by != w.made_by" : "'agent' != 'agent'"
+          } OR m.superseded_by IS NOT w.superseded_by`,
+        ).all();
+        for (const row of decConf) conflicts.push(`decision ${(row as Record<string, unknown>)["id"]}: modified in both`);
       }
+
+      if (hasWtRequirements) {
+        const reqConf = adapter.prepare(
+          `SELECT m.id FROM requirements m INNER JOIN wt.requirements w ON m.id = w.id WHERE m.description != w.description OR m.status != w.status OR m.notes != w.notes OR m.superseded_by IS NOT w.superseded_by`,
+        ).all();
+        for (const row of reqConf) conflicts.push(`requirement ${(row as Record<string, unknown>)["id"]}: modified in both`);
+      }
+
+      const merged: Omit<ReconcileResult, "conflicts"> = {
+        decisions: 0,
+        requirements: 0,
+        artifacts: 0,
+        milestones: 0,
+        slices: 0,
+        tasks: 0,
+        memories: 0,
+        replan_history: 0,
+        assessments: 0,
+        quality_gates: 0,
+        slice_dependencies: 0,
+        verification_evidence: 0,
+        gate_runs: 0,
+        milestone_commit_attributions: 0,
+      };
+      const sliceTargetRepositoriesSql = hasSliceTargetRepositories
+        ? `CASE
+             WHEN w.target_repositories = '[]' AND COALESCE(m.target_repositories, '[]') <> '[]'
+             THEN m.target_repositories
+             ELSE COALESCE(w.target_repositories, m.target_repositories, '[]')
+           END`
+        : "COALESCE(m.target_repositories, '[]')";
+      const taskTargetRepositoriesSql = hasTaskTargetRepositories
+        ? `CASE
+             WHEN w.target_repositories = '[]' AND COALESCE(m.target_repositories, '[]') <> '[]'
+             THEN m.target_repositories
+             ELSE COALESCE(w.target_repositories, m.target_repositories, '[]')
+           END`
+        : "COALESCE(m.target_repositories, '[]')";
 
       adapter.exec("BEGIN");
       try {
         // Join the target decisions so we can prefer an existing main.source
         // when the worktree predates v16 — otherwise a write-through reconcile
         // would clobber 'escalation'-sourced decisions with the literal default.
-        merged.decisions = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO decisions (
-            id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by
-          )
-          SELECT w.id, w.when_context, w.scope, w.decision, w.choice, w.rationale, w.revisable, ${
-            hasMadeBy ? "w.made_by" : "COALESCE(m.made_by, 'agent')"
-          }, ${
-            hasDecisionSource ? "w.source" : "COALESCE(m.source, 'discussion')"
-          }, w.superseded_by
-          FROM wt.decisions w
-          LEFT JOIN decisions m ON m.id = w.id
-        `).run());
+        if (hasWtDecisions) {
+          merged.decisions = countChanges(adapter.prepare(`
+            INSERT INTO decisions (
+              id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by
+            )
+            SELECT w.id, w.when_context, w.scope, w.decision, w.choice, w.rationale, w.revisable, ${
+              hasMadeBy ? "w.made_by" : "COALESCE(m.made_by, 'agent')"
+            }, ${
+              hasDecisionSource ? "w.source" : "COALESCE(m.source, 'discussion')"
+            }, w.superseded_by
+            FROM wt.decisions w
+            LEFT JOIN decisions m ON m.id = w.id
+            WHERE true
+            ON CONFLICT(id) DO UPDATE SET
+              when_context = excluded.when_context,
+              scope = excluded.scope,
+              decision = excluded.decision,
+              choice = excluded.choice,
+              rationale = excluded.rationale,
+              revisable = excluded.revisable,
+              made_by = excluded.made_by,
+              source = excluded.source,
+              superseded_by = excluded.superseded_by
+          `).run());
+        }
 
-        merged.requirements = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO requirements (
-            id, class, status, description, why, source, primary_owner,
-            supporting_slices, validation, notes, full_content, superseded_by
-          )
-          SELECT id, class, status, description, why, source, primary_owner,
-                 supporting_slices, validation, notes, full_content, superseded_by
-          FROM wt.requirements
-        `).run());
+        if (hasWtRequirements) {
+          merged.requirements = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO requirements (
+              id, class, status, description, why, source, primary_owner,
+              supporting_slices, validation, notes, full_content, superseded_by
+            )
+            SELECT id, class, status, description, why, source, primary_owner,
+                   supporting_slices, validation, notes, full_content, superseded_by
+            FROM wt.requirements
+          `).run());
+        }
 
-        // V27: preserve content_hash. If the worktree predates V27 (no column),
-        // fall back to the main DB's existing hash so reconcile doesn't null
-        // out integrity fingerprints on artifacts that were unchanged in wt.
-        merged.artifacts = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO artifacts (
-            path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at, content_hash
-          )
-          SELECT w.path, w.artifact_type, w.milestone_id, w.slice_id, w.task_id, w.full_content, w.imported_at,
-                 ${hasArtifactContentHash ? "w.content_hash" : "m.content_hash"}
-          FROM wt.artifacts w
-          LEFT JOIN artifacts m ON m.path = w.path
-        `).run());
+        // Always recompute artifact hashes from the content being merged. Older
+        // worktree DBs may not have content_hash at all, and migrated old DBs can
+        // carry stale default/null hashes after their content changed.
+        if (hasWtArtifacts) {
+          const artifactRows = adapter.prepare(`
+            SELECT path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at
+            FROM wt.artifacts
+          `).all() as Array<Record<string, unknown>>;
+          const artifactStmt = adapter.prepare(`
+            INSERT OR REPLACE INTO artifacts (
+              path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at, content_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          `);
+          for (const row of artifactRows) {
+            const fullContent = String(row["full_content"] ?? "");
+            merged.artifacts += countChanges(artifactStmt.run(
+              row["path"],
+              row["artifact_type"],
+              row["milestone_id"] ?? null,
+              row["slice_id"] ?? null,
+              row["task_id"] ?? null,
+              fullContent,
+              row["imported_at"],
+              createHash("sha256").update(fullContent).digest("hex"),
+            ));
+          }
+        }
 
         // Merge milestones — worktree may have updated status/planning fields.
         // Never downgrade status: complete > active > pre-planning (#4372).
         // A stale worktree may carry an older 'active' status for a milestone
         // that the main DB has already marked 'complete'; preserve the higher status.
-        merged.milestones = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO milestones (
-            id, title, status, depends_on, created_at, completed_at,
-            vision, success_criteria, key_risks, proof_strategy,
-            verification_contract, verification_integration, verification_operational, verification_uat,
-            definition_of_done, requirement_coverage, boundary_map_markdown, sequence
-          )
-          SELECT w.id, w.title,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.status ELSE w.status
-                 END,
-                 w.depends_on,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.created_at ELSE w.created_at
-                 END,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.completed_at ELSE w.completed_at
-                 END,
-                 w.vision, w.success_criteria, w.key_risks, w.proof_strategy,
-                 w.verification_contract, w.verification_integration, w.verification_operational, w.verification_uat,
-                 w.definition_of_done, w.requirement_coverage, w.boundary_map_markdown,
-                 ${hasMilestoneSequence ? "COALESCE(w.sequence, 0)" : "COALESCE(m.sequence, 0)"}
-          FROM wt.milestones w
-          LEFT JOIN milestones m ON m.id = w.id
-        `).run());
+        if (hasWtMilestones) {
+          merged.milestones = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO milestones (
+              id, title, status, depends_on, created_at, completed_at,
+              vision, success_criteria, key_risks, proof_strategy,
+              verification_contract, verification_integration, verification_operational, verification_uat,
+              definition_of_done, requirement_coverage, boundary_map_markdown, sequence
+            )
+            SELECT w.id, w.title,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.status ELSE w.status
+                   END,
+                   w.depends_on,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.created_at ELSE w.created_at
+                   END,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.completed_at ELSE w.completed_at
+                   END,
+                   w.vision, w.success_criteria, w.key_risks, w.proof_strategy,
+                   w.verification_contract, w.verification_integration, w.verification_operational, w.verification_uat,
+                   w.definition_of_done, w.requirement_coverage, w.boundary_map_markdown,
+                   ${hasMilestoneSequence ? "COALESCE(w.sequence, 0)" : "COALESCE(m.sequence, 0)"}
+            FROM wt.milestones w
+            LEFT JOIN milestones m ON m.id = w.id
+          `).run());
+        }
 
         // Merge slices — preserve worktree progress but never downgrade completed status (#2558).
         // ADR-011 Phase 1: carry is_sketch + sketch_scope so reconcile doesn't
         // silently clear sketch metadata. When the worktree predates v16,
         // fall back to the main DB's existing value rather than a literal 0/''.
-        merged.slices = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO slices (
-            milestone_id, id, title, status, risk, depends, demo, created_at, completed_at,
-            full_summary_md, full_uat_md, goal, success_criteria, proof_level,
-            integration_closure, observability_impact, target_repositories, sequence, replan_triggered_at,
-            is_sketch, sketch_scope
-          )
-          SELECT w.milestone_id, w.id, w.title,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.status ELSE w.status
-                 END,
-                 w.risk, w.depends, w.demo, w.created_at,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.completed_at ELSE w.completed_at
-                 END,
-                 w.full_summary_md, w.full_uat_md, w.goal, w.success_criteria, w.proof_level,
-                 w.integration_closure, w.observability_impact,
-                 ${hasSliceTargetRepositories ? "COALESCE(w.target_repositories, m.target_repositories, '[]')" : "COALESCE(m.target_repositories, '[]')"},
-                 w.sequence, w.replan_triggered_at,
-                 ${hasIsSketch ? "w.is_sketch" : "COALESCE(m.is_sketch, 0)"},
-                 ${hasSketchScope ? "w.sketch_scope" : "COALESCE(m.sketch_scope, '')"}
-          FROM wt.slices w
-          LEFT JOIN slices m ON m.milestone_id = w.milestone_id AND m.id = w.id
-        `).run());
+        if (hasWtSlices) {
+          merged.slices = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO slices (
+              milestone_id, id, title, status, risk, depends, demo, created_at, completed_at,
+              full_summary_md, full_uat_md, goal, success_criteria, proof_level,
+              integration_closure, observability_impact, target_repositories, sequence, replan_triggered_at,
+              is_sketch, sketch_scope
+            )
+            SELECT w.milestone_id, w.id, w.title,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.status ELSE w.status
+                   END,
+                   w.risk, w.depends, w.demo, w.created_at,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.completed_at ELSE w.completed_at
+                   END,
+                   w.full_summary_md, w.full_uat_md, w.goal, w.success_criteria, w.proof_level,
+                   w.integration_closure, w.observability_impact,
+                   ${sliceTargetRepositoriesSql},
+                   w.sequence, w.replan_triggered_at,
+                   ${hasIsSketch ? "w.is_sketch" : "COALESCE(m.is_sketch, 0)"},
+                   ${hasSketchScope ? "w.sketch_scope" : "COALESCE(m.sketch_scope, '')"}
+            FROM wt.slices w
+            LEFT JOIN slices m ON m.milestone_id = w.milestone_id AND m.id = w.id
+          `).run());
+        }
 
         // Merge tasks — preserve execution results, never downgrade completed status (#2558).
         // ADR-011 P2: carry blocker_source + escalation_* columns so worktree reconcile
         // doesn't silently clear escalation state back to defaults.
-        merged.tasks = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO tasks (
-            milestone_id, slice_id, id, title, status, one_liner, narrative,
-            verification_result, duration, completed_at, blocker_discovered,
-            deviations, known_issues, key_files, key_decisions, full_summary_md,
-            description, estimate, files, verify, inputs, expected_output,
-            observability_impact, full_plan_md, target_repositories, sequence,
-            blocker_source, escalation_pending, escalation_awaiting_review,
-            escalation_artifact_path, escalation_override_applied_at
-          )
-          SELECT w.milestone_id, w.slice_id, w.id, w.title,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.status ELSE w.status
-                 END,
-                 w.one_liner, w.narrative,
-                 w.verification_result, w.duration,
-                 CASE
-                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
-                   THEN m.completed_at ELSE w.completed_at
-                 END,
-                 w.blocker_discovered,
-                 w.deviations, w.known_issues, w.key_files, w.key_decisions, w.full_summary_md,
-                 w.description, w.estimate, w.files, w.verify, w.inputs, w.expected_output,
-                 w.observability_impact, w.full_plan_md,
-                 ${hasTaskTargetRepositories ? "COALESCE(w.target_repositories, m.target_repositories, '[]')" : "COALESCE(m.target_repositories, '[]')"},
-                 w.sequence,
-                 ${hasBlockerSource ? "w.blocker_source" : "COALESCE(m.blocker_source, '')"},
-                 ${hasEscalationPending ? "w.escalation_pending" : "COALESCE(m.escalation_pending, 0)"},
-                 ${hasEscalationAwaiting ? "w.escalation_awaiting_review" : "COALESCE(m.escalation_awaiting_review, 0)"},
-                 ${hasEscalationArtifact ? "w.escalation_artifact_path" : "m.escalation_artifact_path"},
-                 ${hasEscalationOverride ? "w.escalation_override_applied_at" : "m.escalation_override_applied_at"}
-          FROM wt.tasks w
-          LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
-        `).run());
+        if (hasWtTasks) {
+          merged.tasks = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO tasks (
+              milestone_id, slice_id, id, title, status, one_liner, narrative,
+              verification_result, duration, completed_at, blocker_discovered,
+              deviations, known_issues, key_files, key_decisions, full_summary_md,
+              description, estimate, files, verify, inputs, expected_output,
+              observability_impact, full_plan_md, target_repositories, sequence,
+              blocker_source, escalation_pending, escalation_awaiting_review,
+              escalation_artifact_path, escalation_override_applied_at
+            )
+            SELECT w.milestone_id, w.slice_id, w.id, w.title,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.status ELSE w.status
+                   END,
+                   w.one_liner, w.narrative,
+                   w.verification_result, w.duration,
+                   CASE
+                     WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
+                     THEN m.completed_at ELSE w.completed_at
+                   END,
+                   w.blocker_discovered,
+                   w.deviations, w.known_issues, w.key_files, w.key_decisions, w.full_summary_md,
+                   w.description, w.estimate, w.files, w.verify, w.inputs, w.expected_output,
+                   w.observability_impact, w.full_plan_md,
+                   ${taskTargetRepositoriesSql},
+                   w.sequence,
+                   ${hasBlockerSource ? "w.blocker_source" : "COALESCE(m.blocker_source, '')"},
+                   ${hasEscalationPending ? "w.escalation_pending" : "COALESCE(m.escalation_pending, 0)"},
+                   ${hasEscalationAwaiting ? "w.escalation_awaiting_review" : "COALESCE(m.escalation_awaiting_review, 0)"},
+                   ${hasEscalationArtifact ? "w.escalation_artifact_path" : "m.escalation_artifact_path"},
+                   ${hasEscalationOverride ? "w.escalation_override_applied_at" : "m.escalation_override_applied_at"}
+            FROM wt.tasks w
+            LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
+          `).run());
+        }
 
         // Merge memories — keep worktree-learned insights.
         // V18 (scope, tags), V21 (structured_fields), V28 (last_hit_at): for each
         // column the wt may not yet have (older worktree DB), fall back to the
         // main DB's existing value via LEFT JOIN so reconcile never silently
         // resets these fields to defaults on rows that already had them.
-        merged.memories = countChanges(adapter.prepare(`
-          INSERT OR REPLACE INTO memories (
-            seq, id, category, content, confidence, source_unit_type, source_unit_id,
-            created_at, updated_at, superseded_by, hit_count,
-            scope, tags, structured_fields, last_hit_at
-          )
-          SELECT w.seq, w.id, w.category, w.content, w.confidence, w.source_unit_type, w.source_unit_id,
-                 w.created_at, w.updated_at, w.superseded_by, w.hit_count,
-                 ${hasMemoryScope ? "w.scope" : "COALESCE(m.scope, 'project')"},
-                 ${hasMemoryTags ? "w.tags" : "COALESCE(m.tags, '[]')"},
-                 ${hasMemoryStructuredFields ? "w.structured_fields" : "m.structured_fields"},
-                 ${hasMemoryLastHitAt ? "w.last_hit_at" : "m.last_hit_at"}
-          FROM wt.memories w
-          LEFT JOIN memories m ON m.id = w.id
-        `).run());
+        if (hasWtMemories) {
+          merged.memories = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO memories (
+              seq, id, category, content, confidence, source_unit_type, source_unit_id,
+              created_at, updated_at, superseded_by, hit_count,
+              scope, tags, structured_fields, last_hit_at
+            )
+            SELECT w.seq, w.id, w.category, w.content, w.confidence, w.source_unit_type, w.source_unit_id,
+                   w.created_at, w.updated_at, w.superseded_by, w.hit_count,
+                   ${hasMemoryScope ? "w.scope" : "COALESCE(m.scope, 'project')"},
+                   ${hasMemoryTags ? "w.tags" : "COALESCE(m.tags, '[]')"},
+                   ${hasMemoryStructuredFields ? "w.structured_fields" : "m.structured_fields"},
+                   ${hasMemoryLastHitAt ? "w.last_hit_at" : "m.last_hit_at"}
+            FROM wt.memories w
+            LEFT JOIN memories m ON m.id = w.id
+          `).run());
+        }
+
+        if (hasWtReplanHistory) {
+          merged.replan_history = countChanges(adapter.prepare(`
+            INSERT INTO replan_history (
+              milestone_id, slice_id, task_id, summary, previous_artifact_path, replacement_artifact_path, created_at
+            )
+            SELECT w.milestone_id, w.slice_id, w.task_id, w.summary, w.previous_artifact_path, w.replacement_artifact_path, w.created_at
+            FROM wt.replan_history w
+            WHERE EXISTS (SELECT 1 FROM milestones m WHERE m.id = w.milestone_id)
+              AND NOT EXISTS (
+                SELECT 1 FROM replan_history m
+                WHERE m.milestone_id = w.milestone_id
+                  AND m.slice_id IS w.slice_id
+                  AND m.task_id IS w.task_id
+                  AND m.summary = w.summary
+                  AND m.previous_artifact_path IS w.previous_artifact_path
+                  AND m.replacement_artifact_path IS w.replacement_artifact_path
+              )
+          `).run());
+        }
+
+        if (hasWtAssessments) {
+          merged.assessments = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO assessments (
+              path, milestone_id, slice_id, task_id, status, scope, full_content, created_at
+            )
+            SELECT w.path, w.milestone_id, w.slice_id, w.task_id, w.status, w.scope, w.full_content, w.created_at
+            FROM wt.assessments w
+            WHERE EXISTS (SELECT 1 FROM milestones m WHERE m.id = w.milestone_id)
+          `).run());
+        }
+
+        if (hasWtQualityGates) {
+          merged.quality_gates = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO quality_gates (
+              milestone_id, slice_id, gate_id, scope, task_id, status, verdict, rationale, findings, evaluated_at
+            )
+            SELECT w.milestone_id, w.slice_id, w.gate_id, w.scope, COALESCE(w.task_id, ''), w.status, w.verdict, w.rationale, w.findings, w.evaluated_at
+            FROM wt.quality_gates w
+            WHERE EXISTS (SELECT 1 FROM slices s WHERE s.milestone_id = w.milestone_id AND s.id = w.slice_id)
+          `).run());
+        }
+
+        if (hasWtSliceDependencies) {
+          merged.slice_dependencies = countChanges(adapter.prepare(`
+            INSERT OR IGNORE INTO slice_dependencies (milestone_id, slice_id, depends_on_slice_id)
+            SELECT w.milestone_id, w.slice_id, w.depends_on_slice_id
+            FROM wt.slice_dependencies w
+            WHERE EXISTS (SELECT 1 FROM slices s WHERE s.milestone_id = w.milestone_id AND s.id = w.slice_id)
+              AND EXISTS (SELECT 1 FROM slices d WHERE d.milestone_id = w.milestone_id AND d.id = w.depends_on_slice_id)
+          `).run());
+        }
 
         // Merge verification evidence — append-only, use INSERT OR IGNORE to avoid duplicates
-        merged.verification_evidence = countChanges(adapter.prepare(`
-          INSERT OR IGNORE INTO verification_evidence (
-            task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at
-          )
-          SELECT task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at
-          FROM wt.verification_evidence
-        `).run());
+        if (hasWtVerificationEvidence) {
+          merged.verification_evidence = countChanges(adapter.prepare(`
+            INSERT OR IGNORE INTO verification_evidence (
+              task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at
+            )
+            SELECT task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at
+            FROM wt.verification_evidence
+          `).run());
+        }
+
+        if (hasWtGateRuns) {
+          merged.gate_runs = countChanges(adapter.prepare(`
+            INSERT INTO gate_runs (
+              trace_id, turn_id, gate_id, gate_type, unit_type, unit_id, milestone_id, slice_id, task_id,
+              outcome, failure_class, rationale, findings, attempt, max_attempts, retryable, evaluated_at
+            )
+            SELECT w.trace_id, w.turn_id, w.gate_id, w.gate_type, w.unit_type, w.unit_id, w.milestone_id, w.slice_id, w.task_id,
+                   w.outcome, w.failure_class, w.rationale, w.findings, w.attempt, w.max_attempts, w.retryable, w.evaluated_at
+            FROM wt.gate_runs w
+            WHERE NOT EXISTS (
+              SELECT 1 FROM gate_runs m
+              WHERE m.trace_id = w.trace_id
+                AND m.turn_id = w.turn_id
+                AND m.gate_id = w.gate_id
+                AND m.attempt = w.attempt
+                AND m.evaluated_at = w.evaluated_at
+            )
+          `).run());
+        }
+
+        if (hasWtMilestoneCommitAttributions) {
+          merged.milestone_commit_attributions = countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO milestone_commit_attributions (
+              commit_sha, milestone_id, slice_id, task_id, source, confidence, files_json, created_at
+            )
+            SELECT w.commit_sha, w.milestone_id, w.slice_id, w.task_id, w.source, w.confidence, w.files_json, w.created_at
+            FROM wt.milestone_commit_attributions w
+            WHERE EXISTS (SELECT 1 FROM milestones m WHERE m.id = w.milestone_id)
+          `).run());
+        }
 
         adapter.exec("COMMIT");
       } catch (txErr) {
@@ -2890,21 +3088,75 @@ export function upsertQualityGate(g: {
 
 /**
  * Atomically replace all workflow state from a manifest. Lifted verbatim from
- * workflow-manifest.ts so the single-writer invariant holds. Only touches
- * engine tables + decisions. Does NOT modify artifacts or memories.
+ * workflow-manifest.ts so the single-writer invariant holds. Restores
+ * correctness-bearing workflow tables; runtime soft state and append-only audit
+ * streams stay outside this recovery path.
  */
 export function restoreManifest(manifest: StateManifest): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   const db = currentDb;
 
   transaction(() => {
-    // Clear engine tables (order matters for foreign-key-like consistency)
+    const restoredMilestoneIds = new Set(manifest.milestones.map((m) => m.id));
+    const restoredSliceKeys = new Set(manifest.slices.map((s) => JSON.stringify([s.milestone_id, s.id])));
+    const preservedReplanHistory = manifest.replan_history === undefined
+      ? db.prepare("SELECT * FROM replan_history ORDER BY id").all() as unknown as NonNullable<StateManifest["replan_history"]>
+      : [];
+    const preservedAssessments = manifest.assessments === undefined
+      ? db.prepare("SELECT * FROM assessments ORDER BY path").all() as unknown as NonNullable<StateManifest["assessments"]>
+      : [];
+    const preservedQualityGates = manifest.quality_gates === undefined
+      ? db.prepare("SELECT * FROM quality_gates ORDER BY milestone_id, slice_id, gate_id, task_id").all() as unknown as NonNullable<StateManifest["quality_gates"]>
+      : [];
+    const preservedCommitAttributions = manifest.milestone_commit_attributions === undefined
+      ? db.prepare("SELECT * FROM milestone_commit_attributions ORDER BY milestone_id, commit_sha").all() as unknown as NonNullable<StateManifest["milestone_commit_attributions"]>
+      : [];
+
+    // Clear workflow tables in dependency order.
     db.exec("DELETE FROM verification_evidence");
+    db.exec("DELETE FROM quality_gates");
+    db.exec("DELETE FROM slice_dependencies");
+    db.exec("DELETE FROM assessments");
+    db.exec("DELETE FROM replan_history");
+    db.exec("DELETE FROM milestone_commit_attributions");
     db.exec("DELETE FROM tasks");
     db.exec("DELETE FROM slices");
     db.exec("DELETE FROM milestone_leases");
     db.exec("DELETE FROM milestones");
     db.exec("DELETE FROM decisions WHERE 1=1");
+    db.exec(`DELETE FROM memories WHERE category = 'architecture' AND structured_fields LIKE '%"sourceDecisionId":"%'`);
+    if (manifest.artifacts !== undefined) db.exec("DELETE FROM artifacts");
+    if (manifest.requirements !== undefined) db.exec("DELETE FROM requirements");
+
+    if (manifest.requirements !== undefined) {
+      const reqStmt = db.prepare(
+        `INSERT INTO requirements (
+          id, class, status, description, why, source, primary_owner,
+          supporting_slices, validation, notes, full_content, superseded_by
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const r of manifest.requirements) {
+        reqStmt.run(
+          r.id, r.class, r.status, r.description, r.why, r.source, r.primary_owner,
+          r.supporting_slices, r.validation, r.notes, r.full_content, r.superseded_by,
+        );
+      }
+    }
+
+    if (manifest.artifacts !== undefined) {
+      const artStmt = db.prepare(
+        `INSERT INTO artifacts (
+          path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at, content_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const a of manifest.artifacts) {
+        const fullContent = a.full_content ?? "";
+        artStmt.run(
+          a.path, a.artifact_type, a.milestone_id, a.slice_id, a.task_id,
+          fullContent, a.imported_at, a.content_hash ?? createHash("sha256").update(fullContent).digest("hex"),
+        );
+      }
+    }
 
     // Restore milestones
     const msStmt = db.prepare(
@@ -2946,16 +3198,25 @@ export function restoreManifest(manifest: StateManifest): void {
       );
     }
 
+    const depStmt = db.prepare(
+      "INSERT OR IGNORE INTO slice_dependencies (milestone_id, slice_id, depends_on_slice_id) VALUES (?, ?, ?)",
+    );
+    for (const s of manifest.slices) {
+      for (const dep of s.depends ?? []) {
+        depStmt.run(s.milestone_id, s.id, dep);
+      }
+    }
+
     // Restore tasks (ADR-011 P2: includes blocker_source + escalation_* columns)
     const tkStmt = db.prepare(
       `INSERT INTO tasks (milestone_id, slice_id, id, title, status,
         one_liner, narrative, verification_result, duration, completed_at,
         blocker_discovered, deviations, known_issues, key_files, key_decisions,
         full_summary_md, description, estimate, files, verify,
-        inputs, expected_output, observability_impact, target_repositories, sequence,
+        inputs, expected_output, observability_impact, full_plan_md, target_repositories, sequence,
         blocker_source, escalation_pending, escalation_awaiting_review,
         escalation_artifact_path, escalation_override_applied_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const t of manifest.tasks) {
       tkStmt.run(
@@ -2965,7 +3226,7 @@ export function restoreManifest(manifest: StateManifest): void {
         JSON.stringify(t.key_files), JSON.stringify(t.key_decisions),
         t.full_summary_md, t.description, t.estimate, JSON.stringify(t.files), t.verify,
         JSON.stringify(t.inputs), JSON.stringify(t.expected_output),
-        t.observability_impact, JSON.stringify(t.target_repositories ?? []), t.sequence,
+        t.observability_impact, t.full_plan_md ?? "", JSON.stringify(t.target_repositories ?? []), t.sequence,
         t.blocker_source ?? "",
         t.escalation_pending ?? 0,
         t.escalation_awaiting_review ?? 0,
@@ -2981,6 +3242,69 @@ export function restoreManifest(manifest: StateManifest): void {
     );
     for (const d of manifest.decisions) {
       dcStmt.run(d.seq, d.id, d.when_context, d.scope, d.decision, d.choice, d.rationale, d.revisable, d.made_by, d.source ?? "discussion", d.superseded_by);
+    }
+
+    const replanHistoryRows = manifest.replan_history ?? preservedReplanHistory.filter((r) => restoredMilestoneIds.has(r.milestone_id));
+    if (replanHistoryRows.length > 0) {
+      const replStmt = db.prepare(
+        `INSERT INTO replan_history (
+          id, milestone_id, slice_id, task_id, summary, previous_artifact_path, replacement_artifact_path, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const r of replanHistoryRows) {
+        replStmt.run(
+          r.id, r.milestone_id, r.slice_id, r.task_id, r.summary,
+          r.previous_artifact_path, r.replacement_artifact_path, r.created_at,
+        );
+      }
+    }
+
+    const assessmentRows = manifest.assessments ?? preservedAssessments.filter((a) => restoredMilestoneIds.has(a.milestone_id));
+    if (assessmentRows.length > 0) {
+      const assessStmt = db.prepare(
+        `INSERT INTO assessments (
+          path, milestone_id, slice_id, task_id, status, scope, full_content, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const a of assessmentRows) {
+        assessStmt.run(
+          a.path, a.milestone_id, a.slice_id, a.task_id,
+          a.status, a.scope, a.full_content, a.created_at,
+        );
+      }
+    }
+
+    const qualityGateRows = manifest.quality_gates ?? preservedQualityGates.filter((g) => (
+      restoredSliceKeys.has(JSON.stringify([g.milestone_id, g.slice_id]))
+    ));
+    if (qualityGateRows.length > 0) {
+      const gateStmt = db.prepare(
+        `INSERT INTO quality_gates (
+          milestone_id, slice_id, gate_id, scope, task_id, status, verdict, rationale, findings, evaluated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const g of qualityGateRows) {
+        gateStmt.run(
+          g.milestone_id, g.slice_id, g.gate_id, g.scope, g.task_id,
+          g.status, g.verdict ?? "", g.rationale, g.findings, g.evaluated_at,
+        );
+      }
+    }
+
+    const commitAttributionRows = manifest.milestone_commit_attributions ??
+      preservedCommitAttributions.filter((a) => restoredMilestoneIds.has(a.milestone_id));
+    if (commitAttributionRows.length > 0) {
+      const attrStmt = db.prepare(
+        `INSERT OR REPLACE INTO milestone_commit_attributions (
+          commit_sha, milestone_id, slice_id, task_id, source, confidence, files_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const a of commitAttributionRows) {
+        attrStmt.run(
+          a.commit_sha, a.milestone_id, a.slice_id, a.task_id,
+          a.source, a.confidence, a.files_json, a.created_at,
+        );
+      }
     }
 
     // Restore verification evidence

--- a/src/resources/extensions/gsd/tests/schema-v21-sequence.test.ts
+++ b/src/resources/extensions/gsd/tests/schema-v21-sequence.test.ts
@@ -24,6 +24,7 @@ import {
   openDatabase,
   closeDatabase,
   _getAdapter,
+  SCHEMA_VERSION,
 } from '../gsd-db.ts';
 
 const _require = createRequire(import.meta.url);
@@ -403,9 +404,10 @@ test('schema v21 migration: upgrading from v20 lands on current SCHEMA_VERSION',
     // The DB must reach the current SCHEMA_VERSION.  If the v21 block was
     // skipped (as it would be when SCHEMA_VERSION was still 20), this
     // assertion catches it.
-    assert.ok(
-      maxVersion >= 21,
-      `DB upgraded from v20 must reach at least schema version 21; got ${maxVersion}`,
+    assert.equal(
+      maxVersion,
+      SCHEMA_VERSION,
+      `DB upgraded from v20 must reach schema version ${SCHEMA_VERSION}; got ${maxVersion}`,
     );
   } finally {
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/schema-v27-v28-sequence.test.ts
+++ b/src/resources/extensions/gsd/tests/schema-v27-v28-sequence.test.ts
@@ -1,16 +1,17 @@
-// gsd-pi / V27 + V28 schema migration regression tests
+// gsd-pi / V27 + V28 + V29 schema migration regression tests
 //
 // Same bug class as #4591 (schema-v21-sequence): a migration block can be
 // added but the SCHEMA_VERSION constant left unchanged, causing fresh-install
-// + upgrade paths to silently skip the column add. This file pins both V27
-// (artifacts.content_hash) and V28 (memories.last_hit_at) at the schema and
-// write-path level on fresh-install DBs.
+// + upgrade paths to silently skip the column add. This file pins V27
+// (artifacts.content_hash), V28 (memories.last_hit_at), and V29
+// (target_repositories) at the schema/write-path level.
 
 import test from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { createRequire } from "node:module";
 
 import {
   openDatabase,
@@ -22,8 +23,10 @@ import {
   SCHEMA_VERSION,
 } from "../gsd-db.ts";
 
+const _require = createRequire(import.meta.url);
+
 function makeTmp(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "gsd-v27v28-"));
+  return fs.mkdtempSync(path.join(os.tmpdir(), "gsd-v27v29-"));
 }
 
 function cleanup(base: string): void {
@@ -31,10 +34,114 @@ function cleanup(base: string): void {
   try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
 }
 
-test("SCHEMA_VERSION constant is at least 28 (V28 migration committed)", () => {
+function columnNames(table: string): Set<string> {
+  const db = _getAdapter()!;
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<Record<string, unknown>>;
+  return new Set(cols.map((c) => c["name"] as string));
+}
+
+function createV28Db(dbPath: string): void {
+  const sqlite = _require("node:sqlite") as {
+    DatabaseSync: new (p: string) => {
+      exec(sql: string): void;
+      close(): void;
+    };
+  };
+  const db = new sqlite.DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode=WAL");
+  db.exec(`
+    CREATE TABLE schema_version (
+      version INTEGER NOT NULL,
+      applied_at TEXT NOT NULL
+    );
+    INSERT INTO schema_version (version, applied_at) VALUES (28, '2026-01-01T00:00:00.000Z');
+
+    CREATE TABLE milestones (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'active',
+      depends_on TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL,
+      vision TEXT NOT NULL DEFAULT '',
+      success_criteria TEXT NOT NULL DEFAULT '[]',
+      key_risks TEXT NOT NULL DEFAULT '[]',
+      proof_strategy TEXT NOT NULL DEFAULT '[]',
+      verification_contract TEXT NOT NULL DEFAULT '',
+      verification_integration TEXT NOT NULL DEFAULT '',
+      verification_operational TEXT NOT NULL DEFAULT '',
+      verification_uat TEXT NOT NULL DEFAULT '',
+      definition_of_done TEXT NOT NULL DEFAULT '[]',
+      requirement_coverage TEXT NOT NULL DEFAULT '',
+      boundary_map_markdown TEXT NOT NULL DEFAULT '',
+      sequence INTEGER DEFAULT 0
+    );
+    CREATE TABLE slices (
+      milestone_id TEXT NOT NULL,
+      id TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      risk TEXT NOT NULL DEFAULT 'medium',
+      depends TEXT NOT NULL DEFAULT '[]',
+      demo TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL,
+      full_summary_md TEXT NOT NULL DEFAULT '',
+      full_uat_md TEXT NOT NULL DEFAULT '',
+      goal TEXT NOT NULL DEFAULT '',
+      success_criteria TEXT NOT NULL DEFAULT '',
+      proof_level TEXT NOT NULL DEFAULT '',
+      integration_closure TEXT NOT NULL DEFAULT '',
+      observability_impact TEXT NOT NULL DEFAULT '',
+      sequence INTEGER DEFAULT 0,
+      replan_triggered_at TEXT DEFAULT NULL,
+      is_sketch INTEGER NOT NULL DEFAULT 0,
+      sketch_scope TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (milestone_id, id),
+      FOREIGN KEY (milestone_id) REFERENCES milestones(id)
+    );
+    CREATE TABLE tasks (
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT NOT NULL,
+      id TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      one_liner TEXT NOT NULL DEFAULT '',
+      narrative TEXT NOT NULL DEFAULT '',
+      verification_result TEXT NOT NULL DEFAULT '',
+      duration TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL,
+      blocker_discovered INTEGER DEFAULT 0,
+      blocker_source TEXT NOT NULL DEFAULT '',
+      escalation_pending INTEGER NOT NULL DEFAULT 0,
+      escalation_awaiting_review INTEGER NOT NULL DEFAULT 0,
+      escalation_artifact_path TEXT DEFAULT NULL,
+      escalation_override_applied_at TEXT DEFAULT NULL,
+      deviations TEXT NOT NULL DEFAULT '',
+      known_issues TEXT NOT NULL DEFAULT '',
+      key_files TEXT NOT NULL DEFAULT '[]',
+      key_decisions TEXT NOT NULL DEFAULT '[]',
+      full_summary_md TEXT NOT NULL DEFAULT '',
+      description TEXT NOT NULL DEFAULT '',
+      estimate TEXT NOT NULL DEFAULT '',
+      files TEXT NOT NULL DEFAULT '[]',
+      verify TEXT NOT NULL DEFAULT '',
+      inputs TEXT NOT NULL DEFAULT '[]',
+      expected_output TEXT NOT NULL DEFAULT '[]',
+      observability_impact TEXT NOT NULL DEFAULT '',
+      full_plan_md TEXT NOT NULL DEFAULT '',
+      sequence INTEGER DEFAULT 0,
+      PRIMARY KEY (milestone_id, slice_id, id),
+      FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id)
+    );
+  `);
+  db.close();
+}
+
+test("SCHEMA_VERSION constant is at least 29 (V29 migration committed)", () => {
   assert.ok(
-    SCHEMA_VERSION >= 28,
-    `SCHEMA_VERSION must be ≥ 28 after V28 migration; got ${SCHEMA_VERSION}`,
+    SCHEMA_VERSION >= 29,
+    `SCHEMA_VERSION must be ≥ 29 after V29 migration; got ${SCHEMA_VERSION}`,
   );
 });
 
@@ -43,11 +150,8 @@ test("fresh-install DB has artifacts.content_hash column (V27)", () => {
   const dbPath = path.join(base, "gsd.db");
   try {
     openDatabase(dbPath);
-    const db = _getAdapter()!;
-    const cols = db.prepare("PRAGMA table_info(artifacts)").all() as Array<Record<string, unknown>>;
-    const colNames = new Set(cols.map((c) => c["name"] as string));
     assert.ok(
-      colNames.has("content_hash"),
+      columnNames("artifacts").has("content_hash"),
       "V27 must add content_hash column to artifacts on fresh install",
     );
   } finally {
@@ -60,11 +164,8 @@ test("fresh-install DB has memories.last_hit_at column (V28)", () => {
   const dbPath = path.join(base, "gsd.db");
   try {
     openDatabase(dbPath);
-    const db = _getAdapter()!;
-    const cols = db.prepare("PRAGMA table_info(memories)").all() as Array<Record<string, unknown>>;
-    const colNames = new Set(cols.map((c) => c["name"] as string));
     assert.ok(
-      colNames.has("last_hit_at"),
+      columnNames("memories").has("last_hit_at"),
       "V28 must add last_hit_at column to memories on fresh install",
     );
   } finally {
@@ -72,7 +173,25 @@ test("fresh-install DB has memories.last_hit_at column (V28)", () => {
   }
 });
 
-test("fresh-install DB stamps SCHEMA_VERSION (≥28) in schema_version table", () => {
+test("fresh-install DB has target_repositories columns (V29)", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  try {
+    openDatabase(dbPath);
+    assert.ok(
+      columnNames("slices").has("target_repositories"),
+      "V29 must add target_repositories column to slices on fresh install",
+    );
+    assert.ok(
+      columnNames("tasks").has("target_repositories"),
+      "V29 must add target_repositories column to tasks on fresh install",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("fresh-install DB stamps current SCHEMA_VERSION in schema_version table", () => {
   const base = makeTmp();
   const dbPath = path.join(base, "gsd.db");
   try {
@@ -80,7 +199,32 @@ test("fresh-install DB stamps SCHEMA_VERSION (≥28) in schema_version table", (
     const db = _getAdapter()!;
     const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as Record<string, unknown> | undefined;
     const max = (row?.["v"] as number) ?? 0;
-    assert.ok(max >= 28, `fresh install must record schema_version ≥ 28; got ${max}`);
+    assert.equal(max, SCHEMA_VERSION, `fresh install must record schema_version ${SCHEMA_VERSION}; got ${max}`);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("upgrading from V28 adds target_repositories and stamps V29", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  createV28Db(dbPath);
+
+  try {
+    openDatabase(dbPath);
+    assert.ok(
+      columnNames("slices").has("target_repositories"),
+      "V29 migration must add target_repositories column to existing slices table",
+    );
+    assert.ok(
+      columnNames("tasks").has("target_repositories"),
+      "V29 migration must add target_repositories column to existing tasks table",
+    );
+
+    const db = _getAdapter()!;
+    const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as Record<string, unknown> | undefined;
+    const max = (row?.["v"] as number) ?? 0;
+    assert.equal(max, SCHEMA_VERSION, `V28 DB must upgrade to schema_version ${SCHEMA_VERSION}; got ${max}`);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts
+++ b/src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts
@@ -7,6 +7,8 @@ import { tmpdir } from "node:os";
 import { DISPATCH_RULES } from "../auto-dispatch.ts";
 import {
   closeDatabase,
+  getArtifact,
+  getAssessment,
   getLatestAssessmentByScope,
   insertMilestone,
   insertSlice,
@@ -46,6 +48,12 @@ test("skipped validation dispatch persists the validation file and DB assessment
 
     assert.deepEqual(action, { action: "skip" });
     assert.equal(existsSync(join(milestoneDir, "M001-VALIDATION.md")), true);
+    assert.equal(existsSync(join(sliceDir, "S01-ASSESSMENT.md")), true);
+    const artifactPath = "milestones/M001/slices/S01/S01-ASSESSMENT.md";
+    const assessmentPath = `.gsd/${artifactPath}`;
+    assert.equal(getArtifact(artifactPath)?.artifact_type, "ASSESSMENT");
+    assert.equal(getAssessment(assessmentPath)?.scope, "run-uat");
+    assert.equal(getAssessment(assessmentPath)?.status, "pass");
     assert.equal(
       getLatestAssessmentByScope("M001", "milestone-validation")?.status,
       "pass",

--- a/src/resources/extensions/gsd/tests/workflow-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-manifest.test.ts
@@ -9,9 +9,17 @@ import * as os from 'node:os';
 import {
   openDatabase,
   closeDatabase,
+  insertRequirement,
+  insertArtifact,
   insertMilestone,
   insertSlice,
   insertTask,
+  insertMemoryRow,
+  insertAssessment,
+  insertGateRow,
+  insertReplanHistory,
+  recordMilestoneCommitAttribution,
+  saveGateResult,
   _getAdapter,
 } from '../gsd-db.ts';
 import {
@@ -20,6 +28,7 @@ import {
   snapshotState,
   bootstrapFromManifest,
 } from '../workflow-manifest.ts';
+import { getAllDecisionsFromMemories } from '../context-store.ts';
 
 function tempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-manifest-'));
@@ -31,6 +40,33 @@ function tempDbPath(base: string): string {
 
 function cleanupDir(dirPath: string): void {
   try { fs.rmSync(dirPath, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+function insertMemoryBackedDecision(id: string): void {
+  const now = '2026-01-01T00:00:00.000Z';
+  insertMemoryRow({
+    id: `MEM-${id}`,
+    category: 'architecture',
+    content: `Decision ${id} content`,
+    confidence: 0.85,
+    sourceUnitType: null,
+    sourceUnitId: null,
+    createdAt: now,
+    updatedAt: now,
+    scope: 'project',
+    tags: [],
+    structuredFields: {
+      sourceDecisionId: id,
+      when_context: 'M001',
+      scope: 'architecture',
+      decision: `Decision ${id}`,
+      choice: `Choice ${id}`,
+      rationale: `Rationale ${id}`,
+      made_by: 'agent',
+      revisable: 'Yes',
+      superseded_by: null,
+    },
+  });
 }
 
 // ─── readManifest: no file ────────────────────────────────────────────────
@@ -75,6 +111,12 @@ test('workflow-manifest: readManifest parses manifest written by writeManifest',
     assert.ok(Array.isArray(manifest!.slices));
     assert.ok(Array.isArray(manifest!.tasks));
     assert.ok(Array.isArray(manifest!.decisions));
+    assert.ok(Array.isArray(manifest!.requirements));
+    assert.ok(Array.isArray(manifest!.artifacts));
+    assert.ok(Array.isArray(manifest!.replan_history));
+    assert.ok(Array.isArray(manifest!.assessments));
+    assert.ok(Array.isArray(manifest!.quality_gates));
+    assert.ok(Array.isArray(manifest!.milestone_commit_attributions));
     assert.ok(Array.isArray(manifest!.verification_evidence));
   } finally {
     closeDatabase();
@@ -120,6 +162,136 @@ test('workflow-manifest: snapshotState captures tasks', () => {
   }
 });
 
+test('workflow-manifest: snapshotState captures memory-backed decisions', () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertMemoryBackedDecision('D900');
+
+    const snap = snapshotState();
+    const decision = snap.decisions.find((r) => r.id === 'D900');
+
+    assert.ok(decision !== undefined, 'D900 should appear in manifest decisions');
+    assert.strictEqual(decision!.decision, 'Decision D900');
+    assert.strictEqual(decision!.choice, 'Choice D900');
+    assert.strictEqual(decision!.rationale, 'Rationale D900');
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
+test('workflow-manifest: bootstrapFromManifest restores extended correctness rows', () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertRequirement({
+      id: 'R100',
+      class: 'functional',
+      status: 'active',
+      description: 'Persist requirements',
+      why: 'Recovery needs requirements',
+      source: 'test',
+      primary_owner: 'S01',
+      supporting_slices: 'S00',
+      validation: 'manifest round-trip',
+      notes: 'important',
+      full_content: 'Full requirement content',
+      superseded_by: null,
+    });
+    insertArtifact({
+      path: '.gsd/milestones/M001/M001-VALIDATION.md',
+      artifact_type: 'VALIDATION',
+      milestone_id: 'M001',
+      slice_id: null,
+      task_id: null,
+      full_content: '# Validation\n\nPASS',
+    });
+    insertArtifact({
+      path: 'milestones/M001/slices/S01/S01-ASSESSMENT.md',
+      artifact_type: 'ASSESSMENT',
+      milestone_id: 'M001',
+      slice_id: 'S01',
+      task_id: null,
+      full_content: '# Assessment\n\nPASS',
+    });
+    insertMilestone({ id: 'M001', title: 'Tracked Milestone' });
+    insertSlice({ id: 'S00', milestoneId: 'M001', title: 'Dependency Slice' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Dependent Slice', depends: ['S00'] });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Tracked Task' });
+    insertAssessment({
+      path: '.gsd/milestones/M001/slices/S01/S01-ASSESSMENT.md',
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      taskId: null,
+      status: 'pass',
+      scope: 'run-uat',
+      fullContent: '# UAT\n\nPASS',
+    });
+    insertReplanHistory({
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      taskId: 'T01',
+      summary: 'Replan preserved',
+      previousArtifactPath: 'old.md',
+      replacementArtifactPath: 'new.md',
+    });
+    insertGateRow({ milestoneId: 'M001', sliceId: 'S01', gateId: 'Q3', scope: 'slice' });
+    saveGateResult({
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      gateId: 'Q3',
+      verdict: 'pass',
+      rationale: 'Gate passed',
+      findings: 'No findings',
+    });
+    recordMilestoneCommitAttribution({
+      commitSha: 'abc123',
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      taskId: 'T01',
+      source: 'recorded',
+      confidence: 0.95,
+      files: ['src/example.ts'],
+      createdAt: '2026-06-05T00:00:00.000Z',
+    });
+
+    writeManifest(base);
+    closeDatabase();
+
+    const newDbPath = path.join(base, 'new.db');
+    openDatabase(newDbPath);
+    const restored = bootstrapFromManifest(base);
+    assert.strictEqual(restored, true);
+
+    const snap = snapshotState();
+    assert.strictEqual(snap.requirements?.find((r) => r.id === 'R100')?.full_content, 'Full requirement content');
+    const artifact = snap.artifacts?.find((r) => r.path === '.gsd/milestones/M001/M001-VALIDATION.md');
+    assert.strictEqual(artifact?.full_content, '# Validation\n\nPASS');
+    assert.ok(artifact?.content_hash, 'artifact content_hash should round-trip through manifest restore');
+    assert.strictEqual(
+      fs.readFileSync(path.join(base, '.gsd', 'milestones', 'M001', 'M001-VALIDATION.md'), 'utf-8'),
+      '# Validation\n\nPASS',
+    );
+    assert.strictEqual(
+      fs.readFileSync(path.join(base, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'S01-ASSESSMENT.md'), 'utf-8'),
+      '# Assessment\n\nPASS',
+    );
+    assert.strictEqual(snap.assessments?.find((r) => r.scope === 'run-uat')?.status, 'pass');
+    assert.strictEqual(snap.replan_history?.find((r) => r.summary === 'Replan preserved')?.replacement_artifact_path, 'new.md');
+    assert.strictEqual(snap.quality_gates?.find((r) => r.gate_id === 'Q3')?.rationale, 'Gate passed');
+    assert.strictEqual(snap.milestone_commit_attributions?.find((r) => r.commit_sha === 'abc123')?.files_json, '["src/example.ts"]');
+
+    const dep = _getAdapter()!.prepare(
+      'SELECT depends_on_slice_id FROM slice_dependencies WHERE milestone_id = ? AND slice_id = ?',
+    ).get('M001', 'S01') as Record<string, unknown> | undefined;
+    assert.strictEqual(dep?.['depends_on_slice_id'], 'S00');
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
 // ─── bootstrapFromManifest ────────────────────────────────────────────────
 
 test('workflow-manifest: bootstrapFromManifest returns false when no manifest file', () => {
@@ -152,7 +324,7 @@ test('workflow-manifest: bootstrapFromManifest restores DB from manifest (round-
       milestoneId: 'M001',
       title: 'Restored Task',
       status: 'complete',
-      planning: { targetRepositories: ['project'] },
+      planning: { fullPlanMd: '# Full Task Plan\n\nKeep this body.', targetRepositories: ['project'] },
     });
     writeManifest(base);
     closeDatabase();
@@ -176,6 +348,7 @@ test('workflow-manifest: bootstrapFromManifest restores DB from manifest (round-
     const t = snap.tasks.find((r) => r.id === 'T01');
     assert.ok(t !== undefined, 'T01 should be restored');
     assert.strictEqual(t!.status, 'complete');
+    assert.strictEqual(t!.full_plan_md, '# Full Task Plan\n\nKeep this body.');
     assert.deepEqual(t!.target_repositories, ['project']);
   } finally {
     closeDatabase();
@@ -201,6 +374,138 @@ test('workflow-manifest: bootstrapFromManifest preserves target_repositories', (
     const snap = snapshotState();
     assert.deepStrictEqual(snap.slices.find((r) => r.id === 'S01')?.target_repositories, ['frontend']);
     assert.deepStrictEqual(snap.tasks.find((r) => r.id === 'T01')?.target_repositories, ['backend']);
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
+test('workflow-manifest: bootstrapFromManifest preserves optional rows from old manifests', () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertMilestone({ id: 'M001', title: 'Old Manifest Milestone' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Old Manifest Slice' });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Old Manifest Task' });
+    writeManifest(base);
+
+    const manifestPath = path.join(base, '.gsd', 'state-manifest.json');
+    const oldManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    delete oldManifest['replan_history'];
+    delete oldManifest['assessments'];
+    delete oldManifest['quality_gates'];
+    delete oldManifest['milestone_commit_attributions'];
+    fs.writeFileSync(manifestPath, JSON.stringify(oldManifest, null, 2));
+    closeDatabase();
+
+    const newDbPath = path.join(base, 'new.db');
+    openDatabase(newDbPath);
+    insertMilestone({ id: 'M001', title: 'Existing Milestone' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Existing Slice' });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Existing Task' });
+    insertAssessment({
+      path: '.gsd/milestones/M001/M001-VALIDATION.md',
+      milestoneId: 'M001',
+      status: 'pass',
+      scope: 'validate-milestone',
+      fullContent: '# Existing Validation',
+    });
+    insertReplanHistory({
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      taskId: 'T01',
+      summary: 'Existing replan row',
+      previousArtifactPath: 'before.md',
+      replacementArtifactPath: 'after.md',
+    });
+    insertGateRow({ milestoneId: 'M001', sliceId: 'S01', gateId: 'Q3', scope: 'slice' });
+    saveGateResult({
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      gateId: 'Q3',
+      verdict: 'pass',
+      rationale: 'Existing gate',
+      findings: 'No findings',
+    });
+    recordMilestoneCommitAttribution({
+      commitSha: 'def456',
+      milestoneId: 'M001',
+      source: 'recorded',
+      confidence: 0.8,
+      files: ['src/kept.ts'],
+      createdAt: '2026-06-05T00:00:00.000Z',
+    });
+
+    const restored = bootstrapFromManifest(base);
+    assert.strictEqual(restored, true);
+
+    const snap = snapshotState();
+    assert.strictEqual(snap.assessments?.find((r) => r.path.endsWith('VALIDATION.md'))?.full_content, '# Existing Validation');
+    assert.strictEqual(snap.replan_history?.find((r) => r.summary === 'Existing replan row')?.replacement_artifact_path, 'after.md');
+    assert.strictEqual(snap.quality_gates?.find((r) => r.gate_id === 'Q3')?.rationale, 'Existing gate');
+    assert.strictEqual(snap.milestone_commit_attributions?.find((r) => r.commit_sha === 'def456')?.files_json, '["src/kept.ts"]');
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
+test('workflow-manifest: bootstrapFromManifest restores memory-backed decisions', () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertMemoryBackedDecision('D901');
+    writeManifest(base);
+    closeDatabase();
+
+    const newDbPath = path.join(base, 'new.db');
+    openDatabase(newDbPath);
+    const restored = bootstrapFromManifest(base);
+    assert.strictEqual(restored, true);
+
+    const decision = getAllDecisionsFromMemories().find((r) => r.id === 'D901');
+    assert.ok(decision !== undefined, 'D901 should be restored into the memory-backed decision surface');
+    assert.strictEqual(decision!.decision, 'Decision D901');
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
+test('workflow-manifest: bootstrapFromManifest replaces stale memory-backed decisions', () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertMemoryBackedDecision('D902');
+    writeManifest(base);
+    closeDatabase();
+
+    const newDbPath = path.join(base, 'new.db');
+    openDatabase(newDbPath);
+    insertMemoryBackedDecision('D-STALE');
+    insertMemoryRow({
+      id: 'MEM-NOTE',
+      category: 'note',
+      content: 'Keep this non-decision memory',
+      confidence: 0.9,
+      sourceUnitType: null,
+      sourceUnitId: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      scope: 'project',
+      tags: ['keep'],
+      structuredFields: { kind: 'ordinary-note' },
+    });
+
+    const restored = bootstrapFromManifest(base);
+    assert.strictEqual(restored, true);
+
+    const decisions = getAllDecisionsFromMemories();
+    assert.ok(decisions.some((r) => r.id === 'D902'), 'manifest decision should be restored into memories');
+    assert.equal(decisions.some((r) => r.id === 'D-STALE'), false, 'stale memory-backed decision should be removed');
+
+    const note = _getAdapter()!.prepare('SELECT id FROM memories WHERE id = ?').get('MEM-NOTE') as Record<string, unknown> | undefined;
+    assert.strictEqual(note?.['id'], 'MEM-NOTE');
   } finally {
     closeDatabase();
     cleanupDir(base);

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -9,6 +9,8 @@ import {
   openDatabase,
   closeDatabase,
   _getAdapter,
+  getArtifact,
+  getAssessment,
   insertAssessment,
   upsertRequirement,
   getAllMilestones,
@@ -659,6 +661,12 @@ test("executeUatResultSave accepts gsd_uat_exec evidence written in a milestone 
     assert.ok(assessment.includes(`worktreeRoot: ${worktree}`));
     assert.match(assessment, /Runtime path C:\\\\tmp\\\|uat evidence/);
     assert.match(assessment, /backslash \\\\ and pipe \\\|/);
+
+    const artifactPath = "milestones/M001/slices/S02/S02-ASSESSMENT.md";
+    const assessmentPath = `.gsd/${artifactPath}`;
+    assert.equal(getArtifact(artifactPath)?.artifact_type, "ASSESSMENT");
+    assert.equal(getAssessment(assessmentPath)?.scope, "run-uat");
+    assert.equal(getAssessment(assessmentPath)?.status, "pass");
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/worktree-db.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-db.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -11,9 +12,23 @@ import {
   insertRequirement,
   insertArtifact,
   insertMilestone,
+  insertSlice,
+  insertTask,
+  insertMemoryRow,
+  insertVerificationEvidence,
+  insertAssessment,
+  insertGateRow,
+  insertReplanHistory,
+  saveGateResult,
+  recordMilestoneCommitAttribution,
   getMilestone,
+  getSlice,
+  getTask,
   getDecisionById,
   getRequirementById,
+  getVerificationEvidence,
+  updateSliceStatus,
+  updateTaskStatus,
   _getAdapter,
   copyWorktreeDb,
   reconcileWorktreeDb,
@@ -62,7 +77,34 @@ function seedMainDb(dbPath: string): void {
   });
 }
 
-function registerCleanup(t: { after: (fn: () => void) => void }, ...dirs: string[]) {
+function seedTrackedTask(options: {
+  milestoneId?: string;
+  sliceId?: string;
+  taskId?: string;
+  sliceTargets?: string[];
+  taskTargets?: string[];
+} = {}): { milestoneId: string; sliceId: string; taskId: string } {
+  const milestoneId = options.milestoneId ?? "M-TRACK";
+  const sliceId = options.sliceId ?? "S-TRACK";
+  const taskId = options.taskId ?? "T-TRACK";
+  insertMilestone({ id: milestoneId, title: "Tracked Milestone", status: "active" });
+  insertSlice({
+    id: sliceId,
+    milestoneId,
+    title: "Tracked Slice",
+    planning: { targetRepositories: options.sliceTargets ?? [] },
+  });
+  insertTask({
+    id: taskId,
+    sliceId,
+    milestoneId,
+    title: "Tracked Task",
+    planning: { targetRepositories: options.taskTargets ?? [] },
+  });
+  return { milestoneId, sliceId, taskId };
+}
+
+function registerCleanup(t: { after: (fn: () => void) => void }, ...dirs: string[]): void {
   t.after(() => {
     closeDatabase();
     for (const dir of dirs) {
@@ -437,4 +479,472 @@ test("reconcileWorktreeDb does not downgrade milestone status complete→active 
   const m = getMilestone("M-COMP");
   assert.ok(m !== null, "milestone M-COMP still exists after reconcile");
   assert.equal(m!.status, "complete", "complete milestone must not be downgraded to active by stale worktree");
+});
+
+test("reconcileWorktreeDb does not downgrade completed slices or tasks", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+  const completedAt = "2026-06-01T00:00:00.000Z";
+
+  seedMainDb(mainDb);
+  const ids = seedTrackedTask({
+    milestoneId: "M-COMPLETE-UNITS",
+    sliceId: "S-COMPLETE",
+    taskId: "T-COMPLETE",
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+
+  openDatabase(mainDb);
+  updateSliceStatus(ids.milestoneId, ids.sliceId, "complete", completedAt);
+  updateTaskStatus(ids.milestoneId, ids.sliceId, ids.taskId, "complete", completedAt);
+  closeDatabase();
+
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  wtAdapter.prepare(
+    "UPDATE slices SET status = 'active', completed_at = NULL WHERE milestone_id = :mid AND id = :sid",
+  ).run({ ":mid": ids.milestoneId, ":sid": ids.sliceId });
+  wtAdapter.prepare(
+    "UPDATE tasks SET status = 'pending', completed_at = NULL WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid",
+  ).run({ ":mid": ids.milestoneId, ":sid": ids.sliceId, ":tid": ids.taskId });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+
+  const slice = getSlice(ids.milestoneId, ids.sliceId);
+  assert.equal(slice?.status, "complete", "complete slice must not be downgraded by stale worktree");
+  assert.equal(slice?.completed_at, completedAt, "complete slice timestamp must be preserved");
+
+  const task = getTask(ids.milestoneId, ids.sliceId, ids.taskId);
+  assert.equal(task?.status, "complete", "complete task must not be downgraded by stale worktree");
+  assert.equal(task?.completed_at, completedAt, "complete task timestamp must be preserved");
+});
+
+test("reconcileWorktreeDb merges V29 target_repositories from worktree units", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  const ids = seedTrackedTask({
+    milestoneId: "M-REPOS",
+    sliceId: "S-REPOS",
+    taskId: "T-REPOS",
+    sliceTargets: ["main-slice"],
+    taskTargets: ["main-task"],
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  wtAdapter.prepare(
+    "UPDATE slices SET target_repositories = :targets WHERE milestone_id = :mid AND id = :sid",
+  ).run({ ":targets": JSON.stringify(["worktree-slice"]), ":mid": ids.milestoneId, ":sid": ids.sliceId });
+  wtAdapter.prepare(
+    "UPDATE tasks SET target_repositories = :targets WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid",
+  ).run({ ":targets": JSON.stringify(["worktree-task"]), ":mid": ids.milestoneId, ":sid": ids.sliceId, ":tid": ids.taskId });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+
+  assert.deepEqual(getSlice(ids.milestoneId, ids.sliceId)?.target_repositories, ["worktree-slice"]);
+  assert.deepEqual(getTask(ids.milestoneId, ids.sliceId, ids.taskId)?.target_repositories, ["worktree-task"]);
+});
+
+test("reconcileWorktreeDb preserves target_repositories when worktree predates V29", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  const ids = seedTrackedTask({
+    milestoneId: "M-OLD-REPOS",
+    sliceId: "S-OLD-REPOS",
+    taskId: "T-OLD-REPOS",
+    sliceTargets: ["main-slice"],
+    taskTargets: ["main-task"],
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  wtAdapter.exec("ALTER TABLE slices DROP COLUMN target_repositories");
+  wtAdapter.exec("ALTER TABLE tasks DROP COLUMN target_repositories");
+  closeDatabase();
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+
+  assert.deepEqual(getSlice(ids.milestoneId, ids.sliceId)?.target_repositories, ["main-slice"]);
+  assert.deepEqual(getTask(ids.milestoneId, ids.sliceId, ids.taskId)?.target_repositories, ["main-task"]);
+});
+
+test("reconcileWorktreeDb preserves target_repositories when migrated old worktree has default empty arrays", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  const ids = seedTrackedTask({
+    milestoneId: "M-MIGRATED-REPOS",
+    sliceId: "S-MIGRATED-REPOS",
+    taskId: "T-MIGRATED-REPOS",
+    sliceTargets: ["main-slice"],
+    taskTargets: ["main-task"],
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  wtAdapter.prepare(
+    "UPDATE slices SET target_repositories = '[]' WHERE milestone_id = :mid AND id = :sid",
+  ).run({ ":mid": ids.milestoneId, ":sid": ids.sliceId });
+  wtAdapter.prepare(
+    "UPDATE tasks SET target_repositories = '[]' WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid",
+  ).run({ ":mid": ids.milestoneId, ":sid": ids.sliceId, ":tid": ids.taskId });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+
+  assert.deepEqual(getSlice(ids.milestoneId, ids.sliceId)?.target_repositories, ["main-slice"]);
+  assert.deepEqual(getTask(ids.milestoneId, ids.sliceId, ids.taskId)?.target_repositories, ["main-task"]);
+});
+
+test("reconcileWorktreeDb preserves memory metadata when worktree predates memory columns", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+  const memoryId = "mem-reconcile";
+  const createdAt = "2026-06-01T00:00:00.000Z";
+  const updatedAt = "2026-06-02T00:00:00.000Z";
+  const lastHitAt = "2026-06-03T00:00:00.000Z";
+
+  seedMainDb(mainDb);
+  insertMemoryRow({
+    id: memoryId,
+    category: "architecture",
+    content: "Main memory content",
+    confidence: 0.7,
+    sourceUnitType: "task",
+    sourceUnitId: "T001",
+    createdAt,
+    updatedAt,
+    scope: "workspace",
+    tags: ["db", "memory"],
+    structuredFields: { sourceDecisionId: "D-MEM" },
+  });
+  _getAdapter()!.prepare(
+    "UPDATE memories SET last_hit_at = :last_hit_at, hit_count = 3 WHERE id = :id",
+  ).run({ ":last_hit_at": lastHitAt, ":id": memoryId });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  wtAdapter.exec("DROP INDEX IF EXISTS idx_memories_scope");
+  wtAdapter.exec("ALTER TABLE memories DROP COLUMN scope");
+  wtAdapter.exec("ALTER TABLE memories DROP COLUMN tags");
+  wtAdapter.exec("ALTER TABLE memories DROP COLUMN structured_fields");
+  wtAdapter.exec("ALTER TABLE memories DROP COLUMN last_hit_at");
+  wtAdapter.prepare(
+    "UPDATE memories SET content = :content, confidence = :confidence, updated_at = :updated_at WHERE id = :id",
+  ).run({
+    ":content": "Worktree memory content",
+    ":confidence": 0.9,
+    ":updated_at": "2026-06-04T00:00:00.000Z",
+    ":id": memoryId,
+  });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+
+  const row = _getAdapter()!.prepare("SELECT * FROM memories WHERE id = :id").get({ ":id": memoryId }) as Record<string, unknown>;
+  assert.equal(row["content"], "Worktree memory content");
+  assert.equal(row["confidence"], 0.9);
+  assert.equal(row["scope"], "workspace");
+  assert.equal(row["tags"], JSON.stringify(["db", "memory"]));
+  assert.equal(row["structured_fields"], JSON.stringify({ sourceDecisionId: "D-MEM" }));
+  assert.equal(row["last_hit_at"], lastHitAt);
+});
+
+test("reconcileWorktreeDb continues when an older worktree is missing an optional table", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  closeDatabase();
+  copyWorktreeDb(mainDb, wtDb);
+
+  openDatabase(wtDb);
+  insertDecision({
+    id: "D-MISSING-TABLE",
+    when_context: "2026-06-01",
+    scope: "M001",
+    decision: "Merge despite old optional tables",
+    choice: "guard table reads",
+    rationale: "Old worktrees may lack newer tables",
+    revisable: "yes",
+    made_by: "agent",
+    superseded_by: null,
+  });
+  _getAdapter()!.exec("DROP TABLE memories");
+  closeDatabase();
+
+  openDatabase(mainDb);
+  const result = reconcileWorktreeDb(mainDb, wtDb);
+
+  assert.equal(result.conflicts.length, 0);
+  assert.equal(getDecisionById("D-MISSING-TABLE")?.choice, "guard table reads");
+});
+
+test("reconcileWorktreeDb preserves decision seq when replaying worktree decisions", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  insertDecision({
+    id: "D002",
+    when_context: "2026-06-02",
+    scope: "M001",
+    decision: "Second decision",
+    choice: "keep order",
+    rationale: "Reconcile must not reset seq",
+    revisable: "yes",
+    made_by: "agent",
+    superseded_by: null,
+  });
+  const before = _getAdapter()!.prepare("SELECT id, seq FROM decisions ORDER BY seq").all();
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+  const after = _getAdapter()!.prepare("SELECT id, seq FROM decisions ORDER BY seq").all();
+
+  assert.deepEqual(after, before);
+});
+
+test("reconcileWorktreeDb recomputes artifact hash when worktree predates content_hash", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+  const artifactPath = "docs/hash.md";
+
+  seedMainDb(mainDb);
+  insertArtifact({
+    path: artifactPath,
+    artifact_type: "plan",
+    milestone_id: "M001",
+    slice_id: null,
+    task_id: null,
+    full_content: "old content",
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  wtAdapter.exec("ALTER TABLE artifacts DROP COLUMN content_hash");
+  wtAdapter.prepare("UPDATE artifacts SET full_content = :content WHERE path = :path").run({
+    ":content": "new content",
+    ":path": artifactPath,
+  });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  reconcileWorktreeDb(mainDb, wtDb);
+  const row = _getAdapter()!.prepare("SELECT full_content, content_hash FROM artifacts WHERE path = :path").get({
+    ":path": artifactPath,
+  }) as Record<string, unknown>;
+
+  assert.equal(row["full_content"], "new content");
+  assert.equal(row["content_hash"], createHash("sha256").update("new content").digest("hex"));
+});
+
+test("reconcileWorktreeDb merges correctness rows from worktree", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  const ids = seedTrackedTask({
+    milestoneId: "M-CORRECTNESS",
+    sliceId: "S-CORRECTNESS",
+    taskId: "T-CORRECTNESS",
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+  openDatabase(wtDb);
+  const wtAdapter = _getAdapter()!;
+  insertSlice({ id: "S-BASE", milestoneId: ids.milestoneId, title: "Base Slice" });
+  insertSlice({ id: "S-DEPENDENT", milestoneId: ids.milestoneId, title: "Dependent Slice", depends: ["S-BASE"] });
+  wtAdapter.prepare(
+    "INSERT INTO slice_dependencies (milestone_id, slice_id, depends_on_slice_id) VALUES (?, ?, ?)",
+  ).run(ids.milestoneId, "S-DEPENDENT", "S-BASE");
+  insertAssessment({
+    path: ".gsd/milestones/M-CORRECTNESS/M-CORRECTNESS-VALIDATION.md",
+    milestoneId: ids.milestoneId,
+    status: "pass",
+    scope: "validate-milestone",
+    fullContent: "# Validation\n\nPASS",
+  });
+  insertReplanHistory({
+    milestoneId: ids.milestoneId,
+    sliceId: ids.sliceId,
+    taskId: ids.taskId,
+    summary: "Replanned in worktree",
+    previousArtifactPath: "old.md",
+    replacementArtifactPath: "new.md",
+  });
+  insertGateRow({ milestoneId: ids.milestoneId, sliceId: ids.sliceId, gateId: "Q3", scope: "slice" });
+  saveGateResult({
+    milestoneId: ids.milestoneId,
+    sliceId: ids.sliceId,
+    gateId: "Q3",
+    verdict: "pass",
+    rationale: "Worktree gate passed",
+    findings: "No findings",
+  });
+  recordMilestoneCommitAttribution({
+    commitSha: "abc123",
+    milestoneId: ids.milestoneId,
+    sliceId: ids.sliceId,
+    taskId: ids.taskId,
+    source: "recorded",
+    confidence: 0.95,
+    files: ["src/example.ts"],
+    createdAt: "2026-06-05T00:00:00.000Z",
+  });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  const result = reconcileWorktreeDb(mainDb, wtDb);
+  const adapter = _getAdapter()!;
+
+  assert.ok(result.assessments > 0, "assessment rows should merge");
+  assert.ok(result.replan_history > 0, "replan history rows should merge");
+  assert.ok(result.quality_gates > 0, "quality gate rows should merge");
+  assert.ok(result.slice_dependencies > 0, "slice dependency rows should merge");
+  assert.ok(result.gate_runs > 0, "gate run rows should merge");
+  assert.ok(result.milestone_commit_attributions > 0, "commit attribution rows should merge");
+  assert.equal(
+    (adapter.prepare("SELECT count(*) AS n FROM assessments WHERE milestone_id = :mid").get({ ":mid": ids.milestoneId }) as Record<string, unknown>)["n"],
+    1,
+  );
+  assert.equal(
+    (adapter.prepare("SELECT count(*) AS n FROM replan_history WHERE summary = 'Replanned in worktree'").get() as Record<string, unknown>)["n"],
+    1,
+  );
+  assert.equal(
+    (adapter.prepare("SELECT verdict FROM quality_gates WHERE milestone_id = :mid AND slice_id = :sid AND gate_id = 'Q3'").get({
+      ":mid": ids.milestoneId,
+      ":sid": ids.sliceId,
+    }) as Record<string, unknown>)["verdict"],
+    "pass",
+  );
+  assert.equal(
+    (adapter.prepare("SELECT depends_on_slice_id FROM slice_dependencies WHERE milestone_id = :mid AND slice_id = 'S-DEPENDENT'").get({
+      ":mid": ids.milestoneId,
+    }) as Record<string, unknown>)["depends_on_slice_id"],
+    "S-BASE",
+  );
+  assert.equal(
+    (adapter.prepare("SELECT count(*) AS n FROM gate_runs WHERE milestone_id = :mid").get({ ":mid": ids.milestoneId }) as Record<string, unknown>)["n"],
+    1,
+  );
+  assert.equal(
+    (adapter.prepare("SELECT commit_sha FROM milestone_commit_attributions WHERE milestone_id = :mid").get({
+      ":mid": ids.milestoneId,
+    }) as Record<string, unknown>)["commit_sha"],
+    "abc123",
+  );
+});
+
+test("reconcileWorktreeDb appends new verification evidence without duplicating copied rows", (t) => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
+  seedMainDb(mainDb);
+  const ids = seedTrackedTask({
+    milestoneId: "M-EVIDENCE",
+    sliceId: "S-EVIDENCE",
+    taskId: "T-EVIDENCE",
+  });
+  insertVerificationEvidence({
+    taskId: ids.taskId,
+    sliceId: ids.sliceId,
+    milestoneId: ids.milestoneId,
+    command: "pnpm test",
+    exitCode: 0,
+    verdict: "pass",
+    durationMs: 100,
+  });
+  closeDatabase();
+
+  copyWorktreeDb(mainDb, wtDb);
+  openDatabase(wtDb);
+  insertVerificationEvidence({
+    taskId: ids.taskId,
+    sliceId: ids.sliceId,
+    milestoneId: ids.milestoneId,
+    command: "pnpm lint",
+    exitCode: 0,
+    verdict: "pass",
+    durationMs: 50,
+  });
+  closeDatabase();
+
+  openDatabase(mainDb);
+  const result = reconcileWorktreeDb(mainDb, wtDb);
+  const evidence = getVerificationEvidence(ids.milestoneId, ids.sliceId, ids.taskId);
+
+  assert.equal(result.verification_evidence, 1, "only the new evidence row should be appended");
+  assert.equal(evidence.length, 2, "copied evidence row should not duplicate during reconcile");
+  assert.deepEqual(evidence.map((row) => row.command).sort(), ["pnpm lint", "pnpm test"]);
 });

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -10,6 +10,7 @@ import {
   getMilestone,
   getSliceStatusSummary,
   getSliceTaskCounts,
+  insertAssessment,
   insertGateRun,
   readTransaction,
   saveGateResult,
@@ -17,7 +18,7 @@ import {
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
-import { clearPathCache, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { clearPathCache, relSliceFile, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";
@@ -997,6 +998,16 @@ export async function executeUatResultSave(
       basePath,
     );
     if (summary.isError) return summary;
+    const assessmentPath = relSliceFile(basePath, run.params.milestoneId, run.params.sliceId, "ASSESSMENT");
+    insertAssessment({
+      path: assessmentPath,
+      milestoneId: run.params.milestoneId,
+      sliceId: run.params.sliceId,
+      taskId: null,
+      status: run.params.verdict.toLowerCase(),
+      scope: "run-uat",
+      fullContent: run.assessment,
+    });
     const attemptPath = await saveUatAttemptArtifact(basePath, run);
     upsertQualityGate({
       milestoneId: run.params.milestoneId,

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -6,24 +6,70 @@ import {
   readTransaction,
   restoreManifest,
 } from "./gsd-db.js";
-import type { MilestoneRow } from "./db-milestone-artifact-rows.js";
+import type { ArtifactRow, MilestoneRow } from "./db-milestone-artifact-rows.js";
 import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { VerificationEvidenceRow } from "./db-verification-evidence-rows.js";
-import type { Decision } from "./types.js";
+import type { Decision, GateRow, Requirement } from "./types.js";
 import { atomicWriteSync } from "./atomic-write.js";
+import { getAllDecisionsFromMemories } from "./context-store.js";
+import { backfillDecisionsToMemories } from "./memory-backfill.js";
+import { invalidateAllCaches } from "./cache.js";
 import { readFileSync, existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 // ─── Manifest Types ──────────────────────────────────────────────────────
+
+export interface ManifestArtifactRow extends ArtifactRow {
+  content_hash: string | null;
+}
+
+export interface ReplanHistoryManifestRow {
+  id: number;
+  milestone_id: string;
+  slice_id: string | null;
+  task_id: string | null;
+  summary: string;
+  previous_artifact_path: string | null;
+  replacement_artifact_path: string | null;
+  created_at: string;
+}
+
+export interface AssessmentManifestRow {
+  path: string;
+  milestone_id: string;
+  slice_id: string | null;
+  task_id: string | null;
+  status: string;
+  scope: string;
+  full_content: string;
+  created_at: string;
+}
+
+export interface MilestoneCommitAttributionManifestRow {
+  commit_sha: string;
+  milestone_id: string;
+  slice_id: string | null;
+  task_id: string | null;
+  source: string;
+  confidence: number;
+  files_json: string;
+  created_at: string;
+}
 
 export interface StateManifest {
   version: 1;
   exported_at: string; // ISO 8601
+  requirements?: Requirement[];
+  artifacts?: ManifestArtifactRow[];
   milestones: MilestoneRow[];
   slices: SliceRow[];
   tasks: TaskRow[];
   decisions: Decision[];
+  replan_history?: ReplanHistoryManifestRow[];
+  assessments?: AssessmentManifestRow[];
+  quality_gates?: GateRow[];
   verification_evidence: VerificationEvidenceRow[];
+  milestone_commit_attributions?: MilestoneCommitAttributionManifestRow[];
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────
@@ -51,11 +97,26 @@ export function toNumeric(value: unknown, fallback: number | null = null): numbe
   return fallback;
 }
 
+function mergeDecisionSurfaces(legacyDecisions: Decision[], memoryDecisions: Decision[]): Decision[] {
+  const byId = new Map<string, Decision>();
+  for (const decision of legacyDecisions) {
+    byId.set(decision.id, decision);
+  }
+  for (const decision of memoryDecisions) {
+    byId.set(decision.id, decision);
+  }
+  return Array.from(byId.values()).sort((a, b) => {
+    const seqDelta = (a.seq ?? 0) - (b.seq ?? 0);
+    return seqDelta === 0 ? a.id.localeCompare(b.id) : seqDelta;
+  });
+}
+
 // ─── snapshotState ───────────────────────────────────────────────────────
 
 /**
- * Capture complete DB state as a StateManifest.
- * Reads all rows from milestones, slices, tasks, decisions, verification_evidence.
+ * Capture DB-backed workflow state as a StateManifest.
+ * Runtime soft state and append-only audit streams stay outside this recovery
+ * substrate; correctness records and persisted evidence are included.
  *
  * Note: rows returned from raw queries are plain objects with TEXT columns for
  * JSON arrays. We parse them into typed Row objects using the same logic as
@@ -67,6 +128,34 @@ export function snapshotState(): StateManifest {
   // Wrap all reads in a deferred transaction so the snapshot is consistent
   // (all SELECTs see the same DB state even if a concurrent write lands between them).
   return readTransaction(() => {
+  const rawRequirements = db.prepare("SELECT * FROM requirements ORDER BY id").all() as Record<string, unknown>[];
+  const requirements: Requirement[] = rawRequirements.map((r) => ({
+    id: r["id"] as string,
+    class: (r["class"] as string) ?? "",
+    status: (r["status"] as string) ?? "",
+    description: (r["description"] as string) ?? "",
+    why: (r["why"] as string) ?? "",
+    source: (r["source"] as string) ?? "",
+    primary_owner: (r["primary_owner"] as string) ?? "",
+    supporting_slices: (r["supporting_slices"] as string) ?? "",
+    validation: (r["validation"] as string) ?? "",
+    notes: (r["notes"] as string) ?? "",
+    full_content: (r["full_content"] as string) ?? "",
+    superseded_by: (r["superseded_by"] as string) ?? null,
+  }));
+
+  const rawArtifacts = db.prepare("SELECT * FROM artifacts ORDER BY path").all() as Record<string, unknown>[];
+  const artifacts: ManifestArtifactRow[] = rawArtifacts.map((r) => ({
+    path: r["path"] as string,
+    artifact_type: (r["artifact_type"] as string) ?? "",
+    milestone_id: (r["milestone_id"] as string) ?? null,
+    slice_id: (r["slice_id"] as string) ?? null,
+    task_id: (r["task_id"] as string) ?? null,
+    full_content: (r["full_content"] as string) ?? "",
+    imported_at: (r["imported_at"] as string) ?? "",
+    content_hash: (r["content_hash"] as string) ?? null,
+  }));
+
   const rawMilestones = db.prepare(
     "SELECT * FROM milestones ORDER BY CASE WHEN sequence > 0 THEN 0 ELSE 1 END, sequence, id",
   ).all() as Record<string, unknown>[];
@@ -152,7 +241,7 @@ export function snapshotState(): StateManifest {
   }));
 
   const rawDecisions = db.prepare("SELECT * FROM decisions ORDER BY seq").all() as Record<string, unknown>[];
-  const decisions: Decision[] = rawDecisions.map((r) => ({
+  const legacyDecisions: Decision[] = rawDecisions.map((r) => ({
     seq: toNumeric(r["seq"], 0) as number,
     id: r["id"] as string,
     when_context: (r["when_context"] as string) ?? "",
@@ -164,6 +253,45 @@ export function snapshotState(): StateManifest {
     made_by: (r["made_by"] as string as Decision["made_by"]) ?? "agent",
     source: (r["source"] as string) ?? "discussion",
     superseded_by: (r["superseded_by"] as string) ?? null,
+  }));
+  const decisions = mergeDecisionSurfaces(legacyDecisions, getAllDecisionsFromMemories());
+
+  const rawReplanHistory = db.prepare("SELECT * FROM replan_history ORDER BY id").all() as Record<string, unknown>[];
+  const replan_history: ReplanHistoryManifestRow[] = rawReplanHistory.map((r) => ({
+    id: toNumeric(r["id"], 0) as number,
+    milestone_id: (r["milestone_id"] as string) ?? "",
+    slice_id: (r["slice_id"] as string) ?? null,
+    task_id: (r["task_id"] as string) ?? null,
+    summary: (r["summary"] as string) ?? "",
+    previous_artifact_path: (r["previous_artifact_path"] as string) ?? null,
+    replacement_artifact_path: (r["replacement_artifact_path"] as string) ?? null,
+    created_at: (r["created_at"] as string) ?? "",
+  }));
+
+  const rawAssessments = db.prepare("SELECT * FROM assessments ORDER BY path").all() as Record<string, unknown>[];
+  const assessments: AssessmentManifestRow[] = rawAssessments.map((r) => ({
+    path: r["path"] as string,
+    milestone_id: (r["milestone_id"] as string) ?? "",
+    slice_id: (r["slice_id"] as string) ?? null,
+    task_id: (r["task_id"] as string) ?? null,
+    status: (r["status"] as string) ?? "",
+    scope: (r["scope"] as string) ?? "",
+    full_content: (r["full_content"] as string) ?? "",
+    created_at: (r["created_at"] as string) ?? "",
+  }));
+
+  const rawQualityGates = db.prepare("SELECT * FROM quality_gates ORDER BY milestone_id, slice_id, gate_id, task_id").all() as Record<string, unknown>[];
+  const quality_gates: GateRow[] = rawQualityGates.map((r) => ({
+    milestone_id: r["milestone_id"] as string,
+    slice_id: r["slice_id"] as string,
+    gate_id: r["gate_id"] as GateRow["gate_id"],
+    scope: r["scope"] as GateRow["scope"],
+    task_id: (r["task_id"] as string) ?? "",
+    status: r["status"] as GateRow["status"],
+    verdict: r["status"] === "pending" ? null : (r["verdict"] as GateRow["verdict"]),
+    rationale: (r["rationale"] as string) ?? "",
+    findings: (r["findings"] as string) ?? "",
+    evaluated_at: (r["evaluated_at"] as string) ?? null,
   }));
 
   const rawEvidence = db.prepare("SELECT * FROM verification_evidence ORDER BY id").all() as Record<string, unknown>[];
@@ -179,14 +307,34 @@ export function snapshotState(): StateManifest {
     created_at: r["created_at"] as string,
   }));
 
+  const rawCommitAttributions = db.prepare(
+    "SELECT * FROM milestone_commit_attributions ORDER BY milestone_id, commit_sha",
+  ).all() as Record<string, unknown>[];
+  const milestone_commit_attributions: MilestoneCommitAttributionManifestRow[] = rawCommitAttributions.map((r) => ({
+    commit_sha: r["commit_sha"] as string,
+    milestone_id: r["milestone_id"] as string,
+    slice_id: (r["slice_id"] as string) ?? null,
+    task_id: (r["task_id"] as string) ?? null,
+    source: (r["source"] as string) ?? "recorded",
+    confidence: toNumeric(r["confidence"], 1) as number,
+    files_json: (r["files_json"] as string) ?? "[]",
+    created_at: (r["created_at"] as string) ?? "",
+  }));
+
   const result: StateManifest = {
     version: 1,
     exported_at: new Date().toISOString(),
+    requirements,
+    artifacts,
     milestones,
     slices,
     tasks,
     decisions,
+    replan_history,
+    assessments,
+    quality_gates,
     verification_evidence,
+    milestone_commit_attributions,
   };
 
   return result;
@@ -232,20 +380,55 @@ export function readManifest(basePath: string): StateManifest | null {
     throw new Error(`Unsupported manifest version: ${parsed.version}`);
   }
 
-  // Validate required fields to avoid cryptic errors during restore
+  // Validate required fields to avoid cryptic errors during restore.
   if (!Array.isArray(parsed.milestones) || !Array.isArray(parsed.slices) ||
       !Array.isArray(parsed.tasks) || !Array.isArray(parsed.decisions) ||
       !Array.isArray(parsed.verification_evidence)) {
     throw new Error("Malformed manifest: missing or invalid required arrays");
   }
 
+  for (const key of ["requirements", "artifacts", "replan_history", "assessments", "quality_gates", "milestone_commit_attributions"] as const) {
+    if (parsed[key] !== undefined && !Array.isArray(parsed[key])) {
+      throw new Error(`Malformed manifest: ${key} must be an array when present`);
+    }
+  }
+
   return parsed;
+}
+
+function stripGsdPrefix(path: string): string {
+  return path.startsWith(".gsd/") ? path.slice(".gsd/".length) : path;
+}
+
+function artifactProjectionPath(basePath: string, artifactPath: string): string {
+  const gsdDir = resolve(basePath, ".gsd");
+  const fullPath = resolve(gsdDir, stripGsdPrefix(artifactPath));
+  const rel = relative(gsdDir, fullPath);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`Malformed manifest: artifact path escapes .gsd: ${artifactPath}`);
+  }
+  return fullPath;
+}
+
+function restoreArtifactProjections(basePath: string, manifest: StateManifest): void {
+  if (manifest.artifacts === undefined) return;
+
+  for (const artifact of manifest.artifacts) {
+    atomicWriteSync(
+      artifactProjectionPath(basePath, artifact.path),
+      artifact.full_content ?? "",
+    );
+  }
 }
 
 // ─── bootstrapFromManifest ──────────────────────────────────────────────
 
 /**
  * Read state-manifest.json and restore DB state from it.
+ * Rehydrates artifact projection files for restored artifacts so file-based
+ * fallback paths see the same evidence as the DB.
+ * Re-mirrors restored legacy decisions into memories so the ADR-013
+ * memory-backed decision readers see bootstrapped decisions immediately.
  * Returns true if bootstrap succeeded, false if manifest file doesn't exist.
  */
 export function bootstrapFromManifest(basePath: string): boolean {
@@ -256,5 +439,8 @@ export function bootstrapFromManifest(basePath: string): boolean {
   }
 
   restoreManifest(manifest);
+  restoreArtifactProjections(basePath, manifest);
+  backfillDecisionsToMemories();
+  invalidateAllCaches();
   return true;
 }

--- a/tests/e2e/migration.e2e.test.ts
+++ b/tests/e2e/migration.e2e.test.ts
@@ -25,14 +25,15 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { createTmpProject, gsdSync } from "./_shared/index.ts";
 
 interface SqliteDb {
 	// Method names match node:sqlite's API surface.
-	// (`run` here is the SQL exec method, not shell exec.)
-	run(sql: string): void;
+	// (`exec` here is the SQL exec method, not shell exec.)
+	exec(sql: string): void;
 	prepare(sql: string): { get(): Record<string, unknown> | undefined; all(): Record<string, unknown>[] };
 	close(): void;
 }
@@ -63,7 +64,7 @@ async function tryLoadSqlite(): Promise<{ ok: true; mod: SqliteModule } | { ok: 
  * minimum invariant is a `schema_version` row with `version = 20`.
  */
 function seedV20Db(sqlite: SqliteModule, dbPath: string): void {
-	const db = new sqlite.DatabaseSync(dbPath) as unknown as { exec(sql: string): void; close(): void };
+	const db = new sqlite.DatabaseSync(dbPath);
 	db.exec("PRAGMA journal_mode=WAL");
 	db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
@@ -82,6 +83,32 @@ function readSchemaVersion(sqlite: SqliteModule, dbPath: string): number {
 			.prepare("SELECT MAX(version) AS v FROM schema_version")
 			.get() as { v?: number } | undefined;
 		return row?.v ?? 0;
+	} finally {
+		db.close();
+	}
+}
+
+async function readBuiltSchemaVersion(): Promise<number> {
+	const bin = process.env.GSD_SMOKE_BINARY;
+	assert.ok(bin, "GSD_SMOKE_BINARY must be set before reading built schema version");
+
+	const modulePath = join(dirname(bin), "resources", "extensions", "gsd", "gsd-db.js");
+	assert.ok(existsSync(modulePath), `expected built gsd-db.js at ${modulePath}`);
+
+	const mod = (await import(pathToFileURL(modulePath).href)) as { SCHEMA_VERSION?: unknown };
+	assert.equal(
+		typeof mod.SCHEMA_VERSION,
+		"number",
+		"expected built gsd-db.js to export numeric SCHEMA_VERSION",
+	);
+	return mod.SCHEMA_VERSION;
+}
+
+function readColumnNames(sqlite: SqliteModule, dbPath: string, table: string): Set<string> {
+	const db = new sqlite.DatabaseSync(dbPath);
+	try {
+		const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+		return new Set(rows.map((row) => row["name"] as string));
 	} finally {
 		db.close();
 	}
@@ -118,6 +145,7 @@ describe("schema migration smoke (forward only)", () => {
 		// Sanity: the seeded DB really is v20 before we hand it to gsd.
 		const before = readSchemaVersion(sqliteLoaded.mod, dbPath);
 		assert.equal(before, 20, `seed step failed — expected v20 before run, got ${before}`);
+		const expectedSchemaVersion = await readBuiltSchemaVersion();
 
 		// Run a no-LLM probe that opens the DB. The mere act of running it
 		// triggers initSchema/migrateSchema in the binary's compiled code.
@@ -137,12 +165,18 @@ describe("schema migration smoke (forward only)", () => {
 			after > before,
 			`expected schema_version to advance past ${before}, still at ${after}`,
 		);
-		// We don't hard-pin `after === SCHEMA_VERSION` because that constant
-		// shifts with normal development. The contract is: forward-only
-		// migration must reach SOME version newer than what we seeded.
+		assert.equal(
+			after,
+			expectedSchemaVersion,
+			`expected schema_version to reach current SCHEMA_VERSION ${expectedSchemaVersion}, got ${after}`,
+		);
 		assert.ok(
-			after >= 21,
-			`expected schema_version to reach at least 21 (the v20→v21 hop), got ${after}`,
+			readColumnNames(sqliteLoaded.mod, dbPath, "slices").has("target_repositories"),
+			"expected migrated slices table to include target_repositories",
+		);
+		assert.ok(
+			readColumnNames(sqliteLoaded.mod, dbPath, "tasks").has("target_repositories"),
+			"expected migrated tasks table to include target_repositories",
 		);
 	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Tracks the GSD database recovery and evidence surfaces that were falling out of manifests, worktree reconciliation, and UAT persistence.
**Why:** DB-backed workflow state could lose correctness rows or disagree with file projections after restore, old manifests, or hidden worktree merges.
**How:** Extends schema/version coverage, manifest snapshot/restore, worktree DB reconciliation, UAT assessment persistence, and regression tests around those paths.

## What

- Adds V29 `target_repositories` coverage for slices and tasks.
- Expands manifest snapshot/restore to include requirements, artifacts, replan history, assessments, quality gates, verification evidence, and milestone commit attributions.
- Rehydrates artifact projection files after manifest restore so file fallback paths see the same evidence as SQLite.
- Extends worktree DB reconciliation to merge correctness rows from hidden worktrees without downgrading existing state.
- Persists UAT assessment evidence into both artifacts and assessments, including validation-time synthesized assessment backfills.
- Updates `docs/db-map.md` to document the new recovery and tool write surfaces.

## Why

Several GSD workflow paths treated SQLite as the durable source of truth, while restore/reconcile/UAT paths still left gaps in DB-backed correctness state. That could make recovered or merged worktrees appear to have evidence on disk but not in the database, or vice versa.

## How

- Adds guarded table-aware reconciliation for optional/older worktree DBs.
- Preserves existing non-empty tracking fields when old DBs only contain migration defaults.
- Recomputes artifact content hashes during imports/restores when needed.
- Keeps old manifest compatibility by preserving optional rows when older manifests omit newer arrays.
- Adds targeted regression tests for schema upgrades, manifest round trips, UAT assessment rows, and worktree reconciliation.

## Validation

- `pnpm run verify:fast`
- `pnpm run typecheck:extensions`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-db.test.ts src/resources/extensions/gsd/tests/workflow-manifest.test.ts src/resources/extensions/gsd/tests/schema-v21-sequence.test.ts src/resources/extensions/gsd/tests/schema-v27-v28-sequence.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- `node --experimental-strip-types --test tests/e2e/migration.e2e.test.ts` (expected skip for binary smoke because `GSD_SMOKE_BINARY` was unset)

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783257571&installation_id=134682257&pr_number=503&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F503&signature=f8fcf05d3abacfe936e82b0c3d0f356d19dba74bf3c238799e2ee7e8f9ac25c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SQLite restore/reconcile and schema migration paths where incorrect merges could drop or corrupt workflow state; risk is mitigated by extensive new regression tests but still touches durable correctness data.
> 
> **Overview**
> **Extends GSD SQLite recovery** so manifests, worktree merges, and UAT paths keep DB-backed evidence aligned with disk projections.
> 
> Adds **schema V29** (`target_repositories` on `slices` and `tasks`) and fixes **task upsert/restore** to include `full_plan_md`. **`state-manifest.json`** now snapshots and restores requirements, artifacts, replan history, assessments, quality gates, verification evidence, and milestone commit attributions; bootstrap **re-writes artifact files under `.gsd`**, merges legacy + memory-backed decisions, and **backfills decision mirrors** after restore (with compatibility for older manifests missing new arrays).
> 
> **`reconcileWorktreeDb`** is broadened to merge those correctness tables from hidden worktrees with **schema-age guards**, **no status downgrades**, smarter **`target_repositories`** when worktrees predate V29 or carry empty defaults, and **SHA-256 recomputation** for merged artifacts. UAT and skipped-validation flows now **persist assessments into `artifacts` + `assessments`** (including auto-dispatch assessment backfill). Docs and regression/e2e tests cover migrations, manifest round-trips, reconciliation, and UAT DB rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0ef99816ddad401330950e3ba0b37d3ee81cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->