### PR TITLE
fix(tui): preserve completed tool card status

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -650,6 +650,9 @@ export class ToolExecutionComponent extends Container {
 	 * Finalize a pending tool call as failed/interrupted while preserving any streamed partial output.
 	 */
 	completeWithError(message?: string): void {
+		if (this.result && !this.isPartial) {
+			return;
+		}
 		this.isPartial = false;
 		this.endedAt = this.endedAt ?? Date.now();
 		if (this.result) {

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -331,6 +331,59 @@ test("handleAgentEvent: standalone completed tool events roll up incrementally",
 	assert.ok(renderCount > 0);
 });
 
+test("handleAgentEvent: assistant error finalization does not fail completed tool calls", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const host = createStreamingHost(chatContainer);
+	const toolCall = {
+		type: "toolCall",
+		id: "exec-1",
+		name: "gsd_exec",
+		arguments: { cmd: "true" },
+	};
+	const runningMessage = {
+		id: "a-tool",
+		role: "assistant",
+		provider: "openai-codex",
+		model: "gpt-5.4",
+		timestamp: 1,
+		stopReason: "stop",
+		content: [toolCall],
+	};
+	const erroredMessage = {
+		...runningMessage,
+		stopReason: "error",
+		errorMessage: "Model hit a transient error",
+	};
+
+	await handleAgentEvent(host, {
+		type: "message_start",
+		message: { ...runningMessage, content: [] },
+	} as any);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: runningMessage,
+		assistantMessageEvent: { type: "toolcall_end", toolCall },
+	} as any);
+	await handleAgentEvent(host, {
+		type: "tool_execution_end",
+		toolCallId: toolCall.id,
+		toolName: toolCall.name,
+		result: { content: [{ type: "text", text: "ok" }], isError: false },
+		isError: false,
+	} as any);
+
+	await handleAgentEvent(host, {
+		type: "message_end",
+		message: erroredMessage,
+	} as any);
+
+	const rendered = stripAnsi(chatContainer.render(100).join("\n"));
+	assert.match(rendered, /success · \d+(ms|s)/);
+	assert.doesNotMatch(rendered, /failed · \d+(ms|s)/);
+	assert.doesNotMatch(rendered, /Model hit a transient error/);
+});
+
 test("handleAgentEvent: Claude Code MCP post-tool text does not erase user-facing pre-tool prose", async () => {
 	initTheme("dark", false);
 	const chatContainer = new Container();


### PR DESCRIPTION
Keeps a completed tool card's success status from being reset during re-render.

## Changes
- `tool-execution.ts` — preserve completed status on tool cards
- `chat-controller.test.ts` — regression coverage

Branch is behind `main`; rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783609932&installation_id=134682257&pr_number=616&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F616&signature=e7a40e33426fca5b9c7b8c1b8b8b0dba229c0c75377ced595f2c58dc81023587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in interactive TUI rendering with a focused regression test; no auth, data, or execution-path changes.
> 
> **Overview**
> Fixes a TUI bug where **assistant turn errors** (`stopReason: "error"`) could mark tool cards as **failed** even after `tool_execution_end` had already recorded a successful result.
> 
> `ToolExecutionComponent.completeWithError` now **returns early** when the tool already has a final, non-partial result, so `message_end` error finalization in the chat controller only affects still-in-flight or incomplete tools.
> 
> Adds a regression test that streams a successful `gsd_exec` completion, then ends the assistant message with an error, and asserts the transcript still shows **success** (not failed / model error text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d70d7993261819a53de89e3d8ce1da73f458c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->