### PR TITLE
fix(issue): Discuss flow emits two next-step blocks: global system.md convention collides with discuss.md "Next steps:" handoff

### DIFF
--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -158,7 +158,7 @@ Fix root causes, not symptoms. If applying temporary mitigation, label it and pr
 - State uncertainty plainly: "Not sure this handles X - testing it." No performed confidence, no hedging paragraphs.
 - All user-visible narration must be grammatical English. Do not emit compressed planner notes like "Need inspect X". If it fits a commit comment or standup note, it is acceptable.
 - When debugging, stay curious. Problems are puzzles. Say what's interesting about the failure before reaching for fixes.
-- After completing a task, give a brief summary and 2-4 numbered next-step options; last option is always "Other". Omit the list for strict output formats.
+- After completing a task, give a brief summary and 2-4 numbered next-step options; last option is always "Other". Omit the list for strict output formats, or when the active workflow prompt already ends with its own explicit "Next steps:" handoff block — in that case follow the workflow's handoff and do not add a second list.
 
   If any next step is destructive/outward-facing, present it via `ask_user_questions` and wait for the user's answer before execution. Do not execute a next-step item from a prior plain-text numbered list without fresh confirmation.
 


### PR DESCRIPTION
## Summary
- Added a carve-out to `prompts/system.md:161` so the global numbered next-steps convention yields when the active workflow prompt already ends with its own "Next steps:" handoff block, eliminating the double next-steps output in the discuss/project-setup flow.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #589
- [#589 Discuss flow emits two next-step blocks: global system.md convention collides with discuss.md "Next steps:" handoff](https://github.com/open-gsd/gsd-pi/issues/589)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/589-discuss-flow-emits-two-next-step-blocks--1780952536`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783544618&installation_id=134682257&pr_number=594&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F594&signature=50f86c4d77aad9d186038c8d44deebce892eb671b0c1d2a885c0e1964f60666c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line prompt guidance change in system.md; no runtime or security impact.
> 
> **Overview**
> **Fixes duplicate “next steps” in discuss/project-setup** by narrowing when the global post-task numbered list applies in `prompts/system.md`.
> 
> The Communication rule still asks for a brief summary and 2–4 numbered options (with **Other** last) after most tasks, but it now **defers** to workflow prompts that already end with an explicit **Next steps:** handoff—e.g. `discuss.md` / `discuss-headless.md` milestone-ready blocks—so the agent follows that handoff once instead of appending a second list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbaec93dadeca1ec3e2a52fde58b7c8302aedae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->