### PR TITLE
ci: prompt open issues after releases

### DIFF
--- a/.github/workflows/release-issue-upgrade-comments.yml
+++ b/.github/workflows/release-issue-upgrade-comments.yml
@@ -1,0 +1,43 @@
+# Project/App: gsd-pi
+# File Purpose: Ask open issue reporters to re-check issues after each stable release.
+
+name: Release Issue Upgrade Comments
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Optional release tag to use. Leave blank to use the latest release.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: release-issue-upgrade-comments-${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  post-upgrade-comments:
+    name: Post upgrade check comments
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Comment on open issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: node scripts/release-issue-upgrade-comments.mjs

--- a/.github/workflows/release-issue-upgrade-comments.yml
+++ b/.github/workflows/release-issue-upgrade-comments.yml
@@ -18,7 +18,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: release-issue-upgrade-comments-${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+  group: release-issue-upgrade-comments-${{ github.event.release.tag_name || inputs.release_tag || 'latest' }}
   cancel-in-progress: false
 
 jobs:

--- a/scripts/__tests__/release-issue-upgrade-comments.test.mjs
+++ b/scripts/__tests__/release-issue-upgrade-comments.test.mjs
@@ -7,8 +7,10 @@ import test from "node:test";
 import YAML from "yaml";
 
 import {
+  RELEASE_UPGRADE_LABEL,
   buildReleaseUpgradeComment,
   hasReleaseComment,
+  issueHasLabel,
   listIssueComments,
   listOpenIssues,
   postReleaseUpgradeComments,
@@ -34,6 +36,15 @@ test("hasReleaseComment detects the per-release marker", () => {
     true,
   );
   assert.equal(hasReleaseComment([{ body: "ordinary comment" }], "v1.2.3"), false);
+});
+
+test("issueHasLabel detects string and object labels", () => {
+  assert.equal(issueHasLabel({ labels: [RELEASE_UPGRADE_LABEL] }, RELEASE_UPGRADE_LABEL), true);
+  assert.equal(
+    issueHasLabel({ labels: [{ name: RELEASE_UPGRADE_LABEL }] }, RELEASE_UPGRADE_LABEL),
+    true,
+  );
+  assert.equal(issueHasLabel({ labels: [{ name: "needs-info" }] }, RELEASE_UPGRADE_LABEL), false);
 });
 
 test("listOpenIssues paginates by raw page size and filters pull requests", async () => {
@@ -70,11 +81,17 @@ test("listIssueComments paginates so duplicate markers are found on later pages"
   assert.equal(calls.length, 2);
 });
 
-test("postReleaseUpgradeComments skips issues already commented for the release", async () => {
-  const posts = [];
+test("postReleaseUpgradeComments tags issues and skips duplicate comments", async () => {
+  const comments = [];
+  const labels = [];
   const githubJson = async (path, options = {}) => {
     if (path === "/repos/open-gsd/gsd-pi/issues?state=open&per_page=100&page=1") {
-      return [{ number: 1 }, { number: 2 }, { number: 3, pull_request: {} }];
+      return [
+        { number: 1, labels: [] },
+        { number: 2, labels: [] },
+        { number: 3, pull_request: {} },
+        { number: 4, labels: [{ name: RELEASE_UPGRADE_LABEL }] },
+      ];
     }
     if (path === "/repos/open-gsd/gsd-pi/issues/1/comments?per_page=100&page=1") {
       return [{ body: releaseMarker("v1.2.3") }];
@@ -82,9 +99,20 @@ test("postReleaseUpgradeComments skips issues already commented for the release"
     if (path === "/repos/open-gsd/gsd-pi/issues/2/comments?per_page=100&page=1") {
       return [];
     }
+    if (path === "/repos/open-gsd/gsd-pi/issues/4/comments?per_page=100&page=1") {
+      return [];
+    }
     if (path === "/repos/open-gsd/gsd-pi/issues/2/comments" && options.method === "POST") {
-      posts.push(JSON.parse(options.body));
+      comments.push(JSON.parse(options.body));
       return { id: 123 };
+    }
+    if (path === "/repos/open-gsd/gsd-pi/issues/4/comments" && options.method === "POST") {
+      comments.push(JSON.parse(options.body));
+      return { id: 124 };
+    }
+    if (path.endsWith("/labels") && options.method === "POST") {
+      labels.push({ path, body: JSON.parse(options.body) });
+      return [{ name: RELEASE_UPGRADE_LABEL }];
     }
     throw new Error(`Unexpected request: ${path}`);
   };
@@ -96,9 +124,14 @@ test("postReleaseUpgradeComments skips issues already commented for the release"
     releaseTag: "v1.2.3",
   });
 
-  assert.deepEqual(result, { totalIssues: 2, posted: 1, skipped: 1 });
-  assert.equal(posts.length, 1);
-  assert.match(posts[0].body, /A new GSD release is available/);
+  assert.deepEqual(result, { totalIssues: 3, posted: 2, skipped: 1, labeled: 2 });
+  assert.equal(comments.length, 2);
+  assert.equal(labels.length, 2);
+  assert.deepEqual(
+    labels.map((request) => request.body.labels),
+    [[RELEASE_UPGRADE_LABEL], [RELEASE_UPGRADE_LABEL]],
+  );
+  assert.match(comments[0].body, /A new GSD release is available/);
 });
 
 test("resolveRelease prefers the release event payload when it matches", async () => {

--- a/scripts/__tests__/release-issue-upgrade-comments.test.mjs
+++ b/scripts/__tests__/release-issue-upgrade-comments.test.mjs
@@ -1,0 +1,130 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for release follow-up comments on open issues.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+import {
+  buildReleaseUpgradeComment,
+  hasReleaseComment,
+  listIssueComments,
+  listOpenIssues,
+  postReleaseUpgradeComments,
+  releaseMarker,
+  resolveRelease,
+} from "../release-issue-upgrade-comments.mjs";
+
+test("buildReleaseUpgradeComment asks reporters to upgrade and retry", () => {
+  const comment = buildReleaseUpgradeComment(
+    "v1.2.3",
+    "https://github.com/open-gsd/gsd-pi/releases/tag/v1.2.3",
+  );
+
+  assert.ok(comment.includes(releaseMarker("v1.2.3")));
+  assert.match(comment, /npm install -g @opengsd\/gsd-pi@latest/);
+  assert.match(comment, /re-run your reproduction steps/);
+  assert.match(comment, /If this still happens on \*\*v1\.2\.3\*\*/);
+});
+
+test("hasReleaseComment detects the per-release marker", () => {
+  assert.equal(
+    hasReleaseComment([{ body: `${releaseMarker("v1.2.3")}\nposted` }], "v1.2.3"),
+    true,
+  );
+  assert.equal(hasReleaseComment([{ body: "ordinary comment" }], "v1.2.3"), false);
+});
+
+test("listOpenIssues paginates by raw page size and filters pull requests", async () => {
+  const calls = [];
+  const firstPage = [
+    ...Array.from({ length: 99 }, (_, index) => ({ number: index + 1 })),
+    { number: 1000, pull_request: {} },
+  ];
+  const githubJson = async (path) => {
+    calls.push(path);
+    return /page=1\b/.test(path) ? firstPage : [{ number: 100 }];
+  };
+
+  const issues = await listOpenIssues(githubJson, "open-gsd", "gsd-pi");
+
+  assert.equal(issues.length, 100);
+  assert.equal(issues.some((issue) => issue.pull_request), false);
+  assert.equal(calls.length, 2);
+});
+
+test("listIssueComments paginates so duplicate markers are found on later pages", async () => {
+  const calls = [];
+  const firstPage = Array.from({ length: 100 }, (_, index) => ({
+    body: `comment ${index}`,
+  }));
+  const githubJson = async (path) => {
+    calls.push(path);
+    return /page=1\b/.test(path) ? firstPage : [{ body: releaseMarker("v1.2.3") }];
+  };
+
+  const comments = await listIssueComments(githubJson, "open-gsd", "gsd-pi", 42);
+
+  assert.equal(hasReleaseComment(comments, "v1.2.3"), true);
+  assert.equal(calls.length, 2);
+});
+
+test("postReleaseUpgradeComments skips issues already commented for the release", async () => {
+  const posts = [];
+  const githubJson = async (path, options = {}) => {
+    if (path === "/repos/open-gsd/gsd-pi/issues?state=open&per_page=100&page=1") {
+      return [{ number: 1 }, { number: 2 }, { number: 3, pull_request: {} }];
+    }
+    if (path === "/repos/open-gsd/gsd-pi/issues/1/comments?per_page=100&page=1") {
+      return [{ body: releaseMarker("v1.2.3") }];
+    }
+    if (path === "/repos/open-gsd/gsd-pi/issues/2/comments?per_page=100&page=1") {
+      return [];
+    }
+    if (path === "/repos/open-gsd/gsd-pi/issues/2/comments" && options.method === "POST") {
+      posts.push(JSON.parse(options.body));
+      return { id: 123 };
+    }
+    throw new Error(`Unexpected request: ${path}`);
+  };
+
+  const result = await postReleaseUpgradeComments({
+    githubJsonFn: githubJson,
+    owner: "open-gsd",
+    repo: "gsd-pi",
+    releaseTag: "v1.2.3",
+  });
+
+  assert.deepEqual(result, { totalIssues: 2, posted: 1, skipped: 1 });
+  assert.equal(posts.length, 1);
+  assert.match(posts[0].body, /A new GSD release is available/);
+});
+
+test("resolveRelease prefers the release event payload when it matches", async () => {
+  const release = await resolveRelease(
+    async () => {
+      throw new Error("API should not be called");
+    },
+    "open-gsd",
+    "gsd-pi",
+    { release: { tag_name: "v1.2.3", html_url: "https://example.test" } },
+    "v1.2.3",
+  );
+
+  assert.equal(release.tag_name, "v1.2.3");
+});
+
+test("release issue upgrade workflow triggers on published releases", () => {
+  const workflow = YAML.parse(
+    readFileSync(".github/workflows/release-issue-upgrade-comments.yml", "utf8"),
+  );
+  const job = workflow.jobs["post-upgrade-comments"];
+
+  assert.deepEqual(workflow.on.release.types, ["published"]);
+  assert.equal(workflow.permissions.issues, "write");
+  assert.equal(job["runs-on"], "blacksmith-4vcpu-ubuntu-2404");
+  assert.ok(
+    job.steps.some((step) => step.run === "node scripts/release-issue-upgrade-comments.mjs"),
+  );
+});

--- a/scripts/__tests__/release-issue-upgrade-comments.test.mjs
+++ b/scripts/__tests__/release-issue-upgrade-comments.test.mjs
@@ -161,3 +161,17 @@ test("release issue upgrade workflow triggers on published releases", () => {
     job.steps.some((step) => step.run === "node scripts/release-issue-upgrade-comments.mjs"),
   );
 });
+
+test("workflow concurrency group uses stable fallback to prevent duplicate-comment races on blank dispatch", () => {
+  const workflow = YAML.parse(
+    readFileSync(".github/workflows/release-issue-upgrade-comments.yml", "utf8"),
+  );
+
+  const group = workflow.concurrency.group;
+  assert.equal(workflow.concurrency["cancel-in-progress"], false);
+  // Must not fall back to run_id, which would give each dispatch its own group
+  // and allow two simultaneous blank-tag dispatches to race and duplicate comments.
+  assert.ok(!group.includes("run_id"), "concurrency group must not use run_id as a fallback");
+  // Stable 'latest' fallback serializes blank-tag dispatches via the queue.
+  assert.ok(group.includes("'latest'"), "concurrency group must fall back to 'latest'");
+});

--- a/scripts/release-issue-upgrade-comments.mjs
+++ b/scripts/release-issue-upgrade-comments.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Project/App: gsd-pi
+// File Purpose: Prompt open issue reporters to retry after a new stable release.
+
+import { readFileSync } from "node:fs";
+
+export const RELEASE_UPGRADE_MARKER_PREFIX = "<!-- gsd-release-upgrade-check:";
+
+export function releaseMarker(releaseTag) {
+  return `${RELEASE_UPGRADE_MARKER_PREFIX}${encodeURIComponent(releaseTag)} -->`;
+}
+
+export function hasReleaseComment(comments, releaseTag) {
+  const marker = releaseMarker(releaseTag);
+  return comments.some((comment) => String(comment.body || "").includes(marker));
+}
+
+export function displayReleaseTag(releaseTag) {
+  return /^v/i.test(releaseTag) ? releaseTag : `v${releaseTag}`;
+}
+
+export function buildReleaseUpgradeComment(releaseTag, releaseUrl = "") {
+  const displayTag = displayReleaseTag(releaseTag);
+  const releaseLink = releaseUrl ? ` [${displayTag}](${releaseUrl})` : ` ${displayTag}`;
+
+  return [
+    releaseMarker(releaseTag),
+    `A new GSD release is available:${releaseLink}.`,
+    "",
+    "Please upgrade to the latest version and re-run your reproduction steps:",
+    "",
+    "```bash",
+    "npm install -g @opengsd/gsd-pi@latest",
+    "gsd --version",
+    "```",
+    "",
+    `If this still happens on **${displayTag}** or newer, please reply with your current version and any updated logs or reproduction details.`,
+    "",
+    "If the release fixed it, a quick note here helps us close this out.",
+    "",
+    "---",
+    "*This is an automated release follow-up.*",
+  ].join("\n");
+}
+
+export function parseRepository(repository) {
+  const [owner, repo] = String(repository || "").split("/");
+  if (!owner || !repo) {
+    throw new Error(`GITHUB_REPOSITORY must be owner/repo, got: ${repository || "<empty>"}`);
+  }
+  return { owner, repo };
+}
+
+export async function listOpenIssues(githubJsonFn, owner, repo) {
+  const perPage = 100;
+  const issues = [];
+
+  for (let page = 1; ; page += 1) {
+    const pageItems = await githubJsonFn(
+      `/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}&page=${page}`,
+    );
+    issues.push(...pageItems.filter((issue) => !issue.pull_request));
+    if (pageItems.length < perPage) break;
+  }
+
+  return issues;
+}
+
+export async function listIssueComments(githubJsonFn, owner, repo, issueNumber) {
+  const perPage = 100;
+  const comments = [];
+
+  for (let page = 1; ; page += 1) {
+    const pageItems = await githubJsonFn(
+      `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${perPage}&page=${page}`,
+    );
+    comments.push(...pageItems);
+    if (pageItems.length < perPage) break;
+  }
+
+  return comments;
+}
+
+export async function resolveRelease(githubJsonFn, owner, repo, event, releaseTag) {
+  const eventRelease = event?.release;
+  if (eventRelease?.tag_name && (!releaseTag || releaseTag === eventRelease.tag_name)) {
+    return eventRelease;
+  }
+
+  if (releaseTag) {
+    return githubJsonFn(`/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(releaseTag)}`);
+  }
+
+  return githubJsonFn(`/repos/${owner}/${repo}/releases/latest`);
+}
+
+export async function postReleaseUpgradeComments({
+  githubJsonFn,
+  owner,
+  repo,
+  releaseTag,
+  releaseUrl = "",
+}) {
+  const issues = await listOpenIssues(githubJsonFn, owner, repo);
+  let posted = 0;
+  let skipped = 0;
+
+  for (const issue of issues) {
+    const comments = await listIssueComments(githubJsonFn, owner, repo, issue.number);
+    if (hasReleaseComment(comments, releaseTag)) {
+      skipped += 1;
+      continue;
+    }
+
+    await githubJsonFn(`/repos/${owner}/${repo}/issues/${issue.number}/comments`, {
+      method: "POST",
+      body: JSON.stringify({
+        body: buildReleaseUpgradeComment(releaseTag, releaseUrl),
+      }),
+    });
+    posted += 1;
+  }
+
+  return {
+    totalIssues: issues.length,
+    posted,
+    skipped,
+  };
+}
+
+function env(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function readEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) return null;
+  return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
+async function githubJson(path, options = {}) {
+  const token = env("GITHUB_TOKEN");
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API request failed: ${response.status} ${body}`);
+  }
+
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function main() {
+  const { owner, repo } = parseRepository(env("GITHUB_REPOSITORY"));
+  const event = readEvent();
+  const release = await resolveRelease(githubJson, owner, repo, event, process.env.RELEASE_TAG || "");
+  const releaseTag = release.tag_name || release.name;
+
+  if (!releaseTag) {
+    throw new Error("Release tag is required");
+  }
+
+  if (release.prerelease) {
+    console.log(`Skipping prerelease ${releaseTag}.`);
+    return;
+  }
+
+  const result = await postReleaseUpgradeComments({
+    githubJsonFn: githubJson,
+    owner,
+    repo,
+    releaseTag,
+    releaseUrl: release.html_url || "",
+  });
+
+  console.log(
+    `Posted ${result.posted} release upgrade comments for ${releaseTag}; skipped ${result.skipped} already-commented issues across ${result.totalIssues} open issues.`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/release-issue-upgrade-comments.mjs
+++ b/scripts/release-issue-upgrade-comments.mjs
@@ -5,6 +5,7 @@
 import { readFileSync } from "node:fs";
 
 export const RELEASE_UPGRADE_MARKER_PREFIX = "<!-- gsd-release-upgrade-check:";
+export const RELEASE_UPGRADE_LABEL = "needs-upgrade";
 
 export function releaseMarker(releaseTag) {
   return `${RELEASE_UPGRADE_MARKER_PREFIX}${encodeURIComponent(releaseTag)} -->`;
@@ -13,6 +14,15 @@ export function releaseMarker(releaseTag) {
 export function hasReleaseComment(comments, releaseTag) {
   const marker = releaseMarker(releaseTag);
   return comments.some((comment) => String(comment.body || "").includes(marker));
+}
+
+export function issueHasLabel(issue, label) {
+  const labels = Array.isArray(issue.labels) ? issue.labels : [];
+
+  return labels.some((entry) => {
+    const name = typeof entry === "string" ? entry : entry?.name;
+    return name === label;
+  });
 }
 
 export function displayReleaseTag(releaseTag) {
@@ -104,27 +114,40 @@ export async function postReleaseUpgradeComments({
   const issues = await listOpenIssues(githubJsonFn, owner, repo);
   let posted = 0;
   let skipped = 0;
+  let labeled = 0;
 
   for (const issue of issues) {
     const comments = await listIssueComments(githubJsonFn, owner, repo, issue.number);
     if (hasReleaseComment(comments, releaseTag)) {
       skipped += 1;
+    } else {
+      await githubJsonFn(`/repos/${owner}/${repo}/issues/${issue.number}/comments`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: buildReleaseUpgradeComment(releaseTag, releaseUrl),
+        }),
+      });
+      posted += 1;
+    }
+
+    if (issueHasLabel(issue, RELEASE_UPGRADE_LABEL)) {
       continue;
     }
 
-    await githubJsonFn(`/repos/${owner}/${repo}/issues/${issue.number}/comments`, {
+    await githubJsonFn(`/repos/${owner}/${repo}/issues/${issue.number}/labels`, {
       method: "POST",
       body: JSON.stringify({
-        body: buildReleaseUpgradeComment(releaseTag, releaseUrl),
+        labels: [RELEASE_UPGRADE_LABEL],
       }),
     });
-    posted += 1;
+    labeled += 1;
   }
 
   return {
     totalIssues: issues.length,
     posted,
     skipped,
+    labeled,
   };
 }
 
@@ -186,7 +209,7 @@ async function main() {
   });
 
   console.log(
-    `Posted ${result.posted} release upgrade comments for ${releaseTag}; skipped ${result.skipped} already-commented issues across ${result.totalIssues} open issues.`,
+    `Posted ${result.posted} release upgrade comments for ${releaseTag}; tagged ${result.labeled} issues with ${RELEASE_UPGRADE_LABEL}; skipped ${result.skipped} already-commented issues across ${result.totalIssues} open issues.`,
   );
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Add release automation that asks open issue reporters to upgrade and re-check their issue after a stable release, tagging those issues with `needs-upgrade`.
**Why:** Maintainers need stale-version reports refreshed before spending time on issues that may already be fixed.
**How:** Add a release-triggered workflow, a paginated/idempotent GitHub API script, focused policy tests, and a stable manual-dispatch concurrency group.

## What

Adds `.github/workflows/release-issue-upgrade-comments.yml` to run on published GitHub releases and manual dispatch. The workflow calls `scripts/release-issue-upgrade-comments.mjs`, which comments on open issues, applies the existing `needs-upgrade` label, filters out pull requests, skips prereleases, and prevents duplicate comments for the same release tag.

Adds `scripts/__tests__/release-issue-upgrade-comments.test.mjs` to cover the release comment text, per-release marker detection, issue/comment pagination, pull request filtering, label detection/application, release payload handling, workflow trigger/permission contract, and the stable blank-dispatch concurrency fallback.

## Why

Closes #555

When a new stable release ships, open issues may already be resolved by that release. Prompting reporters to upgrade and retry keeps triage focused on issues that still reproduce on the latest version, and the `needs-upgrade` label gives maintainers a queryable queue for those follow-ups.

## How

The script resolves the release from the release event payload, an optional manual `release_tag`, or the latest release endpoint. It skips prereleases, lists open issues with pagination, filters pull requests, checks all comments for a release-specific marker, posts a single upgrade prompt per issue per release, and applies `needs-upgrade` when that label is not already present.

The workflow concurrency group is keyed by the release tag when one is available. Blank manual dispatches fall back to a stable `latest` group so concurrent manual runs queue instead of racing the duplicate-comment marker check.

## Validation

- `node --test scripts/__tests__/release-issue-upgrade-comments.test.mjs scripts/__tests__/github-workflows-runner-contract.test.mjs`
- `pnpm run verify:fast`

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Requirements

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated issue comments and label changes across all open issues using `GITHUB_TOKEN`; mistakes could spam or mis-label issues, though idempotency markers and concurrency limits reduce duplicate-post risk.
> 
> **Overview**
> Adds **release-triggered CI** that, after each **published stable release** (or manual dispatch with optional tag), runs `scripts/release-issue-upgrade-comments.mjs` to nudge reporters on **all open issues** (not PRs).
> 
> The script resolves the release from the event, `RELEASE_TAG`, or latest; **skips prereleases**; paginates issues and comments; posts at most **one upgrade comment per issue per release** using an HTML comment marker; and applies the existing **`needs-upgrade`** label when missing. Comments include global install/verify steps and ask for a retest on the new version.
> 
> The workflow grants **issues: write**, uses a **concurrency group** keyed by release tag with a stable **`latest`** fallback (no `run_id`) so blank manual runs queue instead of racing duplicate posts. **Node tests** cover comment text, markers, pagination, PR filtering, labeling, release resolution, and workflow contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf793f1268d9798c94a92a90e0e0107e3fc0116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->