### PR TITLE
fix(claude-code-cli): stop auto-mode watchdogs from self-cancelling interactive prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 ## [Unreleased]
 
 ### Fixed
+- **claude-code-cli**: stop auto-mode watchdogs from self-cancelling ask_user_questions
 - **gsd**: stop duplicate claude code question fallback
 - **issue**: [Bug]: After upgrading to version 1.1.1 GSD is stuck for missing toolset
 

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -254,6 +254,8 @@ Three timeout tiers prevent runaway sessions:
 
 Recovery steering nudges the LLM to finish durable output before timing out. When idle or hard timeout recovery is actively writing durable progress, the unit failsafe records fresh runtime progress in `.gsd/runtime/` and defers its final cancellation check for another short recheck window. This prevents auto mode from pausing while a recovered unit is finalizing, but future-dated or stale runtime timestamps are ignored so clock skew cannot keep the unit alive forever.
 
+Interactive prompts that block waiting for human input (such as `ask_user_questions` during discuss-phase/milestone, or secure value entry) are exempt from the idle and hard timeouts: while one is in flight, the watchdogs re-arm instead of firing, so a long human deliberation never cancels the prompt or aborts its turn. A genuinely hung non-interactive unit still hits the hard cap as usual.
+
 For operator forensics, timeout recovery updates the unit runtime record with fields such as `phase`, `timeoutAt`, `lastProgressAt`, `lastProgressKind`, `recoveryAttempts`, and `lastRecoveryReason`. Finalize timeouts are recorded with `lastProgressKind` values like `finalize-pre-timeout` or `finalize-post-timeout`; successful finalization records `finalize-success`.
 
 The journal also closes every iteration explicitly. After a unit ends, auto mode emits `post-unit-finalize-start` before closeout and `post-unit-finalize-end` with a `status`, `action`, and optional `reason`. Every loop iteration then emits `iteration-end` with the final status and, when available, the failure class, unit type, unit id, and reason. Use these events to distinguish "agent never returned" from "agent returned but finalize/closeout stopped the loop."

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -188,6 +188,8 @@ Three timeout tiers prevent runaway sessions:
 | Idle | 10 min | Detects stalls, intervenes |
 | Hard | 30 min | Pauses auto mode |
 
+Interactive prompts that block waiting for human input (such as questions during discuss-phase/milestone, or secure value entry) are exempt: while one is in flight, the idle and hard watchdogs re-arm instead of firing, so a long human deliberation never cancels the prompt. Genuinely hung non-interactive units still hit the hard cap.
+
 Configure in preferences:
 
 ```yaml

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1412,7 +1412,12 @@ export function createClaudeCodeElicitationHandler(
 			try {
 				const interviewResult = await showInterviewRound(questions, { signal }, { ui } as any).catch(() => undefined);
 				if (interviewResult === undefined) {
-					return promptElicitationWithDialogs(request, questions, ui, signal);
+					// `await` so the dialog human-wait stays inside try/finally and the
+					// in-flight guard is held until the dialog resolves. Without it,
+					// `finally` runs the moment the promise is created and the fallback
+					// wait runs with zero in-flight tools — reintroducing the
+					// self-cancel on this path (Bugbot #1c00624d).
+					return await promptElicitationWithDialogs(request, questions, ui, signal);
 				}
 				if (Object.keys(interviewResult.answers).length === 0) {
 					// A system/host teardown (compaction, session_switch, true

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -45,6 +45,7 @@ import {
 import { resolveWorkflowQuestionToolSurface } from "../gsd/question-transport.js";
 import { buildProjectGsdMcpServers, ensureProjectWorkflowMcpConfig } from "../gsd/mcp-project-config.js";
 import { loadProjectGSDPreferences } from "../gsd/preferences.js";
+import { markToolStart, markToolEnd } from "../gsd/auto.js";
 import {
 	discoverBrowserMcpServerName,
 	discoverMcpServers,
@@ -1371,6 +1372,17 @@ export function createClaudeCodeCanUseToolHandler(
  * is treated as a clean cancel. Falling back to dialogs on dismissal would
  * re-ask the same questions (the duplicate-question bug).
  */
+/**
+ * Monotonic counter so concurrent/sequential elicitations resolved within the
+ * same millisecond get distinct synthetic in-flight-tool ids (the `cc-elicit-*`
+ * namespace never collides with real MCP toolCallIds).
+ */
+let _elicitationSeq = 0;
+function nextElicitationSeq(): number {
+	_elicitationSeq = (_elicitationSeq + 1) % Number.MAX_SAFE_INTEGER;
+	return _elicitationSeq;
+}
+
 export function createClaudeCodeElicitationHandler(
 	ui: ExtensionUIContext | undefined,
 ): ((request: SdkElicitationRequest, options: { signal: AbortSignal }) => Promise<SdkElicitationResult>) | undefined {
@@ -1386,22 +1398,49 @@ export function createClaudeCodeElicitationHandler(
 			const headlessAnswer = answerElicitationFromHeadlessAnswers(questions, loadHeadlessAnswers());
 			if (headlessAnswer) return headlessAnswer;
 
-			const interviewResult = await showInterviewRound(questions, { signal }, { ui } as any).catch(() => undefined);
-			if (interviewResult === undefined) {
-				return promptElicitationWithDialogs(request, questions, ui, signal);
+			// The SDK elicitation blocks waiting for human input, but it is not an
+			// MCP tool dispatch, so markToolStart/markToolEnd are never called for
+			// it. Without this the soft/context/idle/hard watchdogs see zero
+			// in-flight tools and re-dispatch (and ultimately abort) the agent
+			// turn hosting this elicitation, tearing the question down (#2676 /
+			// claude-code-cli self-cancel loop). Bracketing the human wait with
+			// the s.active-gated interactive-tool guard makes it visible to
+			// hasInteractiveToolInFlight()/getInFlightToolCount() so those
+			// watchdogs exempt it. No-op outside auto-mode (wrapper self-gates).
+			const elicId = "cc-elicit-" + ((request as { id?: string | number }).id ?? `${Date.now()}-${nextElicitationSeq()}`);
+			markToolStart(elicId, "ask_user_questions");
+			try {
+				const interviewResult = await showInterviewRound(questions, { signal }, { ui } as any).catch(() => undefined);
+				if (interviewResult === undefined) {
+					return promptElicitationWithDialogs(request, questions, ui, signal);
+				}
+				if (Object.keys(interviewResult.answers).length === 0) {
+					// A system/host teardown (compaction, session_switch, true
+					// interrupt) that aborted the signal mid-wait sets `interrupted`.
+					// Surface that as a non-affirmative `decline` so it is not
+					// laundered into a clean user-declined `cancel` the model re-asks
+					// against. A genuine user dismissal leaves `interrupted` falsy and
+					// keeps the prior `cancel` semantics.
+					return interviewResult.interrupted ? { action: "decline" } : { action: "cancel" };
+				}
+				return {
+					action: "accept",
+					content: roundResultToElicitationContent(questions, interviewResult),
+				};
+			} finally {
+				markToolEnd(elicId);
 			}
-			if (Object.keys(interviewResult.answers).length === 0) {
-				return { action: "cancel" };
-			}
-			return {
-				action: "accept",
-				content: roundResultToElicitationContent(questions, interviewResult),
-			};
 		}
 
 		const textFields = parseTextInputElicitation(request);
 		if (textFields) {
-			return promptTextInputElicitation(request, textFields, ui, signal);
+			const elicId = "cc-elicit-" + ((request as { id?: string | number }).id ?? `${Date.now()}-${nextElicitationSeq()}`);
+			markToolStart(elicId, "secure_env_collect");
+			try {
+				return await promptTextInputElicitation(request, textFields, ui, signal);
+			} finally {
+				markToolEnd(elicId);
+			}
 		}
 
 		return { action: "decline" };

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -38,6 +38,8 @@ import {
 } from "../stream-adapter.ts";
 import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
 import type { SDKUserMessage } from "../sdk-types.ts";
+import { _setAutoActiveForTest } from "../../gsd/auto.ts";
+import { getInFlightToolCount, hasInteractiveToolInFlight, clearInFlightTools } from "../../gsd/auto-tool-tracking.ts";
 
 // ---------------------------------------------------------------------------
 // Env helpers — `GSD_WORKFLOW_MCP_*` save/restore
@@ -1850,6 +1852,115 @@ describe("stream-adapter — MCP elicitation bridge", () => {
 		});
 		assert.equal(inputCalls.length, 1);
 		assert.equal(inputCalls[0]?.opts?.secure, true, "secure_env_collect fields should request secure input");
+	});
+
+	// -- self-cancel loop fix (#2676 / claude-code-cli) ----------------------
+	//
+	// Under claude-code-cli, ask_user_questions arrives as an SDK elicitation,
+	// not an MCP tool dispatch, so the auto-mode watchdogs never saw an in-flight
+	// tool during the human wait and re-dispatched/aborted the turn hosting the
+	// question (the "self-cancel loop"). The fix brackets the human wait with the
+	// interactive-tool guard and disambiguates a system-teardown abort (decline)
+	// from a deliberate user dismissal (cancel).
+
+	test("makes the SDK elicitation visible to the interactive-tool guard during the human wait", async () => {
+		_setAutoActiveForTest(true);
+		clearInFlightTools();
+		try {
+			let countDuringWait = -1;
+			let interactiveDuringWait = false;
+			const handler = createClaudeCodeElicitationHandler({
+				custom: async () => {
+					// Observe the in-flight guard state WHILE the question is open —
+					// this is the window where the watchdogs previously saw 0 tools.
+					countDuringWait = getInFlightToolCount();
+					interactiveDuringWait = hasInteractiveToolInFlight();
+					return {
+						endInterview: false,
+						answers: { storage_scope: { selected: "Cloud-synced", notes: "" }, platform: { selected: ["Web"], notes: "" } },
+					};
+				},
+			} as any);
+			assert.ok(handler);
+
+			const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+
+			assert.equal(countDuringWait, 1, "elicitation must register as an in-flight tool during the human wait");
+			assert.equal(interactiveDuringWait, true, "elicitation must be recognized as an interactive tool during the wait");
+			assert.equal(result.action, "accept");
+			assert.equal(getInFlightToolCount(), 0, "in-flight tool must be cleared after the elicitation resolves");
+		} finally {
+			_setAutoActiveForTest(false);
+			clearInFlightTools();
+		}
+	});
+
+	test("clears the in-flight tool even when the interview UI throws (finally)", async () => {
+		_setAutoActiveForTest(true);
+		clearInFlightTools();
+		try {
+			const handler = createClaudeCodeElicitationHandler({
+				// custom throws -> showInterviewRound rejects -> handler falls back
+				// to dialogs; the in-flight entry must still be cleared via finally.
+				custom: async () => {
+					throw new Error("simulated UI failure");
+				},
+				select: async (_title: string, options: string[], opts?: { allowMultiple?: boolean }) => {
+					if (opts?.allowMultiple) return ["Web"];
+					return options[0];
+				},
+				input: async () => "note",
+			} as any);
+			assert.ok(handler);
+
+			await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+			assert.equal(getInFlightToolCount(), 0, "in-flight tool must be cleared even when the UI throws");
+		} finally {
+			_setAutoActiveForTest(false);
+			clearInFlightTools();
+		}
+	});
+
+	test("returns decline (not cancel) when an interrupt empties the answers", async () => {
+		// A system/host teardown that aborts the signal mid-wait surfaces as
+		// interrupted:true -> the handler must return decline so the model does
+		// not re-ask against a clean user-declined cancel (the re-ask amplifier).
+		const handler = createClaudeCodeElicitationHandler({
+			custom: async () => ({ endInterview: false, answers: {}, interrupted: true }),
+			select: async () => {
+				throw new Error("interrupted elicitation must not re-open dialogs");
+			},
+		} as any);
+		assert.ok(handler);
+
+		const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+		assert.deepEqual(result, { action: "decline" });
+	});
+
+	test("returns cancel (today's semantics) when the user genuinely dismisses", async () => {
+		const handler = createClaudeCodeElicitationHandler({
+			custom: async () => ({ endInterview: false, answers: {} }),
+		} as any);
+		assert.ok(handler);
+
+		const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+		assert.deepEqual(result, { action: "cancel" });
+	});
+
+	test("does not register an in-flight tool outside auto-mode (wrapper self-gates)", async () => {
+		_setAutoActiveForTest(false);
+		clearInFlightTools();
+		let countDuringWait = -1;
+		const handler = createClaudeCodeElicitationHandler({
+			custom: async () => {
+				countDuringWait = getInFlightToolCount();
+				return { endInterview: false, answers: { storage_scope: { selected: "Cloud-synced", notes: "" }, platform: { selected: ["Web"], notes: "" } } };
+			},
+		} as any);
+		assert.ok(handler);
+
+		await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+		assert.equal(countDuringWait, 0, "foreground/non-auto elicitation must not touch the in-flight guard");
 	});
 });
 

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -287,10 +287,23 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
   }, 15000);
 
   // ── 3. Hard timeout ──
-  s.unitTimeoutHandle = setTimeout(async () => {
+  const hardTimeoutBody = async () => {
     try {
       s.unitTimeoutHandle = null;
       if (!s.active) return;
+      // User-interactive tools (ask_user_questions, secure_env_collect) block
+      // waiting for human input by design. Unlike the idle watchdog (above),
+      // the hard timeout had no interactive exemption, so a long human
+      // deliberation crossing the hard cap would still closeout + recover
+      // (triggerTurn) and abort the turn hosting the elicitation, reintroducing
+      // the self-cancel loop on slow answers (#2676). Re-arm instead of firing
+      // while a human is being asked, mirroring the idle watchdog's
+      // refresh-and-return. Conditional on hasInteractiveToolInFlight(), so a
+      // genuinely hung non-interactive unit still hits the hard cap.
+      if (getInFlightToolCount() > 0 && hasInteractiveToolInFlight()) {
+        s.unitTimeoutHandle = setTimeout(hardTimeoutBody, hardTimeoutMs);
+        return;
+      }
       const expectedCurrentUnit = s.currentUnit
         ? { type: s.currentUnit.type, id: s.currentUnit.id, startedAt: s.currentUnit.startedAt }
         : null;
@@ -323,7 +336,8 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
         logWarning("timer", `notification failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-  }, hardTimeoutMs);
+  };
+  s.unitTimeoutHandle = setTimeout(hardTimeoutBody, hardTimeoutMs);
 
   // ── 4. Context-pressure continue-here monitor ──
   if (s.continueHereHandle) {

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -62,6 +62,13 @@ export interface RoundResult {
 	/** Always false — end is handled by showWrapUpScreen, not per-question */
 	endInterview: false;
 	answers: Record<string, { selected: string | string[]; notes: string }>;
+	/**
+	 * Set to true only when the round ended because the external AbortSignal
+	 * fired (e.g. a system/host teardown), as distinct from a deliberate user
+	 * dismissal. Consumers use this to avoid laundering a system teardown into a
+	 * clean user-declined cancel. Additive/optional — native consumers ignore it.
+	 */
+	interrupted?: boolean;
 }
 
 export interface WrapUpResult {
@@ -240,7 +247,7 @@ export async function showInterviewRound(
 
 		// External cancellation (e.g. remote channel won the race)
 		if (opts.signal) {
-			const onAbort = () => finish({ endInterview: false, answers: {} });
+			const onAbort = () => finish({ endInterview: false, answers: {}, interrupted: true });
 			if (opts.signal.aborted) { onAbort(); }
 			else {
 				opts.signal.addEventListener("abort", onAbort, { once: true });


### PR DESCRIPTION
## Intent

Fix the claude-code-cli self-cancel loop: under the claude-code-cli provider (via the GSD PI MCP server), an interactive ask_user_questions prompt was auto-cancelled by the system with no user input (~4s 'Cancelled') and the agent then re-asked in a loop — the CLI 'answering itself' during discuss-milestone/discuss-phase in auto-mode.

Root cause (verified by multi-agent investigation): under claude-code-cli, ask_user_questions arrives as an SDK *elicitation* in createClaudeCodeElicitationHandler, NOT an MCP tool dispatch, so markToolStart/markToolEnd were never called; getInFlightToolCount() stayed 0 during the human wait, so the auto-mode soft trigger, context trigger, idle watchdog, and hard timeout treated the agent as idle and re-dispatched/settled the turn; that abort propagated through the SDK abort bridge, tore down the query hosting the elicitation, finished the interview with empty answers, and the model re-asked.

Deliberate decisions not visible in the diff:
- Scoped to the SDK provider only; native-TUI behavior must stay unchanged. markToolStart/markToolEnd from auto.js are s.active-gated so they no-op outside auto-mode.
- We DELIBERATELY did NOT edit write-gate.ts / register-hooks.ts / ask-user-questions.ts result-shaping (no isError, no re-ask guard, no loop-guard changes): confirmed dead code on the SDK cancel path (SDK elicitation returns {action} straight to the SDK, never hitting the ask_user_questions tool_result hook; the register-hooks approval-gate pause is short-circuited under auto-mode by 'if (dash.active) return;'). Editing them adds blast radius without fixing the loop.
- Three changes: (1) bracket the elicitation human-wait branches (ask_user_questions + secure_env_collect text input + dialogs fallback) with markToolStart/markToolEnd in try/finally keyed on a synthetic cc-elicit-<id>; (2) add the missing interactive exemption to the hard-timeout watchdog in auto-timers.ts (re-arm instead of closeout while hasInteractiveToolInFlight()), mirroring the idle watchdog; (3) defense-in-depth — optional RoundResult.interrupted set only on signal-abort, returning {action:'decline'} on interrupt vs {action:'cancel'} on genuine dismiss.
- nextElicitationSeq counter added because SdkElicitationRequest has no id field and to keep ids unique within a millisecond.
- Accepted gaps: no standalone auto-timers test (no harness for the deep startUnitSupervision closure; exemption mirrors the verified idle exemption line-for-line) and no live runtime smoke test yet (needs a real auto-mode claude-code-cli session via the MCP server). Unrelated packages/pi-ai/src/*.generated.ts churn and untracked build artifacts were intentionally excluded.

## What Changed

- Bracketed the SDK elicitation human-wait branches in `stream-adapter.ts` (`ask_user_questions`, `secure_env_collect` text input, and the dialogs fallback) with `markToolStart`/`markToolEnd` in try/finally, keyed on a synthetic `cc-elicit-<id>` (new `nextElicitationSeq` counter), so an in-flight interactive elicitation is now visible to `getInFlightToolCount()`/`hasInteractiveToolInFlight()` and no longer reads as idle to the auto-mode triggers.
- Added the missing interactive exemption to the hard-timeout watchdog in `gsd/auto-timers.ts` — it now re-arms instead of closing out the unit while an interactive tool is in flight, mirroring the existing idle-watchdog exemption.
- Added defense-in-depth in `shared/interview-ui.ts`: a `RoundResult.interrupted` flag set only on signal-abort, returning `{action:'decline'}` on interrupt versus `{action:'cancel'}` on a genuine user dismiss; plus new `stream-adapter.test.ts` coverage and docs/CHANGELOG updates for the interactive-prompt timeout exemption.

## Risk Assessment

✅ Low: A tightly-scoped, auto-mode-gated fix that only adds in-flight-tool visibility for SDK elicitations and re-arms one watchdog; behavior is backstopped by the idle watchdog, native-TUI paths are untouched, and the change is covered by new tests.

## Testing

After installing deps and building the pi workspace stack (required because the test imports the full stream-adapter graph), the affected test file passes 163/163, including the five new tests that exercise this fix. They demonstrate the user intent at the precise boundary that caused the self-cancel loop: while an `ask_user_questions` elicitation is open, it now registers as an in-flight interactive tool (count=1, hasInteractiveToolInFlight=true) — which is exactly the state the soft/idle/context/hard watchdogs read to decide idleness — so they will exempt the prompt instead of re-dispatching and aborting it. The tests also confirm decline-vs-cancel disambiguation (so a system teardown isn't laundered into a user-declined cancel the model re-asks against) and that the path is a no-op outside auto-mode, keeping native-TUI behavior unchanged. This is a CLI/SDK provider behavioral fix with no rendered UI surface, so the reviewer-visible evidence is the guard-state assertions/CLI test transcript rather than a screenshot — that handler/guard seam is the actual end-user behavior boundary here. One accepted gap: the hard-timeout watchdog's new interactive exemption has no standalone test (line-for-line mirror of the tested idle exemption; author accepted the missing harness). Build artifacts were cleaned up and regenerated *.generated.ts churn reverted, leaving a clean tree.

<details>
<summary>Evidence: Self-cancel-loop fix — new test transcript (5/5 pass)</summary>

<code>▶ stream-adapter — MCP elicitation bridge&#10;✔ makes the SDK elicitation visible to the interactive-tool guard during the human wait&#10;✔ clears the in-flight tool even when the interview UI throws (finally)&#10;✔ returns decline (not cancel) when an interrupt empties the answers&#10;✔ returns cancel (today&#39;s semantics) when the user genuinely dismisses&#10;✔ does not register an in-flight tool outside auto-mode (wrapper self-gates)&#10;ℹ tests 5 ℹ pass 5 ℹ fail 0</code>

```text
▶ stream-adapter — MCP elicitation bridge
  ✔ makes the SDK elicitation visible to the interactive-tool guard during the human wait (1.47775ms)
  ✔ clears the in-flight tool even when the interview UI throws (finally) (0.314916ms)
  ✔ returns decline (not cancel) when an interrupt empties the answers (1.233375ms)
  ✔ returns cancel (today's semantics) when the user genuinely dismisses (0.138708ms)
  ✔ does not register an in-flight tool outside auto-mode (wrapper self-gates) (0.121166ms)
✔ stream-adapter — MCP elicitation bridge (4.390292ms)
ℹ tests 5
ℹ pass 5
ℹ fail 0
```
</details>
- Outcome: ⚠️ 1 info across 1 run (9m53s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/resources/extensions/gsd/auto-timers.ts:303` - The hard-timeout re-arm uses a full `hardTimeoutMs` per cycle (auto-timers.ts:304), so after a slow human answer the unit effectively gets a fresh full hard-timeout window from the re-arm point rather than from unit start. This bounded weakening of the hard cap only occurs after interactive-tool use and is backstopped by the 15s idle watchdog (which would still catch a hung post-answer non-interactive unit), so it&#39;s an acceptable tradeoff — noting for awareness. The leading `getInFlightToolCount() &gt; 0 &amp;&amp;` in the condition is also redundant since `hasInteractiveToolInFlight()` already returns false on an empty map, but it&#39;s harmless/defensive.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `src/resources/extensions/gsd/auto-timers.ts:303` - The auto-timers.ts hard-timeout interactive exemption (re-arm while hasInteractiveToolInFlight()) has no standalone test — it is a line-for-line mirror of the already-present idle-watchdog exemption, and the author explicitly accepted this gap (no harness exists for the deep startUnitSupervision timer closure). The primary mechanism that makes ALL four watchdogs (including the hard timeout) exempt the elicitation — registering it as an in-flight interactive tool during the wait — is directly tested and passing, so the fix&#39;s core behavior is demonstrated. Noted for transparency, not a blocker.
- <code>`pnpm install --frozen-lockfile` + `pnpm run build:pi` (workspace dist needed for the stream-adapter import graph)</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — full file: 163 pass / 0 fail</code>
- <code>New test: `makes the SDK elicitation visible to the interactive-tool guard during the human wait` — asserts getInFlightToolCount()===1 and hasInteractiveToolInFlight()===true mid-wait, then 0 after resolve</code>
- <code>New test: `clears the in-flight tool even when the interview UI throws (finally)`</code>
- <code>New test: `returns decline (not cancel) when an interrupt empties the answers`</code>
- <code>New test: `returns cancel (today&#39;s semantics) when the user genuinely dismisses`</code>
- <code>New test: `does not register an in-flight tool outside auto-mode (wrapper self-gates)` — confirms native-TUI path unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783561195&installation_id=134682257&pr_number=601&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F601&signature=75b2b26b6daeafc7eedf1e1f901259f2ec3e966d0fa97aefc6cf55b615f2636f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to auto-mode-gated elicitation handling and one watchdog branch; native TUI paths unchanged and covered by new tests.
> 
> **Overview**
> Fixes the **claude-code-cli** auto-mode loop where `ask_user_questions` (and similar prompts) were torn down after a few seconds and the model kept re-asking.
> 
> Under Claude Code, those prompts are **SDK elicitations**, not MCP tool calls, so auto-mode never saw an in-flight tool during the human wait. Idle/hard watchdogs treated the unit as idle and aborted the turn hosting the question.
> 
> **`stream-adapter.ts`** wraps the human-wait paths (`ask_user_questions`, `secure_env_collect`, dialog fallback) in **`markToolStart` / `markToolEnd`** with synthetic `cc-elicit-*` ids so **`hasInteractiveToolInFlight()`** stays true while the UI is open (auto-mode only). Dialog fallback is **`await`**ed so the guard is not cleared early. Empty answers after a signal abort return **`decline`** instead of **`cancel`** via optional **`RoundResult.interrupted`** in **`interview-ui.ts`**.
> 
> **`auto-timers.ts`** gives the **hard timeout** the same interactive exemption as idle: re-arm instead of closeout while an interactive tool is in flight.
> 
> Docs and CHANGELOG note the exemption; new **`stream-adapter`** tests cover guard visibility, `finally` cleanup, decline vs cancel, and non-auto no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76796bcee78b35c48a0f84bbd2f4fa9275bc9b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->