### PR TITLE
fix(gsd): avoid false worktree planning pauses

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -639,6 +639,26 @@ export function shouldUseWorktreeIsolation(basePath?: string): boolean {
   return getIsolationMode(basePath) === "worktree";
 }
 
+type AutoIsolationMode = ReturnType<typeof getIsolationMode>;
+
+function resolveEffectiveUnitIsolationMode(
+  configuredMode: AutoIsolationMode,
+  isolationDegraded: boolean,
+): AutoIsolationMode {
+  return configuredMode === "worktree" && isolationDegraded ? "branch" : configuredMode;
+}
+
+export function _resolveEffectiveUnitIsolationModeForTest(
+  configuredMode: AutoIsolationMode,
+  isolationDegraded: boolean,
+): AutoIsolationMode {
+  return resolveEffectiveUnitIsolationMode(configuredMode, isolationDegraded);
+}
+
+function getEffectiveUnitIsolationMode(basePath: string): AutoIsolationMode {
+  return resolveEffectiveUnitIsolationMode(getIsolationMode(basePath), s.isolationDegraded);
+}
+
 /** Crash recovery prompt — set by startAuto, consumed by the main loop */
 
 /** Pending verification retry — set when gate fails with retries remaining, consumed by autoLoop */
@@ -2382,6 +2402,7 @@ export function createWiredAutoOrchestrationModule(
     },
     worktree: {
       async prepareForUnit(unitType, unitId) {
+        const isolationMode = getEffectiveUnitIsolationMode(runtimeBasePath);
         const manifest = resolveManifest(unitType);
         if (!manifest) {
           return {
@@ -2389,16 +2410,13 @@ export function createWiredAutoOrchestrationModule(
             reason: `No Unit manifest is registered for ${unitType}`,
           };
         }
-        if (getIsolationMode(runtimeBasePath) !== "worktree") {
+        if (isolationMode !== "worktree") {
           return { ok: true, reason: "not-required" };
         }
         const writeScope =
           manifest.tools.mode === "all" || manifest.tools.mode === "docs"
             ? "source-writing"
             : "planning-only";
-        if (getIsolationMode(runtimeBasePath) !== "worktree") {
-          return { ok: true, reason: "isolation-not-worktree" };
-        }
         const safety = createWorktreeSafetyModule();
         const activeBasePath = getLiveDispatchBasePath();
         const snapshot = await deriveState(activeBasePath);
@@ -2411,7 +2429,7 @@ export function createWiredAutoOrchestrationModule(
           projectRoot: runtimeBasePath,
           unitRoot: activeBasePath,
           milestoneId,
-          isolationMode: getIsolationMode(runtimeBasePath),
+          isolationMode,
           expectedBranch,
         });
         if (!result.ok) {
@@ -2436,7 +2454,7 @@ export function createWiredAutoOrchestrationModule(
               projectRoot: runtimeBasePath,
               unitRoot: getLiveDispatchBasePath(),
               milestoneId,
-              isolationMode: getIsolationMode(runtimeBasePath),
+              isolationMode: getEffectiveUnitIsolationMode(runtimeBasePath),
               expectedBranch,
             }),
           });

--- a/src/resources/extensions/gsd/prompts/plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/plan-slice.md
@@ -38,7 +38,7 @@ If slice research is inlined, trust its architectural findings, but verify every
 
 1. If requirements are preloaded, identify owned and supporting Active requirements.
 2. Call `memory_query` with keywords from the slice title and source files.
-3. Read `{{planTemplatePath}}` and `{{taskPlanTemplatePath}}`.
+3. Use the inlined Output Template sections already present in this prompt. Do not read template files from disk.
 4. {{skillActivation}} Record expected executor skills in each task plan's `skills_used` frontmatter.
 5. Define slice verification before tasks. Non-trivial slices need real tests or executable assertions; boundary contracts need contract-exercising checks. Tests must not read .gitignore/gitignored paths such as `.gsd/`, `.planning/`, or `.audits/`.
 6. Include Threat Surface (Q3), Requirement Impact (Q4), proof level, observability, integration closure, Failure Modes (Q5), Load Profile (Q6), and Negative Tests (Q7) only where applicable.

--- a/src/resources/extensions/gsd/tests/plan-slice-prompt.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice-prompt.test.ts
@@ -76,8 +76,10 @@ test("plan-slice prompt: compact planning gates survive template substitution", 
   assert.ok(result.includes("Bias toward \"roadmap is fine.\""), "roadmap reassessment brake should remain visible");
   assert.ok(result.includes("Self-audit before finishing"), "self-audit gate should remain visible");
   assert.ok(result.includes("Quality gates: non-trivial slices/tasks include specific Q3-Q7 coverage where applicable."));
-  assert.ok(result.includes("C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\plan.md"));
-  assert.ok(result.includes("C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\task-plan.md"));
+  assert.ok(result.includes("Use the inlined Output Template sections already present in this prompt."));
+  assert.ok(result.includes("Do not read template files from disk."));
+  assert.ok(!result.includes("C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\plan.md"));
+  assert.ok(!result.includes("C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\task-plan.md"));
   assert.ok(!result.includes("{{templatesDir}}/plan.md"));
   assert.ok(!result.includes("{{templatesDir}}/task-plan.md"));
   assert.ok(!result.includes("{{"));

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { _withDetachedAutoKeepaliveForTest } from "../auto.ts";
+import {
+  _resolveEffectiveUnitIsolationModeForTest,
+  _withDetachedAutoKeepaliveForTest,
+} from "../auto.ts";
 import {
   _scheduleAutoStartAfterIdleForTest,
   resolveGuidedExecuteLaunchMode,
@@ -343,9 +346,20 @@ test("prepareForUnit skips worktree safety when isolation is not worktree (#6154
 
   assert.ok(prepareForUnitIdx > -1, "prepareForUnit should exist");
   assert.ok(
-    prepareForUnitBody.includes('if (getIsolationMode(runtimeBasePath) !== "worktree")'),
+    prepareForUnitBody.includes("const isolationMode = getEffectiveUnitIsolationMode(runtimeBasePath);"),
+    "prepareForUnit should resolve the effective isolation mode once",
+  );
+  assert.ok(
+    prepareForUnitBody.includes('if (isolationMode !== "worktree")'),
     "prepareForUnit should bypass worktree safety validation outside worktree isolation mode",
   );
+});
+
+test("effective unit isolation follows degraded branch fallback", () => {
+  assert.equal(_resolveEffectiveUnitIsolationModeForTest("worktree", true), "branch");
+  assert.equal(_resolveEffectiveUnitIsolationModeForTest("worktree", false), "worktree");
+  assert.equal(_resolveEffectiveUnitIsolationModeForTest("branch", true), "branch");
+  assert.equal(_resolveEffectiveUnitIsolationModeForTest("none", true), "none");
 });
 
 test("discuss-to-auto handoff defaults to step mode unless explicitly disabled", () => {

--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -150,6 +150,30 @@ describe("Worktree Safety module", () => {
     assert.equal(result.kind, "safe");
   });
 
+  test("accepts project root for source-writing Unit when isolation mode is branch", () => {
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => true,
+      lstatSync: () => ({ isFile: () => false }),
+      listRegisteredWorktrees: () => [{ path: projectRoot, branch: "milestone/M001" }],
+      getCurrentBranch: () => "milestone/M001",
+    });
+
+    const result = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot: projectRoot,
+      milestoneId: "M001",
+      isolationMode: "branch",
+      expectedBranch: "milestone/M001",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, "safe");
+    assert.equal(result.branch, "milestone/M001");
+  });
+
   test("rejects non-project root for source-writing Unit when isolation mode is none", () => {
     const safety = createWorktreeSafetyModule({
       existsSync: () => true,


### PR DESCRIPTION
## TL;DR

**What:** Fixes two false GSD worktree/planning pauses.
**Why:** Auto-mode could reject valid branch fallback roots and plan-slice prompts could tell agents to read stale absolute template paths.
**How:** Resolve effective isolation after degraded worktree fallback and make plan-slice use inlined templates instead of disk template reads.

## What

- Treat degraded worktree isolation as effective branch mode during unit root validation.
- Keep branch-mode project-root validation guarded by expected milestone branch checks.
- Stop rendering absolute template-read instructions into plan-slice prompts when the templates are already inlined.
- Add regression coverage for degraded isolation and stale template prompt rendering.

## Why

Recent GSD runs paused even though their runtime state was recoverable. One path fell back to branch mode but still validated against a worktree root. Another plan-slice prompt inlined templates while also instructing the model to read global template paths, triggering the stale-path safety rule.

## How

- Added an effective isolation resolver that maps configured worktree mode plus session degradation to branch mode for unit preparation.
- Reused that effective mode for initial and repaired worktree safety validation.
- Updated the plan-slice prompt to use inlined Output Template sections only.
- Added focused tests for the branch fallback and prompt contract.

## Validation

- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/plan-slice-prompt.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/start-auto-detached.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/worktree-safety.test.ts`
- `pnpm run verify:fast`

### Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783296511&installation_id=134682257&pr_number=518&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F518&signature=79771757f2f51064c72cd315a4bfdc23c0379edae6040dcece245c137ca5e111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode isolation and worktree safety gates used before unit dispatch; incorrect effective-mode logic could allow unsafe roots or still block valid branch fallback.
> 
> **Overview**
> Fixes **false auto-mode pauses** when worktree isolation has degraded to branch mode and when plan-slice prompts contradicted inlined templates.
> 
> **Isolation:** `prepareForUnit` now uses **`getEffectiveUnitIsolationMode`**, which maps configured `worktree` + `s.isolationDegraded` to effective **`branch`** for worktree safety validation (initial and post-repair revalidate). A redundant duplicate `worktree` guard in that path was removed.
> 
> **Plan-slice prompt:** Planning rule 3 now tells agents to use **inlined Output Template sections** only and **not** read `plan.md` / `task-plan.md` from disk—avoiding stale absolute template paths that triggered the working-directory safety stop.
> 
> **Tests:** Regression coverage for degraded→branch resolution, `prepareForUnit` wiring, branch-mode project-root acceptance in worktree safety, and updated plan-slice prompt assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937d51da46c14d4f013e13a920f8628ec291f3fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->