### PR TITLE
fix(issue): [Bug]: Stuck in git conflict state

### DIFF
--- a/src/resources/extensions/gsd/git-conflict-state.ts
+++ b/src/resources/extensions/gsd/git-conflict-state.ts
@@ -64,7 +64,23 @@ export function gitDiffCheckFailures(basePath: string): string[] | null {
       .filter(Boolean)
       .join("\n")
       .trim();
-    failures.push(output || `git diff --check ${args.join(" ")} failed`);
+
+    // git diff --check exits non-zero for both whitespace errors and leftover
+    // conflict markers. Only conflict markers block the gate — whitespace errors
+    // in staged files (common in auto-generated code) must not be misread as an
+    // unresolved merge conflict. Filter to lines git explicitly labels as
+    // "leftover conflict marker".
+    if (!output) {
+      failures.push(`git diff --check ${args.join(" ")} failed`);
+      continue;
+    }
+    const conflictMarkerLines = output
+      .split("\n")
+      .filter((line) => /leftover conflict marker/i.test(line))
+      .join("\n");
+    if (conflictMarkerLines) {
+      failures.push(conflictMarkerLines);
+    }
   }
 
   return failures;

--- a/src/resources/extensions/gsd/tests/workspace-git-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/workspace-git-preflight.test.ts
@@ -117,7 +117,6 @@ test("ensureWorkspaceGitReadyForPath does not block on staged files with trailin
   try {
     writeFileSync(join(base, "app.ts"), "const x = 1;   \n"); // trailing whitespace
     git(base, "add", "app.ts");
-    // Verify git diff --check actually sees the whitespace (test precondition)
     const ready = await ensureWorkspaceGitReadyForPath(base);
     assert.equal(ready.ok, true, "trailing whitespace in staged files must not block");
   } finally {

--- a/src/resources/extensions/gsd/tests/workspace-git-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/workspace-git-preflight.test.ts
@@ -109,6 +109,22 @@ test("ensureWorkspaceGitReadyForPath blocks product file conflicts", async () =>
   }
 });
 
+test("ensureWorkspaceGitReadyForPath does not block on staged files with trailing whitespace", async () => {
+  // Regression test for #599: git diff --check exits non-zero for whitespace
+  // errors as well as conflict markers. Staged files from auto-generated code
+  // often have trailing whitespace; these must not trigger the conflict gate.
+  const base = makeTempRepo("gsd-ws-git-whitespace-");
+  try {
+    writeFileSync(join(base, "app.ts"), "const x = 1;   \n"); // trailing whitespace
+    git(base, "add", "app.ts");
+    // Verify git diff --check actually sees the whitespace (test precondition)
+    const ready = await ensureWorkspaceGitReadyForPath(base);
+    assert.equal(ready.ok, true, "trailing whitespace in staged files must not block");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("isWorkspaceGitAllowedCommand allowlists doctor, closeout, and dispatch complete-milestone", () => {
   assert.equal(isWorkspaceGitAllowedCommand("doctor"), true);
   assert.equal(isWorkspaceGitAllowedCommand("doctor fix"), true);


### PR DESCRIPTION
## Summary
- Fixed `gitDiffCheckFailures()` to filter `git diff --check` output to only conflict marker lines, preventing staged files with trailing whitespace from being misread as an unresolved merge conflict and permanently blocking `/gsd auto`.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #599
- [#599 [Bug]: Stuck in git conflict state](https://github.com/open-gsd/gsd-pi/issues/599)

## User
- @steinybot

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/599-bug-stuck-in-git-conflict-state-1780959735`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783552455&installation_id=134682257&pr_number=600&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F600&signature=cf54900832995bfd4f828fdd8a410531aafefdae66efc45fc6bd81abf80000db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows conflict detection in a preflight helper; real conflict markers still fail the gate, with a targeted regression test.
> 
> **Overview**
> Fixes a false positive in the workspace git readiness gate where **`git diff --check`** non-zero exits from **whitespace** (e.g. trailing spaces in staged auto-generated files) were treated like unresolved merge conflicts, leaving **`/gsd auto`** blocked.
> 
> **`gitDiffCheckFailures`** now only records failures when git output includes lines labeled as **leftover conflict marker**; empty output on failure still gets a generic error, but whitespace-only noise is ignored. A regression test confirms staged trailing whitespace does not block **`ensureWorkspaceGitReadyForPath`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d085879f8cc1ff4acb0a0757a1a9880335236ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->