### PR TITLE
ci: update README release highlights

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -461,6 +461,11 @@ jobs:
       - name: Update CHANGELOG.md
         run: node scripts/update-changelog.mjs release-metadata/changelog-entry.md
 
+      - name: Update README release highlights
+        env:
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
+        run: node scripts/update-readme-release-highlights.mjs release-metadata/release-notes.md --version "$RELEASE_VERSION"
+
       - name: Commit and tag release
         env:
           RELEASE_SOURCE_SHA: ${{ needs.prod-release-plan.outputs.source_sha }}
@@ -477,7 +482,7 @@ jobs:
             echo "::error::Re-run NPM Publish so the release includes the latest main."
             exit 1
           fi
-          git add package.json pnpm-lock.yaml CHANGELOG.md native/Cargo.toml native/Cargo.lock native/npm/*/package.json pkg/package.json packages/*/package.json extensions/google-search/package.json
+          git add package.json pnpm-lock.yaml CHANGELOG.md README.md native/Cargo.toml native/Cargo.lock native/npm/*/package.json pkg/package.json packages/*/package.json extensions/google-search/package.json
           git commit -m "release: v${RELEASE_VERSION}"
           git tag "v${RELEASE_VERSION}"
 

--- a/.github/workflows/release-readme-highlights.yml
+++ b/.github/workflows/release-readme-highlights.yml
@@ -1,0 +1,100 @@
+# Project/App: gsd-pi
+# File Purpose: Keep README latest-release highlights in sync after stable releases.
+
+name: Release README Highlights
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Optional release tag to use. Leave blank to use the latest release.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-readme-highlights-${{ github.event.release.tag_name || inputs.release_tag || 'latest' }}
+  cancel-in-progress: false
+
+jobs:
+  update-readme:
+    name: Update README release highlights
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Resolve release notes
+        id: release
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+
+          const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+          const releaseTag = process.env.RELEASE_TAG || "";
+          const releasePath = releaseTag
+            ? `/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(releaseTag)}`
+            : `/repos/${owner}/${repo}/releases/latest`;
+
+          const response = await fetch(`https://api.github.com${releasePath}`, {
+            headers: {
+              accept: "application/vnd.github+json",
+              authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+              "x-github-api-version": "2022-11-28",
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Could not load release notes: ${response.status} ${await response.text()}`);
+          }
+
+          const release = await response.json();
+          const resolvedTag = release.tag_name || release.name;
+
+          if (!resolvedTag) {
+            throw new Error("Release did not include a tag or name.");
+          }
+
+          mkdirSync("release-metadata", { recursive: true });
+          writeFileSync("release-metadata/release-notes.md", release.body || "", "utf8");
+          appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=${resolvedTag}\n`);
+          NODE
+
+      - name: Update README highlights
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: node scripts/update-readme-release-highlights.mjs release-metadata/release-notes.md --version "$RELEASE_TAG"
+
+      - name: Commit README update
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "README release highlights are already current for ${RELEASE_TAG}."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs: update README highlights for ${RELEASE_TAG}"
+          git push origin HEAD:main

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "pipeline:version-stamp": "node scripts/version-stamp.mjs",
     "release:changelog": "node scripts/generate-changelog.mjs",
     "release:bump": "node scripts/bump-version.mjs",
+    "release:update-readme-highlights": "node scripts/update-readme-release-highlights.mjs",
     "release:update-changelog": "node scripts/update-changelog.mjs",
     "docker:build-runtime": "docker build --target runtime -t ghcr.io/open-gsd/gsd-pi .",
     "docker:build-builder": "docker build --target builder -t ghcr.io/open-gsd/gsd-ci-builder .",

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -199,6 +199,21 @@ test("production release publishes workspace packages and verifies ALL packages 
   assert.ok(verifyAll < ghRelease, "verify must run before the GitHub release is created");
 });
 
+test("production release updates README highlights in the release commit", () => {
+  const steps = workflow.jobs["prod-release"].steps;
+  const idx = (name) => steps.findIndex((s) => s.name === name);
+
+  const updateChangelog = idx("Update CHANGELOG.md");
+  const updateReadme = idx("Update README release highlights");
+  const commitRelease = idx("Commit and tag release");
+
+  assert.ok(updateReadme > updateChangelog, "README highlights should use generated release notes");
+  assert.ok(updateReadme < commitRelease, "README highlights must be staged into the release commit");
+  assert.match(steps[updateReadme].run, /update-readme-release-highlights\.mjs/);
+  assert.match(steps[updateReadme].run, /release-metadata\/release-notes\.md/);
+  assert.match(steps[commitRelease].run, /git add .*README\.md/);
+});
+
 test("main package publish uses explicit prepack and disables npm lifecycle reruns", () => {
   const prereleasePublish = workflow.jobs["prerelease-publish"].steps.find(
     (step) => step.name === "Publish @${{ github.event.inputs.channel }}",

--- a/scripts/__tests__/release-readme-highlights-workflow.test.mjs
+++ b/scripts/__tests__/release-readme-highlights-workflow.test.mjs
@@ -1,0 +1,34 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for README release highlights workflow wiring.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+const workflow = YAML.parse(
+  readFileSync(".github/workflows/release-readme-highlights.yml", "utf8"),
+);
+
+test("release README highlights workflow triggers on published releases", () => {
+  const job = workflow.jobs["update-readme"];
+
+  assert.deepEqual(workflow.on.release.types, ["published"]);
+  assert.equal(workflow.permissions.contents, "write");
+  assert.match(job.if, /release\.prerelease == false/);
+  assert.equal(job["runs-on"], "blacksmith-4vcpu-ubuntu-2404");
+});
+
+test("release README highlights workflow updates and commits README.md only when needed", () => {
+  const steps = workflow.jobs["update-readme"].steps;
+  const updateReadme = steps.find((step) => step.name === "Update README highlights");
+  const commitReadme = steps.find((step) => step.name === "Commit README update");
+
+  assert.ok(updateReadme, "workflow should run the README updater");
+  assert.match(updateReadme.run, /update-readme-release-highlights\.mjs/);
+  assert.match(updateReadme.run, /release-metadata\/release-notes\.md/);
+  assert.ok(commitReadme, "workflow should commit README changes");
+  assert.match(commitReadme.run, /git diff --quiet -- README\.md/);
+  assert.match(commitReadme.run, /git add README\.md/);
+  assert.match(commitReadme.run, /git push origin HEAD:main/);
+});

--- a/scripts/__tests__/update-readme-release-highlights.test.mjs
+++ b/scripts/__tests__/update-readme-release-highlights.test.mjs
@@ -1,0 +1,76 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for README release highlight generation.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReadmeReleaseHighlights,
+  collectReleaseHighlights,
+  updateReadmeReleaseHighlights,
+} from "../update-readme-release-highlights.mjs";
+
+test("collectReleaseHighlights prioritizes features before fixes", () => {
+  const releaseNotes = [
+    "### Fixed",
+    "- **gsd**: repair stale milestone summaries",
+    "- **install**: keep native package versions aligned",
+    "",
+    "### Added",
+    "- **browser-tools**: use managed gsd-browser engine",
+    "- add guided installer recovery",
+  ].join("\n");
+
+  assert.deepEqual(collectReleaseHighlights(releaseNotes, 3), [
+    "- **browser-tools:** Use managed gsd-browser engine.",
+    "- **Added:** Add guided installer recovery.",
+    "- **gsd:** Repair stale milestone summaries.",
+  ]);
+});
+
+test("buildReadmeReleaseHighlights includes a normalized latest release label", () => {
+  const section = buildReadmeReleaseHighlights("### Changed\n- **tui**: compact status rail", {
+    version: "1.2.3",
+  });
+
+  assert.match(section, /<!-- release-highlights:start -->/);
+  assert.match(section, /Latest release: \*\*v1\.2\.3\*\*/);
+  assert.match(section, /- \*\*tui:\*\* Compact status rail\./);
+  assert.match(section, /<!-- release-highlights:end -->/);
+});
+
+test("updateReadmeReleaseHighlights replaces only the latest-release section", () => {
+  const readme = [
+    "# GSD Pi",
+    "",
+    "## Feature Roll-Up",
+    "",
+    "Keep this text.",
+    "",
+    "## Latest Release Highlights",
+    "",
+    "- Old release bullet",
+    "",
+    "## Status",
+    "",
+    "Still here.",
+    "",
+  ].join("\n");
+
+  const updated = updateReadmeReleaseHighlights(readme, "### Added\n- **gsd**: add release flow", {
+    version: "v2.0.0",
+  });
+
+  assert.match(updated, /## Feature Roll-Up\n\nKeep this text\./);
+  assert.match(updated, /Latest release: \*\*v2\.0\.0\*\*/);
+  assert.match(updated, /- \*\*gsd:\*\* Add release flow\./);
+  assert.doesNotMatch(updated, /Old release bullet/);
+  assert.match(updated, /## Status\n\nStill here\./);
+});
+
+test("updateReadmeReleaseHighlights fails if the README section is missing", () => {
+  assert.throws(
+    () => updateReadmeReleaseHighlights("# GSD Pi\n", "### Added\n- one"),
+    /Latest Release Highlights/,
+  );
+});

--- a/scripts/update-readme-release-highlights.mjs
+++ b/scripts/update-readme-release-highlights.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+// Project/App: gsd-pi
+// File Purpose: Refresh README latest-release highlights from generated release notes.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_MAX_HIGHLIGHTS = 8;
+
+const README_HEADING = "## Latest Release Highlights";
+const SECTION_START = "<!-- release-highlights:start -->";
+const SECTION_END = "<!-- release-highlights:end -->";
+const CATEGORY_ORDER = ["Added", "Changed", "Fixed", "Removed"];
+
+export function buildReadmeReleaseHighlights(releaseNotes, options = {}) {
+  const highlights = collectReleaseHighlights(
+    releaseNotes,
+    options.maxHighlights ?? DEFAULT_MAX_HIGHLIGHTS,
+  );
+
+  if (highlights.length === 0) {
+    throw new Error("Release notes did not contain any markdown bullet highlights.");
+  }
+
+  const lines = [SECTION_START];
+  const version = formatReleaseVersion(options.version ?? "");
+
+  if (version) {
+    lines.push(`Latest release: **${version}**`, "");
+  }
+
+  lines.push(...highlights, "", SECTION_END);
+
+  return lines.join("\n");
+}
+
+export function updateReadmeReleaseHighlights(readme, releaseNotes, options = {}) {
+  const headingMatch = new RegExp(`^${escapeRegExp(README_HEADING)}\\s*$`, "m").exec(readme);
+
+  if (!headingMatch) {
+    throw new Error(`${README_HEADING} section not found in README.md.`);
+  }
+
+  const sectionStart = headingMatch.index;
+  const bodyStart = sectionStart + headingMatch[0].length;
+  const nextHeadingOffset = readme.slice(bodyStart).search(/\n##\s+/);
+  const sectionEnd =
+    nextHeadingOffset === -1 ? readme.length : bodyStart + nextHeadingOffset;
+
+  const sectionBody = buildReadmeReleaseHighlights(releaseNotes, options);
+  const replacement = `${README_HEADING}\n\n${sectionBody}\n`;
+
+  return `${readme.slice(0, sectionStart)}${replacement}${readme.slice(sectionEnd)}`;
+}
+
+export function collectReleaseHighlights(releaseNotes, maxHighlights = DEFAULT_MAX_HIGHLIGHTS) {
+  const max = Number(maxHighlights);
+
+  if (!Number.isInteger(max) || max <= 0) {
+    throw new Error("--max must be a positive integer.");
+  }
+
+  const items = [];
+  let currentCategory = "";
+
+  for (const rawLine of releaseNotes.replace(/\r\n/g, "\n").split("\n")) {
+    const heading = /^#{2,6}\s+(.+?)\s*$/.exec(rawLine);
+    if (heading) {
+      currentCategory = normalizeCategory(heading[1]);
+      continue;
+    }
+
+    const bullet = /^\s*[-*]\s+(.+?)\s*$/.exec(rawLine);
+    if (!bullet || !currentCategory) {
+      continue;
+    }
+
+    const text = formatHighlight(currentCategory, bullet[1]);
+    if (text) {
+      items.push({
+        category: currentCategory,
+        order: items.length,
+        text,
+      });
+    }
+  }
+
+  const seen = new Set();
+  return items
+    .filter((item) => {
+      const key = item.text.toLowerCase().replace(/[`*_:\s]+/g, " ").trim();
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => {
+      const categoryDiff = categoryRank(a.category) - categoryRank(b.category);
+      return categoryDiff || a.order - b.order;
+    })
+    .slice(0, max)
+    .map((item) => item.text);
+}
+
+function formatHighlight(category, value) {
+  const cleaned = stripInlineMarkdown(cleanReleaseNoteText(value));
+  if (!cleaned) {
+    return "";
+  }
+
+  const scoped = /^\*\*([^*]+)\*\*:\s*(.+)$/.exec(value.trim());
+  const label = scoped ? stripInlineMarkdown(cleanReleaseNoteText(scoped[1])) : category;
+  const description = scoped
+    ? stripInlineMarkdown(cleanReleaseNoteText(scoped[2]))
+    : cleaned;
+
+  if (!label || !description) {
+    return "";
+  }
+
+  return `- **${label}:** ${punctuate(capitalizeFirst(description))}`;
+}
+
+function cleanReleaseNoteText(value) {
+  return value
+    .replace(/<!--.*?-->/g, "")
+    .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g, "#$1")
+    .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)/g, "#$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stripInlineMarkdown(value) {
+  return value
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .trim();
+}
+
+function normalizeCategory(value) {
+  const normalized = value.toLowerCase().trim();
+
+  if (/^(added|features?)$/.test(normalized)) return "Added";
+  if (/^(changed|improvements?|updates?)$/.test(normalized)) return "Changed";
+  if (/^(fixed|fixes|bug fixes?)$/.test(normalized)) return "Fixed";
+  if (/^(removed|deprecated)$/.test(normalized)) return "Removed";
+
+  return value.trim();
+}
+
+function categoryRank(category) {
+  const index = CATEGORY_ORDER.indexOf(category);
+  return index === -1 ? CATEGORY_ORDER.length : index;
+}
+
+function capitalizeFirst(value) {
+  return value.replace(/^[a-z]/, (match) => match.toUpperCase());
+}
+
+function punctuate(value) {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
+function formatReleaseVersion(value) {
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return "";
+  }
+  return /^v/i.test(trimmed) ? trimmed : `v${trimmed}`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseArgs(argv) {
+  const args = {
+    maxHighlights: DEFAULT_MAX_HIGHLIGHTS,
+    readmePath: "README.md",
+    releaseNotesPath: "",
+    version: process.env.RELEASE_VERSION || process.env.RELEASE_TAG || "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--readme") {
+      args.readmePath = requireValue(argv, (index += 1), arg);
+      continue;
+    }
+
+    if (arg === "--version") {
+      args.version = requireValue(argv, (index += 1), arg);
+      continue;
+    }
+
+    if (arg === "--max") {
+      args.maxHighlights = Number(requireValue(argv, (index += 1), arg));
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    if (args.releaseNotesPath) {
+      throw new Error(`Unexpected extra argument: ${arg}`);
+    }
+
+    args.releaseNotesPath = arg;
+  }
+
+  if (!args.releaseNotesPath) {
+    throw new Error("Missing release notes file path.");
+  }
+
+  return args;
+}
+
+function requireValue(argv, index, option) {
+  const value = argv[index];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${option} requires a value.`);
+  }
+  return value;
+}
+
+function printUsage() {
+  console.log(
+    [
+      "Usage: node scripts/update-readme-release-highlights.mjs <release-notes.md> [options]",
+      "",
+      "Options:",
+      "  --readme <path>    README path to update (default: README.md)",
+      "  --version <value>  Release version/tag shown in the highlights section",
+      "  --max <count>      Maximum highlights to include (default: 8)",
+    ].join("\n"),
+  );
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const readmePath = resolve(args.readmePath);
+  const releaseNotesPath = resolve(args.releaseNotesPath);
+  const readme = readFileSync(readmePath, "utf8");
+  const releaseNotes = readFileSync(releaseNotesPath, "utf8");
+  const updated = updateReadmeReleaseHighlights(readme, releaseNotes, args);
+
+  if (updated === readme) {
+    console.log("[update-readme-release-highlights] README.md already current.");
+    return;
+  }
+
+  writeFileSync(readmePath, updated);
+  console.log("[update-readme-release-highlights] Updated README.md release highlights.");
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[update-readme-release-highlights] ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## TL;DR

**What:** Adds release automation that refreshes the README Latest Release Highlights section from generated release notes.
**Why:** The README front page should reflect the newest stable release without manual post-release editing.
**How:** Adds a reusable README highlight updater, wires it into the production publish release commit, and adds a stable-release fallback workflow plus regression tests.

## What

This adds `scripts/update-readme-release-highlights.mjs`, which parses release notes, prioritizes feature/change/fix highlights, caps the list, and replaces only the `## Latest Release Highlights` section in `README.md`.

The production `npm-publish.yml` release path now runs the updater after `CHANGELOG.md` generation and stages `README.md` into the same release commit as the version and changelog updates. A separate `release-readme-highlights.yml` workflow also handles stable GitHub releases created outside the normal npm publish path, with a manual dispatch escape hatch.

Regression coverage includes the updater behavior, fallback workflow wiring, and the production publish workflow contract.

## Why

Release notes and changelog generation already exist, but the README highlights were a manual surface. That lets the front page drift after a new release even though the release pipeline has the exact notes needed to update it.

## How

The updater consumes the generated `release-metadata/release-notes.md` file used for the GitHub release, formats a concise highlights list, and rewrites the README section by heading. The normal production release path performs the update before `Commit and tag release`, so the README, changelog, package versions, and release tag all stay tied to one release commit.

The fallback workflow listens for stable `release.published` events and no-ops if the README is already current, which covers releases made outside the npm publish workflow without duplicating commits for the standard path.

## Validation

- [x] `node --test scripts/__tests__/update-readme-release-highlights.test.mjs scripts/__tests__/release-readme-highlights-workflow.test.mjs scripts/__tests__/npm-publish-workflow.test.mjs scripts/__tests__/github-workflows-runner-contract.test.mjs`
- [x] `pnpm run verify:fast`

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783431748&installation_id=134682257&pr_number=557&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F557&signature=b1a7e56ac7873dce21b568ef26a49550058da6312466c567036217ba94864091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs-only automation with no runtime or auth changes; fallback workflow only commits when README differs.
> 
> **Overview**
> Adds **automated README “Latest Release Highlights”** updates derived from the same release notes used for GitHub releases, so the front page stays current without manual edits.
> 
> A new **`scripts/update-readme-release-highlights.mjs`** parses categorized bullets from release notes, prioritizes Added/Changed over Fixed, caps the list, and rewrites only the `## Latest Release Highlights` block (with version label and HTML comment markers). The **production `npm-publish` `@latest` path** runs it after changelog generation and **stages `README.md` in the release commit** alongside version bumps. A separate **`release-readme-highlights.yml`** workflow runs on stable `release.published` (plus manual dispatch), fetches release body from the API, updates README if needed, and pushes to `main`. **`release:update-readme-highlights`** npm script and workflow/unit tests lock in ordering and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6500c4976799c41efd05758c7f3fa6c8d9a70947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->