### PR TITLE
fix(gsd): persist new milestone question drafts

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: Registers GSD extension runtime hooks and token-saving tool policies.
 
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -12,7 +12,7 @@ import { ALWAYS_PRESERVED_SHIM_TOOL_NAMES } from "@gsd/pi-ai";
 import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-extension-api.js";
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
-import { buildMilestoneFileName, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
+import { buildMilestoneFileName, clearPathCache, milestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
 import { canonicalToolName, clearDiscussionFlowState, isDepthConfirmationAnswer, isMilestoneDepthVerified, isQueuePhaseActive, markApprovalGateVerified, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
@@ -495,6 +495,109 @@ function isContextDraftSummarySave(toolName: string, input: unknown): boolean {
   if (toolName !== "gsd_summary_save" && toolName !== "summary_save") return false;
   if (!input || typeof input !== "object") return false;
   return (input as { artifact_type?: unknown }).artifact_type === "CONTEXT-DRAFT";
+}
+
+type StructuredQuestion = {
+  id?: string;
+  header?: string;
+  question?: string;
+  options?: Array<{ label?: string; description?: string }>;
+};
+
+type StructuredAnswer = {
+  selected?: unknown;
+  notes?: unknown;
+};
+
+function selectedAnswerLabel(selected: unknown): string {
+  if (Array.isArray(selected)) return selected.map(String).join(", ");
+  if (selected == null) return "";
+  return String(selected);
+}
+
+function formatQuestionExchange(
+  questions: StructuredQuestion[],
+  answers: Record<string, StructuredAnswer> | undefined,
+): string {
+  const lines: string[] = [];
+  for (const question of questions) {
+    lines.push(`### ${question.header ?? "Question"}`, "", question.question ?? "");
+    if (Array.isArray(question.options)) {
+      lines.push("");
+      for (const opt of question.options) {
+        lines.push(`- **${opt.label ?? ""}** — ${opt.description ?? ""}`);
+      }
+    }
+
+    const answer = question.id ? answers?.[question.id] : undefined;
+    if (answer) {
+      lines.push("");
+      const selected = selectedAnswerLabel(answer.selected);
+      if (selected) lines.push(`**Selected:** ${selected}`);
+      if (answer.notes) lines.push(`**Notes:** ${String(answer.notes)}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+async function ensureMilestoneShell(basePath: string, milestoneId: string): Promise<string> {
+  const milestoneDir = resolveMilestonePath(basePath, milestoneId)
+    ?? join(milestonesDir(basePath), milestoneId);
+  mkdirSync(milestoneDir, { recursive: true });
+  clearPathCache();
+
+  try {
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    if (await ensureDbOpen(basePath)) {
+      const { getMilestone, insertMilestone } = await import("../gsd-db.js");
+      if (!getMilestone(milestoneId)) {
+        insertMilestone({
+          id: milestoneId,
+          title: `New milestone ${milestoneId}`,
+          status: "queued",
+        });
+      }
+    }
+  } catch (err) {
+    safetyLogWarning("guided", `failed to persist milestone shell for ${milestoneId}: ${(err as Error).message}`);
+  }
+
+  return milestoneDir;
+}
+
+async function saveDiscussionQuestionRound(
+  basePath: string,
+  milestoneId: string,
+  questions: StructuredQuestion[],
+  details: any,
+): Promise<void> {
+  const milestoneDir = await ensureMilestoneShell(basePath, milestoneId);
+  const answers = details?.response?.answers;
+  const timestamp = new Date().toISOString();
+  const exchange = formatQuestionExchange(questions, answers);
+
+  const discussionPath = join(milestoneDir, buildMilestoneFileName(milestoneId, "DISCUSSION"));
+  const existingDiscussion = await loadFile(discussionPath) ?? `# ${milestoneId} Discussion Log\n\n`;
+  await saveFile(
+    discussionPath,
+    `${existingDiscussion}## Exchange — ${timestamp}\n\n${exchange}---\n\n`,
+  );
+
+  const draftPath = join(milestoneDir, buildMilestoneFileName(milestoneId, "CONTEXT-DRAFT"));
+  const existingDraft = await loadFile(draftPath);
+  const draftHeader = existingDraft
+    ?? [
+      `# ${milestoneId}: New milestone ${milestoneId}`,
+      "",
+      "This draft was captured automatically from structured question responses.",
+      "Use it so `/gsd` can resume the in-flight milestone discussion.",
+      "",
+    ].join("\n");
+  await saveFile(
+    draftPath,
+    `${draftHeader.trimEnd()}\n\n## Captured Question Round — ${timestamp}\n\n${exchange}`,
+  );
 }
 
 function withDepthGateDisplayReason<T extends { block: boolean; reason?: string }>(
@@ -1148,7 +1251,6 @@ export function registerHooks(
     if (toolName !== "ask_user_questions") return;
     const basePath = contextBasePath(ctx);
     const milestoneId = await getDiscussionMilestoneIdFor(basePath);
-    const queueActive = isQueuePhaseActive(basePath);
 
     const details = event.details as any;
 
@@ -1227,36 +1329,8 @@ export function registerHooks(
       }
     }
 
-    if (!milestoneId && !queueActive) return;
     if (!milestoneId) return;
-    const milestoneDir = resolveMilestonePath(basePath, milestoneId);
-    if (!milestoneDir) return;
-
-    const discussionPath = join(milestoneDir, buildMilestoneFileName(milestoneId, "DISCUSSION"));
-    const timestamp = new Date().toISOString();
-    const lines: string[] = [`## Exchange — ${timestamp}`, ""];
-    for (const question of questions) {
-      lines.push(`### ${question.header ?? "Question"}`, "", question.question ?? "");
-      if (Array.isArray(question.options)) {
-        lines.push("");
-        for (const opt of question.options) {
-          lines.push(`- **${opt.label}** — ${opt.description ?? ""}`);
-        }
-      }
-      const answer = details.response?.answers?.[question.id];
-      if (answer) {
-        lines.push("");
-        const selected = Array.isArray(answer.selected) ? answer.selected.join(", ") : answer.selected;
-        lines.push(`**Selected:** ${selected}`);
-        if (answer.notes) {
-          lines.push(`**Notes:** ${answer.notes}`);
-        }
-      }
-      lines.push("");
-    }
-    lines.push("---", "");
-    const existing = await loadFile(discussionPath) ?? `# ${milestoneId} Discussion Log\n\n`;
-    await saveFile(discussionPath, existing + lines.join("\n"));
+    await saveDiscussionQuestionRound(basePath, milestoneId, questions, details);
   });
 
   pi.on("tool_execution_start", async (event, ctx) => {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -505,6 +505,8 @@ async function buildRegistryAndFindActive(
     const allSlicesDone = slices.length > 0 && slices.every(s => isStatusDone(s.status));
 
     const title = stripMilestonePrefix(m.title) || m.id;
+    const hasContext = !!resolveMilestoneFile(basePath, m.id, "CONTEXT");
+    const hasDraftContext = !hasContext && !!resolveMilestoneFile(basePath, m.id, "CONTEXT-DRAFT");
 
     if (!activeMilestoneFound) {
       const deps = m.depends_on;
@@ -515,7 +517,7 @@ async function buildRegistryAndFindActive(
         continue;
       }
 
-      if (m.status === 'queued' && slices.length === 0) {
+      if (m.status === 'queued' && slices.length === 0 && !hasContext && !hasDraftContext) {
         if (!firstDeferredQueuedShell) {
           firstDeferredQueuedShell = { id: m.id, title, deps };
         }
@@ -531,7 +533,7 @@ async function buildRegistryAndFindActive(
         continue;
       }
 
-      if (m.status === 'needs-discussion') activeMilestoneHasDraft = true;
+      if ((m.status === 'needs-discussion' && !hasContext) || hasDraftContext) activeMilestoneHasDraft = true;
 
       activeMilestone = { id: m.id, title };
       activeMilestoneSlices = slices;

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -483,7 +483,7 @@ async function buildRegistryAndFindActive(
   let activeMilestoneSlices: SliceRow[] = [];
   let activeMilestoneFound = false;
   let activeMilestoneHasDraft = false;
-  let firstDeferredQueuedShell: { id: string; title: string; deps: string[] } | null = null;
+  let firstDeferredQueuedShell: { id: string; title: string; deps: string[]; hasDraftContext: boolean } | null = null;
 
   for (const m of milestones) {
     if (parkedMilestoneIds.has(m.id)) {
@@ -517,9 +517,9 @@ async function buildRegistryAndFindActive(
         continue;
       }
 
-      if (m.status === 'queued' && slices.length === 0 && !hasContext && !hasDraftContext) {
+      if (m.status === 'queued' && slices.length === 0 && !hasContext) {
         if (!firstDeferredQueuedShell) {
-          firstDeferredQueuedShell = { id: m.id, title, deps };
+          firstDeferredQueuedShell = { id: m.id, title, deps, hasDraftContext };
         }
         registry.push({ id: m.id, title, status: 'pending', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
         continue;
@@ -550,6 +550,7 @@ async function buildRegistryAndFindActive(
     activeMilestone = { id: shell.id, title: shell.title };
     activeMilestoneSlices = [];
     activeMilestoneFound = true;
+    if (shell.hasDraftContext) activeMilestoneHasDraft = true;
     const entry = registry.find(e => e.id === shell.id);
     if (entry) entry.status = 'active';
   }

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -1,10 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { registerHooks } from "../bootstrap/register-hooks.ts";
+import {
+  clearPendingAutoStart,
+  setPendingAutoStart,
+} from "../guided-flow.ts";
+import { closeDatabase, getMilestone } from "../gsd-db.ts";
+import { deriveState, invalidateStateCache } from "../state.ts";
 import {
   getPendingGate,
   resetWriteGateState,
@@ -184,6 +190,100 @@ test("register-hooks unlocks milestone depth verification from question id witho
     false,
     "question-id milestone inference should unlock the matching milestone context write",
   );
+});
+
+test("register-hooks persists first structured question round for new milestone re-entry", async (t) => {
+  const dir = makeTempDir("question-draft");
+  mkdirSync(join(dir, ".gsd", "milestones"), { recursive: true });
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  resetWriteGateState(dir);
+  clearPendingAutoStart(dir);
+
+  t.after(() => {
+    try {
+      resetWriteGateState(dir);
+      clearPendingAutoStart(dir);
+      closeDatabase();
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<void> | void>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<void> | void) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+  const ctx = { cwd: dir, ui: { notify: () => undefined } } as any;
+
+  registerHooks(pi, []);
+  setPendingAutoStart(dir, {
+    basePath: dir,
+    milestoneId: "M004",
+    ctx,
+    pi: { sendMessage: () => undefined } as any,
+  });
+
+  const questions = [
+    {
+      id: "m004_shape",
+      header: "M004 Shape",
+      question: "What are you picturing for M004?",
+      options: [
+        { label: "Planning metadata (Recommended)", description: "Plan the next metadata layer." },
+        { label: "Find and organize", description: "Improve searching and organizing." },
+      ],
+    },
+    {
+      id: "boundary",
+      header: "Boundary",
+      question: "Which boundary should I plan around?",
+      options: [
+        { label: "No new dependencies (Recommended)", description: "Keep implementation vanilla." },
+        { label: "Browser APIs OK", description: "Use browser-native capabilities." },
+      ],
+    },
+  ];
+
+  for (const handler of handlers.get("tool_result") ?? []) {
+    await handler({
+      toolName: "ask_user_questions",
+      input: { questions },
+      details: {
+        response: {
+          answers: {
+            m004_shape: { selected: "Planning metadata (Recommended)" },
+            boundary: { selected: "No new dependencies (Recommended)" },
+          },
+        },
+      },
+    }, ctx);
+  }
+
+  const milestoneDir = join(dir, ".gsd", "milestones", "M004");
+  const draftPath = join(milestoneDir, "M004-CONTEXT-DRAFT.md");
+  const discussionPath = join(milestoneDir, "M004-DISCUSSION.md");
+
+  assert.equal(existsSync(draftPath), true, "first answer round should create a resumable context draft");
+  assert.equal(existsSync(discussionPath), true, "first answer round should create a discussion log");
+
+  const draft = readFileSync(draftPath, "utf-8");
+  assert.match(draft, /What are you picturing for M004\?/);
+  assert.match(draft, /Planning metadata \(Recommended\)/);
+  assert.match(draft, /No new dependencies \(Recommended\)/);
+
+  const row = getMilestone("M004");
+  assert.equal(row?.status, "queued", "new milestone shell should be registered in the DB");
+
+  invalidateStateCache();
+  const state = await deriveState(dir);
+  assert.equal(state.activeMilestone?.id, "M004");
+  assert.equal(state.phase, "needs-discussion");
 });
 
 test("register-hooks clears depth gate when remote (Telegram/Slack/Discord) answer is normalized (#4406)", async (t) => {

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -100,6 +100,7 @@ describe("stale queued milestone selection (#3470)", () => {
     const state = await deriveStateFromDb(base);
 
     assert.equal(state.activeMilestone?.id, "M068", "Queued milestone with draft should become active");
+    assert.equal(state.phase, "needs-discussion", "Queued milestone with draft should resume discussion");
   });
 
   test("queued milestone WITH slices can still be selected as active", async () => {

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -145,4 +145,46 @@ describe("stale queued milestone selection (#3470)", () => {
       assert.equal(entry!.status, "pending", `${id} should be pending, not active`);
     }
   });
+
+  test("queued milestone with stale CONTEXT-DRAFT does not block real active milestone", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // M068: queued, no slices, has a CONTEXT-DRAFT (abandoned discussion)
+    insertMilestone({ id: "M068", title: "Abandoned Draft", status: "queued" });
+    writeFile(base, "milestones/M068/M068-CONTEXT-DRAFT.md", "# M068: Abandoned Draft\n\nDraft left over from an abandoned session.");
+
+    // M070: real active milestone with execution artifacts
+    insertMilestone({ id: "M070", title: "Real Active", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M070", title: "Slice One", status: "active", risk: "low", depends: [] });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M070", title: "Task One", status: "pending" });
+
+    writeFile(base, "milestones/M070/M070-CONTEXT.md", "# M070: Real Active\n\nThis is the real milestone.");
+    writeFile(base, "milestones/M070/M070-ROADMAP.md", "# M070: Real Active\n\n## Slices\n\n- [ ] **S01: Slice One**");
+    writeFile(base, "milestones/M070/slices/S01/S01-PLAN.md", "# S01: Slice One\n\n## Tasks\n\n- [ ] **T01: Task One**");
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone?.id, "M070", "Stale draft on M068 must not block real active M070");
+
+    const m068Entry = state.registry.find((e: any) => e.id === "M068");
+    assert.ok(m068Entry, "M068 should still appear in registry");
+    assert.equal(m068Entry!.status, "pending", "M068 with stale draft should be pending, not active");
+  });
+
+  test("queued milestone with CONTEXT-DRAFT becomes active with needs-discussion phase when nothing else is active", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // M068: queued, no slices, has a CONTEXT-DRAFT — should resume discussion
+    insertMilestone({ id: "M068", title: "Draft Only", status: "queued" });
+    writeFile(base, "milestones/M068/M068-CONTEXT-DRAFT.md", "# M068: Draft Only\n\nPartial context from first question round.");
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone?.id, "M068", "Queued milestone with draft should become active when nothing else is");
+    assert.equal(state.phase, "needs-discussion", "Should resume discussion for queued milestone with draft");
+  });
 });


### PR DESCRIPTION
## TL;DR

**What:** Persists the first structured question round for a new GSD milestone so re-entry can resume instead of restarting.
**Why:** If `/gsd` stopped after the first questions but before context save, the pending milestone only existed in memory and the next run asked the same questions again.
**How:** Create a durable milestone shell on question result, append the discussion log, write a context draft, and treat queued milestones with drafts as resumable discussion.

## What

- Adds durable question-round capture for pending new milestone discussions in the GSD hook layer.
- Creates or reuses the milestone directory, records a queued DB milestone shell, appends `M###-DISCUSSION.md`, and writes `M###-CONTEXT-DRAFT.md`.
- Updates state derivation so queued milestones with a draft become the active `needs-discussion` milestone instead of being deferred as empty shells.
- Adds regression coverage for the first-question-round re-entry path and strengthens queued-draft state coverage.

## Why

A new milestone discussion could lose its first structured answers if the session stopped before `gsd_summary_save` wrote context. On the next `/gsd`, there was no durable M004 row or draft file, so GSD treated the milestone as brand new and prompted for the same choices again.

## How

The hook that receives `ask_user_questions` results now persists the question exchange whenever a pending discussion milestone exists. It saves both a discussion log and a context draft, while also inserting a queued milestone row if the DB does not have one yet. State reconstruction now recognizes that draft as enough evidence to resume milestone discussion.

## Validation

- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`
- `pnpm run verify:fast`

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783268051&installation_id=134682257&pr_number=510&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F510&signature=25bcda73f21b7ad71a0507080b37010886047f1b1fed409811fa83a783fee748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches milestone selection in `deriveState` and automatic filesystem/DB writes on every answered question round; wrong active-milestone choice could mis-route `/gsd`, though new tests target the main regression paths.
> 
> **Overview**
> Fixes **lost first-round milestone discussion** when `/gsd` stops after `ask_user_questions` but before context is saved.
> 
> On **`ask_user_questions` results**, the hook now **`ensureMilestoneShell`** (milestone dir, optional **queued** DB row), appends **`M###-DISCUSSION.md`**, and writes/extends **`M###-CONTEXT-DRAFT.md`** with formatted Q&A via **`saveDiscussionQuestionRound`**—replacing inline logging that required an existing milestone path and dropped queue-only flows.
> 
> **`buildRegistryAndFindActive`** treats **queued, slice-less** milestones with **`CONTEXT-DRAFT`** (and no **`CONTEXT`**) as resumable: they can become **active** in **`needs-discussion`** instead of staying deferred empty shells; a draft on an earlier queued id does not override a later milestone that already has real execution artifacts.
> 
> Tests cover hook persistence + **`deriveState`** re-entry and extend stale-queued-milestone scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22efc3f69770d6a1a972690aebb1c86c591e2c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->