### PR TITLE
fix(release): make workspace package publish resilient to npm propagation

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -323,15 +323,20 @@ jobs:
           wait_for_workspace_package() {
             PACKAGE="$1"
             DELAY=5
-            for attempt in $(seq 1 5); do
+            for attempt in $(seq 1 10); do
               PUBLISHED=$(npm view "${PACKAGE}@${VERSION}" version 2>/dev/null || echo "")
               if [ "${PUBLISHED}" = "${VERSION}" ]; then
                 echo "  ✓ ${PACKAGE}@${VERSION} visible on npm (attempt ${attempt})"
                 return 0
               fi
-              if [ "$attempt" = "5" ]; then
-                echo "::error::${PACKAGE}@${VERSION} not visible on npm after 5 attempts"
-                exit 1
+              if [ "$attempt" = "10" ]; then
+                # `npm publish` already confirmed registry acceptance ("+ pkg@version").
+                # Brand-new packages can lag significantly in read-after-write
+                # propagation, so a slow read MUST NOT abort the remaining publishes
+                # (previously this exited and left later packages, e.g. mcp-server,
+                # unpublished). Warn and continue; the final smoke tests still gate.
+                echo "::warning::${PACKAGE}@${VERSION} not yet visible on npm after ${attempt} attempts; publish was accepted, continuing."
+                return 0
               fi
               echo "  Attempt ${attempt}: ${PACKAGE}@${VERSION} not visible yet, retrying in ${DELAY}s..."
               sleep "$DELAY"
@@ -357,7 +362,15 @@ jobs:
               echo "${workspace}@${VERSION} already published, skipping"
               continue
             fi
-            ( cd "${ROOT}/${dir}" && npm publish --ignore-scripts ${TAG_FLAG} )
+            if OUTPUT=$( cd "${ROOT}/${dir}" && npm publish --ignore-scripts ${TAG_FLAG} 2>&1 ); then
+              echo "$OUTPUT"
+            elif echo "$OUTPUT" | grep -q "cannot publish over the previously published\|You cannot publish over"; then
+              echo "${workspace}@${VERSION} already published, skipping"
+              continue
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
             wait_for_workspace_package "${workspace}"
           done
 


### PR DESCRIPTION
## Problem

In the publish run after #544 ([run 27077071080](https://github.com/open-gsd/gsd-pi/actions/runs/27077071080)), `@opengsd/contracts` published successfully, but the job then failed and `@opengsd/rpc-client` and `@opengsd/mcp-server` were left unpublished.

The log shows the rpc-client publish was **accepted** (`+ @opengsd/rpc-client@1.2.0`), but the follow-up read-verify couldn't see it:

```
+ @opengsd/rpc-client@1.2.0
  Attempt 1: @opengsd/rpc-client@1.2.0 not visible yet, retrying in 5s...
  ...
  Attempt 4: ... retrying in 30s...
##[error]@opengsd/rpc-client@1.2.0 not visible on npm after 5 attempts
```

## Root cause

`wait_for_workspace_package` only waits ~65s and then `exit 1`. Brand-new packages lag in npm's read-after-write propagation, so the verify failed and aborted the loop **before mcp-server was ever attempted** — even though each `npm publish` had already succeeded.

## Fix

In the *Publish workspace packages* step of `build-native.yml`:

- **Verification is no longer fatal.** Extend retries to ~3.5 min and, on timeout, emit a `::warning::` and continue instead of exiting. `npm publish` already confirms registry acceptance; a slow read shouldn't block the remaining packages. The post-publish smoke tests (longer backoff) remain the real gate.
- **Tolerate "cannot publish over the previously published".** A re-run now skips any package that did persist server-side (matching the main-package publish step), instead of erroring.

## After merge

Re-trigger **Build Native Binaries** on `main` (`publish=true`, `publish_auth=token`, `platform_packages_only=false`). `@opengsd/contracts@1.2.0` is already live and will be skipped; the run will publish `@opengsd/rpc-client` and `@opengsd/mcp-server`.

https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaPboSHAMC1en8J1hLNxHN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783382183&installation_id=134682257&pr_number=545&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F545&signature=d1c785d2383d04a0e17ef5461eea597f2c77e63448722404bb2a0e829560869f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release workflow bash in `build-native.yml`; post-publish smoke tests still validate installability.
> 
> **Overview**
> The **Publish workspace packages** step in `build-native.yml` no longer aborts the whole loop when post-publish `npm view` checks lag behind a successful `npm publish`.
> 
> **Read-after-write verification** in `wait_for_workspace_package` now retries up to 10 times (~3.5 min vs ~65s). If the version still isn’t visible, the job emits a **`::warning::`** and continues to the next package instead of **`exit 1`**, so later packages (e.g. `@opengsd/mcp-server`) still get published when an earlier one was accepted by the registry but slow to show up in reads.
> 
> **Workspace `npm publish`** now captures stdout/stderr and treats **“cannot publish over the previously published”** as skip-already-published, matching the main-package publish step so re-runs don’t fail after a partial successful publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ae5446c485291f9d5160b7b0705d12c857a316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->