### PR TITLE
fix(gsd): soften section gate tool redirects

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -3680,6 +3680,22 @@ export async function buildReactiveExecutePrompt(
 // See gate-registry.ts for the full ownership map.
 
 /**
+ * Adapt gate-registry guidance for section-close phases.
+ *
+ * Gate-registry text is shared with the gate-evaluate subagent, where
+ * "Return verdict ..." is literal. Section-close units write artifact sections
+ * instead, so translate that wording at render time without mutating the
+ * canonical guidance.
+ */
+function sectionModeGuidance(guidance: string): string {
+  return guidance.replace(
+    /Return verdict '([^']+)'/g,
+    (_match, verdict: string) =>
+      verdict === "omitted" ? "Leave the section empty" : `Record a \`${verdict}\``,
+  );
+}
+
+/**
  * Render a "Gates to Close" block for turns like `complete-slice` and
  * `validate-milestone` that own gates which are closed as a side-effect
  * of writing artifact sections (not via a dedicated gate-evaluate
@@ -3702,12 +3718,16 @@ function renderGatesToCloseBlock(
     "These quality gates are still pending for this unit. You MUST address every one before calling the closing tool — the handler closes the DB row based on whether the corresponding artifact section is present.",
   );
   lines.push("");
+  lines.push(
+    "**Do NOT call `gsd_save_gate_result` (or any gate-result tool) for these gates** — that tool belongs to a different phase and the call will be blocked. You close each gate purely by writing its named section: a populated section records `pass`, an empty section records `omitted`, and the completion handler persists the verdict for you. Treat any \"return verdict\" wording in the guidance below as describing that section outcome, not as an instruction to call a tool.",
+  );
+  lines.push("");
   for (const def of applicable) {
     lines.push(`### ${def.id} — ${def.promptSection}`);
     lines.push("");
     lines.push(`**Question:** ${def.question}`);
     lines.push("");
-    lines.push(def.guidance);
+    lines.push(sectionModeGuidance(def.guidance));
     if (opts.allowOmit) {
       lines.push("");
       lines.push(

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -136,6 +136,11 @@ export const DETERMINISTIC_POLICY_ERROR_STRINGS = [
   // "Cannot write to milestone CONTEXT.md without depth verification." for direct
   // write tool calls to *-CONTEXT.md paths (different code path than gsd_summary_save).
   "CONTEXT.md without depth verification",
+  // Section-close gate units (execute-task, complete-slice, validate-milestone) that
+  // reach for gsd_save_gate_result get the calm redirect from softGateToolRedirect
+  // (auto-unit-tool-scope.ts) instead of a HARD BLOCK. Still deterministic — those
+  // phases never own that tool, so a retry hits the same redirect every time.
+  "closes its quality gates by writing summary sections",
 ] as const;
 
 /**

--- a/src/resources/extensions/gsd/auto-unit-tool-scope.ts
+++ b/src/resources/extensions/gsd/auto-unit-tool-scope.ts
@@ -35,6 +35,17 @@ const EXECUTE_TASK_UNIT_TYPES = new Set([
   "reactive-execute",
 ]);
 
+// These units own quality gates, but their completion handlers persist verdicts
+// from artifact sections. gsd_save_gate_result belongs to gate-evaluate, so keep
+// blocking it here with a calm redirect to the section-write path.
+const SECTION_CLOSE_GATE_UNIT_TYPES = new Set([
+  "execute-task",
+  "execute-task-simple",
+  "reactive-execute",
+  "complete-slice",
+  "validate-milestone",
+]);
+
 const EXTRA_SCOPED_GSD_LIFECYCLE_TOOLS = [
   "gsd_skip_slice",
   "gsd_slice_reopen",
@@ -52,6 +63,8 @@ const SCOPED_GSD_LIFECYCLE_TOOLS = new Set(
 );
 
 export const GSD_PHASE_SCOPE_DISPLAY_REASON = "This GSD phase only allows its scoped workflow tools.";
+export const GSD_SECTION_CLOSE_GATE_DISPLAY_REASON =
+  "Gates here close by writing summary sections — gsd_save_gate_result isn't needed.";
 
 type AutoUnitToolScopeResult = {
   block: boolean;
@@ -87,6 +100,22 @@ function hardBlock(unitType: string, what: string): AutoUnitToolScopeResult {
     block: true,
     reason: hardBlockReason(unitType, what),
     displayReason: GSD_PHASE_SCOPE_DISPLAY_REASON,
+  };
+}
+
+// This stable marker is registered in auto-tool-tracking.ts so auto-mode treats
+// the redirect as deterministic policy, not a retryable execution failure.
+function softGateToolRedirect(unitType: string): AutoUnitToolScopeResult {
+  return {
+    block: true,
+    reason: [
+      `Skip this call — the "${unitType}" phase closes its quality gates by writing summary sections,`,
+      "not by calling gsd_save_gate_result (that tool belongs to the gate-evaluate phase).",
+      "Record each gate by filling its named section in your summary: a populated section records `pass`,",
+      "an empty one records `omitted`. Then call your completion tool and the handler persists every verdict.",
+      "This is expected, not an error — continue without gsd_save_gate_result.",
+    ].join(" "),
+    displayReason: GSD_SECTION_CLOSE_GATE_DISPLAY_REASON,
   };
 }
 
@@ -169,6 +198,10 @@ export function shouldBlockAutoUnitToolCall(
       unitType,
       `GSD lifecycle tool "${canonicalTool}" is not permitted; ${forbiddenReason} Fix unit-tool-contracts.ts or the ${unitType} prompt.`,
     );
+  }
+
+  if (canonicalTool === "gsd_save_gate_result" && SECTION_CLOSE_GATE_UNIT_TYPES.has(unitType)) {
+    return softGateToolRedirect(unitType);
   }
 
   return hardBlock(

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -9,7 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { join, sep } from 'node:path';
 
-import { GSD_PHASE_SCOPE_DISPLAY_REASON } from '../auto-unit-tool-scope.ts';
+import { GSD_PHASE_SCOPE_DISPLAY_REASON, GSD_SECTION_CLOSE_GATE_DISPLAY_REASON } from '../auto-unit-tool-scope.ts';
 import { ALLOWED_PLANNING_DISPATCH_AGENTS, shouldBlockPlanningUnit } from '../bootstrap/write-gate.ts';
 import { extractSubagentAgentClasses } from '../bootstrap/subagent-input.ts';
 import { isDeterministicPolicyError } from '../auto-tool-tracking.ts';
@@ -377,12 +377,24 @@ test('auto-unit scope: execute-task allows only its task completion lifecycle to
   );
   assert.strictEqual(allowed.block, false);
 
+  // execute-task closes gates from summary sections, so gsd_save_gate_result gets
+  // the softer deterministic redirect instead of the normal HARD BLOCK wall.
   const blocked = shouldBlockPlanningUnit('gsd_save_gate_result', '', BASE, 'execute-task', ALL);
   assert.strictEqual(blocked.block, true);
-  assert.match(blocked.reason!, /HARD BLOCK/);
+  assert.doesNotMatch(blocked.reason!, /HARD BLOCK/);
   assert.match(blocked.reason!, /gsd_save_gate_result/);
-  assert.strictEqual(blocked.displayReason, GSD_PHASE_SCOPE_DISPLAY_REASON);
+  assert.match(blocked.reason!, /summary sections/);
+  assert.strictEqual(blocked.displayReason, GSD_SECTION_CLOSE_GATE_DISPLAY_REASON);
   assert.strictEqual(isDeterministicPolicyError(blocked.reason!), true);
+});
+
+test('auto-unit scope: section-close gate units get the calm gsd_save_gate_result redirect', () => {
+  for (const unit of ['execute-task', 'complete-slice', 'validate-milestone']) {
+    const r = shouldBlockPlanningUnit('gsd_save_gate_result', '', BASE, unit, ALL);
+    assert.strictEqual(r.block, true, `${unit} should still block the call`);
+    assert.doesNotMatch(r.reason!, /HARD BLOCK/, `${unit} should use the calm redirect`);
+    assert.strictEqual(isDeterministicPolicyError(r.reason!), true, `${unit} redirect must stay deterministic`);
+  }
 });
 
 test('auto-unit scope: execute-task blocks sibling task completion', () => {


### PR DESCRIPTION
## TL;DR

**What:** Softens the blocked-tool handling when section-closing GSD units try to call `gsd_save_gate_result`.
**Why:** Those units close gates by writing summary sections, so the old HARD BLOCK wording made an expected phase-boundary redirect look like a severe failure.
**How:** Rewrites shared gate guidance for section-close prompts, adds a targeted soft redirect, and keeps that redirect classified as deterministic policy.

## What

- Adds section-mode guidance rendering for gate prompts so "return verdict" language maps to section outcomes.
- Blocks `gsd_save_gate_result` in execute-task, complete-slice, and validate-milestone with a calmer redirect to summary sections.
- Registers the redirect text as a deterministic policy outcome so auto-mode does not treat it as retryable.
- Updates write-gate tests for the new redirect behavior.

## Why

Section-close phases already persist gate verdicts from summary/artifact sections through their completion handlers. Calling `gsd_save_gate_result` in those phases is still the wrong tool, but the old generic HARD BLOCK message made the correct recovery path feel like a serious orchestration failure.

## How

The prompt builder translates shared gate-registry verdict wording only when rendering section-close gate blocks. The tool-scope guard recognizes `gsd_save_gate_result` for section-close units and returns a policy block with user-facing section-write instructions instead of the generic phase-scope wall.

## Validation

- `pnpm run verify:fast`
- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts`
- `git diff --check`

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783307375&installation_id=134682257&pr_number=519&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F519&signature=fcefcccabb10b4e7dc5a6bae3118002fcce2e3a50d8abef963fcf7083fc74c43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and tool-scope messaging only; gate-evaluate still owns `gsd_save_gate_result`, with tests pinning redirect behavior.
> 
> **Overview**
> **Section-close GSD units** (`execute-task`, `complete-slice`, `validate-milestone`, etc.) now steer agents away from `gsd_save_gate_result` with clearer prompts and a **calm tool-scope redirect** instead of the generic **HARD BLOCK** when that tool is called anyway.
> 
> Prompt **“Gates to Close”** blocks tell the model not to use gate-result tools, map shared gate-registry **“Return verdict …”** text to **section outcomes** via `sectionModeGuidance`, and explain that verdicts come from filled vs empty summary sections handled by completion tools.
> 
> `auto-unit-tool-scope` returns `softGateToolRedirect` for `gsd_save_gate_result` on section-close unit types; the redirect message is registered in `auto-tool-tracking` as a **deterministic policy** error so auto-mode does not retry endlessly. Tests were updated for the new redirect and display reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494d181bc343ba91d788affd8887d2bedc998f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->