### PR TITLE
fix(gsd): self-heal milestone sequence projection

### DIFF
--- a/src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts
+++ b/src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts
@@ -6,7 +6,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { openDatabase, closeDatabase, getAllMilestones } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, getAllMilestones, getArtifact } from "../gsd-db.ts";
+import { parseProject } from "../schemas/parsers.ts";
 import { markApprovalGateVerified, clearDiscussionFlowState } from "../bootstrap/write-gate.ts";
 import { executeSummarySave } from "../tools/workflow-tool-executors.ts";
 
@@ -106,4 +107,66 @@ test("executeSummarySave registers milestones when PROJECT.md uses canonical em-
   assert.notEqual(result.isError, true);
   assert.deepEqual(result.details.registeredMilestones, ["M001", "M002"]);
   assert.equal(getAllMilestones().length, 2);
+});
+
+test("executeSummarySave self-heals the Milestone Sequence when DB already has milestones but content parses zero", async (t) => {
+  const base = setupBase(t);
+
+  // 1) First save registers M001 as complete; DB now holds the milestone with
+  //    authoritative status.
+  const canonical = [
+    "# Project",
+    "",
+    "## Milestone Sequence",
+    "",
+    "<!-- Check off milestones as they complete. -->",
+    "",
+    "- [x] M001: Foo — bar",
+    "",
+  ].join("\n");
+  await inProjectDir(base, () => executeSummarySave({ artifact_type: "PROJECT", content: canonical }, base));
+  assert.equal(getAllMilestones().length, 1);
+
+  // 2) A completion re-save reflows the sequence with an en-dash separator the
+  //    canonical parser rejects → zero parseable lines, but the DB is intact.
+  //    (A trailing non-bullet section prevents MILESTONE_LINE_RE from bridging
+  //    onto a later bullet.) The checkbox here is deliberately WRONG (unchecked)
+  //    to prove the rebuild takes status from the DB, not the malformed content.
+  const malformed = [
+    "# Project",
+    "",
+    "## Milestone Sequence",
+    "",
+    "<!-- Check off milestones as they complete. -->",
+    "",
+    "- [ ] M001: Foo – shipped bar", // en-dash U+2013, not accepted by MILESTONE_LINE_RE
+    "",
+    "## Notes",
+    "",
+    "Trailing prose with no list bullets.",
+    "",
+  ].join("\n");
+
+  const result = await inProjectDir(base, () => executeSummarySave({ artifact_type: "PROJECT", content: malformed }, base));
+
+  // Non-fatal: the save succeeds and reports the self-heal.
+  assert.notEqual(result.isError, true);
+  assert.equal(result.details.milestoneSequenceSelfHealed, true);
+  assert.deepEqual(result.details.registeredMilestones, ["M001"]);
+  assert.equal(getAllMilestones().length, 1);
+
+  // The persisted PROJECT.md now parses canonically and preserves status + prose.
+  const persisted = getArtifact("PROJECT.md");
+  assert.ok(persisted);
+  const parsed = parseProject(persisted!.full_content);
+  assert.equal(parsed.milestones.length, 1);
+  const m001 = parsed.milestones.find(m => m.id === "M001");
+  assert.ok(m001);
+  // Status comes from the DB (M001 complete), not the unchecked box in the
+  // malformed content.
+  assert.equal(m001!.done, true);
+  assert.equal(m001!.title, "Foo");
+  assert.match(m001!.oneLiner, /shipped bar/);
+  // The HTML comment hint survives the rebuild.
+  assert.match(persisted!.full_content, /Check off milestones as they complete/);
 });

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -6,10 +6,11 @@ import { sanitizeCompleteMilestoneParams } from "../bootstrap/sanitize-complete-
 import { loadWriteGateSnapshot, shouldBlockContextArtifactSaveInSnapshot, shouldBlockRootArtifactSaveInSnapshot } from "../bootstrap/write-gate.js";
 import {
   getActiveRequirements,
-  insertMilestone,
+  getAllMilestones,
   getMilestone,
   getSliceStatusSummary,
   getSliceTaskCounts,
+  insertMilestone,
   insertAssessment,
   insertGateRun,
   readTransaction,
@@ -124,6 +125,111 @@ function registerProjectMilestoneSequence(content: string): string[] {
     registered.push(milestone.id);
   }
   return registered;
+}
+
+/** Minimal shape of a DB milestone row needed to re-render the sequence section. */
+interface MilestoneSeqRow {
+  id: string;
+  title: string;
+  status: string;
+  vision: string;
+}
+
+/**
+ * Best-effort recovery of the human one-liner for each milestone id from a
+ * (possibly malformed) Milestone Sequence body. Deliberately lenient: tolerates
+ * any separator the canonical MILESTONE_LINE_RE rejects (en-dash, " : ", a
+ * missing checkbox, etc.) so a model formatting slip does not discard the prose.
+ */
+function recoverMilestoneTails(sequenceBody: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const lenient = /^\s*(?:-\s*)?(?:\[[ xX]\]\s*)?(M\d{3})\b\s*[:.\-–—]*\s*(.*)$/;
+  for (const rawLine of sequenceBody.split("\n")) {
+    const m = rawLine.match(lenient);
+    if (m) out.set(m[1], m[2].trim());
+  }
+  return out;
+}
+
+function firstSentence(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  const idx = trimmed.search(/[.!?](\s|$)/);
+  return (idx >= 0 ? trimmed.slice(0, idx + 1) : trimmed).trim();
+}
+
+/** Render one canonical, parseable milestone line for the given DB row. */
+function renderMilestoneLine(m: MilestoneSeqRow, recoveredTail: string): string {
+  const done = m.status === "complete";
+  let oneLiner = recoveredTail;
+  // The recovered tail often still carries the title (e.g. "Foo — bar" or
+  // "Foo : bar"). Strip a leading repetition of the title, then any separator.
+  if (oneLiner.toLowerCase().startsWith(m.title.toLowerCase())) {
+    oneLiner = oneLiner.slice(m.title.length).replace(/^\s*[:.\-–—]+\s*/, "").trim();
+  } else {
+    const sep = oneLiner.match(/\s+(?:—|–|--|-|:)\s+/);
+    if (sep && sep.index !== undefined) oneLiner = oneLiner.slice(sep.index + sep[0].length).trim();
+  }
+  // MILESTONE_LINE_RE requires non-empty prose after the separator.
+  if (!oneLiner) oneLiner = firstSentence(m.vision) || (done ? "Completed." : "Planned.");
+  return `- [${done ? "x" : " "}] ${m.id}: ${m.title} — ${oneLiner}`;
+}
+
+/**
+ * Rebuild the "## Milestone Sequence" section from authoritative DB rows when a
+ * model-authored PROJECT.md projection parsed to zero milestone lines but the DB
+ * already holds milestones. The DB is the source of truth (markdown is a
+ * projection), so this repairs the projection rather than failing the save.
+ * Preserves a leading HTML comment in the section and recovers one-liners
+ * best-effort. The returned content parses cleanly under MILESTONE_LINE_RE.
+ */
+function rebuildMilestoneSequenceSection(content: string, milestones: MilestoneSeqRow[]): string {
+  const lines = content.split("\n");
+  const headerIdx = lines.findIndex(l => /^##\s+Milestone Sequence\s*$/.test(l));
+
+  const canonicalLines = (() => {
+    // Recover tails from the existing (malformed) body when the section exists.
+    let body = "";
+    if (headerIdx !== -1) {
+      let end = headerIdx + 1;
+      while (end < lines.length && !/^##\s+/.test(lines[end])) end++;
+      body = lines.slice(headerIdx + 1, end).join("\n");
+    }
+    const tails = recoverMilestoneTails(body);
+    return milestones.map(m => renderMilestoneLine(m, tails.get(m.id) ?? ""));
+  })();
+
+  if (headerIdx === -1) {
+    // No section at all — append a fresh, canonical one.
+    const sep = content.endsWith("\n") ? "" : "\n";
+    return `${content}${sep}\n## Milestone Sequence\n\n${canonicalLines.join("\n")}\n`;
+  }
+
+  let bodyEnd = headerIdx + 1;
+  while (bodyEnd < lines.length && !/^##\s+/.test(lines[bodyEnd])) bodyEnd++;
+  const existingBody = lines.slice(headerIdx + 1, bodyEnd);
+
+  // Preserve a contiguous leading HTML comment block (the "Check off…" hint).
+  let i = 0;
+  while (i < existingBody.length && existingBody[i].trim() === "") i++;
+  const preserved: string[] = [];
+  if (i < existingBody.length && existingBody[i].trim().startsWith("<!--")) {
+    while (i < existingBody.length) {
+      preserved.push(existingBody[i]);
+      const closed = existingBody[i].includes("-->");
+      i++;
+      if (closed) break;
+    }
+  }
+
+  return [
+    ...lines.slice(0, headerIdx + 1),
+    "",
+    ...(preserved.length ? [...preserved, ""] : []),
+    ...canonicalLines,
+    "",
+    ...lines.slice(bodyEnd),
+  ].join("\n");
 }
 
 async function mirrorArtifactToActiveWorktreeProjection(
@@ -260,6 +366,7 @@ export async function executeSummarySave(
     await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, contentToSave);
 
     let registeredMilestones: string[] = [];
+    let milestoneSequenceSelfHealed = false;
     if (params.artifact_type === "PROJECT") {
       try {
         registeredMilestones = registerProjectMilestoneSequence(contentToSave);
@@ -294,29 +401,83 @@ export async function executeSummarySave(
         };
       }
       if (registeredMilestones.length === 0) {
-        logError("tool", `gsd_summary_save: PROJECT.md saved to ${relativePath} but parsed zero milestones — registration produced no DB rows`, {
+        const existingMilestones = getAllMilestones();
+        if (existingMilestones.length === 0) {
+          // Genuine first-save failure: no milestones parsed AND none in the DB.
+          // /gsd really would report "No Active Milestone" — hard-fail so the
+          // caller rewrites the sequence before proceeding.
+          logError("tool", `gsd_summary_save: PROJECT.md saved to ${relativePath} but parsed zero milestones — registration produced no DB rows`, {
+            tool: "gsd_summary_save",
+          });
+          // PROJECT.md was persisted; invalidate so subsequent reads see the new
+          // artifacts row even though no milestones registered.
+          invalidateStateCache();
+          return {
+            content: [{
+              type: "text",
+              text:
+                `Error: PROJECT.md was saved to ${relativePath} but contains zero parseable milestone lines, ` +
+                `so no milestones were registered in the DB. /gsd will report "No Active Milestone". ` +
+                `Rewrite PROJECT.md so the "Milestone Sequence" section uses canonical lines: ` +
+                `\`- [ ] M001: <Title> — <One-liner>\` (em-dash, double-dash \`--\`, or single-dash \`-\` separator), then re-call gsd_summary_save(PROJECT).`,
+            }],
+            details: {
+              operation: "save_summary",
+              path: relativePath,
+              artifact_type: params.artifact_type,
+              error: "milestone_registration_empty_parse",
+            },
+            isError: true,
+          };
+        }
+
+        // Existing DB rows mean this is projection drift, not data loss. Rebuild
+        // the section from DB state and re-persist a parseable projection.
+        logWarning("tool", `gsd_summary_save: PROJECT.md parsed zero milestone lines but DB has ${existingMilestones.length} — rebuilding Milestone Sequence from DB (projection self-heal)`, {
           tool: "gsd_summary_save",
+          path: relativePath,
         });
-        // PROJECT.md was persisted; invalidate so subsequent reads see the new
-        // artifacts row even though no milestones registered.
-        invalidateStateCache();
-        return {
-          content: [{
-            type: "text",
-            text:
-              `Error: PROJECT.md was saved to ${relativePath} but contains zero parseable milestone lines, ` +
-              `so no milestones were registered in the DB. /gsd will report "No Active Milestone". ` +
-              `Rewrite PROJECT.md so the "Milestone Sequence" section uses canonical lines: ` +
-              `\`- [ ] M001: <Title> — <One-liner>\` (em-dash, double-dash \`--\`, or single-dash \`-\` separator), then re-call gsd_summary_save(PROJECT).`,
-          }],
-          details: {
-            operation: "save_summary",
+        try {
+          const healed = rebuildMilestoneSequenceSection(contentToSave, existingMilestones);
+          await saveArtifactToDb(
+            { path: relativePath, artifact_type: params.artifact_type, content: healed },
+            basePath,
+          );
+          await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, healed);
+          const healedRegisteredMilestones = registerProjectMilestoneSequence(healed);
+          if (healedRegisteredMilestones.length === 0) {
+            throw new Error("self-healed PROJECT.md still parsed zero milestone lines");
+          }
+          registeredMilestones = healedRegisteredMilestones;
+          milestoneSequenceSelfHealed = true;
+        } catch (healErr) {
+          const msg = healErr instanceof Error ? healErr.message : String(healErr);
+          logError("tool", `gsd_summary_save: Milestone Sequence self-heal failed: ${msg}`, {
+            tool: "gsd_summary_save",
             path: relativePath,
-            artifact_type: params.artifact_type,
-            error: "milestone_registration_empty_parse",
-          },
-          isError: true,
-        };
+            error: msg,
+          });
+          invalidateStateCache();
+          return {
+            content: [{
+              type: "text",
+              text:
+                `Error: PROJECT.md was saved to ${relativePath} but contains zero parseable milestone lines, ` +
+                `and automatic DB-backed Milestone Sequence repair failed: ${msg}. ` +
+                `Rewrite PROJECT.md so the "Milestone Sequence" section uses canonical lines: ` +
+                `\`- [ ] M001: <Title> — <One-liner>\`, then re-call gsd_summary_save(PROJECT).`,
+            }],
+            details: {
+              operation: "save_summary",
+              path: relativePath,
+              artifact_type: params.artifact_type,
+              error: "milestone_sequence_self_heal_failed",
+              self_heal_error: msg,
+            },
+            isError: true,
+          };
+        }
+        invalidateStateCache();
       }
     }
 
@@ -339,6 +500,7 @@ export async function executeSummarySave(
         artifact_type: params.artifact_type,
         content_source: contentSource,
         ...(registeredMilestones.length > 0 ? { registeredMilestones } : {}),
+        ...(milestoneSequenceSelfHealed ? { milestoneSequenceSelfHealed: true } : {}),
       },
     };
   } catch (err) {


### PR DESCRIPTION
## TL;DR

**What:** Adds DB-backed self-heal for PROJECT.md Milestone Sequence saves that parse to zero milestones when the DB already has milestones.
**Why:** Prevents malformed PROJECT.md projection rewrites from leaving GSD with no parseable active milestone even though authoritative DB state exists.
**How:** Rebuilds the Milestone Sequence section from DB rows, preserves section guidance and recovered one-liners, and reports the repair in tool details.

## What

- Updates `executeSummarySave(PROJECT)` to distinguish a true first-save empty parse from projection drift after milestones already exist in the DB.
- Rebuilds malformed Milestone Sequence markdown from authoritative milestone rows when repair is possible.
- Adds regression coverage for the self-heal path while preserving the existing hard failure for a first save with zero parseable milestones.

## Why

A completion or re-save can reflow `PROJECT.md` with a separator the canonical parser rejects. The DB can still contain the correct milestone state, but the markdown projection then parses to zero milestone lines and risks driving the UI back to a misleading no-active-milestone state.

## How

The save path now checks existing milestone rows when PROJECT.md registration returns zero rows. If the DB already has milestones, it reconstructs the sequence section, persists the repaired projection, mirrors it into the active worktree, and re-registers the parseable lines. If repair fails or there are no DB milestones, the existing explicit error path remains.

## Validation

- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts`
- `pnpm run verify:fast`

## Change type checklist

- [ ] `feat` - New feature or capability
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783309146&installation_id=134682257&pr_number=521&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F521&signature=5e2869baea046a20ba5ca4097abbda765780b30223dc36494fba3a5451c352f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PROJECT save and milestone registration behavior when markdown and DB disagree; wrong self-heal could rewrite PROJECT.md, though repair is gated on existing DB rows and re-parse validation.
> 
> **Overview**
> **`executeSummarySave(PROJECT)`** no longer hard-fails on every zero-parse Milestone Sequence when milestones already exist in the DB. It now treats that case as **projection drift**: rebuild the `## Milestone Sequence` section from DB rows (checkbox/status from DB, one-liners recovered leniently from malformed lines or milestone vision), re-persist and mirror `PROJECT.md`, re-register milestones, and set **`milestoneSequenceSelfHealed: true`** in tool details. The existing **`milestone_registration_empty_parse`** error remains only when both parse and DB are empty; a failed repair returns **`milestone_sequence_self_heal_failed`**.
> 
> Helpers added in `workflow-tool-executors.ts`: `recoverMilestoneTails`, `renderMilestoneLine`, and `rebuildMilestoneSequenceSection` (preserves leading HTML comment in the section). Tests cover the self-heal path (e.g. en-dash separator) while keeping the first-save empty-parse failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e324e51a00b04cf9a0db91b5e10fc1de4f4bb9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->