### PR TITLE
fix(browser-tools): scope artifacts to tool cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,11 +166,11 @@
     "discord.js": "^14.26.4",
     "extract-zip": "^2.0.1",
     "file-type": "^21.1.1",
+    "get-east-asian-width": "^1.6.0",
     "glob": "^13.0.1",
     "graceful-fs": "^4.2.4",
-    "get-east-asian-width": "^1.6.0",
-    "hosted-git-info": "^9.0.2",
     "highlight.js": "^10.7.3",
+    "hosted-git-info": "^9.0.2",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
     "ignore": "^7.0.5",
@@ -200,7 +200,7 @@
     "c8": "^11.0.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.25.12",
-    "jiti": "^2.6.1",
+    "jiti": "^2.7.0",
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ importers:
         specifier: ^0.25.12
         version: 0.25.12
       jiti:
-        specifier: ^2.6.1
+        specifier: ^2.7.0
         version: 2.7.0
       typescript:
         specifier: ^5.9.3

--- a/src/resources/extensions/browser-tools/index.ts
+++ b/src/resources/extensions/browser-tools/index.ts
@@ -3,6 +3,7 @@ import { importExtensionModule, type ExtensionAPI, type ExtensionContext } from 
 
 import { closeManagedGsdBrowser, registerManagedGsdBrowserTools, warmUpManagedGsdBrowser } from "./engine/managed-gsd-browser.js";
 import { resolveBrowserEngineMode, type BrowserEngineMode } from "./engine/selection.js";
+import { setArtifactRootForCwd } from "./state.js";
 import { detectWebApp } from "./web-app-detect.js";
 
 let legacyRegistrationPromise: Promise<void> | null = null;
@@ -119,28 +120,29 @@ async function registerLegacyBrowserTools(pi: ExtensionAPI): Promise<void> {
         formatArtifactTimestamp: utils.formatArtifactTimestamp,
       };
 
-      navigation.registerNavigationTools(pi, deps);
-      screenshot.registerScreenshotTools(pi, deps);
-      interaction.registerInteractionTools(pi, deps);
-      inspection.registerInspectionTools(pi, deps);
-      session.registerSessionTools(pi, deps);
-      assertions.registerAssertionTools(pi, deps);
-      refTools.registerRefTools(pi, deps);
-      wait.registerWaitTools(pi, deps);
-      pages.registerPageTools(pi, deps);
-      forms.registerFormTools(pi, deps);
-      intent.registerIntentTools(pi, deps);
-      pdf.registerPdfTools(pi, deps);
-      statePersistence.registerStatePersistenceTools(pi, deps);
-      networkMock.registerNetworkMockTools(pi, deps);
-      device.registerDeviceTools(pi, deps);
-      extract.registerExtractTools(pi, deps);
-      visualDiff.registerVisualDiffTools(pi, deps);
-      zoom.registerZoomTools(pi, deps);
-      codegen.registerCodegenTools(pi, deps);
-      actionCache.registerActionCacheTools(pi, deps);
-      injectionDetection.registerInjectionDetectionTools(pi, deps);
-      verify.registerVerifyTools(pi, deps);
+      const cwdScopedPi = withBrowserArtifactCwdScope(pi);
+      navigation.registerNavigationTools(cwdScopedPi, deps);
+      screenshot.registerScreenshotTools(cwdScopedPi, deps);
+      interaction.registerInteractionTools(cwdScopedPi, deps);
+      inspection.registerInspectionTools(cwdScopedPi, deps);
+      session.registerSessionTools(cwdScopedPi, deps);
+      assertions.registerAssertionTools(cwdScopedPi, deps);
+      refTools.registerRefTools(cwdScopedPi, deps);
+      wait.registerWaitTools(cwdScopedPi, deps);
+      pages.registerPageTools(cwdScopedPi, deps);
+      forms.registerFormTools(cwdScopedPi, deps);
+      intent.registerIntentTools(cwdScopedPi, deps);
+      pdf.registerPdfTools(cwdScopedPi, deps);
+      statePersistence.registerStatePersistenceTools(cwdScopedPi, deps);
+      networkMock.registerNetworkMockTools(cwdScopedPi, deps);
+      device.registerDeviceTools(cwdScopedPi, deps);
+      extract.registerExtractTools(cwdScopedPi, deps);
+      visualDiff.registerVisualDiffTools(cwdScopedPi, deps);
+      zoom.registerZoomTools(cwdScopedPi, deps);
+      codegen.registerCodegenTools(cwdScopedPi, deps);
+      actionCache.registerActionCacheTools(cwdScopedPi, deps);
+      injectionDetection.registerInjectionDetectionTools(cwdScopedPi, deps);
+      verify.registerVerifyTools(cwdScopedPi, deps);
     })().catch((error) => {
       legacyRegistrationPromise = null;
       throw error;
@@ -148,6 +150,21 @@ async function registerLegacyBrowserTools(pi: ExtensionAPI): Promise<void> {
   }
 
   return legacyRegistrationPromise;
+}
+
+function withBrowserArtifactCwdScope(pi: ExtensionAPI): ExtensionAPI {
+  return {
+    ...pi,
+    registerTool(definition) {
+      pi.registerTool({
+        ...definition,
+        async execute(toolCallId, params, signal, onUpdate, ctx) {
+          if (ctx?.cwd) setArtifactRootForCwd(ctx.cwd);
+          return definition.execute(toolCallId, params, signal, onUpdate, ctx);
+        },
+      });
+    },
+  };
 }
 
 async function registerBrowserTools(pi: ExtensionAPI): Promise<void> {

--- a/src/resources/extensions/browser-tools/state.ts
+++ b/src/resources/extensions/browser-tools/state.ts
@@ -186,6 +186,14 @@ export interface BrowserAssertionCheckInput {
 // Mutable state variables — accessed only via get/set functions
 // ---------------------------------------------------------------------------
 
+// 0. artifactRoot
+let _artifactRoot = ARTIFACT_ROOT;
+export function getArtifactRoot(): string { return _artifactRoot; }
+export function setArtifactRootForCwd(cwd: string): string {
+	_artifactRoot = path.resolve(cwd, ".artifacts", "browser");
+	return _artifactRoot;
+}
+
 // 1. browser
 let _browser: Browser | null = null;
 export function getBrowser(): Browser | null { return _browser; }
@@ -290,6 +298,7 @@ export function setHarState(h: HarState): void { _harState = h; }
 // ---------------------------------------------------------------------------
 
 export function resetAllState(): void {
+	_artifactRoot = ARTIFACT_ROOT;
 	_browser = null;
 	_context = null;
 	pageRegistry.pages = [];

--- a/src/resources/extensions/browser-tools/state.ts
+++ b/src/resources/extensions/browser-tools/state.ts
@@ -190,7 +190,11 @@ export interface BrowserAssertionCheckInput {
 let _artifactRoot = ARTIFACT_ROOT;
 export function getArtifactRoot(): string { return _artifactRoot; }
 export function setArtifactRootForCwd(cwd: string): string {
-	_artifactRoot = path.resolve(cwd, ".artifacts", "browser");
+	const newRoot = path.resolve(cwd, ".artifacts", "browser");
+	if (newRoot !== _artifactRoot) {
+		_artifactRoot = newRoot;
+		_sessionArtifactDir = null;
+	}
 	return _artifactRoot;
 }
 

--- a/src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs
+++ b/src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs
@@ -10,6 +10,9 @@
 
 const { describe, it, beforeEach } = require("node:test");
 const assert = require("node:assert/strict");
+const { mkdtempSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
 const jiti = require("jiti")(__filename, { interopDefault: true, debug: false });
 
 // ---------------------------------------------------------------------------
@@ -28,9 +31,12 @@ const {
 	getUrlHash,
 	firstErrorLine,
 	formatArtifactTimestamp,
+	ensureSessionArtifactDir,
 } = jiti("../utils.ts");
 
 const {
+	getArtifactRoot,
+	setArtifactRootForCwd,
 	getBrowser,
 	setBrowser,
 	getContext,
@@ -467,6 +473,34 @@ describe("state accessors", () => {
 		assert.equal(getSessionArtifactDir(), null);
 		setSessionArtifactDir("/tmp/artifacts");
 		assert.equal(getSessionArtifactDir(), "/tmp/artifacts");
+	});
+
+	it("uses the active tool context cwd for session artifact paths", async (t) => {
+		const processRoot = mkdtempSync(join(tmpdir(), "browser-tools-process-"));
+		const contextRoot = mkdtempSync(join(tmpdir(), "browser-tools-context-"));
+		const previousCwd = process.cwd();
+		t.after(() => {
+			process.chdir(previousCwd);
+			rmSync(processRoot, { recursive: true, force: true });
+			rmSync(contextRoot, { recursive: true, force: true });
+		});
+
+		process.chdir(processRoot);
+		resetAllState();
+		const expectedRoot = join(contextRoot, ".artifacts", "browser");
+		setArtifactRootForCwd(contextRoot);
+
+		const sessionDir = await ensureSessionArtifactDir();
+
+		assert.equal(getArtifactRoot(), expectedRoot);
+		assert.ok(
+			sessionDir.startsWith(`${expectedRoot}/`),
+			`session artifact dir should stay under context cwd: ${sessionDir}`,
+		);
+		assert.ok(
+			!sessionDir.startsWith(join(processRoot, ".artifacts", "browser")),
+			`session artifact dir must not use process cwd: ${sessionDir}`,
+		);
 	});
 
 	it("setCurrentRefMap/getCurrentRefMap round-trip", () => {

--- a/src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs
+++ b/src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs
@@ -503,6 +503,29 @@ describe("state accessors", () => {
 		);
 	});
 
+	it("session artifact dir is recomputed when artifact root changes", async (t) => {
+		const root1 = mkdtempSync(join(tmpdir(), "browser-tools-root1-"));
+		const root2 = mkdtempSync(join(tmpdir(), "browser-tools-root2-"));
+		t.after(() => {
+			rmSync(root1, { recursive: true, force: true });
+			rmSync(root2, { recursive: true, force: true });
+		});
+
+		resetAllState();
+		setArtifactRootForCwd(root1);
+		const sessionDir1 = await ensureSessionArtifactDir();
+		assert.ok(sessionDir1.startsWith(join(root1, ".artifacts", "browser")));
+
+		// Change the root — cached session dir must be invalidated
+		setArtifactRootForCwd(root2);
+		const sessionDir2 = await ensureSessionArtifactDir();
+		assert.ok(
+			sessionDir2.startsWith(join(root2, ".artifacts", "browser")),
+			`session dir should be under new root after root change: ${sessionDir2}`,
+		);
+		assert.notEqual(sessionDir1, sessionDir2, "session dir must differ after root change");
+	});
+
 	it("setCurrentRefMap/getCurrentRefMap round-trip", () => {
 		assert.deepStrictEqual(getCurrentRefMap(), {});
 		const refMap = { e1: { ref: "e1", tag: "button" } };

--- a/src/resources/extensions/browser-tools/tools/session.ts
+++ b/src/resources/extensions/browser-tools/tools/session.ts
@@ -9,8 +9,8 @@ import {
 } from "../core.js";
 import type { ToolDeps } from "../state.js";
 import {
-	ARTIFACT_ROOT,
 	HAR_FILENAME,
+	getArtifactRoot,
 	getPageRegistry,
 	getActiveFrame,
 	getConsoleLogs,
@@ -315,7 +315,9 @@ export function registerSessionTools(pi: ExtensionAPI, deps: ToolDeps): void {
 				const { page: p } = await deps.ensureBrowser();
 				const startedAt = Date.now();
 				const sessionDir = await deps.ensureSessionArtifactDir();
-				const bundleDir = path.join(ARTIFACT_ROOT, `${deps.formatArtifactTimestamp(startedAt)}-${deps.sanitizeArtifactName(params.name ?? "debug-bundle", "debug-bundle")}`);
+				const bundleName =
+					`${deps.formatArtifactTimestamp(startedAt)}-${deps.sanitizeArtifactName(params.name ?? "debug-bundle", "debug-bundle")}`;
+				const bundleDir = path.join(getArtifactRoot(), bundleName);
 				await ensureDir(bundleDir);
 				const pages = await deps.getLivePagesSnapshot();
 				const actionTimeline = getActionTimeline();

--- a/src/resources/extensions/browser-tools/utils.ts
+++ b/src/resources/extensions/browser-tools/utils.ts
@@ -21,8 +21,8 @@ import {
 	registryListPages,
 } from "./core.js";
 import {
-	ARTIFACT_ROOT,
 	getActiveFrame,
+	getArtifactRoot,
 	getActiveTraceSession,
 	getConsoleLogs,
 	getDialogLogs,
@@ -119,7 +119,7 @@ export async function ensureSessionArtifactDir(): Promise<string> {
 		return existing;
 	}
 	const startedAt = ensureSessionStartedAt();
-	const dir = path.join(ARTIFACT_ROOT, `${formatArtifactTimestamp(startedAt)}-session`);
+	const dir = path.join(getArtifactRoot(), `${formatArtifactTimestamp(startedAt)}-session`);
 	setSessionArtifactDir(dir);
 	await ensureDir(dir);
 	return dir;
@@ -159,7 +159,7 @@ export function getActiveFrameMetadata() {
 
 export function getSessionArtifactMetadata() {
 	return {
-		artifactRoot: ARTIFACT_ROOT,
+		artifactRoot: getArtifactRoot(),
 		sessionStartedAt: getSessionStartedAt(),
 		sessionArtifactDir: getSessionArtifactDir(),
 		activeTraceSession: getActiveTraceSession(),


### PR DESCRIPTION
## TL;DR

**What:** Scopes legacy browser-tools artifact output to the active tool context cwd.
**Why:** Isolated run-uat sessions could write browser debug bundles into the project root and trip the root-write leak guard.
**How:** Refresh the browser artifact root from `ctx.cwd` on legacy browser tool execution and route session/debug bundle writers through the active artifact root.

## What

This updates the bundled `browser-tools` extension so artifact writers resolve paths from the active tool context rather than the module-load process cwd. The legacy browser tool registrations now wrap tool execution with context-cwd artifact scoping, and session artifact helpers/debug bundle output read the current artifact root through state accessors.

A regression test covers the isolated-worktree case by changing the process cwd, setting a separate tool context cwd, and asserting session artifacts stay under the context root.

## Why

The root-write guard correctly stopped auto-mode after `browser_debug_bundle` wrote `.artifacts/browser/...` under the project root during an isolated `run-uat` unit. The isolated unit worktree was the correct writable location, but the browser-tools artifact root was captured from `process.cwd()` when the module loaded.

## How

- Add mutable artifact-root state initialized from the existing default.
- Set the artifact root from `ctx.cwd` before legacy browser tool execution.
- Route session artifact directory metadata and debug bundle paths through the current artifact root.
- Add a browser-tools unit regression for context-cwd artifact paths.

## Validation

- [x] `git diff --check`
- [x] `pnpm run build:core`
- [x] `node tests/browser-tools-unit.test.cjs`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run test:browser-tools`
- [x] `pnpm run verify:fast`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783290651&installation_id=134682257&pr_number=516&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F516&signature=4179a49be78541422299351a0b72b49fa0fe56f6a154ec3d3d5f8350987a545f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted path-resolution fix with regression tests; only affects where browser artifacts are written, not auth or core agent logic.
> 
> **Overview**
> Legacy **browser-tools** no longer pins artifact output to `process.cwd()` at module load. A mutable artifact root (`<cwd>/.artifacts/browser`) is set from **`ctx.cwd`** before each legacy tool runs via `withBrowserArtifactCwdScope`, and session helpers plus **`browser_debug_bundle`** resolve paths through **`getArtifactRoot()`** instead of the fixed `ARTIFACT_ROOT` constant.
> 
> Changing the root clears the cached session artifact directory so paths stay consistent when the tool context switches (e.g. isolated `run-uat` worktrees). Unit tests cover context-cwd vs process-cwd and root invalidation; **`jiti`** is bumped to **^2.7.0** in devDependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f605a612fa92df2842e5a25017bebb2e4b7bbe94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->