### PR TITLE
fix(tui): suppress redundant Claude Code discuss wait-ack sub-turns

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -96,6 +96,73 @@ test("isRedundantDiscussRestatement: keeps short new follow-up questions", () =>
 	assert.equal(isRedundantDiscussRestatement(prior, next), false);
 });
 
+test("isRedundantDiscussRestatement: drops holding-here wait ack after questions", () => {
+	const prior = [
+		"Oriented. Here's where things stand.",
+		"1. Where should we take this?",
+		"2. One focused capability, or a polish/utility pass?",
+	].join("\n");
+	const next =
+		"I've asked my two questions above and I'm holding here for your answer - no need for anything else from me until you point M002 in a direction.";
+	assert.equal(isRedundantDiscussRestatement(prior, next), true);
+});
+
+test("isRedundantDiscussRestatement: keeps wait ack that adds a new question", () => {
+	const prior = "What do you want to build for M006?";
+	const next = "I've asked about scope above. Should we also add offline support?";
+	assert.equal(isRedundantDiscussRestatement(prior, next), false);
+});
+
+test("handleAgentEvent: suppresses redundant holding-here sub-turn after discuss questions", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const prior = [
+		"Oriented. Here's where things stand.",
+		"1. Where should we take this?",
+		"2. One focused capability, or a polish/utility pass?",
+	].join("\n");
+	const waitAck =
+		"I've asked my two questions above and I'm holding here for your answer - no need for anything else from me until you point M002 in a direction.";
+	function makeMessage(content: any[]): any {
+		return {
+			id: "a-discuss",
+			role: "assistant",
+			provider: "claude-code",
+			model: "claude-opus-4-8",
+			timestamp: 1,
+			stopReason: "stop",
+			content,
+		};
+	}
+	const host = createStreamingHost(chatContainer);
+	const first = makeMessage([{ type: "text", text: prior }]);
+
+	await handleAgentEvent(host, { type: "message_start", message: makeMessage([]) } as any);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: first,
+		assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: prior, partial: first },
+	} as any);
+
+	// Claude Code can replace sub-turn text at the same content index.
+	const replaced = makeMessage([{ type: "text", text: waitAck }]);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: replaced,
+		assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: waitAck, partial: replaced },
+	} as any);
+
+	const final = makeMessage([
+		{ type: "text", text: prior },
+		{ type: "text", text: waitAck },
+	]);
+	await handleAgentEvent(host, { type: "message_end", message: final } as any);
+
+	const rendered = stripAnsi(chatContainer.render(100).join("\n"));
+	assert.match(rendered, /Where should we take this/);
+	assert.doesNotMatch(rendered, /holding here for your answer/);
+});
+
 test("isProvisionalPreToolProse: only treats transient tool scaffolding as disposable", () => {
 	assert.equal(isProvisionalPreToolProse("I'll inspect the current state and then patch it."), true);
 	assert.equal(isProvisionalPreToolProse("Running the focused tests now."), true);

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -113,6 +113,34 @@ test("isRedundantDiscussRestatement: keeps wait ack that adds a new question", (
 	assert.equal(isRedundantDiscussRestatement(prior, next), false);
 });
 
+test("isRedundantDiscussRestatement: keeps new question even when wait language is also present", () => {
+	// Bug 1: ? + wait language together must NOT be suppressed.
+	const prior = [
+		"Oriented. Here's where things stand.",
+		"1. Where should we take this?",
+		"2. One focused capability, or a polish/utility pass?",
+	].join("\n");
+	const next = "I'm holding here. Should we also add offline support?";
+	assert.equal(isRedundantDiscussRestatement(prior, next), false);
+});
+
+test("isRedundantDiscussRestatement: does not suppress long combined text with incidental wait language", () => {
+	// Bug 2: full extractAssistantText (questions + trailing wait-ack, >400 chars) must NOT be suppressed.
+	const prior = "Let me know what you think.";
+	const questions = [
+		"Here is what I need to understand before proceeding:",
+		"1. What is the primary goal of this milestone?",
+		"2. Are there any hard deadlines we must hit?",
+		"3. Which existing modules should this new work integrate with?",
+		"4. Do you have a preference for the data storage approach?",
+		"5. Should we prioritize mobile responsiveness or desktop-first for this phase?",
+		"6. Are there any existing design patterns or component libraries we must follow?",
+	].join("\n");
+	const next = questions + "\n\nI'm holding here for your answers before I can move forward.";
+	assert.ok(next.length > 400, "test fixture must exceed the guard threshold");
+	assert.equal(isRedundantDiscussRestatement(prior, next), false);
+});
+
 test("handleAgentEvent: suppresses redundant holding-here sub-turn after discuss questions", async () => {
 	initTheme("dark", false);
 	const chatContainer = new Container();

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -170,10 +170,11 @@ const HANDOFF_WAIT_RESTATE_RE =
 
 function isHandoffWaitRestatement(next: string): boolean {
 	if (!HANDOFF_WAIT_RESTATE_RE.test(next)) return false;
-	// Keep follow-ups that add a new substantive question, not just a wait ack.
-	if (/\?/.test(next) && !/\b(?:holding|waiting|no\s+need\s+for\s+anything\s+else|until\s+you)\b/i.test(next)) {
-		return false;
-	}
+	// Any question mark signals substantive new content — keep it regardless of wait language.
+	if (/\?/.test(next)) return false;
+	// Only classify as a pure wait ack when the text is short; long text likely
+	// contains substantive content alongside incidental wait language.
+	if (next.length > 400) return false;
 	return true;
 }
 
@@ -189,8 +190,8 @@ export function isRedundantDiscussRestatement(priorText: string, newText: string
 	const isDiscussRestate = DISCUSS_RESTATE_RE.test(next);
 	const isWaitRestate = isHandoffWaitRestatement(next);
 	if (!isDiscussRestate && !isWaitRestate) return false;
-	// Wait acks are short boilerplate even when the prior recap was brief.
-	if (isWaitRestate) return next.length < 900;
+	// Wait acks are gated on length and no-? inside isHandoffWaitRestatement.
+	if (isWaitRestate) return true;
 	if (next.length > prior.length * 1.1) return false;
 	return next.length <= prior.length || next.length < 900;
 }

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -164,6 +164,19 @@ export function textInvitesUserReply(text: string): boolean {
 const DISCUSS_RESTATE_RE =
 	/\b(?:what do you want|what should we|before i can write|context file|placeholder name|need to understand what|what(?:'s| is) (?:on your mind|the next)|help me understand what you want)\b/i;
 
+/** Second sub-turn that only says it is waiting after questions were already asked. */
+const HANDOFF_WAIT_RESTATE_RE =
+	/\b(?:holding\s+(?:here|for)|waiting\s+(?:here|for)|no\s+need\s+for\s+anything\s+else|until\s+you\s+(?:point|tell|let\s+me\s+know|answer|reply)|i(?:'ve| have)\s+asked)\b/i;
+
+function isHandoffWaitRestatement(next: string): boolean {
+	if (!HANDOFF_WAIT_RESTATE_RE.test(next)) return false;
+	// Keep follow-ups that add a new substantive question, not just a wait ack.
+	if (/\?/.test(next) && !/\b(?:holding|waiting|no\s+need\s+for\s+anything\s+else|until\s+you)\b/i.test(next)) {
+		return false;
+	}
+	return true;
+}
+
 /**
  * Claude Code can emit a second text sub-turn that restates the same milestone
  * discuss ask. Drop it when the prior sub-turn already invited a user reply.
@@ -173,9 +186,29 @@ export function isRedundantDiscussRestatement(priorText: string, newText: string
 	const next = newText.trim();
 	if (!prior || !next) return false;
 	if (!textInvitesUserReply(prior)) return false;
-	if (!DISCUSS_RESTATE_RE.test(next)) return false;
+	const isDiscussRestate = DISCUSS_RESTATE_RE.test(next);
+	const isWaitRestate = isHandoffWaitRestatement(next);
+	if (!isDiscussRestate && !isWaitRestate) return false;
+	// Wait acks are short boilerplate even when the prior recap was brief.
+	if (isWaitRestate) return next.length < 900;
 	if (next.length > prior.length * 1.1) return false;
 	return next.length <= prior.length || next.length < 900;
+}
+
+function isSubTurnTextReplacement(
+	blocks: Array<any>,
+	rendered: RenderedSegment[],
+): boolean {
+	for (const seg of rendered) {
+		if (seg.kind !== "text-run") continue;
+		const oldText = (seg.cachedText ?? "").trim();
+		if (!oldText) continue;
+		const newText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex).trim();
+		if (!newText || newText === oldText) continue;
+		// Streaming growth extends prior text; a new sub-turn replaces it wholesale.
+		if (!newText.startsWith(oldText) && !oldText.startsWith(newText)) return true;
+	}
+	return false;
 }
 
 function getTextFromContentBlocks(blocks: Array<any>, startIndex: number, endIndex: number): string {
@@ -731,7 +764,13 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// components don't get overwritten in place with new sub-turn
 				// content (#4144 regression). Prior sub-turn children stay in
 				// chatContainer as frozen history; new segments append after them.
-				if (contentBlocks.length < lastContentLength) {
+				if (
+					contentBlocks.length < lastContentLength
+					|| (
+						contentBlocks.length <= lastContentLength
+						&& isSubTurnTextReplacement(contentBlocks, renderedSegments)
+					)
+				) {
 					// Accumulate across successive shrinks — overwriting would drop
 					// segments displaced by an earlier shrink, leaving them stranded
 					// in chatContainer once the prune pass finally runs.

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -199,7 +199,7 @@ export function isRedundantDiscussRestatement(priorText: string, newText: string
 function isSubTurnTextReplacement(
 	blocks: Array<any>,
 	rendered: RenderedSegment[],
-): boolean {
+): number | null {
 	for (const seg of rendered) {
 		if (seg.kind !== "text-run") continue;
 		const oldText = (seg.cachedText ?? "").trim();
@@ -207,9 +207,9 @@ function isSubTurnTextReplacement(
 		const newText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex).trim();
 		if (!newText || newText === oldText) continue;
 		// Streaming growth extends prior text; a new sub-turn replaces it wholesale.
-		if (!newText.startsWith(oldText) && !oldText.startsWith(newText)) return true;
+		if (!newText.startsWith(oldText) && !oldText.startsWith(newText)) return seg.startIndex;
 	}
-	return false;
+	return null;
 }
 
 function getTextFromContentBlocks(blocks: Array<any>, startIndex: number, endIndex: number): string {
@@ -765,13 +765,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// components don't get overwritten in place with new sub-turn
 				// content (#4144 regression). Prior sub-turn children stay in
 				// chatContainer as frozen history; new segments append after them.
-				if (
-					contentBlocks.length < lastContentLength
-					|| (
-						contentBlocks.length <= lastContentLength
-						&& isSubTurnTextReplacement(contentBlocks, renderedSegments)
-					)
-				) {
+				const replacedAt = contentBlocks.length <= lastContentLength
+					? isSubTurnTextReplacement(contentBlocks, renderedSegments)
+					: null;
+				if (contentBlocks.length < lastContentLength) {
 					// Accumulate across successive shrinks — overwriting would drop
 					// segments displaced by an earlier shrink, leaving them stranded
 					// in chatContainer once the prune pass finally runs.
@@ -779,6 +776,20 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					renderedSegments = [];
 					lastPinnedText = "";
 					lastProcessedContentIndex = 0;
+				} else if (replacedAt !== null) {
+					// Same-index wholesale replacement: orphan only the replaced
+					// text-run and any text-runs after it. Earlier unchanged text
+					// and tool segments stay in renderedSegments so they are not
+					// re-rendered and duplicated in chatContainer.
+					orphanedSegments = [
+						...orphanedSegments,
+						...renderedSegments.filter((seg) => seg.kind === "text-run" && seg.startIndex >= replacedAt),
+					];
+					renderedSegments = renderedSegments.filter(
+						(seg) => !(seg.kind === "text-run" && seg.startIndex >= replacedAt),
+					);
+					lastPinnedText = "";
+					lastProcessedContentIndex = replacedAt;
 				} else if (lastProcessedContentIndex >= contentBlocks.length) {
 					lastProcessedContentIndex = 0;
 				}


### PR DESCRIPTION
## Summary

- Extends `isRedundantDiscussRestatement()` to drop second sub-turns that only say the model is waiting (e.g. "I've asked my two questions above and I'm holding here…") after the prior sub-turn already asked questions.
- Detects same-index sub-turn text replacement so the first question bubble is orphaned instead of overwritten when Claude Code resets content at `content[0]`.
- Adds regression tests for the holding-here pattern and the TUI segment-walker behavior.

Fixes the double-message bug when using `claude-code-cli` with gsd-pi MCP during discuss-milestone flows: Claude Code emits two text sub-turns in one SDK session (recap + questions, then a redundant wait ack) with no user message between them.

## Test plan

- [x] `node --import ../../src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/modes/interactive/controllers/chat-controller.test.ts` (24 tests pass)
- [ ] Run discuss-milestone via claude-code-cli + gsd-pi MCP and confirm only one assistant bubble appears after the initial question round


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive chat streaming and redundancy heuristics; wrong suppression could hide legitimate assistant text, but guards (? and length) and tests limit that risk.
> 
> **Overview**
> Fixes the **double assistant bubble** in discuss-milestone flows when **Claude Code** sends two text sub-turns in one session (questions, then a redundant “holding here” ack).
> 
> **`isRedundantDiscussRestatement`** now also drops short, question-free **wait-only** follow-ups (e.g. “holding here”, “I’ve asked…”) after the prior sub-turn already invited a reply. It still keeps text that adds a **`?`**, or long combined prose (>400 chars) with incidental wait language.
> 
> **Streaming segment handling** adds **`isSubTurnTextReplacement`** so when Claude Code **replaces** text at the same `content[]` index (without shrinking the array), the TUI **orphans** only the replaced text-run(s) instead of overwriting the first question bubble in place.
> 
> Regression tests cover wait-ack heuristics and end-to-end **`handleAgentEvent`** rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9518690f163ce5e0682215abb1c5949e307b954c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783568826&installation_id=134682257&pr_number=603&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F603&signature=6d3b0f7cbdf7170ab2f052572c5bddc8f95652b032d7fd7a9f0635d878774abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->