### PR TITLE
fix(release): install optional deps before web build in native publish

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -291,8 +291,13 @@ jobs:
       - name: Install dependencies
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'
         run: |
+          # Install WITH optional deps. The web host build (next/tailwind) needs
+          # lightningcss's platform-native binary, which ships as an optionalDependency;
+          # --no-optional skips it and breaks `next build` with
+          # "Cannot find module '../lightningcss.linux-x64-gnu.node'". The @opengsd/engine-*
+          # optional deps are already published by this point, so a full install resolves.
           pnpm install --lockfile-only
-          pnpm install --frozen-lockfile --no-optional
+          pnpm install --frozen-lockfile
 
       - name: Build
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.platform_packages_only != 'true'


### PR DESCRIPTION
## Problem

The publish run triggered after #543 ([run 27076774921](https://github.com/open-gsd/gsd-pi/actions/runs/27076774921)) failed in the **Build** step, before reaching the package-publish steps:

```
Error: Cannot find module '../lightningcss.linux-x64-gnu.node'
> Build failed because of webpack errors
gsd-web@0.1.0 build: `next build --webpack`
```

## Root cause

`build-native.yml`'s *Install dependencies* step ran:

```sh
pnpm install --lockfile-only
pnpm install --frozen-lockfile --no-optional
```

`--no-optional` skips **all** optionalDependencies — including `lightningcss`'s platform-native binary (`lightningcss-linux-x64-gnu`), which next/tailwind require to build the web host. So `next build` can't load it and the whole build fails.

The working `prod-release` job in `npm-publish.yml` installs *with* optional deps, which is why production releases build fine.

## Fix

Drop `--no-optional` so the web build gets its native lightningcss binary:

```sh
pnpm install --lockfile-only
pnpm install --frozen-lockfile
```

The `@opengsd/engine-*` optional packages are already published by the time this step runs (the engine-publish step precedes it), so a full frozen install resolves cleanly.

## After merge

Re-trigger **Build Native Binaries** on `main` (`publish=true`, `publish_auth=token`, `platform_packages_only=false`) to publish `@opengsd/contracts`, `@opengsd/rpc-client`, `@opengsd/mcp-server` @ 1.2.0.

https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783381096&installation_id=134682257&pr_number=544&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F544&signature=9bfa6edd6e4d76bce8cc44da8a0f310396281e720305c2e4ace2b22f782a8d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow change with no application runtime or security impact; aligns native publish install with other release jobs.
> 
> **Overview**
> Fixes the **Build Native Binaries** publish job failing on `next build` when `pnpm install` used **`--no-optional`**, which skipped **lightningcss**’s platform native binary and triggered `Cannot find module '../lightningcss.linux-x64-gnu.node'`.
> 
> The **Install dependencies** step in `build-native.yml` now runs **`pnpm install --frozen-lockfile`** (optional deps included), with comments noting that **@opengsd/engine-*** packages are already on npm before this step, so a full frozen install is safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac40744be55af568af59cdf39c710dbac800c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->