### PR TITLE
fix(issue): 'Stream ended without finish_reason' misclassified as unknown → auto-mode pauses indefinitely (OpenAI-completions provider mid-stream cut)

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -58,7 +58,7 @@ const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient cre
 // are emitted by SDK/harness transports for mid-stream disconnects.
 // These indicate transient network-level interruptions.
 // See: https://github.com/open-gsd/gsd-pi/issues/4558
-const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|web ?socket|fetch failed|connection.*reset|dns|unexpected eof|stream idle timeout|partial response received/i;
+const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|web ?socket|fetch failed|connection.*reset|dns|unexpected eof|stream idle timeout|partial response received|stream ended without finish_reason/i;
 // Context overflow errors (context window/length exceeded) should be treated as server-class
 // transient errors so auto-mode can retry with reduced budget or fall back to a larger-context model.
 // See: https://github.com/open-gsd/gsd-pi/issues/4528

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -740,6 +740,15 @@ test("MAX_TRANSIENT_AUTO_RESUMES is at least 8 for sustained overload resilience
   );
 });
 
+// ── OpenAI-completions mid-stream cut (#577) ─────────────────────────────────
+
+test("classifyError: 'Stream ended without finish_reason' is transient network (#577)", () => {
+  const result = classifyError("Stream ended without finish_reason");
+  assert.ok(isTransient(result), "Stream ended without finish_reason must be transient");
+  assert.equal(result.kind, "network");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs > 0);
+});
+
 // ── Stream idle timeout / partial response (#4558) ──────────────────────────
 
 test("classifyError: 'Stream idle timeout - partial response received' is transient network", () => {


### PR DESCRIPTION
## Summary
- Added `stream ended without finish_reason` to `NETWORK_RE` in `error-classifier.ts` so the OpenAI-completions provider's mid-stream cut error is classified as transient network (not unknown), preventing indefinite auto-mode pauses; added a corresponding regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #577
- [#577 'Stream ended without finish_reason' misclassified as unknown → auto-mode pauses indefinitely (OpenAI-completions provider mid-stream cut)](https://github.com/open-gsd/gsd-pi/issues/577)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/577-stream-ended-without-finish-reason-miscl-1780930335`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783522519&installation_id=134682257&pr_number=578&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F578&signature=8951c575dc9191f97c277eea64a993521ebaf1b416b95c564dc1962129232db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single regex addition and one unit test; only affects error classification for a specific provider message string.
> 
> **Overview**
> Treats the OpenAI-completions **"Stream ended without finish_reason"** message as a **transient network** error by extending `NETWORK_RE` in `error-classifier.ts`, alongside existing mid-stream disconnect patterns.
> 
> That change routes the error through the same auto-resume / same-model retry path as other network interruptions instead of **`unknown`**, which had left auto-mode paused indefinitely. A regression test in `provider-errors.test.ts` locks in transient `network` classification for #577.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752a89a8f4b256cdea402683f808dbe6fd964962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->