### PR TITLE
perf(agent-modes): avoid duplicate transcript truncation

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/transcript-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/transcript-design.test.ts
@@ -1,0 +1,26 @@
+// Project/App: gsd-pi
+// File Purpose: Visual contract tests for shared transcript rendering primitives.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { padRight, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+import { renderConnectedCard } from "../transcript-design.js";
+
+initTheme("dark", false);
+
+describe("renderConnectedCard", () => {
+	test("keeps long ANSI body rows on the existing width contract", () => {
+		const width = 32;
+		const indent = 4;
+		const line = `\x1b[36m${"abcdef ".repeat(8)}\x1b[0m`;
+
+		const rendered = renderConnectedCard(width, "tool", [line], { indent, closeBottom: false });
+		const body = rendered[1];
+		const expectedInner = padRight(truncateToWidth("   " + line, width - indent, ""), width - indent);
+
+		assert.ok(body, "expected a body row");
+		assert.equal(body, " ".repeat(indent) + expectedInner);
+		assert.equal(visibleWidth(body), width);
+	});
+});

--- a/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
@@ -135,7 +135,7 @@ export function renderConnectedCard(
 	}
 	const paintBody = (line: string) => {
 		const innerWidth = Math.max(1, width - indent);
-		const inner = padRight(truncateToWidth("   " + line, innerWidth, ""), innerWidth);
+		const inner = padRight("   " + line, innerWidth);
 		const painted = opts.bodyBg ? theme.bg(opts.bodyBg, inner) : inner;
 		return prefix + painted;
 	};


### PR DESCRIPTION
## TL;DR

**What:** Avoid duplicate width-aware truncation while painting connected transcript card body rows.
**Why:** CPU profiling showed transcript rendering repeatedly spending time in `truncateToWidthJs()` for the same body line.
**How:** Let `padRight()` own the truncation step it already performs, and add a visual contract test for long ANSI body rows.

## What

This updates `renderConnectedCard()` in the interactive transcript renderer so body rows call `padRight()` directly instead of pre-truncating and then calling `padRight()`. It also adds a focused regression test that verifies long ANSI body rows keep the existing exact-width output contract.

## Why

A CPU profile from a hot `gsd` process showed the connected-card body render path repeatedly entering `truncateToWidthJs()`. The body row path was doing the same ANSI-aware width work twice because `padRight()` already truncates before padding.

## How

The implementation removes the redundant outer `truncateToWidth()` call and keeps the same output behavior through the existing `padRight()` helper. The test compares rendered body output against the prior width contract and verifies the rendered row still fills the requested width.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `node --experimental-strip-types --test packages/pi-tui/test/truncate-to-width.test.ts`
- `pnpm run build:pi`
- `pnpm --filter @gsd/agent-modes test`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/gsd-agent-modes/src/modes/interactive/components/__tests__/transcript-design.test.ts`
- `pnpm run verify:fast`

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352916&installation_id=134682257&pr_number=531&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F531&signature=dce0d9f23ccd7b45b16f3250b813e6f012d904a8b0d0a11e2d64b4d9585d1d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line render-path change with a test asserting unchanged width contract; no auth, data, or API surface changes.
> 
> **Overview**
> **Performance fix** for connected transcript card body rendering: `renderConnectedCard()` no longer calls `truncateToWidth()` before `padRight()` on each body row, since `padRight()` already performs ANSI-aware truncation.
> 
> Adds a **visual contract test** that long ANSI body lines still match the prior exact-width layout (`visibleWidth(body) === width`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd70a8058d7c8e199405d56d8bb7ca7ccfc00bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->