### PR TITLE
fix(agent-modes): detach spawned URL opener to avoid holding event loop

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/login-dialog.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/login-dialog.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import * as childProcess from "node:child_process";
 import {
 	EditorKeybindingsManager,
 	setEditorKeybindings,
@@ -7,7 +8,12 @@ import {
 	type Terminal,
 } from "@gsd/pi-tui";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
-import { buildAuthUrlPresentation, LoginDialogComponent } from "../login-dialog.js";
+import {
+	buildAuthUrlPresentation,
+	buildExternalUrlOpenCommand,
+	LoginDialogComponent,
+	openExternalUrl,
+} from "../login-dialog.js";
 
 function makeTerminal(): Terminal {
 	return {
@@ -94,5 +100,48 @@ describe("LoginDialogComponent", () => {
 		assert.match(output, /https:\/\/github\.com\/login\/device/);
 		assert.match(output, /Code expires in 15 minutes/);
 		assert.equal(openedUrl, "https://github.com/login/device");
+	});
+
+	test("buildExternalUrlOpenCommand selects platform URL openers safely", () => {
+		const url = "https://auth.example.com/device?state=needs'quote&next=1";
+
+		assert.deepEqual(buildExternalUrlOpenCommand(url, "darwin"), {
+			command: "open",
+			args: [url],
+		});
+		assert.deepEqual(buildExternalUrlOpenCommand(url, "linux"), {
+			command: "xdg-open",
+			args: [url],
+		});
+		assert.deepEqual(buildExternalUrlOpenCommand(url, "win32"), {
+			command: "powershell",
+			args: ["-c", "Start-Process 'https://auth.example.com/device?state=needs''quote&next=1'"],
+		});
+	});
+
+	test("openExternalUrl detaches and unreferences the spawned URL opener", () => {
+		let unrefCalled = false;
+		let spawnCall:
+			| {
+					command: string;
+					args: readonly string[];
+					options: childProcess.SpawnOptions;
+			  }
+			| undefined;
+
+		const spawnUrlOpener = (command: string, args: readonly string[], options: childProcess.SpawnOptions) => {
+			spawnCall = { command, args, options };
+			return {
+				unref() {
+					unrefCalled = true;
+				},
+			};
+		};
+
+		openExternalUrl("https://auth.example.com/device?code=ABCD&state=oauth", spawnUrlOpener);
+
+		assert.ok(spawnCall, "expected openExternalUrl to spawn an opener process");
+		assert.deepEqual(spawnCall.options, { detached: true, stdio: "ignore" });
+		assert.equal(unrefCalled, true, "detached opener should not keep the login process alive");
 	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
@@ -3,7 +3,7 @@
 import type { OAuthDeviceCodeInfo } from "@gsd/pi-ai";
 import { getOAuthProviders } from "@gsd/pi-ai/oauth";
 import { Container, type Focusable, getEditorKeybindings, Input, Spacer, Text, truncateToWidth, type TUI } from "@gsd/pi-tui";
-import { spawn } from "child_process";
+import * as childProcess from "node:child_process";
 import { theme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -29,22 +29,32 @@ export function buildAuthUrlPresentation(url: string, terminalColumns: number): 
 	};
 }
 
-function openExternalUrl(url: string): void {
-	let cmd: string;
-	let args: string[];
-
-	if (process.platform === "win32") {
-		cmd = "powershell";
-		args = ["-c", `Start-Process '${url.replace(/'/g, "''")}'`];
-	} else if (process.platform === "darwin") {
-		cmd = "open";
-		args = [url];
-	} else {
-		cmd = "xdg-open";
-		args = [url];
+export function buildExternalUrlOpenCommand(url: string, platform: NodeJS.Platform = process.platform): {
+	command: string;
+	args: string[];
+} {
+	switch (platform) {
+		case "win32":
+			return {
+				command: "powershell",
+				args: ["-c", `Start-Process '${url.replace(/'/g, "''")}'`],
+			};
+		case "darwin":
+			return { command: "open", args: [url] };
+		default:
+			return { command: "xdg-open", args: [url] };
 	}
+}
 
-	const child = spawn(cmd, args, {
+type UrlOpenerSpawn = (
+	command: string,
+	args: readonly string[],
+	options: childProcess.SpawnOptions,
+) => Pick<childProcess.ChildProcess, "unref">;
+
+export function openExternalUrl(url: string, spawnUrlOpener: UrlOpenerSpawn = childProcess.spawn): void {
+	const { command, args } = buildExternalUrlOpenCommand(url);
+	const child = spawnUrlOpener(command, args, {
 		detached: true,
 		stdio: "ignore",
 	});

--- a/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts
@@ -3,7 +3,7 @@
 import type { OAuthDeviceCodeInfo } from "@gsd/pi-ai";
 import { getOAuthProviders } from "@gsd/pi-ai/oauth";
 import { Container, type Focusable, getEditorKeybindings, Input, Spacer, Text, truncateToWidth, type TUI } from "@gsd/pi-tui";
-import { execFile } from "child_process";
+import { spawn } from "child_process";
 import { theme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -30,14 +30,25 @@ export function buildAuthUrlPresentation(url: string, terminalColumns: number): 
 }
 
 function openExternalUrl(url: string): void {
-	// PowerShell's Start-Process handles URLs with '&' safely; cmd /c start does not.
+	let cmd: string;
+	let args: string[];
+
 	if (process.platform === "win32") {
-		execFile("powershell", ["-c", `Start-Process '${url.replace(/'/g, "''")}'`], () => {});
-		return;
+		cmd = "powershell";
+		args = ["-c", `Start-Process '${url.replace(/'/g, "''")}'`];
+	} else if (process.platform === "darwin") {
+		cmd = "open";
+		args = [url];
+	} else {
+		cmd = "xdg-open";
+		args = [url];
 	}
 
-	const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-	execFile(openCmd, [url], () => {});
+	const child = spawn(cmd, args, {
+		detached: true,
+		stdio: "ignore",
+	});
+	child.unref();
 }
 
 /**


### PR DESCRIPTION
## Linked issue

Closes #526

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace `execFile` with `spawn(detached, stdio:ignore)+unref()` in `openExternalUrl`.
**Why:** `execFile` without `unref()` holds a Node.js event loop reference to the child process, preventing GSD from exiting cleanly when the browser stays open.
**How:** Use the canonical fire-and-forget subprocess pattern: `spawn` with `detached: true`, `stdio: "ignore"`, and `child.unref()`.

## What

`packages/gsd-agent-modes/src/modes/interactive/components/login-dialog.ts` — `openExternalUrl` function.

## Why

`execFile` registers the spawned process with the Node.js event loop. If the child (e.g., `xdg-open` on Linux, or the browser it launches) stays alive, GSD's event loop cannot exit. The Windows path was already safe (PowerShell exits fast), but macOS `open` and Linux `xdg-open` can hold the parent indefinitely.

## How

`spawn` with `{ detached: true, stdio: "ignore" }` + `child.unref()` is the canonical Node.js pattern for fire-and-forget subprocesses. The refactoring also removes the early `return` for Windows, unifying all three platforms into a single `spawn` call at the end.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `pi-tui` — Terminal UI

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — trigger OAuth login dialog, confirm browser opens and GSD process is not held alive
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code — reviewed and validated by the author; Claude Code assisted with branch/PR setup only, the fix itself was authored by the contributor

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783331437&installation_id=134682257&pr_number=527&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F527&signature=74f7c34a19d37db9bc677e10fd37b764c3a9f4f3344bb918f2047d9e738ecdf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->