### PR TITLE
Add running tool rail sweep

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -85,6 +85,18 @@ describe("ToolExecutionComponent", () => {
 		assert.doesNotMatch(rendered, /Tool demo\u00b7do_thing/);
 		assert.match(rendered, /running/);
 		assert.match(rendered, /running · \d+(ms|s)/);
+		assert.match(rendered, /━/, "running cards should show the active rail sweep");
+	});
+
+	test("does not render active rail sweep on completed cards", () => {
+		const rendered = renderToolCollapsed(
+			"mcp__demo__do_thing",
+			{ ok: true },
+			{ content: [{ type: "text", text: "done" }], isError: false },
+		);
+
+		assert.match(rendered, /success · \d+(ms|s)/);
+		assert.doesNotMatch(rendered, /━/);
 	});
 
 	test("does not duplicate running generic tool labels before args", () => {

--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -43,6 +43,7 @@ const BASH_PREVIEW_LINES = 5;
 // During partial write tool-call streaming, re-highlight the first N lines fully
 // to keep multiline tokenization mostly correct without re-highlighting the full file.
 const WRITE_PARTIAL_FULL_HIGHLIGHT_LINES = 50;
+const RUNNING_RAIL_RENDER_INTERVAL_MS = 70;
 
 /**
  * Replace tabs with spaces for consistent rendering
@@ -364,6 +365,7 @@ export class ToolExecutionComponent extends Container {
 	// When true, this component intentionally renders no lines
 	private hideComponent = false;
 	private toolRenderState: Record<string, unknown> = {};
+	private runningRailTimer: ReturnType<typeof setInterval> | undefined;
 
 	private createRenderContext(): ToolRenderContext {
 		return {
@@ -447,12 +449,36 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	dispose(): void {
+		this.stopRunningRailTimer();
 		this.convertedImages.clear();
 		this.imageComponents = [];
 		this.imageSpacers = [];
 		this.editDiffPreview = undefined;
 		this.writeHighlightCache = undefined;
 		this.result = undefined;
+	}
+
+	private syncRunningRailTimer(): void {
+		if (!this.isInFlight() || this.hideComponent) {
+			this.stopRunningRailTimer();
+			return;
+		}
+		if (this.runningRailTimer) return;
+
+		this.runningRailTimer = setInterval(() => {
+			if (!this.isInFlight() || this.hideComponent) {
+				this.stopRunningRailTimer();
+				return;
+			}
+			this.ui.requestRender();
+		}, RUNNING_RAIL_RENDER_INTERVAL_MS);
+		this.runningRailTimer.unref?.();
+	}
+
+	private stopRunningRailTimer(): void {
+		if (!this.runningRailTimer) return;
+		clearInterval(this.runningRailTimer);
+		this.runningRailTimer = undefined;
 	}
 
 	updateArgs(args: any): void {
@@ -1002,6 +1028,7 @@ export class ToolExecutionComponent extends Container {
 		if (!useBuiltInRenderer && this.toolDefinition) {
 			this.hideComponent = !customRendererHasContent && this.imageComponents.length === 0;
 		}
+		this.syncRunningRailTimer();
 	}
 
 	/**

--- a/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
@@ -18,6 +18,10 @@ export function chatMessageWidth(width: number): number {
 
 /** Outer indent for user turns and tool/work cards in the connected transcript. */
 export const TRANSCRIPT_CARD_INDENT = 4;
+const RUNNING_RAIL_FRAME_MS = 70;
+const RUNNING_RAIL_TRAIL = 5;
+const HORIZONTAL_RAIL = "─";
+const HORIZONTAL_RAIL_HEAD = "━";
 
 export function headerLabel(text: string): string {
 	return text.toUpperCase();
@@ -33,6 +37,45 @@ function indentSpaces(cols: number): string {
 
 function connectedRuleFill(width: number, indent = TRANSCRIPT_CARD_INDENT): string {
 	return "─".repeat(Math.max(16, Math.min(40, width - indent - 1)));
+}
+
+function runningRailFrame(): number {
+	return Math.floor(Date.now() / RUNNING_RAIL_FRAME_MS);
+}
+
+function trianglePosition(frame: number, maxPosition: number): number {
+	const max = Math.max(0, maxPosition);
+	if (max === 0) return 0;
+	const period = max * 2;
+	const step = frame % period;
+	return step <= max ? step : period - step;
+}
+
+function renderRailText(text: string, railColor: ThemeColor, sweepFrame?: number): string {
+	if (sweepFrame === undefined) return theme.fg(railColor, text);
+
+	const railCells = Array.from(text).filter((char) => char === HORIZONTAL_RAIL).length;
+	const head = trianglePosition(sweepFrame, railCells - 1);
+	let railIndex = -1;
+	let rendered = "";
+
+	for (const char of text) {
+		if (char !== HORIZONTAL_RAIL) {
+			rendered += theme.fg(railColor, char);
+			continue;
+		}
+
+		railIndex++;
+		const distance = Math.abs(railIndex - head);
+		if (distance === 0) {
+			rendered += theme.fg(railColor, theme.bold(HORIZONTAL_RAIL_HEAD));
+		} else if (distance <= RUNNING_RAIL_TRAIL) {
+			rendered += theme.fg(railColor, HORIZONTAL_RAIL_HEAD);
+		} else {
+			rendered += theme.fg(railColor, HORIZONTAL_RAIL);
+		}
+	}
+	return rendered;
 }
 
 export function renderChatTurnBridge(
@@ -64,12 +107,14 @@ export function renderConnectedCard(
 		titleColor?: ThemeColor;
 		bodyBg?: ThemeBg;
 		closeBottom?: boolean;
+		railSweep?: boolean;
 	} = {},
 ): string[] {
 	const indent = opts.indent ?? TRANSCRIPT_CARD_INDENT;
 	const prefix = indentSpaces(indent);
 	const railColor = opts.railColor ?? "borderAccent";
-	const rail = (text: string) => theme.fg(railColor, text);
+	const sweepFrame = opts.railSweep ? runningRailFrame() : undefined;
+	const rail = (text: string) => renderRailText(text, railColor, sweepFrame);
 	const resolvedTitleColor =
 		opts.titleColor ??
 		(title.includes("✕") ? "error" : title.includes("✓") ? "success" : railColor);
@@ -321,16 +366,32 @@ export function renderUserRail(
  * Render a single titled rule line — the collapsed form of a tool/command
  * card on the "open" surface. `title` and `right` must be pre-styled.
  */
-function openRuleLine(title: string, right: string, width: number, tone: ThemeColor): string {
-	let surface = style()
-		.border("open")
-		.borderColor((text) => theme.fg(tone, text))
-		.title(title);
-	if (right) {
-		surface = surface.titleRight(right);
+function openRuleLine(title: string, right: string, width: number, tone: ThemeColor, sweep = false): string {
+	const w = Math.max(20, width);
+	if (!right) {
+		const clippedTitle = truncateToWidth(title, Math.max(0, w - 6), "");
+		const fill = Math.max(1, w - 5 - visibleWidth(clippedTitle));
+		return padLine(renderRailText("─── ", tone) + clippedTitle + renderRailText(` ${"─".repeat(fill)}`, tone), w);
 	}
-	// render([]) yields [topRule, emptyBody, bottomRule] — we want the rule.
-	return surface.render([], Math.max(20, width))[0];
+
+	const titleBudget = Math.max(0, w - 11);
+	const rightReserve = titleBudget > 1 && visibleWidth(right) > 0 ? 1 : 0;
+	const leftBudget = Math.min(visibleWidth(title), Math.max(0, titleBudget - rightReserve));
+	const rightBudget = Math.max(0, titleBudget - leftBudget);
+	const clippedTitle = truncateToWidth(title, leftBudget, "");
+	const clippedRight = truncateToWidth(right, rightBudget, "");
+	const fixed = 4 + visibleWidth(clippedTitle) + 2 + visibleWidth(clippedRight) + 4;
+	const fill = Math.max(1, w - fixed);
+	const sweepFrame = sweep ? runningRailFrame() : undefined;
+
+	return padLine(
+		renderRailText("─── ", tone) +
+			clippedTitle +
+			renderRailText(` ${"─".repeat(fill)} `, tone, sweepFrame) +
+			clippedRight +
+			renderRailText(" ───", tone),
+		w,
+	);
 }
 
 function indentRenderedLines(lines: string[], indent: number, width: number): string[] {
@@ -365,6 +426,7 @@ export function renderTranscriptCard(
 		indent,
 		titleRight,
 		railColor: tone,
+		railSweep: opts.tone === "running",
 	});
 }
 
@@ -382,7 +444,7 @@ export function renderToolLineCard(
 	}`;
 	const statusText = opts.hidden ? `${opts.status} · output hidden · ctrl+o expand` : opts.status;
 	const right = theme.fg(opts.tone === "success" ? "success" : tone, statusText);
-	const rule = openRuleLine(titleText, right, innerWidth, tone);
+	const rule = openRuleLine(titleText, right, innerWidth, tone, opts.tone === "running");
 	const line = opts.bg ? theme.bg(opts.bg, rule) : rule;
 	return indentRenderedLines([line], indent, width);
 }
@@ -400,7 +462,7 @@ export function renderCommandCard(
 		? `${opts.progress} ${opts.status}`
 		: `${opts.status} · output hidden · ctrl+o expand`;
 	const right = theme.fg(opts.tone === "success" ? "success" : tone, statusText);
-	return indentRenderedLines([openRuleLine(titleText, right, innerWidth, tone)], indent, width);
+	return indentRenderedLines([openRuleLine(titleText, right, innerWidth, tone, opts.tone === "running")], indent, width);
 }
 
 export function renderProgressBar(done: number, total: number, width: number, tone: StatusTone = "success"): string {

--- a/packages/pi-coding-agent/src/theme/themes.ts
+++ b/packages/pi-coding-agent/src/theme/themes.ts
@@ -66,7 +66,7 @@ const dark: ThemeJson = {
 		toolOutput: "textSoft",
 		surfaceTitle: "accent",
 		surfaceAccent: "accent",
-		toolRunning: "accent",
+		toolRunning: "#f59e0b",
 		toolSuccess: "green",
 		toolError: "red",
 

--- a/src/tests/tui-classic-theme.test.ts
+++ b/src/tests/tui-classic-theme.test.ts
@@ -26,7 +26,7 @@ test("dark built-in theme uses the terminal card prototype palette", () => {
 	assert.equal(theme.vars?.toolErrorBg, "#241b22");
 	assert.equal(theme.colors.border, "line");
 	assert.equal(theme.colors.borderAccent, "accent");
-	assert.equal(theme.colors.toolRunning, "accent");
+	assert.equal(theme.colors.toolRunning, "#f59e0b");
 	assert.equal(theme.colors.toolSuccess, "green");
 	assert.equal(theme.colors.toolError, "red");
 });


### PR DESCRIPTION
## TL;DR

**What:** Adds a full-rail sweep animation for running tool cards and makes the running rail orange in the dark theme.
**Why:** The previous running indicator was too subtle to tell whether active work was still moving.
**How:** Reuses the existing transcript rail surface, animates only running rails, drives in-flight tool re-renders with a scoped timer, and leaves completed rails static.

## What

This updates the interactive TUI tool-card rendering so active/running tool cards show a moving rail segment across the header rule. It also changes the dark theme `toolRunning` token from the accent blue to an orange/amber color so running work is visually distinct from completed or idle tool cards.

The change touches the shared transcript rendering primitives, the tool execution component lifecycle, the dark theme token, and focused tool-card rendering tests.

## Why

The current running state is hard to notice in busy terminal output. A larger rail sweep makes active work visibly alive while keeping the existing card layout and status text intact.

## How

Running rails now replace a moving run of `─` cells with heavier `━` cells. The sweep is enabled only for `running` tone cards. `ToolExecutionComponent` starts an unref'd render timer while a tool is in flight and stops it when the tool completes, hides, or disposes, so completed cards do not continue animating.

Focused tests assert that running cards render the sweep and completed cards do not.

## Validation

- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts packages/gsd-agent-modes/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts`
- `pnpm run build:agent-modes`
- `pnpm run verify:fast`
- `git diff --check`

## Change Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783285632&installation_id=134682257&pr_number=513&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F513&signature=e40d45d8361c893d6d3f620a9669a27db67abdfbb10a5bafa23aca6d3b311d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and theme token only; scoped timer lifecycle is tied to in-flight tool components with no auth or data-path changes.
> 
> **Overview**
> **Running tool cards** now show an animated sweep along the header rail: a bold `━` segment moves across `─` fill on collapsed tool/command lines and connected transcript frames when tone is `running`. Completed or static cards keep plain rails with no sweep.
> 
> `ToolExecutionComponent` starts a **70ms unref'd interval** that calls `requestRender` only while the tool is in flight (and stops on completion, hide, or `dispose`). The dark theme **`toolRunning`** color moves from accent blue to amber (`#f59e0b`) so active work reads differently from idle/success states.
> 
> Tests assert running collapsed cards include `━` and successful ones do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987afff30ec0db23807e04fd573929a0762dd22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->