### PR TITLE
fix(issue): [Bug] session-failed TypeError classified as transient causes silent auto-mode stall after provider 429

### DIFF
--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -1035,7 +1035,8 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   public async resume(): Promise<AutoAdvanceResult> {
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
-    this.dispatchKeyWindow = [];
+    // Preserve dispatchKeyWindow across resume so stuck-loop detection
+    // accumulates across pause/resume cycles rather than resetting each time.
     this.lastStuckRecoveryKey = null;
     this.status.phase = "running";
     this.bumpTransition();
@@ -1053,7 +1054,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.status.activeUnit = undefined;
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
-    this.dispatchKeyWindow = [];
+    // Preserve dispatchKeyWindow on pause so stuck-loop detection accumulates
+    // across pause/resume cycles. Only clear on a hard stop.
+    if (reason !== "pause") {
+      this.dispatchKeyWindow = [];
+    }
     this.lastStuckRecoveryKey = null;
     this.bumpTransition();
     this.journalTransition({ name: "stop", reason });

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -130,7 +130,8 @@ export async function runUnit(
       unitId,
       error: msg,
     });
-    return { status: "cancelled", errorContext: { message: `Session creation failed: ${msg}`, category: "session-failed", isTransient: true } };
+    const isStructural = sessionErr instanceof TypeError || /is not a function/i.test(msg);
+    return { status: "cancelled", errorContext: { message: `Session creation failed: ${msg}`, category: "session-failed", isTransient: !isStructural } };
   }
   if (sessionTimeoutHandle) clearTimeout(sessionTimeoutHandle);
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -73,6 +73,8 @@ async function waitForMicrotasks(
 function makeMockSession(opts?: {
   newSessionResult?: { cancelled: boolean };
   newSessionThrows?: string;
+  /** Reject newSession() with a specific Error instance (e.g. TypeError). */
+  newSessionThrowsError?: Error;
   newSessionDelayMs?: number;
   onNewSessionStart?: (session: any) => void;
   onNewSessionSettle?: (session: any) => void;
@@ -87,6 +89,9 @@ function makeMockSession(opts?: {
     cmdCtx: {
       newSession: (options?: { abortSignal?: AbortSignal; workspaceRoot?: string }) => {
         opts?.onNewSessionStart?.(session);
+        if (opts?.newSessionThrowsError) {
+          return Promise.reject(opts.newSessionThrowsError);
+        }
         if (opts?.newSessionThrows) {
           return Promise.reject(new Error(opts.newSessionThrows));
         }
@@ -495,6 +500,73 @@ test("runUnit returns cancelled when session creation fails", async () => {
   assert.equal(result.event, undefined);
   // sendMessage should NOT have been called
   assert.equal(pi.calls.length, 0);
+});
+
+test("runUnit: TypeError from newSession is classified as structural (isTransient: false)", async () => {
+  // Regression for #572: a TypeError thrown from newSession (e.g. "something is
+  // not a function") indicates a programming error, not a transient provider
+  // blip. Before the fix it was always classified isTransient: true, causing
+  // auto-mode to retry indefinitely instead of surfacing the real problem.
+  _resetPendingResolve();
+
+  const baseCtx = {
+    ...makeMockCtx(),
+    ui: { notify: () => {}, setStatus: () => {}, setWorkingMessage: () => {} },
+    sessionManager: { getEntries: () => [] },
+    modelRegistry: { getProviderAuthMode: () => undefined, isProviderRequestReady: () => true },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession({
+    newSessionThrowsError: new TypeError("pi.sendMessage is not a function"),
+  });
+
+  const result = await runUnit(baseCtx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "session-failed");
+  assert.equal(result.errorContext?.isTransient, false, "TypeError must be non-transient");
+});
+
+test("runUnit: 'is not a function' message from newSession is classified as structural", async () => {
+  // Regression for #572: the pattern also catches errors where the thrown
+  // object is not a TypeError instance but the message contains "is not a function".
+  _resetPendingResolve();
+
+  const baseCtx = {
+    ...makeMockCtx(),
+    ui: { notify: () => {}, setStatus: () => {}, setWorkingMessage: () => {} },
+    sessionManager: { getEntries: () => [] },
+    modelRegistry: { getProviderAuthMode: () => undefined, isProviderRequestReady: () => true },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession({ newSessionThrows: "pi.sendMessage is not a function" });
+
+  const result = await runUnit(baseCtx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "session-failed");
+  assert.equal(result.errorContext?.isTransient, false, "'is not a function' errors must be non-transient");
+});
+
+test("runUnit: generic network error from newSession remains transient", async () => {
+  // Confirm that non-structural session errors (e.g. 429, ECONNREFUSED) are
+  // still classified as transient so auto-mode can retry them.
+  _resetPendingResolve();
+
+  const baseCtx = {
+    ...makeMockCtx(),
+    ui: { notify: () => {}, setStatus: () => {}, setWorkingMessage: () => {} },
+    sessionManager: { getEntries: () => [] },
+    modelRegistry: { getProviderAuthMode: () => undefined, isProviderRequestReady: () => true },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession({ newSessionThrows: "connection refused" });
+
+  const result = await runUnit(baseCtx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "session-failed");
+  assert.equal(result.errorContext?.isTransient, true, "network errors must remain transient");
 });
 
 test("runUnit clears queued switch cancellation when session creation fails", async () => {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -696,7 +696,10 @@ test("stuck-loop: start() resets the ring so a fresh saturation cycle is require
   assert.equal(next.kind, "advanced");
 });
 
-test("stuck-loop: resume() resets the ring", async (t) => {
+test("stuck-loop: resume() preserves ring so detection accumulates across pause/resume", async (t) => {
+  // Regression for #572: resume() must NOT reset dispatchKeyWindow. Before the
+  // fix, a pause/resume cycle cleared the window, letting a stuck loop silently
+  // re-accumulate STUCK_WINDOW_SIZE dispatches before being detected again.
   const f = makeFixture();
   t.after(() => f.cleanup());
 
@@ -707,11 +710,39 @@ test("stuck-loop: resume() resets the ring", async (t) => {
   const resumed = await f.orchestrator.resume();
   assert.equal(resumed.kind, "resumed");
 
+  // The ring is preserved, so the next advance pushes it to STUCK_WINDOW_SIZE
+  // and triggers stuck-loop detection — not a fresh dispatch.
   const next = await f.orchestrator.advance();
-  assert.equal(next.kind, "advanced");
+  assert.equal(next.kind, "blocked");
+  if (next.kind !== "blocked") return;
+  assert.equal(next.action, "stop");
+  assert.ok(next.reason.startsWith("stuck-loop:"), `expected stuck-loop reason, got: ${next.reason}`);
 });
 
-test("stuck-loop: stop() resets the ring", async (t) => {
+test("stuck-loop: stop('pause') preserves ring across the stop/resume cycle", async (t) => {
+  // Regression for #572: stop("pause") must behave the same as resume() —
+  // the window must survive so detection accumulates across pause/resume pairs.
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+
+  for (let i = 0; i < STUCK_WINDOW_SIZE - 1; i++) {
+    await f.orchestrator.advance();
+  }
+
+  const stopped = await f.orchestrator.stop("pause");
+  assert.equal(stopped.kind, "stopped");
+
+  const resumed = await f.orchestrator.resume();
+  assert.equal(resumed.kind, "resumed");
+
+  const next = await f.orchestrator.advance();
+  assert.equal(next.kind, "blocked");
+  if (next.kind !== "blocked") return;
+  assert.equal(next.action, "stop");
+  assert.ok(next.reason.startsWith("stuck-loop:"), `expected stuck-loop reason, got: ${next.reason}`);
+});
+
+test("stuck-loop: stop('user-request') resets the ring (hard stop)", async (t) => {
   const f = makeFixture();
   t.after(() => f.cleanup());
 
@@ -722,6 +753,7 @@ test("stuck-loop: stop() resets the ring", async (t) => {
   const stopped = await f.orchestrator.stop("user-request");
   assert.equal(stopped.kind, "stopped");
 
+  // Hard stop clears the ring, so the next advance dispatches fresh.
   const next = await f.orchestrator.advance();
   assert.equal(next.kind, "advanced");
 });


### PR DESCRIPTION
## Summary
- Fixed over-broad transient classification for structural session errors in run-unit.ts and preserved the stuck-loop window across pause/resume cycles in orchestrator.ts.

## Bugs Addressed
- [x] **Over-broad transient classification in `auto/run-unit.js:98`**
- [x] **Orchestrator stuck-window reset on pause/resume (`auto/orchestrator.js:889, 909`)**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #572
- [#572 [Bug] session-failed TypeError classified as transient causes silent auto-mode stall after provider 429](https://github.com/open-gsd/gsd-pi/issues/572)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/572-bug-session-failed-typeerror-classified--1780920832`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783512969&installation_id=134682257&pr_number=574&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F574&signature=6749cb5d825ea456bd7240a1b2a20280afe1a1ac8da2270ad778f4c3c281ff69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-mode retry policy and orchestrator lifecycle state; behavior changes could affect how stalls recover after provider errors versus hard failures.
> 
> **Overview**
> Fixes two auto-mode behaviors that could hide real failures or let stuck loops slip past detection after pause/resume.
> 
> **Session creation errors** in `runUnit` no longer mark every `session-failed` outcome as transient. `TypeError` and messages matching `is not a function` are treated as **structural** (`isTransient: false`) so auto-mode stops retrying programming/integration bugs; ordinary failures like connection refused stay transient for retry.
> 
> **Stuck-loop detection** in the orchestrator no longer clears `dispatchKeyWindow` on `resume()` or on `stop("pause")`. The ring buffer only resets on a hard stop (non-`pause` reason), so repeated dispatches of the same unit still accumulate toward `STUCK_WINDOW_SIZE` across pause/resume cycles instead of starting over.
> 
> Tests cover the new error classification and updated stuck-loop expectations for resume, pause stop, and hard stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4637801437747ef75fd39060a524a07e94a09d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->