### PR TITLE
fix(issue): Bug: gsd_plan_milestone accepts depends values like ["[S01]"] — corrupts DB and produces unrecoverable 'No slice eligible' block

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1150,6 +1150,11 @@ export function insertSlice(s: {
   planning?: Partial<SlicePlanningRecord>;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+  const invalidDep = (s.depends ?? []).find(d => !SLICE_ID_RE.test(d));
+  if (invalidDep !== undefined) {
+    throw new GSDError(GSD_STALE_STATE, `insertSlice: depends element "${invalidDep}" is not a valid slice ID`);
+  }
   currentDb.prepare(
     `INSERT INTO slices (
       milestone_id, id, title, status, risk, depends, demo, created_at,
@@ -2499,6 +2504,13 @@ export function updateSliceFields(milestoneId: string, sliceId: string, fields: 
   demo?: string;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+  if (fields.depends !== undefined) {
+    const invalidDep = fields.depends.find(d => !SLICE_ID_RE.test(d));
+    if (invalidDep !== undefined) {
+      throw new GSDError(GSD_STALE_STATE, `updateSliceFields: depends element "${invalidDep}" is not a valid slice ID`);
+    }
+  }
   currentDb.prepare(
     `UPDATE slices SET
       title = COALESCE(:title, title),

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1150,7 +1150,7 @@ export function insertSlice(s: {
   planning?: Partial<SlicePlanningRecord>;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+  const SLICE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
   const invalidDep = (s.depends ?? []).find(d => !SLICE_ID_RE.test(d));
   if (invalidDep !== undefined) {
     throw new GSDError(GSD_STALE_STATE, `insertSlice: depends element "${invalidDep}" is not a valid slice ID`);
@@ -2504,7 +2504,7 @@ export function updateSliceFields(milestoneId: string, sliceId: string, fields: 
   demo?: string;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+  const SLICE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
   if (fields.depends !== undefined) {
     const invalidDep = fields.depends.find(d => !SLICE_ID_RE.test(d));
     if (invalidDep !== undefined) {

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -171,7 +171,7 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
   lines.push("");
   for (const slice of slices) {
     const done = isClosedStatus(slice.status) ? "x" : " ";
-    const cleanDepends = (slice.depends ?? []).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d));
+    const cleanDepends = (slice.depends ?? []).map(d => d.replace(/^\[|\]$/g, '')).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d));
     const depends = `[${cleanDepends.join(",")}]`;
     const safeTitle = sanitizeInlineRoadmapText(slice.title || slice.id) || slice.id;
     const safeRisk = normalizeRiskLevel(slice.risk);

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -171,7 +171,7 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
   lines.push("");
   for (const slice of slices) {
     const done = isClosedStatus(slice.status) ? "x" : " ";
-    const cleanDepends = (slice.depends ?? []).filter(d => /^[A-Za-z]+\d+$/.test(d));
+    const cleanDepends = (slice.depends ?? []).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d));
     const depends = `[${cleanDepends.join(",")}]`;
     const safeTitle = sanitizeInlineRoadmapText(slice.title || slice.id) || slice.id;
     const safeRisk = normalizeRiskLevel(slice.risk);

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -171,7 +171,8 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
   lines.push("");
   for (const slice of slices) {
     const done = isClosedStatus(slice.status) ? "x" : " ";
-    const depends = `[${(slice.depends ?? []).join(",")}]`;
+    const cleanDepends = (slice.depends ?? []).filter(d => /^[A-Za-z]+\d+$/.test(d));
+    const depends = `[${cleanDepends.join(",")}]`;
     const safeTitle = sanitizeInlineRoadmapText(slice.title || slice.id) || slice.id;
     const safeRisk = normalizeRiskLevel(slice.risk);
     // ADR-011: sketch slices get a `[sketch]` badge so the roadmap shows at a

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -641,7 +641,7 @@ export function migrateHierarchyToDb(basePath: string): {
         title: sliceEntry.title,
         status: sliceStatus,
         risk: sliceEntry.risk,
-        depends: (sliceEntry.depends ?? []).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d)),
+        depends: (sliceEntry.depends ?? []).map(d => d.replace(/^\[|\]$/g, '')).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d)),
         demo: sliceEntry.demo,
         sequence: si + 1, // Preserve roadmap parse order (#3356)
         isSketch: sliceEntry.isSketch ?? false, // ADR-011: preserve the `[sketch]` flag on re-import

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -641,7 +641,7 @@ export function migrateHierarchyToDb(basePath: string): {
         title: sliceEntry.title,
         status: sliceStatus,
         risk: sliceEntry.risk,
-        depends: (sliceEntry.depends ?? []).filter(d => /^[A-Za-z]+\d+$/.test(d)),
+        depends: (sliceEntry.depends ?? []).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d)),
         demo: sliceEntry.demo,
         sequence: si + 1, // Preserve roadmap parse order (#3356)
         isSketch: sliceEntry.isSketch ?? false, // ADR-011: preserve the `[sketch]` flag on re-import

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -641,7 +641,7 @@ export function migrateHierarchyToDb(basePath: string): {
         title: sliceEntry.title,
         status: sliceStatus,
         risk: sliceEntry.risk,
-        depends: sliceEntry.depends,
+        depends: (sliceEntry.depends ?? []).filter(d => /^[A-Za-z]+\d+$/.test(d)),
         demo: sliceEntry.demo,
         sequence: si + 1, // Preserve roadmap parse order (#3356)
         isSketch: sliceEntry.isSketch ?? false, // ADR-011: preserve the `[sketch]` flag on re-import

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -193,8 +193,9 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
       const fallbackDepsMatch = depsMatch ? null : rest.match(/`depends:\[(\[(?:[^\]]*)\](?:,\[(?:[^\]]*)\])*)\]`/);
       const rawDepContent = (depsMatch ?? fallbackDepsMatch)?.[1] ?? "";
       const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+      const RANGE_RE = /^[A-Za-z]+\d+(?:-|\.\.)[A-Za-z]+\d+$/;
       const rawDepParts = rawDepContent.trim()
-        ? rawDepContent.replace(/\[|\]/g, "").split(",").map(s => s.trim()).filter(s => SLICE_ID_RE.test(s))
+        ? rawDepContent.replace(/\[|\]/g, "").split(",").map(s => s.trim()).filter(s => SLICE_ID_RE.test(s) || RANGE_RE.test(s))
         : [];
       const depends = expandDependencies(rawDepParts);
 

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -189,9 +189,14 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
       const risk = (riskMatch ? riskMatch[1] : "low") as RiskLevel;
 
       const depsMatch = rest.match(/`depends:\[([^\]]*)\]`/);
-      const depends = depsMatch && depsMatch[1]!.trim()
-        ? expandDependencies(depsMatch[1]!.split(",").map(s => s.trim()))
+      // Recovery fallback: double-bracket form `[[id]]` from serialized bracket-wrapped IDs
+      const fallbackDepsMatch = depsMatch ? null : rest.match(/`depends:\[(\[(?:[^\]]*)\](?:,\[(?:[^\]]*)\])*)\]`/);
+      const rawDepContent = (depsMatch ?? fallbackDepsMatch)?.[1] ?? "";
+      const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+      const rawDepParts = rawDepContent.trim()
+        ? rawDepContent.replace(/\[|\]/g, "").split(",").map(s => s.trim()).filter(s => SLICE_ID_RE.test(s))
         : [];
+      const depends = expandDependencies(rawDepParts);
 
       // ADR-011: the renderer writes a `[sketch]` badge for sketch slices.
       // Parse it back so the is_sketch flag survives a markdown → DB re-import

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -192,7 +192,7 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
       // Recovery fallback: double-bracket form `[[id]]` from serialized bracket-wrapped IDs
       const fallbackDepsMatch = depsMatch ? null : rest.match(/`depends:\[(\[(?:[^\]]*)\](?:,\[(?:[^\]]*)\])*)\]`/);
       const rawDepContent = (depsMatch ?? fallbackDepsMatch)?.[1] ?? "";
-      const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+      const SLICE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
       const RANGE_RE = /^[A-Za-z]+\d+(?:-|\.\.)[A-Za-z]+\d+$/;
       const rawDepParts = rawDepContent.trim()
         ? rawDepContent.replace(/\[|\]/g, "").split(",").map(s => s.trim()).filter(s => SLICE_ID_RE.test(s) || RANGE_RE.test(s))

--- a/src/resources/extensions/gsd/tests/plan-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone.test.ts
@@ -347,3 +347,48 @@ test('handlePlanMilestone updates depends_on when a queued milestone row already
     cleanup(base);
   }
 });
+
+// Regression #566: bracket-wrapped slice ID in depends should be rejected
+test('handlePlanMilestone rejects bracket-wrapped depends like ["[S01]"]', async () => {
+  const base = makeTmpBase();
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+
+  try {
+    const params = validParams();
+    // Simulate the LLM sending "[S01]" (the markdown fragment) instead of "S01"
+    const corruptSlices = [
+      params.slices[0],
+      { ...params.slices[1], depends: ['[S01]'] },
+    ];
+    const result = await handlePlanMilestone({ ...params, slices: corruptSlices }, base);
+    assert.ok('error' in result, 'should return an error for bracket-wrapped depends');
+    assert.match(result.error, /slices\[1\]\.depends must be an array of valid slice IDs/,
+      'error should mention invalid slice ID format');
+    assert.equal(getMilestoneSlices('M001').length, 0, 'no slices should persist on validation failure');
+  } finally {
+    cleanup(base);
+  }
+});
+
+// Regression #566: unknown slice ID in depends should be rejected
+test('handlePlanMilestone rejects depends referencing a slice not in the same milestone', async () => {
+  const base = makeTmpBase();
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+
+  try {
+    const params = validParams();
+    const corruptSlices = [
+      params.slices[0],
+      { ...params.slices[1], depends: ['S99'] },
+    ];
+    const result = await handlePlanMilestone({ ...params, slices: corruptSlices }, base);
+    assert.ok('error' in result, 'should return an error for unknown depends slice');
+    assert.match(result.error, /references unknown slice "S99"/,
+      'error should name the unknown slice');
+    assert.equal(getMilestoneSlices('M001').length, 0, 'no slices should persist on validation failure');
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/planning-crossval.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-crossval.test.ts
@@ -15,6 +15,7 @@ import {
   insertTask,
   getMilestoneSlices,
   getSliceTasks,
+  _getAdapter,
 } from '../gsd-db.ts';
 import {
   renderRoadmapFromDb,
@@ -417,6 +418,50 @@ console.log('\n=== planning-crossval Test 6: ROADMAP descriptor projection dir =
     assertEq(rendered.roadmapPath, descriptorRoadmapPath, 'T6: roadmap path uses descriptor milestone dir');
     assertTrue(existsSync(descriptorRoadmapPath), 'T6: descriptor roadmap exists');
     assertEq(existsSync(bareMilestoneDir), false, 'T6: bare duplicate milestone dir is not created');
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test 7: Renderer strips bracket-wrapped depends from corrupt DB rows (#566)
+// ═══════════════════════════════════════════════════════════════════════════
+// Simulates a DB that was corrupted before the insertSlice validation guard
+// was added (issue #566). The renderer must recover "[S01]" → "S01" rather
+// than silently dropping the dependency and rendering depends:[].
+
+console.log('\n=== planning-crossval Test 7: renderer recovers bracket-wrapped depends (#566) ===');
+{
+  const base = realpathSync(createFixtureBase());
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  try {
+    scaffoldDirs(base, 'M001', ['S01', 'S02']);
+
+    insertMilestone({
+      id: 'M001',
+      title: 'Bracket Recovery',
+      status: 'active',
+      planning: { vision: 'Recover bracket-wrapped depends from corrupt DB.' },
+    });
+
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Foundation', status: 'pending', risk: 'low', depends: [], demo: 'Foundation done.', sequence: 1 });
+    insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Build', status: 'pending', risk: 'medium', depends: [], demo: 'Build done.', sequence: 2 });
+
+    // Bypass insertSlice validation to simulate pre-fix corrupt DB state
+    // (insertSlice now rejects bracket-wrapped IDs, but old DBs may have them)
+    _getAdapter()?.prepare('UPDATE slices SET depends = ? WHERE id = ? AND milestone_id = ?')
+      .run('["[S01]"]', 'S02', 'M001');
+
+    const rendered = await renderRoadmapFromDb(base, 'M001');
+    const content = readFileSync(rendered.roadmapPath, 'utf-8');
+    const parsed = parseRoadmapSlices(content);
+
+    assertEq(parsed.length, 2, 'T7: 2 slices parsed');
+    assertEq(parsed[1]?.depends.length, 1, 'T7: S02 has 1 dependency after bracket recovery');
+    assertEq(parsed[1]?.depends[0], 'S01', 'T7: recovered dependency is "S01", not "[S01]"');
+    assertTrue(content.includes('`depends:[S01]`'), 'T7: S02 renders with recovered depends:[S01] not empty depends:[]');
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts
@@ -396,4 +396,44 @@ test('T. #1736: Checkbox format unchanged', () => {
     assert.deepStrictEqual(slices[1].done, false, '#1736 checkbox compat: S02 not done');
 });
 
+// ═══════════════════════════════════════════════════════════════════════
+// U. Regression #566: double-bracket depends serialization recovery
+// ═══════════════════════════════════════════════════════════════════════
+test('U. #566: double-bracket depends:[[S01]] recovers to ["S01"]', () => {
+    // Simulates a roadmap written by markdown-renderer when the DB had
+    // depends=["[S01]"] — produces `depends:[[S01]]` on disk.
+    const content = [
+      '# M020: Corrupted Depends',
+      '',
+      '## Slices',
+      '',
+      '- [ ] **S01: Foundation** `risk:low` `depends:[]`',
+      '- [ ] **S02: Build** `risk:medium` `depends:[[S01]]`',
+      '- [ ] **S03: Ship** `risk:high` `depends:[[S01, S02]]`',
+      '',
+    ].join('\n');
+
+    const slices = parseRoadmapSlices(content);
+    assert.deepStrictEqual(slices.length, 3, '#566 double-bracket: 3 slices');
+    assert.deepStrictEqual(slices[1].depends, ['S01'], '#566: S02 depends recovered to ["S01"]');
+    assert.deepStrictEqual(slices[2].depends, ['S01', 'S02'], '#566: S03 depends recovered to ["S01","S02"]');
+});
+
+test('U. #566: bracket-wrapped single element depends:[[S01]] recovers to ["S01"]', () => {
+    // Simulates the exact DB corruption seen in the forensic evidence: depends=["[S01]"]
+    const content = [
+      '# M020: Single Bracket Corruption',
+      '',
+      '## Slices',
+      '',
+      '- [ ] **S01: First** `risk:low` `depends:[]`',
+      '- [ ] **S02: Second** `risk:medium` `depends:[[S01]]`',
+      '',
+    ].join('\n');
+
+    const slices = parseRoadmapSlices(content);
+    assert.deepStrictEqual(slices[1].depends.length, 1, '#566 single: S02 has exactly 1 dep');
+    assert.deepStrictEqual(slices[1].depends[0], 'S01', '#566 single: dep is "S01" not "[S01]"');
+});
+
 });

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -115,7 +115,7 @@ function validateProofStrategy(value: unknown): Array<{ riskOrUnknown: string; r
   });
 }
 
-const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+const SLICE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
 
 function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
   if (!Array.isArray(value) || value.length === 0) {

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -115,10 +115,20 @@ function validateProofStrategy(value: unknown): Array<{ riskOrUnknown: string; r
   });
 }
 
+const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+
 function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
   if (!Array.isArray(value) || value.length === 0) {
     throw new Error("slices must be a non-empty array");
   }
+
+  // Pre-collect all slice IDs so depends cross-validation can reference the full set.
+  const allSliceIds = new Set<string>(
+    (value as unknown[])
+      .filter((e): e is Record<string, unknown> => !!e && typeof e === "object")
+      .map(e => e.sliceId)
+      .filter((id): id is string => isNonEmptyString(id)),
+  );
 
   const seen = new Set<string>();
   return value.map((entry, index) => {
@@ -154,8 +164,13 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
     const titleIssue = validateTitle(title);
     if (titleIssue) throw new Error(`slices[${index}].title is invalid: ${titleIssue}`);
     if (!isNonEmptyString(risk)) throw new Error(`slices[${index}].risk must be a non-empty string`);
-    if (!Array.isArray(depends) || depends.some((item) => !isNonEmptyString(item))) {
-      throw new Error(`slices[${index}].depends must be an array of non-empty strings`);
+    if (!Array.isArray(depends) || depends.some((item) => !isNonEmptyString(item) || !SLICE_ID_RE.test(item as string))) {
+      throw new Error(`slices[${index}].depends must be an array of valid slice IDs (e.g. "S01")`);
+    }
+    for (const dep of depends as string[]) {
+      if (!allSliceIds.has(dep)) {
+        throw new Error(`slices[${index}].depends references unknown slice "${dep}" — check that it is defined in the same milestone`);
+      }
     }
     if (!isNonEmptyString(demo)) throw new Error(`slices[${index}].demo must be a non-empty string`);
     if (!isNonEmptyString(goal)) throw new Error(`slices[${index}].goal must be a non-empty string`);

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -75,12 +75,19 @@ function validateParams(params: ReassessRoadmapParams): ReassessRoadmapParams {
     throw new Error("sliceChanges.removed must be an array");
   }
 
+  const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+
   // Validate each modified slice
   for (let i = 0; i < params.sliceChanges.modified.length; i++) {
     const s = params.sliceChanges.modified[i];
     if (!s || typeof s !== "object") throw new Error(`sliceChanges.modified[${i}] must be an object`);
     if (!isNonEmptyString(s.sliceId)) throw new Error(`sliceChanges.modified[${i}].sliceId is required`);
     if (!isNonEmptyString(s.title)) throw new Error(`sliceChanges.modified[${i}].title is required`);
+    if (s.depends !== undefined) {
+      if (!Array.isArray(s.depends) || s.depends.some((item: unknown) => !isNonEmptyString(item) || !SLICE_ID_RE.test(item as string))) {
+        throw new Error(`sliceChanges.modified[${i}].depends must be an array of valid slice IDs (e.g. "S01")`);
+      }
+    }
   }
 
   // Validate each added slice
@@ -89,6 +96,11 @@ function validateParams(params: ReassessRoadmapParams): ReassessRoadmapParams {
     if (!s || typeof s !== "object") throw new Error(`sliceChanges.added[${i}] must be an object`);
     if (!isNonEmptyString(s.sliceId)) throw new Error(`sliceChanges.added[${i}].sliceId is required`);
     if (!isNonEmptyString(s.title)) throw new Error(`sliceChanges.added[${i}].title is required`);
+    if (s.depends !== undefined) {
+      if (!Array.isArray(s.depends) || s.depends.some((item: unknown) => !isNonEmptyString(item) || !SLICE_ID_RE.test(item as string))) {
+        throw new Error(`sliceChanges.added[${i}].depends must be an array of valid slice IDs (e.g. "S01")`);
+      }
+    }
   }
 
   return params;

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -75,7 +75,7 @@ function validateParams(params: ReassessRoadmapParams): ReassessRoadmapParams {
     throw new Error("sliceChanges.removed must be an array");
   }
 
-  const SLICE_ID_RE = /^[A-Za-z]+\d+$/;
+  const SLICE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
 
   // Validate each modified slice
   for (let i = 0; i < params.sliceChanges.modified.length; i++) {
@@ -175,6 +175,37 @@ export async function handleReassessRoadmap(
         if (completedSliceIds.has(removedId)) {
           guardError = `cannot remove completed slice ${removedId}`;
           return;
+        }
+      }
+
+      // Cross-milestone depends validation — effective slice ID set after this reassessment
+      const removedIds = new Set<string>(params.sliceChanges.removed);
+      const effectiveSliceIds = new Set<string>(
+        existingSlices.map(s => s.id).filter(id => !removedIds.has(id)),
+      );
+      for (const added of params.sliceChanges.added) {
+        effectiveSliceIds.add(added.sliceId);
+      }
+      for (let i = 0; i < params.sliceChanges.modified.length; i++) {
+        const mod = params.sliceChanges.modified[i]!;
+        if (mod.depends !== undefined) {
+          for (const dep of mod.depends) {
+            if (!effectiveSliceIds.has(dep)) {
+              guardError = `sliceChanges.modified[${i}].depends references unknown slice "${dep}" — check that it is defined in this milestone`;
+              return;
+            }
+          }
+        }
+      }
+      for (let i = 0; i < params.sliceChanges.added.length; i++) {
+        const added = params.sliceChanges.added[i]!;
+        if (added.depends !== undefined) {
+          for (const dep of added.depends) {
+            if (!effectiveSliceIds.has(dep)) {
+              guardError = `sliceChanges.added[${i}].depends references unknown slice "${dep}" — check that it is defined in this milestone`;
+              return;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Fixed `gsd_plan_milestone` accepting bracket-wrapped `depends` values like `["[S01]"]` by adding slice ID pattern validation (`/^[A-Za-z]+\d+$/`) and cross-milestone-slice validation in `plan-milestone.ts`, extending the same guard to `reassess-roadmap.ts`, filtering corrupt elements in `markdown-renderer.ts`, and adding double-bracket recovery in `roadmap-slices.ts`; verified with `tsc --noEmit` showing no type errors in the changed files.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #566
- [#566 Bug: gsd_plan_milestone accepts depends values like ["[S01]"] — corrupts DB and produces unrecoverable 'No slice eligible' block](https://github.com/open-gsd/gsd-pi/issues/566)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/566-bug-gsd-plan-milestone-accepts-depends-v-1780905235`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783497739&installation_id=134682257&pr_number=567&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F567&signature=d972a0fe4d6f18d99b8e234b3d68f8494eb849752418ec63de67b3eafe51a22a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes slice dependency validation and eligibility logic across planning tools and the DB; incorrect rules could block valid milestones or still miss edge cases, but scope is localized to GSD slice `depends` handling with strong test coverage.
> 
> **Overview**
> Fixes **#566**: invalid slice `depends` values (e.g. `["[S01]"]` from markdown fragments) could be stored in SQLite and break slice eligibility.
> 
> **Validation at write and tool boundaries:** `plan-milestone` now requires each `depends` entry to match a slice ID pattern and to reference another slice in the same milestone; `reassess-roadmap` adds the same format checks plus cross-validation against the post-change slice set. `insertSlice` and `updateSliceFields` reject invalid `depends` before persisting.
> 
> **Recovery on read/render paths:** Roadmap rendering strips bracket-wrapped IDs and drops non-IDs so corrupt rows still emit `depends:[S01]`. `roadmap-slices` gains a fallback for double-bracket `depends:[[S01]]` and normalizes parsed IDs; markdown hierarchy import sanitizes `depends` the same way before `insertSlice`.
> 
> Regression tests cover plan-milestone rejection, parse recovery, and renderer round-trip from a simulated pre-fix DB row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd85c86e53f88b6c0e17fbb9d11ac20750b4efbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->