### PR TITLE
fix(claude-code-cli): treat dismissed elicitation as cancel instead of re-asking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 ## [Unreleased]
 
 ### Fixed
+- **gsd**: stop duplicate claude code question fallback
 - **issue**: [Bug]: After upgrading to version 1.1.1 GSD is stuck for missing toolset
 
 ## [1.2.0] - 2026-06-06

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1378,14 +1378,16 @@ export function createClaudeCodeElicitationHandler(
 			if (headlessAnswer) return headlessAnswer;
 
 			const interviewResult = await showInterviewRound(questions, { signal }, { ui } as any).catch(() => undefined);
-			if (interviewResult && Object.keys(interviewResult.answers).length > 0) {
-				return {
-					action: "accept",
-					content: roundResultToElicitationContent(questions, interviewResult),
-				};
+			if (interviewResult === undefined) {
+				return promptElicitationWithDialogs(request, questions, ui, signal);
 			}
-
-			return promptElicitationWithDialogs(request, questions, ui, signal);
+			if (Object.keys(interviewResult.answers).length === 0) {
+				return { action: "cancel" };
+			}
+			return {
+				action: "accept",
+				content: roundResultToElicitationContent(questions, interviewResult),
+			};
 		}
 
 		const textFields = parseTextInputElicitation(request);

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1361,7 +1361,16 @@ export function createClaudeCodeCanUseToolHandler(
 // Elicitation handler
 // ---------------------------------------------------------------------------
 
-/** Create an SDK elicitation handler that routes requests through the extension UI dialogs, or undefined if no UI is available. */
+/**
+ * Create an SDK elicitation handler that routes requests through the extension UI dialogs, or undefined if no UI is available.
+ *
+ * For structured (AskUserQuestion) elicitations, the interview round's result
+ * disambiguates two cases that must not be conflated: an `undefined` result
+ * means the custom UI is unavailable, so we fall back to the simpler `select`
+ * dialogs; an empty-answers result means the user dismissed the question, which
+ * is treated as a clean cancel. Falling back to dialogs on dismissal would
+ * re-ask the same questions (the duplicate-question bug).
+ */
 export function createClaudeCodeElicitationHandler(
 	ui: ExtensionUIContext | undefined,
 ): ((request: SdkElicitationRequest, options: { signal: AbortSignal }) => Promise<SdkElicitationResult>) | undefined {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1720,6 +1720,26 @@ describe("stream-adapter — MCP elicitation bridge", () => {
 		});
 	});
 
+	test("createClaudeCodeElicitationHandler returns cancel when custom UI is dismissed", async () => {
+		let selectCalls = 0;
+		const handler = createClaudeCodeElicitationHandler({
+			custom: async () => ({
+				endInterview: false,
+				answers: {},
+			}),
+			select: async () => {
+				selectCalls++;
+				return "Cloud-synced";
+			},
+		} as any);
+		assert.ok(handler);
+
+		const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+
+		assert.deepEqual(result, { action: "cancel" });
+		assert.equal(selectCalls, 0, "dismissed custom question must not re-open dialog fallback");
+	});
+
 	test("parseTextInputElicitation recognizes secure free-text MCP forms", () => {
 		const request = {
 			serverName: "gsd-workflow",


### PR DESCRIPTION
## TL;DR

**What:** Treat dismissed Claude Code structured-question UI as cancellation instead of falling through to the fallback dialog prompts.
**Why:** Dismissing the structured question in Claude Code could re-ask the same question through the fallback path, producing duplicate prompts.
**How:** Distinguish `undefined` custom UI results from empty-answer cancellations in `createClaudeCodeElicitationHandler`, and add regression coverage.

## What

This updates the Claude Code CLI elicitation handler so AskUserQuestion-style forms have three separate outcomes:

- custom UI unavailable: fall back to simple `select` dialogs
- custom UI dismissed with no answers: return `{ action: "cancel" }`
- custom UI answered: accept and normalize the submitted content

It also adds a regression test for the dismissed-custom-UI path and records the fix in the changelog.

## Why

The duplicate-question behavior only happened through the Claude Code CLI path because the SDK-managed elicitation adapter conflated “custom UI unavailable” with “user canceled the custom UI.” When cancellation fell through to the dialog fallback, the same question could be shown again instead of returning a clean cancel to the MCP tool flow.

## How

`showInterviewRound(...)` returning `undefined` remains the signal that the custom UI adapter is unavailable, preserving the legacy fallback path. A returned round with an empty `answers` object is now treated as a deliberate cancel, so the handler does not reopen fallback dialogs after the user dismisses the structured question.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`
