### PR TITLE
refactor(gsd): deepen claude code question flow

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -426,6 +426,11 @@ interface AskUserQuestionsWriteGateModule {
   markDepthVerified(milestoneId?: string | null, basePath?: string): void;
   clearPendingGate(basePath: string): void;
   extractDepthVerificationMilestoneId(questionId: string): string | null;
+  applyAskUserQuestionsGateResult?(options: {
+    basePath: string;
+    questions: AskUserQuestion[];
+    details: AskUserQuestionsStructuredContent;
+  }): unknown;
 }
 
 const OTHER_OPTION_LABEL = 'None of the above';
@@ -647,6 +652,15 @@ async function recordAskUserQuestionsGateResult(
   if (!writeGate) return;
 
   const basePath = askUserQuestionsWriteGateBasePath(deps);
+  if (writeGate.applyAskUserQuestionsGateResult) {
+    writeGate.applyAskUserQuestionsGateResult({
+      basePath,
+      questions: structured.questions,
+      details: structured,
+    });
+    return;
+  }
+
   for (const question of structured.questions) {
     if (!writeGate.isGateQuestionId(question.id)) continue;
     const selected = structured.response.answers[question.id]?.selected;

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -28,10 +28,21 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import {
+	attachExternalResultsToToolBlocks,
+	buildFinalAssistantContent,
+	extractToolResultsFromSdkUserMessage,
+	handleClaudeCodePartialStreamEvent,
+} from "./turn-assembler.js";
+import type {
+	ExternalToolResultPayload,
+	ToolCallWithExternalResult,
+} from "./turn-assembler.js";
+import {
 	buildWorkflowMcpServers,
 	getRequiredWorkflowToolsForAutoUnit,
 	resolveWorkflowMcpProjectRoot,
 } from "../gsd/workflow-mcp.js";
+import { resolveWorkflowQuestionToolSurface } from "../gsd/question-transport.js";
 import { buildProjectGsdMcpServers, ensureProjectWorkflowMcpConfig } from "../gsd/mcp-project-config.js";
 import { loadProjectGSDPreferences } from "../gsd/preferences.js";
 import {
@@ -45,7 +56,6 @@ import {
 import { RUN_UAT_CLAUDE_NATIVE_TOOL_NAMES, RUN_UAT_FORBIDDEN_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES, resolveToolPresentationPlan } from "../gsd/tool-presentation-plan.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
-	BetaRawMessageStreamEvent,
 	SDKAssistantMessage,
 	SDKMessage,
 	SDKPartialAssistantMessage,
@@ -53,25 +63,17 @@ import type {
 	SDKUserMessage,
 } from "./sdk-types.js";
 
-/** A single content block returned by an external (SDK-executed) tool call. */
-export interface ExternalToolResultContentBlock {
-	type: string;
-	text?: string;
-	data?: string;
-	mimeType?: string;
-}
-
-/** The full result payload returned by an external tool, including content blocks and error status. */
-export interface ExternalToolResultPayload {
-	content: ExternalToolResultContentBlock[];
-	details?: Record<string, unknown>;
-	isError: boolean;
-}
-
-/** A `ToolCall` block augmented with the external result attached by the SDK synthetic user message. */
-type ToolCallWithExternalResult = ToolCall & {
-	externalResult?: ExternalToolResultPayload;
-};
+export {
+	buildFinalAssistantContent,
+	extractToolResultsFromSdkUserMessage,
+	handleClaudeCodePartialStreamEvent,
+	mergePendingToolCalls,
+} from "./turn-assembler.js";
+export type {
+	ExternalToolResultContentBlock,
+	ExternalToolResultPayload,
+	ToolCallWithExternalResult,
+} from "./turn-assembler.js";
 
 interface PromptToolContextOptions {
 	workflowMcpServerName?: string | null;
@@ -1743,6 +1745,13 @@ export function buildSdkOptions(
 		workflowServerName,
 		workflowExplicitlyBlocked,
 	);
+	const questionToolSurface = resolveWorkflowQuestionToolSurface({
+		workflowServerName,
+		workflowExplicitlyBlocked,
+		workflowMcpTools,
+		exactWorkflowMcpTools,
+		env: process.env,
+	});
 	const runUatDisallowedTools = gsdPhase === "run-uat" && workflowServerName
 		? [
 				...RUN_UAT_FORBIDDEN_TOOL_NAMES.filter((toolName) => !toolName.startsWith("mcp__")),
@@ -1756,6 +1765,7 @@ export function buildSdkOptions(
 	const disallowedTools: string[] = [...new Set([
 		"ToolSearch",
 		...(workflowMcpTools.length > 0 || exactWorkflowMcpTools.length > 0 ? ["AskUserQuestion"] : []),
+		...questionToolSurface.disallowedTools,
 		...runUatDisallowedTools,
 		...extraDisallowedTools,
 	])];
@@ -1822,261 +1832,6 @@ export function buildSdkOptions(
 		...(effort ? { effort } : {}),
 		...sdkExtraOptions,
 	};
-}
-
-/** Normalise heterogeneous SDK tool-result content (string, array, or object) into a uniform `ExternalToolResultContentBlock[]`. */
-function normalizeToolResultContent(content: unknown): ExternalToolResultContentBlock[] {
-	if (typeof content === "string") {
-		return [{ type: "text", text: content }];
-	}
-
-	if (!Array.isArray(content)) {
-		if (content == null) return [{ type: "text", text: "" }];
-		return [{ type: "text", text: JSON.stringify(content) }];
-	}
-
-	const blocks: ExternalToolResultContentBlock[] = [];
-
-	for (const item of content) {
-		if (typeof item === "string") {
-			blocks.push({ type: "text", text: item });
-			continue;
-		}
-		if (!item || typeof item !== "object") {
-			blocks.push({ type: "text", text: String(item) });
-			continue;
-		}
-
-		const block = item as Record<string, unknown>;
-		if (block.type === "text") {
-			blocks.push({ type: "text", text: typeof block.text === "string" ? block.text : "" });
-			continue;
-		}
-		if (
-			block.type === "image"
-			&& typeof block.data === "string"
-			&& typeof block.mimeType === "string"
-		) {
-			blocks.push({ type: "image", data: block.data, mimeType: block.mimeType });
-			continue;
-		}
-
-		blocks.push({ type: "text", text: JSON.stringify(block) });
-	}
-
-	return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
-}
-
-/**
- * Extract a `details` payload from an MCP tool-result block.
- *
- * MCP's `CallToolResult` carries structured data in `structuredContent` — the
- * protocol's supported channel for non-text payloads. Claude Code's synthetic
- * user message may surface that field in one of two shapes depending on SDK
- * version: as a sibling on the `mcp_tool_result` block itself, or as a
- * dedicated content sub-block with `type: "structuredContent"`. Snake-case
- * (`structured_content`) is accepted defensively in case a transport hop
- * rewrites casing. All other shapes fall back to an empty object so callers
- * can rely on `details` being present.
- */
-function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Record<string, unknown> | undefined {
-	const sibling = block.structuredContent ?? (block as Record<string, unknown>).structured_content;
-	if (sibling && typeof sibling === "object" && !Array.isArray(sibling)) {
-		return sibling as Record<string, unknown>;
-	}
-
-	if (Array.isArray(block.content)) {
-		for (const item of block.content) {
-			if (!item || typeof item !== "object") continue;
-			const sub = item as Record<string, unknown>;
-			if (sub.type !== "structuredContent" && sub.type !== "structured_content") continue;
-			const payload = sub.structuredContent ?? sub.structured_content ?? sub.data ?? sub.value;
-			if (payload && typeof payload === "object" && !Array.isArray(payload)) {
-				return payload as Record<string, unknown>;
-			}
-		}
-	}
-
-	// Return undefined (not {}) when no structured payload is present, matching
-	// the pre-#4477 contract where `details` was nullable. An empty-object
-	// sentinel is truthy and breaks downstream consumers that gate on
-	// `if (details)`. `undefined` matches the type of the field these results
-	// flow into (`Record<string, unknown> | undefined`).
-	return undefined;
-}
-
-/**
- * True for items that are MCP `structuredContent` pseudo-blocks living inside
- * a tool-result `content[]` array. These blocks carry the structured payload
- * (extracted separately by `extractStructuredDetailsFromBlock`) and must NOT
- * leak into the visible content rendered to the user — otherwise the renderer
- * stringifies the JSON pseudo-block and shows it next to the actual tool
- * output. See PR #4477 review (post-fix-round).
- */
-function isStructuredContentPseudoBlock(item: unknown): boolean {
-	if (!item || typeof item !== "object") return false;
-	const type = (item as Record<string, unknown>).type;
-	return type === "structuredContent" || type === "structured_content";
-}
-
-/**
- * Strip `structuredContent` pseudo-blocks from a tool-result content array
- * before normalization. The structured payload is extracted via the sibling
- * `structuredContent` field (or a dedicated extractor pass on the raw block);
- * the visible content path must not include the pseudo-block itself.
- */
-function stripStructuredContentPseudoBlocks(content: unknown): unknown {
-	if (!Array.isArray(content)) return content;
-	return content.filter((item) => !isStructuredContentPseudoBlock(item));
-}
-
-/** Extract tool result payloads from an SDK synthetic user message, keyed by tool-use ID. */
-export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): Array<{
-	toolUseId: string;
-	result: ExternalToolResultPayload;
-}> {
-	const extracted: Array<{ toolUseId: string; result: ExternalToolResultPayload }> = [];
-	const seen = new Set<string>();
-	const rawMessage = message.message as Record<string, unknown> | null | undefined;
-	const content = Array.isArray(rawMessage?.content) ? rawMessage.content : [];
-
-	for (const item of content) {
-		if (!item || typeof item !== "object") continue;
-		const block = item as Record<string, unknown>;
-		const type = typeof block.type === "string" ? block.type : "";
-		if (type !== "tool_result" && type !== "mcp_tool_result") continue;
-
-		const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
-		if (!toolUseId || seen.has(toolUseId)) continue;
-		seen.add(toolUseId);
-
-		extracted.push({
-			toolUseId,
-			result: {
-				content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(block.content)),
-				details: extractStructuredDetailsFromBlock(block),
-				isError: block.is_error === true,
-			},
-		});
-	}
-
-	if (extracted.length === 0) {
-		const fallback = message.tool_use_result;
-		if (fallback && typeof fallback === "object") {
-			const toolResult = fallback as Record<string, unknown>;
-			const toolUseId = typeof toolResult.tool_use_id === "string" ? toolResult.tool_use_id : "";
-			if (toolUseId) {
-				extracted.push({
-					toolUseId,
-					result: {
-						content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(toolResult.content)),
-						details: extractStructuredDetailsFromBlock(toolResult),
-						isError: toolResult.is_error === true,
-					},
-				});
-			}
-		}
-	}
-
-	return extracted;
-}
-
-/** Attach external tool results from the SDK synthetic user message to their corresponding tool-call blocks by ID. */
-function attachExternalResultsToToolBlocks(
-	toolBlocks: AssistantMessage["content"],
-	toolResultsById: ReadonlyMap<string, ExternalToolResultPayload>,
-): void {
-	for (const block of toolBlocks) {
-		if (block.type !== "toolCall" && block.type !== "serverToolUse") continue;
-		const externalResult = toolResultsById.get(block.id);
-		if (!externalResult) continue;
-		(block as ToolCallWithExternalResult & { id: string }).externalResult = externalResult;
-	}
-}
-
-/**
- * Build the final assistant content that Agent Core consumes in
- * `externalToolExecution` mode. This preserves tool-call blocks, attaches any
- * SDK-produced external results by tool-call id, and then appends the final
- * text/thinking blocks for the completed turn.
- */
-export function buildFinalAssistantContent(params: {
-	intermediateToolBlocks: AssistantMessage["content"];
-	pendingContent?: AssistantMessage["content"];
-	toolResultsById: ReadonlyMap<string, ExternalToolResultPayload>;
-	lastThinkingContent?: string;
-	lastTextContent?: string;
-	fallbackResultText?: string;
-}): AssistantMessage["content"] {
-	const mergedToolBlocks = [...params.intermediateToolBlocks];
-	if (params.pendingContent) {
-		mergePendingToolCalls(mergedToolBlocks, params.pendingContent);
-	}
-	attachExternalResultsToToolBlocks(mergedToolBlocks, params.toolResultsById);
-
-	const finalContent: AssistantMessage["content"] = [...mergedToolBlocks];
-	if (params.pendingContent && params.pendingContent.length > 0) {
-		for (const block of params.pendingContent) {
-			if (block.type === "text" || block.type === "thinking") {
-				finalContent.push(block);
-			}
-		}
-	} else {
-		if (params.lastThinkingContent) {
-			finalContent.push({ type: "thinking", thinking: params.lastThinkingContent });
-		}
-		if (params.lastTextContent) {
-			finalContent.push({ type: "text", text: params.lastTextContent });
-		}
-	}
-
-	if (finalContent.length === 0 && params.fallbackResultText) {
-		finalContent.push({ type: "text", text: params.fallbackResultText });
-	}
-
-	return finalContent;
-}
-
-/**
- * Merge tool-call blocks from the active partial-message builder into the
- * running list of intermediate tool calls, preserving order and de-duping
- * by tool-call id. Exposed for testing the F3 fix (final-turn tool calls
- * dropped when `result` arrives without a preceding synthetic `user`).
- */
-export function mergePendingToolCalls(
-	intermediate: AssistantMessage["content"],
-	pending: AssistantMessage["content"],
-): AssistantMessage["content"] {
-	const alreadyIncluded = new Set<string>();
-	for (const block of intermediate) {
-		if (block.type === "toolCall") alreadyIncluded.add(block.id);
-	}
-	for (const block of pending) {
-		if (block.type !== "toolCall") continue;
-		if (alreadyIncluded.has(block.id)) continue;
-		alreadyIncluded.add(block.id);
-		intermediate.push(block);
-	}
-	return intermediate;
-}
-
-export function handleClaudeCodePartialStreamEvent(
-	builder: PartialMessageBuilder | null,
-	event: BetaRawMessageStreamEvent,
-	modelId: string,
-): { builder: PartialMessageBuilder | null; assistantEvent: AssistantMessageEvent | null } {
-	if (event.type === "message_start") {
-		// Claude Code can emit repeated SDK message_start events inside one
-		// logical assistant response. Keep appending until a synthetic user
-		// tool-result boundary explicitly clears the builder.
-		return {
-			builder: builder ?? new PartialMessageBuilder((event as any).message?.model ?? modelId),
-			assistantEvent: null,
-		};
-	}
-
-	if (!builder) return { builder, assistantEvent: null };
-	return { builder, assistantEvent: builder.handleEvent(event) };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -58,6 +58,7 @@ const WORKFLOW_MCP_ENV_KEYS = [
 	"GSD_WORKFLOW_MCP_ARGS",
 	"GSD_WORKFLOW_MCP_ENV",
 	"GSD_WORKFLOW_MCP_CWD",
+	"GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS",
 	"GSD_PROJECT_ROOT",
 	"GSD_WORKFLOW_PROJECT_ROOT",
 ] as const;
@@ -1043,6 +1044,31 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		}
 	});
 
+	test("buildSdkOptions can disable workflow MCP ask_user_questions explicitly", () => {
+		const restore = setWorkflowMcpEnv({
+			GSD_WORKFLOW_MCP_COMMAND: "node",
+			GSD_WORKFLOW_MCP_NAME: "gsd-workflow",
+			GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["packages/mcp-server/dist/cli.js"]),
+			GSD_WORKFLOW_MCP_CWD: "/tmp/project",
+			GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS: "0",
+		});
+		const originalCwd = process.cwd();
+		const emptyDir = mkdtempSync(join(tmpdir(), "claude-mcp-ask-disabled-"));
+		try {
+			process.chdir(emptyDir);
+			const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
+			assert.ok(
+				(options.disallowedTools as string[]).includes("mcp__gsd-workflow__ask_user_questions"),
+				"explicit opt-out must block the MCP question tool even when workflow wildcard is allowed",
+			);
+			assert.ok((options.disallowedTools as string[]).includes("AskUserQuestion"));
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(emptyDir, { recursive: true, force: true });
+			restore();
+		}
+	});
+
 	test("buildSdkOptions scopes run-uat to exact workflow MCP tools", () => {
 		const restore = setWorkflowMcpEnv({
 			GSD_WORKFLOW_MCP_COMMAND: "node",
@@ -1138,6 +1164,38 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		} as Context;
 
 		assert.equal(inferGsdPhaseFromContext(context), "plan-milestone");
+	});
+
+	test("buildSdkOptions presents ask_user_questions for discuss phases", () => {
+		const restore = setWorkflowMcpEnv({
+			GSD_WORKFLOW_MCP_COMMAND: "node",
+			GSD_WORKFLOW_MCP_NAME: "gsd-workflow",
+			GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["packages/mcp-server/dist/cli.js"]),
+			GSD_WORKFLOW_MCP_ENV: JSON.stringify({ GSD_CLI_PATH: "/tmp/gsd" }),
+			GSD_WORKFLOW_MCP_CWD: "/tmp/project",
+		});
+		const originalCwd = process.cwd();
+		const emptyDir = mkdtempSync(join(tmpdir(), "claude-mcp-discuss-"));
+		try {
+			process.chdir(emptyDir);
+			const options = buildSdkOptions("claude-sonnet-4-20250514", "test", undefined, { gsdPhase: "discuss-milestone" });
+			const allowedTools = options.allowedTools as string[];
+			const disallowedTools = options.disallowedTools as string[];
+
+			assert.ok(
+				allowedTools.includes("mcp__gsd-workflow__ask_user_questions"),
+				"discuss phases must expose the exact workflow MCP question tool",
+			);
+			assert.ok(disallowedTools.includes("AskUserQuestion"));
+			assert.ok(
+				!disallowedTools.includes("mcp__gsd-workflow__ask_user_questions"),
+				"workflow MCP ask_user_questions should remain enabled by default",
+			);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(emptyDir, { recursive: true, force: true });
+			restore();
+		}
 	});
 
 	test("buildSdkOptions prefers custom workflow MCP question tools over native AskUserQuestion", () => {

--- a/src/resources/extensions/claude-code-cli/turn-assembler.ts
+++ b/src/resources/extensions/claude-code-cli/turn-assembler.ts
@@ -1,0 +1,287 @@
+// gsd-pi - Claude Code logical turn assembly
+
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	ToolCall,
+} from "@gsd/pi-ai";
+import { PartialMessageBuilder } from "./partial-builder.js";
+import type {
+	BetaRawMessageStreamEvent,
+	SDKUserMessage,
+} from "./sdk-types.js";
+
+/** A single content block returned by an external (SDK-executed) tool call. */
+export interface ExternalToolResultContentBlock {
+	type: string;
+	text?: string;
+	data?: string;
+	mimeType?: string;
+}
+
+/** The full result payload returned by an external tool, including content blocks and error status. */
+export interface ExternalToolResultPayload {
+	content: ExternalToolResultContentBlock[];
+	details?: Record<string, unknown>;
+	isError: boolean;
+}
+
+/** A `ToolCall` block augmented with the external result attached by the SDK synthetic user message. */
+export type ToolCallWithExternalResult = ToolCall & {
+	externalResult?: ExternalToolResultPayload;
+};
+
+/** Normalise heterogeneous SDK tool-result content (string, array, or object) into a uniform `ExternalToolResultContentBlock[]`. */
+function normalizeToolResultContent(content: unknown): ExternalToolResultContentBlock[] {
+	if (typeof content === "string") {
+		return [{ type: "text", text: content }];
+	}
+
+	if (!Array.isArray(content)) {
+		if (content == null) return [{ type: "text", text: "" }];
+		return [{ type: "text", text: JSON.stringify(content) }];
+	}
+
+	const blocks: ExternalToolResultContentBlock[] = [];
+
+	for (const item of content) {
+		if (typeof item === "string") {
+			blocks.push({ type: "text", text: item });
+			continue;
+		}
+		if (!item || typeof item !== "object") {
+			blocks.push({ type: "text", text: String(item) });
+			continue;
+		}
+
+		const block = item as Record<string, unknown>;
+		if (block.type === "text") {
+			blocks.push({ type: "text", text: typeof block.text === "string" ? block.text : "" });
+			continue;
+		}
+		if (
+			block.type === "image"
+			&& typeof block.data === "string"
+			&& typeof block.mimeType === "string"
+		) {
+			blocks.push({ type: "image", data: block.data, mimeType: block.mimeType });
+			continue;
+		}
+
+		blocks.push({ type: "text", text: JSON.stringify(block) });
+	}
+
+	return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
+}
+
+/**
+ * Extract a `details` payload from an MCP tool-result block.
+ *
+ * MCP's `CallToolResult` carries structured data in `structuredContent` — the
+ * protocol's supported channel for non-text payloads. Claude Code's synthetic
+ * user message may surface that field in one of two shapes depending on SDK
+ * version: as a sibling on the `mcp_tool_result` block itself, or as a
+ * dedicated content sub-block with `type: "structuredContent"`. Snake-case
+ * (`structured_content`) is accepted defensively in case a transport hop
+ * rewrites casing. All other shapes return undefined, matching the nullable
+ * `details` contract consumed by tool result renderers.
+ */
+function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Record<string, unknown> | undefined {
+	const sibling = block.structuredContent ?? (block as Record<string, unknown>).structured_content;
+	if (sibling && typeof sibling === "object" && !Array.isArray(sibling)) {
+		return sibling as Record<string, unknown>;
+	}
+
+	if (Array.isArray(block.content)) {
+		for (const item of block.content) {
+			if (!item || typeof item !== "object") continue;
+			const sub = item as Record<string, unknown>;
+			if (sub.type !== "structuredContent" && sub.type !== "structured_content") continue;
+			const payload = sub.structuredContent ?? sub.structured_content ?? sub.data ?? sub.value;
+			if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+				return payload as Record<string, unknown>;
+			}
+		}
+	}
+
+	// Return undefined (not {}) when no structured payload is present, matching
+	// the pre-#4477 contract where `details` was nullable. An empty-object
+	// sentinel is truthy and breaks downstream consumers that gate on
+	// `if (details)`. `undefined` matches the type of the field these results
+	// flow into (`Record<string, unknown> | undefined`).
+	return undefined;
+}
+
+/**
+ * True for items that are MCP `structuredContent` pseudo-blocks living inside
+ * a tool-result `content[]` array. These blocks carry the structured payload
+ * (extracted separately by `extractStructuredDetailsFromBlock`) and must NOT
+ * leak into the visible content rendered to the user — otherwise the renderer
+ * stringifies the JSON pseudo-block and shows it next to the actual tool
+ * output. See PR #4477 review (post-fix-round).
+ */
+function isStructuredContentPseudoBlock(item: unknown): boolean {
+	if (!item || typeof item !== "object") return false;
+	const type = (item as Record<string, unknown>).type;
+	return type === "structuredContent" || type === "structured_content";
+}
+
+/**
+ * Strip `structuredContent` pseudo-blocks from a tool-result content array
+ * before normalization. The structured payload is extracted via the sibling
+ * `structuredContent` field (or a dedicated extractor pass on the raw block);
+ * the visible content path must not include the pseudo-block itself.
+ */
+function stripStructuredContentPseudoBlocks(content: unknown): unknown {
+	if (!Array.isArray(content)) return content;
+	return content.filter((item) => !isStructuredContentPseudoBlock(item));
+}
+
+/** Extract tool result payloads from an SDK synthetic user message, keyed by tool-use ID. */
+export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): Array<{
+	toolUseId: string;
+	result: ExternalToolResultPayload;
+}> {
+	const extracted: Array<{ toolUseId: string; result: ExternalToolResultPayload }> = [];
+	const seen = new Set<string>();
+	const rawMessage = message.message as Record<string, unknown> | null | undefined;
+	const content = Array.isArray(rawMessage?.content) ? rawMessage.content : [];
+
+	for (const item of content) {
+		if (!item || typeof item !== "object") continue;
+		const block = item as Record<string, unknown>;
+		const type = typeof block.type === "string" ? block.type : "";
+		if (type !== "tool_result" && type !== "mcp_tool_result") continue;
+
+		const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+		if (!toolUseId || seen.has(toolUseId)) continue;
+		seen.add(toolUseId);
+
+		extracted.push({
+			toolUseId,
+			result: {
+				content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(block.content)),
+				details: extractStructuredDetailsFromBlock(block),
+				isError: block.is_error === true,
+			},
+		});
+	}
+
+	if (extracted.length === 0) {
+		const fallback = message.tool_use_result;
+		if (fallback && typeof fallback === "object") {
+			const toolResult = fallback as Record<string, unknown>;
+			const toolUseId = typeof toolResult.tool_use_id === "string" ? toolResult.tool_use_id : "";
+			if (toolUseId) {
+				extracted.push({
+					toolUseId,
+					result: {
+						content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(toolResult.content)),
+						details: extractStructuredDetailsFromBlock(toolResult),
+						isError: toolResult.is_error === true,
+					},
+				});
+			}
+		}
+	}
+
+	return extracted;
+}
+
+/** Attach external tool results from the SDK synthetic user message to their corresponding tool-call blocks by ID. */
+export function attachExternalResultsToToolBlocks(
+	toolBlocks: AssistantMessage["content"],
+	toolResultsById: ReadonlyMap<string, ExternalToolResultPayload>,
+): void {
+	for (const block of toolBlocks) {
+		if (block.type !== "toolCall" && block.type !== "serverToolUse") continue;
+		const externalResult = toolResultsById.get(block.id);
+		if (!externalResult) continue;
+		(block as ToolCallWithExternalResult & { id: string }).externalResult = externalResult;
+	}
+}
+
+/**
+ * Build the final assistant content that Agent Core consumes in
+ * `externalToolExecution` mode. This preserves tool-call blocks, attaches any
+ * SDK-produced external results by tool-call id, and then appends the final
+ * text/thinking blocks for the completed turn.
+ */
+export function buildFinalAssistantContent(params: {
+	intermediateToolBlocks: AssistantMessage["content"];
+	pendingContent?: AssistantMessage["content"];
+	toolResultsById: ReadonlyMap<string, ExternalToolResultPayload>;
+	lastThinkingContent?: string;
+	lastTextContent?: string;
+	fallbackResultText?: string;
+}): AssistantMessage["content"] {
+	const mergedToolBlocks = [...params.intermediateToolBlocks];
+	if (params.pendingContent) {
+		mergePendingToolCalls(mergedToolBlocks, params.pendingContent);
+	}
+	attachExternalResultsToToolBlocks(mergedToolBlocks, params.toolResultsById);
+
+	const finalContent: AssistantMessage["content"] = [...mergedToolBlocks];
+	if (params.pendingContent && params.pendingContent.length > 0) {
+		for (const block of params.pendingContent) {
+			if (block.type === "text" || block.type === "thinking") {
+				finalContent.push(block);
+			}
+		}
+	} else {
+		if (params.lastThinkingContent) {
+			finalContent.push({ type: "thinking", thinking: params.lastThinkingContent });
+		}
+		if (params.lastTextContent) {
+			finalContent.push({ type: "text", text: params.lastTextContent });
+		}
+	}
+
+	if (finalContent.length === 0 && params.fallbackResultText) {
+		finalContent.push({ type: "text", text: params.fallbackResultText });
+	}
+
+	return finalContent;
+}
+
+/**
+ * Merge tool-call blocks from the active partial-message builder into the
+ * running list of intermediate tool calls, preserving order and de-duping
+ * by tool-call id. Exposed for testing the F3 fix (final-turn tool calls
+ * dropped when `result` arrives without a preceding synthetic `user`).
+ */
+export function mergePendingToolCalls(
+	intermediate: AssistantMessage["content"],
+	pending: AssistantMessage["content"],
+): AssistantMessage["content"] {
+	const alreadyIncluded = new Set<string>();
+	for (const block of intermediate) {
+		if (block.type === "toolCall") alreadyIncluded.add(block.id);
+	}
+	for (const block of pending) {
+		if (block.type !== "toolCall") continue;
+		if (alreadyIncluded.has(block.id)) continue;
+		alreadyIncluded.add(block.id);
+		intermediate.push(block);
+	}
+	return intermediate;
+}
+
+export function handleClaudeCodePartialStreamEvent(
+	builder: PartialMessageBuilder | null,
+	event: BetaRawMessageStreamEvent,
+	modelId: string,
+): { builder: PartialMessageBuilder | null; assistantEvent: AssistantMessageEvent | null } {
+	if (event.type === "message_start") {
+		// Claude Code can emit repeated SDK message_start events inside one
+		// logical assistant response. Keep appending until a synthetic user
+		// tool-result boundary explicitly clears the builder.
+		return {
+			builder: builder ?? new PartialMessageBuilder((event as any).message?.model ?? modelId),
+			assistantEvent: null,
+		};
+	}
+
+	if (!builder) return { builder, assistantEvent: null };
+	return { builder, assistantEvent: builder.handleEvent(event) };
+}

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -13,7 +13,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
 import { buildMilestoneFileName, clearPathCache, milestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { canonicalToolName, clearDiscussionFlowState, isDepthConfirmationAnswer, isMilestoneDepthVerified, isQueuePhaseActive, markApprovalGateVerified, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
+import { applyAskUserQuestionsGateResult, canonicalToolName, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, isMilestoneDepthVerified, isQueuePhaseActive, markApprovalGateVerified, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
@@ -1329,81 +1329,37 @@ export function registerHooks(
 
     const details = event.details as any;
 
-    // ── Discussion gate enforcement: handle gate question responses ──
-    // If the result is cancelled or has no response, the pending gate stays active
-    // so the model is blocked from non-read-only tools until it re-asks.
-    // If the user responded at all (even "needs adjustment"), clear the pending gate
-    // because the user engaged — the prompt handles the re-ask-after-adjustment flow.
     const questions: any[] = (event.input as any)?.questions ?? [];
-    const currentPendingGate = getPendingGate(basePath);
-    if (currentPendingGate) {
-      if (details?.cancelled || !details?.response) {
-        // Gate stays pending. Direct the agent to the most reliable recovery
-        // path — re-calling ask_user_questions with the same gate id — without
-        // misrepresenting the plain-text path. The plain-text path also works
-        // (isExplicitApprovalResponse on the next before_agent_start clears
-        // the gate when the user replies with an approval keyword), but the
-        // structured re-ask is more deterministic and gives the user a clear UI.
-        resetToolCallLoopGuard();
-        const interrupted = details?.interrupted === true;
-        if (ctx) {
-          await maybePauseAutoForApprovalGate(
-            ctx,
-            pi,
-            true,
-            interrupted
-              ? "Depth confirmation was interrupted — pausing auto-mode until you respond."
-              : "Depth confirmation is waiting for your answer — pausing auto-mode.",
-          );
-        }
-        return {
-          content: [{
-            type: "text" as const,
-            text: [
-              `Waiting for depth confirmation on gate "${currentPendingGate}".`,
-              interrupted
-                ? "The confirmation question was interrupted before a response was recorded."
-                : "No user response was received for the confirmation question.",
-              "Do not infer approval from earlier or prior messages.",
-              "Do not proceed, write files, save artifacts, or call other tools.",
-              `Re-call ask_user_questions with the same gate question id ("${currentPendingGate}") and wait for the user's response.`,
-            ].join(" "),
-          }],
-        };
-      } else {
-        const pendingQuestion = questions.find((question) => question?.id === currentPendingGate);
-        if (pendingQuestion) {
-          const answer = details.response?.answers?.[currentPendingGate];
-          if (isDepthConfirmationAnswer(answer?.selected, pendingQuestion.options)) {
-            markApprovalGateVerified(currentPendingGate, basePath);
-            const milestoneIdFromGate = extractDepthVerificationMilestoneId(currentPendingGate);
-            if (milestoneIdFromGate) markDepthVerified(milestoneIdFromGate, basePath);
-            clearPendingGate(basePath);
-            clearDeferredApprovalGate(basePath);
-          }
-        }
+    const gateResult = applyAskUserQuestionsGateResult({
+      basePath,
+      questions,
+      details,
+      fallbackMilestoneId: milestoneId,
+    });
+    if (gateResult.status === "waiting") {
+      resetToolCallLoopGuard();
+      if (ctx) {
+        await maybePauseAutoForApprovalGate(
+          ctx,
+          pi,
+          true,
+          gateResult.interrupted
+            ? "Depth confirmation was interrupted — pausing auto-mode until you respond."
+            : "Depth confirmation is waiting for your answer — pausing auto-mode.",
+        );
       }
+      return {
+        content: [{
+          type: "text" as const,
+          text: formatPendingAskUserQuestionsGateMessage(gateResult.pendingGateId, gateResult.interrupted),
+        }],
+      };
+    }
+    if (gateResult.status === "verified") {
+      clearDeferredApprovalGate(basePath);
     }
 
     if (details?.cancelled || !details?.response) return;
-
-    for (const question of questions) {
-      if (typeof question.id === "string" && question.id.includes("depth_verification")) {
-        // Only unlock the gate if the user selected the first option (confirmation).
-        // Cross-references against the question's defined options to reject free-form "Other" text.
-        const answer = details.response?.answers?.[question.id];
-        const inferredMilestoneId = extractDepthVerificationMilestoneId(question.id) ?? milestoneId;
-        if (isDepthConfirmationAnswer(answer?.selected, question.options)) {
-          if (currentPendingGate && question.id !== currentPendingGate) break;
-          markApprovalGateVerified(question.id, basePath);
-          markDepthVerified(inferredMilestoneId, basePath);
-          clearPendingGate(basePath);
-          clearDeferredApprovalGate(basePath);
-        }
-        break;
-      }
-    }
-
     if (!milestoneId) return;
     await saveDiscussionQuestionRound(basePath, milestoneId, questions, details);
   });

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -462,6 +462,111 @@ export function isDepthConfirmationAnswer(
   return false;
 }
 
+export interface AskUserQuestionsGateQuestion {
+  id?: unknown;
+  options?: Array<{ label?: string }>;
+}
+
+export interface AskUserQuestionsGateDetails {
+  cancelled?: boolean;
+  interrupted?: boolean;
+  response?: {
+    answers?: Record<string, { selected?: unknown } | undefined>;
+  } | null;
+}
+
+export type AskUserQuestionsGateResult =
+  | { status: "not-gate" }
+  | { status: "waiting"; pendingGateId: string; interrupted: boolean }
+  | { status: "verified"; gateId: string; milestoneId: string | null }
+  | { status: "answered"; gateId: string };
+
+function findGateQuestion(
+  questions: AskUserQuestionsGateQuestion[],
+  gateId: string,
+): AskUserQuestionsGateQuestion | undefined {
+  return questions.find((question) => question?.id === gateId);
+}
+
+function readSelectedGateAnswer(
+  details: AskUserQuestionsGateDetails,
+  questionId: string,
+): unknown {
+  return details.response?.answers?.[questionId]?.selected;
+}
+
+function verifyAnsweredGate(
+  basePath: string,
+  question: AskUserQuestionsGateQuestion,
+  fallbackMilestoneId?: string | null,
+): AskUserQuestionsGateResult {
+  const gateId = typeof question.id === "string" ? question.id : "";
+  const milestoneId = extractDepthVerificationMilestoneId(gateId) ?? fallbackMilestoneId ?? null;
+  markApprovalGateVerified(gateId, basePath);
+  markDepthVerified(milestoneId, basePath);
+  clearPendingGate(basePath);
+  return { status: "verified", gateId, milestoneId };
+}
+
+export function applyAskUserQuestionsGateResult(options: {
+  basePath: string;
+  questions: AskUserQuestionsGateQuestion[];
+  details: AskUserQuestionsGateDetails;
+  fallbackMilestoneId?: string | null;
+}): AskUserQuestionsGateResult {
+  const { basePath, questions, details, fallbackMilestoneId } = options;
+  const currentPendingGate = getPendingGate(basePath);
+  if (currentPendingGate) {
+    if (details.cancelled || !details.response) {
+      return {
+        status: "waiting",
+        pendingGateId: currentPendingGate,
+        interrupted: details.interrupted === true,
+      };
+    }
+
+    const pendingQuestion = findGateQuestion(questions, currentPendingGate);
+    if (pendingQuestion) {
+      const selected = readSelectedGateAnswer(details, currentPendingGate);
+      if (isDepthConfirmationAnswer(selected, pendingQuestion.options)) {
+        return verifyAnsweredGate(basePath, pendingQuestion, fallbackMilestoneId);
+      }
+      return { status: "answered", gateId: currentPendingGate };
+    }
+  }
+
+  if (details.cancelled || !details.response) return { status: "not-gate" };
+
+  for (const question of questions) {
+    if (typeof question.id !== "string" || !isGateQuestionId(question.id)) continue;
+    const selected = readSelectedGateAnswer(details, question.id);
+    if (!isDepthConfirmationAnswer(selected, question.options)) {
+      return { status: "answered", gateId: question.id };
+    }
+    if (currentPendingGate && question.id !== currentPendingGate) {
+      return { status: "answered", gateId: currentPendingGate };
+    }
+    return verifyAnsweredGate(basePath, question, fallbackMilestoneId);
+  }
+
+  return { status: "not-gate" };
+}
+
+export function formatPendingAskUserQuestionsGateMessage(
+  pendingGateId: string,
+  interrupted: boolean,
+): string {
+  return [
+    `Waiting for depth confirmation on gate "${pendingGateId}".`,
+    interrupted
+      ? "The confirmation question was interrupted before a response was recorded."
+      : "No user response was received for the confirmation question.",
+    "Do not infer approval from earlier or prior messages.",
+    "Do not proceed, write files, save artifacts, or call other tools.",
+    `Re-call ask_user_questions with the same gate question id ("${pendingGateId}") and wait for the user's response.`,
+  ].join(" ");
+}
+
 export function shouldBlockContextWrite(
   toolName: string,
   inputPath: string,

--- a/src/resources/extensions/gsd/question-transport.ts
+++ b/src/resources/extensions/gsd/question-transport.ts
@@ -1,0 +1,146 @@
+// Project/App: gsd-pi
+// File Purpose: Resolve how workflow units should ask the user for input.
+
+export type StructuredQuestionsFlag = "true" | "false";
+
+export interface QuestionTransportOptions {
+  activeTools: string[];
+  authMode?: "apiKey" | "oauth" | "externalCli" | "none";
+  baseUrl?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface QuestionTransportResolution {
+  structuredQuestionsAvailable: StructuredQuestionsFlag;
+  questionToolAvailable: boolean;
+  usesWorkflowMcp: boolean;
+  reason: "question-tool-available" | "question-tool-missing" | "workflow-mcp-disabled";
+}
+
+export interface WorkflowQuestionToolSurfaceOptions {
+  workflowServerName?: string;
+  workflowExplicitlyBlocked?: boolean;
+  workflowMcpTools: string[];
+  exactWorkflowMcpTools: string[];
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface WorkflowQuestionToolSurfaceResolution extends QuestionTransportResolution {
+  questionToolName?: string;
+  workflowQuestionsEnabled: boolean;
+  disallowedTools: string[];
+}
+
+function mcpToolParts(toolName: string): { serverName: string; baseName: string } | null {
+  if (!toolName.startsWith("mcp__")) return null;
+  const toolSeparator = toolName.indexOf("__", "mcp__".length);
+  if (toolSeparator < 0) return null;
+  return {
+    serverName: toolName.slice("mcp__".length, toolSeparator),
+    baseName: toolName.slice(toolSeparator + 2),
+  };
+}
+
+function isWorkflowMcpServerName(serverName: string): boolean {
+  const normalized = serverName.toLowerCase();
+  return normalized === "gsd" || normalized.includes("workflow");
+}
+
+export function usesWorkflowMcpTransport(
+  authMode: QuestionTransportOptions["authMode"],
+  baseUrl: string | undefined,
+): boolean {
+  return authMode === "externalCli" && typeof baseUrl === "string" && baseUrl.startsWith("local://");
+}
+
+export function hasAskUserQuestionsTool(activeTools: string[]): boolean {
+  return activeTools.some((toolName) => {
+    if (toolName === "ask_user_questions") return true;
+    const mcp = mcpToolParts(toolName);
+    if (!mcp) return false;
+    if (mcp.baseName === "ask_user_questions") return true;
+    return mcp.baseName === "*" && isWorkflowMcpServerName(mcp.serverName);
+  });
+}
+
+function workflowMcpStructuredQuestionsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env.GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS?.trim().toLowerCase();
+  return value !== "0" && value !== "false" && value !== "off";
+}
+
+export function resolveQuestionTransport(
+  options: QuestionTransportOptions,
+): QuestionTransportResolution {
+  const questionToolAvailable = hasAskUserQuestionsTool(options.activeTools);
+  const usesWorkflowMcp = usesWorkflowMcpTransport(options.authMode, options.baseUrl);
+
+  if (!questionToolAvailable) {
+    return {
+      structuredQuestionsAvailable: "false",
+      questionToolAvailable,
+      usesWorkflowMcp,
+      reason: "question-tool-missing",
+    };
+  }
+
+  if (usesWorkflowMcp && !workflowMcpStructuredQuestionsEnabled(options.env)) {
+    return {
+      structuredQuestionsAvailable: "false",
+      questionToolAvailable,
+      usesWorkflowMcp,
+      reason: "workflow-mcp-disabled",
+    };
+  }
+
+  return {
+    structuredQuestionsAvailable: "true",
+    questionToolAvailable,
+    usesWorkflowMcp,
+    reason: "question-tool-available",
+  };
+}
+
+export function supportsStructuredQuestions(
+  activeTools: string[],
+  options: Omit<QuestionTransportOptions, "activeTools"> = {},
+): boolean {
+  return resolveQuestionTransport({
+    ...options,
+    activeTools,
+  }).structuredQuestionsAvailable === "true";
+}
+
+export function resolveWorkflowQuestionToolSurface(
+  options: WorkflowQuestionToolSurfaceOptions,
+): WorkflowQuestionToolSurfaceResolution {
+  const questionToolName = options.workflowServerName && !options.workflowExplicitlyBlocked
+    ? `mcp__${options.workflowServerName}__ask_user_questions`
+    : undefined;
+  const activeTools = [
+    ...options.exactWorkflowMcpTools,
+    ...options.workflowMcpTools,
+    ...(questionToolName ? [questionToolName] : []),
+  ];
+  const transport = resolveQuestionTransport({
+    activeTools,
+    authMode: "externalCli",
+    baseUrl: "local://claude-code",
+    env: options.env,
+  });
+  const exactQuestionToolAllowed =
+    !!questionToolName && options.exactWorkflowMcpTools.includes(questionToolName);
+  const workflowQuestionsEnabled =
+    transport.structuredQuestionsAvailable === "true" &&
+    (options.workflowMcpTools.length > 0 || exactQuestionToolAllowed);
+  const disallowedTools =
+    options.workflowServerName && transport.questionToolAvailable && !workflowQuestionsEnabled
+      ? [`mcp__${options.workflowServerName}__ask_user_questions`]
+      : [];
+
+  return {
+    ...transport,
+    questionToolName,
+    workflowQuestionsEnabled,
+    disallowedTools,
+  };
+}

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -629,9 +629,33 @@ test("usesWorkflowMcpTransport matches local externalCli providers", () => {
   assert.equal(usesWorkflowMcpTransport("oauth", "local://custom"), false);
 });
 
-test("supportsStructuredQuestions disables local workflow MCP questions unless explicitly enabled", () => {
+test("supportsStructuredQuestions recognizes workflow MCP question tools", () => {
   assert.equal(
     supportsStructuredQuestions(["ask_user_questions"], {
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      env: {},
+    }),
+    true,
+  );
+  assert.equal(
+    supportsStructuredQuestions(["mcp__gsd-workflow__ask_user_questions"], {
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      env: {},
+    }),
+    true,
+  );
+  assert.equal(
+    supportsStructuredQuestions(["mcp__gsd-workflow__*"], {
+      authMode: "externalCli",
+      baseUrl: "local://claude-code",
+      env: {},
+    }),
+    true,
+  );
+  assert.equal(
+    supportsStructuredQuestions(["mcp__gsd-browser__*"], {
       authMode: "externalCli",
       baseUrl: "local://claude-code",
       env: {},
@@ -642,9 +666,9 @@ test("supportsStructuredQuestions disables local workflow MCP questions unless e
     supportsStructuredQuestions(["mcp__gsd-workflow__ask_user_questions"], {
       authMode: "externalCli",
       baseUrl: "local://claude-code",
-      env: { GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS: "1" } as NodeJS.ProcessEnv,
+      env: { GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS: "0" } as NodeJS.ProcessEnv,
     }),
-    true,
+    false,
   );
   assert.equal(
     supportsStructuredQuestions(["ask_user_questions"], {
@@ -954,6 +978,7 @@ test("discuss-milestone guided flow does not abort when all required tools are o
   // Guided flow starts the workflow MCP server as part of dispatch, so the
   // parent session active-tool list is not authoritative for MCP tools.
   const discussMilestoneTools = [
+    "ask_user_questions",
     "gsd_summary_save",
     "gsd_requirement_save",
     "gsd_requirement_update",

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -340,6 +340,8 @@ test('write-gate: reopening a gate revokes its previous verified approval', () =
 // ═══════════════════════════════════════════════════════════════════════
 
 import {
+  applyAskUserQuestionsGateResult,
+  formatPendingAskUserQuestionsGateMessage,
   isGateQuestionId,
   shouldBlockPendingGate,
   shouldBlockPendingGateBash,
@@ -377,6 +379,83 @@ test('write-gate: pending gate lifecycle (set, get, clear)', () => {
   setPendingGate('depth_verification_M002', process.cwd());
   clearDiscussionFlowState(process.cwd());
   assert.strictEqual(getPendingGate(), null, 'clearDiscussionFlowState clears pending gate');
+});
+
+test('write-gate: applyAskUserQuestionsGateResult keeps cancelled pending gate waiting', () => {
+  const base = join(tmpdir(), `gsd-write-gate-ask-waiting-${randomUUID()}`);
+  const gateId = 'depth_verification_M001_confirm';
+
+  try {
+    mkdirSync(base, { recursive: true });
+    clearDiscussionFlowState(base);
+    setPendingGate(gateId, base);
+
+    const result = applyAskUserQuestionsGateResult({
+      basePath: base,
+      questions: [{
+        id: gateId,
+        options: [{ label: 'Confirm depth (Recommended)' }, { label: 'Needs adjustment' }],
+      }],
+      details: { cancelled: true, interrupted: true },
+    });
+
+    assert.deepEqual(result, {
+      status: 'waiting',
+      pendingGateId: gateId,
+      interrupted: true,
+    });
+    assert.strictEqual(getPendingGate(base), gateId, 'cancelled question must leave gate pending');
+    assert.strictEqual(isMilestoneDepthVerified('M001', base), false, 'cancelled question must not verify depth');
+    assert.match(
+      formatPendingAskUserQuestionsGateMessage(gateId, true),
+      /Re-call ask_user_questions with the same gate question id/,
+    );
+  } finally {
+    clearDiscussionFlowState(base);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('write-gate: applyAskUserQuestionsGateResult verifies confirmed pending gate', () => {
+  const base = join(tmpdir(), `gsd-write-gate-ask-verified-${randomUUID()}`);
+  const gateId = 'depth_verification_M001_confirm';
+  const confirmLabel = 'Confirm depth (Recommended)';
+
+  try {
+    mkdirSync(base, { recursive: true });
+    clearDiscussionFlowState(base);
+    setPendingGate(gateId, base);
+
+    const result = applyAskUserQuestionsGateResult({
+      basePath: base,
+      questions: [{
+        id: gateId,
+        options: [{ label: confirmLabel }, { label: 'Needs adjustment' }],
+      }],
+      details: {
+        response: {
+          answers: {
+            [gateId]: { selected: confirmLabel },
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(result, {
+      status: 'verified',
+      gateId,
+      milestoneId: 'M001',
+    });
+    assert.strictEqual(getPendingGate(base), null, 'confirmed gate must clear pending state');
+    assert.strictEqual(isMilestoneDepthVerified('M001', base), true, 'confirmed gate must verify milestone depth');
+    assert.ok(
+      loadWriteGateSnapshot(base).verifiedApprovalGates?.includes(gateId) ?? false,
+      'confirmed gate must record verified approval',
+    );
+  } finally {
+    clearDiscussionFlowState(base);
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 // ─── Scenario 21: shouldBlockPendingGate blocks non-safe tools when gate is pending ──

--- a/src/resources/extensions/gsd/unit-tool-contracts.ts
+++ b/src/resources/extensions/gsd/unit-tool-contracts.ts
@@ -71,6 +71,7 @@ export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
       "gsd_milestone_generate_id",
     ],
     requiredWorkflowTools: [
+      "ask_user_questions",
       "gsd_summary_save",
       "gsd_requirement_save",
       "gsd_requirement_update",
@@ -80,7 +81,7 @@ export const UNIT_TOOL_CONTRACTS: Record<string, UnitToolSurfaceContract> = {
   },
   "discuss-slice": {
     allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
-    requiredWorkflowTools: ["gsd_summary_save"],
+    requiredWorkflowTools: ["ask_user_questions", "gsd_summary_save"],
   },
   "validate-milestone": {
     allowedGsdTools: ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -4,9 +4,15 @@ import { basename, dirname, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { getRequiredWorkflowToolsForUnit } from "./unit-tool-contracts.js";
 import {
+  supportsStructuredQuestions,
+  usesWorkflowMcpTransport,
+} from "./question-transport.js";
+import {
   WORKFLOW_TOOL_SURFACE_NAMES,
   isWorkflowToolSurfaceName,
 } from "./workflow-tool-surface.js";
+
+export { supportsStructuredQuestions, usesWorkflowMcpTransport };
 
 type WorkflowExecutorsModule = typeof import("./tools/workflow-tool-executors.js");
 
@@ -365,22 +371,6 @@ export function getRequiredWorkflowToolsForAutoUnit(unitType: string): string[] 
   return getRequiredWorkflowToolsForUnit(unitType);
 }
 
-export function usesWorkflowMcpTransport(
-  authMode: WorkflowCapabilityOptions["authMode"],
-  baseUrl: string | undefined,
-): boolean {
-  return authMode === "externalCli" && typeof baseUrl === "string" && baseUrl.startsWith("local://");
-}
-
-function hasAskUserQuestionsTool(activeTools: string[]): boolean {
-  return activeTools.some((toolName) => {
-    if (toolName === "ask_user_questions") return true;
-    if (!toolName.startsWith("mcp__")) return false;
-    const toolSeparator = toolName.indexOf("__", "mcp__".length);
-    return toolSeparator >= 0 && toolName.slice(toolSeparator + 2) === "ask_user_questions";
-  });
-}
-
 function hasRequiredTool(requiredTool: string, activeTools: string[]): boolean {
   return activeTools.some((toolName) => {
     if (toolName === requiredTool) return true;
@@ -388,27 +378,6 @@ function hasRequiredTool(requiredTool: string, activeTools: string[]): boolean {
     const toolSeparator = toolName.indexOf("__", "mcp__".length);
     return toolSeparator >= 0 && toolName.slice(toolSeparator + 2) === requiredTool;
   });
-}
-
-function workflowMcpStructuredQuestionsOptIn(env: NodeJS.ProcessEnv = process.env): boolean {
-  const value = env.GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS;
-  return value === "1" || value === "true";
-}
-
-export function supportsStructuredQuestions(
-  activeTools: string[],
-  options: Pick<WorkflowCapabilityOptions, "authMode" | "baseUrl" | "env"> = {},
-): boolean {
-  if (!hasAskUserQuestionsTool(activeTools)) return false;
-  if (usesWorkflowMcpTransport(options.authMode, options.baseUrl)) {
-    // Claude Code local workflow-MCP exposes ask_user_questions, but form
-    // elicitation can return an immediate cancel outside GSD's chat turn. Keep
-    // checkpoints in plain chat unless a caller deliberately opts into testing
-    // that transport.
-    return workflowMcpStructuredQuestionsOptIn(options.env);
-  }
-
-  return true;
 }
 
 export function getWorkflowTransportSupportError(


### PR DESCRIPTION
## TL;DR
Use workflow MCP `ask_user_questions` for Claude Code GSD discussions and keep gate/turn handling unified.

## What
- Routes Claude Code discuss phases to `mcp__gsd-workflow__ask_user_questions` by default, with `GSD_WORKFLOW_MCP_STRUCTURED_QUESTIONS=0/false/off` as an opt-out.
- Adds `question-transport.ts` for question-tool surface resolution and requires `ask_user_questions` for discuss unit contracts.
- Extracts turn assembly into `turn-assembler.ts` while preserving the existing stream-adapter exports.
- Centralizes ask-user gate result handling in `write-gate.ts` and reuses it from hooks and the MCP server.

## Why
- Avoid duplicate plain-chat questions when Claude Code has the workflow MCP available.
- Keep depth-verification writes blocked until the user actually confirms.
- Preserve one logical assistant turn across Claude Code partial `message_start` events while reducing duplicated logic.

## How Verified
- Local focused coverage: stream-adapter, workflow-mcp, write-gate, partial-builder, prompt-contracts, register-hooks-depth-verification, ask-user-questions-dedup, discuss-milestone-structured-questions, and write-gate-predicates all passed in the validation worktree.
- Typecheck: `pnpm run typecheck:extensions` passed.
- Documentation sweep found no docs requiring changes.
- GitHub CI is green: fast-gates, build, node22-smoke, windows-portability, ci-gate, triage, risk, and security checks all passed.

Note: automated review attempts repeatedly failed due an external socket close after surfacing only the already-verified structured-question default change; no code defect was identified by those runs.