### PR TITLE
fix(release): build core before prod typecheck:extensions parity gate

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -454,6 +454,14 @@ jobs:
           pnpm run verify:version-sync && \
           echo "All package.json files are valid"
 
+      # typecheck:extensions resolves @gsd/* workspace imports through each
+      # package's dist/*.d.ts (NodeNext), which only exist after a build. The
+      # @dev job builds core before its parity typecheck; the prod job's build
+      # comes later ("Build release"), so build core here too or the typecheck
+      # fails with TS2307 "Cannot find module '@gsd/...'".
+      - name: Build core
+        run: pnpm run build:core
+
       - name: Typecheck extensions (prepublishOnly parity)
         run: pnpm run typecheck:extensions
 


### PR DESCRIPTION
## Problem

The **Production Release** job in `npm-publish.yml` failed at *Typecheck extensions (prepublishOnly parity)* ([run](https://github.com/open-gsd/gsd-pi/actions/runs/27219163119/job/80372809281)) with 200+ errors that all cascade from one root cause:

```
TS2307: Cannot find module '@gsd/pi-coding-agent' / '@gsd/pi-tui' / '@gsd/agent-modes' / '@gsd/native'
```

The `TS7006 implicitly any` flood is downstream — when imported types resolve to nothing, every typed parameter collapses to `any` under `noImplicitAny`.

## Root cause

`@gsd/*` are workspace packages resolved via `node_modules` symlinks. Under `moduleResolution: NodeNext`, TS resolves each through its `package.json` → `dist/*.d.ts`, which **only exist after a build**.

The prod job ran `typecheck:extensions` immediately after the version bump, with its build (*Build release*) coming later — so no dist existed when the typecheck ran. The **@dev job** already builds core before its parity typecheck and passes; the prod job was asymmetric.

This step was added to the prod job in `ce394a67` (Jun 6). v1.3.0 is the first prod release since, so this is the first time the misordering surfaced.

## Fix

Add a **Build core** step before the prod job's parity typecheck, mirroring the @dev job. `build:core` → `build:pi` builds exactly the four missing packages.

Verified locally: `typecheck:extensions` passes clean (exit 0) once the workspace dist is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783615527&installation_id=134682257&pr_number=620&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F620&signature=289953fcb796f8d809f203f8d4e6e2769a020dbf82f75434e99a390423a1f124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only step ordering in npm-publish.yml; no runtime or publish logic changes beyond unblocking an existing gate.
> 
> **Overview**
> Fixes **Production Release** failing at *Typecheck extensions (prepublishOnly parity)* by running **`pnpm run build:core`** immediately before that step.
> 
> The prod job was typechecking extensions right after the version bump while **`pnpm run build`** still ran later, so `@gsd/*` workspace packages had no **`dist/*.d.ts`** for NodeNext resolution and the gate blew up with TS2307. The prerelease (@dev) path already builds core before the same parity typecheck; this change aligns prod with that ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907fcb01d09b21c7eb9254c3a1b80abd09a8f72f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->