### PR TITLE
fix(gsd): preserve active unit source context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,8 +44,14 @@
 - **Worktree Lifecycle module**: module that owns worktree create/enter/teardown/merge verbs, `s.basePath` mutation, and `process.chdir` discipline. Sole owner of these mutations across single-loop and parallel callers.
 - **Worktree State Projection module**: module that owns the direction-and-rules of state file flow between project root and auto-worktree. Encodes the bug-hardened invariants (additive milestone copy, ASSESSMENT verdict overwrite, completed-units forward-sync, WAL/SHM cleanup) that `syncProjectRootToWorktree` and `syncStateToProjectRoot` carry today.
 - **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, runtime, and reconciliation-drift failures to a Recovery decision.
-- **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, and pre-dispatch validation aligned.
+- **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, source-observation invariants, and pre-dispatch validation aligned.
 - **Task Output Contract**: the concrete files a planned Task promises to create or overwrite. Distinct from task inputs, verification commands, and human-readable success outcomes.
+- **Observation Budgeting**: context-management policy for what prior tool observations remain available to a Provider on later turns. Distinct from Display Truncation: Observation Budgeting changes model-visible context, while Display Truncation changes only the user-visible terminal surface.
+- **Display Truncation**: rendering policy that hides or collapses tool output in the terminal without changing the underlying tool result available to the session.
+- **File Observation**: a durable record that a source file was observed, including enough identity and coverage metadata to let a Unit reason from the file without repeatedly reconstructing it from line windows.
+- **Whole-File Observation**: a File Observation whose source file is small enough to be retained as complete source context for the active Unit. The initial threshold is the read-tool cap: at most 50KB and at most 2000 lines. A narrow read of an under-threshold file auto-upgrades the File Observation to whole-file coverage in the background while preserving the requested tool result shape. After the Unit closes, the observation may degrade to metadata or summary for downstream Units.
+- **Source-observation set**: the files whose observations are protected from lossy Observation Budgeting for the active Unit. Files enter the set when declared by the Unit plan or when successfully read under the Whole-File Observation threshold. For `execute-task`, plan-declared files means `task.files` plus concrete filesystem-looking entries from `task.inputs`, not `expectedOutput`. Plan-declared files are preloaded as Whole-File Observations before the Unit's first Provider turn when they fit the threshold; later read calls can add discovered files.
+- **Source Context Block**: provider-payload context generated from the active Unit's Source-observation set. It is attached deliberately during Provider request assembly instead of relying on historical read-tool results to survive Observation Budgeting unchanged. Files that cannot become Whole-File Observations are represented with explicit unavailable statuses, such as missing, binary/image, over-threshold, glob, directory, or unresolved selector, unless existing pre-execution validation already blocks the Unit.
 - **Provider**: a model execution path inside the Pi/GSD agent loop, selected for a session or Unit and subject to GSD's tool and capability contracts.
 - **External MCP Client**: an AI client outside the Pi/GSD agent loop that connects to project MCP servers and owns discovery, startup, and presentation of those servers.
 - **Browser Automation Contract**: the GSD capability contract for real browser inspection, interaction, assertions, screenshots, and runtime evidence. The contract is distinct from the transport that exposes it.
@@ -91,6 +97,10 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
 - Thinking level should be configurable per Phase alongside the existing per-Phase model selection, resolved as a `(model, thinking)` pair across a hybrid config (`models.<phase>.thinking` and a separate `thinking:` block). The eight main-loop Phases apply it via `setThinkingLevel` at dispatch; the `subagent` Phase applies it via prompt injection + the subagent tool's `--thinking` subprocess flag (#508). The `execute-task` Thinking Floor protects only the session/default path; explicit config punches through. Unsupported levels are capability-clamped at dispatch, never sent to the provider.
 
   See `docs/dev/ADR-026-per-phase-thinking-level.md`.
+
+- Active Units should retain source files through Source Context Blocks generated from File Observations, not by relying on old `read` tool results to survive Observation Budgeting. Tool Contract owns the source-observation invariant; Provider request assembly injects the active Unit's protected Source Context Block.
+
+  See `docs/dev/ADR-027-source-observation-context-block.md`.
 
 - Foreground `/gsd next` and `/gsd auto` runs follow **Closeout Boundary Stop**: after the first durable task, slice, or milestone closeout boundary, the foreground terminal preserves the closeout transcript as the final visible surface instead of replacing it with a terminal roll-up widget. Headless runs may still emit durable terminal completion notifications/widgets for automation.
 
@@ -195,7 +205,7 @@ Recent triage showed repeated failures concentrated in orchestration state coher
 
 - Files: `unit-context-manifest.ts`, prompts under `prompts/`, `bootstrap/write-gate.ts`, `bootstrap/exec-tools.ts`, `workflow-tool-executors.ts`, `pre-execution-checks.ts`, `tools/plan-slice.ts`
 - Problem: Unit prompts, tool schemas, and tool policy drift independently. The model can be instructed to do work the policy blocks, or call a schema value the tool rejects. Some validation waits until after planning artifacts are committed.
-- Refactor target: compile a Unit Tool Contract before dispatch that includes prompt obligations, allowed tools, schema enum values, validation requirements, and closeout tools.
+- Refactor target: compile a Unit Tool Contract before dispatch that includes prompt obligations, allowed tools, schema enum values, validation requirements, closeout tools, and source-observation invariants.
 - Leverage: prompt authors and dispatch code get one reviewable contract per Unit type.
 - Locality: prompt wording, policy gates, schema descriptions, and planner-time validation stop drifting across files.
 - Test focus: prompt/policy/schema parity tests and planner tool validation tests for concrete task inputs.

--- a/docs/dev/ADR-027-source-observation-context-block.md
+++ b/docs/dev/ADR-027-source-observation-context-block.md
@@ -1,0 +1,29 @@
+# Source Observation Context Block
+
+GSD auto-mode should not depend on historical `read` tool results remaining visible in the provider transcript for a Unit to reason about source files. Observation Budgeting, provider-specific payload conversion, and narrow line-window reads can make small files disappear or appear partial on later turns, which encourages repeated rereads and line-number thrash. The long-term fix is a mechanical source-observation contract, not a larger default truncation cap or more prompt guidance.
+
+## Decision
+
+The Tool Contract module owns a source-observation invariant for source-reading Units. Each active Unit has a Source-observation set: files declared by the Unit plan plus files successfully read during the Unit when they fit the Whole-File Observation threshold. For `execute-task`, plan-declared files are `task.files` plus concrete filesystem-looking entries from `task.inputs`; `expectedOutput` is acceptance/output language and does not seed source context.
+
+Whole-File Observations are limited to text files at or below the existing read-tool cap: 50KB and 2000 lines. Plan-declared files that fit the threshold are preloaded before the first Provider turn. If the model asks for a narrow `read` slice of an under-threshold file, the visible tool result remains the requested slice, but the File Observation auto-upgrades to whole-file coverage in the background.
+
+Provider request assembly injects a Source Context Block generated from the active Unit's Source-observation set on every Provider call. This block is deliberate Unit context; it does not rely on old tool-result messages surviving masking, truncation, or Responses-vs-messages conversion. Observation Budgeting may still mask and truncate historical tool results, but it must not silently discard the active Unit's protected Source Context Block.
+
+Files that cannot become Whole-File Observations are represented explicitly in the Source Context Block as unavailable: missing, binary/image, over-threshold, glob, directory, or unresolved selector. Existing pre-execution validation still blocks impossible `task.inputs`; missing `task.files` may be legitimate creation targets and should not fail the Unit by itself.
+
+After the Unit closes, whole-file content may degrade to metadata or summary. Full source text is protected for the active Unit only.
+
+## Consequences
+
+- Known small files are available from the first Provider turn, so the model should not spend turns reconstructing them through `offset`/`limit` windows.
+- `context_management.tool_result_max_chars` can stay a general bloat control instead of carrying source-retention semantics.
+- The read tool, Tool Contract, Unit planning resolver, and provider-payload masking hook need an explicit shared contract for File Observation metadata and Source Context Block injection.
+- Tests should cover plan preloading, narrow-read auto-upgrade, provider payload masking, unavailable statuses, and Unit-close degradation.
+
+## Alternatives Considered
+
+- **Increase `tool_result_max_chars` globally.** This helps the immediate symptom but does not fix narrow reads, history aging, provider payload shape differences, or source files that need deliberate Unit-level retention.
+- **Preserve original `read` tool results verbatim.** Rejected because it couples source context to transcript position and provider conversion details, and it makes old tool output hard to budget.
+- **Prompt the model to stop using line windows.** Rejected as the primary fix because the failure is mechanical: a small file can be known completely even when the model asked for a slice.
+- **Fail preflight for every unavailable plan-declared file.** Rejected because `task.files` can name files the task intends to create; unavailable status is more precise than a false blocker.

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -1,6 +1,7 @@
 // GSD auto-mode runtime state
 import { AutoSession } from "./auto/session.js";
 import type { CurrentUnit } from "./auto/session.js";
+import type { SourceObservationStore } from "./source-observations.js";
 import {
   isDeterministicPolicyError,
   isQueuedUserMessageSkip,
@@ -64,4 +65,8 @@ export function recordToolInvocationError(toolName: string, errorMsg: string): v
 export function clearToolInvocationError(): void {
   if (!autoSession.active) return;
   autoSession.lastToolInvocationError = null;
+}
+
+export function getSourceObservationStore(): SourceObservationStore {
+  return autoSession.sourceObservations;
 }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1557,7 +1557,7 @@ export async function bootstrapAutoSession(
     s.autoStartTime = Date.now();
     s.resourceVersionOnStart = readResourceVersion();
     s.pendingQuickTasks = [];
-    s.currentUnit = null;
+    s.clearCurrentUnit();
     s.currentMilestoneId ??=
       strandedRecoveryAction?.milestoneId ??
       (deepProjectStagePending ? null : state.activeMilestone?.id ?? null);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1246,7 +1246,7 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   const preserveStepSurface = s.preserveStepSurfaceAfterLoopExit;
   const preserveCompletionSurface = s.completionStopInProgress;
   const preservePausedSurface = s.paused;
-  s.currentUnit = null;
+  s.clearCurrentUnit();
   s.active = false;
   deactivateGSD();
   clearUnitTimeout();
@@ -1990,7 +1990,7 @@ export async function pauseAuto(
       // Non-fatal — best-effort closeout on pause
       logWarning("engine", `unit closeout on pause failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
     }
-    s.currentUnit = null;
+    s.clearCurrentUnit();
   }
 
   // Keep STATE.md aligned with the DB-backed state before releasing pause state.
@@ -3311,7 +3311,7 @@ export async function dispatchHookUnit(
     s.stepMode = true;
     s.cmdCtx = ctx as ExtensionCommandContext;
     s.autoStartTime = Date.now();
-    s.currentUnit = null;
+    s.clearCurrentUnit();
     s.pendingQuickTasks = [];
   }
 
@@ -3328,12 +3328,12 @@ export async function dispatchHookUnit(
   const hookUnitType = `hook/${hookName}`;
   const hookStartedAt = Date.now();
 
-  s.currentUnit = {
+  s.setCurrentUnit({
     type: triggerUnitType,
     id: triggerUnitId,
     startedAt: hookStartedAt,
     workspaceRoot: s.basePath,
-  };
+  });
 
   const result = await s.cmdCtx!.newSession({ workspaceRoot: s.basePath });
   if (result.cancelled) {
@@ -3341,12 +3341,12 @@ export async function dispatchHookUnit(
     return false;
   }
 
-  s.currentUnit = {
+  s.setCurrentUnit({
     type: hookUnitType,
     id: triggerUnitId,
     startedAt: hookStartedAt,
     workspaceRoot: s.basePath,
-  };
+  });
 
   if (hookModel) {
     const availableModels = ctx.modelRegistry.getAvailable();

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -539,7 +539,7 @@ async function closeoutAndStop(
       s.currentUnit.startedAt,
       deps.buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
     );
-    s.currentUnit = null;
+    s.clearCurrentUnit();
   }
   await deps.stopAuto(ctx, pi, reason);
 }
@@ -807,7 +807,7 @@ async function failClosedOnFinalizeTimeout(
   );
 
   await deps.pauseAuto(ctx, pi);
-  s.currentUnit = null;
+  s.clearCurrentUnit();
   clearCurrentPhase();
   drainLogs();
   return { action: "break", reason: progressKind };
@@ -1389,7 +1389,7 @@ export async function runPreDispatch(
         s.currentUnit.startedAt,
         deps.buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
       );
-      s.currentUnit = null;
+      s.clearCurrentUnit();
     }
     await deps.stopAuto(ctx, pi, `Milestone ${mid} complete`, {
       completionWidget: {
@@ -2342,7 +2342,19 @@ export async function runUnitPhase(
   _resetLogs();
   const unitStartedAt = Date.now();
   s.unitDispatchCount.set(dispatchKey, nextDispatchCount);
-  s.currentUnit = { type: unitType, id: unitId, startedAt: unitStartedAt, workspaceRoot: s.basePath };
+  s.setCurrentUnit({ type: unitType, id: unitId, startedAt: unitStartedAt, workspaceRoot: s.basePath });
+  if (unitType === "execute-task") {
+    const { milestone, slice, task } = parseUnitId(unitId);
+    if (milestone && slice && task && isDbAvailable()) {
+      try {
+        const taskRow = getTask(milestone, slice, task);
+        if (taskRow) s.sourceObservations.observePlanTask(taskRow);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logWarning("prompt", `failed to preload source observations for ${unitId}: ${message}`);
+      }
+    }
+  }
   s.rootWriteBaseline = isIsolatedWorktreeSession(s)
     ? captureRootDirtySnapshot(s.originalBasePath)
     : null;
@@ -2453,7 +2465,7 @@ export async function runUnitPhase(
       category: "unknown",
       isTransient: true,
     });
-    s.currentUnit = null;
+    s.clearCurrentUnit();
     await deps.pauseAuto(ctx, pi);
     return { action: "break", reason: "ghost-completion" };
   }
@@ -2893,7 +2905,7 @@ export async function runFinalize(
       s.currentUnit?.id === preUnitSnapshot.id &&
       s.currentUnit?.startedAt === preUnitSnapshot.startedAt
     ) {
-      s.currentUnit = null;
+      s.clearCurrentUnit();
     }
     s.rootWriteBaseline = null;
   };

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -22,6 +22,7 @@ import type { Api, Model } from "@gsd/pi-ai";
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
+import { SourceObservationStore } from "../source-observations.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
 import type { AutoOrchestrationModule } from "./contracts.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
@@ -156,6 +157,7 @@ export class AutoSession {
   currentTurnId: string | null = null;
   currentUnitRouting: UnitRouting | null = null;
   currentMilestoneId: string | null = null;
+  readonly sourceObservations = new SourceObservationStore();
 
   // ── Model state ──────────────────────────────────────────────────────────
   autoModeStartModel: StartModel | null = null;
@@ -283,6 +285,21 @@ export class AutoSession {
     this.unitLifetimeDispatches.clear();
   }
 
+  setCurrentUnit(unit: CurrentUnit): void {
+    this.currentUnit = unit;
+    this.sourceObservations.beginUnit({
+      unitType: unit.type,
+      unitId: unit.id,
+      startedAt: unit.startedAt,
+      basePath: unit.workspaceRoot ?? this.basePath,
+    });
+  }
+
+  clearCurrentUnit(): void {
+    this.currentUnit = null;
+    this.sourceObservations.clear();
+  }
+
   get lockBasePath(): string {
     return resolveWorktreeProjectRoot(this.basePath, this.originalBasePath);
   }
@@ -340,7 +357,7 @@ export class AutoSession {
     this.unitRecoveryCount.clear();
 
     // Unit
-    this.currentUnit = null;
+    this.clearCurrentUnit();
     this.currentTraceId = null;
     this.currentTurnId = null;
     this.currentUnitRouting = null;

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -22,7 +22,7 @@ import type { Api, Model } from "@gsd/pi-ai";
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
-import { SourceObservationStore } from "../source-observations.js";
+import { SourceObservationStore, supportsSourceObservationsForUnit } from "../source-observations.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
 import type { AutoOrchestrationModule } from "./contracts.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
@@ -287,6 +287,10 @@ export class AutoSession {
 
   setCurrentUnit(unit: CurrentUnit): void {
     this.currentUnit = unit;
+    if (!supportsSourceObservationsForUnit(unit.type)) {
+      this.sourceObservations.clear();
+      return;
+    }
     this.sourceObservations.beginUnit({
       unitType: unit.type,
       unitId: unit.id,

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -17,7 +17,17 @@ import { canonicalToolName, clearDiscussionFlowState, isDepthConfirmationAnswer,
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
-import { clearToolInvocationError, getAutoRuntimeSnapshot, isAutoActive, isAutoCompletionStopInProgress, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto-runtime-state.js";
+import {
+  clearToolInvocationError,
+  getAutoRuntimeSnapshot,
+  getSourceObservationStore,
+  isAutoActive,
+  isAutoCompletionStopInProgress,
+  isAutoPaused,
+  markToolEnd,
+  markToolStart,
+  recordToolInvocationError,
+} from "../auto-runtime-state.js";
 
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { maybePauseAutoForApprovalGate, resetPendingGatePauseGuard } from "./pending-gate-pause.js";
@@ -39,6 +49,7 @@ import { registerPlanMilestoneSchemaRecovery } from "./plan-milestone-schema-rec
 import { AUTO_UNIT_SCOPED_TOOLS, RUN_UAT_BROWSER_TOOL_NAMES, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
 import { filterToolsForProvider } from "../model-router.js";
 import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
+import { injectSourceContextBlockIntoPayload } from "../source-observations.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -1232,6 +1243,19 @@ export function registerHooks(
     if (isAutoActive() && typeof event.toolCallId === "string") {
       markToolEnd(event.toolCallId);
     }
+    if (isAutoActive() && event.toolName === "read" && !event.isError) {
+      const dash = getAutoRuntimeSnapshot();
+      if (dash.currentUnit) {
+        const store = getSourceObservationStore();
+        store.beginUnit({
+          unitType: dash.currentUnit.type,
+          unitId: dash.currentUnit.id,
+          startedAt: dash.currentUnit.startedAt,
+          basePath: dash.basePath || contextBasePath(ctx),
+        });
+        store.observeRead(event.input);
+      }
+    }
     if (isAutoActive() && event.isError) {
       const resultPayload = ("result" in event ? event.result : undefined) as any;
       const errorText = typeof resultPayload === "string"
@@ -1423,6 +1447,14 @@ export function registerHooks(
       const input = payload.input;
       if (Array.isArray(input)) {
         payload.input = truncateResponsesInputResultItems(input as any, maxChars);
+      }
+    } catch { /* non-fatal */ }
+
+    try {
+      const sourceContextBlock = getSourceObservationStore().renderActiveBlock();
+      if (sourceContextBlock) {
+        const nextPayload = injectSourceContextBlockIntoPayload(payload, sourceContextBlock);
+        Object.assign(payload, nextPayload);
       }
     } catch { /* non-fatal */ }
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -485,6 +485,36 @@ function contextBasePath(ctx?: { cwd?: string }): string {
   return typeof ctx?.cwd === "string" ? ctx.cwd : process.cwd();
 }
 
+function beginSourceObservationStoreForCurrentUnit(
+  ctx?: { cwd?: string },
+): ReturnType<typeof getSourceObservationStore> | null {
+  if (!isAutoActive()) return null;
+  const dash = getAutoRuntimeSnapshot();
+  if (!dash.currentUnit) return null;
+
+  const store = getSourceObservationStore();
+  store.beginUnit({
+    unitType: dash.currentUnit.type,
+    unitId: dash.currentUnit.id,
+    startedAt: dash.currentUnit.startedAt,
+    basePath: dash.basePath || contextBasePath(ctx),
+  });
+  return store;
+}
+
+function refreshSourceObservationAfterMutation(
+  canonicalName: string,
+  input: unknown,
+  ctx?: { cwd?: string },
+): void {
+  if (canonicalName !== "edit" && canonicalName !== "write") return;
+  if (!input || typeof input !== "object") return;
+
+  const store = beginSourceObservationStoreForCurrentUnit(ctx);
+  if (!store) return;
+  store.observeMutation(input as { path?: unknown; file_path?: unknown });
+}
+
 function activateDeferredApprovalGate(basePath: string): void {
   if (deferredApprovalGate?.basePath !== basePath) return;
   setPendingGate(deferredApprovalGate.gateId, basePath);
@@ -1243,18 +1273,15 @@ export function registerHooks(
     if (isAutoActive() && typeof event.toolCallId === "string") {
       markToolEnd(event.toolCallId);
     }
-    if (isAutoActive() && event.toolName === "read" && !event.isError) {
-      const dash = getAutoRuntimeSnapshot();
-      if (dash.currentUnit) {
-        const store = getSourceObservationStore();
-        store.beginUnit({
-          unitType: dash.currentUnit.type,
-          unitId: dash.currentUnit.id,
-          startedAt: dash.currentUnit.startedAt,
-          basePath: dash.basePath || contextBasePath(ctx),
-        });
+    const toolName = canonicalToolName(event.toolName);
+    if (isAutoActive() && toolName === "read" && !event.isError) {
+      const store = beginSourceObservationStoreForCurrentUnit(ctx);
+      if (store) {
         store.observeRead(event.input);
       }
+    }
+    if (!event.isError) {
+      refreshSourceObservationAfterMutation(toolName, event.input, ctx);
     }
     if (isAutoActive() && event.isError) {
       const resultPayload = ("result" in event ? event.result : undefined) as any;
@@ -1271,7 +1298,6 @@ export function registerHooks(
     } else if (isAutoActive()) {
       clearToolInvocationError();
     }
-    const toolName = canonicalToolName(event.toolName);
     if (toolName !== "ask_user_questions") return;
     const basePath = contextBasePath(ctx);
     const milestoneId = await getDiscussionMilestoneIdFor(basePath);

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -49,7 +49,7 @@ import { registerPlanMilestoneSchemaRecovery } from "./plan-milestone-schema-rec
 import { AUTO_UNIT_SCOPED_TOOLS, RUN_UAT_BROWSER_TOOL_NAMES, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
 import { filterToolsForProvider } from "../model-router.js";
 import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
-import { injectSourceContextBlockIntoPayload } from "../source-observations.js";
+import { injectSourceContextBlockIntoPayload, supportsSourceObservationsForUnit } from "../source-observations.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -491,6 +491,7 @@ function beginSourceObservationStoreForCurrentUnit(
   if (!isAutoActive()) return null;
   const dash = getAutoRuntimeSnapshot();
   if (!dash.currentUnit) return null;
+  if (!supportsSourceObservationsForUnit(dash.currentUnit.type)) return null;
 
   const store = getSourceObservationStore();
   store.beginUnit({
@@ -513,6 +514,24 @@ function refreshSourceObservationAfterMutation(
   const store = beginSourceObservationStoreForCurrentUnit(ctx);
   if (!store) return;
   store.observeMutation(input as { path?: unknown; file_path?: unknown });
+}
+
+function clearSourceObservationsAfterShell(
+  canonicalName: string,
+): void {
+  if (!isAutoActive()) return;
+  if (!isShellExecutionTool(canonicalName)) return;
+  const dash = getAutoRuntimeSnapshot();
+  if (!dash.currentUnit || !supportsSourceObservationsForUnit(dash.currentUnit.type)) return;
+  getSourceObservationStore().clear();
+}
+
+function isShellExecutionTool(canonicalName: string): boolean {
+  return canonicalName === "bash" ||
+    canonicalName === "bg_shell" ||
+    canonicalName === "async_bash" ||
+    canonicalName === "shell" ||
+    canonicalName === "powershell";
 }
 
 function activateDeferredApprovalGate(basePath: string): void {
@@ -1282,6 +1301,7 @@ export function registerHooks(
     }
     if (!event.isError) {
       refreshSourceObservationAfterMutation(toolName, event.input, ctx);
+      clearSourceObservationsAfterShell(toolName);
     }
     if (isAutoActive() && event.isError) {
       const resultPayload = ("result" in event ? event.result : undefined) as any;

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -497,7 +497,7 @@ function beginSourceObservationStoreForCurrentUnit(
     unitType: dash.currentUnit.type,
     unitId: dash.currentUnit.id,
     startedAt: dash.currentUnit.startedAt,
-    basePath: dash.basePath || contextBasePath(ctx),
+    basePath: dash.currentUnit.workspaceRoot ?? (dash.basePath || contextBasePath(ctx)),
   });
   return store;
 }
@@ -1477,10 +1477,12 @@ export function registerHooks(
     } catch { /* non-fatal */ }
 
     try {
-      const sourceContextBlock = getSourceObservationStore().renderActiveBlock();
-      if (sourceContextBlock) {
-        const nextPayload = injectSourceContextBlockIntoPayload(payload, sourceContextBlock);
-        Object.assign(payload, nextPayload);
+      if (isAutoActive()) {
+        const sourceContextBlock = getSourceObservationStore().renderActiveBlock();
+        if (sourceContextBlock) {
+          const nextPayload = injectSourceContextBlockIntoPayload(payload, sourceContextBlock);
+          Object.assign(payload, nextPayload);
+        }
       }
     } catch { /* non-fatal */ }
 

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -469,6 +469,13 @@ export function shouldValidatePlanningPathReference(raw: string): boolean {
   return shouldValidateInputAsPath(raw);
 }
 
+export function extractPlanningPathReference(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed || NON_PATH_SENTINEL_RE.test(trimmed)) return null;
+  if (!shouldValidateInputAsPath(trimmed)) return null;
+  return extractPathFromAnnotation(trimmed);
+}
+
 function shouldValidateInputAsPath(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) return false;

--- a/src/resources/extensions/gsd/source-observations.ts
+++ b/src/resources/extensions/gsd/source-observations.ts
@@ -26,11 +26,13 @@ export interface SourceObservationUnit {
   basePath: string;
 }
 
+export type SourceObservationSource = "plan" | "read" | "mutation";
+
 export interface SourceObservation {
   path: string;
   absolutePath: string | null;
   status: SourceObservationStatus;
-  source: "plan" | "read";
+  source: SourceObservationSource;
   text?: string;
   bytes?: number;
   lines?: number;
@@ -82,6 +84,13 @@ export class SourceObservationStore {
     this.observePath(rawPath, "read");
   }
 
+  observeMutation(input: { path?: unknown; file_path?: unknown; [key: string]: unknown }): void {
+    if (!this.active) return;
+    const rawPath = readPathFromInput(input);
+    if (!rawPath.trim()) return;
+    this.observePath(rawPath, "mutation", { replaceExisting: true });
+  }
+
   renderActiveBlock(): string | null {
     if (!this.active || this.active.observations.size === 0) return null;
     const observations = [...this.active.observations.values()]
@@ -129,12 +138,16 @@ export class SourceObservationStore {
       current.basePath === unit.basePath;
   }
 
-  private observePath(rawPath: string, source: "plan" | "read"): void {
+  private observePath(
+    rawPath: string,
+    source: SourceObservationSource,
+    options: { replaceExisting?: boolean } = {},
+  ): void {
     if (!this.active) return;
     const observation = observeSourcePath(this.active.unit.basePath, rawPath, source);
     const key = observation.absolutePath ?? `${observation.status}:${observation.path}`;
     const existing = this.active.observations.get(key);
-    if (!existing || observation.status === "whole" || existing.status !== "whole") {
+    if (options.replaceExisting || !existing || observation.status === "whole" || existing.status !== "whole") {
       this.active.observations.set(key, observation);
     }
   }
@@ -158,7 +171,7 @@ export function planDeclaredSourceEntries(
 export function observeSourcePath(
   basePath: string,
   rawPath: string,
-  source: "plan" | "read",
+  source: SourceObservationSource,
 ): SourceObservation {
   const normalizedRaw = normalizeFilePath(rawPath.trim());
   const displayPath = normalizedRaw || rawPath.trim();
@@ -269,7 +282,7 @@ function unavailable(
   path: string,
   absolutePath: string | null,
   status: Exclude<SourceObservationStatus, "whole">,
-  source: "plan" | "read",
+  source: SourceObservationSource,
   reason?: string,
 ): SourceObservation {
   return { path, absolutePath, status, source, reason };

--- a/src/resources/extensions/gsd/source-observations.ts
+++ b/src/resources/extensions/gsd/source-observations.ts
@@ -1,0 +1,369 @@
+// Project/App: gsd-pi
+// File Purpose: Active-unit source observations for provider payload context.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import type { TaskRow } from "./db-task-slice-rows.js";
+import { extractPlanningPathReference, normalizeFilePath } from "./pre-execution-checks.js";
+
+export const WHOLE_FILE_OBSERVATION_MAX_BYTES = 50 * 1024;
+export const WHOLE_FILE_OBSERVATION_MAX_LINES = 2000;
+
+export type SourceObservationStatus =
+  | "whole"
+  | "missing"
+  | "binary/image"
+  | "over-threshold"
+  | "glob"
+  | "directory"
+  | "unresolved selector";
+
+export interface SourceObservationUnit {
+  unitType: string;
+  unitId: string;
+  startedAt: number;
+  basePath: string;
+}
+
+export interface SourceObservation {
+  path: string;
+  absolutePath: string | null;
+  status: SourceObservationStatus;
+  source: "plan" | "read";
+  text?: string;
+  bytes?: number;
+  lines?: number;
+  reason?: string;
+}
+
+interface ActiveSourceObservationSet {
+  unit: SourceObservationUnit;
+  observations: Map<string, SourceObservation>;
+}
+
+const SOURCE_CONTEXT_TITLE = "## Source Context Block";
+
+export class SourceObservationStore {
+  private active: ActiveSourceObservationSet | null = null;
+
+  beginUnit(unit: SourceObservationUnit): void {
+    if (this.matches(unit)) return;
+    this.active = { unit: { ...unit }, observations: new Map() };
+  }
+
+  clear(): void {
+    this.active = null;
+  }
+
+  degradeUnit(unit: Pick<SourceObservationUnit, "unitType" | "unitId" | "startedAt">): void {
+    if (!this.active) return;
+    const current = this.active.unit;
+    if (
+      current.unitType === unit.unitType &&
+      current.unitId === unit.unitId &&
+      current.startedAt === unit.startedAt
+    ) {
+      this.active = null;
+    }
+  }
+
+  observePlanTask(task: TaskRow): void {
+    if (!this.active) return;
+    for (const entry of planDeclaredSourceEntries(task)) {
+      this.observePath(entry.path, "plan");
+    }
+  }
+
+  observeRead(input: { path?: unknown; file_path?: unknown; [key: string]: unknown }): void {
+    if (!this.active) return;
+    const rawPath = readPathFromInput(input);
+    if (!rawPath.trim()) return;
+    this.observePath(rawPath, "read");
+  }
+
+  renderActiveBlock(): string | null {
+    if (!this.active || this.active.observations.size === 0) return null;
+    const observations = [...this.active.observations.values()]
+      .sort((a, b) => a.path.localeCompare(b.path));
+    const lines = [
+      SOURCE_CONTEXT_TITLE,
+      `Active Unit: ${this.active.unit.unitType} ${this.active.unit.unitId}`,
+      "",
+      "The files below are protected active-Unit source context. " +
+        "Use this block instead of rereading small files just to recover line windows.",
+    ];
+
+    const wholeFiles = observations.filter((observation) => observation.status === "whole");
+    const unavailable = observations.filter((observation) => observation.status !== "whole");
+
+    if (wholeFiles.length > 0) {
+      lines.push("", "### Whole-File Observations");
+      for (const observation of wholeFiles) {
+        lines.push(
+          "",
+          `#### ${observation.path}`,
+          `Status: whole-file (${observation.lines ?? 0} lines, ${formatSize(observation.bytes ?? 0)})`,
+          fencedSource(observation.text ?? ""),
+        );
+      }
+    }
+
+    if (unavailable.length > 0) {
+      lines.push("", "### Unavailable Source Observations");
+      for (const observation of unavailable) {
+        const detail = observation.reason ? ` - ${observation.reason}` : "";
+        lines.push(`- ${observation.path}: ${observation.status}${detail}`);
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  private matches(unit: SourceObservationUnit): boolean {
+    if (!this.active) return false;
+    const current = this.active.unit;
+    return current.unitType === unit.unitType &&
+      current.unitId === unit.unitId &&
+      current.startedAt === unit.startedAt &&
+      current.basePath === unit.basePath;
+  }
+
+  private observePath(rawPath: string, source: "plan" | "read"): void {
+    if (!this.active) return;
+    const observation = observeSourcePath(this.active.unit.basePath, rawPath, source);
+    const key = observation.absolutePath ?? `${observation.status}:${observation.path}`;
+    const existing = this.active.observations.get(key);
+    if (!existing || observation.status === "whole" || existing.status !== "whole") {
+      this.active.observations.set(key, observation);
+    }
+  }
+}
+
+export function planDeclaredSourceEntries(
+  task: TaskRow,
+): Array<{ path: string; field: "files" | "inputs" }> {
+  const entries: Array<{ path: string; field: "files" | "inputs" }> = [];
+  for (const file of task.files) {
+    const path = extractPlanningPathReference(file) ?? file.trim();
+    if (path) entries.push({ path, field: "files" });
+  }
+  for (const input of task.inputs) {
+    const path = extractPlanningPathReference(input);
+    if (path) entries.push({ path, field: "inputs" });
+  }
+  return entries;
+}
+
+export function observeSourcePath(
+  basePath: string,
+  rawPath: string,
+  source: "plan" | "read",
+): SourceObservation {
+  const normalizedRaw = normalizeFilePath(rawPath.trim());
+  const displayPath = normalizedRaw || rawPath.trim();
+  if (!normalizedRaw) {
+    return unavailable(displayPath || "<empty>", null, "unresolved selector", source);
+  }
+  if (containsGlobPattern(normalizedRaw)) {
+    return unavailable(displayPath, null, "glob", source, "glob selectors are not whole files");
+  }
+  if (rawPath.trim().endsWith("/")) {
+    return unavailable(displayPath, null, "directory", source, "directory selectors are not whole files");
+  }
+
+  const absolutePath = isAbsolute(normalizedRaw) ? normalizedRaw : resolve(basePath, normalizedRaw);
+  const path = formatObservationPath(basePath, absolutePath, displayPath);
+
+  if (!existsSync(absolutePath)) {
+    return unavailable(path, absolutePath, "missing", source, "file does not exist in the active Unit root");
+  }
+
+  let stat;
+  try {
+    stat = statSync(absolutePath);
+  } catch {
+    return unavailable(path, absolutePath, "missing", source, "file could not be inspected");
+  }
+
+  if (stat.isDirectory()) {
+    return unavailable(path, absolutePath, "directory", source, "directory selectors are not whole files");
+  }
+  if (!stat.isFile()) {
+    return unavailable(path, absolutePath, "unresolved selector", source, "path is not a regular file");
+  }
+  if (stat.size > WHOLE_FILE_OBSERVATION_MAX_BYTES) {
+    return unavailable(
+      path,
+      absolutePath,
+      "over-threshold",
+      source,
+      `${formatSize(stat.size)} exceeds ${formatSize(WHOLE_FILE_OBSERVATION_MAX_BYTES)}`,
+    );
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = readFileSync(absolutePath);
+  } catch {
+    return unavailable(path, absolutePath, "missing", source, "file could not be read");
+  }
+
+  if (isBinaryOrImage(buffer)) {
+    return unavailable(path, absolutePath, "binary/image", source, "binary or image files are not inlined as source text");
+  }
+
+  const text = buffer.toString("utf8");
+  const lines = countLines(text);
+  if (lines > WHOLE_FILE_OBSERVATION_MAX_LINES) {
+    return unavailable(
+      path,
+      absolutePath,
+      "over-threshold",
+      source,
+      `${lines} lines exceeds ${WHOLE_FILE_OBSERVATION_MAX_LINES}`,
+    );
+  }
+
+  return {
+    path,
+    absolutePath,
+    status: "whole",
+    source,
+    text,
+    bytes: buffer.byteLength,
+    lines,
+  };
+}
+
+export function injectSourceContextBlockIntoPayload(
+  payload: Record<string, unknown>,
+  block: string,
+): Record<string, unknown> {
+  const messages = payload.messages;
+  if (Array.isArray(messages)) {
+    return {
+      ...payload,
+      messages: [
+        ...withoutExistingSourceContextMessages(messages),
+        { role: "user", content: [{ type: "text", text: block }] },
+      ],
+    };
+  }
+
+  const input = payload.input;
+  if (Array.isArray(input)) {
+    return {
+      ...payload,
+      input: [
+        ...withoutExistingSourceContextItems(input),
+        { role: "user", content: [{ type: "input_text", text: block }] },
+      ],
+    };
+  }
+
+  return payload;
+}
+
+function unavailable(
+  path: string,
+  absolutePath: string | null,
+  status: Exclude<SourceObservationStatus, "whole">,
+  source: "plan" | "read",
+  reason?: string,
+): SourceObservation {
+  return { path, absolutePath, status, source, reason };
+}
+
+function formatObservationPath(basePath: string, absolutePath: string, fallback: string): string {
+  const rel = relative(basePath, absolutePath);
+  if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+    return rel.split(sep).join("/");
+  }
+  return fallback;
+}
+
+function containsGlobPattern(candidate: string): boolean {
+  return ["*", "?", "[", "]", "{", "}"].some((char) => candidate.includes(char));
+}
+
+function readPathFromInput(input: { path?: unknown; file_path?: unknown }): string {
+  if (typeof input.path === "string") return input.path;
+  if (typeof input.file_path === "string") return input.file_path;
+  return "";
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function isBinaryOrImage(buffer: Buffer): boolean {
+  if (buffer.includes(0)) return true;
+  if (startsWith(buffer, [0xff, 0xd8, 0xff])) return true;
+  if (startsWith(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return true;
+  if (startsWithAscii(buffer, "GIF")) return true;
+  if (
+    startsWithAscii(buffer, "RIFF") &&
+    buffer.length >= 12 &&
+    buffer.subarray(8, 12).toString("ascii") === "WEBP"
+  ) return true;
+  return false;
+}
+
+function startsWith(buffer: Buffer, signature: readonly number[]): boolean {
+  if (buffer.length < signature.length) return false;
+  return signature.every((byte, index) => buffer[index] === byte);
+}
+
+function startsWithAscii(buffer: Buffer, text: string): boolean {
+  return buffer.length >= text.length && buffer.subarray(0, text.length).toString("ascii") === text;
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  return text.endsWith("\n") ? text.split("\n").length - 1 : text.split("\n").length;
+}
+
+function fencedSource(text: string): string {
+  const longest = longestBacktickRun(text);
+  const fence = longest >= 3 ? "`".repeat(longest + 1) : "```";
+  return `${fence}\n${text}\n${fence}`;
+}
+
+function longestBacktickRun(text: string): number {
+  let longest = 0;
+  let current = 0;
+  for (const char of text) {
+    if (char === "`") {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+  return longest;
+}
+
+function firstText(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const block = content.find((entry) =>
+    entry && typeof entry === "object" && "text" in entry,
+  ) as { text?: unknown } | undefined;
+  return typeof block?.text === "string" ? block.text : null;
+}
+
+function isSourceContextMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  return firstText((message as { content?: unknown }).content)?.startsWith(SOURCE_CONTEXT_TITLE) === true;
+}
+
+function withoutExistingSourceContextMessages(messages: unknown[]): unknown[] {
+  return messages.filter((message) => !isSourceContextMessage(message));
+}
+
+function withoutExistingSourceContextItems(items: unknown[]): unknown[] {
+  return items.filter((item) => !isSourceContextMessage(item));
+}

--- a/src/resources/extensions/gsd/source-observations.ts
+++ b/src/resources/extensions/gsd/source-observations.ts
@@ -45,11 +45,20 @@ interface ActiveSourceObservationSet {
 }
 
 const SOURCE_CONTEXT_TITLE = "## Source Context Block";
+const SOURCE_OBSERVATION_UNIT_TYPE = "execute-task";
+
+export function supportsSourceObservationsForUnit(unitType: string): boolean {
+  return unitType === SOURCE_OBSERVATION_UNIT_TYPE;
+}
 
 export class SourceObservationStore {
   private active: ActiveSourceObservationSet | null = null;
 
   beginUnit(unit: SourceObservationUnit): void {
+    if (!supportsSourceObservationsForUnit(unit.unitType)) {
+      this.clear();
+      return;
+    }
     if (this.matches(unit)) return;
     this.active = { unit: { ...unit }, observations: new Map() };
   }
@@ -93,6 +102,7 @@ export class SourceObservationStore {
 
   renderActiveBlock(): string | null {
     if (!this.active || this.active.observations.size === 0) return null;
+    if (!supportsSourceObservationsForUnit(this.active.unit.unitType)) return null;
     const observations = [...this.active.observations.values()]
       .sort((a, b) => a.path.localeCompare(b.path));
     const lines = [
@@ -185,8 +195,13 @@ export function observeSourcePath(
     return unavailable(displayPath, null, "directory", source, "directory selectors are not whole files");
   }
 
-  const absolutePath = isAbsolute(normalizedRaw) ? normalizedRaw : resolve(basePath, normalizedRaw);
-  const path = formatObservationPath(basePath, absolutePath, displayPath);
+  const rootPath = resolve(basePath);
+  const absolutePath = isAbsolute(normalizedRaw) ? resolve(normalizedRaw) : resolve(rootPath, normalizedRaw);
+  const path = formatObservationPath(rootPath, absolutePath, displayPath);
+
+  if (!isPathInsideRoot(rootPath, absolutePath)) {
+    return unavailable(displayPath, absolutePath, "unresolved selector", source, "path is outside active Unit root");
+  }
 
   if (!existsSync(absolutePath)) {
     return unavailable(path, absolutePath, "missing", source, "file does not exist in the active Unit root");
@@ -294,6 +309,11 @@ function formatObservationPath(basePath: string, absolutePath: string, fallback:
     return rel.split(sep).join("/");
   }
   return fallback;
+}
+
+function isPathInsideRoot(rootPath: string, absolutePath: string): boolean {
+  const rel = relative(rootPath, absolutePath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
 function containsGlobPattern(candidate: string): boolean {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1127,6 +1127,8 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
       getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
     },
     clearTimers: () => {},
+    setCurrentUnit(unit: any) { (this as any).currentUnit = unit; },
+    clearCurrentUnit() { (this as any).currentUnit = null; },
     ...overrides,
   } as any;
 }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -36,6 +36,7 @@ import { registerAutoWorker } from "../db/auto-workers.js";
 import { claimMilestoneLease } from "../db/milestone-leases.js";
 import { recordDispatchClaim, markCanceled } from "../db/unit-dispatches.js";
 import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.js";
+import { SourceObservationStore } from "../source-observations.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1102,6 +1103,7 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
     currentMilestoneId: "M001",
     currentUnit: null,
     currentUnitRouting: null,
+    sourceObservations: new SourceObservationStore(),
     completedUnits: [],
     resourceVersionOnStart: null,
     lastPromptCharCount: undefined,
@@ -1126,9 +1128,20 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
       newSession: () => Promise.resolve({ cancelled: false }),
       getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
     },
+    setCurrentUnit(this: any, unit: any) {
+      this.currentUnit = unit;
+      this.sourceObservations.beginUnit({
+        unitType: unit.type,
+        unitId: unit.id,
+        startedAt: unit.startedAt,
+        basePath: unit.workspaceRoot ?? this.basePath,
+      });
+    },
+    clearCurrentUnit(this: any) {
+      this.currentUnit = null;
+      this.sourceObservations.clear();
+    },
     clearTimers: () => {},
-    setCurrentUnit(unit: any) { (this as any).currentUnit = unit; },
-    clearCurrentUnit() { (this as any).currentUnit = null; },
     ...overrides,
   } as any;
 }

--- a/src/resources/extensions/gsd/tests/before-provider-context-management.test.ts
+++ b/src/resources/extensions/gsd/tests/before-provider-context-management.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { _setAutoActiveForTest } from "../auto.ts";
+import { autoSession } from "../auto-runtime-state.js";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 
 type HookHandler = (event: any, ctx?: any) => Promise<any> | any;
@@ -95,4 +96,50 @@ test("before_provider_request truncates tool results outside auto-mode", async (
   assert.ok(truncatedResponsesOutput.length < responsesOutput.length);
   assert.doesNotMatch(truncatedMessage, /result masked/);
   assert.doesNotMatch(truncatedResponsesOutput, /result masked/);
+});
+
+test("successful shell result clears source context before provider injection", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-before-provider-source-"));
+  const project = join(dir, "project");
+  mkdirSync(project, { recursive: true });
+  writeFileSync(join(project, "app.ts"), "export const value = 'before';\n");
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.basePath = project;
+  autoSession.setCurrentUnit({
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: 123,
+    workspaceRoot: project,
+  });
+  autoSession.sourceObservations.observeRead({ path: "app.ts" });
+
+  t.after(() => {
+    autoSession.reset();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  assert.match(autoSession.sourceObservations.renderActiveBlock() ?? "", /before/);
+
+  const handlers = createHookHandlers();
+  const toolResult = requireHook(handlers, "tool_result");
+  const beforeProviderRequest = requireHook(handlers, "before_provider_request");
+
+  await toolResult({
+    toolCallId: "toolu_bash",
+    toolName: "bash",
+    input: { command: "printf after > app.ts" },
+    isError: false,
+    result: "ok",
+  }, { cwd: project });
+
+  const payload = {
+    messages: [{ role: "user", content: [{ type: "text", text: "continue" }] }],
+  };
+  await beforeProviderRequest({ payload });
+
+  assert.equal(autoSession.sourceObservations.renderActiveBlock(), null);
+  assert.equal(payload.messages.length, 1);
+  assert.doesNotMatch(payload.messages[0].content[0].text, /Source Context Block/);
 });

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -141,6 +141,8 @@ function makeLoopSession(overrides?: Record<string, unknown>) {
     },
     clearTimers: () => {},
     lockBasePath: "/tmp/project",
+    setCurrentUnit(unit: any) { (this as any).currentUnit = unit; },
+    clearCurrentUnit() { (this as any).currentUnit = null; },
     ...overrides,
   } as any;
 }

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -18,7 +18,7 @@ import type { LoopDeps } from "../auto/loop-deps.js";
 import { WorktreeStateProjection } from "../worktree-state-projection.js";
 import type { SessionLockStatus } from "../session-lock.js";
 import { writeGraph, readGraph, type WorkflowGraph, type GraphStep } from "../graph.ts";
-import { writeFileSync } from "node:fs";
+import { SourceObservationStore } from "../source-observations.js";
 import { stringify } from "yaml";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -115,6 +115,7 @@ function makeLoopSession(overrides?: Record<string, unknown>) {
     currentMilestoneId: null,
     currentUnit: null,
     currentUnitRouting: null,
+    sourceObservations: new SourceObservationStore(),
     completedUnits: [],
     resourceVersionOnStart: null,
     lastPromptCharCount: undefined,
@@ -139,10 +140,21 @@ function makeLoopSession(overrides?: Record<string, unknown>) {
       newSession: () => Promise.resolve({ cancelled: false }),
       getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
     },
+    setCurrentUnit(this: any, unit: any) {
+      this.currentUnit = unit;
+      this.sourceObservations.beginUnit({
+        unitType: unit.type,
+        unitId: unit.id,
+        startedAt: unit.startedAt,
+        basePath: unit.workspaceRoot ?? this.basePath,
+      });
+    },
+    clearCurrentUnit(this: any) {
+      this.currentUnit = null;
+      this.sourceObservations.clear();
+    },
     clearTimers: () => {},
     lockBasePath: "/tmp/project",
-    setCurrentUnit(unit: any) { (this as any).currentUnit = unit; },
-    clearCurrentUnit() { (this as any).currentUnit = null; },
     ...overrides,
   } as any;
 }

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -30,6 +30,7 @@ import {
   insertTask,
   openDatabase,
 } from "../gsd-db.js";
+import { SourceObservationStore } from "../source-observations.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -186,6 +187,7 @@ function makeSession() {
     currentMilestoneId: "M001",
     currentUnit: null,
     currentUnitRouting: null,
+    sourceObservations: new SourceObservationStore(),
     completedUnits: [],
     resourceVersionOnStart: null,
     lastPromptCharCount: undefined,
@@ -206,6 +208,19 @@ function makeSession() {
     cmdCtx: {
       newSession: () => Promise.resolve({ cancelled: false }),
       getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
+    },
+    setCurrentUnit(this: any, unit: any) {
+      this.currentUnit = unit;
+      this.sourceObservations.beginUnit({
+        unitType: unit.type,
+        unitId: unit.id,
+        startedAt: unit.startedAt,
+        basePath: unit.workspaceRoot ?? this.basePath,
+      });
+    },
+    clearCurrentUnit(this: any) {
+      this.currentUnit = null;
+      this.sourceObservations.clear();
     },
     clearTimers: () => {},
   } as any;

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -67,6 +67,14 @@ test("Tool Contract compiles known Unit prompt and tool policy", () => {
   assert.deepEqual(result.ok && result.contract.forbiddenWorkflowTools, []);
   assert.equal(result.ok && result.contract.toolsPolicy.mode, "all");
   assert.ok(result.ok && result.contract.validationRules.includes("closeout-tool-present"));
+  assert.ok(result.ok && result.contract.validationRules.includes("source-observation-contract-present"));
+  assert.deepEqual(result.ok && result.contract.sourceObservations, {
+    mode: "whole-file-active-unit",
+    seedFields: ["task.files", "task.inputs"],
+    excludedFields: ["expectedOutput"],
+    maxBytes: 50 * 1024,
+    maxLines: 2000,
+  });
 });
 
 test("Tool Contract records high-risk cross-phase tool boundaries without single-owning every tool", () => {

--- a/src/resources/extensions/gsd/tests/source-observations.test.ts
+++ b/src/resources/extensions/gsd/tests/source-observations.test.ts
@@ -117,6 +117,39 @@ test("narrow reads of under-threshold files auto-upgrade to whole-file observati
   assert.match(block, /line three/);
 });
 
+test("successful file mutations refresh active whole-file observations", () => {
+  const basePath = tempProject();
+  writeFileSync(join(basePath, "app.ts"), "export const value = 'before';\n");
+
+  const store = beginStore(basePath);
+  store.observeRead({ path: "app.ts" });
+
+  assert.match(store.renderActiveBlock() ?? "", /before/);
+
+  writeFileSync(join(basePath, "app.ts"), "export const value = 'after';\n");
+  store.observeMutation({ path: "app.ts" });
+
+  const block = store.renderActiveBlock() ?? "";
+  assert.match(block, /after/);
+  assert.doesNotMatch(block, /before/);
+});
+
+test("successful writes promote missing plan observations to whole files", () => {
+  const basePath = tempProject();
+  const store = beginStore(basePath);
+  store.observePlanTask(makeTask({ files: ["generated.ts"] }));
+
+  assert.match(store.renderActiveBlock() ?? "", /generated\.ts: missing/);
+
+  writeFileSync(join(basePath, "generated.ts"), "export const generated = true;\n");
+  store.observeMutation({ path: "generated.ts" });
+
+  const block = store.renderActiveBlock() ?? "";
+  assert.match(block, /#### generated\.ts/);
+  assert.match(block, /export const generated = true;/);
+  assert.doesNotMatch(block, /generated\.ts: missing/);
+});
+
 test("over-threshold files are explicit unavailable observations", () => {
   const basePath = tempProject();
   writeFileSync(join(basePath, "large.txt"), "a".repeat(51 * 1024));

--- a/src/resources/extensions/gsd/tests/source-observations.test.ts
+++ b/src/resources/extensions/gsd/tests/source-observations.test.ts
@@ -1,0 +1,187 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SourceObservationStore,
+  injectSourceContextBlockIntoPayload,
+  observeSourcePath,
+  planDeclaredSourceEntries,
+} from "../source-observations.js";
+import { AutoSession } from "../auto/session.js";
+import { truncateContextResultMessages, truncateResponsesInputResultItems } from "../context-masker.js";
+import type { TaskRow } from "../db-task-slice-rows.js";
+
+function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    milestone_id: "M001",
+    slice_id: "S01",
+    id: "T01",
+    title: "Task",
+    status: "pending",
+    one_liner: "",
+    narrative: "",
+    verification_result: "",
+    duration: "",
+    completed_at: null,
+    blocker_discovered: false,
+    deviations: "",
+    known_issues: "",
+    key_files: [],
+    key_decisions: [],
+    full_summary_md: "",
+    description: "",
+    estimate: "",
+    files: [],
+    verify: "",
+    inputs: [],
+    expected_output: [],
+    observability_impact: "",
+    full_plan_md: "",
+    sequence: 1,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
+    ...overrides,
+  };
+}
+
+function tempProject(): string {
+  return mkdtempSync(join(tmpdir(), "gsd-source-observations-"));
+}
+
+function beginStore(basePath: string): SourceObservationStore {
+  const store = new SourceObservationStore();
+  store.beginUnit({ unitType: "execute-task", unitId: "M001/S01/T01", startedAt: 123, basePath });
+  return store;
+}
+
+test("plan-declared source entries use task.files and concrete task.inputs, not expectedOutput", () => {
+  const task = makeTask({
+    files: ["src/app.ts"],
+    inputs: ["Current enum shape", "`src/input.ts` - existing input"],
+    expected_output: ["src/generated.ts"],
+  });
+
+  assert.deepEqual(planDeclaredSourceEntries(task), [
+    { path: "src/app.ts", field: "files" },
+    { path: "src/input.ts", field: "inputs" },
+  ]);
+});
+
+test("preloaded plan observations render whole files and unavailable statuses", () => {
+  const basePath = tempProject();
+  mkdirSync(join(basePath, "src"), { recursive: true });
+  writeFileSync(join(basePath, "src", "app.ts"), "export const value = 1;\n");
+  mkdirSync(join(basePath, "src", "directory"), { recursive: true });
+  writeFileSync(join(basePath, "image.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+
+  const store = beginStore(basePath);
+  store.observePlanTask(makeTask({
+    files: [
+      "src/app.ts",
+      "src/missing.ts",
+      "src/*.ts",
+      "src/directory/",
+      "image.png",
+    ],
+  }));
+
+  const block = store.renderActiveBlock();
+  assert.ok(block);
+  assert.match(block, /## Source Context Block/);
+  assert.match(block, /#### src\/app\.ts/);
+  assert.match(block, /export const value = 1;/);
+  assert.match(block, /src\/missing\.ts: missing/);
+  assert.match(block, /src\/\*\.ts: glob/);
+  assert.match(block, /src\/directory: directory/);
+  assert.match(block, /image\.png: binary\/image/);
+});
+
+test("narrow reads of under-threshold files auto-upgrade to whole-file observations", () => {
+  const basePath = tempProject();
+  mkdirSync(join(basePath, "src"), { recursive: true });
+  writeFileSync(join(basePath, "src", "app.ts"), ["line one", "line two", "line three"].join("\n"));
+
+  const store = beginStore(basePath);
+  store.observeRead({ path: "src/app.ts", offset: 2, limit: 1 });
+
+  const block = store.renderActiveBlock();
+  assert.ok(block);
+  assert.match(block, /line one/);
+  assert.match(block, /line two/);
+  assert.match(block, /line three/);
+});
+
+test("over-threshold files are explicit unavailable observations", () => {
+  const basePath = tempProject();
+  writeFileSync(join(basePath, "large.txt"), "a".repeat(51 * 1024));
+
+  const observation = observeSourcePath(basePath, "large.txt", "plan");
+
+  assert.equal(observation.status, "over-threshold");
+  assert.match(observation.reason ?? "", /exceeds/);
+});
+
+test("source context block injection survives tool-result truncation for messages payloads", () => {
+  const payload = {
+    messages: truncateContextResultMessages([
+      { role: "toolResult", content: [{ type: "text", text: "x".repeat(200) }], toolCallId: "read-1", toolName: "read", isError: false },
+    ] as any, 10),
+  };
+
+  const injected = injectSourceContextBlockIntoPayload(payload, "## Source Context Block\n\nfull source text");
+
+  assert.match((injected.messages as any[])[0].content[0].text, /truncated/);
+  assert.equal((injected.messages as any[])[1].content[0].text, "## Source Context Block\n\nfull source text");
+});
+
+test("source context block injection supports Responses input payloads", () => {
+  const payload = {
+    input: truncateResponsesInputResultItems([
+      { type: "function_call_output", call_id: "read-1", output: "x".repeat(200) },
+    ] as any, 10),
+  };
+
+  const injected = injectSourceContextBlockIntoPayload(payload, "## Source Context Block\n\nfull source text");
+
+  assert.match((injected.input as any[])[0].output, /truncated/);
+  assert.equal((injected.input as any[])[1].content[0].text, "## Source Context Block\n\nfull source text");
+});
+
+test("unit-close degradation removes active whole-file source text", () => {
+  const basePath = tempProject();
+  writeFileSync(join(basePath, "app.ts"), "export const value = 1;");
+  const store = beginStore(basePath);
+  store.observeRead({ path: "app.ts" });
+
+  assert.match(store.renderActiveBlock() ?? "", /export const value = 1/);
+
+  store.degradeUnit({ unitType: "execute-task", unitId: "M001/S01/T01", startedAt: 123 });
+
+  assert.equal(store.renderActiveBlock(), null);
+});
+
+test("AutoSession current-unit clear removes active source observations", () => {
+  const basePath = tempProject();
+  writeFileSync(join(basePath, "app.ts"), "export const value = 1;");
+  const session = new AutoSession();
+  session.basePath = basePath;
+  session.setCurrentUnit({
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: 123,
+    workspaceRoot: basePath,
+  });
+  session.sourceObservations.observeRead({ path: "app.ts" });
+
+  assert.match(session.sourceObservations.renderActiveBlock() ?? "", /export const value = 1/);
+
+  session.clearCurrentUnit();
+
+  assert.equal(session.sourceObservations.renderActiveBlock(), null);
+});

--- a/src/resources/extensions/gsd/tests/source-observations.test.ts
+++ b/src/resources/extensions/gsd/tests/source-observations.test.ts
@@ -160,6 +160,36 @@ test("over-threshold files are explicit unavailable observations", () => {
   assert.match(observation.reason ?? "", /exceeds/);
 });
 
+test("outside-root paths are unavailable and never inlined", () => {
+  const root = tempProject();
+  const basePath = join(root, "project");
+  const outsidePath = join(root, "outside");
+  mkdirSync(basePath, { recursive: true });
+  mkdirSync(outsidePath, { recursive: true });
+  writeFileSync(join(outsidePath, "secret.txt"), "do not inline me\n");
+
+  const absoluteObservation = observeSourcePath(basePath, join(outsidePath, "secret.txt"), "read");
+  const relativeObservation = observeSourcePath(basePath, "../outside/secret.txt", "read");
+
+  assert.equal(absoluteObservation.status, "unresolved selector");
+  assert.equal(relativeObservation.status, "unresolved selector");
+  assert.match(absoluteObservation.reason ?? "", /outside active Unit root/);
+  assert.match(relativeObservation.reason ?? "", /outside active Unit root/);
+  assert.equal(absoluteObservation.text, undefined);
+  assert.equal(relativeObservation.text, undefined);
+});
+
+test("source observations only render for execute-task units", () => {
+  const basePath = tempProject();
+  writeFileSync(join(basePath, "plan.md"), "planning context\n");
+
+  const store = new SourceObservationStore();
+  store.beginUnit({ unitType: "plan-slice", unitId: "M001/S01", startedAt: 123, basePath });
+  store.observeRead({ path: "plan.md" });
+
+  assert.equal(store.renderActiveBlock(), null);
+});
+
 test("source context block injection survives tool-result truncation for messages payloads", () => {
   const payload = {
     messages: truncateContextResultMessages([
@@ -215,6 +245,31 @@ test("AutoSession current-unit clear removes active source observations", () => 
   assert.match(session.sourceObservations.renderActiveBlock() ?? "", /export const value = 1/);
 
   session.clearCurrentUnit();
+
+  assert.equal(session.sourceObservations.renderActiveBlock(), null);
+});
+
+test("AutoSession clears source observations when switching to non-execute units", () => {
+  const basePath = tempProject();
+  writeFileSync(join(basePath, "app.ts"), "export const value = 1;");
+  const session = new AutoSession();
+  session.basePath = basePath;
+  session.setCurrentUnit({
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: 123,
+    workspaceRoot: basePath,
+  });
+  session.sourceObservations.observeRead({ path: "app.ts" });
+
+  assert.match(session.sourceObservations.renderActiveBlock() ?? "", /export const value = 1/);
+
+  session.setCurrentUnit({
+    type: "plan-slice",
+    id: "M001/S01",
+    startedAt: 124,
+    workspaceRoot: basePath,
+  });
 
   assert.equal(session.sourceObservations.renderActiveBlock(), null);
 });

--- a/src/resources/extensions/gsd/tool-contract.ts
+++ b/src/resources/extensions/gsd/tool-contract.ts
@@ -9,6 +9,10 @@ import {
 } from "./unit-context-manifest.js";
 import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
 import { getUnitToolSurfaceContract } from "./unit-tool-contracts.js";
+import {
+  WHOLE_FILE_OBSERVATION_MAX_BYTES,
+  WHOLE_FILE_OBSERVATION_MAX_LINES,
+} from "./source-observations.js";
 
 export interface UnitToolContract {
   unitType: string;
@@ -19,12 +23,23 @@ export interface UnitToolContract {
   promptObligations: readonly string[];
   validationRules: readonly string[];
   closeoutTools: readonly string[];
+  sourceObservations: UnitSourceObservationContract;
   artifacts: {
     inline: readonly ArtifactKey[];
     excerpt: readonly ArtifactKey[];
     onDemand: readonly ArtifactKey[];
   };
 }
+
+export type UnitSourceObservationContract =
+  | { mode: "none" }
+  | {
+      mode: "whole-file-active-unit";
+      seedFields: readonly ["task.files", "task.inputs"];
+      excludedFields: readonly ["expectedOutput"];
+      maxBytes: number;
+      maxLines: number;
+    };
 
 export type ToolContractResult =
   | { ok: true; contract: UnitToolContract }
@@ -72,14 +87,27 @@ export function compileUnitToolContract(unitType: string): ToolContractResult {
         "unit-manifest-present",
         "workflow-tool-surface-present",
         ...(requiresCloseoutTool(unitType) ? ["closeout-tool-present"] : []),
+        ...(unitType === "execute-task" ? ["source-observation-contract-present"] : []),
       ],
       closeoutTools,
+      sourceObservations: sourceObservationContractForUnit(unitType),
       artifacts: {
         inline: manifest.artifacts.inline,
         excerpt: manifest.artifacts.excerpt,
         onDemand: manifest.artifacts.onDemand,
       },
     },
+  };
+}
+
+function sourceObservationContractForUnit(unitType: string): UnitSourceObservationContract {
+  if (unitType !== "execute-task") return { mode: "none" };
+  return {
+    mode: "whole-file-active-unit",
+    seedFields: ["task.files", "task.inputs"],
+    excludedFields: ["expectedOutput"],
+    maxBytes: WHOLE_FILE_OBSERVATION_MAX_BYTES,
+    maxLines: WHOLE_FILE_OBSERVATION_MAX_LINES,
   };
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Adds active-Unit Source Context Blocks for GSD auto-mode source files.
**Why:** Auto-mode was relying on historical `read` tool output surviving masking, truncation, and provider payload conversion, which caused repeated rereads and line-window thrash.
**How:** Introduces Source Observations owned by the Unit lifecycle, preloads planned execute-task files, refreshes observations after reads and mutations, and injects protected source context after observation budgeting.

## What

This PR adds ADR-027 and implements the active-Unit source-observation contract for GSD auto-mode.

Key changes:

- Adds `SourceObservationStore` with whole-file thresholds, unavailable statuses, source block rendering, and provider payload injection helpers.
- Extends the Tool Contract for `execute-task` with source-observation invariants.
- Preloads `task.files` plus concrete filesystem-looking `task.inputs` before execute-task dispatch, while excluding `expected_output`.
- Observes successful `read` calls as whole-file source context when files fit the threshold.
- Refreshes active observations after successful `edit` and `write` mutations so the protected source block does not go stale.
- Clears source observations whenever the active Unit is cleared.
- Documents the decision in ADR-027 and updates `CONTEXT.md` terminology.

## Why

Small source files should remain mechanically available to the active Unit. The prior behavior depended on older tool-result messages staying model-visible, which breaks down when observation masking, truncation, narrow reads, or provider-specific payload conversion drops or shrinks that history.

This fixes the long-term failure mode where simple tasks spend turns reconstructing already-read files through repeated `offset` and `limit` reads.

## How

The implementation stores a Unit-scoped source-observation set. Whole-file observations are limited to text files at or below 50KB and 2000 lines. Plan-declared files are loaded before the first provider turn when available, narrow reads upgrade the background observation to whole-file coverage, and provider request assembly injects the generated Source Context Block after normal observation budgeting.

Files that cannot become whole-file observations remain visible as explicit unavailable statuses such as missing, binary/image, over-threshold, glob, directory, or unresolved selector.

The Unit lifecycle now routes current-Unit set and clear paths through `AutoSession` helpers so active source text cannot leak into later Units.

## Change type checklist

- [x] `fix` - Bug fix
- [ ] `feat` - New feature or capability
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [x] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Validation

- `pnpm run verify:fast`
- `pnpm run build:pi`
- `pnpm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/source-observations.test.ts src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783285633&installation_id=134682257&pr_number=514&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F514&signature=2c2382b2b044702c21dbc1227490eaf6c79dd6227cf888ced4277da47ae26423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider request assembly and execute-task dispatch/hooks in the auto loop; scope is limited to execute-task with non-fatal injection failures, but shell success clears all observations which may drop context after bash-driven edits.
> 
> **Overview**
> Implements **ADR-027**: active `execute-task` units no longer depend on old `read` tool results surviving observation budgeting. A new **`SourceObservationStore`** on `AutoSession` tracks plan-declared and read/mutated files (whole-file up to 50KB / 2000 lines), renders a **Source Context Block**, and **`before_provider_request`** injects it after truncation for both messages and Responses payloads.
> 
> **Lifecycle:** direct `currentUnit` assignments become **`setCurrentUnit` / `clearCurrentUnit`**, which begin or clear observations per unit. Dispatch **preloads** `task.files` and path-like **`task.inputs`** (not `expected_output`) from the DB. Hooks record successful **`read`** (narrow reads still upgrade to whole-file in the store), refresh on **`edit`/`write`**, and **clear the store after successful shell** tools because filesystem state may be unknown.
> 
> The **Tool Contract** for `execute-task` now includes source-observation invariants; **`extractPlanningPathReference`** supports seeding from annotated planning paths. Docs and tests cover preloading, unavailable statuses, payload injection, unit close, and shell clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9a390476dca50d01570df4399b29e71b938e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->