### PR TITLE
fix(gsd): honor manual validation verdict overrides in auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -16,13 +16,13 @@
 import type { ExtensionContext, ExtensionAPI } from "@gsd/pi-coding-agent";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { gsdProjectionRoot, resolveSliceFile, resolveSlicePath, resolveMilestoneFile } from "./paths.js";
+import { resolveMilestoneValidationVerdict } from "./milestone-validation-verdict.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { parseUnitId } from "./unit-id.js";
 import { isDbAvailable, getTask, getSliceTasks, getMilestoneSlices } from "./gsd-db.js";
 import type { TaskRow } from "./db-task-slice-rows.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { GSDPreferences } from "./preferences-types.js";
-import { extractVerdict } from "./verdict-parser.js";
 import { isClosedStatus } from "./status-guards.js";
 import { loadFile } from "./files.js";
 import { parseRoadmap } from "./parsers-legacy.js";
@@ -269,18 +269,8 @@ async function runValidateMilestonePostCheck(
     mid,
     `${mid}-VALIDATION.md`,
   );
-  if (!validationFile) {
-    if (await reassessmentInvalidatedValidation()) {
-      clearValidationRetry();
-      return "continue";
-    }
-    return setToolFailureRetry(
-      "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
-    );
-  }
-
-  const validationContent = await loadFile(validationFile);
-  if (!validationContent) {
+  const validationContent = validationFile ? await loadFile(validationFile) : null;
+  if (validationFile && validationContent !== null && validationContent.trim() === "") {
     if (await reassessmentInvalidatedValidation()) {
       clearValidationRetry();
       return "continue";
@@ -290,7 +280,16 @@ async function runValidateMilestonePostCheck(
     );
   }
 
-  const verdict = extractVerdict(validationContent);
+  const verdict = await resolveMilestoneValidationVerdict(s.basePath, mid);
+  if (!verdict) {
+    if (await reassessmentInvalidatedValidation()) {
+      clearValidationRetry();
+      return "continue";
+    }
+    return setToolFailureRetry(
+      "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
+    );
+  }
   if (verdict === "needs-attention") {
     ctx.ui.notify(
       `Milestone ${mid} validation returned verdict=needs-attention. Pausing for human review.`,

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -269,8 +269,8 @@ async function runValidateMilestonePostCheck(
     mid,
     `${mid}-VALIDATION.md`,
   );
-  const validationContent = validationFile ? await loadFile(validationFile) : null;
-  if (validationFile && validationContent !== null && validationContent.trim() === "") {
+  const validationContent = await loadFile(validationFile);
+  if (validationContent !== null && validationContent.trim() === "") {
     if (await reassessmentInvalidatedValidation()) {
       clearValidationRetry();
       return "continue";

--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -4,7 +4,9 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { loadFile } from "./files.js";
-import { resolveMilestoneFile } from "./paths.js";
+import { gsdProjectionRoot, resolveMilestoneFile } from "./paths.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { join } from "node:path";
 import { deriveState } from "./state.js";
 import { executeValidateMilestone } from "./tools/workflow-tool-executors.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
@@ -123,8 +125,22 @@ async function loadExistingValidation(
   basePath: string,
   milestoneId: string,
 ): Promise<ExistingValidation | null> {
+  const canonicalBase = resolveCanonicalMilestoneRoot(basePath, milestoneId);
+  const canonicalValidationPath = join(
+    gsdProjectionRoot(canonicalBase),
+    "milestones",
+    milestoneId,
+    `${milestoneId}-VALIDATION.md`,
+  );
+  if (canonicalValidationPath) {
+    const canonicalContent = await loadFile(canonicalValidationPath);
+    if (canonicalContent) {
+      return { content: canonicalContent, source: canonicalValidationPath };
+    }
+  }
+
   const validationPath = resolveMilestoneFile(basePath, milestoneId, "VALIDATION");
-  if (validationPath) {
+  if (validationPath && validationPath !== canonicalValidationPath) {
     const content = await loadFile(validationPath);
     if (content) return { content, source: validationPath };
   }

--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -132,11 +132,9 @@ async function loadExistingValidation(
     milestoneId,
     `${milestoneId}-VALIDATION.md`,
   );
-  if (canonicalValidationPath) {
-    const canonicalContent = await loadFile(canonicalValidationPath);
-    if (canonicalContent) {
-      return { content: canonicalContent, source: canonicalValidationPath };
-    }
+  const canonicalContent = await loadFile(canonicalValidationPath);
+  if (canonicalContent) {
+    return { content: canonicalContent, source: canonicalValidationPath };
   }
 
   const validationPath = resolveMilestoneFile(basePath, milestoneId, "VALIDATION");

--- a/src/resources/extensions/gsd/milestone-validation-verdict.ts
+++ b/src/resources/extensions/gsd/milestone-validation-verdict.ts
@@ -1,0 +1,80 @@
+// Project/App: gsd-pi
+// File Purpose: Resolve the authoritative milestone validation verdict across DB and disk projections.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
+import { loadFile } from "./files.js";
+import { getLatestAssessmentByScope, isDbAvailable } from "./gsd-db.js";
+import { gsdProjectionRoot } from "./paths.js";
+import {
+  extractVerdict,
+  isValidMilestoneVerdict,
+  type ValidationVerdict,
+} from "./verdict-parser.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+
+function verdictFromContent(content: string | null | undefined): ValidationVerdict | undefined {
+  if (!content) return undefined;
+  const verdict = extractVerdict(content);
+  return verdict && isValidMilestoneVerdict(verdict) ? verdict : undefined;
+}
+
+function verdictFromDb(milestoneId: string): ValidationVerdict | undefined {
+  if (!isDbAvailable()) return undefined;
+  const assessment = getLatestAssessmentByScope(milestoneId, "milestone-validation");
+  const status = typeof assessment?.status === "string" ? assessment.status : undefined;
+  return status && isValidMilestoneVerdict(status) ? status : undefined;
+}
+
+async function verdictFromValidationPath(path: string | null): Promise<ValidationVerdict | undefined> {
+  if (!path || !existsSync(path)) return undefined;
+  return verdictFromContent(await loadFile(path));
+}
+
+/**
+ * Resolve the milestone validation verdict using the same authority order as
+ * DB-backed state derivation, with filesystem fallbacks that mirror
+ * `resolveExpectedArtifactPath` (canonical worktree projection, then project
+ * root). Manual `/gsd verdict` overrides persist to the DB first; a stale
+ * worktree-local VALIDATION.md must not re-block auto-mode after the override.
+ */
+export async function resolveMilestoneValidationVerdict(
+  basePath: string,
+  milestoneId: string,
+): Promise<ValidationVerdict | undefined> {
+  const dbVerdict = verdictFromDb(milestoneId);
+  if (dbVerdict) return dbVerdict;
+
+  const canonicalBase = resolveCanonicalMilestoneRoot(basePath, milestoneId);
+  const canonicalPath = resolveExpectedArtifactPath(
+    "validate-milestone",
+    milestoneId,
+    canonicalBase,
+  );
+  const canonicalVerdict = await verdictFromValidationPath(canonicalPath);
+  if (canonicalVerdict) return canonicalVerdict;
+
+  const projectRoot = resolveWorktreeProjectRoot(basePath);
+  if (projectRoot !== canonicalBase) {
+    const projectPath = resolveExpectedArtifactPath(
+      "validate-milestone",
+      milestoneId,
+      projectRoot,
+    );
+    const projectVerdict = await verdictFromValidationPath(projectPath);
+    if (projectVerdict) return projectVerdict;
+  }
+
+  // Last resort: direct canonical projection path even when resolveDir helpers
+  // have not materialized the milestone directory yet.
+  const directPath = join(
+    gsdProjectionRoot(canonicalBase),
+    "milestones",
+    milestoneId,
+    `${milestoneId}-VALIDATION.md`,
+  );
+  return verdictFromValidationPath(directPath);
+}

--- a/src/resources/extensions/gsd/tests/milestone-validation-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-validation-verdict.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveMilestoneValidationVerdict } from "../milestone-validation-verdict.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertAssessment,
+  insertMilestone,
+} from "../gsd-db.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import { _clearGsdRootCache } from "../paths.ts";
+
+function setup(base: string): void {
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  process.chdir(base);
+  _clearGsdRootCache();
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  invalidateAllCaches();
+}
+
+test("resolveMilestoneValidationVerdict prefers DB pass over stale worktree needs-attention", async () => {
+  const base = join(tmpdir(), `validation-verdict-${Date.now()}`);
+  mkdirSync(base, { recursive: true });
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(worktree, ".git"), "gitdir: ../.git/worktrees/M001\n", "utf-8");
+  writeFileSync(
+    join(worktree, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+    "---\nverdict: needs-attention\n---\n\n# Validation\nStale worktree copy.\n",
+  );
+
+  try {
+    setup(base);
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+    insertAssessment({
+      path: join(worktree, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      milestoneId: "M001",
+      sliceId: null,
+      taskId: null,
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "---\nverdict: pass\n---\n\n# Validation\nManual override.\n",
+    });
+
+    const verdict = await resolveMilestoneValidationVerdict(base, "M001");
+    assert.equal(verdict, "pass");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
@@ -12,6 +12,7 @@ import { clearPathCache } from "../paths.ts";
 import {
   openDatabase,
   closeDatabase,
+  insertAssessment,
   insertMilestone,
   insertSlice,
 } from "../gsd-db.ts";
@@ -220,6 +221,44 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
     assert.equal(result, "continue");
     assert.equal(pauseAutoMock.mock.callCount(), 0);
     assert.equal(s.pendingVerificationRetry, null);
+  });
+
+  test("continues when DB pass overrides stale worktree needs-attention after /gsd verdict", async () => {
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice 1", status: "complete" });
+    writeWorktreeValidationFile("needs-attention");
+
+    const worktreeValidationPath = join(
+      tempDir,
+      ".gsd",
+      "worktrees",
+      "M001",
+      ".gsd",
+      "milestones",
+      "M001",
+      "M001-VALIDATION.md",
+    );
+    insertAssessment({
+      path: worktreeValidationPath,
+      milestoneId: "M001",
+      sliceId: null,
+      taskId: null,
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "---\nverdict: pass\n---\n\n# Validation\nManually overridden via /gsd verdict\n",
+    });
+    invalidateAllCaches();
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, "validate-milestone", "M001");
+
+    const result = await runPostUnitVerification({ s, ctx, pi } as VerificationContext, pauseAutoMock);
+
+    assert.equal(result, "continue");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.equal(ctx.ui.notify.mock.callCount(), 0);
   });
 
   test("retries when no VALIDATION file exists yet", async () => {

--- a/src/resources/extensions/gsd/tests/worktree-projection-writers.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-projection-writers.test.ts
@@ -171,7 +171,7 @@ test("validate-milestone invoked from the project root writes VALIDATION under t
   const projectProjection = join(projectRoot, ".gsd", "milestones", MID, "M001-VALIDATION.md");
   assert.equal(result.validationPath, expected);
   assert.equal(existsSync(expected), true);
-  assert.equal(existsSync(projectProjection), false);
+  assert.equal(existsSync(projectProjection), true, "VALIDATION should mirror to project root for consistent reads");
 });
 
 test("complete-milestone writes SUMMARY under the active worktree projection", async (t) => {

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -22,6 +22,7 @@ import {
 } from "../gsd-db.js";
 import { gsdProjectionRoot, clearPathCache } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
+import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { VALIDATION_VERDICTS, isValidMilestoneVerdict } from "../verdict-parser.js";
@@ -201,6 +202,24 @@ export async function handleValidateMilestone(
   let projectionStale = false;
   try {
     await saveFile(validationPath, validationMd);
+    const projectRoot = resolveWorktreeProjectRoot(basePath);
+    if (projectRoot !== artifactBasePath) {
+      const projectValidationPath = join(
+        gsdProjectionRoot(projectRoot),
+        "milestones",
+        effectiveParams.milestoneId,
+        `${effectiveParams.milestoneId}-VALIDATION.md`,
+      );
+      try {
+        await saveFile(projectValidationPath, validationMd);
+      } catch (mirrorErr) {
+        logWarning(
+          "projection",
+          `validate_milestone project-root VALIDATION mirror failed for ${effectiveParams.milestoneId}`,
+          { error: (mirrorErr as Error).message },
+        );
+      }
+    }
   } catch (renderErr) {
     projectionStale = true;
     logWarning("projection", `validate_milestone projection write failed for ${effectiveParams.milestoneId}; DB validation remains committed`, {

--- a/src/resources/extensions/gsd/validation-block-guard.ts
+++ b/src/resources/extensions/gsd/validation-block-guard.ts
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 
 import { getAutoWorktreePath, isInAutoWorktree } from "./auto-worktree.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
+import { refreshWorkflowDatabaseFromDisk } from "./db-workspace.js";
 import { getIsolationMode } from "./preferences.js";
 import { deriveState } from "./state.js";
 import type { GSDState } from "./types.js";
@@ -91,6 +92,7 @@ export async function getValidationBlockMessageForBase(
   attemptedCommand = "",
 ): Promise<string | null> {
   await ensureDbOpen(base);
+  refreshWorkflowDatabaseFromDisk();
   let state = await deriveState(base);
 
   if (

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -74,6 +74,30 @@ const VERDICT_RE = /verdict:\s*[\w-]+/i;
  * Only overwrites when the source has a verdict — never clobbers a
  * worktree ASSESSMENT with a verdictless project-root copy.
  */
+function forceOverwriteValidationWithVerdict(
+  srcMilestoneDir: string,
+  dstMilestoneDir: string,
+  milestoneId: string,
+): void {
+  if (!existsSync(srcMilestoneDir) || !milestoneId) return;
+
+  const srcFile = join(srcMilestoneDir, `${milestoneId}-VALIDATION.md`);
+  if (!existsSync(srcFile)) return;
+
+  try {
+    const srcContent = readFileSync(srcFile, "utf-8");
+    if (!VERDICT_RE.test(srcContent)) return;
+
+    mkdirSync(dstMilestoneDir, { recursive: true });
+    safeCopy(srcFile, join(dstMilestoneDir, `${milestoneId}-VALIDATION.md`), { force: true });
+  } catch (err) {
+    logWarning(
+      "worktree",
+      `validation force-copy failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 function forceOverwriteAssessmentsWithVerdict(
   srcMilestoneDir: string,
   dstMilestoneDir: string,
@@ -260,10 +284,10 @@ export function _projectRootToWorktreeImpl(
   // session resume the DB is rebuilt from disk, and if the stale ASSESSMENT
   // persists, checkNeedsRunUat finds no passing verdict → re-dispatches
   // run-uat indefinitely (stuck-loop ×9).
-  forceOverwriteAssessmentsWithVerdict(
-    join(prGsd, "milestones", milestoneId),
-    join(wtGsd, "milestones", milestoneId),
-  );
+  const prMilestoneDir = join(prGsd, "milestones", milestoneId);
+  const wtMilestoneDir = join(wtGsd, "milestones", milestoneId);
+  forceOverwriteValidationWithVerdict(prMilestoneDir, wtMilestoneDir, milestoneId);
+  forceOverwriteAssessmentsWithVerdict(prMilestoneDir, wtMilestoneDir);
 
   // Forward-sync completed-units.json from project root to worktree.
   // Project root is authoritative for completion state after crash recovery;


### PR DESCRIPTION
## Summary
- Fixes auto-mode pausing after `/gsd verdict pass` when a stale worktree `VALIDATION.md` still showed `needs-attention`
- Resolves milestone validation verdicts DB-first (with filesystem fallbacks) so manual overrides take effect on the first try
- Mirrors `VALIDATION.md` to the project root and force-syncs validation artifacts during worktree projection to keep readers aligned
- Refreshes the workflow DB from disk before validation block checks so `/gsd auto` sees updated verdicts immediately

## Test plan
- [x] `milestone-validation-verdict.test.ts` — DB pass wins over stale worktree file
- [x] `validate-milestone-stuck-guard.test.ts` — post-unit check continues after manual override
- [x] `worktree-projection-writers.test.ts` — validation mirrors to project root
- [ ] Reproduce on a blocked milestone: `/gsd verdict pass --rationale "..."` then `/gsd auto` should resume without a second verdict


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783606730&installation_id=134682257&pr_number=611&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F611&signature=5e9e3a855f5fde48ac52822ad4c97090657fee95197f51ca2c6388d9b6a1d8e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation authority, worktree projection overwrite rules, and command gating for auto-mode; behavior is well covered by new tests but touches core workflow unblock paths.
> 
> **Overview**
> Fixes auto-mode incorrectly pausing after `/gsd verdict pass` when a stale worktree `VALIDATION.md` still showed `needs-attention`.
> 
> **Authoritative verdict resolution:** Adds `resolveMilestoneValidationVerdict`, which reads the milestone validation verdict **DB-first**, then canonical worktree and project-root `VALIDATION.md` paths. Auto-mode’s validate-milestone post-check and `/gsd verdict` loading use this instead of parsing only the local worktree file.
> 
> **Projection alignment:** `validate-milestone` now **mirrors** `VALIDATION.md` to the project root when writing from a worktree. Worktree enter sync **force-overwrites** worktree `VALIDATION.md` from the project root when the source has a verdict (parallel to existing ASSESSMENT sync). Validation block checks call **`refreshWorkflowDatabaseFromDisk`** before `deriveState` so `/gsd auto` sees fresh overrides.
> 
> Regression tests cover DB-over-stale-file, post-unit continue after override, and project-root mirroring on validate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3341b9b65dfb90edcd4730d6cb25254b9a1a01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->