### PR TITLE
fix(gsd): suppress external CLI structured questions

### DIFF
--- a/src/resources/extensions/gsd/question-transport.ts
+++ b/src/resources/extensions/gsd/question-transport.ts
@@ -83,7 +83,7 @@ export function resolveQuestionTransport(
     };
   }
 
-  if (usesWorkflowMcp && !workflowMcpStructuredQuestionsEnabled(options.env)) {
+  if (options.authMode === "externalCli" && !workflowMcpStructuredQuestionsEnabled(options.env)) {
     return {
       structuredQuestionsAvailable: "false",
       questionToolAvailable,

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -686,6 +686,39 @@ test("supportsStructuredQuestions recognizes workflow MCP question tools", () =>
   );
 });
 
+test("supportsStructuredQuestions gates non-local externalCli providers", () => {
+  assert.equal(
+    supportsStructuredQuestions(["ask_user_questions"], {
+      authMode: "externalCli",
+      env: {},
+    }),
+    true,
+  );
+  assert.equal(
+    supportsStructuredQuestions(["ask_user_questions"], {
+      authMode: "externalCli",
+      baseUrl: "https://api.example.com",
+      env: {},
+    }),
+    true,
+  );
+  assert.equal(
+    supportsStructuredQuestions(["ask_user_questions"], {
+      authMode: "externalCli",
+      env: { GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS: "0" } as NodeJS.ProcessEnv,
+    }),
+    false,
+  );
+  assert.equal(
+    supportsStructuredQuestions(["ask_user_questions"], {
+      authMode: "externalCli",
+      baseUrl: "https://api.example.com",
+      env: { GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS: "0" } as NodeJS.ProcessEnv,
+    }),
+    false,
+  );
+});
+
 test("transport compatibility passes when required tools fit current MCP surface", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",


### PR DESCRIPTION
## TL;DR

**What:** Suppress structured question availability for external CLI providers when opted out.
**Why:** External CLI workflow MCP transports can expose ask_user_questions even when the host cannot render form elicitation, producing false cancelled responses.
**How:** Gate supportsStructuredQuestions on authMode === "externalCli" instead of requiring a local:// baseUrl and extend workflow-mcp regression coverage.

Refs #533

## What

This updates the workflow MCP structured-question availability check so the `GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS=0` opt-out env var now applies to **all** external CLI providers, including those with no `baseUrl` or a non-local `baseUrl`. Previously only `local://` providers were covered by the gate.

## Why

Issue #533 shows Claude Code/external CLI sessions advertising structured questions while the user-visible host never receives the form. The old guard only handled externalCli providers with a local:// baseUrl, but registered CLI providers can have no baseUrl, so the helper fell through to structuredQuestionsAvailable=true and ignored the opt-out env var.

## How

supportsStructuredQuestions now treats authMode === "externalCli" as the transport signal for the structured-question gate. Structured questions remain available by default for external CLI providers; set `GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS=0` to suppress them. The workflow MCP test now covers externalCli with no baseUrl, externalCli with a non-local baseUrl (both with and without the opt-out flag), plus the legacy local:// shape, OAuth behavior, and missing ask_user_questions.

## Verification

- [x] /Users/jeremymcspadden/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp.test.ts
- [x] pnpm run typecheck:extensions
- [x] pnpm run verify:fast
- [x] Node 24 merge-gate phases from /private/tmp/gsd-pi-issue-533-verify: build:core, build:web-host, typecheck:extensions, validate-pack, verify:workspace-coverage, verify:extension-coverage, unit, package, integration, and e2e phases passed

## Impact analysis

- Blast radius: moderate; this changes prompt/tool-use routing for external CLI providers using the GSD workflow MCP surface.
- Affected workflows: guided discussion and auto dispatch prompts that derive structuredQuestionsAvailable from supportsStructuredQuestions.
- Compatibility notes: API-key and OAuth-backed providers continue to advertise structured questions when ask_user_questions is available. External CLI providers can suppress structured questions with GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS=0.
- Follow-up: direct ask_user_questions calls still use the existing cancellation/error contract; this PR addresses the advertised-availability path from the issue addendum without rewriting the direct tool response shape.