### PR TITLE
fix(issue): Bug: createWorktree throws stale-state error for orphaned worktree directories not registered with git

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-manager.test.ts
@@ -121,6 +121,27 @@ describe("createWorktree", () => {
     run("git rev-parse --git-dir", info.path);
     assert.ok(!existsSync(join(info.path, "orphan.txt")), "stale file removed by recovery");
   });
+
+  test("removes stale worktree directory with .git file not registered with git and recreates", () => {
+    // Simulate the scenario from issue #590: removeWorktree() failed to delete
+    // the directory (e.g. EPERM on Windows) but git worktree prune cleaned up
+    // the registry — leaving an orphaned directory with a .git *file* (not
+    // directory) that git no longer knows about.
+    const staleDir = worktreePath(base, "M010");
+    mkdirSync(staleDir, { recursive: true });
+    // Write a .git file (worktree gitdir pointer) — not a directory
+    writeFileSync(join(staleDir, ".git"), "gitdir: ../../../../.git/worktrees/M010\n", "utf-8");
+    writeFileSync(join(staleDir, "orphan.txt"), "stale leftover\n", "utf-8");
+
+    // createWorktree must detect the orphan (not in git worktree list), clean it
+    // up, and succeed — not throw GSD_STALE_STATE as if it were a live conflict.
+    const info = createWorktree(base, "M010");
+    assert.strictEqual(info.name, "M010");
+    assert.ok(existsSync(info.path));
+    assert.ok(existsSync(join(info.path, ".git")), "recovered worktree has .git marker");
+    run("git rev-parse --git-dir", info.path);
+    assert.ok(!existsSync(join(info.path, "orphan.txt")), "stale file removed by recovery");
+  });
 });
 
 describe("createWorktree — duplicate rejection", () => {


### PR DESCRIPTION
## Summary
- Added a regression test covering the exact scenario from issue #590 — an orphaned worktree directory with a `.git` file not registered in git's list — confirming the existing fix in `isRegisteredGitWorktreeAtPath`/`removeStaleWorktreeDirectory` handles it correctly; all 16 tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #590
- [#590 Bug: createWorktree throws stale-state error for orphaned worktree directories not registered with git](https://github.com/open-gsd/gsd-pi/issues/590)

## User
- @TerminalSausage

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/590-bug-createworktree-throws-stale-state-er-1780950739`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783542949&installation_id=134682257&pr_number=593&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F593&signature=1444dd96ec8e141b6ea7b5ce913347fdca4e51255f182378858f87fbb90239f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or API modifications.
> 
> **Overview**
> Adds a **regression test** for issue #590: when a worktree folder is left on disk with a `.git` **file** (gitdir pointer) but is **not** in `git worktree list`—for example after `removeWorktree` fails to delete the directory while prune drops the registry—`createWorktree` must **remove the orphan and recreate** the worktree instead of raising a stale-state “already exists” error.
> 
> The new case mirrors the existing test for a stale directory with a standalone `.git` **directory**, but uses the `.git` file shape called out in the bug report. **No production code changes** in this PR; it locks in behavior already implemented via `isRegisteredGitWorktreeAtPath` / `removeStaleWorktreeDirectory` in `worktree-manager.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e400d252f9af58671f07130689c41398d30a53ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->