### PR TITLE
ci: run dev publish before prod approval

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "npm dist-tag to publish"
+        description: "npm dist-tag or release path to publish; latest publishes/verifies @dev first, then waits for prod approval"
         required: true
         default: "dev"
         type: choice
@@ -17,7 +17,7 @@ on:
           - next
           - latest
       ref:
-        description: "Branch or SHA for prerelease publishes (defaults: dev -> main, next -> next; latest always uses main)"
+        description: "Branch or SHA for standalone prerelease publishes (defaults: dev -> main, next -> next; latest always uses main)"
         required: false
         default: ""
       publish_auth:
@@ -30,7 +30,7 @@ on:
           - "token"
 
 concurrency:
-  group: npm-publish-${{ github.event.inputs.channel }}-${{ github.event.inputs.ref || 'default' }}
+  group: npm-publish-${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}-${{ github.event.inputs.channel == 'latest' && 'main' || github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
   cancel-in-progress: false
 
 permissions:
@@ -47,11 +47,10 @@ env:
 
 jobs:
   prerelease-publish:
-    name: Publish @${{ github.event.inputs.channel }}
-    if: ${{ github.event.inputs.channel != 'latest' }}
+    name: Publish @${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
     # npm trusted publishing + provenance require GitHub-hosted runners (not Blacksmith).
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.channel }}
+    environment: ${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
     container:
       image: ghcr.io/open-gsd/gsd-ci-builder:latest
       credentials:
@@ -64,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.ref != '' && github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
+          ref: ${{ github.event.inputs.channel == 'latest' && 'main' || github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
           token: ${{ github.token }}
           fetch-depth: 0
 
@@ -114,7 +113,7 @@ jobs:
       - name: Stamp prerelease version and sync platform packages
         id: stamp
         env:
-          VERSION_CHANNEL: ${{ github.event.inputs.channel }}
+          VERSION_CHANNEL: ${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
         run: |
           pnpm run pipeline:version-stamp
           pnpm run sync-platform-versions
@@ -133,9 +132,9 @@ jobs:
       - name: Validate package is installable
         run: pnpm run validate-pack
 
-      - name: Publish @${{ github.event.inputs.channel }}
+      - name: Publish @${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
         env:
-          CHANNEL: ${{ github.event.inputs.channel }}
+          CHANNEL: ${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
           EXISTING=$(npm view "@opengsd/gsd-pi@${VERSION}" version 2>/dev/null || true)
@@ -175,14 +174,13 @@ jobs:
           exit 1
 
   prerelease-verify:
-    name: Verify @${{ github.event.inputs.channel }} package
-    if: ${{ github.event.inputs.channel != 'latest' }}
+    name: Verify @${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }} package
     needs: prerelease-publish
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.ref != '' && github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
+          ref: ${{ github.event.inputs.channel == 'latest' && 'main' || github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -195,10 +193,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
-      - name: Install published @opengsd/gsd-pi@${{ github.event.inputs.channel }} globally (with registry propagation retry)
+      - name: Install published @opengsd/gsd-pi@${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }} globally (with registry propagation retry)
         env:
           PUBLISH_VERSION: ${{ needs.prerelease-publish.outputs.version }}
-          CHANNEL: ${{ github.event.inputs.channel }}
+          CHANNEL: ${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
         run: |
           for i in 1 2 3 4 5 6; do
             npm install -g "@opengsd/gsd-pi@${PUBLISH_VERSION}" && exit 0
@@ -228,7 +226,7 @@ jobs:
         if: failure()
         env:
           PUBLISH_VERSION: ${{ needs.prerelease-publish.outputs.version }}
-          CHANNEL: ${{ github.event.inputs.channel }}
+          CHANNEL: ${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}
         run: |
           echo "::error::Post-publish verification failed for @opengsd/gsd-pi@${PUBLISH_VERSION}."
           echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate @opengsd/gsd-pi@${PUBLISH_VERSION} \"broken ${CHANNEL} build; see Actions run\"', (3) cut a fix and re-run NPM Publish."
@@ -237,6 +235,7 @@ jobs:
   prod-release-plan:
     name: Plan Production Release
     if: ${{ github.event.inputs.channel == 'latest' }}
+    needs: prerelease-verify
     runs-on: ubuntu-latest
     outputs:
       source_sha: ${{ steps.release.outputs.source_sha }}

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -63,7 +63,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/open-gsd/gsd-pi:latest --version
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
 | CI | `ci.yml` | PR + push to main | Build, test, typecheck — **gate for all promotions** |
-| NPM Publish | `npm-publish.yml` | Manual dispatch | Publish approved `@dev`, `@next`, or `@latest` releases |
+| NPM Publish | `npm-publish.yml` | Manual dispatch | Publish approved `@dev` and `@next` releases; for `@latest`, publish and verify `@dev` first, then wait for Prod approval |
 | Release Pipeline | `pipeline.yml` | After CI succeeds on main | Three-stage promotion |
 | Native Binaries | `build-native.yml` | `v*` tags | Cross-compile platform binaries |
 | Dev Cleanup | `cleanup-dev-versions.yml` | Weekly (Monday 06:00 UTC) | Unpublish `-dev.` versions older than 30 days |
@@ -135,7 +135,7 @@ The pipeline only triggers after `ci.yml` passes. Key gating tests include:
 ### Approving a Prod Release
 
 1. A version reaches the Test stage automatically
-2. In GitHub Actions, run **NPM Publish** with `channel=latest`; the workflow plans the release, builds all five native binaries, then the `prod-release` job will show "Waiting for review"
+2. In GitHub Actions, run **NPM Publish** with `channel=latest`; the workflow publishes and verifies `@dev` from `main`, then plans the release, builds all five native binaries, and the `prod-release` job will show "Waiting for review"
 3. Click **Review deployments** → select `prod` → **Approve**
 4. The workflow publishes the matching `@opengsd/engine-*` packages, verifies they are visible on npm, publishes `@opengsd/gsd-pi@latest`, pushes the release commit/tag, and creates a GitHub Release
 

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -10,6 +10,13 @@ const workflow = YAML.parse(
   readFileSync(".github/workflows/npm-publish.yml", "utf8"),
 );
 
+const latestCondition = "${{ github.event.inputs.channel == 'latest' }}";
+const prereleaseChannel =
+  "${{ github.event.inputs.channel == 'latest' && 'dev' || github.event.inputs.channel }}";
+const prereleaseRef =
+  "${{ github.event.inputs.channel == 'latest' && 'main' || github.event.inputs.ref || (github.event.inputs.channel == 'next' && 'next' || 'main') }}";
+const prereleasePublishStep = `Publish @${prereleaseChannel}`;
+
 test("npm publish exposes only supported npm channels", () => {
   const channel = workflow.on.workflow_dispatch.inputs.channel;
 
@@ -18,18 +25,12 @@ test("npm publish exposes only supported npm channels", () => {
   assert.deepEqual(channel.options, ["dev", "next", "latest"]);
 });
 
-test("prerelease publish gates through the selected GitHub Environment", () => {
-  assert.equal(
-    workflow.jobs["prerelease-publish"].environment,
-    "${{ github.event.inputs.channel }}",
-  );
+test("prerelease publish gates through the effective prerelease GitHub Environment", () => {
+  assert.equal(workflow.jobs["prerelease-publish"].environment, prereleaseChannel);
 });
 
 test("production publish keeps the prod approval gate", () => {
-  assert.equal(
-    workflow.jobs["prod-release"].if,
-    "${{ github.event.inputs.channel == 'latest' }}",
-  );
+  assert.equal(workflow.jobs["prod-release"].if, latestCondition);
   assert.deepEqual(workflow.jobs["prod-release"].needs, [
     "prod-release-plan",
     "prod-native-build",
@@ -44,6 +45,8 @@ test("prerelease publish preserves channel-specific default refs", () => {
 
   assert.equal(workflow.on.workflow_dispatch.inputs.ref.default, "");
   assert.equal(checkout.with.token, "${{ github.token }}");
+  assert.equal(checkout.with.ref, prereleaseRef);
+  assert.match(checkout.with.ref, /github\.event\.inputs\.channel == 'latest'/);
   assert.match(checkout.with.ref, /github\.event\.inputs\.channel == 'next'/);
   assert.match(checkout.with.ref, /'next'/);
   assert.match(checkout.with.ref, /'main'/);
@@ -74,7 +77,8 @@ test("production publish plans the release and builds native artifacts in the sa
   const nativeBuild = workflow.jobs["prod-native-build"];
 
   assert.ok(plan, "production publish must plan the release version");
-  assert.equal(plan.if, "${{ github.event.inputs.channel == 'latest' }}");
+  assert.equal(plan.if, latestCondition);
+  assert.equal(plan.needs, "prerelease-verify");
   assert.equal(plan.outputs.version, "${{ steps.release.outputs.version }}");
   assert.equal(plan.outputs.source_sha, "${{ steps.release.outputs.source_sha }}");
   assert.ok(
@@ -113,7 +117,7 @@ test("main package publish verifies native engine packages first", () => {
     (step) => step.name === "Verify native platform packages exist",
   );
   const prereleasePublishIndex = prereleaseSteps.findIndex(
-    (step) => step.name === "Publish @${{ github.event.inputs.channel }}",
+    (step) => step.name === prereleasePublishStep,
   );
   const prereleaseVerifyIndex = prereleaseSteps.indexOf(prereleaseVerify);
 
@@ -155,7 +159,7 @@ test("main package publish validates tarball before publishing", () => {
     (step) => step.name === "Validate package is installable",
   );
   const prereleasePublishIndex = prereleaseSteps.findIndex(
-    (step) => step.name === "Publish @${{ github.event.inputs.channel }}",
+    (step) => step.name === prereleasePublishStep,
   );
 
   assert.ok(prereleaseValidate, "prerelease publish must run validate-pack");
@@ -177,7 +181,7 @@ test("main package publish validates tarball before publishing", () => {
 
 test("main package publish uses explicit prepack and disables npm lifecycle reruns", () => {
   const prereleasePublish = workflow.jobs["prerelease-publish"].steps.find(
-    (step) => step.name === "Publish @${{ github.event.inputs.channel }}",
+    (step) => step.name === prereleasePublishStep,
   );
   assert.match(prereleasePublish.run, /prepack-resolve-workspace\.cjs/);
   assert.match(prereleasePublish.run, /postpack-restore-workspace\.cjs/);


### PR DESCRIPTION
Reorders the npm publish workflow so the dev publish runs before the prod approval gate.

## Changes
- `.github/workflows/npm-publish.yml` — dev publish step now precedes prod approval
- `docs/dev/ci-cd-pipeline.md` — doc updated to match
- `scripts/__tests__/npm-publish-workflow.test.mjs` — test expectations updated

Branch is behind `main`; rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783609930&installation_id=134682257&pr_number=615&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F615&signature=c858309f549fed85169fbbecb7b7bf017a7abfc7493c3c46bf4e6d6faebb9a3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders the production release gate and changes which jobs run for channel=latest, so a failed @dev verify blocks prod planning even though @latest publish logic is unchanged.
> 
> **Overview**
> **`channel=latest` now runs the full prerelease path as `@dev` on `main` before any production work**, instead of skipping `prerelease-publish` / `prerelease-verify`.
> 
> The workflow maps `latest` → effective channel **`dev`** (GitHub Environment, version stamp, publish tag, checkout ref forced to `main`, concurrency group, and job/step labels). **`prod-release-plan` now depends on `prerelease-verify`**, so changelog/version planning and native builds only start after the `@dev` publish and post-publish smoke/live regression checks succeed. Standalone `dev` / `next` dispatches are unchanged aside from clarified input descriptions.
> 
> Docs and **`npm-publish-workflow.test.mjs`** were updated to describe the new `latest` flow and lock in the effective prerelease channel/ref and `prod-release-plan.needs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605db211e206b9215263b5756671a7cf63b06498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->