### PR TITLE
fix(tui): realign viewport after phase-complete pinned output teardown

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -587,6 +587,86 @@ test("handleAgentEvent: message_end keeps the current handoff reply visible", as
 	assert.match(stripAnsi(chatContainer.render(100).join("\n")), /What do you want to build next/);
 });
 
+test("handleAgentEvent: message_end does not force-render viewport when pinned zone was never shown", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	let forceRenderCalled = false;
+	const host = createStreamingHost(chatContainer);
+	host.ui.requestRender = (force?: boolean) => {
+		if (force) forceRenderCalled = true;
+	};
+
+	const message = {
+		id: "a-simple",
+		role: "assistant",
+		provider: "claude-code",
+		model: "claude-opus-4-8",
+		timestamp: 1,
+		stopReason: "stop",
+		content: [{ type: "text", text: "Here is my response." }],
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: { ...message, content: [] } } as any);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message,
+		assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Here is my response.", partial: message },
+	} as any);
+	await handleAgentEvent(host, { type: "message_end", message } as any);
+
+	assert.equal(
+		forceRenderCalled,
+		false,
+		"viewport must not be force-realigned at message_end when no pinned zone was shown this turn",
+	);
+});
+
+test("handleAgentEvent: agent_end does not force-render viewport when pinned zone was never shown", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	let forceRenderCalled = false;
+	const host = {
+		isInitialized: true,
+		footer: { invalidate() {} },
+		settingsManager: {
+			getTimestampFormat() {
+				return "date-time-iso";
+			},
+			getShowImages() {
+				return false;
+			},
+		},
+		getRegisteredToolDefinition() {
+			return undefined;
+		},
+		chatContainer,
+		pendingTools: new Map(),
+		loadingAnimation: undefined,
+		statusContainer: { clear() {} },
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		pinnedMessageContainer: { clear() {} },
+		checkShutdownRequested: async () => {},
+		ui: {
+			requestRender(force?: boolean) {
+				if (force) forceRenderCalled = true;
+			},
+		},
+	} as any;
+
+	await handleAgentEvent(host, {
+		type: "agent_end",
+		messages: [],
+		willRetry: false,
+	} as any);
+
+	assert.equal(
+		forceRenderCalled,
+		false,
+		"viewport must not be force-realigned at agent_end when no pinned zone was shown this turn",
+	);
+});
+
 test("handleAgentEvent: agent_end finalizes orphaned pending tool cards", async () => {
 	initTheme("dark", false);
 	const chatContainer = new Container();

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -553,6 +553,25 @@ let hasToolsInTurn = false;
 let pinnedBorder: DynamicBorder | undefined;
 // Reference to the pinned markdown component below the border
 let pinnedTextComponent: Markdown | undefined;
+// Set when the pinned zone was shown this turn; used to realign viewport after teardown.
+let pinnedZoneNeedsViewportRealign = false;
+
+function tearDownPinnedZone(
+	host: { pinnedMessageContainer: { clear(): void }; ui: { requestRender(force?: boolean): void } },
+	options?: { realignViewport?: boolean },
+): void {
+	const needsRealign = pinnedZoneNeedsViewportRealign;
+	if (pinnedBorder) pinnedBorder.stopSpinner();
+	pinnedBorder = undefined;
+	pinnedTextComponent = undefined;
+	host.pinnedMessageContainer.clear();
+	lastPinnedText = "";
+	hasToolsInTurn = false;
+	pinnedZoneNeedsViewportRealign = false;
+	if (options?.realignViewport && needsRealign) {
+		host.ui.requestRender(true);
+	}
+}
 
 function mergeToolPhases(phases: ToolExecutionPhase[]): ToolExecutionPhase[] {
 	const merged: ToolExecutionPhase[] = [];
@@ -675,14 +694,9 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 	if (event.type === "message_start" && event.message.role === "assistant") {
 		lastProcessedContentIndex = 0;
 		lastContentLength = 0;
-		lastPinnedText = "";
-		hasToolsInTurn = false;
 		renderedSegments = [];
 		orphanedSegments = [];
-		if (pinnedBorder) pinnedBorder.stopSpinner();
-		pinnedBorder = undefined;
-		pinnedTextComponent = undefined;
-		host.pinnedMessageContainer.clear();
+		tearDownPinnedZone(host);
 	}
 
 	switch (event.type) {
@@ -695,15 +709,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					host.streamingMessage = undefined;
 					host.pendingTools.clear();
 					host.pendingMessagesContainer.clear();
-					host.pinnedMessageContainer.clear();
-					lastPinnedText = "";
-					hasToolsInTurn = false;
+					tearDownPinnedZone(host);
 					renderedSegments = [];
 					orphanedSegments = [];
 					lastContentLength = 0;
-					if (pinnedBorder) pinnedBorder.stopSpinner();
-					pinnedBorder = undefined;
-					pinnedTextComponent = undefined;
 					host.compactionQueuedMessages = [];
 					host.rebuildChatFromMessages();
 					host.updatePendingMessagesDisplay();
@@ -1111,6 +1120,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 								// doesn't exceed the viewport and cause render flashing.
 								pinnedTextComponent.maxLines = pinnedMax;
 								host.pinnedMessageContainer.addChild(pinnedTextComponent);
+								pinnedZoneNeedsViewportRealign = true;
 								// Hide the separate status loader — the pinned zone replaces it
 								if (host.loadingAnimation) {
 									host.loadingAnimation.stop();
@@ -1129,11 +1139,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					} else if (pinnedBorder) {
 						// Every candidate is still visible in the chat scrollback —
 						// tear down the pinned zone so we don't duplicate on-screen text.
-						pinnedBorder.stopSpinner();
-						pinnedBorder = undefined;
-						pinnedTextComponent = undefined;
-						host.pinnedMessageContainer.clear();
-						lastPinnedText = "";
+						tearDownPinnedZone(host);
 						if (!host.loadingAnimation) {
 							host.statusContainer.clear();
 							startLoadingAnimation(host);
@@ -1323,12 +1329,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// Clear pinned output once the message is finalized in the chat
 				// container — prevents duplicate display when the agent continues
 				// (e.g. form elicitation) after the assistant message ends.
-				if (pinnedBorder) pinnedBorder.stopSpinner();
-				host.pinnedMessageContainer.clear();
-				lastPinnedText = "";
-				hasToolsInTurn = false;
-				pinnedBorder = undefined;
-				pinnedTextComponent = undefined;
+				tearDownPinnedZone(host, { realignViewport: true });
 				host.footer.invalidate();
 			}
 			host.ui.requestRender();
@@ -1398,14 +1399,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			host.pendingTools.clear();
 			// Pinned output is only useful while work is actively streaming.
 			// Keep chat history as the single source after completion.
-			if (pinnedBorder) {
-				pinnedBorder.stopSpinner();
-			}
-			host.pinnedMessageContainer.clear();
-			lastPinnedText = "";
-			hasToolsInTurn = false;
-			pinnedBorder = undefined;
-			pinnedTextComponent = undefined;
+			tearDownPinnedZone(host, { realignViewport: true });
 			await host.checkShutdownRequested();
 			host.ui.requestRender();
 			break;

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-extension-widgets.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-extension-widgets.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+import { setExtensionWidget } from "./interactive-extension-widgets.js";
+
+function createWidgetHost() {
+	const renderCalls: Array<true | undefined> = [];
+	return {
+		host: {
+			extensionWidgetsAbove: new Map(),
+			extensionWidgetsBelow: new Map(),
+			// Leave widget containers undefined so renderWidgets() returns early,
+			// isolating only the gsd-outcome force-render path under test.
+			widgetContainerAbove: undefined,
+			widgetContainerBelow: undefined,
+			pinnedMessageContainer: { children: [] },
+			ui: {
+				requestRender(force?: boolean) {
+					if (force) renderCalls.push(true);
+				},
+			},
+		} as any,
+		renderCalls,
+	};
+}
+
+test("setExtensionWidget: forces viewport realign when key is gsd-outcome", () => {
+	initTheme("dark", false);
+	const { host, renderCalls } = createWidgetHost();
+	setExtensionWidget(host, "gsd-outcome", ["Step complete"]);
+	assert.equal(renderCalls.length, 1, "requestRender(true) should be called once for gsd-outcome");
+});
+
+test("setExtensionWidget: does not force viewport realign for non-gsd-outcome keys", () => {
+	initTheme("dark", false);
+	const { host, renderCalls } = createWidgetHost();
+	setExtensionWidget(host, "gsd-progress", ["Working..."]);
+	assert.equal(renderCalls.length, 0, "requestRender(true) should not be called for non-gsd-outcome keys");
+});
+
+test("setExtensionWidget: does not force viewport realign when removing a widget (content undefined)", () => {
+	initTheme("dark", false);
+	const { host, renderCalls } = createWidgetHost();
+	setExtensionWidget(host, "gsd-outcome", undefined);
+	assert.equal(renderCalls.length, 0, "requestRender(true) should not be called when content is undefined");
+});

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-extension-widgets.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-extension-widgets.ts
@@ -168,6 +168,12 @@ export function setExtensionWidget(host: InteractiveModeDelegateHost, key: strin
 		const targetMap = placement === "belowEditor" ? host.extensionWidgetsBelow : host.extensionWidgetsAbove;
 		targetMap.set(key, component);
 		renderWidgets(host, );
+		// Step-complete / handoff widgets replace the live progress panel and can
+		// shrink the layout after pinned streaming output is torn down. Force a
+		// full viewport realign so the transcript stays visible.
+		if (key === "gsd-outcome" && content !== undefined) {
+			host.ui.requestRender(true);
+		}
 	}
 
 export function clearExtensionWidgets(host: InteractiveModeDelegateHost): void {


### PR DESCRIPTION
## Summary

- Fixes a blank TUI screen after GSD units complete in step/next mode when tool-heavy work used the pinned "Latest Output" zone during streaming.
- Forces a full viewport realign when the pinned zone is torn down at `message_end` / `agent_end`, and when the `gsd-outcome` step-complete widget replaces `gsd-progress`.

## Problem

After research/execute phases with many tool calls, the transcript is still in session history but the terminal viewport stays anchored to stale scrollback once pinned streaming output is cleared. Users see an empty middle area with only the header and "Step complete" footer.

## Test plan

- [x] `npx tsx --test packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts` (28/28 pass)
- [ ] Run `gsd-dev`, complete a tool-heavy unit via `/gsd next`, confirm completed transcript is visible instead of a blank screen
- [ ] Repeat across phases (research-milestone, execute-task, etc.)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783606793&installation_id=134682257&pr_number=613&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F613&signature=d597f73b251a8272c7532ef6bc3f2b3163c25ecc83aaacb7920ad4a455465b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI scroll/render behavior only; guarded so force realign runs only when the pinned zone was shown or gsd-outcome is set.
> 
> **Overview**
> Fixes a **blank middle area** in the interactive TUI after tool-heavy GSD steps when streaming used the pinned **“Latest Output”** zone: the transcript stayed in history but the viewport stayed on stale scrollback after that zone was cleared.
> 
> Pinned teardown is centralized in **`tearDownPinnedZone`**, which tracks whether the pinned zone was shown this turn and only then calls **`requestRender(true)`** when teardown runs with **`realignViewport`** at **`message_end`** and **`agent_end`**. Showing the **`gsd-outcome`** step-complete widget also triggers a forced realign when layout shrinks after progress/pinned UI is removed.
> 
> Tests assert forced realign does **not** run when the pinned zone was never shown, and that **`gsd-outcome`** (but not other widget keys or removal) forces realign.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35df652678023e8be6c7d5a8dcfeef26ceb1a86f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->