### PR TITLE
fix(ci): drop pnpm cache from build-native publish job (fixes bootstrap-run failure)

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -136,11 +136,16 @@ jobs:
         with:
           version: 10.12.1
 
+      # No `cache: pnpm` here. In platform_packages_only bootstrap mode the
+      # "Install dependencies" step is skipped, so `pnpm install` never creates a
+      # store — and setup-node's post-job cache save then fails the whole job with
+      # "Path Validation Error: Path(s) specified for caching do(es) not exist",
+      # even though every publish step succeeded. The publish job's single install
+      # gains little from caching, so drop it for reliability.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: pnpm
 
       - name: Verify npm publish toolchain
         run: |


### PR DESCRIPTION
## Problem

[Run 27082550073](https://github.com/open-gsd/gsd-pi/actions/runs/27082550073/job/79931068018) (Build Native Binaries on `main`) failed even though **every publish and verify step succeeded** — all 5 native builds passed, "Publish platform packages" and "Verify platform packages are published" were green.

The only failing step was **`Post Run actions/setup-node@v6`**:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

## Root cause

The publish job sets `cache: pnpm` on `actions/setup-node`. In **`platform_packages_only` bootstrap mode**, the "Install dependencies" step is gated off, so `pnpm install` never runs and no pnpm store is created. setup-node's post-job cache save then can't find the store path and fails the whole job — turning a successful bootstrap publish red.

## Fix

Remove `cache: pnpm` from the publish job's `setup-node`. The publish job runs at most one conditional install, so caching there saves little, and removing it makes bootstrap runs (where install is skipped) reliable. The heavy native build jobs use `Swatinem/rust-cache` and are unaffected.

Verified: `build-native-workflow.test.mjs` passes (7/7), YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783423858&installation_id=134682257&pr_number=551&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F551&signature=10c3d37658b3a1f9dc0b7b9574f6d334c795399b7e63e12271dbb5f30d57ecab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow tweak with no runtime or publish logic changes; only disables pnpm cache on one CI job.
> 
> **Overview**
> Fixes **false-red** `build-native` publish jobs when **`platform_packages_only`** bootstrap runs skip **`pnpm install`**.
> 
> The publish job no longer passes **`cache: pnpm`** to **`actions/setup-node@v6`**, because without an install there is no pnpm store and the post-job cache save errors with a path validation failure even after successful publishes. A short workflow comment documents that tradeoff (minimal cache benefit on this job vs reliability).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff576854ede984118ba8e78ed916c733541296b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->