### PR TITLE
fix(gsd): keep milestone closeout surface durable

### DIFF
--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -47,6 +47,10 @@ export function isAutoCompletionStopInProgress(): boolean {
   return autoSession.completionStopInProgress;
 }
 
+export function clearAutoCompletionStopInProgress(): void {
+  autoSession.completionStopInProgress = false;
+}
+
 export function markToolStart(toolCallId: string, toolName?: string): void {
   markTrackedToolStart(toolCallId, autoSession.active, toolName);
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1138,6 +1138,48 @@ function setLifecycleOutcome(
   });
 }
 
+const TERMINAL_CLOSEOUT_COMMANDS = [
+  "/gsd status for overview",
+  "/gsd visualize to inspect",
+  "/gsd notifications for history",
+  "/gsd start for new work",
+];
+
+function setTerminalCloseoutOutcome(
+  ctx: ExtensionContext | undefined,
+  input: {
+    milestoneId?: string | null;
+    milestoneTitle?: string | null;
+    allMilestonesComplete?: boolean;
+    reason?: string;
+  },
+): void {
+  if (!ctx?.hasUI) return;
+  const milestoneLabel = input.milestoneId ? `Milestone ${input.milestoneId}` : "Milestone";
+  const title = input.allMilestonesComplete ? "All milestones complete" : `${milestoneLabel} complete`;
+  const titleLine = input.milestoneTitle && input.milestoneId
+    ? `${input.milestoneTitle}. `
+    : "";
+  const nextAction = input.allMilestonesComplete
+    ? "Review the closeout, then start new work when ready."
+    : "Review the closeout, then start the next milestone when ready.";
+
+  ctx.ui.setHeader?.(() => ({
+    render(): string[] { return []; },
+    invalidate(): void {},
+  }));
+  ctx.ui.setStatus?.("gsd-step", undefined);
+  ctx.ui.setWidget?.("gsd-progress", undefined);
+  setLifecycleOutcome(ctx, {
+    status: "complete",
+    title,
+    detail: `${titleLine}${input.reason ?? "Milestone closeout finished."}`,
+    nextAction,
+    commands: TERMINAL_CLOSEOUT_COMMANDS,
+    unitLabel: input.milestoneId ? `complete-milestone ${input.milestoneId}` : null,
+  });
+}
+
 function handleLostSessionLock(
   ctx?: ExtensionContext,
   lockStatus?: SessionLockStatus,
@@ -1283,7 +1325,6 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   if (!s.paused) {
     if (preserveCompletionSurface) {
       ctx.ui.setStatus("gsd-auto", undefined);
-      s.completionStopInProgress = false;
       if (preserveStepSurface) {
         s.preserveStepSurfaceAfterLoopExit = false;
       }
@@ -1426,6 +1467,7 @@ export async function stopAuto(
     options.preserveCloseoutTranscript ?? completionStopRequested
   );
   const installCompletionWidget = completionStopRequested && !preserveCloseoutTranscript;
+  const installTerminalCloseoutOutcome = completionStopRequested && preserveCloseoutTranscript;
   const preserveCompletionSurface = completionStopRequested || preserveCloseoutTranscript;
   s.completionStopInProgress = preserveCompletionSurface;
   playNotificationBell("stop", loadedPreferences?.notifications);
@@ -1757,6 +1799,15 @@ export async function stopAuto(
       if (process.env.GSD_HEADLESS === "1") {
         ctx.ui.notify(`${stopNotificationPrefix}.`, "info");
       }
+    }
+
+    if (installTerminalCloseoutOutcome && ctx && options.completionWidget) {
+      setTerminalCloseoutOutcome(ctx, {
+        milestoneId: completionMilestoneId,
+        milestoneTitle: options.completionWidget.milestoneTitle ?? null,
+        allMilestonesComplete: options.completionWidget.allMilestonesComplete,
+        reason: reason ?? "Milestone closeout finished.",
+      });
     }
 
     // ── Step 9: Cmux sidebar / event log ──

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -18,6 +18,7 @@ import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import {
+  clearAutoCompletionStopInProgress,
   clearToolInvocationError,
   getAutoRuntimeSnapshot,
   getSourceObservationStore,
@@ -790,6 +791,7 @@ export function registerHooks(
   });
 
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
+    clearAutoCompletionStopInProgress();
     resetPendingGatePauseGuard();
     applyMinimalGsdToolSurface(pi);
 

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -21,6 +21,14 @@ function runGit(args: string[], cwd: string): void {
   });
 }
 
+function renderOutcomeWidget(widget: unknown): string {
+  const component = (widget as any)(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  return component.render(100).join("\n");
+}
+
 test("cleanupAfterLoopExit preserves paused auto badge after provider pause", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-paused-cleanup-"));
   const previousCwd = process.cwd();
@@ -167,13 +175,17 @@ test("cleanupAfterLoopExit preserves completion closeout surface after stopAuto 
       false,
       "completion cleanup must not replace the closeout surface with a generic outcome card",
     );
-    assert.equal(autoSession.completionStopInProgress, false);
+    assert.equal(
+      autoSession.completionStopInProgress,
+      true,
+      "completion closeout preservation must survive post-loop cleanup until the next agent turn",
+    );
   } finally {
     autoSession.reset();
   }
 });
 
-test("cleanupAfterLoopExit clears completionStopInProgress even when preserveStepSurfaceAfterLoopExit is also set", async () => {
+test("cleanupAfterLoopExit preserves completionStopInProgress even when preserveStepSurfaceAfterLoopExit is also set", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
 
@@ -196,8 +208,8 @@ test("cleanupAfterLoopExit clears completionStopInProgress even when preserveSte
 
     assert.equal(
       autoSession.completionStopInProgress,
-      false,
-      "completionStopInProgress must be cleared even when preserveStepSurfaceAfterLoopExit was also set",
+      true,
+      "completionStopInProgress must survive cleanup even when preserveStepSurfaceAfterLoopExit was also set",
     );
     assert.equal(autoSession.preserveStepSurfaceAfterLoopExit, false);
   } finally {
@@ -642,6 +654,10 @@ test("stopAuto foreground completion closeout reroots session and preserves the 
       "foreground completion stop must not install a replacement roll-up widget over the transcript",
     );
     assert.ok(
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
+      "foreground completion stop must clear stale progress controls in the rerooted session",
+    );
+    assert.ok(
       notifications.every(message => !message.includes("/gsd auto to resume")),
       "completion stop notification must not tell users to resume a finished auto run",
     );
@@ -649,10 +665,15 @@ test("stopAuto foreground completion closeout reroots session and preserves the 
       notifications.every(message => !message.includes("Auto-mode stopped") && !message.includes("Session:") && !message.includes("Debug log written")),
       "completion stop must not append generic stop/session/debug notifications after the report",
     );
-    assert.ok(
-      widgetCalls.every(([key, value]) => key !== "gsd-outcome" || value === undefined),
-      "foreground completion stop must not replace the transcript with a generic outcome card",
+    const outcome = widgetCalls.find(([key, value]) => key === "gsd-outcome" && typeof value === "function")?.[1];
+    assert.equal(
+      typeof outcome,
+      "function",
+      "foreground completion stop must install a durable closeout outcome in the rerooted session",
     );
+    const rendered = renderOutcomeWidget(outcome);
+    assert.match(rendered, /Milestone M003 complete/);
+    assert.match(rendered, /Review the closeout/);
 
     const widgetCallCountBeforePostLoopCleanup = widgetCalls.length;
     await cleanupAfterLoopExit(ctx);
@@ -822,7 +843,7 @@ test("stopAuto closeout-transcript preservation suppresses generic stop widgets"
   }
 });
 
-test("stopAuto foreground all-complete closeout preserves the transcript surface", async () => {
+test("stopAuto foreground all-complete closeout installs a durable terminal outcome", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-all-complete-closeout-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -875,8 +896,15 @@ test("stopAuto foreground all-complete closeout preserves the transcript surface
       false,
       "foreground all-complete closeout must not replace the visible transcript with a roll-up widget",
     );
-    const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1);
-    assert.equal(finalOutcome?.[1], undefined, "foreground all-complete closeout must not add an outcome replacement");
+    const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1)?.[1];
+    assert.equal(
+      typeof finalOutcome,
+      "function",
+      "foreground all-complete closeout must install a durable terminal outcome",
+    );
+    const rendered = renderOutcomeWidget(finalOutcome);
+    assert.match(rendered, /All milestones complete/);
+    assert.match(rendered, /start new work/);
   } finally {
     try { closeDatabase(); } catch { /* noop */ }
     autoSession.reset();


### PR DESCRIPTION
## TL;DR

**What:** Keeps milestone closeout on a durable terminal outcome after auto-mode reroots the session.
**Why:** Foreground closeout previously tried to preserve a transcript that `newSession()` clears, letting the idle welcome screen replace the actual closeout.
**How:** Install a compact completion outcome after reroot, keep closeout preservation alive until the next agent turn, and cover foreground/all-complete closeout cleanup.

## What

- Adds a terminal closeout outcome for foreground completion stops after session reroot.
- Keeps completion closeout preservation through post-loop cleanup and clears it at the next agent turn.
- Updates stop cleanup tests for normal milestone and all-milestones-complete closeout paths.

## Why

The previous closeout path suppressed replacement widgets in foreground mode because it expected the transcript to stay visible. The same stop path also reroots via `newSession()`, which clears that transcript, so the terminal could land on a fresh Project Console instead of the closeout endpoint.

## How

- `stopAuto()` now installs a compact `gsd-outcome` closeout surface when foreground completion stops preserve transcript output.
- The closeout surface suppresses the startup header and clears stale progress controls.
- The completion preservation flag survives post-loop cleanup, then resets on the next agent turn.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `pnpm exec node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
- `pnpm exec node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/session-start-footer.test.ts`
- `pnpm exec node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts`
- `pnpm exec node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/commands-dispatcher-unmerged-milestone.test.ts`
- `pnpm exec node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/closeout-wizard.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783356551&installation_id=134682257&pr_number=532&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F532&signature=50144d0ef80d3893eba7b4d36934867a40fef25987392e835087759a7d35d03e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-mode stop/cleanup and session-start UI hooks; behavior is localized to completion closeout but affects what users see at milestone end.
> 
> **Overview**
> Fixes **foreground milestone closeout** landing on the idle welcome screen after auto-mode **reroots** the command session via `newSession()`, which clears the transcript the old path tried to keep visible.
> 
> When a completion stop preserves the closeout transcript (non-headless), **`stopAuto()`** now installs a compact **`gsd-outcome`** terminal surface via **`setTerminalCloseoutOutcome`**: milestone or all-complete title, closeout detail, next-step copy, and suggested `/gsd` commands, while clearing stale **`gsd-progress`** and suppressing the startup header.
> 
> **`completionStopInProgress`** stays set through post-loop **`cleanupAfterLoopExit`** so session hooks still treat the UI as closeout-preserving (e.g. skip welcome header on **`session_start`**); **`clearAutoCompletionStopInProgress()`** runs at the next **`before_agent_start`** to drop the flag once the durable outcome is in place.
> 
> Tests in **`auto-paused-ui-cleanup.test.ts`** assert the new outcome widget, progress clearing, and that the preservation flag survives cleanup until the next agent turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53f56616baa588d593d269ce55f0b8fb075264b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->