### PR TITLE
fix(issue): execute-task: gsd_task_complete missing from tool surface when MCP registers alias gsd_complete_task (adjust_tool_set strips alias before resolveScopedToolNames)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -50,7 +50,7 @@ import { resolveSkillManifest } from "../skill-manifest.js";
 import { applyUnitSkillVisibility, unitHasSkillManifest } from "../skill-scope.js";
 import { getGuidedUnitContext } from "../guided-unit-context.js";
 import { registerPlanMilestoneSchemaRecovery } from "./plan-milestone-schema-recovery.js";
-import { AUTO_UNIT_SCOPED_TOOLS, RUN_UAT_BROWSER_TOOL_NAMES, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
+import { AUTO_UNIT_SCOPED_TOOLS, RUN_UAT_BROWSER_TOOL_NAMES, canonicalWorkflowToolName, isWorkflowAliasTool } from "../auto-unit-tool-scope.js";
 import { filterToolsForProvider } from "../model-router.js";
 import { mcpToolMatchesBaseName } from "../mcp-tool-name.js";
 import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
@@ -217,6 +217,9 @@ function resolveScopedToolNames(
 
     for (const activeName of activeToolNames) {
       if (mcpToolMatchesBaseName(activeName, requested)) {
+        scopedMatches.push(activeName);
+      } else if (isWorkflowAliasTool(activeName) && canonicalWorkflowToolName(activeName) === requested) {
+        // Alias registered in place of canonical: include the alias so the agent can call it.
         scopedMatches.push(activeName);
       }
     }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -214,14 +214,20 @@ function resolveScopedToolNames(
 
   for (const requested of requestedToolNames) {
     const scopedMatches: string[] = [];
+    const aliasFallbacks: string[] = [];
 
     for (const activeName of activeToolNames) {
       if (mcpToolMatchesBaseName(activeName, requested)) {
         scopedMatches.push(activeName);
       } else if (isWorkflowAliasTool(activeName) && canonicalWorkflowToolName(activeName) === requested) {
-        // Alias registered in place of canonical: include the alias so the agent can call it.
-        scopedMatches.push(activeName);
+        aliasFallbacks.push(activeName);
       }
+    }
+
+    // Only use alias as fallback when canonical is absent — not directly and not via MCP scoping.
+    // Prevents the alias from resurfacing alongside the canonical when both are in the active set.
+    if (!exact.has(requested) && scopedMatches.length === 0) {
+      scopedMatches.push(...aliasFallbacks);
     }
 
     if (requested.startsWith("browser_") && scopedMatches.length > 0) {

--- a/src/resources/extensions/gsd/tests/tool-availability-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-availability-audit.test.ts
@@ -141,6 +141,25 @@ for (const customType of ["gsd-discuss", "gsd-run"] as const) {
   });
 }
 
+for (const unitType of ["execute-task", "execute-task-simple", "reactive-execute"] as const) {
+  test(`${unitType}: resolves gsd_task_complete via alias gsd_complete_task when only alias is registered`, () => {
+    // Simulates the MCP transport registering gsd_complete_task (alias) instead of gsd_task_complete.
+    // adjust_tool_set strips aliases from providerCompatible, so gsd_complete_task is only present
+    // in registeredToolNames. resolveScopedToolNames must still surface it so the agent can complete tasks.
+    const aliasOnlyRegistered = FULL_REGISTERED_TOOLS
+      .filter((name) => name !== "gsd_task_complete")
+      .concat("gsd_complete_task");
+    const aliasStrippedActive = aliasOnlyRegistered.filter((name) => name !== "gsd_complete_task");
+
+    const result = buildMinimalAutoGsdToolSet(aliasStrippedActive, unitType, aliasOnlyRegistered);
+
+    assert.ok(
+      result.includes("gsd_task_complete") || result.includes("gsd_complete_task"),
+      `${unitType} missing gsd_task_complete / gsd_complete_task — agent cannot complete tasks`,
+    );
+  });
+}
+
 test("discuss-milestone two-stage scoping matches adjust_tool_set request scope", () => {
   const activeTools = simulateDiscussAllowlistFilter(FULL_REGISTERED_TOOLS);
   const dispatchScoped = buildMinimalAutoGsdToolSet(

--- a/src/resources/extensions/gsd/tests/tool-availability-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-availability-audit.test.ts
@@ -146,7 +146,8 @@ for (const unitType of ["execute-task", "execute-task-simple", "reactive-execute
     // Simulates the MCP transport registering gsd_complete_task (alias) instead of gsd_task_complete.
     // adjust_tool_set strips aliases from providerCompatible, so gsd_complete_task is only present
     // in registeredToolNames. resolveScopedToolNames must still surface it so the agent can complete tasks.
-    const aliasOnlyRegistered = FULL_REGISTERED_TOOLS
+    const base: string[] = [...FULL_REGISTERED_TOOLS];
+    const aliasOnlyRegistered = base
       .filter((name) => name !== "gsd_task_complete")
       .concat("gsd_complete_task");
     const aliasStrippedActive = aliasOnlyRegistered.filter((name) => name !== "gsd_complete_task");
@@ -156,6 +157,21 @@ for (const unitType of ["execute-task", "execute-task-simple", "reactive-execute
     assert.ok(
       result.includes("gsd_task_complete") || result.includes("gsd_complete_task"),
       `${unitType} missing gsd_task_complete / gsd_complete_task — agent cannot complete tasks`,
+    );
+  });
+
+  test(`${unitType}: alias does not duplicate canonical when both are in the active set`, () => {
+    // When both canonical and alias are registered/active, only the canonical should be surfaced.
+    const bothPresent: string[] = [...FULL_REGISTERED_TOOLS, "gsd_complete_task"];
+
+    const result = buildMinimalAutoGsdToolSet(bothPresent, unitType, bothPresent);
+
+    const hasCanonical = result.includes("gsd_task_complete");
+    const hasAlias = result.includes("gsd_complete_task");
+    assert.ok(hasCanonical || hasAlias, `${unitType} missing completion tool`);
+    assert.ok(
+      !(hasCanonical && hasAlias),
+      `${unitType} surfaces both gsd_task_complete and gsd_complete_task — alias should not duplicate canonical`,
     );
   });
 }


### PR DESCRIPTION
## Summary
- The secret scan completed successfully (exit code 0) — no secrets detected in the changes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #605
- [#605 execute-task: gsd_task_complete missing from tool surface when MCP registers alias gsd_complete_task (adjust_tool_set strips alias before resolveScopedToolNames)](https://github.com/open-gsd/gsd-pi/issues/605)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/605-execute-task-gsd-task-complete-missing-f-1780992736`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585284&installation_id=134682257&pr_number=606&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F606&signature=90872727718d1ac2ca2af8a607519fae4bef995db48f1861d0d25faeafe13d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to tool-name resolution for auto unit scoping with new audit tests; no auth, data, or security paths touched.
> 
> **Overview**
> **`resolveScopedToolNames`** now treats workflow **alias** tools (e.g. `gsd_complete_task`) as a fallback when scoping requested canonical names (e.g. `gsd_task_complete`) onto the active tool set. Aliases are used only if the canonical name is not in the active set and there is no MCP-scoped match—so execute-task units still get a task-completion tool when MCP registers the alias but **`adjust_tool_set`** strips aliases from the model-facing surface.
> 
> Regression tests cover **`execute-task`**, **`execute-task-simple`**, and **`reactive-execute`**: alias-only registration still surfaces completion tooling, and when both canonical and alias are present, only the canonical is advertised (no duplicate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1aa9a854c3df1a1fe432f2ec2e58636a96c0d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->