### PR TITLE
fix(gsd): stop malformed milestone lines from swallowing the next one

### DIFF
--- a/src/resources/extensions/gsd/schemas/parsers.ts
+++ b/src/resources/extensions/gsd/schemas/parsers.ts
@@ -67,7 +67,12 @@ export interface ParsedRoadmap {
 const TEMPLATE_TOKEN_RE = /\{\{[^}]+\}\}/;
 const H2_RE = /^##\s+(.+)$/gm;
 const H3_RE = /^###\s+(.+)$/gm;
-const MILESTONE_LINE_RE = /^-\s+\[([ x])\]\s+(M\d{3}):\s+(.+?)\s+(?:—|--|-)\s+(.+)$/gm;
+// A milestone line is single-line by construction. Every inter-token gap uses
+// horizontal-whitespace classes (`[^\S\n]`) rather than `\s`, because `\s`
+// matches newlines: a line missing a valid separator would otherwise let the
+// `\s+(?:—|--|-)\s+` clause "bridge" onto the NEXT bullet's `- `, consuming it
+// as the separator and silently swallowing the following well-formed milestone.
+const MILESTONE_LINE_RE = /^-[^\S\n]+\[([ x])\][^\S\n]+(M\d{3}):[^\S\n]+(.+?)[^\S\n]+(?:—|--|-)[^\S\n]+(.+)$/gm;
 const SLICE_HEADER_RE = /^###\s+(S\d{2})\s*(?:—|--|-)\s+(.+)$/m;
 const REQUIREMENT_HEADER_RE = /^###\s+(R\d{3})\s*(?:—|--|-)\s+(.+)$/m;
 

--- a/src/resources/extensions/gsd/tests/parse-project-milestone-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/parse-project-milestone-bridge.test.ts
@@ -1,0 +1,77 @@
+// gsd-pi / parseProject MILESTONE_LINE_RE bridging regression
+//
+// Guards against a silent data-integrity bug: MILESTONE_LINE_RE used `\s+`
+// around its separator, and `\s` matches newlines. A milestone line lacking a
+// valid internal separator could therefore "bridge" onto the NEXT bullet's
+// `- `, consuming it as the separator and swallowing the following well-formed
+// milestone. The separator gaps are now horizontal-whitespace-only so a line
+// can never span a newline.
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseProject } from "../schemas/parsers.ts";
+
+function milestoneSection(...lines: string[]): string {
+  return ["# Project", "", "## Milestone Sequence", "", ...lines, ""].join("\n");
+}
+
+describe("parseProject milestone bridging", () => {
+  test("a malformed milestone line does not swallow the following well-formed one", () => {
+    // M001 uses an invalid " : " separator; M002 is canonical. Before the fix
+    // this returned a SINGLE match (M001 with oneLiner "[ ] M002: Baz — qux"),
+    // dropping M002 entirely.
+    const content = milestoneSection(
+      "- [ ] M001: Foo : bar",
+      "- [ ] M002: Baz — qux",
+    );
+
+    const { milestones } = parseProject(content);
+
+    // M002 must survive intact — it must NOT be consumed as M001's one-liner.
+    const m002 = milestones.find(m => m.id === "M002");
+    assert.ok(m002, "M002 must be registered, not swallowed by the malformed M001 line");
+    assert.equal(m002!.title, "Baz", "M002 title parsed cleanly");
+    assert.equal(m002!.oneLiner, "qux", "M002 one-liner parsed cleanly");
+
+    // No milestone may have bridged the M002 bullet into its own one-liner.
+    assert.ok(
+      !milestones.some(m => m.oneLiner.includes("M002")),
+      "no milestone may bridge across the newline and consume the M002 bullet",
+    );
+
+    // M001 has no valid separator, so it is skipped — consistent with the
+    // empty-parse hard-fail in execute-summary-save-empty-project.test.ts.
+    // The fixture therefore yields exactly the one well-formed milestone.
+    assert.deepEqual(milestones.map(m => m.id), ["M002"], "only the well-formed milestone parses");
+  });
+
+  test("two well-formed milestones on adjacent lines both parse", () => {
+    const content = milestoneSection(
+      "- [x] M001: Foo — bar",
+      "- [ ] M002: Baz — qux",
+    );
+
+    const { milestones } = parseProject(content);
+    assert.deepEqual(
+      milestones.map(m => ({ id: m.id, title: m.title, oneLiner: m.oneLiner, done: m.done })),
+      [
+        { id: "M001", title: "Foo", oneLiner: "bar", done: true },
+        { id: "M002", title: "Baz", oneLiner: "qux", done: false },
+      ],
+      "adjacent canonical milestone lines are parsed independently",
+    );
+  });
+
+  test("a trailing malformed line cannot bridge onto a following bullet of any kind", () => {
+    // The last milestone is malformed and is followed by a non-milestone list
+    // bullet. The malformed line must be skipped without consuming the bullet.
+    const content = milestoneSection(
+      "- [ ] M001: Foo — bar",
+      "- [ ] M002: Baz : qux",
+      "- some unrelated bullet",
+    );
+
+    const { milestones } = parseProject(content);
+    assert.deepEqual(milestones.map(m => m.id), ["M001"], "malformed M002 is skipped, not bridged onto the unrelated bullet");
+  });
+});


### PR DESCRIPTION
## Problem

`MILESTONE_LINE_RE` in `schemas/parsers.ts` wrapped its separator in `\s+`, and `\s` matches newlines. A milestone line lacking a valid `—`/`--`/`-` separator could **bridge** onto the *next* bullet's `- `, consume it as the separator, and silently drop the following well-formed milestone in `parseProject()`.

Concrete repro — `content.matchAll(MILESTONE_LINE_RE)` returned a **single** match for:

```
- [ ] M001: Foo : bar
- [ ] M002: Baz — qux
```

→ `id=M001, title="Foo : bar", oneLiner="[ ] M002: Baz — qux"`. M002 was consumed and never registered — a silent data-integrity bug in milestone registration (`registerProjectMilestoneSequence`).

## Fix

Constrain every inter-token gap in the regex to horizontal-whitespace-only (`[^\S\n]`) so a milestone line can never span a newline:

```js
const MILESTONE_LINE_RE = /^-[^\S\n]+\[([ x])\][^\S\n]+(M\d{3}):[^\S\n]+(.+?)[^\S\n]+(?:—|--|-)[^\S\n]+(.+)$/gm;
```

A malformed line is now **skipped** rather than corrupting its neighbor. This is consistent with the existing `milestone_registration_empty_parse` hard-fail, which already treats an identically-malformed single line as zero parseable milestones — so M001 (no valid separator) is skipped and M002 parses cleanly.

## Tests

New `parse-project-milestone-bridge.test.ts` covering:
- malformed-then-valid (M002 not swallowed; M001 skipped → exactly `[M002]`)
- two adjacent canonical milestones both parse
- a trailing malformed line cannot bridge onto a following non-milestone bullet

## Verification

- `npx tsx --test` on the new test + `execute-summary-save-empty-project.test.ts` → all pass
- `tsc --noEmit --incremental false --project tsconfig.extensions.json` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783309574&installation_id=134682257&pr_number=522&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F522&signature=3786816447e864c80d7c49fa96ce06a21cdfbdc91b65efc87545b9d05624a854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PROJECT milestone extraction used by milestone registration on save; wrong parsing could drop or mis-register milestones, though the fix reduces silent data loss.
> 
> **Overview**
> Fixes a **silent milestone loss** in `parseProject()` when a malformed **Milestone Sequence** bullet sits above a valid one. `MILESTONE_LINE_RE` no longer uses `\s` between tokens; gaps are **horizontal whitespace only** (`[^\S\n]`), so a line without a real `—`/`--`/`-` separator cannot match across a newline and treat the next bullet’s `-` as the separator.
> 
> Malformed lines are **skipped** instead of corrupting neighbors (e.g. only `M002` registers when `M001` uses `:` as separator). Adds **`parse-project-milestone-bridge.test.ts`** for malformed-then-valid lines, adjacent canonical lines, and trailing malformed lines before unrelated bullets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df9479a8706666daf2f3267c9ee5267d06becb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->