### PR TITLE
fix(gsd): quiet section-close gate-tool block + stop nudging executors toward gsd_save_gate_result

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -3680,6 +3680,25 @@ export async function buildReactiveExecutePrompt(
 // See gate-registry.ts for the full ownership map.
 
 /**
+ * Adapt gate-registry guidance for section-close phases.
+ *
+ * The registry guidance is written in verdict vocabulary ("Return verdict
+ * 'omitted' …") because the same text also feeds the gate-evaluate subagent
+ * loop, which DOES emit verdicts via gsd_save_gate_result. Units rendered by
+ * renderGatesToCloseBlock close gates by writing artifact sections instead, so
+ * the verdict phrasing nudges the executor toward a tool call that the unit
+ * contract blocks. Rewrite that phrasing to section language at render time so
+ * the canonical registry text stays untouched for the gate-evaluate path.
+ */
+function sectionModeGuidance(guidance: string): string {
+  return guidance.replace(
+    /Return verdict '([^']+)'/g,
+    (_match, verdict: string) =>
+      verdict === "omitted" ? "Leave the section empty" : `Record a \`${verdict}\``,
+  );
+}
+
+/**
  * Render a "Gates to Close" block for turns like `complete-slice` and
  * `validate-milestone` that own gates which are closed as a side-effect
  * of writing artifact sections (not via a dedicated gate-evaluate
@@ -3702,12 +3721,16 @@ function renderGatesToCloseBlock(
     "These quality gates are still pending for this unit. You MUST address every one before calling the closing tool — the handler closes the DB row based on whether the corresponding artifact section is present.",
   );
   lines.push("");
+  lines.push(
+    "**Do NOT call `gsd_save_gate_result` (or any gate-result tool) for these gates** — that tool belongs to a different phase and the call will be blocked. You close each gate purely by writing its named section: a populated section records `pass`, an empty section records `omitted`, and the completion handler persists the verdict for you. Treat any \"return verdict\" wording in the guidance below as describing that section outcome, not as an instruction to call a tool.",
+  );
+  lines.push("");
   for (const def of applicable) {
     lines.push(`### ${def.id} — ${def.promptSection}`);
     lines.push("");
     lines.push(`**Question:** ${def.question}`);
     lines.push("");
-    lines.push(def.guidance);
+    lines.push(sectionModeGuidance(def.guidance));
     if (opts.allowOmit) {
       lines.push("");
       lines.push(

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -136,6 +136,11 @@ export const DETERMINISTIC_POLICY_ERROR_STRINGS = [
   // "Cannot write to milestone CONTEXT.md without depth verification." for direct
   // write tool calls to *-CONTEXT.md paths (different code path than gsd_summary_save).
   "CONTEXT.md without depth verification",
+  // Section-close gate units (execute-task, complete-slice, validate-milestone) that
+  // reach for gsd_save_gate_result get the calm redirect from softGateToolRedirect
+  // (auto-unit-tool-scope.ts) instead of a HARD BLOCK. Still deterministic — those
+  // phases never own that tool, so a retry hits the same redirect every time.
+  "closes its quality gates by writing summary sections",
 ] as const;
 
 /**

--- a/src/resources/extensions/gsd/auto-unit-tool-scope.ts
+++ b/src/resources/extensions/gsd/auto-unit-tool-scope.ts
@@ -35,6 +35,24 @@ const EXECUTE_TASK_UNIT_TYPES = new Set([
   "reactive-execute",
 ]);
 
+// Units that OWN quality gates but close them by writing artifact sections —
+// the unit's completion-tool handler (gsd_task_complete, gsd_slice_complete,
+// gsd_validate_milestone) persists each verdict from the section content. The
+// gsd_save_gate_result tool belongs to the separate gate-evaluate phase. A
+// model in one of these units is nudged toward gsd_save_gate_result by the
+// "return verdict" vocabulary in the gate guidance, but calling it here would
+// double-write the exact rows the completion handler already closes. We still
+// block it, but with a calm redirect (softGateToolRedirect) instead of the
+// HARD BLOCK wall, since the outcome is unaffected and the correct path is
+// clear. See gate-registry.ts ownerTurn fields and complete-task.ts gate close.
+const SECTION_CLOSE_GATE_UNIT_TYPES = new Set([
+  "execute-task",
+  "execute-task-simple",
+  "reactive-execute",
+  "complete-slice",
+  "validate-milestone",
+]);
+
 const EXTRA_SCOPED_GSD_LIFECYCLE_TOOLS = [
   "gsd_skip_slice",
   "gsd_slice_reopen",
@@ -52,6 +70,8 @@ const SCOPED_GSD_LIFECYCLE_TOOLS = new Set(
 );
 
 export const GSD_PHASE_SCOPE_DISPLAY_REASON = "This GSD phase only allows its scoped workflow tools.";
+export const GSD_SECTION_CLOSE_GATE_DISPLAY_REASON =
+  "Gates here close by writing summary sections — gsd_save_gate_result isn't needed.";
 
 type AutoUnitToolScopeResult = {
   block: boolean;
@@ -87,6 +107,27 @@ function hardBlock(unitType: string, what: string): AutoUnitToolScopeResult {
     block: true,
     reason: hardBlockReason(unitType, what),
     displayReason: GSD_PHASE_SCOPE_DISPLAY_REASON,
+  };
+}
+
+// Calm, instructive block for the known-benign case: a section-close gate unit
+// reaching for gsd_save_gate_result. Still blocks (calling it would double-write
+// the rows the completion handler already closes) but replaces the alarming
+// HARD BLOCK wall with a one-line redirect to the correct section-write path.
+// The "closes its quality gates by writing summary sections" phrase is a stable
+// marker registered in auto-tool-tracking.ts so this stays classified as a
+// deterministic (expected, non-retryable) policy outcome, not a real error.
+function softGateToolRedirect(unitType: string): AutoUnitToolScopeResult {
+  return {
+    block: true,
+    reason: [
+      `Skip this call — the "${unitType}" phase closes its quality gates by writing summary sections,`,
+      "not by calling gsd_save_gate_result (that tool belongs to the gate-evaluate phase).",
+      "Record each gate by filling its named section in your summary: a populated section records `pass`,",
+      "an empty one records `omitted`. Then call your completion tool and the handler persists every verdict.",
+      "This is expected, not an error — continue without gsd_save_gate_result.",
+    ].join(" "),
+    displayReason: GSD_SECTION_CLOSE_GATE_DISPLAY_REASON,
   };
 }
 
@@ -169,6 +210,10 @@ export function shouldBlockAutoUnitToolCall(
       unitType,
       `GSD lifecycle tool "${canonicalTool}" is not permitted; ${forbiddenReason} Fix unit-tool-contracts.ts or the ${unitType} prompt.`,
     );
+  }
+
+  if (canonicalTool === "gsd_save_gate_result" && SECTION_CLOSE_GATE_UNIT_TYPES.has(unitType)) {
+    return softGateToolRedirect(unitType);
   }
 
   return hardBlock(

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -9,7 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { join, sep } from 'node:path';
 
-import { GSD_PHASE_SCOPE_DISPLAY_REASON } from '../auto-unit-tool-scope.ts';
+import { GSD_PHASE_SCOPE_DISPLAY_REASON, GSD_SECTION_CLOSE_GATE_DISPLAY_REASON } from '../auto-unit-tool-scope.ts';
 import { ALLOWED_PLANNING_DISPATCH_AGENTS, shouldBlockPlanningUnit } from '../bootstrap/write-gate.ts';
 import { extractSubagentAgentClasses } from '../bootstrap/subagent-input.ts';
 import { isDeterministicPolicyError } from '../auto-tool-tracking.ts';
@@ -377,12 +377,27 @@ test('auto-unit scope: execute-task allows only its task completion lifecycle to
   );
   assert.strictEqual(allowed.block, false);
 
+  // gsd_save_gate_result is owned by the gate-evaluate phase. execute-task closes
+  // Q5/Q6/Q7 by writing summary sections (the completion handler persists each
+  // verdict), so a reach for the tool gets a calm redirect — still blocked (calling
+  // it would double-write the rows complete-task closes) but NOT the HARD BLOCK
+  // wall, and still classified as a deterministic (expected, non-retryable) outcome.
   const blocked = shouldBlockPlanningUnit('gsd_save_gate_result', '', BASE, 'execute-task', ALL);
   assert.strictEqual(blocked.block, true);
-  assert.match(blocked.reason!, /HARD BLOCK/);
+  assert.doesNotMatch(blocked.reason!, /HARD BLOCK/);
   assert.match(blocked.reason!, /gsd_save_gate_result/);
-  assert.strictEqual(blocked.displayReason, GSD_PHASE_SCOPE_DISPLAY_REASON);
+  assert.match(blocked.reason!, /summary sections/);
+  assert.strictEqual(blocked.displayReason, GSD_SECTION_CLOSE_GATE_DISPLAY_REASON);
   assert.strictEqual(isDeterministicPolicyError(blocked.reason!), true);
+});
+
+test('auto-unit scope: section-close gate units get the calm gsd_save_gate_result redirect', () => {
+  for (const unit of ['execute-task', 'complete-slice', 'validate-milestone']) {
+    const r = shouldBlockPlanningUnit('gsd_save_gate_result', '', BASE, unit, ALL);
+    assert.strictEqual(r.block, true, `${unit} should still block the call`);
+    assert.doesNotMatch(r.reason!, /HARD BLOCK/, `${unit} should use the calm redirect`);
+    assert.strictEqual(isDeterministicPolicyError(r.reason!), true, `${unit} redirect must stay deterministic`);
+  }
 });
 
 test('auto-unit scope: execute-task blocks sibling task completion', () => {


### PR DESCRIPTION
## Problem

During `execute-task`, the executor (gpt-5.4) repeatedly tried to call `gsd_save_gate_result` for Q5/Q6/Q7 and got three red `failed` cards:

> HARD BLOCK: Tool Contract failure for unit "execute-task" — GSD lifecycle tool "gsd_save_gate_result" is not permitted… You MUST NOT proceed, retry the same call, or route around this block.

The task actually **completed fine** — the cards were pure noise from a benign wrong-phase reach.

## Root cause

GSD has two mutually exclusive gate-write paths (keyed by `ownerTurn` in `gate-registry.ts`):

- **`gate-evaluate`** (Q3/Q4) — the only phase that may call `gsd_save_gate_result`.
- **section-close units** (`execute-task` → Q5/Q6/Q7, `complete-slice` → Q8, `validate-milestone` → MV01-04) — close gates by writing named summary **sections**; the completion-tool handler ([`complete-task.ts:366`](https://github.com/open-gsd/gsd-pi/blob/main/src/resources/extensions/gsd/tools/complete-task.ts#L366)) persists each verdict from section content.

Allowing the tool in `execute-task` would **double-write** the rows `gsd_task_complete` already owns, so the contract is *correct* to block it. But:

1. The gate guidance injected into the prompt used verdict vocabulary (*"Return verdict 'omitted'…"*) — the exact schema of `gsd_save_gate_result` — nudging the executor to call a tool it must not.
2. The block surfaced as the alarming `HARD BLOCK` wall instead of a calm redirect.

## Fix (guidance + quiet block)

- **`auto-prompts.ts`** — `renderGatesToCloseBlock` now rewrites verdict phrasing to section language (`sectionModeGuidance`) and adds an explicit *"Do NOT call `gsd_save_gate_result`"* line. Registry text stays canonical for the gate-evaluate path.
- **`auto-unit-tool-scope.ts`** — section-close gate units get `softGateToolRedirect` (a one-line "skip this call, write the section instead") instead of `HARD BLOCK`. Still blocks (no double-write).
- **`auto-tool-tracking.ts`** — registers a stable marker so the redirect stays classified as a *deterministic* policy outcome → orchestrator won't retry/loop.

## Audit

Reviewed all 24 unit tool-contracts — every allowlist correctly matches the gates/tools its unit owns; the two `forbidden` entries (`complete-slice`, `run-uat`) have sound reasons. No unit had a wrong allowlist; the only defect was the prompt contradiction + noisy UX.

## Verification

- `write-gate-planning-unit` / deterministic-error / prompt-contract tests: **pass** (updated the test that pinned the old `HARD BLOCK` text; added coverage across execute-task/complete-slice/validate-milestone).
- `tsc --noEmit --incremental false`: **exit 0**.
- Ran the real runtime function via the source loader: section-close units → calm redirect + `deterministic: true`; `gate-evaluate` → still allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783308679&installation_id=134682257&pr_number=520&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F520&signature=f0e74b8c8b2d2e885804c2cb763944cdcd6013f0ef5f3a2a52175ac65f45243a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and UX/policy-classification changes only; tool calls remain blocked where they were, with no change to gate-evaluate ownership or completion handlers.
> 
> **Overview**
> Section-close units (`execute-task`, `complete-slice`, `validate-milestone`, etc.) close quality gates by writing summary **sections**, not via `gsd_save_gate_result`, but prompts and blocks were steering models toward that tool and surfacing alarming **HARD BLOCK** failures even when work completed fine.
> 
> **Prompts:** `renderGatesToCloseBlock` now rewrites registry verdict wording to section outcomes (`sectionModeGuidance`), adds an explicit ban on `gsd_save_gate_result`, and keeps canonical gate-registry text for the `gate-evaluate` path.
> 
> **Tool scope:** Wrong-phase `gsd_save_gate_result` calls still block (avoids double-writing DB rows) but return **`softGateToolRedirect`** with a short “write the section, then complete” message and `GSD_SECTION_CLOSE_GATE_DISPLAY_REASON` instead of a HARD BLOCK.
> 
> **Auto-mode:** The redirect’s stable phrase is registered in **`isDeterministicPolicyError`** so orchestration treats it as expected policy, not a retry loop. Tests updated/added for execute-task and sibling section-close units.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c09daecf694f22510ab8b99bc7717da79d73b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->