### PR TITLE
fix(issue): auto-mode subprocess cannot call memory_query or capture_thought — tool name mismatch between pi-native and MCP-workflow surfaces

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -139,7 +139,9 @@ export const MINIMAL_GSD_TOOL_NAMES = [
   "gsd_checkpoint_db",
   "gsd_plan_milestone",
   "memory_query",
+  "gsd_memory_query",
   "capture_thought",
+  "gsd_capture_thought",
 ] as const;
 
 export const MINIMAL_AUTO_BASE_TOOL_NAMES = [

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -24,7 +24,9 @@ test("buildMinimalGsdToolSet preserves non-GSD tools and replaces broad GSD surf
     "gsd_milestone_status",
     "gsd_checkpoint_db",
     "memory_query",
+    "gsd_memory_query",
     "capture_thought",
+    "gsd_capture_thought",
     "gsd_graph",
   ]);
 

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -575,6 +575,42 @@ test("scopeGsdWorkflowToolsForDispatch applies and restores per-unit skill visib
   assert.equal(calls.filter((call) => call.kind === "skills").length, 2);
 });
 
+// ── Regression #534: auto-mode subprocess cannot call gsd_memory_query / gsd_capture_thought ──
+// MCP-workflow subprocesses register the gsd_-prefixed variants, not the pi-native names.
+// MINIMAL_GSD_TOOL_NAMES must include both so resolveScopedToolNames exposes them.
+
+test("MINIMAL_GSD_TOOL_NAMES includes gsd_memory_query and gsd_capture_thought (regression #534)", () => {
+  assert.ok(
+    (MINIMAL_GSD_TOOL_NAMES as readonly string[]).includes("gsd_memory_query"),
+    "MINIMAL_GSD_TOOL_NAMES must include gsd_memory_query for MCP-workflow surface parity",
+  );
+  assert.ok(
+    (MINIMAL_GSD_TOOL_NAMES as readonly string[]).includes("gsd_capture_thought"),
+    "MINIMAL_GSD_TOOL_NAMES must include gsd_capture_thought for MCP-workflow surface parity",
+  );
+});
+
+test("buildMinimalAutoGsdToolSet resolves MCP-scoped gsd_memory_query and gsd_capture_thought when subprocess only registers gsd_-prefixed variants (regression #534)", () => {
+  // Simulate a subprocess that only exposes gsd_-prefixed MCP tool names,
+  // not the pi-native memory_query / capture_thought variants.
+  const result = buildMinimalAutoGsdToolSet([
+    "bash",
+    "read",
+    "mcp__gsd-workflow__gsd_exec",
+    "mcp__gsd-workflow__gsd_memory_query",
+    "mcp__gsd-workflow__gsd_capture_thought",
+  ], "execute-task");
+
+  assert.ok(
+    result.includes("mcp__gsd-workflow__gsd_memory_query"),
+    "mcp__gsd-workflow__gsd_memory_query must be included when only the gsd_-prefixed variant is available",
+  );
+  assert.ok(
+    result.includes("mcp__gsd-workflow__gsd_capture_thought"),
+    "mcp__gsd-workflow__gsd_capture_thought must be included when only the gsd_-prefixed variant is available",
+  );
+});
+
 test("applyUnitSkillVisibility sets manifest or clears for wildcard", () => {
   const calls: Array<string[] | undefined> = [];
   applyUnitSkillVisibility({


### PR DESCRIPTION
## Summary
- Added `gsd_memory_query` and `gsd_capture_thought` to `MINIMAL_GSD_TOOL_NAMES` in `register-hooks.ts` so auto-mode subprocesses using MCP-workflow transport can resolve both the pi-native and MCP-namespaced tool names; verified no new type errors were introduced.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #534
- [#534 auto-mode subprocess cannot call memory_query or capture_thought — tool name mismatch between pi-native and MCP-workflow surfaces](https://github.com/open-gsd/gsd-pi/issues/534)

## User
- @mattiaverio

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/534-auto-mode-subprocess-cannot-call-memory--1780772846`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783364968&installation_id=134682257&pr_number=536&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F536&signature=7c4b50a0b012056c37443aec36aff5d4e38d28463295c5451c55264e590c2533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist change in tool gating with targeted regression tests; no auth, data, or runtime behavior beyond which tools are advertised to the model.
> 
> **Overview**
> Fixes **#534**: auto-mode subprocesses on the MCP-workflow surface could not use memory or thought-capture tools because only **`gsd_memory_query`** and **`gsd_capture_thought`** are registered there, while minimal tool scoping still requested **`memory_query`** and **`capture_thought`**.
> 
> **`MINIMAL_GSD_TOOL_NAMES`** now lists both the pi-native and **`gsd_`-prefixed** names so **`resolveScopedToolNames`** / **`buildMinimalAutoGsdToolSet`** can expose MCP names like **`mcp__gsd-workflow__gsd_memory_query`** when subprocesses lack the unprefixed variants. Existing gating tests were updated, and regression tests lock in the allowlist and MCP-only registration case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a43ddc1ea835cba8d5a435d48573a4af7c31435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->