### PR TITLE
test(ci): match workflow action versions by name, not exact tag

### DIFF
--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -39,7 +39,7 @@ test("production publish keeps the prod approval gate", () => {
 
 test("prerelease publish preserves channel-specific default refs", () => {
   const checkout = workflow.jobs["prerelease-publish"].steps.find(
-    (step) => step.uses === "actions/checkout@v6",
+    (step) => step.uses?.startsWith("actions/checkout@"),
   );
 
   assert.equal(workflow.on.workflow_dispatch.inputs.ref.default, "");
@@ -56,7 +56,7 @@ test("npm publish supports token auth fallback for prerelease", () => {
   assert.deepEqual(input.options, ["trusted", "token"]);
 
   const setupNode = workflow.jobs["prerelease-publish"].steps.find(
-    (step) => step.uses === "actions/setup-node@v6",
+    (step) => step.uses?.startsWith("actions/setup-node@"),
   );
   assert.equal(
     setupNode.env.NODE_AUTH_TOKEN,
@@ -78,7 +78,7 @@ test("production publish plans the release and builds native artifacts in the sa
   assert.equal(plan.outputs.version, "${{ steps.release.outputs.version }}");
   assert.equal(plan.outputs.source_sha, "${{ steps.release.outputs.source_sha }}");
   assert.ok(
-    plan.steps.some((step) => step.uses === "actions/upload-artifact@v5"),
+    plan.steps.some((step) => step.uses?.startsWith("actions/upload-artifact@")),
     "release metadata must be passed to the gated publish job",
   );
 
@@ -95,7 +95,7 @@ test("production publish plans the release and builds native artifacts in the sa
     ],
   );
   assert.ok(
-    nativeBuild.steps.some((step) => step.uses === "actions/upload-artifact@v5"),
+    nativeBuild.steps.some((step) => step.uses?.startsWith("actions/upload-artifact@")),
     "native artifacts must be uploaded for the production release job",
   );
 });

--- a/scripts/__tests__/pipeline-workflow.test.mjs
+++ b/scripts/__tests__/pipeline-workflow.test.mjs
@@ -15,7 +15,7 @@ test("pipeline workflow can be manually dispatched to bootstrap the builder imag
 });
 
 test("manual pipeline dispatch checks out main and forces a builder image push", () => {
-  const checkout = job.steps.find((step) => step.uses === "actions/checkout@v6");
+  const checkout = job.steps.find((step) => step.uses?.startsWith("actions/checkout@"));
   const check = job.steps.find((step) => step.id === "check");
 
   assert.match(checkout.with.ref, /github\.event_name == 'workflow_dispatch'/);


### PR DESCRIPTION
## Problem

[Run 27091345588](https://github.com/open-gsd/gsd-pi/actions/runs/27091345588/job/79955400934?pr=550) — CI on PR #550 (an unrelated bug fix) failed at **fast-gates**, which then failed **ci-gate**, blocking the PR. The actual failure was a unit test:

```
test at scripts/__tests__/npm-publish-workflow.test.mjs:72:1
✖ production publish plans the release and builds native artifacts in the same workflow
  AssertionError: release metadata must be passed to the gated publish job
  actual: false, expected: true
```

## Root cause

PR #550's branch carries Dependabot's github-actions bumps — `actions/upload-artifact@v5 → v7`, `download-artifact@v5 → v8` (the `github-actions` ecosystem was just enabled). The workflow regression tests asserted the exact pinned tag:

```js
step.uses === "actions/upload-artifact@v5"   // false once it's @v7
```

So every Dependabot action bump (and any SHA-pin) flips these to `false` and fails CI on otherwise-unrelated PRs. The tests only mean to assert *"this action is present in this step"*, not *"exactly this version"*.

## Fix

Match by action **name prefix** across all 5 brittle assertions (4 in `npm-publish-workflow.test.mjs`, 1 in `pipeline-workflow.test.mjs`):

```js
step.uses?.startsWith("actions/upload-artifact@")
```

Robust to both Dependabot version bumps and SHA-pinning. Verified the new matcher passes against PR #550's actual `@v7`/`@v8` workflow; all 22 affected tests pass.

> Note: PR #550 still needs to merge/rebase `main` once this lands to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783424369&installation_id=134682257&pr_number=552&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F552&signature=aac56634795d4365b17f0ecf82cc1f12996b26f00943e32a1394be7b35650d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion changes; no workflow or runtime behavior is modified.
> 
> **Overview**
> Workflow regression tests no longer require **exact** GitHub Action tags (e.g. `@v5` / `@v6`), which were failing CI when Dependabot bumped versions on unrelated PRs.
> 
> Assertions in `npm-publish-workflow.test.mjs` and `pipeline-workflow.test.mjs` now locate steps with `step.uses?.startsWith("actions/<action>@")` for **checkout**, **setup-node**, and **upload-artifact**, so tests still verify the right actions are present without pinning a specific version or SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63a7ce8c037051f2273cf8a6886076eab656e2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->