### PR TITLE
fix(ci): repair Discord release changelog announcements

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -711,17 +711,11 @@ jobs:
             --latest
 
       - name: Post to Discord
-        if: ${{ env.DISCORD_WEBHOOK != '' }}
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
-        run: |
-          NOTES=$(cat release-metadata/release-notes.md)
-          # allowed_mentions disables @everyone/@here/role pings — release notes
-          # are derived from commit subjects and must not be able to mass-ping.
-          curl -s -X POST "$DISCORD_WEBHOOK" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg c "**GSD v${RELEASE_VERSION} Released**\n\n${NOTES}\n\n\`npm i @opengsd/gsd-pi@${RELEASE_VERSION}\`" '{content:$c, allowed_mentions:{parse:[]}}')"
+        run: node scripts/release-discord-summary.cjs --tag "v${RELEASE_VERSION}" --post --allow-missing-webhook
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/release-discord-changelog.yml
+++ b/.github/workflows/release-discord-changelog.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Post release changelog to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}

--- a/.github/workflows/release-discord-changelog.yml
+++ b/.github/workflows/release-discord-changelog.yml
@@ -19,131 +19,16 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     steps:
+      - uses: actions/checkout@v6
+
       - name: Post release changelog to Discord
-        uses: actions/github-script@v9
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        with:
-          script: |
-            const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
-
-            if (!webhookUrl) {
-              core.setFailed("Missing DISCORD_CHANGELOG_WEBHOOK secret.");
-              return;
-            }
-
-            if (context.eventName !== "release" && context.eventName !== "workflow_dispatch") {
-              core.info(`Skipping ${context.eventName}; this workflow only posts releases.`);
-              return;
-            }
-
-            const release = await getRelease();
-            const messages = buildReleaseMessages(release);
-
-            for (const content of messages) {
-              const response = await fetch(webhookUrl, {
-                method: "POST",
-                headers: {
-                  "content-type": "application/json",
-                },
-                body: JSON.stringify({
-                  username: "Repo Changelog",
-                  content,
-                  allowed_mentions: {
-                    parse: [],
-                  },
-                }),
-              });
-
-              if (!response.ok) {
-                core.setFailed(`Discord webhook failed with ${response.status}: ${await response.text()}`);
-                return;
-              }
-            }
-
-            async function getRelease() {
-              if (context.eventName === "release") {
-                return context.payload.release;
-              }
-
-              const releaseTag = process.env.RELEASE_TAG;
-              const response = releaseTag
-                ? await github.rest.repos.getReleaseByTag({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    tag: releaseTag,
-                  })
-                : await github.rest.repos.getLatestRelease({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                  });
-
-              return response.data;
-            }
-
-            function buildReleaseMessages(release) {
-              const tag = release.tag_name || release.name || "release";
-              const title = release.name || tag;
-              const notes = formatReleaseNotes(release.body || "") || "No release notes provided.";
-              const fullMessage = `**${title} Released**\n\n${notes}`;
-
-              return splitDiscordMessage(fullMessage, 1900);
-            }
-
-            function formatReleaseNotes(value) {
-              return truncate(
-                value
-                  .replace(/\r\n/g, "\n")
-                  .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g, "#$1")
-                  .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)/g, "#$1")
-                  .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/commit\/([0-9a-f]{7})[0-9a-f]*/gi, "$1")
-                  .replace(/https:\/\/github\.com\/\S+/g, "")
-                  .trim()
-                  .split("\n")
-                  .map((line) => {
-                    const heading = line.match(/^#{1,6}\s+(.+)$/);
-                    return heading ? `**${heading[1].trim()}**` : line;
-                  })
-                  .join("\n")
-                  .replace(/\n{3,}/g, "\n\n")
-                  .trim(),
-                3900,
-              );
-            }
-
-            function splitDiscordMessage(value, maxLength) {
-              if (value.length <= maxLength) {
-                return [value];
-              }
-
-              const chunks = [];
-              let remaining = value;
-
-              while (remaining.length > maxLength) {
-                let splitAt = remaining.lastIndexOf("\n", maxLength);
-
-                if (splitAt < 500) {
-                  splitAt = remaining.lastIndexOf(" ", maxLength);
-                }
-
-                if (splitAt < 500) {
-                  splitAt = maxLength;
-                }
-
-                chunks.push(remaining.slice(0, splitAt).trim());
-                remaining = remaining.slice(splitAt).trim();
-              }
-
-              if (remaining) {
-                chunks.push(remaining);
-              }
-
-              return chunks.map((chunk, index) =>
-                index === 0 ? chunk : `**Changelog continued**\n\n${chunk}`,
-              );
-            }
-
-            function truncate(value, maxLength) {
-              return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
-            }
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${RELEASE_TAG}" ]; then
+            node scripts/release-discord-summary.cjs --tag "${RELEASE_TAG}" --post
+          else
+            node scripts/release-discord-summary.cjs --latest --post
+          fi

--- a/scripts/__tests__/release-discord-summary.test.cjs
+++ b/scripts/__tests__/release-discord-summary.test.cjs
@@ -38,7 +38,11 @@ const sampleRelease = {
 describe('release Discord summary', () => {
   test('builds a payload with a preserved full changelog URL', () => {
     const payload = buildDiscordReleasePayload({
-      release: sampleRelease,
+      release: {
+        ...sampleRelease,
+        html_url: sampleRelease.url,
+        url: 'https://api.github.com/repos/open-gsd/gsd-pi/releases/123',
+      },
       packageName: '@opengsd/gsd-pi',
       maxContent: 1850,
     });

--- a/scripts/__tests__/release-discord-summary.test.cjs
+++ b/scripts/__tests__/release-discord-summary.test.cjs
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { describe, test } = require('node:test');
+const {
+  buildDiscordReleasePayload,
+  cleanBullet,
+  collectSections,
+  extractInstallCommand,
+} = require('../release-discord-summary.cjs');
+
+const sampleRelease = {
+  tagName: 'v1.3.0',
+  name: 'v1.3.0',
+  isPrerelease: false,
+  url: 'https://github.com/open-gsd/gsd-pi/releases/tag/v1.3.0',
+  body: [
+    '## Install',
+    '',
+    '```bash',
+    'npm i @opengsd/gsd-pi@1.3.0',
+    '```',
+    '',
+    '### Added',
+    '- feat(cli): add release smoke check by @trek-e in https://github.com/open-gsd/gsd-pi/pull/10',
+    '- feat(web): add dashboard export by @trek-e in https://github.com/open-gsd/gsd-pi/pull/11',
+    '- feat(agent): add planner mode by @trek-e in https://github.com/open-gsd/gsd-pi/pull/12',
+    '- feat(native): add signed binary probe by @trek-e in https://github.com/open-gsd/gsd-pi/pull/13',
+    '- feat(hooks): add release hook by @trek-e in https://github.com/open-gsd/gsd-pi/pull/14',
+    '',
+    '### Fixed',
+    '- fix(release): keep [#8](https://github.com/open-gsd/gsd-pi/issues/8) visible by @trek-e in https://github.com/open-gsd/gsd-pi/pull/15',
+    '',
+    '**Full Changelog**: https://github.com/open-gsd/gsd-pi/compare/v1.2.0...v1.3.0',
+  ].join('\n'),
+};
+
+describe('release Discord summary', () => {
+  test('builds a payload with a preserved full changelog URL', () => {
+    const payload = buildDiscordReleasePayload({
+      release: sampleRelease,
+      packageName: '@opengsd/gsd-pi',
+      maxContent: 1850,
+    });
+
+    assert.equal(payload.username, 'GSD Releases');
+    assert.match(payload.content, /\*\*@opengsd\/gsd-pi v1\.3\.0 is out\*\*/);
+    assert.match(payload.content, /`npm i @opengsd\/gsd-pi@1\.3\.0`/);
+    assert.match(payload.content, /Full changelog: https:\/\/github\.com\/open-gsd\/gsd-pi\/releases\/tag\/v1\.3\.0/);
+    assert.doesNotMatch(payload.content, /\*\*Full Changelog\*\*:\s*$/m);
+    assert.match(payload.content, /add release smoke check \(#10\)/);
+    assert.match(payload.content, /\.\.\.and 1 more added/);
+    assert.equal(payload.embeds[0].fields[1].value, '`latest`');
+    assert.ok(payload.content.length <= 1850);
+  });
+
+  test('summarizes auto-generated What Changed bullets', () => {
+    const sections = collectSections([
+      '## What\'s Changed',
+      '* feat: add thing by @trek-e in https://github.com/open-gsd/gsd-pi/pull/20',
+      '* fix: repair thing by @trek-e in https://github.com/open-gsd/gsd-pi/pull/21',
+      '* docs: explain thing by @trek-e in https://github.com/open-gsd/gsd-pi/pull/22',
+    ].join('\n'));
+
+    assert.deepEqual(sections.get('Added'), ['add thing (#20)']);
+    assert.deepEqual(sections.get('Fixed'), ['repair thing (#21)']);
+    assert.deepEqual(sections.get('Changed'), ['explain thing (#22)']);
+  });
+
+  test('cleans common GitHub release-note link noise without deleting issue references', () => {
+    assert.equal(
+      cleanBullet('* fix: repair [#8](https://github.com/open-gsd/gsd-pi/issues/8) by @trek-e in https://github.com/open-gsd/gsd-pi/pull/15'),
+      'repair #8 (#15)'
+    );
+    assert.equal(
+      cleanBullet('- **issue**: [Bug]: Auto-mode re-dispatch loop'),
+      'Auto-mode re-dispatch loop'
+    );
+  });
+
+  test('falls back to the release channel when no install block exists', () => {
+    assert.equal(
+      extractInstallCommand('', '@opengsd/gsd-pi', { tagName: 'v1.4.0-rc.1', isPrerelease: true }),
+      'npm i @opengsd/gsd-pi@next'
+    );
+    assert.equal(
+      extractInstallCommand('', '@opengsd/gsd-pi', { tagName: 'v1.4.0', isPrerelease: false }),
+      'npm i @opengsd/gsd-pi@latest'
+    );
+  });
+});

--- a/scripts/release-discord-summary.cjs
+++ b/scripts/release-discord-summary.cjs
@@ -37,7 +37,7 @@ function releaseName(release) {
 }
 
 function releaseUrl(release) {
-  return release.url || release.html_url || '';
+  return release.html_url || release.url || '';
 }
 
 function releaseIsPrerelease(release) {

--- a/scripts/release-discord-summary.cjs
+++ b/scripts/release-discord-summary.cjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+'use strict';
+
+const cp = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_MAX_CONTENT = 1850;
+const SECTION_LIMITS = Object.freeze([
+  ['Breaking', 4],
+  ['Security', 4],
+  ['Added', 4],
+  ['Fixed', 4],
+  ['Changed', 3],
+  ['Removed', 3],
+  ['Internal', 2],
+  ['New Contributors', 3],
+]);
+
+class ExitError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function normalizeNewlines(value) {
+  return String(value || '').replace(/\r\n/g, '\n');
+}
+
+function releaseTag(release) {
+  return release.tagName || release.tag_name || release.name || 'release';
+}
+
+function releaseName(release) {
+  return release.name || releaseTag(release);
+}
+
+function releaseUrl(release) {
+  return release.url || release.html_url || '';
+}
+
+function releaseIsPrerelease(release) {
+  return release.isPrerelease === true || release.prerelease === true || /-/.test(releaseTag(release));
+}
+
+function loadPackageName(repoRoot = path.resolve(__dirname, '..')) {
+  const pkgJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  return pkgJson.name || 'package';
+}
+
+function normalizeHeading(value) {
+  const heading = value.trim().replace(/:$/, '');
+  const lower = heading.toLowerCase();
+
+  if (lower.includes('breaking')) return 'Breaking';
+  if (lower.includes('security')) return 'Security';
+  if (lower === 'added' || lower === 'additions' || lower === 'feature' || lower === 'features') return 'Added';
+  if (lower === 'fixed' || lower === 'fix' || lower === 'fixes' || lower === 'bug fixes') return 'Fixed';
+  if (lower === 'changed' || lower === 'change' || lower === 'enhancement' || lower === 'enhancements' || lower === 'improvements') return 'Changed';
+  if (lower === 'removed' || lower === 'removals') return 'Removed';
+  if (lower === 'internal' || lower === 'maintenance') return 'Internal';
+  if (lower === 'new contributors') return 'New Contributors';
+  if (lower === "what's changed" || lower === 'whats changed') return "What's Changed";
+  return heading;
+}
+
+function classifyTitle(value) {
+  const text = String(value)
+    .replace(/^[*-]\s+/, '')
+    .replace(/^\[codex\]\s+/i, '')
+    .trim()
+    .toLowerCase();
+
+  if (/^(fix|bugfix|patch)(?:\(|:|!)/.test(text)) return 'Fixed';
+  if (/^(feat|feature)(?:\(|:|!)/.test(text)) return 'Added';
+  if (/^(revert|remove|removed)(?:\(|:|!)/.test(text)) return 'Removed';
+  if (/^(docs|chore|ci|refactor|test|tests|perf|style|build)(?:\(|:|!)/.test(text)) return 'Changed';
+  return 'Changed';
+}
+
+function collectSections(body) {
+  const sections = new Map();
+  let current = null;
+
+  for (const line of normalizeNewlines(body).split('\n')) {
+    const trimmed = line.trim();
+    const heading = trimmed.match(/^#{2,3}\s+(.+)$/);
+
+    if (heading) {
+      current = normalizeHeading(heading[1]);
+      continue;
+    }
+
+    const bullet = trimmed.match(/^([*-])\s+(.+)$/);
+    if (!bullet || !current) continue;
+
+    let section = current;
+    if (section === "What's Changed") {
+      section = classifyTitle(trimmed);
+    }
+
+    if (!sections.has(section)) sections.set(section, []);
+    sections.get(section).push(cleanBullet(trimmed));
+  }
+
+  return sections;
+}
+
+function cleanBullet(value) {
+  let text = String(value)
+    .replace(/^[*-]\s+/, '')
+    .replace(/\s+by\s+@[A-Za-z0-9-]+\s+in\s+https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g, ' (#$1)')
+    .replace(/\[([^\]]+)\]\((https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:pull|issues)\/(\d+))\)/g, '$1 (#$3)')
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '$1')
+    .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g, '#$1')
+    .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)/g, '#$1')
+    .replace(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/commit\/([0-9a-f]{7})[0-9a-f]*/gi, '$1')
+    .replace(/\*\*/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  text = text
+    .replace(/^\[codex\]\s+/i, '')
+    .replace(/^(?:feat|feature|fix|docs|chore|ci|refactor|test|tests|perf|style|build|revert)(?:\([^)]+\))?!?:\s+/i, '')
+    .replace(/^(?:issue|bug):\s+/i, '')
+    .replace(/^\[bug\]:\s+/i, '');
+  text = text.replace(/#(\d+)\s+\(#\1\)/g, '#$1');
+  text = text.replace(/\s+\(#(\d+)\)\s+\(#\1\)$/g, ' (#$1)');
+
+  return truncateAtWord(text, 220);
+}
+
+function truncateAtWord(value, maxLength) {
+  if (value.length <= maxLength) return value;
+  const splitAt = value.lastIndexOf(' ', maxLength - 3);
+  if (splitAt < 80) return `${value.slice(0, maxLength - 3)}...`;
+  return `${value.slice(0, splitAt)}...`;
+}
+
+function extractInstallCommand(body, packageName, release) {
+  const lines = normalizeNewlines(body).split('\n');
+  let inInstall = false;
+  let inFence = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (/^##\s+Install\b/i.test(trimmed)) {
+      inInstall = true;
+      continue;
+    }
+
+    if (inInstall && /^##\s+/.test(trimmed)) break;
+    if (!inInstall) continue;
+
+    if (trimmed.startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+
+    if (inFence && /^(?:npm|pnpm)\s+(?:i|install|add)\s+/.test(trimmed)) {
+      return trimmed;
+    }
+  }
+
+  const channel = releaseIsPrerelease(release) ? 'next' : 'latest';
+  return `npm i ${packageName}@${channel}`;
+}
+
+function buildDiscordReleasePayload({ release, packageName = loadPackageName(), maxContent = DEFAULT_MAX_CONTENT }) {
+  const tag = releaseTag(release);
+  const name = releaseName(release);
+  const url = releaseUrl(release);
+  const prerelease = releaseIsPrerelease(release);
+  const channel = prerelease ? 'next' : 'latest';
+  const body = release.body || '';
+  const sections = collectSections(body);
+  const footer = url ? `Full changelog: ${url}` : `Full changelog: ${tag}`;
+  const baseLines = [
+    `**${packageName} ${name}${prerelease ? ' pre-release' : ''} is out**`,
+    '',
+    'Install:',
+    `\`${extractInstallCommand(body, packageName, release)}\``,
+  ];
+
+  const lines = baseLines.slice();
+  for (const [section, limit] of SECTION_LIMITS) {
+    appendSection(lines, section, sections.get(section) || [], limit, footer, maxContent);
+  }
+
+  if (lines.length === baseLines.length) {
+    appendLineGroup(lines, ['', 'No release notes were provided.'], footer, maxContent);
+  }
+
+  while (lines.length > baseLines.length && joinedLength(lines, footer) > maxContent) {
+    lines.pop();
+  }
+
+  const content = [...lines, '', footer].join('\n');
+  return {
+    username: 'GSD Releases',
+    content,
+    embeds: [
+      {
+        title: 'Release details',
+        url: url || undefined,
+        color: prerelease ? 0xd9a441 : 0x2f9e44,
+        fields: [
+          { name: 'Package', value: `\`${packageName}\``, inline: true },
+          { name: 'Channel', value: `\`${channel}\``, inline: true },
+          { name: 'Version', value: `\`${tag}\``, inline: true },
+        ],
+      },
+    ],
+    allowed_mentions: { parse: [] },
+  };
+}
+
+function appendSection(lines, section, bullets, limit, footer, maxContent) {
+  if (bullets.length === 0) return;
+
+  const selected = [];
+  for (const bullet of bullets.slice(0, limit)) {
+    const candidate = ['', `**${section}**`, ...selected.map((item) => `- ${item}`), `- ${bullet}`];
+    if (joinedLength([...lines, ...candidate], footer) > maxContent) break;
+    selected.push(bullet);
+  }
+
+  if (selected.length === 0) return;
+
+  const group = ['', `**${section}**`, ...selected.map((item) => `- ${item}`)];
+  const remaining = bullets.length - selected.length;
+  if (remaining > 0) {
+    const moreLine = `- ...and ${remaining} more ${section.toLowerCase()}`;
+    if (joinedLength([...lines, ...group, moreLine], footer) <= maxContent) {
+      group.push(moreLine);
+    }
+  }
+
+  appendLineGroup(lines, group, footer, maxContent);
+}
+
+function appendLineGroup(lines, group, footer, maxContent) {
+  if (joinedLength([...lines, ...group], footer) <= maxContent) {
+    lines.push(...group);
+  }
+}
+
+function joinedLength(lines, footer) {
+  return [...lines, '', footer].join('\n').length;
+}
+
+function fetchRelease({ tag, repo, latest = false }) {
+  const args = ['release', 'view'];
+  if (!latest && tag) args.push(tag);
+  args.push('--json', 'tagName,name,isPrerelease,body,url');
+  if (repo) args.push('--repo', repo);
+  const raw = cp.execFileSync('gh', args, { encoding: 'utf8' });
+  return JSON.parse(raw);
+}
+
+async function postWebhook(webhookUrl, payload) {
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new ExitError(1, `Discord webhook failed with ${response.status}: ${await response.text()}`);
+  }
+}
+
+function parseArgs(argv) {
+  const opts = {
+    tag: null,
+    repo: null,
+    latest: false,
+    stdin: false,
+    post: false,
+    json: false,
+    allowMissingWebhook: false,
+    packageName: null,
+    maxContent: DEFAULT_MAX_CONTENT,
+  };
+
+  const args = argv.slice();
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === '--tag') {
+      opts.tag = requireValue(args, arg);
+    } else if (arg === '--repo') {
+      opts.repo = requireValue(args, arg);
+    } else if (arg === '--package') {
+      opts.packageName = requireValue(args, arg);
+    } else if (arg === '--max-content') {
+      opts.maxContent = Number(requireValue(args, arg));
+    } else if (arg === '--latest') {
+      opts.latest = true;
+    } else if (arg === '--stdin') {
+      opts.stdin = true;
+    } else if (arg === '--post') {
+      opts.post = true;
+    } else if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--allow-missing-webhook') {
+      opts.allowMissingWebhook = true;
+    } else if (arg === '--help' || arg === '-h') {
+      process.stdout.write(
+        'Usage: node scripts/release-discord-summary.cjs [--tag <tag>|--latest|--stdin] [options]\n' +
+        '\n' +
+        'Options:\n' +
+        '  --tag <tag>                 GitHub release tag to announce\n' +
+        '  --latest                    Announce the latest GitHub release\n' +
+        '  --stdin                     Read release JSON from stdin\n' +
+        '  --repo <owner/repo>          Repository for gh release view\n' +
+        '  --package <name>             Package name override\n' +
+        '  --post                      POST to DISCORD_WEBHOOK_URL\n' +
+        '  --allow-missing-webhook      Warn and skip instead of failing when posting without a webhook\n' +
+        '  --json                      Print webhook payload JSON instead of content preview\n' +
+        '  --max-content <n>            Max Discord content characters before webhook footer\n'
+      );
+      throw new ExitError(0);
+    } else {
+      throw new ExitError(2, `error: unknown argument ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(opts.maxContent) || opts.maxContent < 500 || opts.maxContent > 2000) {
+    throw new ExitError(2, 'error: --max-content must be between 500 and 2000');
+  }
+
+  return opts;
+}
+
+function requireValue(args, flag) {
+  const value = args.shift();
+  if (!value || value.startsWith('-')) {
+    throw new ExitError(2, `error: ${flag} requires a value`);
+  }
+  return value;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  let release;
+
+  if (opts.stdin) {
+    release = JSON.parse(fs.readFileSync(0, 'utf8'));
+  } else {
+    release = fetchRelease(opts);
+  }
+
+  const payload = buildDiscordReleasePayload({
+    release,
+    packageName: opts.packageName || loadPackageName(),
+    maxContent: opts.maxContent,
+  });
+
+  if (opts.post) {
+    const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+    if (!webhookUrl) {
+      if (opts.allowMissingWebhook) {
+        process.stderr.write('warning: DISCORD_WEBHOOK_URL is not set; skipping Discord announcement\n');
+      } else {
+        throw new ExitError(1, 'error: DISCORD_WEBHOOK_URL is not set');
+      }
+    } else {
+      await postWebhook(webhookUrl, payload);
+    }
+  }
+
+  process.stdout.write(opts.json ? `${JSON.stringify(payload, null, 2)}\n` : `${payload.content}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    if (error instanceof ExitError) {
+      if (error.message) {
+        const stream = error.code === 0 ? process.stdout : process.stderr;
+        stream.write(`${error.message}\n`);
+      }
+      process.exit(error.code);
+    }
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildDiscordReleasePayload,
+  cleanBullet,
+  collectSections,
+  extractInstallCommand,
+};


### PR DESCRIPTION
## Linked issue

Closes #559

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace the inline Discord release changelog formatting with a reusable tested summary script.
**Why:** The current release-event workflow can be skipped for `GITHUB_TOKEN` releases, and the inline `curl` payload can silently fail or exceed Discord's content limit.
**How:** Wire both release workflows through `scripts/release-discord-summary.cjs`, preserve the final changelog URL, cap the wide content body, and keep embeds for compact metadata.

## What

This updates the release Discord announcement path:

- Adds `scripts/release-discord-summary.cjs` to build and optionally post a Discord webhook payload.
- Updates `.github/workflows/release-discord-changelog.yml` so manual/release re-runs checkout the repo and call the shared script.
- Updates `.github/workflows/npm-publish.yml` so production releases post Discord announcements immediately after creating the GitHub release.
- Adds focused tests in `scripts/__tests__/release-discord-summary.test.cjs`.

## Why

`release: published` is not reliable for releases created by the default `GITHUB_TOKEN`, because GitHub suppresses recursive workflow triggers. `npm-publish.yml` already posted directly, but it sent raw release notes as one Discord content body and used `curl -s`, so overlong notes or webhook failures could be missed.

This mirrors the fix from `gsd-core`: the release workflow itself posts the announcement, while the standalone workflow remains useful for manual replays.

## How

The new script fetches a release by tag or latest release through `gh`, summarizes common release-note sections, removes generated GitHub link noise, keeps the final `Full changelog:` release URL intact, and posts a hybrid payload: wide message content for readable changelog text plus a small embed for package/channel/version metadata.

The production release step uses `--allow-missing-webhook` so a missing Discord secret does not break an already-published npm release, while an actual webhook error still fails when the secret is present.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Validation run locally:

- `node --test scripts\__tests__\release-discord-summary.test.cjs`
- Parsed `.github/workflows/release-discord-changelog.yml` and `.github/workflows/npm-publish.yml` with `yaml`
- `git diff --check`
- Previewed latest release payload with `node scripts\release-discord-summary.cjs --latest --repo open-gsd/gsd-pi --json` and confirmed the content is 953 characters with the final changelog URL intact

## AI disclosure

- [x] This PR includes AI-assisted code. Codex prepared the workflow/script changes and ran the validation listed above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783436145&installation_id=134682257&pr_number=560&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F560&signature=13d1e84b6d7b71dbafcf2204fc07fbf118f97bb60a98e8468c7ac23fedf82f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->