### PR TITLE
fix(issue): [Bug]: Auto-mode re-dispatch loop: zero-tool rate-limit guard is blind to reasoning/thinking blocks

### DIFF
--- a/src/resources/extensions/gsd/tests/user-input-boundary.test.ts
+++ b/src/resources/extensions/gsd/tests/user-input-boundary.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import * as userInputBoundary from "../user-input-boundary.ts";
+import { isAwaitingUserInput, shouldPauseForUserApprovalQuestion } from "../user-input-boundary.ts";
 
 test("lastAssistantText extracts the latest assistant text block content", () => {
   const lastAssistantText = (userInputBoundary as {
@@ -41,4 +42,47 @@ test("lastAssistantText includes thinking blocks so rate-limit notices are not d
     },
   ]);
   assert.ok(result?.includes("You've hit your limit"), `expected rate-limit text, got: ${JSON.stringify(result)}`);
+});
+
+test("isAwaitingUserInput does not trigger on thinking-block question marks", () => {
+  // A thinking block with a question mark must NOT pause auto-mode —
+  // it's internal reasoning, not a user-visible prompt.
+  const messages = [
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Should I skip research? Let me check the config." },
+      ],
+    },
+  ];
+  assert.equal(isAwaitingUserInput(messages), false);
+  assert.equal(shouldPauseForUserApprovalQuestion("discuss-project", messages), false);
+});
+
+test("isAwaitingUserInput does not trigger on thinking-block approval phrases", () => {
+  // A thinking block with approval phrases must NOT pause auto-mode.
+  const messages = [
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "The user confirmed and approved the plan. Should I proceed?" },
+      ],
+    },
+  ];
+  assert.equal(isAwaitingUserInput(messages), false);
+  assert.equal(shouldPauseForUserApprovalQuestion("discuss-requirements", messages), false);
+});
+
+test("isAwaitingUserInput still triggers on text-block question marks when thinking is also present", () => {
+  // When thinking + text are both present and the text asks a question, it should still pause.
+  const messages = [
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Internal reasoning without questions." },
+        { type: "text", text: "Does this look correct?" },
+      ],
+    },
+  ];
+  assert.equal(isAwaitingUserInput(messages), true);
 });

--- a/src/resources/extensions/gsd/tests/user-input-boundary.test.ts
+++ b/src/resources/extensions/gsd/tests/user-input-boundary.test.ts
@@ -24,3 +24,21 @@ test("lastAssistantText extracts the latest assistant text block content", () =>
   );
   assert.equal(lastAssistantText?.(null), "");
 });
+
+test("lastAssistantText includes thinking blocks so rate-limit notices are not dropped", () => {
+  const lastAssistantText = (userInputBoundary as {
+    lastAssistantText?: (messages: unknown[] | null | undefined) => string;
+  }).lastAssistantText;
+
+  assert.equal(typeof lastAssistantText, "function");
+  // Turn with only a thinking block (no text block) — must not return ""
+  const result = lastAssistantText?.([
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "You've hit your limit · resets in 2h" },
+      ],
+    },
+  ]);
+  assert.ok(result?.includes("You've hit your limit"), `expected rate-limit text, got: ${JSON.stringify(result)}`);
+});

--- a/src/resources/extensions/gsd/user-input-boundary.ts
+++ b/src/resources/extensions/gsd/user-input-boundary.ts
@@ -23,6 +23,23 @@ const APPROVAL_CHANGE_QUESTION_RE =
 const RESEARCH_DECISION_QUESTION_RE =
   /\b(?:research|skip)\b/i;
 
+function extractVisibleTextFromMessage(msg: unknown): string {
+  if (!msg || typeof msg !== "object") return "";
+  const content = (msg as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type === "text" && typeof typed.text === "string") {
+      parts.push(typed.text);
+    }
+    // thinking blocks intentionally excluded — they are internal reasoning, not user-visible
+  }
+  return parts.join("\n");
+}
+
 function extractTextFromMessage(msg: unknown): string {
   if (!msg || typeof msg !== "object") return "";
   const content = (msg as { content?: unknown }).content;
@@ -54,12 +71,24 @@ export function lastAssistantText(messages: unknown[] | null | undefined): strin
   return "";
 }
 
+function lastAssistantVisibleText(messages: unknown[] | null | undefined): string {
+  if (!Array.isArray(messages)) return "";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") continue;
+    if ((msg as { role?: unknown }).role !== "assistant") continue;
+    const text = extractVisibleTextFromMessage(msg).trim();
+    if (text) return text;
+  }
+  return "";
+}
+
 function anyMessageMatches(messages: unknown[] | undefined, pattern: RegExp): boolean {
   if (!Array.isArray(messages)) return false;
   return messages.some((msg) => {
     if (!msg || typeof msg !== "object") return false;
     if ((msg as { role?: unknown }).role === "user") return false;
-    return pattern.test(extractTextFromMessage(msg));
+    return pattern.test(extractVisibleTextFromMessage(msg));
   });
 }
 
@@ -137,7 +166,7 @@ export function isExplicitApprovalResponse(
 export function isAwaitingUserInput(messages: unknown[] | undefined): boolean {
   if (anyMessageMatches(messages, /ask_user_questions was cancelled before receiving a response/i)) return true;
   if (anyMessageMatches(messages, REMOTE_QUESTION_FAILURE_RE)) return true;
-  const text = lastAssistantText(messages);
+  const text = lastAssistantVisibleText(messages);
   if (!text) return false;
   if (APPROVAL_WAIT_RE.test(text)) return true;
   const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
@@ -148,7 +177,7 @@ export function isAwaitingUserInput(messages: unknown[] | undefined): boolean {
 export function isAwaitingApprovalBoundary(messages: unknown[] | undefined): boolean {
   if (anyMessageMatches(messages, /ask_user_questions was cancelled before receiving a response/i)) return true;
   if (anyMessageMatches(messages, REMOTE_QUESTION_FAILURE_RE)) return true;
-  const text = lastAssistantText(messages);
+  const text = lastAssistantVisibleText(messages);
   if (!text) return false;
   if (APPROVAL_WAIT_RE.test(text)) return true;
   return hasApprovalQuestion(text);
@@ -161,7 +190,7 @@ export function shouldPauseForUserApprovalQuestion(
   if (!unitType || !USER_APPROVAL_UNIT_TYPES.has(unitType)) return false;
   if (anyMessageMatches(messages, /ask_user_questions was cancelled before receiving a response/i)) return true;
   if (anyMessageMatches(messages, REMOTE_QUESTION_FAILURE_RE)) return true;
-  const text = lastAssistantText(messages);
+  const text = lastAssistantVisibleText(messages);
   if (!text) return false;
   if (APPROVAL_WAIT_RE.test(text)) return true;
   if (unitType === "research-decision") return hasResearchDecisionQuestion(text);

--- a/src/resources/extensions/gsd/user-input-boundary.ts
+++ b/src/resources/extensions/gsd/user-input-boundary.ts
@@ -31,9 +31,12 @@ function extractTextFromMessage(msg: unknown): string {
   const parts: string[] = [];
   for (const block of content) {
     if (!block || typeof block !== "object") continue;
-    const typed = block as { type?: unknown; text?: unknown };
+    const typed = block as { type?: unknown; text?: unknown; thinking?: unknown };
     if (typed.type === "text" && typeof typed.text === "string") {
       parts.push(typed.text);
+    }
+    if (typed.type === "thinking" && typeof typed.thinking === "string") {
+      parts.push(typed.thinking);
     }
   }
   return parts.join("\n");


### PR DESCRIPTION
## Summary
- Fixed zero-tool rate-limit guard blindness to thinking blocks by extending `extractTextFromMessage` in `user-input-boundary.ts` to also collect `type === "thinking"` content, and added a test to verify; both tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #537
- [#537 [Bug]: Auto-mode re-dispatch loop: zero-tool rate-limit guard is blind to reasoning/thinking blocks](https://github.com/open-gsd/gsd-pi/issues/537)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/537-bug-auto-mode-re-dispatch-loop-zero-tool-1780776445`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783368591&installation_id=134682257&pr_number=540&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F540&signature=1eee64a73fbc5d3361d324467fd932bff2356725c788e2dd3cde7d57a5f234ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode pause and zero-tool classification behavior; scope is limited to `user-input-boundary.ts` with targeted tests.
> 
> **Overview**
> **Splits assistant message parsing** so auto-mode can see rate-limit text in `thinking` blocks without treating internal reasoning as user-facing prompts.
> 
> `extractTextFromMessage` now includes `type === "thinking"` content, so **`lastAssistantText`** (used by the zero-tool provider guard in auto phases) no longer returns empty when the only assistant output is a thinking block. **`extractVisibleTextFromMessage`** and **`lastAssistantVisibleText`** were added for text-only content; **`isAwaitingUserInput`**, **`isAwaitingApprovalBoundary`**, **`shouldPauseForUserApprovalQuestion`**, and **`anyMessageMatches`** now use visible text so question marks and approval phrases inside thinking blocks do not pause auto-mode. User-visible `text` blocks still trigger waits when they ask questions.
> 
> Tests cover thinking-only rate-limit text, thinking-only false positives, and mixed thinking + text behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d8d3dcb7456b95c0ba9ca2e3c960faf4bf448d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->