### PR TITLE
fix(ci): revert pnpm/action-setup v6 -> v4 (restores node-gyp, fixes build job)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,10 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      # pnpm/action-setup v6 stops exposing pnpm's bundled node-gyp on PATH, so
+      # native rebuilds (node-pty, etc.) fail in the CI `build` job with
+      # "node-gyp: not found" (regressed main in #548). Stay on v4 until v6+ is
+      # verified to keep node-gyp available.
+      - dependency-name: "pnpm/action-setup"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -132,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: bash scripts/ci-classify-changes.sh
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 
@@ -126,7 +126,7 @@ jobs:
           git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 
@@ -240,7 +240,7 @@ jobs:
           git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 
@@ -330,7 +330,7 @@ jobs:
           git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -44,7 +44,7 @@ jobs:
           git checkout --force --detach "$GITHUB_SHA"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,7 +72,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 
@@ -215,7 +215,7 @@ jobs:
           ref: ${{ github.event.inputs.ref != '' && github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 
@@ -408,7 +408,7 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 


### PR DESCRIPTION
## Problem

The CI `build` job is failing on `main` (and every PR branched from it, e.g. #550, #552) at **`pnpm install --frozen-lockfile`**:

```
node-pty install: > Rebuilding because .../prebuilds/linux-x64 does not exist
node-pty install: sh: 1: node-gyp: not found
 ELIFECYCLE  Command failed.
```

`fast-gates` passes (it installs with `--ignore-scripts`); `build` runs lifecycle scripts, so it hits node-pty's native rebuild.

## Root cause

`#548` (Dependabot, from the `github-actions` ecosystem) bumped **`pnpm/action-setup` v4 → v6.0.8**. Under v6, pnpm's bundled **`node-gyp` is no longer exposed on PATH**. The last green build (`e896b91d`, the #546 merge) used **v4**, where the same node-pty rebuild succeeded with `node-gyp@11.1.0` — node-pty has no linux-x64 prebuild, so it always rebuilds and *needs* node-gyp.

## Fix

- Revert all 9 `pnpm/action-setup` refs to the known-good **v4** SHA (`b906affc…`) across `ci.yml`, `npm-publish.yml`, `build-native.yml`, `coverage-report.yml`.
- Add a Dependabot **ignore** for `pnpm/action-setup` major bumps so this can't silently regress again until v6+ is verified to keep node-gyp available.

The `upload-artifact`/`download-artifact` bumps from #548 are **kept** — they're fine, and the workflow regression tests now match action names regardless of version (#552).

Verified: all workflow YAML parses; 22 workflow regression tests pass.

> This unblocks `main`'s `build` job; #550 (and any open PR) should merge/rebase `main` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin and Dependabot policy; no application runtime or auth logic changes.
> 
> **Overview**
> Reverts **`pnpm/action-setup` from v6 back to v4** everywhere it was bumped (CI `fast-gates`/`build`/Windows/Node 22 jobs, coverage, native publish, and npm publish paths), restoring pnpm’s bundled **`node-gyp` on PATH** so lifecycle installs (e.g. **node-pty** native rebuild) succeed again.
> 
> Adds a **Dependabot ignore** for **`pnpm/action-setup` semver-major** bumps, with a comment tying the pin to the node-gyp regression on v6, so Dependabot cannot silently re-break the `build` job until v6+ is verified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b865dd0b8798e9e399fd2aef32ae5b1bbfc8c43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783424754&installation_id=134682257&pr_number=553&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F553&signature=0dd73f2aac2797ee5b57e62659ebc2f387eb786f8545714dd7aca9d2e4d36680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->