### PR TITLE
Hide thinking transcript cards by default

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -183,7 +183,9 @@ describe("AssistantMessageComponent open surface", () => {
 		} as unknown as AssistantMessage;
 		const component = new AssistantMessageComponent(message, true);
 
-		assert.match(component.render(80).map((line) => stripAnsi(line)).join("\n"), /Thinking\.\.\./);
+		const hiddenThinking = component.render(80).map((line) => stripAnsi(line)).join("\n");
+		assert.doesNotMatch(hiddenThinking, /Thinking\.\.\./);
+		assert.doesNotMatch(hiddenThinking, /Private reasoning trace/);
 
 		component.setHideThinkingBlock(false);
 		const expandedThinking = component.render(80).map((line) => stripAnsi(line)).join("\n");

--- a/packages/gsd-agent-modes/src/modes/interactive/components/assistant-message.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/assistant-message.ts
@@ -34,7 +34,7 @@ export class AssistantMessageComponent extends Container {
 
 	constructor(
 		message?: AssistantMessage,
-		hideThinkingBlock = false,
+		hideThinkingBlock = true,
 		markdownTheme: MarkdownTheme = getMarkdownTheme(),
 		timestampFormat: TimestampFormat = "date-time-iso",
 		range?: ContentRange,
@@ -116,9 +116,10 @@ export class AssistantMessageComponent extends Container {
 		const end = this.range?.endIndex ?? message.content.length - 1;
 		const slice = message.content.slice(start, end + 1);
 
-		const hasVisibleContent = slice.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
-		);
+		const hasVisibleContent = slice.some((content) => {
+			if (content.type === "text") return content.text.trim().length > 0;
+			return !this.hideThinkingBlock && content.type === "thinking" && content.thinking.trim().length > 0;
+		});
 		const hasTextContent = message.content.some((c) => c.type === "text" && c.text.trim().length > 0);
 		const hasToolContent = message.content.some((c) => isToolContentBlock(c));
 		// Claude Code often emits long reasoning blocks ahead of user-visible text/tool
@@ -134,33 +135,25 @@ export class AssistantMessageComponent extends Container {
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, this.markdownTheme));
 			} else if (content.type === "thinking" && content.thinking.trim()) {
+				if (this.hideThinkingBlock) continue;
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = slice
 					.slice(i + 1)
 					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
 
-				if (this.hideThinkingBlock) {
-					// Show static "Thinking..." label when hidden
-					this.contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 1, 0));
-					if (hasVisibleContentAfter) {
-						this.contentContainer.addChild(new Spacer(1));
-					}
-				} else {
-					// Thinking traces in thinkingText color, italic
-					const thinkingMarkdown = new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
-						color: (text: string) => theme.fg("thinkingText", text),
-						italic: true,
-					});
-					// Keep visible chat output readable when thinking traces are long.
-					// Tool-bearing turns can stream text in a later assistant message.
-					if (shouldCapThinking) {
-						thinkingMarkdown.maxLines = 8;
-					}
-					this.contentContainer.addChild(thinkingMarkdown);
-					if (hasVisibleContentAfter) {
-						this.contentContainer.addChild(new Spacer(1));
-					}
+				const thinkingMarkdown = new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
+					color: (text: string) => theme.fg("thinkingText", text),
+					italic: true,
+				});
+				// Keep visible chat output readable when thinking traces are long.
+				// Tool-bearing turns can stream text in a later assistant message.
+				if (shouldCapThinking) {
+					thinkingMarkdown.maxLines = 8;
+				}
+				this.contentContainer.addChild(thinkingMarkdown);
+				if (hasVisibleContentAfter) {
+					this.contentContainer.addChild(new Spacer(1));
 				}
 			}
 		}
@@ -200,6 +193,7 @@ export class AssistantMessageComponent extends Container {
 		const frameWidth = Math.max(20, width);
 		const contentWidth = Math.max(1, frameWidth - 3);
 		const lines = super.render(contentWidth);
+		if (lines.length === 0) return [];
 		const metaParts = [];
 		if (this.lastMessage?.model) metaParts.push(this.lastMessage.model);
 		if (this.showMetadata && this.lastMessage?.timestamp != null) {

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -175,6 +175,36 @@ test("findLatestPinnableText: thinking blocks are not pinnable", () => {
 	assert.equal(findLatestPinnableText(blocks), "");
 });
 
+test("handleAgentEvent: hidden thinking-only updates do not render transcript cards", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const host = createStreamingHost(chatContainer);
+	const message = {
+		id: "a-thinking",
+		role: "assistant",
+		provider: "claude-code",
+		model: "claude-opus-4-8",
+		timestamp: 1,
+		stopReason: "stop",
+		content: [{ type: "thinking", thinking: "I'm thinking through the next step." }],
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: { ...message, content: [] } } as any);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message,
+		assistantMessageEvent: {
+			type: "thinking_delta",
+			contentIndex: 0,
+			delta: "I'm thinking through the next step.",
+			partial: message,
+		},
+	} as any);
+	await handleAgentEvent(host, { type: "message_end", message } as any);
+
+	assert.equal(stripAnsi(chatContainer.render(100).join("\n")).trim(), "");
+});
+
 test("handleAgentEvent: agent_start clears stale adaptive blocking error", async () => {
 	initTheme("dark", false);
 	let cleared = false;

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -146,8 +146,9 @@ function markFirstVisibleAssistantOutput(
 	host.session?.markFirstVisibleTurnLatency?.(kind, data);
 }
 
-function getVisibleTextLikeBlockType(block: any): "text" | "thinking" | undefined {
+function getVisibleTextLikeBlockType(block: any, hideThinkingBlock = false): "text" | "thinking" | undefined {
 	if (block?.type === "text" && typeof block.text === "string" && block.text.trim().length > 0) return "text";
+	if (hideThinkingBlock) return undefined;
 	if (block?.type === "thinking" && typeof block.thinking === "string" && block.thinking.trim().length > 0) return "thinking";
 	return undefined;
 }
@@ -291,7 +292,7 @@ function shouldSuppressRedundantHandoffText(
 
 function buildDesiredSegments(
 	blocks: Array<any>,
-	options: { shouldSkipTextBlock?: (block: any, index: number) => boolean } = {},
+	options: { hideThinkingBlock?: boolean; shouldSkipTextBlock?: (block: any, index: number) => boolean } = {},
 ): DesiredSegment[] {
 	const desired: DesiredSegment[] = [];
 	let runStart = -1;
@@ -308,7 +309,7 @@ function buildDesiredSegments(
 
 	for (let i = 0; i < blocks.length; i++) {
 		const block = blocks[i];
-		const blockType = getVisibleTextLikeBlockType(block);
+		const blockType = getVisibleTextLikeBlockType(block, options.hideThinkingBlock);
 		const isInvisibleTextLike = blockType === undefined && (block?.type === "text" || block?.type === "thinking");
 		const isTool = block?.type === "toolCall" || block?.type === "serverToolUse";
 
@@ -397,20 +398,24 @@ function getProvisionalPreToolPrunePlan(message: { provider?: string; content: A
 	};
 }
 
-function buildDesiredSegmentsForMessage(message: { provider?: string; content: Array<any> }): DesiredSegment[] {
+function buildDesiredSegmentsForMessage(
+	message: { provider?: string; content: Array<any> },
+	options: { hideThinkingBlock?: boolean } = {},
+): DesiredSegment[] {
 	const { shouldPrune, firstToolIdx } = getProvisionalPreToolPrunePlan(message);
 	return buildDesiredSegments(message.content, {
+		hideThinkingBlock: options.hideThinkingBlock,
 		shouldSkipTextBlock: (block: any, index: number) => {
 			if (!shouldPrune || firstToolIdx < 0 || index >= firstToolIdx) return false;
-			if (getVisibleTextLikeBlockType(block) !== "text") return false;
+			if (getVisibleTextLikeBlockType(block, options.hideThinkingBlock) !== "text") return false;
 			const textValue = typeof block?.text === "string" ? block.text : "";
 			return isProvisionalPreToolProse(textValue);
 		},
 	});
 }
 
-function hasVisibleAssistantContent(message: { content: Array<any> }): boolean {
-	return message.content.some((c) => getVisibleTextLikeBlockType(c) !== undefined);
+function hasVisibleAssistantContent(message: { content: Array<any> }, hideThinkingBlock = false): boolean {
+	return message.content.some((c) => getVisibleTextLikeBlockType(c, hideThinkingBlock) !== undefined);
 }
 
 function hasAssistantToolBlocks(message: { content: Array<any> }): boolean {
@@ -817,7 +822,9 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					// so MCP tool-only windows do not blank the assistant content.
 					const { shouldPrune: shouldPruneProvisionalPreToolProse } =
 						getProvisionalPreToolPrunePlan(host.streamingMessage);
-					let desired = buildDesiredSegmentsForMessage(host.streamingMessage);
+					let desired = buildDesiredSegmentsForMessage(host.streamingMessage, {
+						hideThinkingBlock: host.hideThinkingBlock,
+					});
 					desired = filterRedundantDiscussTextRuns(desired, blocks);
 
 					// Claude Code MCP can emit provisional pre-tool prose that gets
@@ -1048,18 +1055,19 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				if (event.message.role === "assistant") {
 					host.streamingMessage = event.message;
 					let errorMessage: string | undefined;
-				if (host.streamingMessage.stopReason === "aborted") {
-					const retryAttempt = host.session.retryAttempt;
-					errorMessage = retryAttempt > 0
-						? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-						: "Operation aborted";
-					host.streamingMessage.errorMessage = errorMessage;
-				}
+					if (host.streamingMessage.stopReason === "aborted") {
+						const retryAttempt = host.session.retryAttempt;
+						errorMessage = retryAttempt > 0
+							? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
+							: "Operation aborted";
+						host.streamingMessage.errorMessage = errorMessage;
+					}
 
-					const shouldRenderAssistant = hasVisibleAssistantContent(host.streamingMessage)
-						|| (
-							(host.streamingMessage.stopReason === "aborted" || host.streamingMessage.stopReason === "error")
-							&& !hasAssistantToolBlocks(host.streamingMessage)
+					const shouldRenderAssistant =
+						hasVisibleAssistantContent(host.streamingMessage, host.hideThinkingBlock) ||
+						(
+							(host.streamingMessage.stopReason === "aborted" || host.streamingMessage.stopReason === "error") &&
+							!hasAssistantToolBlocks(host.streamingMessage)
 						);
 					const suppressRedundantHandoff = shouldSuppressRedundantHandoffText(
 						host.session.messages,
@@ -1075,7 +1083,9 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					if (renderedSegments.length > 0) {
 						const finalBlocks = host.streamingMessage.content;
 						const desired = filterRedundantDiscussTextRuns(
-							buildDesiredSegmentsForMessage(host.streamingMessage),
+							buildDesiredSegmentsForMessage(host.streamingMessage, {
+								hideThinkingBlock: host.hideThinkingBlock,
+							}),
 							finalBlocks,
 						);
 

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.ts
@@ -151,7 +151,9 @@ export function addMessageToChat(host: InteractiveModeDelegateHost, message: Age
 				break;
 			}
 			case "assistant": {
-				if (!hasAssistantVisibleContent(message.content, host.hideThinkingBlock)) break;
+				const hasToolBlocks = message.content.some((c: any) => isToolContentBlock(c));
+				const isAbortOrError = message.stopReason === "aborted" || message.stopReason === "error";
+				if (!hasAssistantVisibleContent(message.content, host.hideThinkingBlock) && !(isAbortOrError && !hasToolBlocks)) break;
 				const connectedToUser = chatTurnFollowsUser(host.chatContainer.children);
 				const assistantComponent = new AssistantMessageComponent(
 					message,

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.ts
@@ -64,6 +64,14 @@ function addUserMessageComponent(host: InteractiveModeDelegateHost, userComponen
 	host.chatContainer.addChild(userComponent);
 }
 
+function hasAssistantVisibleContent(content: Array<any>, hideThinkingBlock: boolean): boolean {
+	return content.some((c: any) => {
+		if (c?.type === "text" && typeof c.text === "string" && c.text.trim().length > 0) return true;
+		if (!hideThinkingBlock && c?.type === "thinking" && typeof c.thinking === "string" && c.thinking.trim().length > 0) return true;
+		return false;
+	});
+}
+
 function finalizeChatMutation(host: InteractiveModeDelegateHost): void {
 	trimChatHistory(host);
 	reconcileChatTurnConnections(host.chatContainer.children);
@@ -143,6 +151,7 @@ export function addMessageToChat(host: InteractiveModeDelegateHost, message: Age
 				break;
 			}
 			case "assistant": {
+				if (!hasAssistantVisibleContent(message.content, host.hideThinkingBlock)) break;
 				const connectedToUser = chatTurnFollowsUser(host.chatContainer.children);
 				const assistantComponent = new AssistantMessageComponent(
 					message,
@@ -209,6 +218,8 @@ export function renderSessionContext(host: InteractiveModeDelegateHost,
 
 				for (const segment of replaySegments) {
 					if (segment.kind === "assistant") {
+						const segContent = message.content.slice(segment.startIndex, segment.endIndex + 1);
+						if (!hasAssistantVisibleContent(segContent, host.hideThinkingBlock)) continue;
 						const connectedToUser = chatTurnFollowsUser(host.chatContainer.children);
 						const assistantComponent = new AssistantMessageComponent(
 							message,

--- a/packages/pi-coding-agent/docs/settings.md
+++ b/packages/pi-coding-agent/docs/settings.md
@@ -18,7 +18,7 @@ Edit directly or use `/settings` for common options.
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
-| `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
+| `hideThinkingBlock` | boolean | `true` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
 
 #### thinkingBudgets

--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -793,7 +793,7 @@ export class SettingsManager {
 	}
 
 	getHideThinkingBlock(): boolean {
-		return this.settings.hideThinkingBlock ?? false;
+		return this.settings.hideThinkingBlock ?? true;
 	}
 
 	setHideThinkingBlock(hide: boolean): void {

--- a/src/tests/assistant-message-thinking-visibility.test.ts
+++ b/src/tests/assistant-message-thinking-visibility.test.ts
@@ -21,7 +21,7 @@ test("assistant-message caps thinking block height when text content is present"
       { type: "thinking", thinking: longThinking() },
       { type: "text", text: "final answer" },
     ],
-  } as any);
+  } as any, false);
 
   assert.equal(firstRenderedMarkdown(component).maxLines, 8);
 });
@@ -37,7 +37,7 @@ test("assistant-message caps thinking block height when tool content is present"
       { type: "thinking", thinking: longThinking() },
       { type: "toolCall", toolCallId: "tool-1", toolName: "bash", args: {} },
     ],
-  } as any);
+  } as any, false);
 
   assert.equal(firstRenderedMarkdown(component).maxLines, 8);
 });
@@ -50,7 +50,7 @@ test("assistant-message caps claude-code thinking-only traces", () => {
     provider: "claude-code",
     model: "test-model",
     content: [{ type: "thinking", thinking: longThinking() }],
-  } as any);
+  } as any, false);
 
   assert.equal(firstRenderedMarkdown(component).maxLines, 8);
 });


### PR DESCRIPTION
## TL;DR

**What:** Hide raw thinking blocks from the interactive transcript by default.
**Why:** Thinking text looked like the agent was talking to itself instead of giving concise user-facing updates.
**How:** Default hidden thinking on, skip hidden thinking in stream segment rendering, and cover the behavior with focused renderer/controller tests.

## What

- Default `hideThinkingBlock` to `true` and update the settings docs.
- Stop hidden thinking blocks from rendering placeholder transcript cards.
- Pass the hide-thinking setting through the interactive stream segment planner so thinking-only updates do not create empty `GSD` cards.
- Add focused regression coverage for hidden thinking-only updates and explicit thinking visibility.

## Why

The interactive transcript treated reasoning blocks as visible content. Even when thinking was hidden, the renderer still emitted a `Thinking...` placeholder, which made GSD feel like it was narrating private draft work to itself.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts`
- `pnpm run build:agent-modes`
- `pnpm run build:pi-coding-agent`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783290626&installation_id=134682257&pr_number=515&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F515&signature=a02eff9e205ba05184cf6d5adb3965f23703e1feef5d2704e17ada48b2c18abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI display and default settings only; thinking can still be shown via settings, with regression tests for streaming and replay paths.
> 
> **Overview**
> **Hides model reasoning from the interactive transcript by default** so the UI no longer looks like the agent is talking to itself.
> 
> `hideThinkingBlock` now defaults to **true** in settings and `AssistantMessageComponent`. When hidden, thinking blocks are **omitted entirely**—the old italic **"Thinking..."** placeholder is gone—and assistant cards with **only** thinking render **nothing** (no empty `GSD` rails).
> 
> The stream **segment planner** and history replay (`chat-controller`, `interactive-chat-render`) treat thinking as invisible when the setting is on, so thinking-only streaming updates do not create transcript cards. Users can still **show** thinking via `setHideThinkingBlock(false)` / settings.
> 
> Tests cover hidden thinking-only agent events and visibility toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae97d70ef8a77557f3907ae1ad0af64f90f8fdf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->