### PR TITLE
Fix browser UAT tool availability

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -45,6 +45,7 @@ import { logWarning } from "./workflow-logger.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { readUnitRuntimeRecord, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
 import { describeMilestoneReadinessPhase } from "./milestone-readiness.js";
+import type { ToolSurfaceSnapshot } from "./tool-surface-snapshot.js";
 
 const ACTIVE_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 
@@ -86,6 +87,8 @@ export interface AutoDashboardData {
   rtkEnabled?: boolean;
   /** Cross-process: another auto-mode session detected via auto.lock (PID, startedAt) */
   remoteSession?: { pid: number; startedAt: string; unitType: string; unitId: string };
+  /** Last typed tool-surface snapshot for active auto-mode scoping/debugging. */
+  toolSurface?: ToolSurfaceSnapshot | null;
 }
 
 export interface CompletionDashboardSnapshot {
@@ -188,6 +191,18 @@ export function unitPhaseLabel(unitType: string): string {
     case "custom-step": return "WORKFLOW";
     default: return unitType.toUpperCase();
   }
+}
+
+export function formatToolSurfaceSnapshot(snapshot: ToolSurfaceSnapshot | null | undefined): string | null {
+  if (!snapshot) return null;
+  const counts = [
+    `model ${snapshot.modelFacingToolNames.length}`,
+    `registered ${snapshot.registeredToolNames.length}`,
+    `scoped ${snapshot.scopedToolNames.length}`,
+    `presented ${snapshot.presentedToolNames.length}`,
+  ];
+  const label = snapshot.unitType ?? snapshot.phase ?? snapshot.source;
+  return `${label}: ${counts.join(" / ")}`;
 }
 
 function peekNext(unitType: string, state: GSDState): string {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -153,6 +153,8 @@ export interface DispatchContext {
   sessionProvider?: string;
   /** Active tools in the current session, used for transport preflight checks. */
   activeTools?: string[];
+  /** Registered tools in the current session, used for run-uat tools re-scoped at dispatch. */
+  registeredTools?: string[];
   /** Session model base URL, used for transport preflight checks. */
   sessionBaseUrl?: string;
   /** Session model auth mode, used for transport preflight checks. */
@@ -734,7 +736,17 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "run-uat (post-completion)",
-    match: async ({ state, mid, basePath, prefs, sessionProvider, sessionAuthMode, activeTools, sessionBaseUrl }) => {
+    match: async ({
+      state,
+      mid,
+      basePath,
+      prefs,
+      sessionProvider,
+      sessionAuthMode,
+      activeTools,
+      registeredTools,
+      sessionBaseUrl,
+    }) => {
       const needsRunUat = await checkNeedsRunUat(basePath, mid, state, prefs);
       if (!needsRunUat) return null;
       const { sliceId, uatType } = needsRunUat;
@@ -753,6 +765,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const browserToolError = getUatBrowserToolSupportError({
         uatType,
         activeTools,
+        registeredTools,
         milestoneId: mid,
         sliceId,
       });

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -122,6 +122,14 @@ export function getToolBaselineSnapshot(pi: ExtensionAPI): string[] {
   return [...new Set([...baseline, ...live])];
 }
 
+export function getRegisteredToolSnapshot(pi: ExtensionAPI): string[] {
+  if (typeof pi.getAllTools !== "function") return getToolBaselineSnapshot(pi);
+  const names = pi.getAllTools()
+    .map((tool) => tool.name)
+    .filter((name): name is string => typeof name === "string" && name.length > 0);
+  return [...new Set(names)];
+}
+
 /**
  * Models eligible for the pre-dispatch policy gate. Prefer registry-available
  * models; when that list is empty (common after worktree resume before registry

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -9,8 +9,19 @@ import {
   markToolEnd as markTrackedToolEnd,
   markToolStart as markTrackedToolStart,
 } from "./auto-tool-tracking.js";
+import {
+  createToolSurfaceSnapshot,
+  type ToolSurfaceSnapshot,
+  type ToolSurfaceSnapshotInput,
+} from "./tool-surface-snapshot.js";
+
+export type {
+  ToolSurfaceSnapshot,
+  ToolSurfaceSnapshotInput,
+} from "./tool-surface-snapshot.js";
 
 export const autoSession = new AutoSession();
+let currentToolSurfaceSnapshot: ToolSurfaceSnapshot | null = null;
 
 export type AutoRuntimeSnapshot = {
   active: boolean;
@@ -20,6 +31,7 @@ export type AutoRuntimeSnapshot = {
   orchestrationPhase?: "idle" | "running" | "paused" | "stopped" | "error";
   orchestrationTransitionCount?: number;
   orchestrationLastTransitionAt?: number;
+  toolSurface: ToolSurfaceSnapshot | null;
 };
 
 export function getAutoRuntimeSnapshot(): AutoRuntimeSnapshot {
@@ -32,7 +44,17 @@ export function getAutoRuntimeSnapshot(): AutoRuntimeSnapshot {
     orchestrationPhase: orchestrationStatus?.phase,
     orchestrationTransitionCount: orchestrationStatus?.transitionCount,
     orchestrationLastTransitionAt: orchestrationStatus?.lastTransitionAt,
+    toolSurface: autoSession.active || autoSession.paused ? currentToolSurfaceSnapshot : null,
   };
+}
+
+export function recordAutoToolSurfaceSnapshot(input: ToolSurfaceSnapshotInput): ToolSurfaceSnapshot {
+  currentToolSurfaceSnapshot = createToolSurfaceSnapshot(input);
+  return currentToolSurfaceSnapshot;
+}
+
+export function clearAutoToolSurfaceSnapshot(): void {
+  currentToolSurfaceSnapshot = null;
 }
 
 export function isAutoActive(): boolean {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -320,7 +320,7 @@ export type {
   UnitRouting,
   StartModel,
 } from "./auto/session.js";
-import { autoSession as s } from "./auto-runtime-state.js";
+import { autoSession as s, getAutoRuntimeSnapshot } from "./auto-runtime-state.js";
 import { gsdHome } from "./gsd-home.js";
 import { createWorkspace, scopeMilestone } from "./workspace.js";
 import {
@@ -791,6 +791,7 @@ export { type AutoDashboardData } from "./auto-dashboard.js";
 
 export function getAutoDashboardData(): AutoDashboardData {
   const ledger = getLedger();
+  const runtimeSnapshot = getAutoRuntimeSnapshot();
   const totals = ledger ? getProjectTotals(ledger.units) : null;
   const sessionId = s.cmdCtx?.sessionManager?.getSessionId?.() ?? null;
   const rtkSavings = sessionId && s.basePath
@@ -822,6 +823,7 @@ export function getAutoDashboardData(): AutoDashboardData {
     pendingCaptureCount,
     rtkSavings,
     rtkEnabled,
+    toolSurface: runtimeSnapshot.toolSurface,
   };
 }
 

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -48,7 +48,7 @@ import { WorktreeStateProjection } from "../worktree-state-projection.js";
 import { WorktreeLifecycle } from "../worktree-lifecycle.js";
 import { createWorkspace, scopeMilestone } from "../workspace.js";
 import { supportsStructuredQuestions } from "../workflow-mcp.js";
-import { getToolBaselineSnapshot } from "../auto-model-selection.js";
+import { getRegisteredToolSnapshot, getToolBaselineSnapshot } from "../auto-model-selection.js";
 import { deriveState } from "../state.js";
 import { parseUnitId } from "../unit-id.js";
 import { isClosedStatus } from "../status-guards.js";
@@ -207,6 +207,7 @@ export async function decideOrchestratorDispatch(
   // active set may be narrowed by the prior unit before selectAndApplyModel
   // restores it, causing false transport-preflight failures (#477 follow-up).
   const activeTools = getToolBaselineSnapshot(pi);
+  const registeredTools = getRegisteredToolSnapshot(pi);
   // Mirrors runDispatch: deep-planning keeps approval gates in plain chat
   // because structured questions can be cancelled outside the chat turn on
   // some transports.
@@ -254,6 +255,7 @@ export async function decideOrchestratorDispatch(
     sessionProvider,
     modelRegistry,
     activeTools,
+    registeredTools,
     sessionAuthMode: authMode,
     sessionBaseUrl: ctx.model?.baseUrl,
   });

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -86,7 +86,12 @@ import {
   supportsStructuredQuestions,
 } from "../workflow-mcp.js";
 import { prepareWorkflowMcpForProject } from "../workflow-mcp-auto-prep.js";
-import { getToolBaselineSnapshot, applyThinkingLevelForModel, floorThinkingLevelForUnit } from "../auto-model-selection.js";
+import {
+  applyThinkingLevelForModel,
+  floorThinkingLevelForUnit,
+  getRegisteredToolSnapshot,
+  getToolBaselineSnapshot,
+} from "../auto-model-selection.js";
 import type { DispatchAction } from "../auto-dispatch.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { createWorktreeSafetyModule, type WorktreeSafetyResult } from "../worktree-safety.js";
@@ -1459,6 +1464,7 @@ export async function runDispatch(
   // Checking a stale-narrowed set causes false transport-preflight warnings
   // that repeat on every /gsd auto resume (#477 follow-up).
   const activeTools = getToolBaselineSnapshot(pi);
+  const registeredTools = getRegisteredToolSnapshot(pi);
   // Deep planning intentionally keeps human checkpoints in plain chat. In
   // Claude Code/local MCP transports, structured question requests can be
   // cancelled outside the normal chat flow, which made approval gates easy to
@@ -1483,6 +1489,7 @@ export async function runDispatch(
     sessionProvider: ctx.model?.provider,
     modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
     activeTools,
+    registeredTools,
     sessionBaseUrl: ctx.model?.baseUrl,
     sessionAuthMode: authMode,
   });
@@ -1509,6 +1516,7 @@ export async function runDispatch(
       sessionProvider: ctx.model?.provider,
       modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
       activeTools,
+      registeredTools,
       sessionBaseUrl: ctx.model?.baseUrl,
       sessionAuthMode: authMode,
     });

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -27,6 +27,7 @@ import {
   isAutoPaused,
   markToolEnd,
   markToolStart,
+  recordAutoToolSurfaceSnapshot,
   recordToolInvocationError,
 } from "../auto-runtime-state.js";
 import { applyProviderPayloadPolicy } from "../provider-payload-policy.js";
@@ -50,6 +51,7 @@ import { getGuidedUnitContext } from "../guided-unit-context.js";
 import { registerPlanMilestoneSchemaRecovery } from "./plan-milestone-schema-recovery.js";
 import { AUTO_UNIT_SCOPED_TOOLS, RUN_UAT_BROWSER_TOOL_NAMES, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
 import { filterToolsForProvider } from "../model-router.js";
+import { mcpToolMatchesBaseName } from "../mcp-tool-name.js";
 import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
 import { supportsSourceObservationsForUnit } from "../source-observations.js";
 
@@ -213,10 +215,7 @@ function resolveScopedToolNames(
     const scopedMatches: string[] = [];
 
     for (const activeName of activeToolNames) {
-      if (!activeName.startsWith("mcp__")) continue;
-      const toolSeparator = activeName.indexOf("__", "mcp__".length);
-      if (toolSeparator < 0) continue;
-      if (activeName.slice(toolSeparator + 2) === requested) {
+      if (mcpToolMatchesBaseName(activeName, requested)) {
         scopedMatches.push(activeName);
       }
     }
@@ -277,7 +276,7 @@ export function buildRunUatGsdToolSet(
   const resolved = [...new Set(scoped)];
 
   const unresolved = RUN_UAT_WORKFLOW_TOOL_NAMES.filter(
-    (tool) => !resolved.some((name) => name === tool || (name.startsWith("mcp__") && name.endsWith(`__${tool}`))),
+    (tool) => !resolved.some((name) => name === tool || mcpToolMatchesBaseName(name, tool)),
   );
   if (unresolved.length > 0) {
     safetyLogWarning(
@@ -369,11 +368,21 @@ function applyMinimalGsdToolSurface(pi: ExtensionAPI): void {
   if (isFullGsdToolSurfaceRequested()) return;
   const dash = getAutoRuntimeSnapshot();
   if (dash.active && dash.currentUnit) {
-    pi.setActiveTools(buildMinimalAutoGsdToolSet(
-      pi.getActiveTools(),
+    const currentToolNames = pi.getActiveTools();
+    const registeredToolNames = resolveRegisteredToolNames(pi, currentToolNames);
+    const scopedToolNames = buildMinimalAutoGsdToolSet(
+      currentToolNames,
       dash.currentUnit.type,
-      resolveRegisteredToolNames(pi, pi.getActiveTools()),
-    ));
+      registeredToolNames,
+    );
+    recordAutoToolSurfaceSnapshot({
+      source: "runtime-scope",
+      unitType: dash.currentUnit.type,
+      modelFacingToolNames: scopedToolNames,
+      registeredToolNames,
+      scopedToolNames,
+    });
+    pi.setActiveTools(scopedToolNames);
     return;
   }
   if (!isGeneralGsdToolScopingRequested()) return;
@@ -390,6 +399,13 @@ export function scopeGsdWorkflowToolsForDispatch(
   const scoped = unitType
     ? buildMinimalAutoGsdToolSet(current, unitType, registeredToolNames)
     : buildMinimalGsdWorkflowToolSet(current, registeredToolNames);
+  recordAutoToolSurfaceSnapshot({
+    source: "dispatch-scope",
+    unitType,
+    modelFacingToolNames: scoped,
+    registeredToolNames,
+    scopedToolNames: scoped,
+  });
   const toolsChanged = !(scoped.length === current.length && scoped.every((name, index) => name === current[index]));
   const canScopeSkills = unitHasSkillManifest(unitType) && pi.getVisibleSkills && pi.setVisibleSkills;
   if (!toolsChanged && !canScopeSkills) {
@@ -1460,25 +1476,44 @@ export function registerHooks(
       event.selectedModelProvider,
     ).compatible.filter((name) => !(dropAliases && isWorkflowAliasTool(name)));
     const guidedUnit = getGuidedUnitContext();
+    const requestRegisteredToolNames = guidedUnit?.unitType === "run-uat"
+      ? compatibleRegisteredToolNames
+      : registeredToolNames;
     const requestScoped = buildRequestScopedGsdToolSet(
       guidedUnit?.unitType === "run-uat" ? aliasFilteredCompatible : providerCompatible,
       event.requestCustomMessages,
-      guidedUnit?.unitType === "run-uat" ? compatibleRegisteredToolNames : registeredToolNames,
+      requestRegisteredToolNames,
       guidedUnit?.unitType,
     );
     if (requestScoped) {
+      recordAutoToolSurfaceSnapshot({
+        source: "provider-adjustment",
+        unitType: guidedUnit?.unitType,
+        modelFacingToolNames: requestScoped,
+        registeredToolNames: requestRegisteredToolNames,
+        scopedToolNames: requestScoped,
+      });
       return { toolNames: requestScoped };
     }
     const dash = getAutoRuntimeSnapshot();
     if (dash.active && dash.currentUnit) {
+      const registeredForUnit = dash.currentUnit.type === "run-uat"
+        ? compatibleRegisteredToolNames
+        : resolveRegisteredToolNames(pi, event.activeToolNames);
+      const scopedToolNames = buildMinimalAutoGsdToolSet(
+        dash.currentUnit.type === "run-uat" ? aliasFilteredCompatible : providerCompatible,
+        dash.currentUnit.type,
+        registeredForUnit,
+      );
+      recordAutoToolSurfaceSnapshot({
+        source: "provider-adjustment",
+        unitType: dash.currentUnit.type,
+        modelFacingToolNames: scopedToolNames,
+        registeredToolNames: registeredForUnit,
+        scopedToolNames,
+      });
       return {
-        toolNames: buildMinimalAutoGsdToolSet(
-          dash.currentUnit.type === "run-uat" ? aliasFilteredCompatible : providerCompatible,
-          dash.currentUnit.type,
-          dash.currentUnit.type === "run-uat"
-            ? compatibleRegisteredToolNames
-            : resolveRegisteredToolNames(pi, event.activeToolNames),
-        ),
+        toolNames: scopedToolNames,
       };
     }
     if (isGeneralGsdToolScopingRequested()) {

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { minimatch } from "minimatch";
 
 import { GSD_PHASE_SCOPE_DISPLAY_REASON, shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
+import { stripMcpToolPrefix } from "../mcp-tool-name.js";
 import { getIsolationMode } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
@@ -123,9 +124,7 @@ const GATE_SAFE_TOOLS = new Set([
 ]);
 
 export function canonicalToolName(toolName: string): string {
-  if (!toolName.startsWith("mcp__")) return toolName;
-  const toolSeparator = toolName.indexOf("__", "mcp__".length);
-  return toolSeparator >= 0 ? toolName.slice(toolSeparator + 2) : toolName;
+  return stripMcpToolPrefix(toolName);
 }
 
 export interface WriteGateSnapshot {

--- a/src/resources/extensions/gsd/mcp-filter.ts
+++ b/src/resources/extensions/gsd/mcp-filter.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 
 import type { ClaudeCodeMcpConfig } from "./preferences-types.js";
+import { toMcpWildcardToolName } from "./mcp-tool-name.js";
 import { resolveModelMcpConfig } from "./preferences-mcp.js";
 
 interface McpJsonFile {
@@ -159,5 +160,5 @@ export function computeMcpDisallowedTools(
     blocked.delete(workflowServerName);
   }
 
-  return [...blocked].map((name) => `mcp__${name}__*`);
+  return [...blocked].map(toMcpWildcardToolName);
 }

--- a/src/resources/extensions/gsd/mcp-tool-name.ts
+++ b/src/resources/extensions/gsd/mcp-tool-name.ts
@@ -1,0 +1,35 @@
+// Project/App: gsd-pi
+// File Purpose: Shared parsing and formatting helpers for MCP-scoped tool names.
+
+const MCP_TOOL_PREFIX = "mcp__";
+
+export interface ParsedMcpToolName {
+  serverName: string;
+  toolName: string;
+}
+
+export function parseMcpToolName(toolName: string): ParsedMcpToolName | null {
+  if (!toolName.startsWith(MCP_TOOL_PREFIX)) return null;
+  const toolSeparator = toolName.indexOf("__", MCP_TOOL_PREFIX.length);
+  if (toolSeparator < 0) return null;
+  return {
+    serverName: toolName.slice(MCP_TOOL_PREFIX.length, toolSeparator),
+    toolName: toolName.slice(toolSeparator + 2),
+  };
+}
+
+export function stripMcpToolPrefix(toolName: string): string {
+  return parseMcpToolName(toolName)?.toolName ?? toolName;
+}
+
+export function toMcpToolName(serverName: string, toolName: string): string {
+  return `${MCP_TOOL_PREFIX}${serverName}__${toolName}`;
+}
+
+export function toMcpWildcardToolName(serverName: string): string {
+  return toMcpToolName(serverName, "*");
+}
+
+export function mcpToolMatchesBaseName(toolName: string, baseName: string): boolean {
+  return parseMcpToolName(toolName)?.toolName === baseName;
+}

--- a/src/resources/extensions/gsd/question-transport.ts
+++ b/src/resources/extensions/gsd/question-transport.ts
@@ -1,6 +1,8 @@
 // Project/App: gsd-pi
 // File Purpose: Resolve how workflow units should ask the user for input.
 
+import { parseMcpToolName, toMcpToolName } from "./mcp-tool-name.js";
+
 export type StructuredQuestionsFlag = "true" | "false";
 
 export interface QuestionTransportOptions {
@@ -31,16 +33,6 @@ export interface WorkflowQuestionToolSurfaceResolution extends QuestionTransport
   disallowedTools: string[];
 }
 
-function mcpToolParts(toolName: string): { serverName: string; baseName: string } | null {
-  if (!toolName.startsWith("mcp__")) return null;
-  const toolSeparator = toolName.indexOf("__", "mcp__".length);
-  if (toolSeparator < 0) return null;
-  return {
-    serverName: toolName.slice("mcp__".length, toolSeparator),
-    baseName: toolName.slice(toolSeparator + 2),
-  };
-}
-
 function isWorkflowMcpServerName(serverName: string): boolean {
   const normalized = serverName.toLowerCase();
   return normalized === "gsd" || normalized.includes("workflow");
@@ -56,10 +48,10 @@ export function usesWorkflowMcpTransport(
 export function hasAskUserQuestionsTool(activeTools: string[]): boolean {
   return activeTools.some((toolName) => {
     if (toolName === "ask_user_questions") return true;
-    const mcp = mcpToolParts(toolName);
+    const mcp = parseMcpToolName(toolName);
     if (!mcp) return false;
-    if (mcp.baseName === "ask_user_questions") return true;
-    return mcp.baseName === "*" && isWorkflowMcpServerName(mcp.serverName);
+    if (mcp.toolName === "ask_user_questions") return true;
+    return mcp.toolName === "*" && isWorkflowMcpServerName(mcp.serverName);
   });
 }
 
@@ -114,7 +106,7 @@ export function resolveWorkflowQuestionToolSurface(
   options: WorkflowQuestionToolSurfaceOptions,
 ): WorkflowQuestionToolSurfaceResolution {
   const questionToolName = options.workflowServerName && !options.workflowExplicitlyBlocked
-    ? `mcp__${options.workflowServerName}__ask_user_questions`
+    ? toMcpToolName(options.workflowServerName, "ask_user_questions")
     : undefined;
   const activeTools = [
     ...options.exactWorkflowMcpTools,
@@ -134,7 +126,7 @@ export function resolveWorkflowQuestionToolSurface(
     (options.workflowMcpTools.length > 0 || exactQuestionToolAllowed);
   const disallowedTools =
     options.workflowServerName && transport.questionToolAvailable && !workflowQuestionsEnabled
-      ? [`mcp__${options.workflowServerName}__ask_user_questions`]
+      ? [toMcpToolName(options.workflowServerName, "ask_user_questions")]
       : [];
 
   return {

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -29,11 +29,16 @@ import {
   _refreshLastCommitForTests,
   _getLastCommitForTests,
   _getLastCommitFetchedAtForTests,
+  formatToolSurfaceSnapshot,
   formatRuntimeHealthSignal,
   shouldRenderRoadmapProgress,
 } from "../auto-dashboard.ts";
 import { getAutoDashboardData } from "../auto.ts";
-import { autoSession } from "../auto-runtime-state.ts";
+import {
+  autoSession,
+  clearAutoToolSurfaceSnapshot,
+  recordAutoToolSurfaceSnapshot,
+} from "../auto-runtime-state.ts";
 import { formatRtkSavingsLabel } from "../../shared/rtk-session-stats.ts";
 import {
   openDatabase,
@@ -528,6 +533,29 @@ test("getAutoDashboardData returns RTK savings in the dashboard payload", () => 
     cleanup(autoSession.basePath);
     autoSession.reset();
   }
+});
+
+test("getAutoDashboardData exposes typed tool-surface snapshots", () => {
+  autoSession.reset();
+  clearAutoToolSurfaceSnapshot();
+  autoSession.active = true;
+  recordAutoToolSurfaceSnapshot({
+    source: "provider-adjustment",
+    unitType: "run-uat",
+    modelFacingToolNames: ["read"],
+    registeredToolNames: ["read", "browser_navigate"],
+    scopedToolNames: ["read", "browser_navigate"],
+    presentedToolNames: ["browser_navigate"],
+    capturedAt: 456,
+  });
+
+  const data = getAutoDashboardData();
+
+  assert.equal(data.toolSurface?.source, "provider-adjustment");
+  assert.equal(formatToolSurfaceSnapshot(data.toolSurface), "run-uat: model 1 / registered 2 / scoped 2 / presented 1");
+
+  autoSession.reset();
+  clearAutoToolSurfaceSnapshot();
 });
 
 test("RTK savings label formats the dashboard footer text", () => {

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -33,6 +33,7 @@ import {
   selectAndApplyModel,
   ModelPolicyDispatchBlockedError,
   clearToolBaseline,
+  getRegisteredToolSnapshot,
   getToolBaselineSnapshot,
 } from "../auto-model-selection.js";
 import { applyModelPolicyFilter } from "../uok/model-policy.js";
@@ -772,4 +773,21 @@ test("baseline union (#477): getToolBaselineSnapshot includes live tools not pre
     env.restoreEnv();
     env.cleanup();
   }
+});
+
+test("registered tool snapshot includes tools hidden from the active surface", () => {
+  const pi = {
+    getActiveTools: () => ["read"],
+    getAllTools: () => [
+      { name: "read" },
+      { name: "browser_navigate" },
+      { name: "mcp__gsd-browser__*" },
+    ],
+  };
+
+  assert.deepEqual(getRegisteredToolSnapshot(pi as any), [
+    "read",
+    "browser_navigate",
+    "mcp__gsd-browser__*",
+  ]);
 });

--- a/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
@@ -6,12 +6,15 @@ import assert from "node:assert/strict";
 
 import {
   autoSession,
+  clearAutoToolSurfaceSnapshot,
   clearToolInvocationError,
   getAutoRuntimeSnapshot,
+  recordAutoToolSurfaceSnapshot,
 } from "../auto-runtime-state.ts";
 
 test("getAutoRuntimeSnapshot includes orchestration phase when available", () => {
   autoSession.reset();
+  clearAutoToolSurfaceSnapshot();
   autoSession.active = true;
   autoSession.basePath = "/tmp/project";
   autoSession.orchestration = {
@@ -33,8 +36,38 @@ test("getAutoRuntimeSnapshot includes orchestration phase when available", () =>
   assert.equal(snap.orchestrationPhase, "running");
   assert.equal(snap.orchestrationTransitionCount, 3);
   assert.equal(snap.orchestrationLastTransitionAt, 123);
+  assert.equal(snap.toolSurface, null);
 
   autoSession.reset();
+});
+
+test("getAutoRuntimeSnapshot includes the active typed tool-surface snapshot", () => {
+  autoSession.reset();
+  clearAutoToolSurfaceSnapshot();
+  autoSession.active = true;
+
+  recordAutoToolSurfaceSnapshot({
+    source: "dispatch-scope",
+    unitType: "run-uat",
+    modelFacingToolNames: ["read", "read", "gsd_uat_exec"],
+    registeredToolNames: ["read", "browser_navigate"],
+    scopedToolNames: ["read", "browser_navigate"],
+    presentedToolNames: ["gsd_uat_exec"],
+    capturedAt: 123,
+  });
+
+  const snap = getAutoRuntimeSnapshot();
+
+  assert.equal(snap.toolSurface?.source, "dispatch-scope");
+  assert.equal(snap.toolSurface?.unitType, "run-uat");
+  assert.deepEqual(snap.toolSurface?.modelFacingToolNames, ["read", "gsd_uat_exec"]);
+  assert.deepEqual(snap.toolSurface?.registeredToolNames, ["read", "browser_navigate"]);
+  assert.deepEqual(snap.toolSurface?.scopedToolNames, ["read", "browser_navigate"]);
+  assert.deepEqual(snap.toolSurface?.presentedToolNames, ["gsd_uat_exec"]);
+  assert.equal(snap.toolSurface?.capturedAt, 123);
+
+  autoSession.reset();
+  clearAutoToolSurfaceSnapshot();
 });
 
 test("clearToolInvocationError clears stale tool error state for active auto sessions", () => {
@@ -56,4 +89,5 @@ test("getAutoRuntimeSnapshot omits orchestration phase when seam not wired", () 
   assert.equal(snap.orchestrationPhase, undefined);
   assert.equal(snap.orchestrationTransitionCount, undefined);
   assert.equal(snap.orchestrationLastTransitionAt, undefined);
+  assert.equal(snap.toolSurface, null);
 });

--- a/src/resources/extensions/gsd/tests/dispatch-run-uat-browser-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-run-uat-browser-tools.test.ts
@@ -1,0 +1,88 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for run-uat browser tool availability checks.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+
+type DispatchRuleEntry = (typeof DISPATCH_RULES)[number];
+
+function runUatRule(): DispatchRuleEntry {
+  const rule = DISPATCH_RULES.find((entry) => entry.name === "run-uat (post-completion)");
+  assert.ok(rule, "run-uat dispatch rule must exist");
+  return rule;
+}
+
+function makeState(): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Browser UAT" },
+    activeSlice: { id: "S02", title: "Next Slice" },
+    activeTask: null,
+    phase: "verifying",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+  };
+}
+
+function scaffoldRunUatProject(basePath: string): void {
+  const milestoneDir = join(basePath, ".gsd", "milestones", "M001");
+  const sliceDir = join(milestoneDir, "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+
+  writeFileSync(join(milestoneDir, "M001-ROADMAP.md"), [
+    "# M001: Browser UAT",
+    "",
+    "## Slices",
+    "",
+    "- [x] **S01: Completed browser slice** `risk:low` `depends:[]`",
+    "- [ ] **S02: Next slice** `risk:low` `depends:[S01]`",
+    "",
+  ].join("\n"), "utf-8");
+
+  writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# S01 Summary\n\nDone.\n", "utf-8");
+  writeFileSync(join(sliceDir, "S01-UAT.md"), [
+    "# S01 UAT",
+    "",
+    "## UAT Type",
+    "- UAT mode: human-experience",
+    "",
+    "Open the app in a browser and verify the completed user flow.",
+    "",
+  ].join("\n"), "utf-8");
+}
+
+function makeContext(basePath: string, overrides: Partial<DispatchContext> = {}): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Browser UAT",
+    state: makeState(),
+    prefs: undefined,
+    activeTools: ["read", "gsd_uat_exec", "gsd_uat_result_save"],
+    ...overrides,
+  };
+}
+
+test("run-uat browser preflight uses registered tools when the active surface is scoped", async (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-run-uat-browser-tools-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+  scaffoldRunUatProject(basePath);
+
+  const blocked = await runUatRule().match(makeContext(basePath));
+  assert.equal(blocked?.action, "stop");
+  assert.match(blocked?.action === "stop" ? blocked.reason : "", /run-uat tool surface has none/);
+
+  const dispatched = await runUatRule().match(makeContext(basePath, {
+    registeredTools: ["browser_navigate"],
+  }));
+  assert.equal(dispatched?.action, "dispatch");
+  assert.equal(dispatched?.action === "dispatch" ? dispatched.unitType : undefined, "run-uat");
+  assert.equal(dispatched?.action === "dispatch" ? dispatched.unitId : undefined, "M001/S01");
+});

--- a/src/resources/extensions/gsd/tests/mcp-tool-name.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-tool-name.test.ts
@@ -1,0 +1,34 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for shared MCP tool-name parsing helpers.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  mcpToolMatchesBaseName,
+  parseMcpToolName,
+  stripMcpToolPrefix,
+  toMcpToolName,
+  toMcpWildcardToolName,
+} from "../mcp-tool-name.ts";
+
+test("parseMcpToolName parses exact and wildcard MCP tool names", () => {
+  assert.deepEqual(parseMcpToolName("mcp__gsd-workflow__ask_user_questions"), {
+    serverName: "gsd-workflow",
+    toolName: "ask_user_questions",
+  });
+  assert.deepEqual(parseMcpToolName("mcp__gsd-browser__*"), {
+    serverName: "gsd-browser",
+    toolName: "*",
+  });
+  assert.equal(parseMcpToolName("browser_navigate"), null);
+});
+
+test("MCP tool-name helpers strip, match, and format names consistently", () => {
+  assert.equal(stripMcpToolPrefix("mcp__custom-workflow__gsd_exec"), "gsd_exec");
+  assert.equal(stripMcpToolPrefix("read"), "read");
+  assert.equal(mcpToolMatchesBaseName("mcp__custom-workflow__gsd_exec", "gsd_exec"), true);
+  assert.equal(mcpToolMatchesBaseName("mcp__custom-workflow__gsd_exec", "gsd_summary_save"), false);
+  assert.equal(toMcpToolName("custom-workflow", "gsd_exec"), "mcp__custom-workflow__gsd_exec");
+  assert.equal(toMcpWildcardToolName("custom-workflow"), "mcp__custom-workflow__*");
+});

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   RUN_UAT_BROWSER_TOOL_NAMES,
+  resolveToolPresentationPlan,
   buildRunUatResultPresentation,
   buildRunUatPresentationForType,
   RUN_UAT_READ_ONLY_TOOL_NAMES,
@@ -177,6 +178,33 @@ test("browser-executable UAT presentation uses direct browser tools", () => {
     assert.ok(presentation.presentedTools.includes(toolName), `presentation should include browser tool ${toolName}`);
   }
   assert.ok(!presentation.presentedTools.some((toolName) => toolName.startsWith("mcp__gsd-browser__")));
+});
+
+test("run-uat presentation plans carry typed tool-surface snapshots", () => {
+  const plan = resolveToolPresentationPlan({
+    phase: "run-uat",
+    surface: "mcp",
+    workflowMcpServerName: "gsd-workflow",
+    availableToolNames: [
+      "gsd_uat_exec",
+      "gsd_uat_result_save",
+      "read",
+    ],
+    includeBrowserTools: [],
+  });
+
+  assert.equal(plan.toolSurface.source, "presentation-plan");
+  assert.equal(plan.toolSurface.phase, "run-uat");
+  assert.deepEqual(plan.toolSurface.scopedToolNames, [
+    "gsd_uat_exec",
+    "gsd_uat_result_save",
+    "read",
+  ]);
+  assert.deepEqual(plan.toolSurface.presentedToolNames, [
+    "mcp__gsd-workflow__gsd_uat_exec",
+    "mcp__gsd-workflow__gsd_uat_result_save",
+    "read",
+  ]);
 });
 
 test("live-runtime and mixed UAT presentations also surface browser tools", () => {

--- a/src/resources/extensions/gsd/tests/uat-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-policy.test.ts
@@ -66,6 +66,9 @@ describe("uat-policy", () => {
   it("detects direct and MCP-shaped browser tool surfaces", () => {
     assert.equal(hasUatBrowserToolSurface(["read", "browser_navigate"]), true);
     assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-browser__browser_navigate"]), true);
+    assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-browser__*"]), true);
+    assert.equal(hasUatBrowserToolSurface(["read", "mcp__browser-uat__*"]), true);
+    assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-workflow__*"]), false);
     assert.equal(hasUatBrowserToolSurface(["read", "gsd_uat_exec"]), false);
     assert.equal(hasUatBrowserToolSurface(undefined), false);
   });
@@ -84,6 +87,26 @@ describe("uat-policy", () => {
       getUatBrowserToolSupportError({
         uatType: "browser-executable",
         activeTools: undefined,
+        milestoneId: "M001",
+        sliceId: "S01",
+      }),
+      null,
+    );
+    assert.equal(
+      getUatBrowserToolSupportError({
+        uatType: "human-experience",
+        activeTools: ["read", "gsd_uat_exec"],
+        registeredTools: ["browser_navigate"],
+        milestoneId: "M001",
+        sliceId: "S01",
+      }),
+      null,
+    );
+    assert.equal(
+      getUatBrowserToolSupportError({
+        uatType: "human-experience",
+        activeTools: ["read", "gsd_uat_exec"],
+        registeredTools: ["mcp__gsd-browser__*"],
         milestoneId: "M001",
         sliceId: "S01",
       }),

--- a/src/resources/extensions/gsd/tool-presentation-plan.ts
+++ b/src/resources/extensions/gsd/tool-presentation-plan.ts
@@ -7,6 +7,8 @@ import {
   RUN_UAT_TOOL_PRESENTATION_PLAN_ID,
   RUN_UAT_WORKFLOW_TOOL_NAMES,
 } from "./unit-tool-contracts.js";
+import { parseMcpToolName, toMcpToolName } from "./mcp-tool-name.js";
+import { createToolSurfaceSnapshot, type ToolSurfaceSnapshot } from "./tool-surface-snapshot.js";
 import { uatTypeIncludesBrowser } from "./uat-policy.js";
 import { canonicalWorkflowSurfaceToolName } from "./workflow-tool-surface.js";
 
@@ -34,6 +36,7 @@ export interface ToolPresentationPlan {
   blockedToolNames: Array<{ name: string; reason: string }>;
   aliases: Array<{ requested: string; canonical: string }>;
   diagnostics: string[];
+  toolSurface: ToolSurfaceSnapshot;
 }
 
 export interface RunUatResultPresentation {
@@ -67,18 +70,10 @@ export function canonicalWorkflowToolName(toolName: string): string {
   return canonicalWorkflowSurfaceToolName(toolName);
 }
 
-export function parseMcpToolName(toolName: string): { server: string; tool: string } | null {
-  if (!toolName.startsWith("mcp__")) return null;
-  const toolSeparator = toolName.indexOf("__", "mcp__".length);
-  if (toolSeparator < 0) return null;
-  return {
-    server: toolName.slice("mcp__".length, toolSeparator),
-    tool: toolName.slice(toolSeparator + 2),
-  };
-}
+export { parseMcpToolName } from "./mcp-tool-name.js";
 
 export function toWorkflowMcpToolName(serverName: string, toolName: string): string {
-  return `mcp__${serverName}__${canonicalWorkflowToolName(toolName)}`;
+  return toMcpToolName(serverName, canonicalWorkflowToolName(toolName));
 }
 
 function dedupe(values: readonly string[]): string[] {
@@ -191,6 +186,14 @@ export function resolveToolPresentationPlan(options: {
           : name
       )
     : allowedToolNames;
+  const toolSurface = createToolSurfaceSnapshot({
+    source: "presentation-plan",
+    phase: options.phase,
+    modelFacingToolNames: options.availableToolNames ?? requested,
+    registeredToolNames: options.availableToolNames ?? requested,
+    scopedToolNames: allowedToolNames,
+    presentedToolNames,
+  });
 
   if (options.phase === "run-uat") {
     for (const forbidden of RUN_UAT_FORBIDDEN_TOOL_NAMES) {
@@ -207,5 +210,6 @@ export function resolveToolPresentationPlan(options: {
     blockedToolNames,
     aliases,
     diagnostics: [],
+    toolSurface,
   };
 }

--- a/src/resources/extensions/gsd/tool-surface-snapshot.ts
+++ b/src/resources/extensions/gsd/tool-surface-snapshot.ts
@@ -1,0 +1,47 @@
+// Project/App: gsd-pi
+// File Purpose: Typed snapshots for model-facing, registered, scoped, and presented tool surfaces.
+
+export type ToolSurfaceSnapshotSource =
+  | "runtime-scope"
+  | "dispatch-scope"
+  | "provider-adjustment"
+  | "presentation-plan";
+
+export interface ToolSurfaceSnapshot {
+  source: ToolSurfaceSnapshotSource;
+  unitType?: string;
+  phase?: string;
+  modelFacingToolNames: string[];
+  registeredToolNames: string[];
+  scopedToolNames: string[];
+  presentedToolNames: string[];
+  capturedAt: number;
+}
+
+export interface ToolSurfaceSnapshotInput {
+  source: ToolSurfaceSnapshotSource;
+  unitType?: string;
+  phase?: string;
+  modelFacingToolNames?: readonly string[];
+  registeredToolNames?: readonly string[];
+  scopedToolNames?: readonly string[];
+  presentedToolNames?: readonly string[];
+  capturedAt?: number;
+}
+
+function dedupeToolNames(toolNames: readonly string[] | undefined): string[] {
+  return [...new Set(toolNames ?? [])];
+}
+
+export function createToolSurfaceSnapshot(input: ToolSurfaceSnapshotInput): ToolSurfaceSnapshot {
+  return {
+    source: input.source,
+    unitType: input.unitType,
+    phase: input.phase,
+    modelFacingToolNames: dedupeToolNames(input.modelFacingToolNames),
+    registeredToolNames: dedupeToolNames(input.registeredToolNames),
+    scopedToolNames: dedupeToolNames(input.scopedToolNames),
+    presentedToolNames: dedupeToolNames(input.presentedToolNames),
+    capturedAt: input.capturedAt ?? Date.now(),
+  };
+}

--- a/src/resources/extensions/gsd/uat-policy.ts
+++ b/src/resources/extensions/gsd/uat-policy.ts
@@ -4,6 +4,7 @@
 import { extractUatType } from "./files.js";
 import type { UatType } from "./files.js";
 import { hasBrowserRequiredText } from "./browser-evidence.js";
+import { parseMcpToolName } from "./mcp-tool-name.js";
 
 export type { UatType } from "./files.js";
 
@@ -122,31 +123,39 @@ export function uatTypeIncludesBrowser(uatType: string | undefined): boolean {
   return isUatType(uatType) && UAT_MODE_POLICIES[uatType].browserTools;
 }
 
-function canonicalPresentedToolName(toolName: string): string {
-  if (!toolName.startsWith("mcp__")) return toolName;
-  const toolSeparator = toolName.indexOf("__", "mcp__".length);
-  return toolSeparator >= 0 ? toolName.slice(toolSeparator + 2) : toolName;
-}
-
 export function isUatBrowserToolName(toolName: string): boolean {
-  return canonicalPresentedToolName(toolName).startsWith("browser_");
+  const parsed = parseMcpToolName(toolName);
+  const canonicalName = parsed?.toolName ?? toolName;
+  if (canonicalName.startsWith("browser_")) return true;
+  return parsed?.toolName === "*" && parsed.serverName.toLowerCase().includes("browser");
 }
 
 export function hasUatBrowserToolSurface(activeTools: readonly string[] | undefined): boolean {
   return Array.isArray(activeTools) && activeTools.some(isUatBrowserToolName);
 }
 
+export function resolveUatBrowserToolSurface(options: {
+  activeTools: readonly string[] | undefined;
+  registeredTools?: readonly string[] | undefined;
+}): readonly string[] | undefined {
+  const surfaces = [options.activeTools, options.registeredTools].filter(Array.isArray);
+  if (surfaces.length === 0) return undefined;
+  return [...new Set(surfaces.flat())];
+}
+
 export function getUatBrowserToolSupportError(options: {
   uatType: UatType;
   activeTools: readonly string[] | undefined;
+  registeredTools?: readonly string[] | undefined;
   milestoneId: string;
   sliceId: string;
 }): string | null {
   if (!uatTypeIncludesBrowser(options.uatType)) return null;
-  if (!Array.isArray(options.activeTools)) return null;
-  if (hasUatBrowserToolSurface(options.activeTools)) return null;
+  const toolSurface = resolveUatBrowserToolSurface(options);
+  if (!toolSurface) return null;
+  if (hasUatBrowserToolSurface(toolSurface)) return null;
 
-  return `Cannot dispatch browser-backed run-uat for ${options.milestoneId}/${options.sliceId}: UAT mode "${options.uatType}" requires browser tools, but the active tool surface has none. Enable browser tools or change the UAT to a runtime-executable Playwright command, then rerun /gsd auto.`;
+  return `Cannot dispatch browser-backed run-uat for ${options.milestoneId}/${options.sliceId}: UAT mode "${options.uatType}" requires browser tools, but the run-uat tool surface has none. Enable browser tools or change the UAT to a runtime-executable Playwright command, then rerun /gsd auto.`;
 }
 
 export function isPartialEligibleUatType(uatType: UatType | undefined): boolean {

--- a/src/resources/extensions/gsd/uat-run.ts
+++ b/src/resources/extensions/gsd/uat-run.ts
@@ -103,7 +103,7 @@ function mergeBlockedTools(
 ): UatPresentationInput["blockedTools"] {
   const merged = new Map<string, { name: string; reason: string }>();
   for (const entry of [...(current ?? []), ...canonical]) {
-    merged.set(canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name), entry);
+    merged.set(canonicalWorkflowToolName(parseMcpToolName(entry.name)?.toolName ?? entry.name), entry);
   }
   return [...merged.values()];
 }
@@ -301,7 +301,7 @@ function quoteToolNames(toolNames: readonly string[]): string {
 function validateCanonicalPresentation(params: UatResultSaveParams): string | null {
   const errors: string[] = [];
   for (const toolName of params.presentation.presentedTools) {
-    const baseName = parseMcpToolName(toolName)?.tool ?? toolName;
+    const baseName = parseMcpToolName(toolName)?.toolName ?? toolName;
     const canonical = canonicalWorkflowToolName(baseName);
     if (canonical !== baseName) {
       errors.push(`presentation tool "${toolName}" uses an alias; use canonical "${canonical}"`);
@@ -310,7 +310,7 @@ function validateCanonicalPresentation(params: UatResultSaveParams): string | nu
 
   const presentedCanonical = new Set(
     params.presentation.presentedTools.map((toolName) =>
-      canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName)
+      canonicalWorkflowToolName(parseMcpToolName(toolName)?.toolName ?? toolName)
     ),
   );
   const missingRequiredTools = RUN_UAT_WORKFLOW_TOOL_NAMES.filter(
@@ -325,11 +325,11 @@ function validateCanonicalPresentation(params: UatResultSaveParams): string | nu
   const forbiddenCanonical = new Set(
     RUN_UAT_FORBIDDEN_TOOL_NAMES
       .filter((toolName) => !toolName.includes("*"))
-      .map((toolName) => canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName)),
+      .map((toolName) => canonicalWorkflowToolName(parseMcpToolName(toolName)?.toolName ?? toolName)),
   );
   const forbiddenPresentedTools: string[] = [];
   for (const toolName of params.presentation.presentedTools) {
-    const canonical = canonicalWorkflowToolName(parseMcpToolName(toolName)?.tool ?? toolName);
+    const canonical = canonicalWorkflowToolName(parseMcpToolName(toolName)?.toolName ?? toolName);
     if (toolName === "mcp__gsd-workflow__*" || forbiddenCanonical.has(canonical)) {
       forbiddenPresentedTools.push(toolName);
     }
@@ -342,7 +342,7 @@ function validateCanonicalPresentation(params: UatResultSaveParams): string | nu
 
   const blockedCanonical = new Set(
     params.presentation.blockedTools.map((entry) =>
-      canonicalWorkflowToolName(parseMcpToolName(entry.name)?.tool ?? entry.name)
+      canonicalWorkflowToolName(parseMcpToolName(entry.name)?.toolName ?? entry.name)
     ),
   );
   const missingBlockedTools = ["gsd_exec", "gsd_summary_save", "gsd_save_gate_result"].filter(

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -3,6 +3,7 @@ import { existsSync, realpathSync } from "node:fs";
 import { basename, dirname, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { getRequiredWorkflowToolsForUnit } from "./unit-tool-contracts.js";
+import { mcpToolMatchesBaseName } from "./mcp-tool-name.js";
 import {
   supportsStructuredQuestions,
   usesWorkflowMcpTransport,
@@ -374,9 +375,7 @@ export function getRequiredWorkflowToolsForAutoUnit(unitType: string): string[] 
 function hasRequiredTool(requiredTool: string, activeTools: string[]): boolean {
   return activeTools.some((toolName) => {
     if (toolName === requiredTool) return true;
-    if (!toolName.startsWith("mcp__")) return false;
-    const toolSeparator = toolName.indexOf("__", "mcp__".length);
-    return toolSeparator >= 0 && toolName.slice(toolSeparator + 2) === requiredTool;
+    return mcpToolMatchesBaseName(toolName, requiredTool);
   });
 }
 

--- a/src/resources/extensions/gsd/workflow-tool-surface.ts
+++ b/src/resources/extensions/gsd/workflow-tool-surface.ts
@@ -7,6 +7,7 @@ import {
   WORKFLOW_TOOL_CONTRACTS as CONTRACT_WORKFLOW_TOOL_CONTRACTS,
   WORKFLOW_TOOL_NAMES as CONTRACT_WORKFLOW_TOOL_NAMES,
 } from "@opengsd/contracts";
+import { stripMcpToolPrefix } from "./mcp-tool-name.js";
 
 export interface WorkflowToolAliasPair {
   canonical: string;
@@ -51,11 +52,7 @@ export const WORKFLOW_TOOL_SURFACE_NAMES = [
 
 const WORKFLOW_TOOL_SURFACE_NAME_SET = new Set(WORKFLOW_TOOL_SURFACE_NAMES);
 
-export function stripMcpToolPrefix(toolName: string): string {
-  if (!toolName.startsWith("mcp__")) return toolName;
-  const toolSeparator = toolName.indexOf("__", "mcp__".length);
-  return toolSeparator >= 0 ? toolName.slice(toolSeparator + 2) : toolName;
-}
+export { stripMcpToolPrefix } from "./mcp-tool-name.js";
 
 export function canonicalWorkflowSurfaceToolName(toolName: string): string {
   const baseName = stripMcpToolPrefix(toolName);


### PR DESCRIPTION
## TL;DR

**What:** Fix browser-backed `run-uat` dispatch so browser tools registered for the session satisfy the preflight even when the active model-facing surface is scoped down.
**Why:** Auto-mode could pause before dispatching human-experience/browser UAT because it checked only active tools, even though browser tools were registered and would be scoped into `run-uat`.
**How:** Add shared MCP tool-name helpers, pass registered tool snapshots into dispatch, and add typed tool-surface snapshots for runtime and presentation surfaces.

## What

This updates GSD auto-mode and UAT tool policy around browser-backed UAT:

- `run-uat` browser preflight now resolves browser availability from active plus registered tool surfaces.
- Direct `browser_*`, concrete MCP browser tools, and browser MCP wildcard surfaces such as `mcp__gsd-browser__*` are recognized consistently.
- MCP tool-name parsing/formatting is centralized in a shared helper instead of repeated string slicing.
- Runtime, dispatch, provider-adjusted, and presentation tool surfaces now have a typed snapshot shape for debugging and dashboard consumers.
- Regression tests cover browser UAT dispatch, MCP wildcard parsing, runtime/dashboard snapshots, and presentation-plan snapshots.

## Why

The failing behavior was:

> Cannot dispatch browser-backed run-uat ... UAT mode "human-experience" requires browser tools, but the active tool surface has none.

That was a false negative in token-scoped sessions. Browser tools can stay registered/callable while being hidden from the general model-facing surface until `run-uat` scopes them in. The dispatch preflight ran before that scoping and only inspected the active surface, so auto-mode paused before the tools could be presented.

## How

The fix keeps the existing token-saving behavior intact:

- `getRegisteredToolSnapshot()` reads `pi.getAllTools()` and falls back to the baseline active snapshot.
- `DispatchContext` carries `registeredTools` to the `run-uat` rule.
- UAT policy unions active and registered surfaces for browser-tool support checks.
- `mcp-tool-name.ts` owns MCP parsing/composition used by workflow transport, UAT policy, tool presentation, MCP filtering, write-gate, and hook scoping.
- `tool-surface-snapshot.ts` gives model-facing, registered, scoped, and presented tools explicit names instead of treating every array as interchangeable.

## Validation

- `pnpm run typecheck:extensions`
- Focused regression run: 188 tests passing
- `pnpm run build:mcp-server`
- `packages/mcp-server/src/workflow-tools.test.ts`: 51 tests passing
- `pnpm run test:compile`
- `pnpm run verify:fast`
- `git diff --check`

## Change type

- [x] `fix` — Bug fix
- [x] `refactor` — Code restructuring
- [x] `test` — Adding or updating tests

## Breaking changes

None expected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783539766&installation_id=134682257&pr_number=587&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F587&signature=0da6410e6f20618b8e7c320104ccfba52d182912b98afa35830142122efe9cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode dispatch preflight and tool-scoping hooks; scope is bounded by regression tests but affects when run-uat proceeds vs pauses.
> 
> **Overview**
> Fixes **false browser-UAT preflight failures** in auto-mode when browser tools are **registered** but not on the narrowed **active** tool surface until `run-uat` scopes them in.
> 
> **`run-uat` dispatch** now passes **`registeredTools`** (from `getRegisteredToolSnapshot()` / `getAllTools()`) into **`getUatBrowserToolSupportError`**, which unions active + registered surfaces and treats browser MCP wildcards (e.g. `mcp__gsd-browser__*`) consistently. Shared **`mcp-tool-name.ts`** replaces ad-hoc `mcp__` string parsing across hooks, transport, write-gate, and presentation.
> 
> Adds **`ToolSurfaceSnapshot`** recording at runtime/dispatch/provider/presentation scoping and surfaces it on the **auto dashboard/runtime** (`formatToolSurfaceSnapshot`) for debugging—not a user-facing behavior change beyond the UAT fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baca309cb034489f31a79f2ff5e8c3309352237b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->