### PR TITLE
fix(claude-code-cli): load user Claude settings

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1725,9 +1725,9 @@ export function buildSdkOptions(
 	const sdkMcpServers = inlinePhaseMcpServers ?? filteredMcpServers;
 	const strictMcpConfig = !!inlinePhaseMcpServers;
 	// Strict phase configs inline the exact MCP servers GSD needs. Loading
-	// project/local settings at the same time can duplicate those servers and
+	// Claude Code settings at the same time can duplicate those servers and
 	// leave allowed mcp__... tools with no registered backing tool.
-	const settingSources = strictMcpConfig ? [] : ["project", "local"];
+	const settingSources = strictMcpConfig ? [] : ["user", "project", "local"];
 	const exactWorkflowMcpTools = resolveExactWorkflowMcpToolsForPhase(
 		gsdPhase,
 		workflowServerName,

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -38,6 +38,7 @@ import {
 	discoverBrowserMcpServerName,
 	discoverMcpServers,
 	discoverMcpServerNames,
+	discoverUserMcpServerNames,
 	discoverWorkflowMcpServerName,
 	computeMcpDisallowedTools,
 } from "../gsd/mcp-filter.js";
@@ -1658,14 +1659,23 @@ export function buildSdkOptions(
 	const workflowServerName = projectWorkflowServerName ?? injectedWorkflowServerName;
 	const browserServerName = projectBrowserServerName ?? injectedBrowserServerName;
 
-	// If a default GSD MCP server is already declared in the project's .mcp.json
-	// or .claude/settings.json, do not inject it again via mcpServers. Passing the
-	// same server name from two sources causes a duplicate registration conflict
-	// that prevents the MCP server from loading (tools become unavailable).
+	// Non-strict (non-phase) sessions load ~/.claude/settings.json via settingSources
+	// including "user". If the user declared the same server names there, injecting them
+	// again via mcpServers causes duplicate registration and leaves MCP tools unavailable.
+	// Strict (gsdPhase) sessions set settingSources=[] so user settings are not loaded.
+	const userDiscovered = !gsdPhase ? discoverUserMcpServerNames() : [];
+	const allDiscovered = discovered.length > 0 || userDiscovered.length > 0
+		? [...discovered, ...userDiscovered]
+		: discovered;
+
+	// If a default GSD MCP server is already declared in project config or in the user's
+	// ~/.claude/settings.json (when that file will be loaded), do not inject it again via
+	// mcpServers. Passing the same server name from two sources causes a duplicate
+	// registration conflict that prevents the MCP server from loading (tools become unavailable).
 	const workflowAlreadyInProject = projectWorkflowServerName !== undefined
-		|| (injectedWorkflowServerName !== undefined && discovered.includes(injectedWorkflowServerName));
+		|| (injectedWorkflowServerName !== undefined && allDiscovered.includes(injectedWorkflowServerName));
 	const browserAlreadyInProject = projectBrowserServerName !== undefined
-		|| (injectedBrowserServerName !== undefined && discovered.includes(injectedBrowserServerName));
+		|| (injectedBrowserServerName !== undefined && allDiscovered.includes(injectedBrowserServerName));
 	const mcpServersToInject = { ...defaultMcpServers.servers };
 	if (workflowAlreadyInProject && injectedWorkflowServerName) delete mcpServersToInject[injectedWorkflowServerName];
 	if (browserAlreadyInProject && injectedBrowserServerName) delete mcpServersToInject[injectedBrowserServerName];

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -796,9 +796,9 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		assert.equal(options.persistSession, true, "persistSession must default to true");
 	});
 
-	test("buildSdkOptions loads project and local settings so approved .mcp.json servers are active", () => {
+	test("buildSdkOptions loads user, project, and local settings so approved Claude Code config is active", () => {
 		const options = buildSdkOptions("claude-sonnet-4-20250514", "test prompt");
-		assert.deepEqual(options.settingSources, ["project", "local"]);
+		assert.deepEqual(options.settingSources, ["user", "project", "local"]);
 	});
 
 	test("buildSdkOptions sets model and prompt correctly", () => {

--- a/src/resources/extensions/gsd/mcp-filter.ts
+++ b/src/resources/extensions/gsd/mcp-filter.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 
 import type { ClaudeCodeMcpConfig } from "./preferences-types.js";
@@ -113,6 +114,12 @@ export function discoverBrowserMcpServerName(projectDir: string): string | undef
 
 export function discoverMcpServerNames(projectDir: string): string[] {
   return discoverMcpServers(projectDir).map((server) => server.name);
+}
+
+export function discoverUserMcpServerNames(): string[] {
+  const userSettingsPath = resolve(homedir(), ".claude", "settings.json");
+  const userSettings = readJsonFile(userSettingsPath, true) as ClaudeSettingsFile | undefined;
+  return collectServerEntries(userSettings?.mcpServers).map((s) => s.name);
 }
 
 export function computeMcpDisallowedTools(


### PR DESCRIPTION
## Linked issue

Closes #517

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Loads user-scope Claude Code settings for non-strict `claude-code-cli` SDK sessions.
**Why:** Enterprise Claude Code setups often keep auth, base URL, and routing in `~/.claude/settings.json`, and excluding that scope can leave GSD stuck waiting on an unreachable default endpoint.
**How:** Adds `user` to the normal `settingSources` list while preserving strict GSD-phase MCP isolation, and updates the regression test for the provider option.

## What

- Updates `buildSdkOptions()` so normal Claude Code SDK sessions use `settingSources: ["user", "project", "local"]`.
- Keeps strict GSD phase sessions at `settingSources: []` when GSD inlines exact MCP servers to avoid duplicate server registration.
- Updates the stream-adapter test to assert the user/project/local settings contract.

## Why

The standalone Claude Code CLI can rely on user-scope settings for `apiKeyHelper`, custom base URLs, provider routing environment, and model overrides. GSD should delegate to the same local Claude Code runtime settings in normal sessions instead of dropping the user scope and silently falling back to defaults.

## How

The change is limited to the SDK option assembly path. Strict phase configs still bypass Claude Code settings because those sessions inline the exact MCP servers GSD needs, and loading additional settings at the same time can duplicate MCP servers.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config
- [x] `claude-code-cli` — Claude Code provider extension

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] `pnpm run build:core`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=180000 src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- [x] `pnpm run verify:fast`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run test:unit` with Node 24

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783309726&installation_id=134682257&pr_number=523&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F523&signature=7ac59a3dae06e634ce63a5cc1229df8a37076cd73d3cf6e74adaba59edbad137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SDK option assembly and MCP registration paths; incorrect dedupe could hide tools, but strict GSD phases are unchanged and scope is limited to claude-code-cli.
> 
> **Overview**
> Normal **claude-code-cli** SDK sessions now load **`user`** Claude Code settings alongside project and local, so `~/.claude/settings.json` (auth, API routing, `apiKeyHelper`, etc.) applies the same way as the standalone CLI.
> 
> **`buildSdkOptions()`** sets `settingSources` to `["user", "project", "local"]` when not in a strict GSD phase; strict phase runs still use `settingSources: []` with inlined MCP servers unchanged.
> 
> To avoid duplicate MCP registration when user settings declare the same server names, **`discoverUserMcpServerNames()`** reads `mcpServers` from the user settings file and those names are merged into duplicate-detection before GSD skips injecting default workflow/browser MCP configs.
> 
> The stream-adapter regression test now asserts the user/project/local `settingSources` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889e30b45eab47711d6c585021b3c0c46990cf0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->