### PR TITLE
fix(gsd): surface preference parse and validation diagnostics

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -119,6 +119,10 @@ Common block reasons and operator actions:
 
 Recovery classification now treats deterministic policy, tool-schema, stale-worker, and invalid-worktree failures as non-transient stops. Provider failures still use provider-specific transient classification and may retry automatically, while verification drift and unknown runtime failures escalate for inspection because repeating the same dispatch can preserve the drift.
 
+### Preference Diagnostics at Preflight
+
+When you start auto mode, GSD re-surfaces any GSD preference parse or validation diagnostics (malformed `PREFERENCES.md` frontmatter or invalid settings) as notifications before the loop begins, so you get actionable file/line guidance before long-running automation proceeds. These re-surface at the auto-mode preflight even if the same problem was already shown at session start; each surface still dedupes repeated diagnostics. Preference problems do not block auto mode — they are advisory. See [Configuration](./configuration.md#invalid-or-malformed-preferences) and [Troubleshooting](./troubleshooting.md#preferences-file-ignored-or-settings-not-taking-effect).
+
 ### Context Pre-Loading
 
 The dispatch prompt is carefully constructed with:

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -56,6 +56,15 @@ planning_depth: deep
 - **Array fields** (`always_use_skills`, etc.): concatenated (global first, then project)
 - **Object fields** (`models`, `git`, `auto_supervisor`): shallow-merged, project overrides per-key
 
+### Invalid or malformed preferences
+
+Preference loading never throws. When a `PREFERENCES.md` file is malformed or contains invalid settings, GSD keeps running with safe defaults but attaches diagnostics so the problem is visible instead of silently ignored:
+
+- **Parse failures** (missing closing `---` delimiter, YAML syntax error, unrecognized format) cause the whole file to be ignored. GSD falls back to a valid global or legacy preferences file rather than blocking.
+- **Invalid settings** (unknown keys, type mismatches) are sanitized or dropped; the remaining valid settings in the file still apply.
+
+Diagnostics surface through session-start notifications, `/gsd doctor` (with file path and, for YAML errors, line and column), and auto-mode preflight. See [Troubleshooting](./troubleshooting.md#preferences-file-ignored-or-settings-not-taking-effect).
+
 ## Global API Keys (`/gsd config`)
 
 Tool API keys are stored globally in `~/.gsd/agent/auth.json` and apply to all projects automatically. Set them once with `/gsd config` — no need to configure per-project `.env` files.

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -15,6 +15,7 @@ It checks:
 - Git worktree health (worktree and branch modes only — skipped in none mode)
 - Stale DB-backed runtime records and orphaned runtime files
 - Disk-only orphan milestone stub directories
+- Preference parse and validation diagnostics (malformed `PREFERENCES.md` frontmatter or invalid settings)
 
 ## Common Issues
 
@@ -233,6 +234,14 @@ For common provider setup issues (role errors, streaming errors, model ID mismat
 **Symptoms:** Auto mode pauses with "Budget ceiling reached."
 
 **Fix:** Increase `budget_ceiling` in preferences, or switch to `budget` token profile to reduce per-unit cost, then resume with `/gsd auto`.
+
+### Preferences file ignored or settings not taking effect
+
+**Symptoms:** On session start, `/gsd doctor`, or when starting auto mode, GSD reports a warning or error like `GSD project preferences error: .gsd/PREFERENCES.md could not be parsed.` or `GSD global preferences warning: ~/.gsd/PREFERENCES.md contains invalid settings.` Settings from the file appear to have no effect.
+
+**Cause:** The preferences file has malformed YAML frontmatter (for example a missing closing `---` delimiter or a YAML syntax error) or contains invalid settings. Parse failures cause the whole file to be ignored — GSD falls back to a valid global or legacy preferences file. Invalid individual settings are sanitized or dropped while the rest of the file still applies. Preferences never throw; the diagnostics make the problem visible instead of failing silently.
+
+**Fix:** Run `/gsd doctor` to see the file path, the parse/validation message, and (for YAML errors) the line and column. Fix the reported issue in the named file, then rerun the command. Auto-mode re-surfaces these diagnostics at preflight so they are visible before long-running automation proceeds.
 
 ### Auto mode says another session is running
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -41,6 +41,7 @@ import { logWarning as safetyLogWarning } from "../workflow-logger.js";
 import { installNotifyInterceptor } from "./notify-interceptor.js";
 import { initNotificationStore } from "../notification-store.js";
 import { initNotificationWidget } from "../notification-widget.js";
+import { notifyPreferenceDiagnostics } from "../preferences-diagnostics.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { extractSubagentAgentClasses } from "./subagent-input.js";
 import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserApprovalQuestion } from "../user-input-boundary.js";
@@ -698,6 +699,7 @@ function initSessionNotifications(ctx: ExtensionContext): void {
   initNotificationStore(resolveNotificationStoreBasePath(contextBasePath(ctx)));
   installNotifyInterceptor(ctx);
   initNotificationWidget(ctx);
+  notifyPreferenceDiagnostics(ctx, contextBasePath(ctx), { surface: "session-start" });
 }
 
 async function prepareWorkflowMcpForHookContext(

--- a/src/resources/extensions/gsd/commands/handlers/auto.ts
+++ b/src/resources/extensions/gsd/commands/handlers/auto.ts
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import { enableDebug } from "../../debug-logger.js";
 import { getAutoDashboardData, isAutoActive, isAutoPaused, pauseAuto, startAutoDetached, stopAuto, stopAutoRemote } from "../../auto.js";
 import { handleRate } from "../../commands-rate.js";
+import { notifyPreferenceDiagnostics } from "../../preferences-diagnostics.js";
 import { setSessionModelOverride } from "../../session-model-override.js";
 import { guardRemoteSession, projectRoot } from "../context.js";
 import { findMilestoneIds } from "../../milestone-id-utils.js";
@@ -91,6 +92,7 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
     if (!(await guardRemoteSession(ctx, pi))) return true;
     const basePath = projectRoot();
     if (await hasUnresolvedCloseoutBlocker(ctx, basePath)) return true;
+    notifyPreferenceDiagnostics(ctx, basePath, { surface: "auto-preflight" });
 
     // Validate the milestone target exists and is not already complete.
     if (milestoneId) {
@@ -118,6 +120,7 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
     if (!(await guardRemoteSession(ctx, pi))) return true;
     const basePath = projectRoot();
     if (await hasUnresolvedCloseoutBlocker(ctx, basePath)) return true;
+    notifyPreferenceDiagnostics(ctx, basePath, { surface: "auto-preflight" });
 
     // Validate the milestone target exists and is not already complete.
     if (milestoneId) {

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -73,6 +73,15 @@ These are **separate concerns**:
 
 Setting `prefer_skills: []` does **not** disable skill discovery — it just means you have no preference overrides. Use `skill_discovery: off` to disable discovery entirely.
 
+### Parse & Validation Diagnostics
+
+Preference loading never throws. When a file is malformed or contains invalid settings, GSD falls back to safe defaults but attaches structured diagnostics (see `collectPreferenceDiagnostics()` in `preferences-diagnostics.ts`) so the problem is reported instead of silently ignored:
+
+- **Parse failures** (missing closing `---` delimiter, YAML syntax error, or an unrecognized file format) cause the whole file to be ignored. Loading continues to the next candidate — a valid global or legacy preferences file is still used, and a malformed project file never becomes the effective wrapper or blocks fallback.
+- **Validation problems** (unknown keys, type mismatches) are sanitized or dropped per-field; the remaining valid settings in the file still apply.
+
+Diagnostics record the file path, scope (global/project), severity (error/warning), kind (parse/validation), and — for YAML parse errors — the line and column. They surface through session-start notifications, `/gsd doctor`, and auto-mode preflight, with each surface deduping repeated diagnostics.
+
 ---
 
 ## Field Guide

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -9,6 +9,7 @@ import { resolveMilestoneFile, resolveMilestonePath, resolveSliceFile, resolveSl
 import { deriveState, isMilestoneComplete } from "./state.js";
 import { invalidateAllCaches } from "./cache.js";
 import { loadEffectiveGSDPreferences, type GSDPreferences } from "./preferences.js";
+import { collectPreferenceDiagnostics, formatPreferenceDiagnosticDetail } from "./preferences-diagnostics.js";
 import { isClosedStatus } from "./status-guards.js";
 
 import type { DoctorIssue, DoctorIssueCode, DoctorReport } from "./doctor-types.js";
@@ -331,6 +332,17 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
   };
 
   const prefs = loadEffectiveGSDPreferences(basePath);
+  for (const diagnostic of collectPreferenceDiagnostics(basePath)) {
+    issues.push({
+      severity: diagnostic.severity,
+      code: "invalid_preferences",
+      scope: "project",
+      unitId: diagnostic.scope,
+      message: `GSD preferences ${diagnostic.kind}: ${formatPreferenceDiagnosticDetail(diagnostic)}`,
+      file: diagnostic.path,
+      fixable: false,
+    });
+  }
   if (prefs) {
     const prefIssues = validatePreferenceShape(prefs.preferences);
     for (const issue of prefIssues) {

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -337,7 +337,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
       severity: diagnostic.severity,
       code: "invalid_preferences",
       scope: "project",
-      unitId: diagnostic.scope,
+      unitId: "project",
       message: `GSD preferences ${diagnostic.kind}: ${formatPreferenceDiagnosticDetail(diagnostic)}`,
       file: diagnostic.path,
       fixable: false,

--- a/src/resources/extensions/gsd/preferences-diagnostics.ts
+++ b/src/resources/extensions/gsd/preferences-diagnostics.ts
@@ -1,0 +1,98 @@
+import type { PreferenceDiagnostic } from "./preferences-types.js";
+import {
+  loadGlobalGSDPreferences,
+  loadProjectGSDPreferences,
+} from "./preferences.js";
+
+interface PreferenceNotificationContext {
+  ui: {
+    notify(message: string, type?: "info" | "warning" | "error" | "success"): void;
+  };
+}
+
+interface PreferenceDiagnosticNotificationOptions {
+  surface?: string;
+}
+
+const notifiedPreferenceDiagnostics = new Set<string>();
+
+export function collectPreferenceDiagnostics(basePath?: string): PreferenceDiagnostic[] {
+  const diagnostics = [
+    ...(loadGlobalGSDPreferences()?.diagnostics ?? []),
+    ...(loadProjectGSDPreferences(basePath)?.diagnostics ?? []),
+  ];
+
+  const seen = new Set<string>();
+  const unique: PreferenceDiagnostic[] = [];
+  for (const diagnostic of diagnostics) {
+    const signature = preferenceDiagnosticSignature(diagnostic);
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    unique.push(diagnostic);
+  }
+  return unique;
+}
+
+export function formatPreferenceDiagnostic(diagnostic: PreferenceDiagnostic): string {
+  const scope = diagnostic.scope === "global" ? "global" : "project";
+  const level = diagnostic.severity === "error" ? "error" : "warning";
+  const heading = diagnostic.kind === "parse"
+    ? `GSD ${scope} preferences ${level}: ${diagnostic.path} could not be parsed.`
+    : `GSD ${scope} preferences ${level}: ${diagnostic.path} contains invalid settings.`;
+  const detail = formatPreferenceDiagnosticDetail(diagnostic);
+  const impact = diagnostic.ignored
+    ? "Preferences from this file were ignored; auto-mode may be using defaults."
+    : "Invalid settings were ignored or sanitized; auto-mode may be using defaults for them.";
+  return `${heading}\n${detail}\n${impact}\nRun /gsd doctor for details.`;
+}
+
+export function formatPreferenceDiagnosticDetail(diagnostic: PreferenceDiagnostic): string {
+  if (diagnostic.line !== undefined && diagnostic.column !== undefined) {
+    return `YAML error at line ${diagnostic.line}, column ${diagnostic.column}: ${diagnostic.message}`;
+  }
+  return diagnostic.message;
+}
+
+export function notifyPreferenceDiagnostics(
+  ctx: PreferenceNotificationContext,
+  basePath?: string,
+  options?: PreferenceDiagnosticNotificationOptions,
+): number {
+  let notified = 0;
+  for (const diagnostic of collectPreferenceDiagnostics(basePath)) {
+    const signature = preferenceDiagnosticNotificationSignature(diagnostic, options?.surface);
+    if (notifiedPreferenceDiagnostics.has(signature)) continue;
+    notifiedPreferenceDiagnostics.add(signature);
+    ctx.ui.notify(
+      formatPreferenceDiagnostic(diagnostic),
+      diagnostic.severity === "error" ? "error" : "warning",
+    );
+    notified++;
+  }
+  return notified;
+}
+
+export function _resetPreferenceDiagnosticNotificationsForTests(): void {
+  notifiedPreferenceDiagnostics.clear();
+}
+
+function preferenceDiagnosticSignature(diagnostic: PreferenceDiagnostic): string {
+  return [
+    diagnostic.path,
+    diagnostic.scope,
+    diagnostic.severity,
+    diagnostic.kind,
+    diagnostic.message,
+    diagnostic.line ?? "",
+    diagnostic.column ?? "",
+    diagnostic.ignored === true ? "ignored" : "",
+    diagnostic.sanitized === true ? "sanitized" : "",
+  ].join("\u0000");
+}
+
+function preferenceDiagnosticNotificationSignature(
+  diagnostic: PreferenceDiagnostic,
+  surface = "default",
+): string {
+  return `${surface}\u0000${preferenceDiagnosticSignature(diagnostic)}`;
+}

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -594,8 +594,24 @@ export interface LoadedGSDPreferences {
   path: string;
   scope: "global" | "project";
   preferences: GSDPreferences;
+  /** True when the file exists but its contents were ignored before merging. */
+  ignored?: boolean;
   /** Validation warnings (unknown keys, type mismatches, deprecations). Empty when preferences are clean. */
   warnings?: string[];
+  /** Structured parse/validation diagnostics for user-visible reporting. */
+  diagnostics?: PreferenceDiagnostic[];
+}
+
+export interface PreferenceDiagnostic {
+  path: string;
+  scope: "global" | "project";
+  severity: "error" | "warning";
+  kind: "parse" | "validation";
+  message: string;
+  line?: number;
+  column?: number;
+  ignored?: boolean;
+  sanitized?: boolean;
 }
 
 export interface SkillResolution {

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -29,6 +29,7 @@ import {
   type WorkflowMode,
   type GSDPreferences,
   type LoadedGSDPreferences,
+  type PreferenceDiagnostic,
   type SkillResolution,
   type SkillDiscoveryMode,
   formatSkillRef,
@@ -59,6 +60,7 @@ export type {
   ClaudeCodeMcpConfig,
   GSDPreferences,
   LoadedGSDPreferences,
+  PreferenceDiagnostic,
   SkillResolution,
   SkillResolutionReport,
 } from "./preferences-types.js";
@@ -173,14 +175,18 @@ export function normalizePreferencesShape(
 // ─── Loading ────────────────────────────────────────────────────────────────
 
 export function loadGlobalGSDPreferences(): LoadedGSDPreferences | null {
-  return loadPreferencesFile(globalPreferencesPath(), "global")
-    ?? loadPreferencesFile(legacyGlobalPreferencesPathLowercase(), "global")
-    ?? loadPreferencesFile(legacyGlobalPreferencesPath(), "global");
+  return loadFirstUsablePreferencesFile([
+    globalPreferencesPath(),
+    legacyGlobalPreferencesPathLowercase(),
+    legacyGlobalPreferencesPath(),
+  ], "global");
 }
 
 export function loadProjectGSDPreferences(basePath?: string): LoadedGSDPreferences | null {
-  return loadPreferencesFile(projectPreferencesPath(basePath), "project")
-    ?? loadPreferencesFile(legacyProjectPreferencesPathLowercase(basePath), "project");
+  return loadFirstUsablePreferencesFile([
+    projectPreferencesPath(basePath),
+    legacyProjectPreferencesPathLowercase(basePath),
+  ], "project");
 }
 
 export function loadEffectiveGSDPreferences(
@@ -189,25 +195,24 @@ export function loadEffectiveGSDPreferences(
 ): LoadedGSDPreferences | null {
   const globalPreferences = loadGlobalGSDPreferences();
   const projectPreferences = loadProjectGSDPreferences(basePath);
-  const projectHasPlanningDepth = projectPreferences?.preferences.planning_depth !== undefined;
+  const effectiveProjectPreferences = projectPreferences?.ignored ? null : projectPreferences;
+  const projectHasPlanningDepth = effectiveProjectPreferences?.preferences.planning_depth !== undefined;
 
-  if (!globalPreferences && !projectPreferences) return null;
+  if (!globalPreferences && !effectiveProjectPreferences) return null;
 
   let result: LoadedGSDPreferences;
   if (!globalPreferences) {
-    result = projectPreferences!;
-  } else if (!projectPreferences) {
-    result = globalPreferences;
+    result = effectiveProjectPreferences!;
+  } else if (!effectiveProjectPreferences) {
+    result = mergePreferenceMetadata(globalPreferences, projectPreferences);
   } else {
-    const mergedWarnings = [
-      ...(globalPreferences.warnings ?? []),
-      ...(projectPreferences.warnings ?? []),
-    ];
+    const metadata = mergePreferenceMetadata(globalPreferences, effectiveProjectPreferences);
     result = {
-      path: projectPreferences.path,
+      path: effectiveProjectPreferences.path,
       scope: "project",
-      preferences: mergePreferences(globalPreferences.preferences, projectPreferences.preferences),
-      ...(mergedWarnings.length > 0 ? { warnings: mergedWarnings } : {}),
+      preferences: mergePreferences(globalPreferences.preferences, effectiveProjectPreferences.preferences),
+      ...(metadata.warnings ? { warnings: metadata.warnings } : {}),
+      ...(metadata.diagnostics ? { diagnostics: metadata.diagnostics } : {}),
     };
   }
 
@@ -240,6 +245,43 @@ export function loadEffectiveGSDPreferences(
   return result;
 }
 
+function mergePreferenceMetadata(
+  primary: LoadedGSDPreferences,
+  secondary: LoadedGSDPreferences | null,
+): LoadedGSDPreferences {
+  const mergedWarnings = [
+    ...(primary.warnings ?? []),
+    ...(secondary?.warnings ?? []),
+  ];
+  const mergedDiagnostics = [
+    ...(primary.diagnostics ?? []),
+    ...(secondary?.diagnostics ?? []),
+  ];
+  return {
+    ...primary,
+    ...(mergedWarnings.length > 0 ? { warnings: mergedWarnings } : {}),
+    ...(mergedDiagnostics.length > 0 ? { diagnostics: mergedDiagnostics } : {}),
+  };
+}
+
+function loadFirstUsablePreferencesFile(
+  paths: string[],
+  scope: "global" | "project",
+): LoadedGSDPreferences | null {
+  let ignoredPreferences: LoadedGSDPreferences | null = null;
+
+  for (const path of paths) {
+    const loaded = loadPreferencesFile(path, scope);
+    if (!loaded) continue;
+    if (!loaded.ignored) return mergePreferenceMetadata(loaded, ignoredPreferences);
+    ignoredPreferences = ignoredPreferences
+      ? mergePreferenceMetadata(ignoredPreferences, loaded)
+      : loaded;
+  }
+
+  return ignoredPreferences;
+}
+
 function stripInheritedPlanningDepth(
   loaded: LoadedGSDPreferences,
   projectHasPlanningDepth: boolean,
@@ -260,17 +302,40 @@ function loadPreferencesFile(path: string, scope: "global" | "project"): LoadedG
   if (!existsSync(path)) return null;
 
   const raw = readFileSync(path, "utf-8");
-  const preferences = parsePreferencesMarkdown(raw);
-  if (!preferences) return null;
+  const parsed = parsePreferencesMarkdownWithDiagnostics(raw);
+  if (!parsed.preferences && parsed.diagnostics.length === 0) return null;
 
+  const ignored = parsed.diagnostics.some((diagnostic) => diagnostic.ignored === true);
+  const preferences = parsed.preferences ?? {};
   const validation = validatePreferences(preferences);
   const allWarnings = [...validation.warnings, ...validation.errors];
+  const diagnostics: PreferenceDiagnostic[] = [
+    ...parsed.diagnostics.map((diagnostic) => ({ ...diagnostic, path, scope })),
+    ...validation.errors.map((message): PreferenceDiagnostic => ({
+      path,
+      scope,
+      severity: "error",
+      kind: "validation",
+      message,
+      sanitized: true,
+    })),
+    ...validation.warnings.map((message): PreferenceDiagnostic => ({
+      path,
+      scope,
+      severity: "warning",
+      kind: "validation",
+      message,
+      sanitized: true,
+    })),
+  ];
 
   return {
     path,
     scope,
     preferences: validation.preferences,
+    ...(ignored ? { ignored: true } : {}),
     ...(allWarnings.length > 0 ? { warnings: allWarnings } : {}),
+    ...(diagnostics.length > 0 ? { diagnostics } : {}),
   };
 }
 
@@ -286,20 +351,44 @@ export function _resetParseWarningFlag(): void {
 
 /** @internal Exported for testing only */
 export function parsePreferencesMarkdown(content: string): GSDPreferences | null {
+  return parsePreferencesMarkdownWithDiagnostics(content).preferences;
+}
+
+type PreferenceParseDiagnostic = Omit<PreferenceDiagnostic, "path" | "scope">;
+
+interface PreferenceParseResult {
+  preferences: GSDPreferences | null;
+  diagnostics: PreferenceParseDiagnostic[];
+}
+
+function parsePreferencesMarkdownWithDiagnostics(content: string): PreferenceParseResult {
   // Use indexOf instead of [\s\S]*? regex to avoid backtracking (#468)
   const startMarker = content.startsWith('---\r\n') ? '---\r\n' : '---\n';
   if (content.startsWith(startMarker)) {
     const searchStart = startMarker.length;
     const endIdx = content.indexOf('\n---', searchStart);
-    if (endIdx === -1) return null;
+    if (endIdx === -1) {
+      return {
+        preferences: null,
+        diagnostics: [{
+          severity: "error",
+          kind: "parse",
+          message: "preferences frontmatter is missing a closing --- delimiter",
+          ignored: true,
+        }],
+      };
+    }
     const block = content.slice(searchStart, endIdx);
-    return parseFrontmatterBlock(block.replace(/\r/g, ''));
+    return parseFrontmatterBlockWithDiagnostics(block.replace(/\r/g, ''), 1);
   }
 
   // Fallback: heading+list format (e.g. "## Git\n- isolation: none") (#2036)
   // GSD agents may write preferences files without frontmatter delimiters.
   if (/^##\s+\w/m.test(content)) {
-    return parseHeadingListFormat(content);
+    return {
+      preferences: parseHeadingListFormat(content),
+      diagnostics: [],
+    };
   }
 
   // Warn when a non-empty file exists but lacks frontmatter delimiters (#2036).
@@ -310,25 +399,80 @@ export function parsePreferencesMarkdown(content: string): GSDPreferences | null
       "Wrap your preferences in --- fences. See https://github.com/open-gsd/gsd-pi/issues/2036",
     );
   }
-  return null;
+  return {
+    preferences: null,
+    diagnostics: content.trim().length > 0
+      ? [{
+          severity: "error",
+          kind: "parse",
+          message: "preferences file has unrecognized format; expected YAML frontmatter delimiters (---) or markdown preference sections",
+          ignored: true,
+        }]
+      : [],
+  };
 }
 
 let _warnedFrontmatterParse = false;
-function parseFrontmatterBlock(frontmatter: string): GSDPreferences {
+function parseFrontmatterBlockWithDiagnostics(
+  frontmatter: string,
+  lineOffset: number,
+): { preferences: GSDPreferences; diagnostics: PreferenceParseDiagnostic[] } {
   try {
     const parsed = parseYaml(frontmatter);
     if (typeof parsed !== 'object' || parsed === null) {
-      return {} as GSDPreferences;
+      return {
+        preferences: {} as GSDPreferences,
+        diagnostics: [{
+          severity: "error",
+          kind: "validation",
+          message: "preferences frontmatter must be a YAML object",
+          ignored: true,
+        }],
+      };
     }
-    return normalizeParsedPreferences(parsed as GSDPreferences);
+    return {
+      preferences: normalizeParsedPreferences(parsed as GSDPreferences),
+      diagnostics: [],
+    };
   } catch (e) {
     // Warn at most once per session to avoid flooding TUI (#3376)
     if (!_warnedFrontmatterParse) {
       _warnedFrontmatterParse = true;
       logWarning("guided", `YAML parse error in preferences frontmatter (suppressing further): ${(e as Error).message}`);
     }
-    return {} as GSDPreferences;
+    const location = extractYamlErrorLocation(e, lineOffset);
+    return {
+      preferences: {} as GSDPreferences,
+      diagnostics: [{
+        severity: "error",
+        kind: "parse",
+        message: cleanYamlErrorMessage(e),
+        ...(location.line !== undefined ? { line: location.line } : {}),
+        ...(location.column !== undefined ? { column: location.column } : {}),
+        ignored: true,
+      }],
+    };
   }
+}
+
+function cleanYamlErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const firstLine = message.split("\n")[0]?.trim() ?? "unknown YAML parse error";
+  return firstLine.replace(/\s+at line \d+, column \d+:?$/, "");
+}
+
+function extractYamlErrorLocation(
+  error: unknown,
+  lineOffset: number,
+): { line?: number; column?: number } {
+  const linePos = (error as { linePos?: Array<{ line?: unknown; col?: unknown }> })?.linePos;
+  const first = Array.isArray(linePos) ? linePos[0] : undefined;
+  const line = typeof first?.line === "number" ? first.line + lineOffset : undefined;
+  const column = typeof first?.col === "number" ? first.col : undefined;
+  return {
+    ...(line !== undefined ? { line } : {}),
+    ...(column !== undefined ? { column } : {}),
+  };
 }
 
 function normalizeParsedPreferences(preferences: GSDPreferences): GSDPreferences {

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -195,22 +195,23 @@ export function loadEffectiveGSDPreferences(
 ): LoadedGSDPreferences | null {
   const globalPreferences = loadGlobalGSDPreferences();
   const projectPreferences = loadProjectGSDPreferences(basePath);
+  const effectiveGlobalPreferences = globalPreferences?.ignored ? null : globalPreferences;
   const effectiveProjectPreferences = projectPreferences?.ignored ? null : projectPreferences;
   const projectHasPlanningDepth = effectiveProjectPreferences?.preferences.planning_depth !== undefined;
 
-  if (!globalPreferences && !effectiveProjectPreferences) return null;
+  if (!effectiveGlobalPreferences && !effectiveProjectPreferences) return null;
 
   let result: LoadedGSDPreferences;
-  if (!globalPreferences) {
+  if (!effectiveGlobalPreferences) {
     result = effectiveProjectPreferences!;
   } else if (!effectiveProjectPreferences) {
-    result = mergePreferenceMetadata(globalPreferences, projectPreferences);
+    result = mergePreferenceMetadata(effectiveGlobalPreferences, projectPreferences);
   } else {
-    const metadata = mergePreferenceMetadata(globalPreferences, effectiveProjectPreferences);
+    const metadata = mergePreferenceMetadata(effectiveGlobalPreferences, effectiveProjectPreferences);
     result = {
       path: effectiveProjectPreferences.path,
       scope: "project",
-      preferences: mergePreferences(globalPreferences.preferences, effectiveProjectPreferences.preferences),
+      preferences: mergePreferences(effectiveGlobalPreferences.preferences, effectiveProjectPreferences.preferences),
       ...(metadata.warnings ? { warnings: metadata.warnings } : {}),
       ...(metadata.diagnostics ? { diagnostics: metadata.diagnostics } : {}),
     };

--- a/src/resources/extensions/gsd/tests/auto-milestone-target.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-milestone-target.test.ts
@@ -1,7 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { parseMilestoneTarget, parseModelFlag } from "../commands/handlers/auto.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe("parseMilestoneTarget", () => {
   it("extracts a simple milestone ID", () => {
@@ -57,6 +62,24 @@ describe("parseMilestoneTarget", () => {
   it("does not match bare numbers without M prefix", () => {
     const result = parseMilestoneTarget("auto 016");
     assert.equal(result.milestoneId, null);
+  });
+});
+
+describe("auto preference diagnostics", () => {
+  it("notifies preference diagnostics before launching auto-mode", () => {
+    const source = readFileSync(join(__dirname, "..", "commands", "handlers", "auto.ts"), "utf-8");
+    const autoBlockIndex = source.indexOf('if (trimmed === "auto" || trimmed.startsWith("auto "))');
+    assert.ok(autoBlockIndex >= 0, "auto command block should exist");
+    const nextBlockIndex = source.indexOf('if (trimmed === "stop")', autoBlockIndex);
+    const autoBlock = source.slice(autoBlockIndex, nextBlockIndex);
+    const notifyIndex = autoBlock.indexOf("notifyPreferenceDiagnostics");
+    assert.ok(notifyIndex >= 0, "auto command should notify preference diagnostics");
+    for (const match of autoBlock.matchAll(/startAutoDetached/g)) {
+      assert.ok(
+        notifyIndex < match.index!,
+        "preference diagnostics should be notified before each auto-mode launch",
+      );
+    }
   });
 });
 

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -26,6 +26,24 @@ test("filterDoctorIssues keeps project and environment issues in scoped reports"
   );
 });
 
+test("filterDoctorIssues keeps invalid_preferences issues regardless of preferences file scope", () => {
+  // Both global and project preference diagnostics should survive scope filtering.
+  // doctor.ts uses unitId: "project" for all invalid_preferences issues so they
+  // pass through the scope filter the same way other project-level issues do.
+  const issues = [
+    { severity: "error", code: "invalid_preferences", scope: "project", unitId: "project", message: "global PREFERENCES.md parse error", fixable: false },
+    { severity: "error", code: "invalid_preferences", scope: "project", unitId: "project", message: "project PREFERENCES.md parse error", fixable: false },
+    { severity: "error", code: "invalid_preferences", scope: "project", unitId: "global", message: "stale unitId — should be filtered out", fixable: false },
+  ] as const;
+
+  const filtered = filterDoctorIssues([...issues], { scope: "M016", includeWarnings: true });
+  assert.deepEqual(
+    filtered.map((issue) => issue.message),
+    ["global PREFERENCES.md parse error", "project PREFERENCES.md parse error"],
+    "invalid_preferences issues with unitId: project survive scope filtering; unitId: global is dropped",
+  );
+});
+
 test("checkEngineHealth reports db_unavailable when gsd.db exists but the DB is closed", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-db-unavailable-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/preferences-diagnostics.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-diagnostics.test.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  _resetPreferenceDiagnosticNotificationsForTests,
+  notifyPreferenceDiagnostics,
+} from "../preferences-diagnostics.ts";
+import { _resetParseWarningFlag } from "../preferences.ts";
+
+test("notifyPreferenceDiagnostics dedupes within a surface but re-surfaces across surfaces", (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-notify-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-notify-home-"));
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+    _resetPreferenceDiagnosticNotificationsForTests();
+    _resetParseWarningFlag();
+  });
+
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+  _resetPreferenceDiagnosticNotificationsForTests();
+  _resetParseWarningFlag();
+
+  writeFileSync(
+    join(tempProject, ".gsd", "PREFERENCES.md"),
+    "---\nversion: 3\n---\n",
+    "utf-8",
+  );
+
+  const notifications: Array<{ message: string; type?: string }> = [];
+  const ctx = {
+    ui: {
+      notify(message: string, type?: "info" | "warning" | "error" | "success") {
+        notifications.push({ message, type });
+      },
+    },
+  };
+
+  assert.equal(
+    notifyPreferenceDiagnostics(ctx, tempProject, { surface: "session-start" }),
+    1,
+  );
+  assert.equal(
+    notifyPreferenceDiagnostics(ctx, tempProject, { surface: "session-start" }),
+    0,
+  );
+  assert.equal(
+    notifyPreferenceDiagnostics(ctx, tempProject, { surface: "auto-preflight" }),
+    1,
+  );
+  assert.equal(notifications.length, 2);
+  assert.equal(notifications[0]!.type, "error");
+  assert.match(notifications[0]!.message, /GSD project preferences error/);
+  assert.match(notifications[0]!.message, /unsupported version 3/);
+  assert.match(notifications[0]!.message, /Run \/gsd doctor for details/);
+  assert.equal(notifications[1]!.message, notifications[0]!.message);
+});

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -957,6 +957,51 @@ test("malformed project preferences do not override effective global wrapper", (
   );
 });
 
+test("malformed global preferences: loadEffectiveGSDPreferences returns null without project file", (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-effective-malformed-global-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-effective-malformed-home-"));
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+    _resetParseWarningFlag();
+    _resetLogs();
+  });
+
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+  _resetParseWarningFlag();
+  _resetLogs();
+
+  const globalPath = getGlobalGSDPreferencesPath();
+  writeFileSync(
+    globalPath,
+    [
+      "---",
+      "version: 1",
+      "models:",
+      "  validation:",
+      "    openrouter/deepseek/deepseek-v4-pro",
+      "    thinking: high",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const globalPrefs = loadGlobalGSDPreferences();
+  assert.equal(globalPrefs?.ignored, true, "malformed global should be marked ignored");
+
+  // Symmetric with malformed project + no global: effective result should be null,
+  // not an effective object with ignored:true leaking through.
+  const loaded = loadEffectiveGSDPreferences(tempProject);
+  assert.equal(loaded, null, "effective preferences should be null when only global file is malformed");
+});
+
 // ── Experimental preferences ─────────────────────────────────────────────────
 
 test("experimental.rtk: true is accepted and stored", () => {

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -26,6 +26,7 @@ import {
   renderPreferencesForSystemPrompt,
   _resetParseWarningFlag,
 } from "../preferences.ts";
+import { collectPreferenceDiagnostics, formatPreferenceDiagnostic } from "../preferences-diagnostics.ts";
 import { formatConfiguredModel, toPersistedModelId } from "../commands-prefs-wizard.ts";
 import { _resetLogs, peekLogs } from "../workflow-logger.ts";
 import type { GSDPreferences, GSDModelConfigV2, GSDPhaseModelConfig } from "../preferences.ts";
@@ -817,6 +818,143 @@ bad: [
 
   _resetParseWarningFlag();
   _resetLogs();
+});
+
+test("malformed global preferences load with a structured parse diagnostic", (t) => {
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-diagnostic-home-"));
+  t.after(() => {
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempGsdHome, { recursive: true, force: true });
+    _resetParseWarningFlag();
+    _resetLogs();
+  });
+
+  process.env.GSD_HOME = tempGsdHome;
+  _resetParseWarningFlag();
+  _resetLogs();
+  writeFileSync(
+    join(tempGsdHome, "PREFERENCES.md"),
+    [
+      "---",
+      "version: 1",
+      "models:",
+      "  validation:",
+      "    openrouter/deepseek/deepseek-v4-pro",
+      "    thinking: high",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const loaded = loadGlobalGSDPreferences();
+  assert.notEqual(loaded, null);
+  assert.deepEqual(loaded!.preferences, {});
+  const diagnostic = loaded!.diagnostics?.[0];
+  assert.equal(diagnostic?.kind, "parse");
+  assert.equal(diagnostic?.severity, "error");
+  assert.equal(diagnostic?.line, 5);
+  assert.equal(diagnostic?.column, 5);
+  assert.equal(diagnostic?.ignored, true);
+  assert.match(diagnostic?.message ?? "", /Implicit keys need/);
+
+  const formatted = formatPreferenceDiagnostic(diagnostic!);
+  assert.match(formatted, /GSD global preferences error/);
+  assert.match(formatted, /line 5, column 5/);
+  assert.match(formatted, /Preferences from this file were ignored/);
+});
+
+test("project preference validation errors load with structured diagnostics", (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-validation-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-validation-home-"));
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+  writeFileSync(
+    join(tempProject, ".gsd", "PREFERENCES.md"),
+    "---\nversion: 3\n---\n",
+    "utf-8",
+  );
+
+  const loaded = loadProjectGSDPreferences(tempProject);
+  assert.notEqual(loaded, null);
+  assert.equal(loaded!.preferences.version, undefined);
+  const diagnostic = loaded!.diagnostics?.find((item) => item.kind === "validation");
+  assert.equal(diagnostic?.scope, "project");
+  assert.equal(diagnostic?.severity, "error");
+  assert.equal(diagnostic?.sanitized, true);
+  assert.match(diagnostic?.message ?? "", /unsupported version 3/);
+
+  const collected = collectPreferenceDiagnostics(tempProject);
+  assert.ok(
+    collected.some((item) => item.path === loaded!.path && item.message.includes("unsupported version 3")),
+    "collector should include project validation diagnostics",
+  );
+});
+
+test("malformed project preferences do not override effective global wrapper", (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-effective-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-effective-home-"));
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+    _resetParseWarningFlag();
+    _resetLogs();
+  });
+
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+  _resetParseWarningFlag();
+  _resetLogs();
+
+  const globalPath = getGlobalGSDPreferencesPath();
+  const projectPath = getProjectGSDPreferencesPath(tempProject);
+  writeFileSync(globalPath, "---\nlanguage: Spanish\n---\n", "utf-8");
+  writeFileSync(
+    projectPath,
+    [
+      "---",
+      "version: 1",
+      "models:",
+      "  validation:",
+      "    openrouter/deepseek/deepseek-v4-pro",
+      "    thinking: high",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const projectPrefs = loadProjectGSDPreferences(tempProject);
+  assert.equal(projectPrefs?.ignored, true);
+
+  const loaded = loadEffectiveGSDPreferences(tempProject);
+  assert.notEqual(loaded, null);
+  assert.equal(loaded!.path, globalPath);
+  assert.equal(loaded!.scope, "global");
+  assert.equal(loaded!.preferences.language, "Spanish");
+  assert.ok(
+    loaded!.diagnostics?.some((item) => item.path === projectPath && item.kind === "parse"),
+    "effective global preferences should carry malformed project diagnostics",
+  );
 });
 
 // ── Experimental preferences ─────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 
 import { autoSession } from "../auto-runtime-state.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { _resetPreferenceDiagnosticNotificationsForTests } from "../preferences-diagnostics.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HOOKS_SOURCE = readFileSync(
@@ -484,4 +485,83 @@ test("session_start and session_switch apply disabled model provider policy from
     ["anthropic"],
     "session_switch should re-read preferences for the switched project/session context",
   );
+});
+
+test("session_start surfaces malformed preference diagnostics through visible notifications", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-session-pref-diagnostics-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const tempGsdHome = join(dir, "home");
+  mkdirSync(tempGsdHome, { recursive: true });
+
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(dir);
+  _resetPreferenceDiagnosticNotificationsForTests();
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    _resetPreferenceDiagnosticNotificationsForTests();
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  writeFileSync(
+    join(dir, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "version: 1",
+      "models:",
+      "  validation:",
+      "    openrouter/deepseek/deepseek-v4-pro",
+      "    thinking: high",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<void> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
+  const ctx = {
+    hasUI: true,
+    ui: {
+      notify: (message: string, level?: string) => notifications.push({ message, level }),
+      setStatus: () => {},
+      setFooter: () => {},
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: () => {},
+    },
+    sessionManager: { getSessionId: () => null },
+    model: null,
+    setCompactionThresholdOverride: () => {},
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => false,
+    },
+  };
+
+  registerHooks(pi, []);
+
+  const sessionStart = handlers.get("session_start");
+  assert.ok(sessionStart, "session_start handler must be registered");
+  await sessionStart!({}, ctx);
+
+  const diagnostic = notifications.find((notification) =>
+    notification.message.includes("GSD project preferences error"),
+  );
+  assert.equal(diagnostic?.level, "error");
+  assert.match(diagnostic?.message ?? "", /could not be parsed/);
+  assert.match(diagnostic?.message ?? "", /line 5, column 5/);
+  assert.match(diagnostic?.message ?? "", /Preferences from this file were ignored/);
 });


### PR DESCRIPTION
## Intent

Issue #582 asks for GSD preference parse and validation failures to be prominent instead of silently ignored. The intended behavior is to preserve the existing non-throwing preference fallback semantics, but attach structured diagnostics for parse and validation problems; surface those diagnostics through session-start notifications, /gsd doctor, and auto-mode preflight so users get actionable file/line guidance before long-running automation proceeds. Auto-mode diagnostics must re-surface even if the same problem was shown at session start, while each surface still dedupes repeats. Malformed parse-ignored project files should carry diagnostics without becoming the effective wrapper or blocking fallback to valid global or legacy preference files. Keep the change scoped to GSD preference loading/diagnostics and avoid unrelated workflow behavior changes.

## What Changed

- Preference loading now attaches structured parse/validation diagnostics (file, scope, severity) instead of silently ignoring malformed files, while keeping the existing non-throwing fallback so a malformed project file still falls back to valid global/legacy preferences without becoming the effective wrapper.
- Added `preferences-diagnostics.ts` to collect and dedupe diagnostics and surface them through three channels — session-start notifications (via `register-hooks.ts`), `/gsd doctor`, and the auto-mode preflight (`commands/handlers/auto.ts`) — where auto-mode re-surfaces problems even if already shown at session start, each surface still deduping repeats.
- Documented the new behavior across user docs (configuration, troubleshooting, auto-mode, preferences reference) and added test coverage for diagnostics collection, preference loading fallback, and the session-start footer.

## Risk Assessment

✅ Low: The change is additive and well-bounded, carefully preserves existing non-throwing fallback semantics, has no observable behavior change for existing callers, and is covered by focused tests; the only finding is a harmless metadata inconsistency.

## Testing

ran tests and captured transcript, all pass

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/resources/extensions/gsd/preferences.ts:207` - Asymmetric handling of the `ignored` flag in loadEffectiveGSDPreferences: when the project file is malformed, effectiveProjectPreferences is nulled and (with no global) the function returns null. But when the GLOBAL file is malformed and there is no project file, the `else if (!effectiveProjectPreferences)` branch returns mergePreferenceMetadata(globalPreferences, ...) which spreads `...primary`, so the result carries `ignored: true` with empty preferences. Both cases yield default/empty effective prefs so behavior is harmless, but the leaked `ignored` flag on an effective result is inconsistent. Consider treating a malformed global identically (drop the flag or normalize it out of the effective result).

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `unit tests pass`
- `end to end transcript captured`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/zh-CN/user-docs/configuration.md` - Chinese translations under docs/zh-CN/ are not synced with the new preference-diagnostics behavior. docs/zh-CN/user-docs/configuration.md mirrors the English configuration doc but lacks the new &#39;Invalid or malformed preferences&#39; content; zh-CN has no troubleshooting.md or auto-mode.md at all, indicating translations are maintained as a separate batched effort. Left unfixed because injecting English text into the Chinese docs would be inconsistent and proper translation requires human/translator judgment.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783539029&installation_id=134682257&pr_number=584&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F584&signature=80f971a9fc64904b61309f11effaff135b9bb97092f86b38d3fbdd4d2951e300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive reporting and clearer fallback merge for preferences; existing non-throwing semantics are preserved and covered by tests. No auth, data, or auto-loop behavior changes beyond advisory notifications.
> 
> **Overview**
> Surfaces **malformed or invalid `PREFERENCES.md`** through structured diagnostics instead of silent fallback, while keeping preference loading non-throwing.
> 
> **Loading & merge:** `preferences.ts` now records parse/validation issues (including YAML line/column), marks parse-failed files as `ignored`, walks global/legacy candidates via `loadFirstUsablePreferencesFile`, and excludes ignored files from effective merge so a bad project file does not become the effective wrapper.
> 
> **User visibility:** New `preferences-diagnostics.ts` collects, formats, and notifies with per-surface dedupe. Diagnostics appear at **session start**, **`/gsd auto` preflight** (re-shown across surfaces), and **`/gsd doctor`** as `invalid_preferences` issues.
> 
> **Docs & tests:** User docs and preferences reference describe the behavior; tests cover loading fallback, notifications, doctor filtering, and auto preflight ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e7dee74353fcdab2831d7e4d9dcb6b61ec53f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->