### PR TITLE
fix(claude-code-cli): keep foreground ask_user_questions elicitation alive through the approval pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 ## [Unreleased]
 
 ### Fixed
+- **claude-code-cli**: keep in-flight ask_user_questions elicitation alive through the foreground approval pause
 - **claude-code-cli**: stop auto-mode watchdogs from self-cancelling ask_user_questions
 - **gsd**: stop duplicate claude code question fallback
 - **issue**: [Bug]: After upgrading to version 1.1.1 GSD is stuck for missing toolset

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -47,6 +47,10 @@ import { buildProjectGsdMcpServers, ensureProjectWorkflowMcpConfig } from "../gs
 import { loadProjectGSDPreferences } from "../gsd/preferences.js";
 import { markToolStart, markToolEnd } from "../gsd/auto.js";
 import {
+	markInteractiveElicitationStart,
+	markInteractiveElicitationEnd,
+} from "../gsd/auto-tool-tracking.js";
+import {
 	discoverBrowserMcpServerName,
 	discoverMcpServers,
 	discoverMcpServerNames,
@@ -1407,7 +1411,15 @@ export function createClaudeCodeElicitationHandler(
 			// the s.active-gated interactive-tool guard makes it visible to
 			// hasInteractiveToolInFlight()/getInFlightToolCount() so those
 			// watchdogs exempt it. No-op outside auto-mode (wrapper self-gates).
+			//
+			// markInteractiveElicitationStart/End is a SEPARATE, ungated signal that
+			// is observable in FOREGROUND (where the s.active-gated markToolStart is a
+			// no-op). The foreground approval-gate pause path (register-hooks
+			// message_update) consults isInteractiveElicitationInFlight() and bails so
+			// it does not tear down the very elicitation that IS the human boundary
+			// (#cc-elicitation-self-cancel). It clears in the finally on every exit.
 			const elicId = "cc-elicit-" + ((request as { id?: string | number }).id ?? `${Date.now()}-${nextElicitationSeq()}`);
+			markInteractiveElicitationStart();
 			markToolStart(elicId, "ask_user_questions");
 			try {
 				const interviewResult = await showInterviewRound(questions, { signal }, { ui } as any).catch(() => undefined);
@@ -1434,6 +1446,7 @@ export function createClaudeCodeElicitationHandler(
 				};
 			} finally {
 				markToolEnd(elicId);
+				markInteractiveElicitationEnd();
 			}
 		}
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -39,7 +39,7 @@ import {
 import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
 import type { SDKUserMessage } from "../sdk-types.ts";
 import { _setAutoActiveForTest } from "../../gsd/auto.ts";
-import { getInFlightToolCount, hasInteractiveToolInFlight, clearInFlightTools } from "../../gsd/auto-tool-tracking.ts";
+import { getInFlightToolCount, hasInteractiveToolInFlight, clearInFlightTools, isInteractiveElicitationInFlight } from "../../gsd/auto-tool-tracking.ts";
 
 // ---------------------------------------------------------------------------
 // Env helpers — `GSD_WORKFLOW_MCP_*` save/restore
@@ -1961,6 +1961,57 @@ describe("stream-adapter — MCP elicitation bridge", () => {
 
 		await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
 		assert.equal(countDuringWait, 0, "foreground/non-auto elicitation must not touch the in-flight guard");
+	});
+
+	// The FOREGROUND self-cancel regression guard: the s.active-gated in-flight
+	// guard above is a no-op in foreground, so the foreground approval-gate pause
+	// path needs a SEPARATE, ungated signal to see the elicitation as the active
+	// human boundary. isInteractiveElicitationInFlight() must be true DURING the
+	// wait and false after, even with auto inactive (#cc-elicitation-self-cancel).
+	test("sets the ungated interactive-elicitation marker in FOREGROUND (auto inactive)", async () => {
+		_setAutoActiveForTest(false);
+		clearInFlightTools();
+		try {
+			let markerDuringWait = false;
+			let countDuringWait = -1;
+			const handler = createClaudeCodeElicitationHandler({
+				custom: async () => {
+					markerDuringWait = isInteractiveElicitationInFlight();
+					countDuringWait = getInFlightToolCount();
+					return {
+						endInterview: false,
+						answers: { storage_scope: { selected: "Cloud-synced", notes: "" }, platform: { selected: ["Web"], notes: "" } },
+					};
+				},
+			} as any);
+			assert.ok(handler);
+
+			const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+
+			assert.equal(markerDuringWait, true, "ungated marker must be true during the foreground human wait");
+			assert.equal(countDuringWait, 0, "the separate marker must NOT touch the in-flight tool count in foreground");
+			assert.equal(result.action, "accept");
+			assert.equal(isInteractiveElicitationInFlight(), false, "marker must clear after the elicitation resolves");
+		} finally {
+			clearInFlightTools();
+		}
+	});
+
+	test("clears the ungated marker even when the interview UI throws in FOREGROUND (finally)", async () => {
+		_setAutoActiveForTest(false);
+		clearInFlightTools();
+		try {
+			const handler = createClaudeCodeElicitationHandler({
+				custom: async () => {
+					throw new Error("ui exploded");
+				},
+			} as any);
+			assert.ok(handler);
+			await handler!(askUserQuestionsRequest, { signal: new AbortController().signal }).catch(() => undefined);
+			assert.equal(isInteractiveElicitationInFlight(), false, "marker must clear via finally on throw");
+		} finally {
+			clearInFlightTools();
+		}
 	});
 });
 

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -9,6 +9,10 @@ import {
   markToolEnd as markTrackedToolEnd,
   markToolStart as markTrackedToolStart,
 } from "./auto-tool-tracking.js";
+// Re-exported as a pure pass-through. Must stay UNGATED (no autoSession.active
+// argument, unlike markToolStart at the bottom of this file) so it is true in
+// foreground where the foreground approval-gate pause consults it.
+export { isInteractiveElicitationInFlight } from "./auto-tool-tracking.js";
 import {
   createToolSurfaceSnapshot,
   type ToolSurfaceSnapshot,

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -20,6 +20,17 @@ const inFlightTools = new Map<string, InFlightTool>();
 const INTERACTIVE_TOOLS = new Set(["ask_user_questions", "secure_env_collect"]);
 
 /**
+ * Mode-agnostic refcount of in-flight interactive elicitations that are an
+ * active human boundary (the model ASKED via ask_user_questions). Unlike the
+ * `inFlightTools` Map, this is NOT gated by auto-session.active, so it is true
+ * in FOREGROUND (where s.active is false). Kept SEPARATE from inFlightTools so
+ * getInFlightToolCount()/getOldestInFlightToolAgeMs()/hasInteractiveToolInFlight()
+ * and the auto-watchdog accounting are byte-for-byte unchanged. A refcount (not
+ * a boolean) handles nested/back-to-back elicitations in a single turn.
+ */
+let interactiveElicitationDepth = 0;
+
+/**
  * Mark a tool execution as in-flight.
  * Records start time and tool name so the idle watchdog can detect tools
  * hung longer than the idle timeout while exempting interactive tools.
@@ -34,6 +45,29 @@ export function markToolStart(toolCallId: string, isActive: boolean, toolName?: 
  */
 export function markToolEnd(toolCallId: string): void {
   inFlightTools.delete(toolCallId);
+}
+
+/**
+ * Mark an interactive elicitation (the model asking via ask_user_questions) as
+ * in flight. Ungated by auto-session.active so it is observable in foreground.
+ */
+export function markInteractiveElicitationStart(): void {
+  interactiveElicitationDepth++;
+}
+
+/**
+ * Mark an interactive elicitation as completed. Idempotent below zero.
+ */
+export function markInteractiveElicitationEnd(): void {
+  if (interactiveElicitationDepth > 0) interactiveElicitationDepth--;
+}
+
+/**
+ * Returns true if any interactive elicitation is currently the active human
+ * boundary. True in ALL modes (foreground and auto) while one is in flight.
+ */
+export function isInteractiveElicitationInFlight(): boolean {
+  return interactiveElicitationDepth > 0;
 }
 
 /**
@@ -84,6 +118,7 @@ export function hasInteractiveToolInFlight(): boolean {
  */
 export function clearInFlightTools(): void {
   inFlightTools.clear();
+  interactiveElicitationDepth = 0;
 }
 
 // ─── Tool invocation error classification (#2883) ────────────────────────

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -25,6 +25,7 @@ import {
   isAutoActive,
   isAutoCompletionStopInProgress,
   isAutoPaused,
+  isInteractiveElicitationInFlight,
   markToolEnd,
   markToolStart,
   recordAutoToolSurfaceSnapshot,
@@ -1013,6 +1014,14 @@ export function registerHooks(
 
   pi.on("message_update", async (event, ctx: ExtensionContext) => {
     if (approvalQuestionAbortInFlight) return;
+    // If the model asked via ask_user_questions, that in-flight elicitation IS
+    // the human boundary. Arming the pause/gate here (and emitting the "waiting
+    // for your approval - pausing" notice) would tear it down and trigger the
+    // foreground self-cancel/re-ask loop. The marker is set only by the
+    // claude-code-cli SDK elicitation handler and is ungated, so it is true in
+    // foreground; under the native-TUI provider it is always false and this path
+    // runs unchanged (#cc-elicitation-self-cancel).
+    if (isInteractiveElicitationInFlight()) return;
 
     const dash = getAutoRuntimeSnapshot();
     if (dash.active) return;

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -18,6 +18,11 @@ import {
 } from "../bootstrap/write-gate.ts";
 import { classifyCommand } from "../safety/destructive-guard.ts";
 import { toRoundResultResponse } from "../../remote-questions/manager.ts";
+import {
+  markInteractiveElicitationStart,
+  markInteractiveElicitationEnd,
+  clearInFlightTools,
+} from "../auto-tool-tracking.ts";
 
 function makeTempDir(prefix: string): string {
   const dir = join(
@@ -707,4 +712,93 @@ test("register-hooks gates MCP ask_user_questions cancellation before requiremen
 
   assert.equal(requirementBlock?.block, true, "requirement save must be blocked while gate is pending");
   assert.match(requirementBlock?.reason ?? "", /has not been confirmed/);
+});
+
+// ─── Foreground self-cancel regression (#cc-elicitation-self-cancel) ───
+// Product-visible symptom: under claude-code-cli + gsd-MCP, ask_user_questions
+// is routed as an SDK elicitation (the human boundary). The message_update hook
+// would arm the approval-gate pause and emit the "waiting for your approval -
+// pausing" notice, tearing down that elicitation and looping a re-ask. The fix
+// makes message_update bail while an interactive elicitation is in flight, while
+// still pausing for prose-only approvals (native-TUI provider, where the marker
+// is always false). This drives the real registered hook end-to-end.
+test("register-hooks message_update does NOT pause while an interactive elicitation is the human boundary, but still pauses otherwise", async (t) => {
+  const dir = makeTempDir("elicitation-pause-guard");
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  resetWriteGateState(dir);
+  clearPendingAutoStart(dir);
+  clearInFlightTools();
+
+  t.after(() => {
+    try {
+      resetWriteGateState(dir);
+      clearPendingAutoStart(dir);
+      clearInFlightTools();
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  const notices: Array<{ text: string; level: string }> = [];
+  const ctx = {
+    cwd: dir,
+    ui: { notify: (text: string, level: string) => notices.push({ text, level }) },
+  } as any;
+
+  registerHooks(pi, []);
+
+  // A discuss-milestone is the active unit, so the approval text would normally
+  // arm the pause/notice path.
+  setPendingAutoStart(dir, {
+    basePath: dir,
+    milestoneId: "M001",
+    ctx,
+    pi: { sendMessage: () => undefined } as any,
+  });
+
+  // The model's plain-text approval question — identical in both phases.
+  const approvalMessage = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Here is the milestone plan.\n\nDid I capture the project correctly?" },
+    ],
+  };
+
+  const fireMessageUpdate = async () => {
+    for (const handler of handlers.get("message_update") ?? []) {
+      await handler({ message: approvalMessage }, ctx);
+    }
+  };
+
+  // Phase 1 — FIX: an interactive elicitation is in flight (claude-code-cli
+  // foreground). The pause/notice MUST be suppressed.
+  markInteractiveElicitationStart();
+  await fireMessageUpdate();
+  assert.equal(
+    notices.some((n) => /waiting for your approval - pausing/.test(n.text)),
+    false,
+    "must NOT emit the approval-pause notice while the elicitation is the human boundary",
+  );
+  markInteractiveElicitationEnd();
+
+  // Phase 2 — control: no elicitation in flight (native-TUI provider or a
+  // prose-only approval). The same message MUST still pause.
+  notices.length = 0;
+  await fireMessageUpdate();
+  assert.equal(
+    notices.some((n) => /discuss-milestone M001 is waiting for your approval - pausing/.test(n.text)),
+    true,
+    "prose-only approval with no elicitation in flight must still arm the pause notice",
+  );
 });

--- a/src/tests/auto-tool-tracking.test.ts
+++ b/src/tests/auto-tool-tracking.test.ts
@@ -6,6 +6,9 @@ import {
   getOldestInFlightToolAgeMs,
   getInFlightToolCount,
   clearInFlightTools,
+  markInteractiveElicitationStart,
+  markInteractiveElicitationEnd,
+  isInteractiveElicitationInFlight,
 } from "../resources/extensions/gsd/auto-tool-tracking.js";
 
 describe("auto-tool-tracking", () => {
@@ -42,5 +45,41 @@ describe("auto-tool-tracking", () => {
     assert.equal(getInFlightToolCount(), 2);
     clearInFlightTools();
     assert.equal(getInFlightToolCount(), 0);
+  });
+
+  describe("interactive elicitation refcount", () => {
+    it("is false with no elicitation in flight", () => {
+      assert.equal(isInteractiveElicitationInFlight(), false);
+    });
+
+    it("is true while at least one elicitation is in flight (refcounted)", () => {
+      markInteractiveElicitationStart();
+      markInteractiveElicitationStart();
+      assert.equal(isInteractiveElicitationInFlight(), true);
+      markInteractiveElicitationEnd();
+      // Nested: still true until the last one ends — a boolean would clear early.
+      assert.equal(isInteractiveElicitationInFlight(), true);
+      markInteractiveElicitationEnd();
+      assert.equal(isInteractiveElicitationInFlight(), false);
+    });
+
+    it("never goes below zero", () => {
+      markInteractiveElicitationEnd();
+      assert.equal(isInteractiveElicitationInFlight(), false);
+    });
+
+    it("is independent of the inFlightTools count (auto-watchdog accounting unchanged)", () => {
+      markInteractiveElicitationStart();
+      assert.equal(isInteractiveElicitationInFlight(), true);
+      assert.equal(getInFlightToolCount(), 0, "marker must not touch inFlightTools");
+      markInteractiveElicitationEnd();
+    });
+
+    it("is reset by clearInFlightTools()", () => {
+      markInteractiveElicitationStart();
+      assert.equal(isInteractiveElicitationInFlight(), true);
+      clearInFlightTools();
+      assert.equal(isInteractiveElicitationInFlight(), false);
+    });
   });
 });


### PR DESCRIPTION
## Intent

Fix the FOREGROUND (non-auto) claude-code-cli self-cancel of ask_user_questions. Background: under the claude-code-cli provider + the gsd-workflow MCP server, ask_user_questions is forced to the MCP tool (SDK-native AskUserQuestion is disabled at stream-adapter.ts:1835) and routed as an MCP elicitation to createClaudeCodeElicitationHandler. The interactive prompt was auto-cancelled by the system with no user input (~8s 'Cancelled') and the model re-asked in a loop; the 'waiting for your approval - pausing' notice fired. Other providers run ask_user_questions as a normal blocking MCP tool and are unaffected — this is provider-specific by design.

PR #601 (already merged) fixed only the AUTO-MODE sub-path: it marks the SDK elicitation as in-flight via markToolStart/markToolEnd, but those are s.active-gated and no-op in foreground, so the foreground vector remained.

This change adds a mode-agnostic fix:
- A SEPARATE, UNGATED interactiveElicitationDepth refcount in auto-tool-tracking.ts (markInteractiveElicitationStart/End/isInteractiveElicitationInFlight), zeroed in clearInFlightTools(). Deliberately kept distinct from the inFlightTools Map so getInFlightToolCount()/hasInteractiveToolInFlight() accounting and the existing 'getInFlightToolCount===0 outside auto-mode' test stay unchanged.
- stream-adapter.ts brackets the ask_user_questions elicitation human-wait with the ungated marker (start before the existing gated markToolStart, end in the same finally so it balances on accept/cancel/decline/dialog-fallback/throw). secure_env_collect intentionally untouched (the approval pause only matches discussion/approval unit types).
- auto-runtime-state.ts re-exports isInteractiveElicitationInFlight UNGATED (must NOT be wrapped with autoSession.active like markToolStart, or it would re-break foreground).
- register-hooks.ts message_update hook bails when isInteractiveElicitationInFlight() before arming deferApprovalGate/approvalQuestionAbortInFlight/notify — the in-flight elicitation IS the human boundary.

Deliberate decisions a reviewer won't infer from the diff:
- Native-TUI is intentionally untouched: it never enters createClaudeCodeElicitationHandler (it calls ask-user-questions execute() directly), so the marker stays false and the pause path runs exactly as today.
- Non-elicitation plain-text approval questions MUST still pause: the guard keys on the in-flight elicitation, not the approval-text regex, so prose-only approvals still arm the gate.
- interrupt->decline disambiguation from PR #601 is intentionally left untouched.
- The *.generated.ts churn (packages/pi-ai) was intentionally excluded from the commit.
- Known accepted limit: the actual host-side turn-abort caller lives in packages/gsd-agent-core (agent-session-prompt/agent-session-compaction); this fix removes the GSD-owned pause/gate/notice that produces the visible symptom (including the notice), but end-to-end proof needs a live foreground claude-code-cli + gsd-MCP repro, which unit tests cannot provide.

## What Changed

- Added a separate, mode-agnostic `interactiveElicitationDepth` refcount in `gsd/auto-tool-tracking.ts` (`markInteractiveElicitationStart`/`End`/`isInteractiveElicitationInFlight`), kept distinct from the `s.active`-gated `inFlightTools` map so it works in FOREGROUND as well as auto-mode and is zeroed by `clearInFlightTools()`; re-exported ungated via `auto-runtime-state.ts`.
- Bracketed the `ask_user_questions` elicitation human-wait in `claude-code-cli/stream-adapter.ts` with the new marker (start before the existing gated `markToolStart`, end in the same `finally` so it balances on accept/cancel/decline/dialog-fallback/throw).
- Made the `register-hooks.ts` `message_update` hook bail when `isInteractiveElicitationInFlight()` so the in-flight elicitation is treated as the human boundary and the "waiting for your approval — pausing" notice no longer fires over it; plain-text approval questions still pause. Added coverage in `auto-tool-tracking.test.ts`, `stream-adapter.test.ts`, and a new `register-hooks-depth-verification.test.ts`, plus a CHANGELOG entry.

## Risk Assessment

✅ Low: Additive, well-bounded fix: a separate ungated refcount plus a single early-return guard that provably leaves auto-mode and native-TUI paths unchanged, balanced in a finally on every exit, and backed by direct unit tests.

## Testing

Installed deps and built the contracts/pi package chain to satisfy the stream-adapter test's workspace imports, then ran the project's node:test suites for the three files this change touches. The existing diff tests cover the marker mechanism and the foreground stream-adapter handler, but nothing exercised the register-hooks message_update path that produces the user-visible "waiting for your approval - pausing" notice — the actual symptom — so I added a test that drives the real registered hook end-to-end and asserts the notice is suppressed while an elicitation is in flight yet still fires for prose-only approvals (native-TUI path). I proved the test is meaningful by removing the guard line and watching it fail with the exact assertion, then restored the source. As a host-side/CLI fix the end-user surface is a terminal notice rather than a rendered screen, so evidence is the hook-level transcript saved to the evidence dir; the author themselves noted full end-to-end proof needs a live foreground claude-code-cli + gsd-MCP repro that unit tests cannot provide. All 186 tests pass and the working tree holds only the intentional new test.

<details>
<summary>Evidence: Foreground self-cancel fix — consolidated test transcript</summary>

<code>== register-hooks message_update suppresses the user-visible approval-pause notice (drives the REAL registered hook end-to-end) ==&#10;✔ register-hooks message_update does NOT pause while an interactive elicitation is the human boundary, but still pauses otherwise&#10;ℹ tests 11 ℹ pass 11 ℹ fail 0&#10;&#10;== marker mechanism (foreground) + claude-code-cli SDK handler ==&#10;✔ sets the ungated interactive-elicitation marker in FOREGROUND (auto inactive)&#10;✔ clears the ungated marker even when the interview UI throws in FOREGROUND (finally)</code>

```text
### Foreground self-cancel fix (#cc-elicitation-self-cancel) — test evidence

== 1. Ungated marker mechanism (auto-tool-tracking) ==
  ▶ interactive elicitation refcount
    ✔ is true while at least one elicitation is in flight (refcounted) (0.125708ms)
    ✔ never goes below zero (0.079ms)
    ✔ is independent of the inFlightTools count (auto-watchdog accounting unchanged) (0.096333ms)
    ✔ is reset by clearInFlightTools() (0.116792ms)
  ✔ interactive elicitation refcount (0.777583ms)
ℹ tests 10
ℹ pass 10
ℹ fail 0

== 2. claude-code-cli SDK handler sets the marker in FOREGROUND (auto inactive) ==
  ✔ sets the ungated interactive-elicitation marker in FOREGROUND (auto inactive) (0.094042ms)
  ✔ clears the ungated marker even when the interview UI throws in FOREGROUND (finally) (0.155625ms)
✔ bashCommandMatchesSavedRules — compound command bypass (10.698791ms)
ℹ tests 165
ℹ pass 165
ℹ fail 0

== 3. register-hooks message_update suppresses the user-visible approval-pause notice ==
    (drives the REAL registered hook end-to-end)
✔ register-hooks message_update does NOT pause while an interactive elicitation is the human boundary, but still pauses otherwise (3.230459ms)
ℹ tests 11
ℹ pass 11
ℹ fail 0
```
</details>
<details>
<summary>Evidence: Negative control — test fails when the guard is removed</summary>

```text
After deleting `if (isInteractiveElicitationInFlight()) return;` from register-hooks.ts message_update:
✖ register-hooks message_update does NOT pause while an interactive elicitation is the human boundary, but still pauses otherwise
AssertionError: must NOT emit the approval-pause notice while the elicitation is the human boundary
ℹ tests 11 ℹ pass 10 ℹ fail 1
(guard restored afterward; git diff clean for register-hooks.ts)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/resources/extensions/gsd/auto-tool-tracking.ts:31` - interactiveElicitationDepth is a single process-global refcount, and the message_update guard (register-hooks.ts:1024) consults it with no per-context scoping. If the host ever runs multiple agent contexts concurrently in one process (e.g. parallel-orchestrator), an ask_user_questions elicitation in context A would suppress the foreground approval-gate pause for context B until it resolves. Impact is low and this mirrors the existing process-global inFlightTools design, so it&#39;s an accepted-precedent tradeoff rather than a regression — noting for awareness only.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/auto-tool-tracking.test.ts` — ungated interactive-elicitation refcount (refcounted true-while-in-flight, never below zero, independent of inFlightTools count, reset by clearInFlightTools)</code>
- <code>`node ... --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — `sets the ungated interactive-elicitation marker in FOREGROUND (auto inactive)` and `clears the ungated marker even when the interview UI throws in FOREGROUND (finally)` (165 tests pass)</code>
- <code>`node ... --test src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts` — added and ran `register-hooks message_update does NOT pause while an interactive elicitation is the human boundary, but still pauses otherwise`, driving the real registered hook with a notify spy</code>
- <code>Negative control: temporarily removed the `if (isInteractiveElicitationInFlight()) return;` guard in register-hooks.ts and confirmed the new test fails with `must NOT emit the approval-pause notice while the elicitation is the human boundary`, then restored the file (no leftover diff)</code>
- `Combined final run of all three affected files: 186/186 pass`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783567321&installation_id=134682257&pr_number=602&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F602&signature=5e2b21d75c33302ec7e7c15444a94db12d9651b9483364892f8160da512c22af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive refcount plus one early-return in message_update; auto-mode and native-TUI paths unchanged when the marker is false, with regression tests including a negative control on the hook guard.
> 
> **Overview**
> Fixes **foreground** claude-code-cli sessions where `ask_user_questions` (SDK elicitation) was cancelled and re-asked in a loop because the approval-gate `message_update` path fired **"waiting for your approval - pausing"** over the active prompt. Auto-mode already used gated `markToolStart`/`markToolEnd`; that path is a no-op when auto is inactive.
> 
> Adds a **mode-agnostic** `interactiveElicitationDepth` refcount (`markInteractiveElicitationStart`/`End`, `isInteractiveElicitationInFlight`) kept separate from `inFlightTools` so watchdog counts stay unchanged. The claude-code elicitation handler brackets the human wait with this marker (cleared in `finally`). **`register-hooks`** skips the foreground approval pause while the marker is set; prose-only approvals still pause when no elicitation is in flight.
> 
> Unit tests cover the refcount, the stream-adapter handler in foreground, and the registered hook end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf55faaf8846602479e5afb1a41648d996bd209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->