### PR TITLE
fix(release): publish @opengsd workspace packages from their dirs

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -334,12 +334,25 @@ jobs:
               if [ "$DELAY" -gt 30 ]; then DELAY=30; fi
             done
           }
-          for workspace in @opengsd/contracts @opengsd/rpc-client @opengsd/mcp-server; do
+          # Publish each package from its own directory. `npm publish --workspace`
+          # does NOT work here: this repo defines its workspace via pnpm-workspace.yaml,
+          # and root package.json has no npm "workspaces" field, so npm reports
+          # "No workspaces found" and the packages never get published. Publish order
+          # matters — rpc-client depends on contracts, and mcp-server depends on both —
+          # so keep contracts → rpc-client → mcp-server. prepack-resolve-workspace.cjs
+          # (run above) has already rewritten their internal workspace:* ranges to ^VERSION.
+          ROOT="$(pwd)"
+          for entry in \
+            "@opengsd/contracts:packages/contracts" \
+            "@opengsd/rpc-client:packages/rpc-client" \
+            "@opengsd/mcp-server:packages/mcp-server"; do
+            workspace="${entry%%:*}"
+            dir="${entry#*:}"
             if npm view "${workspace}@${VERSION}" version >/dev/null 2>&1; then
               echo "${workspace}@${VERSION} already published, skipping"
               continue
             fi
-            npm publish --workspace "${workspace}" --ignore-scripts ${TAG_FLAG}
+            ( cd "${ROOT}/${dir}" && npm publish --ignore-scripts ${TAG_FLAG} )
             wait_for_workspace_package "${workspace}"
           done
 


### PR DESCRIPTION
## Problem

Three workspace packages that the v1.2.0 release expects on npm are missing entirely:

- `@opengsd/contracts`
- `@opengsd/rpc-client`
- `@opengsd/mcp-server`

(All return `E404` on the registry. The native-build publish job and the post-publish MCP smoke test both expect them to exist.)

## Root cause

The `Publish workspace packages` step in `build-native.yml` published them with:

```sh
npm publish --workspace "${workspace}" --ignore-scripts ${TAG_FLAG}
```

But this repo defines its workspace via `pnpm-workspace.yaml`, and root `package.json` has **no npm `workspaces` field**. npm ignores `pnpm-workspace.yaml`, so `npm publish --workspace …` fails with:

```
npm error No workspaces found:
npm error   --workspace=@opengsd/contracts
```

The packages therefore never publish. (Separately, the previous publish runs were invoked with `platform_packages_only=true`, which skips this step entirely — so the bug was never even reached until now.)

## Fix

Publish each package from its own directory instead of using `--workspace`, preserving the `contracts → rpc-client → mcp-server` order their interdependencies require:

```sh
( cd "${ROOT}/${dir}" && npm publish --ignore-scripts ${TAG_FLAG} )
```

`prepack-resolve-workspace.cjs` (already run in this step) rewrites the internal `workspace:*` ranges to `^VERSION` before publish, so the packed manifests contain no `workspace:` protocol leaks.

## Verification

- `npm publish --dry-run` from each package directory packs cleanly (correct name/version, `dist`/`bin` present, no `workspace:` leaks) after the prepack resolver runs.
- Reproduced the original failure: `npm publish --workspace @opengsd/contracts` → `No workspaces found`.
- YAML parses cleanly.

## After merge

Trigger **Build Native Binaries** on `main` with `publish=true`, `publish_auth=token`, `platform_packages_only=false` to bootstrap-publish the three packages at `1.2.0`. (`NPM_TOKEN` / `jeremymcs` has publish access; the engine + main packages already exist and are skipped gracefully.)

https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783380185&installation_id=134682257&pr_number=543&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F543&signature=2bdd34b75c56f93f6e64022e6e6ae35b731f92229607a9080afe9d214638a24e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only publish path change with no runtime or auth logic changes; behavior matches the intended bootstrap publish flow already documented in the PR.
> 
> **Overview**
> Fixes the **Publish workspace packages** step in `build-native.yml` so `@opengsd/contracts`, `@opengsd/rpc-client`, and `@opengsd/mcp-server` actually reach npm.
> 
> Instead of `npm publish --workspace …`, the job now **`cd`s into each package path** and runs `npm publish` there. npm does not read `pnpm-workspace.yaml` and the root `package.json` has no npm `workspaces` field, so `--workspace` was failing with **No workspaces found** and those three packages were never published. **Order is unchanged** (contracts → rpc-client → mcp-server) for dependency resolution; existing **prepack-resolve-workspace.cjs** still rewrites `workspace:*` before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0469e568277618e8a3cb7b20f1be0d6c13ce318d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->