### PR TITLE
feat(gsd): gate all-complete auto exit on milestone settlement

### DIFF
--- a/src/resources/extensions/gsd/artifact-projection.ts
+++ b/src/resources/extensions/gsd/artifact-projection.ts
@@ -1,0 +1,31 @@
+// Project/App: gsd-pi
+// File Purpose: Resolves closeout artifact projection roots across project and milestone worktrees.
+
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+
+export interface CloseoutArtifactProjectionInput {
+  milestoneId: string;
+  basePath: string;
+  originalBasePath?: string;
+}
+
+export interface CloseoutArtifactProjection {
+  projectRoot: string;
+  canonicalMilestoneRoot: string;
+  summaryArtifactBasePath: string;
+  gateEvidenceBasePath: string;
+}
+
+export function resolveCloseoutArtifactProjection(
+  input: CloseoutArtifactProjectionInput,
+): CloseoutArtifactProjection {
+  const projectRoot = resolveWorktreeProjectRoot(input.basePath, input.originalBasePath);
+  const canonicalMilestoneRoot = resolveCanonicalMilestoneRoot(projectRoot, input.milestoneId);
+  return {
+    projectRoot,
+    canonicalMilestoneRoot,
+    summaryArtifactBasePath: canonicalMilestoneRoot,
+    gateEvidenceBasePath: canonicalMilestoneRoot,
+  };
+}

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1479,12 +1479,17 @@ export async function stopAuto(
   // worktree was active, and whether the current milestone was merged before
   // stopAuto. The unmerged-work warning is only meaningful for real worktrees.
   try {
-    const { emitAutoExit, normalizeAutoExitReason } = await import("./worktree-telemetry.js");
+    const {
+      autoExitReasonForTerminalOutcome,
+      emitAutoExit,
+      normalizeAutoExitReason,
+    } = await import("./worktree-telemetry.js");
     // Normalize the free-form reason to a closed set so the telemetry
     // aggregator buckets stably. Raw detail is preserved in the phases.ts
     // notification and the notify'd error string.
     const rawReason = reason ?? "stop";
-    const normalizedReason = normalizeAutoExitReason(rawReason);
+    const normalizedReason = autoExitReasonForTerminalOutcome(options.terminalOutcome)
+      ?? normalizeAutoExitReason(rawReason);
     const telemetryBase = s.originalBasePath || s.basePath;
     emitAutoExit(telemetryBase, {
       reason: normalizedReason,

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -27,13 +27,43 @@ export interface AutoStatus {
   transitionCount: number;
 }
 
+export type AutoTerminalOutcome =
+  | {
+      code: "all-complete";
+      displayReason: string;
+      allMilestonesComplete: true;
+    }
+  | {
+      code: "no-remaining-units";
+      displayReason: string;
+      allMilestonesComplete: false;
+    }
+  | {
+      code: "settlement-blocked";
+      displayReason: string;
+      nextAction: string;
+      milestoneId: string;
+      allMilestonesComplete: false;
+    };
+
 export type AutoAdvanceResult =
   | { kind: "started" }
   | { kind: "resumed" }
   | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState }
   | { kind: "skipped"; reason: string; stateSnapshot?: GSDState }
-  | { kind: "blocked"; reason: string; action: "pause" | "stop"; stateSnapshot?: GSDState }
-  | { kind: "stopped"; reason: string; stateSnapshot?: GSDState }
+  | {
+      kind: "blocked";
+      reason: string;
+      action: "pause" | "stop";
+      stateSnapshot?: GSDState;
+      terminalOutcome?: AutoTerminalOutcome;
+    }
+  | {
+      kind: "stopped";
+      reason: string;
+      stateSnapshot?: GSDState;
+      terminalOutcome?: AutoTerminalOutcome;
+    }
   | { kind: "paused"; reason: string }
   | { kind: "error"; reason: string };
 

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -7,6 +7,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import type { AutoSession } from "./session.js";
+import type { AutoTerminalOutcome } from "./contracts.js";
 import type { ErrorContext } from "./types.js";
 import type { GSDPreferences } from "../preferences.js";
 import type { GSDState } from "../types.js";
@@ -33,6 +34,7 @@ export interface StopAutoOptions {
     milestoneTitle?: string | null;
     allMilestonesComplete?: boolean;
   };
+  terminalOutcome?: AutoTerminalOutcome;
   /**
    * Foreground closeout-boundary stops already have the useful final surface in
    * the transcript. Preserve it instead of installing a replacement widget.

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AutoSession } from "./session.js";
+import type { AutoTerminalOutcome } from "./contracts.js";
 import type { LoopDeps, StopAutoOptions } from "./loop-deps.js";
 import type { GSDState } from "../types.js";
 import {
@@ -136,6 +137,25 @@ function resolveCompletionStopFromState(
         milestoneTitle: completedMilestone?.title ?? null,
         allMilestonesComplete: true,
       },
+    },
+  };
+}
+
+function resolveCompletionStopFromOutcome(
+  outcome: AutoTerminalOutcome | undefined,
+  stateSnapshot: GSDState | undefined,
+): { reason: string; options: StopAutoOptions } | null {
+  if (outcome?.code !== "all-complete") return null;
+  const completedMilestone = stateSnapshot?.lastCompletedMilestone ?? stateSnapshot?.activeMilestone;
+  return {
+    reason: outcome.displayReason,
+    options: {
+      completionWidget: {
+        milestoneId: completedMilestone?.id ?? null,
+        milestoneTitle: completedMilestone?.title ?? null,
+        allMilestonesComplete: true,
+      },
+      terminalOutcome: outcome,
     },
   };
 }
@@ -871,16 +891,22 @@ export async function autoLoop(
 
           if (orchestrationResult.kind === "blocked") {
             s.pendingOrchestrationDispatch = null;
+            const blockMessage = orchestrationResult.terminalOutcome?.code === "settlement-blocked"
+              ? [
+                  orchestrationResult.terminalOutcome.displayReason,
+                  `Next: ${orchestrationResult.terminalOutcome.nextAction}`,
+                ].join("\n")
+              : orchestrationResult.reason;
             if (orchestrationResult.action === "pause") {
               await deps.pauseAuto(ctx, pi, {
-                message: orchestrationResult.reason,
+                message: blockMessage,
                 category: "unknown",
               }, {
                 expectedCurrentUnit: null,
               });
               finishTurn("paused", "manual-attention", "orchestration-blocked");
             } else {
-              await deps.stopAuto(ctx, pi, orchestrationResult.reason);
+              await deps.stopAuto(ctx, pi, blockMessage);
               finishTurn("stopped", "manual-attention", "orchestration-blocked");
             }
             finishIncompleteIteration({
@@ -926,7 +952,11 @@ export async function autoLoop(
 
           if (orchestrationResult.kind === "stopped") {
             s.pendingOrchestrationDispatch = null;
-            const completionStop = resolveCompletionStopFromState(orchestrationResult.stateSnapshot);
+            let completionStop = resolveCompletionStopFromOutcome(
+              orchestrationResult.terminalOutcome,
+              orchestrationResult.stateSnapshot,
+            );
+            completionStop ??= resolveCompletionStopFromState(orchestrationResult.stateSnapshot);
             if (completionStop) {
               await deps.stopAuto(ctx, pi, completionStop.reason, completionStop.options);
             } else {

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -12,10 +12,12 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
-import type { AutoAdvanceResult, AutoOrchestrationModule, AutoSessionContext, AutoStatus } from "./contracts.js";
+import type { AutoAdvanceResult, AutoOrchestrationModule, AutoSessionContext, AutoStatus, AutoTerminalOutcome } from "./contracts.js";
 import type { AutoSession, PendingOrchestrationDispatch } from "./session.js";
 import type { GSDState } from "../types.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
+
+type BlockedAdvanceResult = Extract<AutoAdvanceResult, { kind: "blocked" }>;
 
 import { debugCount, debugTime } from "../debug-logger.js";
 import { reconcileBeforeDispatch } from "../state-reconciliation.js";
@@ -63,6 +65,7 @@ import { getErrorMessage } from "../error-utils.js";
 import { logWarning } from "../workflow-logger.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { evaluateAllCompleteSettlement } from "../milestone-settlement.js";
 
 function now(): number {
   return Date.now();
@@ -78,11 +81,19 @@ function now(): number {
  */
 export const STUCK_WINDOW_SIZE = 6;
 
-function noRemainingUnitsReason(stateSnapshot: GSDState): string {
+function noRemainingUnitsOutcome(stateSnapshot: GSDState): AutoTerminalOutcome {
   if (stateSnapshot.phase === "complete") {
-    return "all milestones complete";
+    return {
+      code: "all-complete",
+      displayReason: "All milestones complete",
+      allMilestonesComplete: true,
+    };
   }
-  return "no remaining units";
+  return {
+    code: "no-remaining-units",
+    displayReason: "No remaining units",
+    allMilestonesComplete: false,
+  };
 }
 
 /**
@@ -541,6 +552,31 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     return decideOrchestratorDispatch(this.ctx, this.pi, this.dispatchBasePath, this.s, input);
   }
 
+  private evaluateNoRemainingUnitsSettlement(stateSnapshot: GSDState): BlockedAdvanceResult | null {
+    const settlement = evaluateAllCompleteSettlement({
+      milestoneId: this.s.currentMilestoneId ?? stateSnapshot.activeMilestone?.id,
+      statePhase: stateSnapshot.phase,
+      basePath: this.s.basePath || this.getLiveDispatchBasePath(),
+      originalBasePath: this.s.originalBasePath || this.runtimeBasePath,
+      milestoneMerged: this.s.milestoneMergedInPhases,
+    });
+    this.s.milestoneSettlement = settlement;
+    if (settlement.ok) return null;
+    return {
+      kind: "blocked",
+      reason: settlement.message,
+      action: settlement.action,
+      stateSnapshot,
+      terminalOutcome: {
+        code: "settlement-blocked",
+        displayReason: settlement.message,
+        nextAction: settlement.nextAction,
+        milestoneId: settlement.milestoneId,
+        allMilestonesComplete: false,
+      },
+    };
+  }
+
   private clearPendingDispatch(): void {
     this.s.pendingOrchestrationDispatch = null;
   }
@@ -842,10 +878,23 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
       const decision = await this.decideNextUnit({ stateSnapshot: reconciliation.stateSnapshot });
       if (!decision) {
+        const settlementBlock = this.evaluateNoRemainingUnitsSettlement(reconciliation.stateSnapshot);
+        if (settlementBlock) {
+          this.status.phase = "paused";
+          this.status.activeUnit = undefined;
+          this.lastAdvanceKey = null;
+          this.dispatchKeyWindow = [];
+          this.bumpTransition();
+          this.journalTransition({ name: "advance-blocked", reason: settlementBlock.reason });
+          this.postAdvanceRecord(settlementBlock);
+          return settlementBlock;
+        }
+        const terminalOutcome = noRemainingUnitsOutcome(reconciliation.stateSnapshot);
         const stopped: AutoAdvanceResult = {
           kind: "stopped",
-          reason: noRemainingUnitsReason(reconciliation.stateSnapshot),
+          reason: terminalOutcome.displayReason,
           stateSnapshot: reconciliation.stateSnapshot,
+          terminalOutcome,
         };
         this.status.phase = "stopped";
         this.status.activeUnit = undefined;

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -29,6 +29,7 @@ import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { normalizeRealPath } from "../paths.js";
 import type { MilestoneScope } from "../workspace.js";
 import type { RootDirtySnapshot } from "../root-write-leak-guard.js";
+import type { MilestoneSettlementOutcome } from "../milestone-settlement.js";
 
 // ─── Exported Types ──────────────────────────────────────────────────────────
 
@@ -230,6 +231,8 @@ export class AutoSession {
   /** Set to true after phases.ts successfully calls mergeAndExit, so that
    *  stopAuto does not attempt the same merge a second time (#2645). */
   milestoneMergedInPhases = false;
+  /** Last milestone settlement result observed by Auto Orchestration. */
+  milestoneSettlement: MilestoneSettlementOutcome | null = null;
 
   // #4765 — slice-cadence collapse: main-branch SHAs at the moment each
   // milestone's first slice merge began. Used by resquashMilestoneOnMain at
@@ -410,6 +413,7 @@ export class AutoSession {
     this.strandedRecoveryIsolationMode = null;
     this.rootWriteBaseline = null;
     this.milestoneMergedInPhases = false;
+    this.milestoneSettlement = null;
     this.milestoneStartShas = new Map();
     this.checkpointSha = null;
 

--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -1,6 +1,8 @@
 // Project/App: gsd-pi
 // File Purpose: Shared DB-backed guard for milestone closeout finalization.
 
+import { dirname } from "node:path";
+
 import {
   getLatestAssessmentByScope,
   getMilestone,
@@ -14,6 +16,7 @@ import {
   refreshWorkflowDatabaseFromDisk,
 } from "./db-workspace.js";
 import { isClosedStatus } from "./status-guards.js";
+import { closeQualityGatesFromEvidence } from "./quality-gate-closure.js";
 
 export const CLOSEOUT_CONSISTENCY_BLOCKED_REASON = "closeout-consistency-blocked";
 
@@ -40,6 +43,7 @@ export type CloseoutConsistencyResult =
 export interface CloseoutConsistencyOptions {
   refreshFromDisk?: boolean;
   allowOpenMilestone?: boolean;
+  artifactBasePath?: string;
 }
 
 function blocked(reason: CloseoutConsistencyFailureReason, message: string): CloseoutConsistencyResult {
@@ -53,6 +57,12 @@ function blocked(reason: CloseoutConsistencyFailureReason, message: string): Clo
 
 function isFileBackedDbPath(path: string | null): boolean {
   return Boolean(path && path !== ":memory:");
+}
+
+function artifactBasePathFromDb(): string | undefined {
+  const dbPath = getWorkflowDatabasePath();
+  if (!isFileBackedDbPath(dbPath)) return undefined;
+  return dirname(dirname(dbPath!));
 }
 
 export function checkCloseoutConsistencyGate(
@@ -87,8 +97,10 @@ export function checkCloseoutConsistencyGate(
     );
   }
 
+  const validation = milestone.status === "skipped"
+    ? null
+    : getLatestAssessmentByScope(milestoneId, "milestone-validation");
   if (milestone.status !== "skipped") {
-    const validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
     if (validation?.status !== "pass") {
       return blocked(
         "validation-not-pass",
@@ -103,6 +115,13 @@ export function checkCloseoutConsistencyGate(
       "slice-missing",
       `Closeout consistency blocked for ${milestoneId}: no slices exist in canonical DB.`,
     );
+  }
+
+  if (milestone.status !== "skipped") {
+    closeQualityGatesFromEvidence(milestoneId, {
+      artifactBasePath: options.artifactBasePath ?? artifactBasePathFromDb(),
+      milestoneValidationPassed: validation?.status === "pass",
+    });
   }
 
   for (const slice of slices) {

--- a/src/resources/extensions/gsd/milestone-closeout-proof.ts
+++ b/src/resources/extensions/gsd/milestone-closeout-proof.ts
@@ -101,6 +101,7 @@ export function proveMilestoneCloseout(
   const consistency = checkCloseoutConsistencyGate(milestoneId, {
     refreshFromDisk: options.refreshFromDisk,
     allowOpenMilestone: options.allowOpenMilestone,
+    artifactBasePath: options.summaryArtifactBasePath,
   });
   if (!consistency.ok) return fromConsistencyResult(consistency);
 

--- a/src/resources/extensions/gsd/milestone-settlement.ts
+++ b/src/resources/extensions/gsd/milestone-settlement.ts
@@ -1,0 +1,81 @@
+// Project/App: gsd-pi
+// File Purpose: Milestone closeout settlement state across DB proof, artifacts, merge, and cleanup.
+
+import { isInAutoWorktree } from "./auto-worktree.js";
+import {
+  formatCloseoutProofBlock,
+  proveMilestoneCloseout,
+} from "./milestone-closeout-proof.js";
+import { resolveCloseoutArtifactProjection } from "./artifact-projection.js";
+
+export type MilestoneSettlementOutcome =
+  | { ok: true; reason: "settled" | "not-applicable" }
+  | {
+      ok: false;
+      reason: "closeout-blocked" | "merge-pending";
+      action: "pause";
+      message: string;
+      nextAction: string;
+      milestoneId: string;
+    };
+
+export interface MilestoneSettlementInput {
+  milestoneId: string | null | undefined;
+  statePhase: string;
+  basePath: string;
+  originalBasePath: string;
+  milestoneMerged: boolean;
+}
+
+function isActiveUnmergedWorktree(input: MilestoneSettlementInput): boolean {
+  if (!input.milestoneId || input.milestoneMerged) return false;
+  return isInAutoWorktree(input.basePath);
+}
+
+export function evaluateAllCompleteSettlement(
+  input: MilestoneSettlementInput,
+): MilestoneSettlementOutcome {
+  if (input.statePhase !== "complete") {
+    return { ok: true, reason: "not-applicable" };
+  }
+  if (!isActiveUnmergedWorktree(input)) {
+    return { ok: true, reason: "settled" };
+  }
+
+  const milestoneId = input.milestoneId;
+  if (!milestoneId) {
+    return { ok: true, reason: "settled" };
+  }
+
+  const projection = resolveCloseoutArtifactProjection({
+    milestoneId,
+    basePath: input.basePath,
+    originalBasePath: input.originalBasePath,
+  });
+  const proof = proveMilestoneCloseout(milestoneId, {
+    refreshFromDisk: true,
+    summaryArtifactBasePath: projection.summaryArtifactBasePath,
+  });
+
+  if (!proof.ok) {
+    return {
+      ok: false,
+      reason: "closeout-blocked",
+      action: "pause",
+      message: `${formatCloseoutProofBlock(proof)} The milestone branch has not been merged to main.`,
+      nextAction: `Resolve closeout blockers, then retry \`/gsd dispatch complete-milestone ${milestoneId}\`.`,
+      milestoneId,
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "merge-pending",
+    action: "pause",
+    message:
+      `Milestone ${milestoneId} is complete, but its worktree branch has not been merged to main. ` +
+      `Retry with \`/gsd dispatch complete-milestone ${milestoneId}\` or merge manually.`,
+    nextAction: `Retry \`/gsd dispatch complete-milestone ${milestoneId}\` or merge manually.`,
+    milestoneId,
+  };
+}

--- a/src/resources/extensions/gsd/quality-gate-closure.ts
+++ b/src/resources/extensions/gsd/quality-gate-closure.ts
@@ -1,0 +1,140 @@
+// Project/App: gsd-pi
+// File Purpose: Canonical quality-gate closure from durable DB and artifact evidence.
+
+import { existsSync, readFileSync } from "node:fs";
+
+import { extractSection } from "./files.js";
+import { getGateDefinition } from "./gate-registry.js";
+import { getMilestoneSlices, getPendingGates, saveGateResult } from "./gsd-db.js";
+import { resolveSliceFile, resolveTaskFile } from "./paths.js";
+import type { GateId, GateRow, GateVerdict } from "./types.js";
+
+export interface QualityGateClosureOptions {
+  artifactBasePath?: string;
+  milestoneValidationPassed?: boolean;
+}
+
+export interface QualityGateClosureResult {
+  repaired: Array<{ gateId: GateId; sliceId: string; taskId?: string; verdict: GateVerdict }>;
+  unresolved: GateRow[];
+}
+
+interface GateEvidence {
+  verdict: GateVerdict;
+  rationale: string;
+  findings: string;
+}
+
+const GATE_SECTION_HEADINGS: Partial<Record<GateId, string[]>> = {
+  Q3: ["Threat Surface", "Abuse Surface"],
+  Q4: ["Requirement Impact", "Broken Promises"],
+  Q5: ["Failure Modes"],
+  Q6: ["Load Profile"],
+  Q7: ["Negative Tests"],
+  Q8: ["Operational Readiness"],
+};
+
+function readFile(path: string | null): string | null {
+  if (!path || !existsSync(path)) return null;
+  return readFileSync(path, "utf-8");
+}
+
+function firstSection(content: string | null, gateId: GateId): string | null {
+  if (!content) return null;
+  for (const heading of GATE_SECTION_HEADINGS[gateId] ?? []) {
+    const section = extractSection(content, heading);
+    if (section) return section;
+  }
+  return null;
+}
+
+function evidenceArtifactContent(row: GateRow, basePath: string): string | null {
+  const def = getGateDefinition(row.gate_id);
+  switch (def?.ownerTurn) {
+    case "gate-evaluate":
+      return readFile(resolveSliceFile(basePath, row.milestone_id, row.slice_id, "PLAN"));
+    case "execute-task":
+      return readFile(resolveTaskFile(basePath, row.milestone_id, row.slice_id, row.task_id, "SUMMARY"));
+    case "complete-slice":
+      return readFile(resolveSliceFile(basePath, row.milestone_id, row.slice_id, "SUMMARY"));
+    default:
+      return null;
+  }
+}
+
+function closureEvidence(row: GateRow, options: QualityGateClosureOptions): GateEvidence | null {
+  const def = getGateDefinition(row.gate_id);
+  if (!def) return null;
+
+  if (def.ownerTurn === "validate-milestone" && options.milestoneValidationPassed) {
+    return {
+      verdict: "pass",
+      rationale: `${def.promptSection} covered by passing milestone validation`,
+      findings: "",
+    };
+  }
+
+  if (!options.artifactBasePath) return null;
+
+  const section = firstSection(evidenceArtifactContent(row, options.artifactBasePath), row.gate_id);
+  if (section) {
+    return {
+      verdict: "pass",
+      rationale: `${def.promptSection} evidence found in durable artifact`,
+      findings: section,
+    };
+  }
+
+  if (!options.milestoneValidationPassed) return null;
+  return {
+    verdict: "omitted",
+    rationale: `${def.promptSection} has no durable artifact section; milestone validation passed`,
+    findings: "",
+  };
+}
+
+function closeGate(row: GateRow, evidence: GateEvidence): void {
+  saveGateResult({
+    milestoneId: row.milestone_id,
+    sliceId: row.slice_id,
+    gateId: row.gate_id,
+    taskId: row.task_id,
+    verdict: evidence.verdict,
+    rationale: evidence.rationale,
+    findings: evidence.findings,
+  });
+}
+
+export function closeQualityGatesFromEvidence(
+  milestoneId: string,
+  options: QualityGateClosureOptions = {},
+): QualityGateClosureResult {
+  const repaired: QualityGateClosureResult["repaired"] = [];
+  const unresolved: GateRow[] = [];
+
+  for (const slice of getMilestoneSlices(milestoneId)) {
+    const sliceId = slice.id;
+    for (const row of getPendingGates(milestoneId, sliceId)) {
+      if (!getGateDefinition(row.gate_id)) {
+        unresolved.push(row);
+        continue;
+      }
+
+      const evidence = closureEvidence(row, options);
+      if (!evidence) {
+        unresolved.push(row);
+        continue;
+      }
+
+      closeGate(row, evidence);
+      repaired.push({
+        gateId: row.gate_id,
+        sliceId: row.slice_id,
+        ...(row.task_id ? { taskId: row.task_id } : {}),
+        verdict: evidence.verdict,
+      });
+    }
+  }
+
+  return { repaired, unresolved };
+}

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2404,8 +2404,13 @@ test("autoLoop stops orchestrator complete state through completion surface", as
       start: async () => ({ kind: "stopped" as const, reason: "unused" }),
       advance: async () => ({
         kind: "stopped" as const,
-        reason: "all milestones complete",
+        reason: "legacy text not used",
         stateSnapshot,
+        terminalOutcome: {
+          code: "all-complete" as const,
+          displayReason: "All milestones complete",
+          allMilestonesComplete: true as const,
+        },
       }),
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
@@ -2431,6 +2436,7 @@ test("autoLoop stops orchestrator complete state through completion surface", as
     milestoneTitle: "Priority Levels",
     allMilestonesComplete: true,
   });
+  assert.equal((stopCalls[0]?.options as any)?.terminalOutcome?.code, "all-complete");
   assert.equal(
     deps.callLog.includes("resolveDispatch"),
     false,

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -33,6 +33,8 @@ import type { UnifiedRule } from "../rule-types.js";
 import { supportsStructuredQuestions } from "../workflow-mcp.js";
 import {
   closeDatabase,
+  insertAssessment,
+  insertGateRow,
   insertMilestone,
   insertSlice,
   insertTask,
@@ -414,8 +416,63 @@ test("advance() reports completion when complete state has no next unit", async 
 
   assert.equal(result.kind, "stopped");
   if (result.kind !== "stopped") return;
-  assert.equal(result.reason, "all milestones complete");
+  assert.equal(result.reason, "All milestones complete");
+  assert.equal(result.terminalOutcome?.code, "all-complete");
   assert.equal(f.orchestrator.getStatus().phase, "stopped");
+});
+
+test("advance() blocks all-complete stop when completed milestone is still unmerged in a worktree", async (t) => {
+  const f = makeFixture({ complete: true, noTask: true });
+  t.after(() => f.cleanup());
+
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Slice",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+  insertGateRow({
+    milestoneId: "M001",
+    sliceId: "S01",
+    gateId: "Q3",
+    scope: "slice",
+    status: "pending",
+  });
+
+  const worktreePath = join(f.base, ".gsd", "worktrees", "M001");
+  mkdirSync(join(f.base, ".gsd", "worktrees"), { recursive: true });
+  execFileSync("git", ["worktree", "add", "-b", "milestone/M001", worktreePath], { cwd: f.base, stdio: "ignore" });
+  mkdirSync(join(worktreePath, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(worktreePath, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Milestone Summary\n");
+  f.session.basePath = worktreePath;
+  f.session.originalBasePath = f.base;
+  f.session.currentMilestoneId = "M001";
+  f.session.milestoneMergedInPhases = false;
+
+  const result = await f.orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  if (result.kind !== "blocked") return;
+  assert.equal(result.action, "pause");
+  assert.equal(result.terminalOutcome?.code, "settlement-blocked");
+  assert.match(result.reason, /worktree branch has not been merged to main/);
+  assert.doesNotMatch(result.reason, /quality gate Q3 is still pending/);
+  assert.equal(f.orchestrator.getStatus().phase, "paused");
+  assert.equal(f.session.milestoneSettlement?.ok, false);
+  const names = f.journalNames();
+  assert.ok(names.includes("advance-blocked"));
+  assert.ok(!names.includes("advance-stopped"));
 });
 
 test("advance() stopped clears previous activeUnit and resets idempotent lock", async (t) => {

--- a/src/resources/extensions/gsd/tests/canonical-milestone-root.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-milestone-root.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.ts";
+import { resolveCloseoutArtifactProjection } from "../artifact-projection.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-canon-test-${randomUUID()}`);
@@ -102,6 +103,25 @@ test("only returns the worktree for the requested milestone, not siblings", () =
     makeLiveWorktree(base, "M001");
     const result = resolveCanonicalMilestoneRoot(base, "M002");
     assert.equal(result, base, "M002 has no worktree → basePath");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("resolveCloseoutArtifactProjection names project and canonical artifact roots", () => {
+  const base = makeTmpBase();
+  try {
+    const wtPath = makeLiveWorktree(base, "M001");
+    const projection = resolveCloseoutArtifactProjection({
+      milestoneId: "M001",
+      basePath: wtPath,
+      originalBasePath: base,
+    });
+
+    assert.equal(projection.projectRoot, base);
+    assert.equal(projection.canonicalMilestoneRoot, wtPath);
+    assert.equal(projection.summaryArtifactBasePath, wtPath);
+    assert.equal(projection.gateEvidenceBasePath, wtPath);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -14,7 +14,15 @@ import { execFileSync } from "node:child_process";
 
 import { DISPATCH_RULES, resolveDispatch, type DispatchContext } from "../auto-dispatch.ts";
 import { AutoSession } from "../auto/session.ts";
-import { closeDatabase, insertAssessment, insertGateRow, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
+import {
+  closeDatabase,
+  getPendingGates,
+  insertAssessment,
+  insertGateRow,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+} from "../gsd-db.ts";
 
 function makeBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-complete-dispatch-"));
@@ -243,7 +251,7 @@ describe("complete phase dispatch guard (#5683)", () => {
     assert.equal(result?.reason, "All milestones complete.");
   });
 
-  test("blocks terminal stop when closed milestone still has pending gates", async () => {
+  test("closes stale pending gates from milestone validation before terminal stop", async () => {
     base = makeBase();
     openDatabase(join(base, ".gsd", "gsd.db"));
     insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
@@ -269,9 +277,32 @@ describe("complete phase dispatch guard (#5683)", () => {
     const result = await rule.match(ctx);
 
     assert.equal(result?.action, "stop");
+    assert.equal(result?.reason, "All milestones complete.");
+    assert.deepEqual(getPendingGates("M001", "S01"), []);
+  });
+
+  test("blocks terminal stop when pending gates have no closeout evidence", async () => {
+    base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+    insertGateRow({
+      milestoneId: "M001",
+      sliceId: "S01",
+      gateId: "Q3",
+      scope: "slice",
+      status: "pending",
+    });
+
+    const ctx = buildDispatchCtx(base);
+    ctx.state.phase = "complete";
+
+    const result = await rule.match(ctx);
+
+    assert.equal(result?.action, "stop");
     assert.equal(result?.level, "warning");
     assert.match(result?.reason ?? "", /closeout-consistency-blocked/);
-    assert.match(result?.reason ?? "", /quality gate Q3 is still pending/);
+    assert.match(result?.reason ?? "", /latest milestone validation is "absent"/);
   });
 });
 

--- a/src/resources/extensions/gsd/tests/gate-state-canonicalization.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-state-canonicalization.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -18,6 +18,7 @@ import {
   insertSlice,
 } from "../gsd-db.ts";
 import type { GateVerdict } from "../types.ts";
+import { closeQualityGatesFromEvidence } from "../quality-gate-closure.ts";
 
 describe("gate-state canonicalization (#4950)", () => {
   let tmpDir: string;
@@ -98,5 +99,51 @@ describe("gate-state canonicalization (#4950)", () => {
     for (const g of results) {
       assert.notEqual(g.verdict, "", `gate ${g.gate_id} verdict must not be empty string`);
     }
+  });
+
+  test("closeQualityGatesFromEvidence repairs pending gate from durable section", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    mkdirSync(join(tmpDir, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+      [
+        "# S01",
+        "",
+        "## Threat Surface",
+        "",
+        "- Credential stuffing is rate-limited.",
+      ].join("\n"),
+    );
+
+    const result = closeQualityGatesFromEvidence("M001", { artifactBasePath: tmpDir });
+
+    assert.deepEqual(result.unresolved, []);
+    assert.deepEqual(result.repaired, [{ gateId: "Q3", sliceId: "S01", verdict: "pass" }]);
+    assert.equal(getPendingGates("M001", "S01").length, 0);
+    assert.equal(getGateResults("M001", "S01")[0].verdict, "pass");
+  });
+
+  test("closeQualityGatesFromEvidence omits stale pending gate after validation pass", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+
+    const result = closeQualityGatesFromEvidence("M001", {
+      artifactBasePath: tmpDir,
+      milestoneValidationPassed: true,
+    });
+
+    assert.deepEqual(result.unresolved, []);
+    assert.deepEqual(result.repaired, [{ gateId: "Q4", sliceId: "S01", verdict: "omitted" }]);
+    assert.equal(getGateResults("M001", "S01")[0].verdict, "omitted");
+  });
+
+  test("closeQualityGatesFromEvidence leaves pending gate unresolved without evidence", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+
+    const result = closeQualityGatesFromEvidence("M001", { artifactBasePath: tmpDir });
+
+    assert.deepEqual(result.repaired, []);
+    assert.equal(result.unresolved.length, 1);
+    assert.equal(result.unresolved[0].gate_id, "Q3");
+    assert.equal(getPendingGates("M001", "S01").length, 1);
   });
 });

--- a/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
@@ -18,6 +18,7 @@ import {
   emitWorktreeOrphaned,
   emitAutoExit,
   emitCanonicalRootRedirect,
+  autoExitReasonForTerminalOutcome,
   normalizeAutoExitReason,
   summarizeWorktreeTelemetry,
   percentile,
@@ -115,6 +116,27 @@ test("normalizeAutoExitReason maps new buckets and ignores casing", () => {
   for (const { rawReason, expected } of cases) {
     assert.equal(normalizeAutoExitReason(rawReason), expected);
   }
+});
+
+test("autoExitReasonForTerminalOutcome maps typed terminal outcomes", () => {
+  assert.equal(
+    autoExitReasonForTerminalOutcome({
+      code: "all-complete",
+      displayReason: "All milestones complete",
+      allMilestonesComplete: true,
+    }),
+    "all-complete",
+  );
+  assert.equal(
+    autoExitReasonForTerminalOutcome({
+      code: "settlement-blocked",
+      displayReason: "Milestone complete, merge blocked",
+      nextAction: "Retry closeout",
+      milestoneId: "M001",
+      allMilestonesComplete: false,
+    }),
+    "blocked",
+  );
 });
 
 test("summarizeWorktreeTelemetry only counts unmerged exits from active worktrees", (t) => {

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -22,6 +22,7 @@
 import { randomUUID } from "node:crypto";
 import { emitJournalEvent, queryJournal } from "./journal.js";
 import type { JournalEntry } from "./journal.js";
+import type { AutoTerminalOutcome } from "./auto/contracts.js";
 
 function now(): string {
   return new Date().toISOString();
@@ -89,6 +90,21 @@ export function normalizeAutoExitReason(rawReason?: string): AutoExitReason {
                           : reasonLc === "stop" || reasonLc === "pause"
                             ? reasonLc
                             : "other";
+}
+
+export function autoExitReasonForTerminalOutcome(
+  outcome: AutoTerminalOutcome | undefined,
+): AutoExitReason | null {
+  switch (outcome?.code) {
+    case "all-complete":
+      return "all-complete";
+    case "settlement-blocked":
+      return "blocked";
+    case "no-remaining-units":
+      return "stop";
+    default:
+      return null;
+  }
 }
 
 // ─── Emitters ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Auto Orchestration previously emitted a terminal **"all milestones complete"** stop as soon as no units remained — even when the completed milestone's worktree branch was never merged to `main` and its closeout proof had not passed. That let Auto declare success over unsettled work.

This PR introduces a typed `AutoTerminalOutcome` carried on blocked/stopped advance results so the loop and telemetry can distinguish `all-complete`, `no-remaining-units`, and `settlement-blocked` exits instead of pattern-matching free-form reason strings, and gates the all-complete exit on actual milestone settlement.

## Changes

- **`milestone-settlement.ts`** (new) — `evaluateAllCompleteSettlement` gates the all-complete exit. In an active unmerged worktree it runs the closeout proof and *pauses* with a `settlement-blocked` / `merge-pending` outcome plus a concrete next action (`/gsd dispatch complete-milestone <id>`), rather than stopping as complete.
- **`artifact-projection.ts`** (new) — resolves closeout summary / gate-evidence roots from the canonical milestone worktree instead of the live base path.
- **`quality-gate-closure.ts`** (new) — closes stale pending quality gates from durable DB and artifact evidence (PLAN/SUMMARY sections, or `omitted` when milestone validation passed). Wired into the closeout-consistency gate so validated milestones are no longer blocked by gates that were never written back.
- **`worktree-telemetry.ts`** — `autoExitReasonForTerminalOutcome` maps typed terminal outcomes to stable auto-exit buckets so telemetry reflects the real exit reason.
- **`auto/contracts.ts`, `auto/loop.ts`, `auto/orchestrator.ts`, `auto/session.ts`, `auto/loop-deps.ts`, `auto.ts`** — thread `AutoTerminalOutcome` through advance results, the loop's blocked/stopped handling, and `stopAuto` telemetry.

## Testing

- `pnpm run typecheck:extensions` — clean
- Affected unit suites pass (202 tests): `auto-orchestrator`, `auto-loop`, `canonical-milestone-root`, `dispatch-complete-milestone-guard`, `gate-state-canonicalization`, `worktree-telemetry`

New coverage: settlement gating of unmerged worktrees, artifact projection roots, gate closure from durable evidence, and terminal-outcome telemetry mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783549845&installation_id=134682257&pr_number=597&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F597&signature=8920ef490303f1b67d56242f2b10108436f4d7c7aaae7ff776b15c9e0c2a4100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when auto declares success vs pauses for unsettled worktree merges and closeout proof; touches orchestration stop paths and DB gate closure, but behavior is covered by new tests.
> 
> **Overview**
> Auto no longer treats “no units left” as **all milestones complete** when the finished milestone is still on an **unmerged worktree**. A new **milestone settlement** step runs closeout proof (using **canonical milestone worktree** artifact roots) and **pauses** with `settlement-blocked` / merge-pending guidance instead of a success stop.
> 
> **Typed terminal exits:** `AutoTerminalOutcome` on blocked/stopped advance results (`all-complete`, `no-remaining-units`, `settlement-blocked`) replaces string matching in the loop, completion widget wiring, and **`autoExitReasonForTerminalOutcome`** telemetry.
> 
> **Closeout / gates:** `closeQualityGatesFromEvidence` repairs pending gates from PLAN/SUMMARY sections (or omits when validation passed) inside the closeout-consistency gate; milestone closeout proof accepts an explicit summary artifact base path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a738c8e771043d8896682d5e119944c486f73e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->