### PR TITLE
fix(gsd): stop auto timer after milestone closeout

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,31 +158,6 @@ importers:
       zod:
         specifier: ^4.0.0
         version: 4.4.3
-    devDependencies:
-      '@types/node':
-        specifier: ^24.12.0
-        version: 24.12.4
-      '@types/picomatch':
-        specifier: ^4.0.2
-        version: 4.0.3
-      '@types/proper-lockfile':
-        specifier: ^4.1.4
-        version: 4.1.4
-      c8:
-        specifier: ^11.0.0
-        version: 11.0.0
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
-      esbuild:
-        specifier: ^0.25.12
-        version: 0.25.12
-      jiti:
-        specifier: ^2.6.1
-        version: 2.7.0
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
     optionalDependencies:
       '@mariozechner/clipboard':
         specifier: 0.3.6
@@ -208,6 +183,31 @@ importers:
       koffi:
         specifier: ^2.9.0
         version: 2.16.2
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.12.4
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.3
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
+      esbuild:
+        specifier: ^0.25.12
+        version: 0.25.12
+      jiti:
+        specifier: ^2.6.1
+        version: 2.7.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   extensions/google-search:
     dependencies:
@@ -383,16 +383,16 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
-        version: 0.91.1(zod@3.25.76)
+        version: 0.91.1(zod@4.4.3)
       '@anthropic-ai/vertex-sdk':
         specifier: 0.14.4
-        version: 0.14.4(zod@3.25.76)
+        version: 0.14.4(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
       '@google/genai':
         specifier: 1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai':
         specifier: 2.2.1
         version: 2.2.1
@@ -407,7 +407,7 @@ importers:
         version: 7.0.6
       openai:
         specifier: 6.26.0
-        version: 6.26.0(ws@8.21.0)(zod@3.25.76)
+        version: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json:
         specifier: 0.1.7
         version: 0.1.7
@@ -505,6 +505,10 @@ importers:
       yaml:
         specifier: 2.9.0
         version: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard':
+        specifier: 0.3.6
+        version: 0.3.6
     devDependencies:
       '@types/cross-spawn':
         specifier: 6.0.6
@@ -536,10 +540,6 @@ importers:
       vitest:
         specifier: 4.1.0
         version: 4.1.0(@types/node@24.12.4)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
-    optionalDependencies:
-      '@mariozechner/clipboard':
-        specifier: 0.3.6
-        version: 0.3.6
 
   packages/pi-tui:
     dependencies:
@@ -6412,26 +6412,11 @@ snapshots:
 
   '@anthropic-ai/sdk@0.52.0': {}
 
-  '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
-
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-
-  '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.76)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      google-auth-library: 9.15.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-      - zod
 
   '@anthropic-ai/vertex-sdk@0.14.4(zod@4.4.3)':
     dependencies:
@@ -7312,19 +7297,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.6.1
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
@@ -7640,29 +7612,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -11570,11 +11519,6 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
-
-  openai@6.26.0(ws@8.21.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 3.25.76
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1269,11 +1269,14 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   // A transient provider-error pause intentionally leaves the paused badge
   // visible so the user still has a resumable auto-mode signal on screen.
   if (!s.paused) {
-    if (preserveStepSurface) {
-      s.preserveStepSurfaceAfterLoopExit = false;
-    } else if (preserveCompletionSurface) {
+    if (preserveCompletionSurface) {
       ctx.ui.setStatus("gsd-auto", undefined);
       s.completionStopInProgress = false;
+      if (preserveStepSurface) {
+        s.preserveStepSurfaceAfterLoopExit = false;
+      }
+    } else if (preserveStepSurface) {
+      s.preserveStepSurfaceAfterLoopExit = false;
     } else {
       ctx.ui.setStatus("gsd-auto", undefined);
       ctx.ui.setWidget("gsd-progress", undefined);

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1353,7 +1353,9 @@ export async function autoLoop(
       stuckStatePersistedThisIteration = true;
       finishTurn("completed");
       if (finalizeDecision.action === "complete-and-break") {
-        s.preserveStepSurfaceAfterLoopExit = true;
+        if (!s.completionStopInProgress) {
+          s.preserveStepSurfaceAfterLoopExit = true;
+        }
         break;
       }
     } catch (loopErr) {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1284,7 +1284,7 @@ export async function autoLoop(
         unitId: iterData.unitId,
       });
       const finalizeReason = finalizeResult.action === "break" ? finalizeResult.reason : undefined;
-      const finalizeStatus = finalizeReason === "step-wizard"
+      const finalizeStatus = (finalizeReason === "step-wizard" || finalizeReason === "milestone-complete")
         ? "completed"
         : finalizeResult.action === "next"
           ? "completed"

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -3170,5 +3170,15 @@ export async function runFinalize(
     }
   }
 
+  if (preUnitSnapshot?.type === "complete-milestone" && s.currentMilestoneId) {
+    await deps.stopAuto(ctx, pi, `Milestone ${s.currentMilestoneId} complete`, {
+      completionWidget: {
+        milestoneId: s.currentMilestoneId,
+        milestoneTitle: iterData.midTitle,
+      },
+    });
+    return { action: "break", reason: "milestone-complete" };
+  }
+
   return { action: "next", data: undefined as void };
 }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -3171,6 +3171,9 @@ export async function runFinalize(
   }
 
   if (preUnitSnapshot?.type === "complete-milestone" && s.currentMilestoneId) {
+    // cleanupAfterLoopExit skips gsd-progress when preserveCompletionSurface is true, so clear stale controls here.
+    ctx.ui.setStatus?.("gsd-step", undefined);
+    ctx.ui.setWidget?.("gsd-progress", undefined);
     await deps.stopAuto(ctx, pi, `Milestone ${s.currentMilestoneId} complete`, {
       completionWidget: {
         milestoneId: s.currentMilestoneId,

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -284,6 +284,7 @@ const COMPLETE_AND_BREAK_REASONS = [
   "verification-pause",
   "finalize-pre-timeout",
   "finalize-post-timeout",
+  "milestone-complete",
 ] as const;
 
 function isCompleteAndBreakReason(

--- a/src/resources/extensions/gsd/closeout-wizard.ts
+++ b/src/resources/extensions/gsd/closeout-wizard.ts
@@ -5,6 +5,7 @@ import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import type { NextAction } from "../shared/next-action-ui.js";
 import type { GSDState } from "./types.js";
+import { setAutoOutcomeWidget } from "./auto-dashboard.js";
 import { invalidateAllCaches } from "./cache.js";
 import { mergeCompletedMilestone } from "./parallel-merge.js";
 import { cleanupQuickBranch, detectStrandedQuickBranch, type StrandedQuickBranch } from "./quick.js";
@@ -20,6 +21,13 @@ export interface CloseoutContext {
   strandedQuick: StrandedQuickBranch | null;
   unmergedMilestones: UnmergedMilestoneBlocker[];
 }
+
+const MILESTONE_MERGE_CLOSEOUT_COMMANDS = [
+  "/gsd status for overview",
+  "/gsd visualize to inspect",
+  "/gsd notifications for history",
+  "/gsd start for new work",
+];
 
 export async function loadCloseoutContext(basePath: string): Promise<CloseoutContext> {
   const unmergedMilestones = await findUnmergedCompletedMilestones(basePath);
@@ -91,6 +99,23 @@ export function buildIdleMenuSummary(state: GSDState, closeout: CloseoutContext)
   return [state.nextAction || "No active milestone."];
 }
 
+export function showMilestoneMergeCloseout(
+  ctx: ExtensionCommandContext,
+  blocker: UnmergedMilestoneBlocker,
+): void {
+  ctx.ui.setStatus?.("gsd-auto", undefined);
+  ctx.ui.setStatus?.("gsd-step", undefined);
+  ctx.ui.setWidget?.("gsd-progress", undefined);
+
+  setAutoOutcomeWidget(ctx, {
+    status: "complete",
+    title: `Milestone ${blocker.milestoneId} merged`,
+    detail: `Merged ${blocker.branch} into ${blocker.integrationBranch}. Product changes are now on ${blocker.integrationBranch}.`,
+    nextAction: "Review the closeout, then start the next milestone when ready.",
+    commands: MILESTONE_MERGE_CLOSEOUT_COMMANDS,
+  });
+}
+
 export async function runMergeQuickTask(
   ctx: ExtensionCommandContext,
   basePath: string,
@@ -113,6 +138,33 @@ export async function runMergeQuickTask(
   return false;
 }
 
+export async function runMergeMilestoneBlocker(
+  ctx: ExtensionCommandContext,
+  basePath: string,
+  blocker: UnmergedMilestoneBlocker,
+): Promise<boolean> {
+  ctx.ui.notify(
+    `Completing preserved milestone merge for ${blocker.milestoneId} from ${blocker.branch} into ${blocker.integrationBranch}.`,
+    "info",
+  );
+  const result = await mergeCompletedMilestone(basePath, blocker.milestoneId);
+  if (result.success) {
+    invalidateAllCaches();
+    showMilestoneMergeCloseout(ctx, blocker);
+    ctx.ui.notify(
+      `Milestone ${blocker.milestoneId} merged to ${blocker.integrationBranch}. Closeout is complete.`,
+      "info",
+    );
+    return true;
+  }
+
+  ctx.ui.notify(
+    `Milestone ${blocker.milestoneId} merge failed: ${result.error ?? "unknown error"}`,
+    "error",
+  );
+  return false;
+}
+
 export async function runMergeMilestone(
   ctx: ExtensionCommandContext,
   basePath: string,
@@ -127,25 +179,7 @@ export async function runMergeMilestone(
     return false;
   }
 
-  ctx.ui.notify(
-    `Completing preserved milestone merge for ${blocker.milestoneId} from ${blocker.branch} into ${blocker.integrationBranch}.`,
-    "info",
-  );
-  const result = await mergeCompletedMilestone(basePath, blocker.milestoneId);
-  if (result.success) {
-    ctx.ui.notify(
-      `Milestone ${blocker.milestoneId} merged to ${blocker.integrationBranch}. Run /gsd again when ready.`,
-      "info",
-    );
-    invalidateAllCaches();
-    return true;
-  }
-
-  ctx.ui.notify(
-    `Milestone ${blocker.milestoneId} merge failed: ${result.error ?? "unknown error"}`,
-    "error",
-  );
-  return false;
+  return runMergeMilestoneBlocker(ctx, basePath, blocker);
 }
 
 export async function handleCloseoutChoice(

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -19,7 +19,7 @@ import { handleSessionReport } from "../../commands-session-report.js";
 import { handlePrBranch } from "../../commands-pr-branch.js";
 import { currentDirectoryRoot, projectRoot } from "../context.js";
 import { findUnmergedCompletedMilestones } from "../../unmerged-milestone-guard.js";
-import { mergeCompletedMilestone } from "../../parallel-merge.js";
+import { runMergeMilestoneBlocker } from "../../closeout-wizard.js";
 
 async function handleCompletedMilestoneRecovery(
   phase: string,
@@ -37,22 +37,7 @@ async function handleCompletedMilestoneRecovery(
     : blockers[0];
   if (!blocker) return false;
 
-  ctx.ui.notify(
-    `Completing preserved milestone merge for ${blocker.milestoneId} from ${blocker.branch} into ${blocker.integrationBranch}.`,
-    "info",
-  );
-  const result = await mergeCompletedMilestone(basePath, blocker.milestoneId);
-  if (result.success) {
-    ctx.ui.notify(
-      `Milestone ${blocker.milestoneId} merged to ${blocker.integrationBranch}. Run /gsd again when ready.`,
-      "info",
-    );
-  } else {
-    ctx.ui.notify(
-      `Milestone ${blocker.milestoneId} merge recovery failed: ${result.error}`,
-      "error",
-    );
-  }
+  await runMergeMilestoneBlocker(ctx, basePath, blocker);
   return true;
 }
 

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -12,7 +12,7 @@
 import { readFileSync, existsSync, mkdirSync } from "node:fs";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus } from "./status-guards.js";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { createRequire } from "node:module";
 import {
   getAllMilestones,
@@ -380,6 +380,7 @@ export async function renderPlanFromDb(
   basePath: string,
   milestoneId: string,
   sliceId: string,
+  outputPath?: string,
 ): Promise<{ planPath: string; taskPlanPaths: string[]; content: string }> {
   const slice = getSlice(milestoneId, sliceId);
   if (!slice) {
@@ -391,9 +392,16 @@ export async function renderPlanFromDb(
     throw new Error(`no tasks found for ${milestoneId}/${sliceId}`);
   }
 
-  const slicePath = join(gsdProjectionRoot(basePath), "milestones", milestoneId, "slices", sliceId);
-  mkdirSync(slicePath, { recursive: true });
-  const absPath = join(slicePath, `${sliceId}-PLAN.md`);
+  const defaultPlanPath = join(
+    gsdProjectionRoot(basePath),
+    "milestones",
+    milestoneId,
+    "slices",
+    sliceId,
+    `${sliceId}-PLAN.md`,
+  );
+  const absPath = outputPath ?? defaultPlanPath;
+  mkdirSync(dirname(absPath), { recursive: true });
   const artifactPath = toArtifactPath(absPath, basePath);
   const sliceGates = getGateResults(milestoneId, sliceId, "slice");
   const content = renderSlicePlanMarkdown(slice, tasks, sliceGates);
@@ -508,6 +516,7 @@ export async function renderPlanCheckboxes(
   basePath: string,
   milestoneId: string,
   sliceId: string,
+  outputPath?: string,
 ): Promise<boolean> {
   const tasks = getSliceTasks(milestoneId, sliceId);
   if (tasks.length === 0) {
@@ -517,7 +526,7 @@ export async function renderPlanCheckboxes(
     return false;
   }
 
-  await renderPlanFromDb(basePath, milestoneId, sliceId);
+  await renderPlanFromDb(basePath, milestoneId, sliceId, outputPath);
   return true;
 }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -63,10 +63,14 @@ function isRepairableStaleRenderReason(reason: string): boolean {
 
 function canonicalizeMilestoneId(dirSegment: string): string {
   if (getMilestone(dirSegment)) return dirSegment;
-  // Descriptor layout: e.g. M001-old → M001; M001-a1b2c3 → M001
-  const canonical = dirSegment.match(/^(M\d+(?:-[a-z0-9]{6})?)/i)?.[1];
-  if (canonical && getMilestone(canonical)) return canonical;
-  return canonical ?? dirSegment;
+  const suffixId = dirSegment.match(/^(M\d+-[a-z0-9]{6})(?:$|-)/)?.[1];
+  if (suffixId && getMilestone(suffixId)) return suffixId;
+
+  // Descriptor layout: e.g. M001-DESCRIPTOR → M001
+  const baseId = dirSegment.match(/^(M\d+)(?:$|-)/i)?.[1];
+  if (baseId && getMilestone(baseId)) return baseId;
+
+  return suffixId ?? baseId ?? dirSegment;
 }
 
 function resolveRoadmapMilestoneIdFromPath(normPath: string): string {
@@ -115,7 +119,12 @@ async function repairStaleRenderFromBasePath(
       );
     }
     const milestoneId = canonicalizeMilestoneId(pathMatch[1]);
-    const wrote = await renderPlanCheckboxes(basePath, milestoneId, pathMatch[2]);
+    const wrote = await renderPlanCheckboxes(
+      basePath,
+      milestoneId,
+      pathMatch[2],
+      record.renderPath,
+    );
     if (!wrote) {
       throw new Error(
         `stale-render drift: plan re-render wrote nothing for ${milestoneId}/${pathMatch[2]} ` +

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -173,6 +173,38 @@ test("cleanupAfterLoopExit preserves completion closeout surface after stopAuto 
   }
 });
 
+test("cleanupAfterLoopExit clears completionStopInProgress even when preserveStepSurfaceAfterLoopExit is also set", async () => {
+  const statusCalls: unknown[] = [];
+  const widgetCalls: unknown[] = [];
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = false;
+  autoSession.completionStopInProgress = true;
+  autoSession.preserveStepSurfaceAfterLoopExit = true;
+
+  try {
+    await cleanupAfterLoopExit({
+      hasUI: true,
+      ui: {
+        setStatus: (...args: unknown[]) => statusCalls.push(args),
+        setWidget: (...args: unknown[]) => widgetCalls.push(args),
+        setHeader: () => {},
+        notify: () => {},
+      },
+    } as any);
+
+    assert.equal(
+      autoSession.completionStopInProgress,
+      false,
+      "completionStopInProgress must be cleared even when preserveStepSurfaceAfterLoopExit was also set",
+    );
+    assert.equal(autoSession.preserveStepSurfaceAfterLoopExit, false);
+  } finally {
+    autoSession.reset();
+  }
+});
+
 test("pauseAuto preserves artifact retry counts across pause/resume", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-pause-retry-count-"));
   const previousCwd = process.cwd();

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -207,6 +207,7 @@ test("runFinalize merges a verified complete-milestone immediately and only once
   const startedAt = Date.now();
   let lifecycleMergeCalls = 0;
   let resolverMergeCalls = 0;
+  const stopAutoCalls: Array<{ reason?: string; options?: unknown }> = [];
   s.basePath = base;
   s.originalBasePath = base;
   s.currentMilestoneId = "M001";
@@ -219,6 +220,9 @@ test("runFinalize merges a verified complete-milestone immediately and only once
   const result = await runFinalizeWithDeps(s, {
     preflightCleanRoot: () => ({ stashPushed: false }),
     postflightPopStash: () => ({ needsManualRecovery: false }),
+    stopAuto: async (_ctx: unknown, _pi: unknown, reason?: string, options?: unknown) => {
+      stopAutoCalls.push({ reason, options });
+    },
     resolver: {
       mergeAndExit() {
         resolverMergeCalls++;
@@ -232,10 +236,19 @@ test("runFinalize merges a verified complete-milestone immediately and only once
     },
   });
 
-  assert.equal(result.action, "next");
+  assert.equal(result.action, "break");
+  assert.equal(result.reason, "milestone-complete");
   assert.equal(lifecycleMergeCalls, 1);
   assert.equal(resolverMergeCalls, 0);
   assert.equal(s.milestoneMergedInPhases, true);
+  assert.equal(stopAutoCalls.length, 1);
+  assert.equal(stopAutoCalls[0]?.reason, "Milestone M001 complete");
+  assert.deepEqual(stopAutoCalls[0]?.options, {
+    completionWidget: {
+      milestoneId: "M001",
+      milestoneTitle: "Milestone",
+    },
+  });
 
   s.currentUnit = {
     type: "complete-milestone",
@@ -245,6 +258,9 @@ test("runFinalize merges a verified complete-milestone immediately and only once
   const second = await runFinalizeWithDeps(s, {
     preflightCleanRoot: () => ({ stashPushed: false }),
     postflightPopStash: () => ({ needsManualRecovery: false }),
+    stopAuto: async (_ctx: unknown, _pi: unknown, reason?: string, options?: unknown) => {
+      stopAutoCalls.push({ reason, options });
+    },
     resolver: {
       mergeAndExit() {
         resolverMergeCalls++;
@@ -258,9 +274,11 @@ test("runFinalize merges a verified complete-milestone immediately and only once
     },
   });
 
-  assert.equal(second.action, "next");
+  assert.equal(second.action, "break");
+  assert.equal(second.reason, "milestone-complete");
   assert.equal(lifecycleMergeCalls, 1);
   assert.equal(resolverMergeCalls, 0);
+  assert.equal(stopAutoCalls.length, 2);
 });
 
 test("runFinalize does not render next-phase handoff for complete-milestone", async (t) => {
@@ -302,7 +320,7 @@ test("runFinalize does not render next-phase handoff for complete-milestone", as
     },
   );
 
-  assert.equal(result.action, "next");
+  assert.equal(result.action, "break");
   assert.equal(
     widgetCalls.some(([key]) => key === "gsd-outcome"),
     false,

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -328,6 +328,60 @@ test("runFinalize does not render next-phase handoff for complete-milestone", as
   );
 });
 
+test("runFinalize clears gsd-step and gsd-progress before stopAuto on complete-milestone", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-finalize-stale-widget-"));
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const s = new AutoSession();
+  s.basePath = base;
+  s.originalBasePath = base;
+  s.currentMilestoneId = "M001";
+  s.currentUnit = {
+    type: "complete-milestone",
+    id: "M001",
+    startedAt: Date.now(),
+  };
+
+  const statusCalls: Array<[string, unknown]> = [];
+  const widgetCalls: Array<[string, unknown]> = [];
+
+  await runFinalizeWithDeps(
+    s,
+    {
+      preflightCleanRoot: () => ({ stashPushed: false }),
+      postflightPopStash: () => ({ needsManualRecovery: false }),
+      lifecycle: {
+        exitMilestone() {
+          return { ok: true, merged: true, codeFilesChanged: false };
+        },
+      },
+    },
+    {
+      hasUI: true,
+      ui: {
+        notify() {},
+        setStatus(key: string, value: unknown) {
+          statusCalls.push([key, value]);
+        },
+        setWidget(key: string, value: unknown) {
+          widgetCalls.push([key, value]);
+        },
+      },
+    },
+  );
+
+  assert.ok(
+    statusCalls.some(([key, val]) => key === "gsd-step" && val === undefined),
+    "gsd-step status should be cleared before stopAuto",
+  );
+  assert.ok(
+    widgetCalls.some(([key, val]) => key === "gsd-progress" && val === undefined),
+    "gsd-progress widget should be cleared before stopAuto",
+  );
+});
+
 test("runFinalize stops before merge when an isolated unit leaks app files into project root", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "gsd-root-leak-root-"));
   const worktree = join(root, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tests/closeout-wizard.test.ts
+++ b/src/resources/extensions/gsd/tests/closeout-wizard.test.ts
@@ -8,6 +8,7 @@ import {
   buildCloseoutMenuActions,
   buildIdleMenuSummary,
   getPrimaryCloseoutRecommendation,
+  showMilestoneMergeCloseout,
 } from "../closeout-wizard.ts";
 import { buildGsdHomeModel } from "../gsd-command-home.ts";
 import type { GSDState } from "../types.ts";
@@ -118,4 +119,47 @@ test("/gsd home recommends merge milestone when closeout is pending", () => {
   const merge = model.actions.find((action) => action.id === "finish_milestone");
   assert.equal(merge?.recommended, true);
   assert.equal(merge?.enabled, true);
+});
+
+test("milestone merge closeout clears stale timer controls and installs the closeout outcome", () => {
+  const statuses: Array<[string, string | undefined]> = [];
+  const widgets: Array<[string, unknown]> = [];
+
+  showMilestoneMergeCloseout({
+    hasUI: true,
+    ui: {
+      setStatus: (key: string, value: string | undefined) => {
+        statuses.push([key, value]);
+      },
+      setWidget: (key: string, value: unknown) => {
+        widgets.push([key, value]);
+      },
+    },
+  } as any, {
+    milestoneId: "M004",
+    branch: "milestone/M004",
+    integrationBranch: "main",
+    files: ["src/app.ts"],
+    dirtyOverlap: [],
+  });
+
+  assert.deepEqual(statuses, [
+    ["gsd-auto", undefined],
+    ["gsd-step", undefined],
+  ]);
+  assert.ok(
+    widgets.some(([key, value]) => key === "gsd-progress" && value === undefined),
+    "stale progress/timer widget should be cleared",
+  );
+  const outcome = widgets.find(([key]) => key === "gsd-outcome")?.[1];
+  assert.equal(typeof outcome, "function");
+
+  const component = (outcome as any)(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  const rendered = component.render(100).join("\n");
+  assert.match(rendered, /Milestone M004 merged/);
+  assert.match(rendered, /Review the closeout/);
+  assert.doesNotMatch(rendered, /\/gsd auto/);
 });

--- a/src/resources/extensions/gsd/tests/commands-dispatcher-unmerged-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-dispatcher-unmerged-milestone.test.ts
@@ -40,6 +40,7 @@ function makeMockCtx(base: string): {
   return {
     ctx: {
       cwd: base,
+      hasUI: true,
       ui: {
         notify: (message: string, kind: string) => {
           calls.push({ message, kind });
@@ -217,7 +218,7 @@ test("dispatcher recovers a completed unmerged milestone through complete-milest
   const base = makeTempRepo("gsd-dispatch-unmerged-");
   try {
     seedRegisteredCompletedWorktree(base);
-    const { ctx, calls } = makeMockCtx(base);
+    const { ctx, calls, widgets, statuses } = makeMockCtx(base);
     const { pi, messages } = makeMockPi();
 
     await handleGSDCommand("dispatch complete-milestone M008", ctx, pi);
@@ -230,6 +231,30 @@ test("dispatcher recovers a completed unmerged milestone through complete-milest
     assert.ok(
       calls.some((call) => call.message.includes("Milestone M008 merged to main")),
       "user sees merge recovery success",
+    );
+    assert.ok(
+      calls.some((call) => call.message.includes("Closeout is complete")),
+      "merge recovery ends at a closeout-complete message",
+    );
+    assert.ok(
+      calls.every((call) => !call.message.includes("Run /gsd again when ready")),
+      "merge recovery must not send the user past the closeout endpoint",
+    );
+    assert.ok(
+      statuses.some(([key, value]) => key === "gsd-auto" && value === undefined),
+      "merge recovery clears stale auto status so the run timer stops",
+    );
+    assert.ok(
+      statuses.some(([key, value]) => key === "gsd-step" && value === undefined),
+      "merge recovery clears stale step status",
+    );
+    assert.ok(
+      widgets.some(([key, value]) => key === "gsd-progress" && value === undefined),
+      "merge recovery clears stale progress/timer controls",
+    );
+    assert.ok(
+      widgets.some(([key, value]) => key === "gsd-outcome" && typeof value === "function"),
+      "merge recovery installs a durable closeout outcome",
     );
     assert.equal(readFileSync(join(base, "index.html"), "utf-8"), "<h1>M008</h1>\n");
     assert.equal(git(base, "branch", "--list", "milestone/M008"), "");

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -172,6 +172,13 @@ test("decideFinalizeResult maps step-wizard breaks to completed step exits", () 
   );
 });
 
+test("decideFinalizeResult maps milestone-complete breaks to completed exits", () => {
+  assert.deepEqual(
+    decideFinalizeResult({ action: "break", reason: "milestone-complete" }),
+    { action: "complete-and-break" },
+  );
+});
+
 test("decideFinalizeResult maps finalize pause breaks to completed exits", () => {
   for (const reason of [
     "post-verification-stopped",

--- a/tests/e2e/multi-milestone-sequence.e2e.test.ts
+++ b/tests/e2e/multi-milestone-sequence.e2e.test.ts
@@ -1,5 +1,5 @@
 // Project/App: gsd-pi
-// File Purpose: E2E gate for headless multi-milestone sequencing through auto-mode.
+// File Purpose: E2E gate for headless multi-milestone closeout boundaries through auto-mode.
 
 import { execFileSync } from "node:child_process";
 import assert from "node:assert/strict";
@@ -56,14 +56,14 @@ function pushText(turns: TranscriptTurn[], text: string, expect?: TranscriptTurn
 	});
 }
 
-function slicePlanInput(milestoneId: "M001" | "M002", file: string, verify: string, expected: string): Record<string, unknown> {
+function slicePlanInput(file: string, verify: string, expected: string): Record<string, unknown> {
 	return {
-		milestoneId,
+		milestoneId: "M001",
 		sliceId: "S01",
 		goal: `Update ${file} and verify the behavior.`,
 		successCriteria: expected,
 		proofLevel: `Run ${verify}.`,
-		integrationClosure: milestoneId === "M002" ? "Full fixture command passes after both milestones." : "Focused source behavior only.",
+		integrationClosure: "Focused source behavior only.",
 		observabilityImpact: "None.",
 		tasks: [{
 			taskId: "T01",
@@ -80,7 +80,6 @@ function slicePlanInput(milestoneId: "M001" | "M002", file: string, verify: stri
 }
 
 function completeTaskInput(
-	milestoneId: "M001" | "M002",
 	file: string,
 	verify: string,
 	oneLiner: string,
@@ -88,7 +87,7 @@ function completeTaskInput(
 	return {
 		taskId: "T01",
 		sliceId: "S01",
-		milestoneId,
+		milestoneId: "M001",
 		oneLiner,
 		narrative: `Changed ${file} and verified it with ${verify}.`,
 		verification: `${verify} exited 0.`,
@@ -107,7 +106,6 @@ function completeTaskInput(
 }
 
 function completeSliceInput(
-	milestoneId: "M001" | "M002",
 	title: string,
 	file: string,
 	verify: string,
@@ -115,7 +113,7 @@ function completeSliceInput(
 ): Record<string, unknown> {
 	return {
 		sliceId: "S01",
-		milestoneId,
+		milestoneId: "M001",
 		sliceTitle: title,
 		oneLiner,
 		narrative: `The planned task changed ${file} and verified it with ${verify}.`,
@@ -131,13 +129,12 @@ function completeSliceInput(
 }
 
 function validationInput(
-	milestoneId: "M001" | "M002",
 	success: string,
 	integration: string,
 	requirements: string,
 ): Record<string, unknown> {
 	return {
-		milestoneId,
+		milestoneId: "M001",
 		verdict: "pass",
 		remediationRound: 0,
 		successCriteriaChecklist: success,
@@ -150,21 +147,20 @@ function validationInput(
 }
 
 function completionInput(
-	milestoneId: "M001" | "M002",
 	title: string,
 	oneLiner: string,
 	narrative: string,
 	keyFile: string,
 ): Record<string, unknown> {
 	return {
-		milestoneId,
+		milestoneId: "M001",
 		title,
 		oneLiner,
 		narrative,
 		verificationPassed: true,
 		successCriteriaResults: "- PASS: planned source behavior is present.\n- PASS: validation passed before completion.",
 		definitionOfDoneResults: "- PASS: source module changed.\n- PASS: slice and task completed.\n- PASS: milestone validation passed.",
-		requirementOutcomes: `${milestoneId === "M001" ? "R001" : "R002"} satisfied by ${milestoneId}/S01/T01.`,
+		requirementOutcomes: "R001 satisfied by M001/S01/T01.",
 		keyDecisions: ["Let the dispatcher activate the next milestone only after the prior milestone is complete."],
 		keyFiles: [keyFile],
 		lessonsLearned: ["Milestone sequencing should be validated through real auto-mode dispatch boundaries."],
@@ -206,7 +202,7 @@ function buildTranscript(): string {
 	pushTool(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The status module returns the requested done value after M001 completes.",
-		why: "M002 proves the workflow activates downstream milestones after closeout.",
+		why: "M002 proves downstream work remains queued after M001 closeout.",
 		source: "spec",
 		status: "active",
 		primary_owner: "M002/S01",
@@ -247,7 +243,7 @@ function buildTranscript(): string {
 			"## Done",
 			"- `src/answer.js` returns `ready`.",
 			"- `node --test test/answer.test.js` exits 0.",
-			"- M001 validates and completes before M002 activates.",
+			"- M001 validates and completes before M002 planning.",
 			"",
 		].join("\n"),
 	}, "m001-context", { hasToolResultFor: "ask_user_questions" });
@@ -268,7 +264,7 @@ function buildTranscript(): string {
 			integrationClosure: "Focused module behavior only.",
 			observabilityImpact: "None.",
 		}],
-		successCriteria: ["answer() returns ready.", "M001 completes before M002 activates."],
+		successCriteria: ["answer() returns ready.", "M001 stops at closeout before M002 planning."],
 		keyRisks: [{
 			risk: "M002 could activate before M001 is durably complete.",
 			whyItMatters: "Milestone sequencing depends on closeout state agreement.",
@@ -279,7 +275,7 @@ function buildTranscript(): string {
 			whatWillBeProven: "M001 completes after verification and validation.",
 		}],
 		verificationContract: "Focused node:test command exits 0.",
-		verificationIntegration: "M002 verifies the full fixture after M001.",
+		verificationIntegration: "M002 remains queued for the next command after M001.",
 		verificationOperational: "Headless process exits 0 without blocked or error notifications.",
 		verificationUat: "Slice UAT summary records pass verdict.",
 		definitionOfDone: ["`src/answer.js` is changed.", "M001 validation passes.", "M001 completion is durable."],
@@ -344,7 +340,7 @@ function buildTranscript(): string {
 		content: "# S01 - Research\n\nUse `src/answer.js` and verify with `node --test test/answer.test.js`.\n",
 	}, "m001-s01-research");
 	pushText(turns, "M001/S01 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("M001", "src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "m001-s01-plan");
+	pushTool(turns, "gsd_plan_slice", slicePlanInput("src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "m001-s01-plan");
 	pushText(turns, "M001/S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
 	pushTool(turns, "write", {
 		path: "src/answer.js",
@@ -354,98 +350,23 @@ function buildTranscript(): string {
 		command: "node --test test/answer.test.js",
 		timeout: 30,
 	}, "verify-answer", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("M001", "src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "m001-task", { hasToolResultFor: "bash" });
+	pushTool(turns, "gsd_task_complete", completeTaskInput("src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "m001-task", { hasToolResultFor: "bash" });
 	pushText(turns, "M001/S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("M001", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "m001-slice");
+	pushTool(turns, "gsd_slice_complete", completeSliceInput("Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "m001-slice");
 	pushText(turns, "M001/S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
 	pushTool(turns, "gsd_validate_milestone", validationInput(
-		"M001",
-		"- PASS: answer() returns ready.\n- PASS: M001 completes before M002 activates.",
-		"M001 is a focused source change; M002 performs the downstream full fixture verification.",
+		"- PASS: answer() returns ready.\n- PASS: M001 stops before M002 planning.",
+		"M001 is a focused source change; M002 remains queued for a later command.",
 		"R001 is covered by M001/S01/T01.",
 	), "m001-validation");
 	pushText(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
 	pushTool(turns, "gsd_complete_milestone", completionInput(
-		"M001",
 		"Answer Ready",
 		"Updated answer() to return ready and validated M001.",
 		"M001 completed its source change, focused verification, slice closeout, milestone validation, and milestone completion before M002 work began.",
 		"src/answer.js",
 	), "m001-complete");
 	pushText(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
-
-	pushTool(turns, "gsd_summary_save", {
-		milestone_id: "M002",
-		artifact_type: "RESEARCH",
-		content: "# M002 - Research\n\nM001 is complete. Use `src/status.js` and verify both modules with `npm test`.\n",
-	}, "m002-research");
-	pushText(turns, "Milestone M002 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_milestone", {
-		milestoneId: "M002",
-		title: "Status Done",
-		vision: "Second source behavior change that verifies both milestones together.",
-		status: "active",
-		dependsOn: ["M001"],
-		slices: [{
-			sliceId: "S01",
-			title: "Update status module",
-			risk: "low",
-			depends: [],
-			demo: "Calling status() returns done and the full fixture test suite passes.",
-			goal: "Change the status module and verify the full fixture.",
-			successCriteria: "status() returns done and answer() still returns ready.",
-			proofLevel: "Full command exits 0.",
-			integrationClosure: "Both milestone source changes are verified by one command.",
-			observabilityImpact: "None.",
-		}],
-		successCriteria: ["status() returns done.", "answer() still returns ready.", "Both milestones complete."],
-		keyRisks: [{
-			risk: "The workflow may stop after M001 instead of activating M002.",
-			whyItMatters: "Multi-milestone specs need sequential closeout without manual recovery.",
-		}],
-		proofStrategy: [{
-			riskOrUnknown: "M002 activation after M001 completion",
-			retireIn: "S01",
-			whatWillBeProven: "M002 plans, executes, validates, and completes after M001.",
-		}],
-		verificationContract: "Full node:test command exits 0.",
-		verificationIntegration: "The full fixture command verifies both source modules together.",
-		verificationOperational: "Headless process exits 0 without blocked or error notifications.",
-		verificationUat: "Slice UAT summary records pass verdict.",
-		definitionOfDone: ["`src/status.js` is changed.", "`npm test` passes.", "M002 validation and completion are durable."],
-		requirementCoverage: "R002 is owned by M002/S01. R001 remains covered by M001/S01.",
-		boundaryMapMarkdown: "| Boundary | Decision |\n| --- | --- |\n| M001 -> M002 | `npm test` proves M001 behavior still holds while M002 changes status. |\n",
-	}, "m002-roadmap");
-	pushText(turns, "Milestone M002 planned.", { hasToolResultFor: "gsd_plan_milestone" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("M002", "src/status.js", "npm test", "status() returns done."), "m002-s01-plan");
-	pushText(turns, "M002/S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
-	pushTool(turns, "write", {
-		path: "src/status.js",
-		content: "export function status() {\n\treturn \"done\";\n}\n",
-	}, "write-status");
-	pushTool(turns, "bash", {
-		command: "npm test",
-		timeout: 30,
-	}, "verify-status", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("M002", "src/status.js", "npm test", "Updated status() to return done."), "m002-task", { hasToolResultFor: "bash" });
-	pushText(turns, "M002/S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("M002", "Update status module", "src/status.js", "npm test", "status() now returns done."), "m002-slice");
-	pushText(turns, "M002/S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
-	pushTool(turns, "gsd_validate_milestone", validationInput(
-		"M002",
-		"- PASS: status() returns done.\n- PASS: answer() still returns ready.\n- PASS: both milestones complete.",
-		"The M002 `npm test` command verifies both milestone source modules together.",
-		"R002 is covered by M002/S01/T01; R001 remained covered by M001/S01/T01.",
-	), "m002-validation");
-	pushText(turns, "Milestone M002 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
-	pushTool(turns, "gsd_complete_milestone", completionInput(
-		"M002",
-		"Status Done",
-		"Updated status() to return done and verified both milestones together.",
-		"M002 activated after M001 completed, planned the status source change, verified the full fixture, validated the milestone, and completed the sequence.",
-		"src/status.js",
-	), "m002-complete");
-	pushText(turns, "Milestone M002 complete.", { hasToolResultFor: "gsd_complete_milestone" });
 
 	return writeTranscript(turns);
 }
@@ -454,7 +375,7 @@ describe("multi-milestone sequence e2e (fake LLM)", () => {
 	const avail = binaryAvailable();
 	const skipReason = avail.ok ? null : avail.reason;
 
-	test("headless new-milestone --auto completes M001 then M002", { skip: skipReason ?? false, timeout: 300_000 }, (t) => {
+	test("headless new-milestone --auto stops at M001 closeout before M002", { skip: skipReason ?? false, timeout: 300_000 }, (t) => {
 		const project = createTmpProject({
 			git: true,
 			files: {
@@ -559,20 +480,20 @@ describe("multi-milestone sequence e2e (fake LLM)", () => {
 		assert.deepEqual(badOperatorSignals, [], `unexpected blocked/error operator signals: ${badOperatorSignals.join("\n")}`);
 		assert.deepEqual(toolErrors, [], `unexpected tool errors:\n${toolErrors.join("\n")}`);
 		assert.equal(toolNames.filter((toolName) => toolName === "gsd_milestone_generate_id").length, 2, "multi-milestone planning must generate two IDs");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_plan_milestone").length, 2, "both milestones must be planned through the workflow tool");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_validate_milestone").length, 2, "both milestones must validate before completion");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_complete_milestone").length, 2, "both milestones must complete");
+		assert.equal(toolNames.filter((toolName) => toolName === "gsd_plan_milestone").length, 1, "auto stops at M001 closeout before planning M002");
+		assert.equal(toolNames.filter((toolName) => toolName === "gsd_validate_milestone").length, 1, "auto validates only M001 before stopping");
+		assert.equal(toolNames.filter((toolName) => toolName === "gsd_complete_milestone").length, 1, "auto completes only M001 before stopping");
 		assert.equal(discussionManifestWrites.length, 1, "multi-milestone discussion manifest must be written before auto execution");
 		assert.ok(
-			notifyMessages.some((message) => /auto-mode stopped/i.test(message) && /all milestones complete|milestone m002 complete/i.test(message)),
-			`expected terminal all-milestones completion notification, got:\n${notifyMessages.join("\n")}`,
+			notifyMessages.some((message) => /auto-mode stopped/i.test(message) && /milestone m001 complete/i.test(message)),
+			`expected M001 closeout stop notification, got:\n${notifyMessages.join("\n")}`,
 		);
 		assert.doesNotThrow(
-			() => execFileSync("npm", ["test"], { cwd: project.dir, stdio: "pipe" }),
-			"full fixture verification command must pass after both milestones complete",
+			() => execFileSync("node", ["--test", "test/answer.test.js"], { cwd: project.dir, stdio: "pipe" }),
+			"M001 focused verification command must pass after closeout",
 		);
 
-		for (const milestoneId of ["M001", "M002"]) {
+		for (const milestoneId of ["M001"]) {
 			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-CONTEXT.md`)), `${milestoneId} context artifact is present`);
 			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-ROADMAP.md`)), `${milestoneId} roadmap artifact is present`);
 			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-VALIDATION.md`)), `${milestoneId} validation artifact is present`);
@@ -580,22 +501,23 @@ describe("multi-milestone sequence e2e (fake LLM)", () => {
 			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, "slices", "S01", "S01-SUMMARY.md")), `${milestoneId}/S01 summary artifact is present`);
 			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, "slices", "S01", "tasks", "T01-SUMMARY.md")), `${milestoneId}/S01/T01 summary artifact is present`);
 		}
+		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M002", "M002-CONTEXT.md")), "M002 context artifact is queued");
+		assert.equal(existsSync(join(project.dir, ".gsd", "milestones", "M002", "M002-ROADMAP.md")), false, "M002 roadmap is not planned before the next command");
 
 		const db = new DatabaseSync(join(project.dir, ".gsd", "gsd.db"));
 		t.after(() => db.close());
-		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM milestones WHERE status = 'complete'"), "2");
+		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM milestones WHERE status = 'complete'"), "1");
 		assert.equal(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M001" }), "complete");
-		assert.equal(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M002" }), "complete");
-		assert.match(scalar(db, "SELECT depends_on AS value FROM milestones WHERE id = :id", { id: "M002" }) ?? "", /M001/);
-		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM slices WHERE status = 'complete'"), "2");
-		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM tasks WHERE status = 'complete'"), "2");
-		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM assessments WHERE scope = 'milestone-validation' AND status = 'pass'"), "2");
+		assert.notEqual(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M002" }), "complete");
+		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM slices WHERE status = 'complete'"), "1");
+		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM tasks WHERE status = 'complete'"), "1");
+		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM assessments WHERE scope = 'milestone-validation' AND status = 'pass'"), "1");
 		assert.equal(
 			scalar(
 				db,
 				"SELECT COUNT(*) AS value FROM quality_gates WHERE scope = 'milestone' AND task_id = '' AND status = 'complete' AND verdict = 'pass'",
 			),
-			"8",
+			"4",
 		);
 	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Stops auto-mode timer controls and renders the milestone closeout outcome when completing preserved milestone merges.
**Why:** Milestone merge recovery could send users past the intended closeout endpoint while stale timer UI kept showing a long-running session.
**How:** Reuses the closeout wizard merge path from dispatcher recovery, clears stale status/progress widgets, and stops auto finalization after complete-milestone merges.

## What

This updates the GSD milestone closeout path so preserved completed-milestone merges land on the closeout screen instead of telling the user to run `/gsd` again. It also clears stale auto-mode status/progress UI and adds regression coverage around dispatcher recovery, closeout rendering, and the auto finalizer lifecycle.

Affected areas:

- `src/resources/extensions/gsd/closeout-wizard.ts`
- `src/resources/extensions/gsd/commands/handlers/ops.ts`
- `src/resources/extensions/gsd/auto/phases.ts`
- focused GSD regression tests for closeout, dispatcher recovery, and auto finalization

## Why

A completed milestone merge could finish without restoring the intended closeout endpoint. In that state, stale timer controls could remain visible and make the session look like it had been running for hundreds of minutes after the work was actually complete.

## How

The dispatcher recovery path now delegates to the closeout wizard merge helper. Successful milestone merge recovery invalidates caches, clears stale timer/status UI, installs a durable closeout outcome widget, and gives the user closeout-oriented next commands.

The auto finalizer now treats a verified `complete-milestone` unit as a terminal boundary after merge by calling `stopAuto` with the milestone completion widget and breaking the loop, which resets the session timer state instead of continuing to the next auto step.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/closeout-wizard.test.ts src/resources/extensions/gsd/tests/commands-dispatcher-unmerged-milestone.test.ts src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783263982&installation_id=134682257&pr_number=507&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F507&signature=393cb94cf086744ff4f6f24d8091f5b20f7461d2a2a8dfd47c12a3f442d79bed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-loop termination, finalize/stopAuto UI cleanup, and milestone merge recovery paths—user-visible workflow boundaries with broad test coverage but non-trivial orchestration risk.
> 
> **Overview**
> **Milestone closeout is now a hard auto-mode boundary** instead of rolling into the next milestone. After a verified `complete-milestone` unit, finalize clears stale `gsd-step` / `gsd-progress` UI, calls `stopAuto` with the completion widget, and breaks the loop with reason `milestone-complete` (treated like other terminal finalize exits). `cleanupAfterLoopExit` prioritizes completion cleanup so `completionStopInProgress` resets even when step-surface preservation is also set.
> 
> **Preserved merge recovery lands on a real closeout screen.** Dispatcher `complete-milestone` recovery and closeout actions route through shared `runMergeMilestoneBlocker`, which invalidates caches, clears auto timer/status widgets, and installs a durable `gsd-outcome` closeout (no more “run `/gsd` again” as the endpoint).
> 
> **Supporting fixes:** plan re-renders during stale-render drift can target the on-disk path; milestone ID canonicalization in drift repair is tightened; the multi-milestone e2e now expects auto to stop after M001 only. Lockfile entries reflect zod 4 peer resolution and dependency block ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1063f1ceb684c9c61a9378c3c1bceda9072e3104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->