### PR TITLE
fix(pi-coding-agent): ignore empty stored api keys

### DIFF
--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -45,6 +45,14 @@ type LockResult<T> = {
 	next?: string;
 };
 
+function isUsableApiKeyCredential(credential: AuthCredential): credential is ApiKeyCredential {
+	return credential.type === "api_key" && credential.key.trim().length > 0;
+}
+
+function isUsableStoredCredential(credential: AuthCredential): boolean {
+	return credential.type === "oauth" || isUsableApiKeyCredential(credential);
+}
+
 export interface AuthStorageBackend {
 	withLock<T>(fn: (current: string | undefined) => LockResult<T>): T;
 	withLockAsync<T>(fn: (current: string | undefined) => Promise<LockResult<T>>): Promise<T>;
@@ -347,7 +355,7 @@ export class AuthStorage {
 	 */
 	hasAuth(provider: string): boolean {
 		if (this.runtimeOverrides.has(provider)) return true;
-		if (this.getCredentialsForProvider(provider).length > 0) return true;
+		if (this.getCredentialsForProvider(provider).some(isUsableStoredCredential)) return true;
 		if (getEnvApiKey(provider)) return true;
 		if (this.fallbackResolver?.(provider)) return true;
 		return false;
@@ -383,7 +391,7 @@ export class AuthStorage {
 	 * Return auth status without exposing credential values or refreshing tokens.
 	 */
 	getAuthStatus(provider: string): AuthStatus {
-		if (this.getCredentialsForProvider(provider).length > 0) {
+		if (this.getCredentialsForProvider(provider).some(isUsableStoredCredential)) {
 			return { configured: true, source: "stored" };
 		}
 
@@ -511,7 +519,9 @@ export class AuthStorage {
 		}
 
 		const creds = this.getCredentialsForProvider(providerId);
-		const cred = creds.find((entry) => entry.type === "api_key") ?? creds.find((entry) => entry.type === "oauth");
+		const apiKeyCredential = creds.find(isUsableApiKeyCredential);
+		const oauthCredential = creds.find((entry) => entry.type === "oauth");
+		const cred = apiKeyCredential ?? oauthCredential;
 
 		if (cred?.type === "api_key") {
 			return resolveConfigValue(cred.key);

--- a/packages/pi-coding-agent/test/auth-storage.test.ts
+++ b/packages/pi-coding-agent/test/auth-storage.test.ts
@@ -156,6 +156,22 @@ describe("AuthStorage", () => {
 			expect(apiKey).toBe("literal_api_key_value");
 		});
 
+		test("empty apiKey placeholders are skipped when resolving stored keys", async () => {
+			const validCredential = ["minimax", "valid", "test", "credential"].join("-");
+
+			writeAuthJson({
+				minimax: [
+					{ type: "api_key", key: "" },
+					{ type: "api_key", key: validCredential },
+				],
+			});
+
+			authStorage = AuthStorage.create(authJsonPath);
+			const apiKey = await authStorage.getApiKey("minimax");
+
+			expect(apiKey).toBe(validCredential);
+		});
+
 		test("apiKey command can use shell features like pipes", async () => {
 			writeAuthJson({
 				anthropic: { type: "api_key", key: "!echo 'hello world' | tr ' ' '-'" },
@@ -456,6 +472,16 @@ describe("AuthStorage", () => {
 			expect(JSON.stringify(authStorage.getAuthStatus("anthropic"))).not.toContain("secret-api-key");
 			expect(JSON.stringify(authStorage.getAuthStatus("openai"))).not.toContain("secret-access-token");
 			expect(JSON.stringify(authStorage.getAuthStatus("openai"))).not.toContain("secret-refresh-token");
+		});
+
+		test("empty stored API keys do not count as configured auth", () => {
+			authStorage = AuthStorage.inMemory({
+				"custom-provider": { type: "api_key", key: "" },
+			});
+
+			expect(authStorage.has("custom-provider")).toBe(true);
+			expect(authStorage.hasAuth("custom-provider")).toBe(false);
+			expect(authStorage.getAuthStatus("custom-provider")).toEqual({ configured: false });
 		});
 	});
 

--- a/packages/pi-coding-agent/test/model-registry.test.ts
+++ b/packages/pi-coding-agent/test/model-registry.test.ts
@@ -243,6 +243,54 @@ describe("ModelRegistry", () => {
 			expect(registry.hasConfiguredAuth(model!)).toBe(true);
 		});
 
+		test("MiniMax ignores empty stored key placeholders when checking request readiness", async () => {
+			const originalMinimaxKey = process.env.MINIMAX_API_KEY;
+			const validCredential = ["minimax", "valid", "test", "credential"].join("-");
+
+			try {
+				delete process.env.MINIMAX_API_KEY;
+				authStorage = AuthStorage.inMemory({
+					minimax: { type: "api_key", key: "" },
+				});
+
+				const registryWithoutKey = ModelRegistry.create(authStorage, modelsJsonPath);
+				const minimaxModelWithoutKey = registryWithoutKey.find("minimax", "MiniMax-M2.7");
+
+				expect(minimaxModelWithoutKey).toBeDefined();
+				expect(registryWithoutKey.isProviderRequestReady("minimax")).toBe(false);
+				expect(registryWithoutKey.getProviderAuthStatus("minimax")).toEqual({ configured: false });
+
+				authStorage = AuthStorage.inMemory({
+					minimax: [
+						{ type: "api_key", key: "" },
+						{ type: "api_key", key: validCredential },
+					],
+				});
+
+				const registryWithKey = ModelRegistry.create(authStorage, modelsJsonPath);
+				const minimaxModelWithKey = registryWithKey.find("minimax", "MiniMax-M2.7");
+
+				expect(minimaxModelWithKey).toBeDefined();
+				const auth = await registryWithKey.getApiKeyAndHeaders(minimaxModelWithKey!);
+
+				expect(registryWithKey.isProviderRequestReady("minimax")).toBe(true);
+				expect(registryWithKey.getProviderAuthStatus("minimax")).toEqual({
+					configured: true,
+					source: "stored",
+				});
+				expect(auth.ok).toBe(true);
+				if (auth.ok) {
+					expect(auth.apiKey).toBe(validCredential);
+				}
+			} finally {
+				if (originalMinimaxKey === undefined) {
+					delete process.env.MINIMAX_API_KEY;
+				} else {
+					process.env.MINIMAX_API_KEY = originalMinimaxKey;
+				}
+			}
+		});
+
 		test("Anthropic Vertex built-in models are available when project auth is configured", () => {
 			const originalProjectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID;
 


### PR DESCRIPTION
## Linked issue

Closes #367

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Ignore empty stored API-key placeholders when deciding provider auth readiness and resolving stored keys.
**Why:** Legacy blank auth entries can make MiniMax look configured while masking a later valid key.
**How:** Treat only OAuth credentials and non-empty API-key credentials as usable auth, while preserving raw stored-entry visibility for cleanup flows.

## What

- Added usable-credential guards in `AuthStorage` for `hasAuth`, `getAuthStatus`, and `getApiKey`.
- Kept `has(provider)` as a raw storage-entry check so empty legacy entries remain visible to cleanup/removal flows.
- Added regression coverage for empty API-key placeholders and the MiniMax model-registry readiness path.

## Why

MiniMax can surface a misleading invalid-key/login error when GSD routes a request with an empty stored credential, even if a valid MiniMax key is present later in auth storage.

## How

`AuthStorage` now skips blank `api_key` entries for request auth and readiness decisions. OAuth entries remain usable, and non-empty API-key entries keep the existing priority over OAuth/env/fallback sources.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:

- `pnpm exec vitest run --config /tmp/gsd-pi-issue367-vitest.config.ts packages/pi-coding-agent/test/auth-storage.test.ts packages/pi-coding-agent/test/model-registry.test.ts -t "empty apiKey placeholders|empty stored API keys|MiniMax ignores empty stored key placeholders"`
- `pnpm run build:pi-coding-agent`
- `pnpm run verify:fast`

Note: live MiniMax API validation was not run locally because no MiniMax credential was available in this worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783310080&installation_id=134682257&pr_number=524&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F524&signature=34d6e81cfaaf1bb07f365073d29978b22c0b0e8e7e3784b367f31a86068e9f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth-resolution fix in pi-coding-agent with tests; only changes behavior when stored api_key values are empty.
> 
> **Overview**
> **`AuthStorage`** now treats only **OAuth** and **non-empty** stored **`api_key`** entries as usable auth. Blank or whitespace-only keys are skipped in **`hasAuth`**, **`getAuthStatus`**, and **`getApiKey`**, including when multiple credentials exist per provider so a later valid key is chosen instead of an empty placeholder first.
> 
> **`has(provider)`** is unchanged: it still reflects any stored row so legacy empty entries stay visible for cleanup.
> 
> Regression tests cover empty-key skipping, auth status when only an empty key exists, and MiniMax **`ModelRegistry`** request readiness / key resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a2bca4103fdc258c4f1b2232e88bf972450ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->