### PR TITLE
fix(gsd): re-project markdown after milestone transitions and startup drift

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -630,6 +630,16 @@ export async function _runMilestoneMergeWithStashRestore(
   );
   if (exitResult.ok) {
     s.milestoneMergedInPhases = true;
+    try {
+      const projectRoot = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
+      const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.js");
+      await rebuildMarkdownProjectionsFromDb(projectRoot);
+    } catch (err) {
+      logWarning(
+        "engine",
+        `markdown projection rebuild after milestone merge failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   } else {
     mergeError = exitResult.cause ?? new Error(`exit ${exitResult.reason}`);
   }
@@ -1237,6 +1247,19 @@ export async function runPreDispatch(
       await deps.rebuildState(s.basePath);
     } catch (e) {
       logWarning("engine", "STATE.md rebuild failed after milestone transition", { error: String(e) });
+    }
+
+    // Re-project ROADMAP/PLAN markdown from the authoritative DB. Worktree DB
+    // reconciliation during merge can leave main-branch markdown stale relative
+    // to gsd.db (the 3M/3S/10T vs 3M/5S/16T drift class at /gsd startup).
+    try {
+      const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.js");
+      await rebuildMarkdownProjectionsFromDb(s.canonicalProjectRoot);
+      if (s.basePath !== s.canonicalProjectRoot) {
+        await rebuildMarkdownProjectionsFromDb(s.basePath);
+      }
+    } catch (e) {
+      logWarning("engine", "markdown projection rebuild failed after milestone transition", { error: String(e) });
     }
   }
 

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -11,7 +11,7 @@ import { deriveState } from "./state.js";
 import { gsdProjectionRoot, gsdRoot } from "./paths.js";
 import { nativeBranchList, nativeDetectMainBranch, nativeBranchListMerged, nativeBranchDelete, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
 import { logWarning } from "./workflow-logger.js";
-import { backupWorkflowDatabaseSnapshot } from "./db-workspace.js";
+import { backupWorkflowDatabaseSnapshot, refreshWorkflowDatabaseFromDisk } from "./db-workspace.js";
 
 export async function handleCleanupBranches(ctx: ExtensionCommandContext, basePath: string): Promise<void> {
   let branches: string[];
@@ -750,6 +750,62 @@ function parseRebuildTarget(args: string): RebuildTarget {
   return "usage";
 }
 
+export interface RebuildMarkdownProjectionsResult {
+  rendered: number;
+  skipped: number;
+  errors: string[];
+  quarantined: number;
+  quarantinedPaths: string[];
+}
+
+/**
+ * Re-render markdown planning projections from the authoritative DB.
+ *
+ * Quarantines open-unit SUMMARY files that contradict DB status before
+ * rendering. Safe to call after milestone merge/transition or during startup
+ * self-heal when the DB holds rows markdown lacks.
+ */
+export async function rebuildMarkdownProjectionsFromDb(
+  basePath: string,
+): Promise<RebuildMarkdownProjectionsResult> {
+  const { deleteArtifactByPath } = await import("./gsd-db.js");
+  const { detectArtifactDbDrift } = await import("./state-reconciliation/drift/artifact-db.js");
+  const { renderAllFromDb } = await import("./markdown-renderer.js");
+  const { invalidateStateCache } = await import("./state.js");
+
+  invalidateStateCache();
+  refreshWorkflowDatabaseFromDisk();
+
+  const state = await deriveState(basePath);
+  const drifts = detectArtifactDbDrift(state, { basePath, state });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const quarantined: string[] = [];
+  const seen = new Set<string>();
+
+  for (const drift of drifts) {
+    if (drift.kind !== "artifact-db-status-divergence") continue;
+    if (drift.artifactType !== "SUMMARY" || !drift.artifactPath) continue;
+    const absPath = resolveDiskArtifactPath(basePath, drift.artifactPath);
+    if (seen.has(absPath) || !existsSync(absPath)) continue;
+    seen.add(absPath);
+    const artifactDbPath = artifactPathForDb(basePath, absPath);
+    const target = quarantineProjectionFile(basePath, absPath, stamp);
+    deleteArtifactByPath(artifactDbPath);
+    quarantined.push(target);
+  }
+
+  const rendered = await renderAllFromDb(basePath);
+  invalidateStateCache();
+
+  return {
+    rendered: rendered.rendered,
+    skipped: rendered.skipped,
+    errors: rendered.errors,
+    quarantined: quarantined.length,
+    quarantinedPaths: quarantined,
+  };
+}
+
 /**
  * `gsd rebuild markdown` — Re-render markdown projections from the authoritative DB.
  *
@@ -758,10 +814,7 @@ function parseRebuildTarget(args: string): RebuildTarget {
  * under `.gsd/quarantine/projections/` before DB projections are rendered.
  */
 export async function handleRebuild(ctx: ExtensionCommandContext, basePath: string, args = ""): Promise<void> {
-  const { isDbAvailable: dbAvailable, deleteArtifactByPath } = await import("./gsd-db.js");
-  const { detectArtifactDbDrift } = await import("./state-reconciliation/drift/artifact-db.js");
-  const { renderAllFromDb } = await import("./markdown-renderer.js");
-  const { invalidateStateCache } = await import("./state.js");
+  const { isDbAvailable: dbAvailable } = await import("./gsd-db.js");
 
   const target = parseRebuildTarget(args);
   if (target === "usage") {
@@ -795,54 +848,34 @@ export async function handleRebuild(ctx: ExtensionCommandContext, basePath: stri
   }
 
   try {
-    invalidateStateCache();
-    const state = await deriveState(basePath);
-    const drifts = detectArtifactDbDrift(state, { basePath, state });
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const quarantined: string[] = [];
-    const seen = new Set<string>();
-
-    for (const drift of drifts) {
-      if (drift.kind !== "artifact-db-status-divergence") continue;
-      if (drift.artifactType !== "SUMMARY" || !drift.artifactPath) continue;
-      const absPath = resolveDiskArtifactPath(basePath, drift.artifactPath);
-      if (seen.has(absPath) || !existsSync(absPath)) continue;
-      seen.add(absPath);
-      const artifactDbPath = artifactPathForDb(basePath, absPath);
-      const target = quarantineProjectionFile(basePath, absPath, stamp);
-      deleteArtifactByPath(artifactDbPath);
-      quarantined.push(target);
-    }
-
-    const rendered = await renderAllFromDb(basePath);
-    invalidateStateCache();
+    const result = await rebuildMarkdownProjectionsFromDb(basePath);
 
     const lines = [
       "gsd rebuild markdown: rebuilt markdown projections from the canonical DB",
-      `  Rendered:    ${rendered.rendered}`,
-      `  Skipped:     ${rendered.skipped}`,
-      `  Quarantined: ${quarantined.length}`,
+      `  Rendered:    ${result.rendered}`,
+      `  Skipped:     ${result.skipped}`,
+      `  Quarantined: ${result.quarantined}`,
     ];
-    if (rendered.errors.length > 0) {
-      lines.push(`  Errors:      ${rendered.errors.length}`);
-      for (const err of rendered.errors.slice(0, 5)) {
+    if (result.errors.length > 0) {
+      lines.push(`  Errors:      ${result.errors.length}`);
+      for (const err of result.errors.slice(0, 5)) {
         lines.push(`    - ${err}`);
       }
-      if (rendered.errors.length > 5) {
-        lines.push(`    - ${rendered.errors.length - 5} more`);
+      if (result.errors.length > 5) {
+        lines.push(`    - ${result.errors.length - 5} more`);
       }
     }
-    if (quarantined.length > 0) {
+    if (result.quarantined > 0) {
       lines.push("", "  Quarantine:");
-      for (const target of quarantined.slice(0, 5)) {
+      for (const target of result.quarantinedPaths.slice(0, 5)) {
         lines.push(`    - ${target}`);
       }
-      if (quarantined.length > 5) {
-        lines.push(`    - ${quarantined.length - 5} more`);
+      if (result.quarantined > 5) {
+        lines.push(`    - ${result.quarantined - 5} more`);
       }
     }
 
-    ctx.ui.notify(lines.join("\n"), rendered.errors.length > 0 ? "warning" : "success");
+    ctx.ui.notify(lines.join("\n"), result.errors.length > 0 ? "warning" : "success");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logWarning("command", `rebuild failed: ${msg}`);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1825,11 +1825,42 @@ export async function showSmartEntry(
       const { checkMarkdownHierarchyAgainstDb } = await import("./migration-auto-check.js");
       const result = await checkMarkdownHierarchyAgainstDb(basePath);
       if (result.action === "recovery-required") {
-        ctx.ui.notify(
-          result.message ??
-            `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd recover --confirm"}\` to import markdown explicitly.`,
-          "warning",
-        );
+        if (result.recoveryCommand === "/gsd rebuild markdown") {
+          try {
+            const { rebuildMarkdownProjectionsFromDb } = await import("./commands-maintenance.js");
+            const rebuild = await rebuildMarkdownProjectionsFromDb(basePath);
+            const after = await checkMarkdownHierarchyAgainstDb(basePath);
+            if (after.action === "none") {
+              ctx.ui.notify(
+                `Self-heal: rebuilt markdown projections from the authoritative DB ` +
+                  `(${rebuild.rendered} rendered${rebuild.errors.length > 0 ? `, ${rebuild.errors.length} error(s)` : ""}).`,
+                rebuild.errors.length > 0 ? "warning" : "info",
+              );
+            } else {
+              ctx.ui.notify(
+                (result.message ?? "Markdown planning artifacts still diverge from the DB after auto-rebuild.") +
+                  (rebuild.errors.length > 0
+                    ? `\nAuto-rebuild had ${rebuild.errors.length} projection error(s). Run \`/gsd rebuild markdown\` after review.`
+                    : ""),
+                "warning",
+              );
+            }
+          } catch (rebuildErr) {
+            const rebuildMessage = rebuildErr instanceof Error ? rebuildErr.message : String(rebuildErr);
+            logWarning("guided", `markdown auto-rebuild failed: ${rebuildMessage}`, { file: "guided-flow.ts" });
+            ctx.ui.notify(
+              result.message ??
+                `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd rebuild markdown"}\` to re-project from the DB.`,
+              "warning",
+            );
+          }
+        } else {
+          ctx.ui.notify(
+            result.message ??
+              `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd recover --confirm"}\` to import markdown explicitly.`,
+            "warning",
+          );
+        }
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -287,3 +287,61 @@ test("migration auto-check refreshes a stale open DB handle before comparing", a
     cleanup(base);
   }
 });
+
+test("rebuildMarkdownProjectionsFromDb realigns markdown when DB holds extra rows", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Legacy Slice",
+      status: "pending",
+      risk: "medium",
+      depends: [],
+      demo: "Legacy slice demo",
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Legacy Task",
+      status: "pending",
+    });
+    insertSlice({
+      id: "S02",
+      milestoneId: "M001",
+      title: "Added in DB",
+      status: "pending",
+      risk: "medium",
+      depends: [],
+      demo: "d",
+      sequence: 2,
+    });
+    insertTask({
+      id: "T02",
+      sliceId: "S02",
+      milestoneId: "M001",
+      title: "Added task",
+      status: "pending",
+    });
+
+    const before = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(before.recoveryCommand, "/gsd rebuild markdown");
+
+    const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.ts");
+    const rebuild = await rebuildMarkdownProjectionsFromDb(base);
+    assert.ok(rebuild.rendered > 0, "expected markdown projections to render");
+
+    const after = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(after.action, "none");
+    assert.equal(after.reason, "in-sync");
+    assert.deepEqual(after.markdown, { milestones: 1, slices: 2, tasks: 2 });
+    assert.deepEqual(after.beforeDb, { milestones: 1, slices: 2, tasks: 2 });
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## Summary
- Extract `rebuildMarkdownProjectionsFromDb()` so `/gsd rebuild markdown` and internal callers share the same DB→markdown re-projection path (quarantine + `renderAllFromDb`).
- Auto-heal on `/gsd` startup when the DB holds milestones/slices/tasks that markdown lacks, instead of only warning to run rebuild manually.
- Rebuild markdown projections after milestone merge (post worktree DB reconcile) and after entering the next milestone (project root + worktree when they differ).

Fixes the recurring post-closeout drift where users saw warnings like `3M/3S/10T` markdown vs `3M/5S/16T` DB after starting a new milestone.

## Test plan
- [x] `migration-auto-check.test.ts` — all 9 tests pass, including new `rebuildMarkdownProjectionsFromDb realigns markdown when DB holds extra rows`
- [ ] Close a milestone in auto mode with worktree isolation, start the next milestone, run `/gsd` — should not warn about stale markdown projection
- [ ] If drift already exists, `/gsd` should self-heal with an info notice instead of requiring manual `/gsd rebuild markdown`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783609022&installation_id=134682257&pr_number=614&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F614&signature=195f3e6bd5943ee29d3f8d12cf9ced44d14ffba2cae75cd2065d5ed23f3bcd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches milestone merge/transition and startup paths that rewrite markdown from the DB; failures are non-fatal but wrong quarantine/render could briefly skew on-disk planning artifacts.
> 
> **Overview**
> Fixes post-milestone drift where **ROADMAP/PLAN markdown** lags **gsd.db** after worktree merge/reconcile (e.g. `3M/3S/10T` vs `3M/5S/16T`).
> 
> **Shared rebuild path:** DB→markdown re-projection is extracted into `rebuildMarkdownProjectionsFromDb()` (cache invalidation, `refreshWorkflowDatabaseFromDisk`, SUMMARY quarantine on artifact/DB drift, `renderAllFromDb`). `/gsd rebuild markdown` delegates to it.
> 
> **Auto lifecycle hooks:** After a successful milestone **merge** and after **entering the next milestone**, the auto loop calls that helper on the project root (and on the worktree path when it differs from canonical root). Failures are logged only so merge/transition is not blocked.
> 
> **Startup self-heal:** On `/gsd`, when hierarchy check says recovery is `/gsd rebuild markdown`, guided flow runs the same rebuild automatically and notifies success or falls back to the manual warning.
> 
> **Tests:** New case verifies extra DB rows trigger rebuild and return hierarchy to in-sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035fbb9f454de7bd6cc0c3040a0b6a28a9f816f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->