### PR TITLE
fix(release): restore native engine packages in lockfile and prevent recurrence

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -560,6 +560,28 @@ jobs:
       - name: Verify native platform packages for release version
         run: pnpm run verify:native-platform-packages
 
+      - name: Fold native packages into release lockfile
+        env:
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
+        run: |
+          # The release commit + tag are created (in "Commit and tag release") BEFORE
+          # the @opengsd/engine-* native packages are published to npm. bump-version.mjs
+          # runs `pnpm install --lockfile-only` at that point, and pnpm silently drops
+          # the still-unpublished engine packages from optionalDependencies — so the
+          # committed pnpm-lock.yaml is missing them. They are published and verified
+          # now, so regenerate the lockfile and fold it back into the release commit
+          # (and move the tag) before either is pushed. Without this every post-release
+          # `pnpm install --frozen-lockfile` on main fails with ERR_PNPM_OUTDATED_LOCKFILE.
+          pnpm install --lockfile-only
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "pnpm-lock.yaml already resolves the native packages — nothing to fold in."
+            exit 0
+          fi
+          git add pnpm-lock.yaml
+          git commit --amend --no-edit
+          git tag -f "v${RELEASE_VERSION}"
+          echo "Folded refreshed pnpm-lock.yaml into release commit and tag v${RELEASE_VERSION}."
+
       - name: Validate package is installable
         run: pnpm run validate-pack
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,21 @@ importers:
       '@mariozechner/clipboard':
         specifier: 0.3.6
         version: 0.3.6
+      '@opengsd/engine-darwin-arm64':
+        specifier: 1.2.0
+        version: 1.2.0
+      '@opengsd/engine-darwin-x64':
+        specifier: 1.2.0
+        version: 1.2.0
+      '@opengsd/engine-linux-arm64-gnu':
+        specifier: 1.2.0
+        version: 1.2.0
+      '@opengsd/engine-linux-x64-gnu':
+        specifier: 1.2.0
+        version: 1.2.0
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.2.0
+        version: 1.2.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1909,6 +1924,31 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opengsd/engine-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-mUY8cS2n3tHYTtAlKDb6/VbIFQ2KXvx3i5dfbx2UjKDg1IRg+S/vyQTVBGG335S2qRTg/l069RNBmaUglO17gg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opengsd/engine-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-eQ0twIlE8yYaMwj76V62oeuI/dgE+MRjrjmRuXHp3wDqXSgWbircfjuZV7v+L7y9pgJFAhE7ayukrTiY4Rc/Qg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opengsd/engine-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-W09b3VZD695+Rb6fj9lq2bmbFXtqV+ovf9noVWV6WTLcM/YyLGnFRxX5wnANdcZhJ88c0jBda1RzPZKNO/eVzQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opengsd/engine-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-EZZ7BqKJ/avr5NRRDirIz3zTOoARb+ejp6ZI2WNcFHdXOGurAB/cfy6g5eMemD0xuMuqqaA2RIdno7aFI72e/Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-LuDYptDo0mjqvxJTLh3IOVQRGOHKK1ogDOsDksDyjaNna6ye1Ja7UPrKPoDx2jFErzXlJ3ZzN9eJYpbKUepOcQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@opengsd/gsd-browser@0.1.27':
     resolution: {integrity: sha512-bUSdFD5VgX1gOk1l5PaZrMBPRc+eh6zQsMLS6nwX4PHDpQgLojIFqD+NTZzifEOynSlHPBy8LbD8T8Bj1iQnDg==}
@@ -7701,6 +7741,21 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opengsd/engine-darwin-arm64@1.2.0':
+    optional: true
+
+  '@opengsd/engine-darwin-x64@1.2.0':
+    optional: true
+
+  '@opengsd/engine-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@opengsd/engine-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.2.0':
+    optional: true
 
   '@opengsd/gsd-browser@0.1.27': {}
 


### PR DESCRIPTION
## Problem

CI on `main` is broken after the `release: v1.2.0` commit. `pnpm install --frozen-lockfile` fails with:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json
* 5 dependencies were added: @opengsd/engine-darwin-arm64@1.2.0, @opengsd/engine-darwin-x64@1.2.0,
  @opengsd/engine-linux-arm64-gnu@1.2.0, @opengsd/engine-linux-x64-gnu@1.2.0, @opengsd/engine-win32-x64-msvc@1.2.0
```

(Failing job: https://github.com/open-gsd/gsd-pi/actions/runs/27075822811/job/79912941158)

The `release: v1.2.0` commit bumped the five native engine `optionalDependencies` to `1.2.0` in `package.json` but **dropped them entirely from `pnpm-lock.yaml`** (they were present at `1.1.1`).

## Root cause

`scripts/bump-version.mjs:41` runs `pnpm install --lockfile-only` *while building the release commit*, which happens **before** the `@opengsd/engine-*` packages are published to npm (publishing is a later step in the same `prod-release` job). pnpm silently omits `optionalDependencies` it can't resolve, so the committed lockfile never contains the freshly-versioned native packages. Because the release commits straight to `main`, this bypasses PR CI and only surfaces on the next push.

## Fix

1. **Immediate unblock** — regenerated `pnpm-lock.yaml` now that `@opengsd/engine-*@1.2.0` are published. The diff is purely additive (the five importer specifiers plus their package/snapshot entries).

2. **Prevent recurrence** — added a `Fold native packages into release lockfile` step to the `prod-release` job, after the native packages are published and verified. It regenerates the lockfile and folds it back into the release commit (and moves the tag) before either is pushed, so future releases ship a complete lockfile instead of reintroducing this drift.

## Verification

- `pnpm install --frozen-lockfile` now passes (the exact step that was failing).
- `pnpm run verify:version-sync` passes.
- Workflow YAML parses cleanly.

> Note: the workflow change only runs during a production `latest` release, which can't be exercised end-to-end in this PR. The logic is localized (regenerate → `git add pnpm-lock.yaml` → `git commit --amend --no-edit` → `git tag -f`, all before the existing push step); the first real release after merge is the true test.

https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783378905&installation_id=134682257&pr_number=541&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F541&signature=92336147b25e4858d03f83d6c2d40c48aeb18be7e4d8018a5a6f32ec27a62bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to lockfile content and a post-publish amend step in the npm release workflow; no runtime or auth logic is modified.
> 
> **Overview**
> **Restores `pnpm-lock.yaml` entries** for the five `@opengsd/engine-*@1.2.0` optional dependencies so `pnpm install --frozen-lockfile` on `main` matches `package.json` again.
> 
> **Adds a production release workflow step** (`Fold native packages into release lockfile`) after native packages are published and verified: run `pnpm install --lockfile-only`, and if the lockfile changed, `git commit --amend` and move the release tag before push—so future releases do not commit a lockfile generated while those packages were still unpublished (when `bump-version.mjs` drops them from the lock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94775369a4ee5f3cd63504f500597e10755c3e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->