### PR TITLE
fix(gsd): restore workflow MCP transport gate for scoped runtime tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+### Fixed
+- **issue**: [Bug]: After upgrading to version 1.1.1 GSD is stuck for missing toolset
+
 ## [1.2.0] - 2026-06-06
 
 ### Added

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -835,7 +835,7 @@ test("transport compatibility now allows replan-slice over workflow MCP surface"
   assert.equal(error, null);
 });
 
-test("transport compatibility rejects MCP tools not connected in active tool surface", () => {
+test("transport compatibility accepts workflow MCP tools absent from parent active tool surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
     ["gsd_summary_save"],
@@ -850,10 +850,10 @@ test("transport compatibility rejects MCP tools not connected in active tool sur
     },
   );
 
-  assert.match(error ?? "", /requires gsd_summary_save/);
+  assert.equal(error, null);
 });
 
-test("transport compatibility checks all required tools against active tool surface", () => {
+test("transport compatibility still checks non-MCP tools against parent active tool surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
     ["gsd_summary_save", "secure_env_collect"],
@@ -868,9 +868,54 @@ test("transport compatibility checks all required tools against active tool surf
     },
   );
 
-  assert.match(error ?? "", /requires.*(?:gsd_summary_save|secure_env_collect)/);
-  assert.match(error ?? "", /gsd_summary_save/);
-  assert.match(error ?? "", /secure_env_collect/);
+  assert.match(error ?? "", /requires secure_env_collect/);
+  assert.doesNotMatch(error ?? "", /gsd_summary_save/);
+});
+
+test("transport compatibility allows plan-slice MCP tools when parent surface is scoped (regression #457)", () => {
+  const error = getWorkflowTransportSupportError(
+    "claude-code",
+    getRequiredWorkflowToolsForAutoUnit("plan-slice"),
+    {
+      projectRoot: "/tmp/project",
+      env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
+      surface: "auto-mode",
+      unitType: "plan-slice",
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      activeTools: [
+        "ScheduleWakeup",
+        "ToolSearch",
+        "ask_user_questions",
+        "async_bash",
+        "await_job",
+        "bash",
+        "bg_shell",
+        "cancel_job",
+        "capture_thought",
+        "discover_configs",
+        "edit",
+        "fetch_page",
+        "get_library_docs",
+        "gsd_checkpoint_db",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_milestone_status",
+        "gsd_resume",
+        "mcp_call",
+        "mcp_discover",
+        "mcp_servers",
+        "memory_query",
+        "read",
+        "resolve_library",
+        "secure_env_collect",
+        "subagent",
+        "write",
+      ],
+    },
+  );
+
+  assert.equal(error, null);
 });
 
 test("transport compatibility still blocks units whose MCP tools are not exposed", () => {

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -488,7 +488,7 @@ export function getWorkflowTransportSupportError(
 
   const uniqueRequired = [...new Set(requiredTools)];
   const missing = (options.activeTools && options.activeTools.length > 0)
-    ? uniqueRequired.filter((tool) => !hasRequiredTool(tool, options.activeTools!))
+    ? uniqueRequired.filter((tool) => !MCP_WORKFLOW_TOOL_SURFACE.has(tool) && !hasRequiredTool(tool, options.activeTools!))
     : uniqueRequired.filter((tool) => !MCP_WORKFLOW_TOOL_SURFACE.has(tool));
   if (missing.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- restore workflow transport compatibility checks so workflow-MCP-surface tools are treated as transport-backed when workflow MCP is configured
- keep strict `activeTools` verification for non-MCP required tools only
- add regression coverage for the plan-slice failure path reported in #457
- update changelog under Unreleased

## Root cause
A recent change made `getWorkflowTransportSupportError()` validate **all** required tools against parent `activeTools` whenever that list was present. In Claude Code sessions, the parent runtime surface is intentionally scoped and may omit `gsd_plan_slice`, even though the workflow MCP transport provides it.

## Fix
In `src/resources/extensions/gsd/workflow-mcp.ts`, when `activeTools` is available:
- MCP workflow tools are considered satisfied by transport presence
- only non-MCP required tools must be present in `activeTools`

## Tests
- added/updated assertions in `src/resources/extensions/gsd/tests/workflow-mcp.test.ts`:
  - accepts MCP tools absent from parent active surface
  - still rejects missing non-MCP tools
  - explicit regression for plan-slice with a scoped active toolset (issue #457)
- focused run passed:
  - `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern "transport compatibility accepts workflow MCP tools absent from parent active tool surface|transport compatibility still checks non-MCP tools against parent active tool surface|transport compatibility allows plan-slice MCP tools when parent surface is scoped" src/resources/extensions/gsd/tests/workflow-mcp.test.ts`

Closes #457

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783476419&installation_id=134682257&pr_number=565&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F565&signature=678d6ccdd004285f36eca01f5159ad41cac8454397da94520ef57e2c6b5a9633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->