### PR TITLE
refactor(gsd): two-altitude state machine — phase invariant, status core, typed vocabulary (ADR-030)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -141,6 +141,13 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
 
   Takeaway: the `transaction()` discipline is used correctly almost everywhere; candidate 1's value is primarily **locality** (deduping the cascade rule into one home), with one real atomicity bug (now fixed).
 
+- The state machine should be enforced at **two altitudes sharing one typed vocabulary**, with the Phase matrix as an assertion rather than a decision-maker:
+  - **Phase altitude** — `advance()` runs the **Phase Transition Invariant**: `isLegalEdge(lastDerivedPhase, reconciledPhase)` is checked after State Reconciliation; `lastDerivedPhase` is in-memory (reset on start/resume/stop, skipped when null); self-edges are legal; the `illegal-transition` Recovery kind exists for enforcement. `deriveState` still chooses the Phase. **Ships in advisory mode (telemetry only)** because the matrix is a sparse hardening spec, not yet a validated legal-edge graph; enforcing would false-positive on real edges. Enforcement is a one-line flip once the matrix is expanded. See ADR-030 "Implementation status".
+  - **Row altitude** — the **Status Transition Core** (`db/writers/status.ts`, `applyStatusTransition`) is the single chokepoint for status writes. The three `update*Status` functions become thin faces delegating to it; zero call-site churn. **Shipped behavior-neutral this pass:** the milestone closed→open guard is centralized here, but generalizing it to task/slice, write-normalization via `toStatus`, and the transition journal / cache-invalidation responsibilities are deferred (each behavior-sensitive). See ADR-030 "Implementation status".
+  - **Vocabulary** — a canonical `type Status` plus `toStatus(raw): Status` (normalize-on-read, alias-mapping, quarantine unknowns) is the single source for the closed-status predicates and `TERMINAL_STATUS_SQL`; the DB column stays free-form and converges to canonical over time (no forced migration).
+
+  See `docs/dev/ADR-030-two-altitude-state-machine.md`.
+
 - Foreground `/gsd next` and `/gsd auto` runs follow **Closeout Boundary Stop**: after the first durable task, slice, or milestone closeout boundary, the foreground terminal preserves the closeout transcript as the final visible surface instead of replacing it with a terminal roll-up widget. Headless runs may still emit durable terminal completion notifications/widgets for automation.
 
 ## Current implementation snapshot (phase 1)

--- a/docs/dev/ADR-030-two-altitude-state-machine.md
+++ b/docs/dev/ADR-030-two-altitude-state-machine.md
@@ -1,0 +1,115 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: ADR for two-altitude state-machine enforcement — Phase Transition Invariant, Status Transition Core, and a typed Status vocabulary. -->
+
+# ADR-030: Two-Altitude State Machine — Phase Transition Invariant, Status Transition Core, Typed Vocabulary
+
+**Status:** Accepted
+**Date:** 2026-06-09
+**Author:** GSD architecture review
+**Related:** ADR-014 (deep Auto Orchestration module / `advance()`), ADR-015 (runtime invariant modules / Recovery Classification), ADR-017 (drift-driven State Reconciliation — the Phase guard runs *after* it), the Single Writer Layer decision (CONTEXT.md "Current decision in force" — the Status Transition Core lives under `db/writers/`)
+
+## Context
+
+A re-evaluation of "the state machine" found that GSD has **two** state machines speaking **two** vocabularies, joined only by a hardcoded mapping — and the one that looks like the state machine is dead code.
+
+1. **`state-transition-matrix.ts` is a hypothetical seam.** It defines a 12-entry `STATE_TRANSITION_MATRIX` over the `Phase` type plus `findTransition`/`validateTransitionMatrix`, but it has **zero production imports** — only its own test file references it. It passes the deletion test: delete the file and nothing in production changes. That is the bad result, not the good one.
+
+2. **The matrix speaks a vocabulary that is never stored.** Its `from`/`to` are milestone-lifecycle `Phase` values (`planning → executing → summarizing → validating-milestone → …`). `Phase` is **derived**, not persisted: `deriveState` (`state.ts`) recomputes it from row statuses on every call; `advance()` (`auto/orchestrator.ts:797`) never *chooses* a phase, it *discovers* one. So the matrix cannot be consulted on a status write — they are different alphabets. `advance()` does not retain the prior derived phase at all; it tracks orchestration status (`idle/running/paused`) and `lastAdvanceKey` (the `unitType:unitId`), the latter reset to `null` on pause/stop (`auto/orchestrator.ts:885,901,1115`).
+
+3. **Status writes have no chokepoint.** 44 non-test call sites write entity status through three near-verbatim SQL pass-throughs — `updateTaskStatus` (`gsd-db.ts:530`), `updateSliceStatus` (`gsd-db.ts:584`), `updateMilestoneStatus` (`gsd-db.ts:762`). All three take `status: string`. Only `updateMilestoneStatus` carries a guard — the closed→open block at `gsd-db.ts:765` that forces an explicit reopen. Tasks and slices have no equivalent. Completion-timestamp, journal, and cache-invalidation rules are re-implemented or forgotten per call site.
+
+4. **The status vocabulary is untyped and re-derived.** No `type Status` exists; every signature is `status: string`. The closed-status set is encoded in `isClosedStatus` (`status-guards.ts:13`) and again in `TERMINAL_STATUS_SQL` (`db/sql-constants.ts:8`) — they agree today by coincidence, not by construction — and is re-derived inline as `status === "complete" || …` across ~57 non-test files. The DB stores free-form strings with aliases and legacy/imported values (`done`/`closed` ≡ `complete`, `planned` ≡ `pending`), documented in the `status-guards.ts` header, which already pleads: *"Every inline `status === "complete" || …` should use `isClosedStatus()`."*
+
+The matrix is structurally well-formed but earns nothing. The real transition logic lives scattered across `deriveState`, dispatch resolution, and 44 write sites.
+
+## Decision
+
+Treat the state machine as **two stacked altitudes sharing one typed vocabulary**, and give each altitude a real enforced seam. The Phase matrix is an **assertion**, not a decision-maker — `deriveState` keeps choosing the phase.
+
+### 1. Phase Transition Invariant (Phase altitude)
+
+`state-transition-matrix.ts` gains an **edge-keyed** predicate:
+
+```ts
+// true when (from → to) matches any matrix entry, honoring the "*" wildcard rows.
+// Self-edges (from === to) are trivially legal — no transition to assert.
+export function isLegalEdge(from: Phase, to: Phase): boolean;
+```
+
+`advance()` imports it and enforces it as an invariant guard:
+
+- Carry `lastDerivedPhase` **in-memory**, tracked like `lastAdvanceKey`; reset to `null` on pause/stop. When `null` (cold start, first advance after resume), the edge check is **skipped** — there is no edge to assert yet.
+- The guard runs **after** State Reconciliation (ADR-017), on the reconciled snapshot, **before** the Dispatch decision is recorded. Reconciliation repairs drift first; the guard only judges what survives repair.
+- An illegal edge that **survives reconciliation** is not repairable drift. The guard detects; it does not decide. It hands a typed failure to Recovery Classification as a new kind **`illegal-transition`** (sibling to `reconciliation-drift`), which owns the retry/escalate/abort decision.
+
+The deletion test now *fails the right way*: delete the matrix and `advance()` loses its legality net.
+
+### 2. Status Transition Core (row altitude)
+
+Introduce one `applyTransition` core in the Single Writer Layer (`db/writers/status.ts`) that every row-level status write funnels through. It owns:
+
+- the write,
+- the **closed→open guard, generalized** from milestone-only to task/slice/milestone,
+- the completion-timestamp invariant,
+- the transition journal entry,
+- derived-cache invalidation.
+
+`updateTaskStatus`/`updateSliceStatus`/`updateMilestoneStatus` — the single-row primitives the Single Writer decision keeps public — become **thin entity-typed faces** that delegate to the core. Their signatures are preserved, so all 44 existing callers gain the policy with **zero call-site churn and no bypass window**. The **Hierarchy Status Cascade** ops in `db/writers/cascades.ts` (`completeSliceCascade`, `reopenSliceCascade`, …) call the core once per row inside their existing `transaction()`, so multi-row changes inherit the same guard/timestamp/journal policy without each cascade re-deriving it. This matches the ADR-017 pattern: owning modules retain raw primitives, but the policy composition lives in one place.
+
+### 3. Status vocabulary + normalization (shared)
+
+Define the canonical typed set and a single parse seam:
+
+```ts
+export type Status =
+  | "pending" | "in_progress" | "complete"
+  | "skipped" | "blocked" | "active" | "parked" | "deferred";
+
+// the single seam where free-form DB strings enter the typed domain.
+// maps aliases to canonical (done/closed → complete, planned → pending);
+// quarantines unknown values instead of forcing a data migration.
+export function toStatus(raw: string): Status;
+```
+
+- The closed-status predicates **and** `TERMINAL_STATUS_SQL` derive from this one source, replacing the coincidentally-agreeing duplicates and the ~57 inline re-derivations.
+- The DB column **stays free-form `string`** so legacy/imported values still load. The typed vocabulary governs the in-memory domain.
+- The Status Transition Core (2) writes canonical, so the store **converges to canonical over time** without a data migration — respecting the DB-is-source-of-truth drift invariant (ADR-017).
+
+### Sequencing
+
+3 → 2 → 1. The vocabulary (3) is what the others lean on; the core (2) consumes `Status`/`toStatus`; the Phase guard (1) is independent and can land anytime. Typing the faces as `Status` in step 2 turns every site that writes an alias (`"done"`, etc.) into a compile error — each a latent bug surfaced, which is bounded, valuable churn.
+
+## Implementation status (2026-06-09)
+
+Landed:
+
+- **③ Vocabulary** — `Status`, `toStatus`, `RAW_CLOSED_STATUSES` in `status-guards.ts`; `TERMINAL_STATUS_SQL` derived from the single source. `isClosedStatus` is behavior-preserving.
+- **② Core** — `applyStatusTransition` in `db/writers/status.ts`; the three `update*Status` faces delegate; the milestone closed→open guard moved into the core. Behavior-neutral.
+- **① Phase guard** — `isLegalEdge` + `IllegalPhaseTransitionError` in `state-transition-matrix.ts`; `illegal-transition` recovery kind recognized by class; `advance()` carries `lastDerivedPhase` (reset on start/resume/stop) and checks the edge after reconciliation.
+
+Deferred, with reasons (each a clean follow-up):
+
+- **Phase guard runs in ADVISORY mode, not enforcing.** The matrix is a sparse hardening spec, not a complete legal-edge graph; `deriveState` emits edges the matrix never enumerates (`planning→replanning-slice`, `executing→escalating-task`, `executing→evaluating-gates`, …). Enforcing now would false-positive and stall the loop. `advance()` logs `phase-transition-advisory` telemetry instead of throwing. Enforcement is a one-line flip (`throw violation;`) once the matrix is expanded into a validated graph against observed phase sequences.
+- **closed→open guard stays milestone-only.** Four legitimate reopen callers (`undo`, `tools/reopen-task`, `auto-post-unit`, `tools/plan-slice`) move task/slice entities to open statuses through the generic faces. Generalizing safely needs sanctioned `reopenTaskStatus`/`reopenSliceStatus` faces first, mirroring `updateMilestoneStatus`/`reopenMilestoneStatus`.
+- **No write-normalization via `toStatus`.** `workflow-reconcile` replays journal events that write raw `"done"`/`"in-progress"`, and tests assert those stored values; converging on write is a separate, behavior-sensitive change (normalize the replay/import sources first). `toStatus` is wired and tested for read-side adoption.
+
+## Consequences
+
+- `state-transition-matrix.ts` becomes live code with a real caller; its test surface shifts from "matrix is well-formed" to "`advance()` rejects illegal edges and routes them to Recovery Classification."
+- Recovery Classification gains the `illegal-transition` kind in its taxonomy (`recovery-classification.ts`).
+- `advance()` gains one field (`lastDerivedPhase`) and one guard step; the guard is a no-op on self-edges and on the first advance of a session.
+- `db/writers/status.ts` gains the `applyTransition` core; the three update functions shrink to faces; `db/writers/cascades.ts` ops call the core per row. The closed→open guard now protects tasks and slices, not just milestones. The structural invariant (`tests/single-writer-invariant.test.ts`) is satisfied — the new write policy lives under `db/writers/`.
+- A new `Status` type and `toStatus` parse land; `isClosedStatus`/`TERMINAL_STATUS_SQL` and the ~57 inline comparisons collapse onto the single source over time.
+- The Phase guard's detector cost is one edge lookup per `advance()` tick — negligible.
+
+## Alternatives considered
+
+- **Delete the matrix.** `deriveState` + reconciliation already encode the guards the matrix states in prose, so the matrix is partly a cross-check of existing logic. Rejected: the cross-check has value (it catches illegal *derived* jumps such as `executing → complete` skipping validation that no single reconciliation repair would flag), and wiring it in is cheap. Deletion stays the fallback if the invariant proves noisy.
+- **Re-express the matrix over entity status and enforce it at the write path.** Rejected as a category error: a task going `pending → complete` is not a Phase transition. Phase and status are genuinely different altitudes; collapsing them would force row writes through a milestone-lifecycle table.
+- **Event-keyed guard** (keep `findTransition(from, event)`; have `deriveState` emit a transition event). Rejected: re-plumbs the matrix into the derivation path, pulling it back toward being a second decision-maker. The edge-keyed assertion needs no change to `deriveState`.
+- **Recover `from` from the transition journal** so the first post-resume advance is still guarded. Rejected for now in favor of the in-memory field (reset on pause): simpler, matches the existing `lastAdvanceKey` lifecycle, and a skipped check on the first advance is low-risk. Revisit if post-resume illegal edges are observed.
+- **Full per-entity status transition table** (a second matrix at row altitude). Rejected as likely shallow — an interface as wide as its implementation, most entries encoding transitions nothing attempts. Only the closed→open rule has demonstrated bug-history value; build that, not a speculative table.
+- **Pure-plumbing chokepoint** (no row legality; lean on the Phase guard). Rejected: under-enforces — a wrongly-reset task status often will not surface as an illegal Phase edge.
+- **One public `applyStatusTransition` verb; migrate all 44 sites.** Rejected: a large risky diff across recovery/undo/import/reconcile, plus a bypass window until every site is migrated. The faces-over-core shape gets the locality win immediately.
+- **Strict `type Status` with a one-time DB migration to canonical.** Rejected: a data migration on user DBs is in direct tension with the DB-is-source-of-truth drift invariant and breaks tolerance for future legacy imports. Normalize-on-read converges without the migration.
+- **Tolerant `string` + single source, no `type Status`.** Rejected as a partial win: kills the duplication but leaves writes able to pass a typo'd or non-canonical string. The typed vocabulary plus `toStatus` is the deeper seam.

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -14,13 +14,14 @@ import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import type { AutoAdvanceResult, AutoOrchestrationModule, AutoSessionContext, AutoStatus, AutoTerminalOutcome } from "./contracts.js";
 import type { AutoSession, PendingOrchestrationDispatch } from "./session.js";
-import type { GSDState } from "../types.js";
+import type { GSDState, Phase } from "../types.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 
 type BlockedAdvanceResult = Extract<AutoAdvanceResult, { kind: "blocked" }>;
 
-import { debugCount, debugTime } from "../debug-logger.js";
+import { debugCount, debugLog, debugTime } from "../debug-logger.js";
 import { reconcileBeforeDispatch } from "../state-reconciliation.js";
+import { isLegalEdge, IllegalPhaseTransitionError } from "../state-transition-matrix.js";
 import { resolveDispatch } from "../auto-dispatch.js";
 import { classifyFailure } from "../recovery-classification.js";
 import { verifyExpectedArtifact, refreshRecoveryDbForArtifact } from "../auto-recovery.js";
@@ -330,6 +331,10 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   private lastAdvanceKey: string | null = null;
   private lastFinalizedUnitKey: string | null = null;
   private dispatchKeyWindow: string[] = [];
+  // ADR-030 Phase Transition Invariant: the prior advance's reconciled Phase,
+  // the "from" endpoint of the edge check. In-memory; reset on start/resume/stop
+  // so the first advance of a session has no edge to assert.
+  private lastDerivedPhase: Phase | null = null;
   // #442: the unit key we last attempted graduated stuck-recovery for. Bounds
   // recovery to one attempt per stuck episode per run (reset on start/resume/
   // stop), mirroring the legacy Level-1-then-Level-2 escalation in phases.ts.
@@ -724,6 +729,21 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     return { action: recovery.action, reason: recovery.reason };
   }
 
+  /**
+   * ADR-030 Phase Transition Invariant (advisory mode). The matrix is an
+   * assertion, not a decision-maker — deriveState already chose the phase; we
+   * only observe illegal *derived* edges that survived reconciliation. The
+   * matrix is still a sparse hardening spec, so this is telemetry-only (no
+   * block) until it is expanded into a validated legal-edge graph. To enforce:
+   * `throw violation;` instead of logging — recovery-classification maps
+   * IllegalPhaseTransitionError to kind "illegal-transition" (escalate).
+   */
+  private observePhaseTransition(from: Phase, to: Phase): void {
+    if (isLegalEdge(from, to)) return;
+    const violation = new IllegalPhaseTransitionError(from, to);
+    debugLog("phase-transition-advisory", { from, to, message: violation.message });
+  }
+
   // ── Lifecycle verbs ──────────────────────────────────────────────────────
 
   /**
@@ -787,6 +807,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.lastFinalizedUnitKey = null;
     this.dispatchKeyWindow = [];
     this.lastStuckRecoveryKey = null;
+    this.lastDerivedPhase = null;
     this.status.phase = "running";
     this.bumpTransition();
     this.journalTransition({ name: "start" });
@@ -875,6 +896,12 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         this.postAdvanceRecord(blocked);
         return blocked;
       }
+
+      const reconciledPhase = reconciliation.stateSnapshot.phase;
+      if (this.lastDerivedPhase !== null) {
+        this.observePhaseTransition(this.lastDerivedPhase, reconciledPhase);
+      }
+      this.lastDerivedPhase = reconciledPhase;
 
       const decision = await this.decideNextUnit({ stateSnapshot: reconciliation.stateSnapshot });
       if (!decision) {
@@ -1146,6 +1173,9 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     // Preserve dispatchKeyWindow across resume so stuck-loop detection
     // accumulates across pause/resume cycles rather than resetting each time.
     this.lastStuckRecoveryKey = null;
+    // ADR-030: drop the prior "from" — the first advance after resume has no
+    // edge to assert (avoids a false illegal-edge across the pause boundary).
+    this.lastDerivedPhase = null;
     this.status.phase = "running";
     this.bumpTransition();
     this.journalTransition({ name: "resume" });
@@ -1162,6 +1192,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.status.activeUnit = undefined;
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
+    this.lastDerivedPhase = null;
     // Preserve dispatchKeyWindow on pause so stuck-loop detection accumulates
     // across pause/resume cycles. Only clear on a hard stop.
     if (reason !== "pause") {

--- a/src/resources/extensions/gsd/db/sql-constants.ts
+++ b/src/resources/extensions/gsd/db/sql-constants.ts
@@ -2,7 +2,11 @@
 // File Purpose: Shared SQL literal fragments for the single-writer layer.
 // Kept out of the barrel surface (imported as values, not re-exported) so it
 // stays an implementation detail of the writers.
+import { RAW_CLOSED_STATUSES } from "../status-guards.js";
 
 /** Status values that mean a unit is closed; used in ON CONFLICT guards to
- *  prevent an upsert from reopening a completed slice/task. */
-export const TERMINAL_STATUS_SQL = "'complete', 'done', 'skipped', 'closed'";
+ *  prevent an upsert from reopening a completed slice/task. Derived from the
+ *  single source `RAW_CLOSED_STATUSES` (ADR-030) so the SQL fragment cannot
+ *  drift from `isClosedStatus()`. Renders as `'complete', 'done', 'skipped',
+ *  'closed'`. */
+export const TERMINAL_STATUS_SQL = RAW_CLOSED_STATUSES.map((s) => `'${s}'`).join(", ");

--- a/src/resources/extensions/gsd/db/writers/status.ts
+++ b/src/resources/extensions/gsd/db/writers/status.ts
@@ -1,0 +1,88 @@
+// Project/App: gsd-pi
+// File Purpose: Status Transition Core (ADR-030) — the single row-level
+// chokepoint every generic status write funnels through. Owns the milestone
+// closed→open guard and is the one place future row-level status policy lands.
+// The update*Status faces in gsd-db.ts delegate here.
+//
+// Behavior this pass is intentionally identical to the prior per-face writes.
+// Two ADR-030 responsibilities are deferred for safety and documented inline:
+//   - Write-normalization via toStatus(): workflow-reconcile replays journal
+//     events that write raw "done"/"in-progress" and tests assert those exact
+//     stored values, so converging on write is a separate, behavior-sensitive
+//     change (migrate replay/import to canonical first).
+//   - Generalizing the closed→open guard to task/slice: four legitimate reopen
+//     callers (undo, tools/reopen-task, auto-post-unit, tools/plan-slice) move
+//     entities to open statuses through the generic faces. Generalizing safely
+//     needs sanctioned reopenTaskStatus/reopenSliceStatus faces first, mirroring
+//     the existing milestone updateMilestoneStatus/reopenMilestoneStatus split.
+import { getDbOrNull } from "../engine.js";
+import { GSDError, GSD_STALE_STATE } from "../../errors.js";
+import { isClosedStatus } from "../../status-guards.js";
+
+/** A single row-level status write, discriminated by entity (the faces' arity). */
+export type StatusTransition =
+  | { entity: "task"; milestoneId: string; sliceId: string; taskId: string; status: string; completedAt?: string | null }
+  | { entity: "slice"; milestoneId: string; sliceId: string; status: string; completedAt?: string | null }
+  | { entity: "milestone"; milestoneId: string; status: string; completedAt?: string | null };
+
+function requireDb() {
+  const db = getDbOrNull();
+  if (!db) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  return db;
+}
+
+/**
+ * Apply a row-level status transition. The single chokepoint for generic status
+ * writes — the update*Status faces delegate here so the guard and (future)
+ * normalization/journal/cache policy live in one place rather than per face.
+ *
+ * Milestone closed→open guard: generic updates may close, park/unpark, or
+ * advance a milestone, but may not reopen a closed one; callers must use
+ * reopenMilestoneStatus() (gsd_milestone_reopen). Tasks and slices are not yet
+ * guarded — see the file header.
+ */
+export function applyStatusTransition(t: StatusTransition): void {
+  const db = requireDb();
+  const completedAt = t.completedAt ?? null;
+
+  switch (t.entity) {
+    case "task":
+      db.prepare(
+        `UPDATE tasks SET status = :status, completed_at = :completed_at
+         WHERE milestone_id = :milestone_id AND slice_id = :slice_id AND id = :id`,
+      ).run({
+        ":status": t.status,
+        ":completed_at": completedAt,
+        ":milestone_id": t.milestoneId,
+        ":slice_id": t.sliceId,
+        ":id": t.taskId,
+      });
+      return;
+
+    case "slice":
+      db.prepare(
+        `UPDATE slices SET status = :status, completed_at = :completed_at
+         WHERE milestone_id = :milestone_id AND id = :id`,
+      ).run({
+        ":status": t.status,
+        ":completed_at": completedAt,
+        ":milestone_id": t.milestoneId,
+        ":id": t.sliceId,
+      });
+      return;
+
+    case "milestone": {
+      const row = db.prepare("SELECT status FROM milestones WHERE id = :id").get({ ":id": t.milestoneId });
+      const currentStatus = typeof row?.["status"] === "string" ? (row["status"] as string) : null;
+      if (currentStatus && isClosedStatus(currentStatus) && !isClosedStatus(t.status)) {
+        throw new Error(
+          `Cannot update closed milestone ${t.milestoneId} from ${currentStatus} to ${t.status}; use gsd_milestone_reopen for an explicit reopen.`,
+        );
+      }
+      db.prepare(
+        `UPDATE milestones SET status = :status, completed_at = :completed_at WHERE id = :id`,
+      ).run({ ":status": t.status, ":completed_at": completedAt, ":id": t.milestoneId });
+      return;
+    }
+  }
+}

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -64,6 +64,7 @@ export type { ActiveTaskSummary, IdStatusSummary, TaskStatusCounts } from "./db-
 export type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 
 import { TERMINAL_STATUS_SQL } from "./db/sql-constants.js";
+import { applyStatusTransition } from "./db/writers/status.js";
 
 export function insertDecision(d: Omit<Decision, "seq">): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
@@ -528,17 +529,7 @@ export function insertTask(t: {
 }
 
 export function updateTaskStatus(milestoneId: string, sliceId: string, taskId: string, status: string, completedAt?: string): void {
-  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  getDbOrNull()!.prepare(
-    `UPDATE tasks SET status = :status, completed_at = :completed_at
-     WHERE milestone_id = :milestone_id AND slice_id = :slice_id AND id = :id`,
-  ).run({
-    ":status": status,
-    ":completed_at": completedAt ?? null,
-    ":milestone_id": milestoneId,
-    ":slice_id": sliceId,
-    ":id": taskId,
-  });
+  applyStatusTransition({ entity: "task", milestoneId, sliceId, taskId, status, completedAt });
 }
 
 export function setTaskBlockerDiscovered(milestoneId: string, sliceId: string, taskId: string, discovered: boolean): void {
@@ -582,16 +573,7 @@ export function upsertTaskPlanning(milestoneId: string, sliceId: string, taskId:
 
 
 export function updateSliceStatus(milestoneId: string, sliceId: string, status: string, completedAt?: string): void {
-  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  getDbOrNull()!.prepare(
-    `UPDATE slices SET status = :status, completed_at = :completed_at
-     WHERE milestone_id = :milestone_id AND id = :id`,
-  ).run({
-    ":status": status,
-    ":completed_at": completedAt ?? null,
-    ":milestone_id": milestoneId,
-    ":id": sliceId,
-  });
+  applyStatusTransition({ entity: "slice", milestoneId, sliceId, status, completedAt });
 }
 
 export function setTaskSummaryMd(milestoneId: string, sliceId: string, taskId: string, md: string): void {
@@ -760,14 +742,7 @@ function writeMilestoneStatus(milestoneId: string, status: string, completedAt?:
  * must use reopenMilestoneStatus(), which is reserved for gsd_milestone_reopen.
  */
 export function updateMilestoneStatus(milestoneId: string, status: string, completedAt?: string | null): void {
-  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  const currentStatus = getMilestoneStatusForUpdate(milestoneId);
-  if (currentStatus && isClosedStatus(currentStatus) && !isClosedStatus(status)) {
-    throw new Error(
-      `Cannot update closed milestone ${milestoneId} from ${currentStatus} to ${status}; use gsd_milestone_reopen for an explicit reopen.`,
-    );
-  }
-  writeMilestoneStatus(milestoneId, status, completedAt);
+  applyStatusTransition({ entity: "milestone", milestoneId, status, completedAt });
 }
 
 /**

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -3,6 +3,7 @@
 
 import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
 import { ReconciliationFailedError } from "./state-reconciliation.js";
+import { IllegalPhaseTransitionError } from "./state-transition-matrix.js";
 
 export type RecoveryFailureKind =
   | "tool-schema"
@@ -13,6 +14,7 @@ export type RecoveryFailureKind =
   | "worktree-invalid"
   | "verification-drift"
   | "reconciliation-drift"
+  | "illegal-transition"
   | "provider"
   | "runtime-unknown";
 
@@ -43,7 +45,9 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
   const failureKind =
     input.error instanceof ReconciliationFailedError
       ? "reconciliation-drift"
-      : input.failureKind ?? inferFailureKind(message);
+      : input.error instanceof IllegalPhaseTransitionError
+        ? "illegal-transition"
+        : input.failureKind ?? inferFailureKind(message);
 
   switch (failureKind) {
     case "tool-schema":
@@ -110,6 +114,15 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         exitReason: "reconciliation-drift",
         remediation:
           "Inspect the persistent or repair-failed drift kinds reported by the State Reconciliation Module before resuming.",
+      };
+    case "illegal-transition":
+      return {
+        failureKind,
+        action: "escalate",
+        reason: `Illegal phase transition${unitSuffix(input)}: ${message}`,
+        exitReason: "illegal-transition",
+        remediation:
+          "A derived Phase edge rejected by the Phase Transition Invariant survived reconciliation; inspect deriveState and the State Reconciliation Module before resuming.",
       };
     case "provider": {
       const providerClass = classifyError(message, input.retryAfterMs);

--- a/src/resources/extensions/gsd/state-transition-matrix.ts
+++ b/src/resources/extensions/gsd/state-transition-matrix.ts
@@ -131,6 +131,43 @@ export function findTransition(
   );
 }
 
+/**
+ * Edge-keyed legality check for the Phase Transition Invariant (ADR-030).
+ * `advance()` derives the next Phase and asserts the (from → to) edge here.
+ *
+ * The matrix is an assertion, not a decision-maker — `deriveState` already
+ * chose the Phase. A self-edge is trivially legal (no transition to assert). An
+ * edge is legal when some matrix entry permits it, honoring the `*` wildcard
+ * rows (e.g. any → blocked via manual-block, any → executing via
+ * retryable-failure).
+ *
+ * Note: the matrix is currently a sparse hardening spec, not a complete
+ * legal-edge graph, so `advance()` consumes this in advisory mode (telemetry
+ * only). It must be expanded to cover every edge `deriveState` emits before
+ * enforcement flips on.
+ */
+export function isLegalEdge(from: Phase, to: Phase): boolean {
+  if (from === to) return true;
+  return STATE_TRANSITION_MATRIX.some(
+    (entry) => (entry.from === from || entry.from === "*") && entry.to === to,
+  );
+}
+
+/**
+ * Thrown when an illegal derived Phase edge survives reconciliation. Carries
+ * both endpoints so Recovery Classification can report them. Recognized by
+ * class in `classifyFailure` and mapped to the `illegal-transition` kind.
+ */
+export class IllegalPhaseTransitionError extends Error {
+  constructor(
+    readonly from: Phase,
+    readonly to: Phase,
+  ) {
+    super(`Illegal phase transition ${from} -> ${to} survived reconciliation`);
+    this.name = "IllegalPhaseTransitionError";
+  }
+}
+
 export function validateTransitionMatrix(requiredEvents: readonly string[]): MatrixValidationResult {
   const seen = new Set<string>();
   const duplicateKeys: string[] = [];

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -1,17 +1,68 @@
 /**
- * Status predicates for GSD state-machine guards.
+ * Status predicates and the canonical status vocabulary for GSD state-machine
+ * guards (ADR-030).
  *
- * The DB stores status as free-form strings. Three values indicate
- * "closed": "complete" (canonical), "done" (legacy / alias),
- * "closed" (legacy/imported), and
- * "skipped" (user-directed skip via rethink or backtrack).
- * Every inline `status === "complete" || status === "done"` should
- * use isClosedStatus() instead.
+ * The DB column is free-form `string` so legacy/imported rows still load. Three
+ * raw values besides canonical "complete"/"skipped" indicate "closed": "done"
+ * (legacy alias), "closed" (legacy/imported), and "skipped" (user-directed skip
+ * via rethink or backtrack). `RAW_CLOSED_STATUSES` is the single source for both
+ * `isClosedStatus()` and the SQL terminal-status fragment
+ * (`db/sql-constants.ts` derives `TERMINAL_STATUS_SQL` from it), replacing the
+ * prior independent definitions.
+ *
+ * `toStatus()` is the single seam where a free-form string becomes the canonical
+ * `Status` vocabulary; the Status Transition Core writes canonical, so the store
+ * converges over time without a forced migration.
  */
+
+/**
+ * Canonical, normalized entity-status vocabulary across milestones, slices, and
+ * tasks — the single source for both the `Status` type and the runtime
+ * membership set. The in-memory domain speaks `Status`; the DB column stays
+ * free-form.
+ */
+export const CANONICAL_STATUSES = [
+  "pending", "queued", "active", "parked", "in_progress", "blocked", "complete", "skipped", "deferred",
+] as const;
+export type Status = (typeof CANONICAL_STATUSES)[number];
+const CANONICAL_STATUS_SET: ReadonlySet<string> = new Set(CANONICAL_STATUSES);
+
+/**
+ * Raw status values that mean a unit is closed — the single source of truth.
+ * Includes legacy/imported aliases ("done", "closed") alongside canonical
+ * "complete"/"skipped" because the DB column is free-form and older rows /
+ * imports still carry them. Order matters: `TERMINAL_STATUS_SQL` is derived
+ * from this array verbatim.
+ */
+export const RAW_CLOSED_STATUSES = ["complete", "done", "skipped", "closed"] as const;
+const RAW_CLOSED_SET: ReadonlySet<string> = new Set(RAW_CLOSED_STATUSES);
+
+/** Free-form aliases mapped to their canonical Status on read. */
+const ALIAS_TO_CANONICAL: Readonly<Record<string, Status>> = {
+  done: "complete",
+  closed: "complete",
+  planned: "pending",
+  "in-progress": "in_progress",
+};
+
+/**
+ * Normalize a free-form DB status string into the canonical `Status`
+ * vocabulary. Maps known aliases (done/closed → complete, planned → pending,
+ * in-progress → in_progress). An unrecognized/legacy value is **quarantined** —
+ * preserved verbatim rather than silently remapped to a wrong canonical state —
+ * so reads never fail and reconciliation/telemetry can surface it.
+ */
+export function toStatus(raw: string): Status {
+  const value = raw.trim();
+  if (CANONICAL_STATUS_SET.has(value)) return value as Status;
+  const alias = ALIAS_TO_CANONICAL[value];
+  if (alias) return alias;
+  return value as Status;
+}
 
 /** Returns true when a milestone, slice, or task status indicates closure. */
 export function isClosedStatus(status: string): boolean {
-  return status === "complete" || status === "done" || status === "skipped" || status === "closed";
+  return RAW_CLOSED_SET.has(status);
 }
 
 /** Returns true when a slice status indicates it was deferred by a decision. */

--- a/src/resources/extensions/gsd/tests/recovery-classification-illegal-transition.test.ts
+++ b/src/resources/extensions/gsd/tests/recovery-classification-illegal-transition.test.ts
@@ -1,0 +1,30 @@
+// GSD — recovery-classification: illegal-transition kind (ADR-030)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { classifyFailure } from "../recovery-classification.ts";
+import { IllegalPhaseTransitionError } from "../state-transition-matrix.ts";
+
+test("classifyFailure recognizes IllegalPhaseTransitionError by class and escalates", () => {
+  const classification = classifyFailure({
+    error: new IllegalPhaseTransitionError("executing", "complete"),
+    unitType: "execute-task",
+    unitId: "T-1",
+  });
+
+  assert.equal(classification.failureKind, "illegal-transition");
+  assert.equal(classification.action, "escalate");
+  assert.equal(classification.exitReason, "illegal-transition");
+  assert.match(classification.reason, /Illegal phase transition/);
+});
+
+test("classifyFailure routes an explicit illegal-transition failureKind to the same case", () => {
+  const classification = classifyFailure({
+    error: new Error("derived edge rejected"),
+    failureKind: "illegal-transition",
+  });
+
+  assert.equal(classification.failureKind, "illegal-transition");
+  assert.equal(classification.action, "escalate");
+});

--- a/src/resources/extensions/gsd/tests/state-transition-matrix.test.ts
+++ b/src/resources/extensions/gsd/tests/state-transition-matrix.test.ts
@@ -5,6 +5,8 @@ import {
   STATE_TRANSITION_MATRIX,
   findTransition,
   validateTransitionMatrix,
+  isLegalEdge,
+  IllegalPhaseTransitionError,
 } from "../state-transition-matrix.ts";
 
 test("state transition matrix covers required swarm hardening events", () => {
@@ -41,4 +43,38 @@ test("state transition matrix entries all have guard and reason codes", () => {
     assert.ok(entry.guard.length > 0, `${entry.event} must document its guard`);
     assert.ok(entry.reasonCode.length > 0, `${entry.event} must include reason code`);
   }
+});
+
+// ─── ADR-030: Phase Transition Invariant ───────────────────────────────────
+
+test("isLegalEdge treats a self-edge as trivially legal", () => {
+  assert.equal(isLegalEdge("executing", "executing"), true);
+  assert.equal(isLegalEdge("planning", "planning"), true);
+});
+
+test("isLegalEdge accepts edges enumerated in the matrix", () => {
+  assert.equal(isLegalEdge("planning", "executing"), true);
+  assert.equal(isLegalEdge("executing", "summarizing"), true);
+  assert.equal(isLegalEdge("summarizing", "validating-milestone"), true);
+  assert.equal(isLegalEdge("completing-milestone", "complete"), true);
+});
+
+test("isLegalEdge honors the * wildcard rows (any -> blocked, any -> executing)", () => {
+  assert.equal(isLegalEdge("planning", "blocked"), true);
+  assert.equal(isLegalEdge("summarizing", "executing"), true);
+});
+
+test("isLegalEdge rejects an edge no matrix entry permits", () => {
+  // executing -> complete skips validation — exactly the illegal jump the
+  // invariant exists to catch.
+  assert.equal(isLegalEdge("executing", "complete"), false);
+  assert.equal(isLegalEdge("planning", "summarizing"), false);
+});
+
+test("IllegalPhaseTransitionError carries both endpoints and a descriptive message", () => {
+  const err = new IllegalPhaseTransitionError("executing", "complete");
+  assert.equal(err.from, "executing");
+  assert.equal(err.to, "complete");
+  assert.equal(err.name, "IllegalPhaseTransitionError");
+  assert.match(err.message, /executing -> complete/);
 });

--- a/src/resources/extensions/gsd/tests/status-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/status-guards.test.ts
@@ -9,7 +9,10 @@ import {
   isDeferredStatus,
   isInactiveStatus,
   isSkippedForDispatch,
+  toStatus,
+  RAW_CLOSED_STATUSES,
 } from '../status-guards.ts';
+import { TERMINAL_STATUS_SQL } from '../db/sql-constants.ts';
 
 test('isClosedStatus: "complete" returns true', () => {
   assert.equal(isClosedStatus('complete'), true);
@@ -94,4 +97,39 @@ test('isSkippedForDispatch does NOT skip pending/active/planned', () => {
   for (const s of ['pending', 'active', 'planned', 'queued']) {
     assert.equal(isSkippedForDispatch(s), false, `${s} should block dispatch ordering`);
   }
+});
+
+// ─── ADR-030: canonical Status vocabulary + normalization ──────────────────
+
+test('toStatus passes canonical values through unchanged', () => {
+  for (const s of ['pending', 'queued', 'active', 'parked', 'in_progress', 'blocked', 'complete', 'skipped', 'deferred']) {
+    assert.equal(toStatus(s), s, `${s} is canonical and should be returned verbatim`);
+  }
+});
+
+test('toStatus maps known aliases to canonical', () => {
+  assert.equal(toStatus('done'), 'complete');
+  assert.equal(toStatus('closed'), 'complete');
+  assert.equal(toStatus('planned'), 'pending');
+  assert.equal(toStatus('in-progress'), 'in_progress');
+});
+
+test('toStatus trims surrounding whitespace before matching', () => {
+  assert.equal(toStatus('  complete  '), 'complete');
+  assert.equal(toStatus(' done '), 'complete');
+});
+
+test('toStatus quarantines unknown values verbatim (tolerant read, no throw)', () => {
+  assert.equal(toStatus('weird-legacy-value'), 'weird-legacy-value');
+});
+
+test('RAW_CLOSED_STATUSES is the single source: every member is closed', () => {
+  for (const s of RAW_CLOSED_STATUSES) {
+    assert.equal(isClosedStatus(s), true, `${s} is in RAW_CLOSED_STATUSES so must be closed`);
+  }
+});
+
+test('TERMINAL_STATUS_SQL is derived from RAW_CLOSED_STATUSES and renders identically', () => {
+  assert.equal(TERMINAL_STATUS_SQL, "'complete', 'done', 'skipped', 'closed'");
+  assert.equal(TERMINAL_STATUS_SQL, RAW_CLOSED_STATUSES.map((s) => `'${s}'`).join(', '));
 });


### PR DESCRIPTION
> **Stacked on #623** (Single Writer Layer split) — the Status Transition Core lives in `db/writers/`, which #623 introduces. Retarget to `main` after #623 merges.

## What

An architecture review of the GSD state machine found two state machines speaking two vocabularies, joined only by `deriveState`:

- `state-transition-matrix.ts` (over the derived `Phase`) had **zero production imports** — it passed the deletion test.
- 44 call sites wrote free-form entity `status` through three raw-SQL pass-throughs, with a single milestone-only guard, and the closed-status set was independently defined in ≥4 places (~57 files re-derive `=== "complete"` inline).

This implements [ADR-030](docs/dev/ADR-030-two-altitude-state-machine.md): the state machine enforced at **two altitudes sharing one typed vocabulary**, with the Phase matrix as an assertion, not a decision-maker.

### ③ Status vocabulary (`status-guards.ts`)
- One `CANONICAL_STATUSES` const drives both `type Status` and the runtime membership set.
- `toStatus(raw)` normalizes aliases (`done`/`closed` → `complete`, `planned` → `pending`, `in-progress` → `in_progress`) and quarantines unknowns — tolerant read, no forced data migration.
- `RAW_CLOSED_STATUSES` is the single source for `isClosedStatus()` **and** `TERMINAL_STATUS_SQL` (derived, renders identically) — the SQL fragment can no longer drift from the TS predicate.

### ② Status Transition Core (`db/writers/status.ts`)
- New `applyStatusTransition` — the single chokepoint for generic status writes.
- The three `update*Status` faces in `gsd-db.ts` become thin delegates (zero call-site churn, no bypass window).
- The milestone closed→open guard moves into the core.

### ① Phase Transition Invariant (`state-transition-matrix.ts` + orchestrator)
- `isLegalEdge(from, to)` (edge-keyed, honors `*` wildcards, self-edges trivially legal) + `IllegalPhaseTransitionError`.
- New `illegal-transition` recovery kind, recognized by class in `classifyFailure` (same pattern as `ReconciliationFailedError`).
- `advance()` carries `lastDerivedPhase` (reset on start/resume/stop) and checks the edge after State Reconciliation via `observePhaseTransition`.
- **The matrix is now imported in production — the deletion test finally fails.**

## Deliberately deferred (documented in ADR-030 "Implementation status")

1. **Phase guard ships in advisory mode (telemetry only).** The matrix is a sparse hardening spec; `deriveState` emits real edges it doesn't enumerate (`planning→replanning-slice`, `executing→escalating-task`, …). Enforcing now would false-positive and stall the auto loop. Flip is one line (`throw violation;`) once the matrix is expanded into a validated legal-edge graph.
2. **closed→open guard stays milestone-only.** Four legitimate reopen flows (`undo`, `tools/reopen-task`, `auto-post-unit`, `tools/plan-slice`) reopen via the generic faces; generalizing needs sanctioned `reopenTaskStatus`/`reopenSliceStatus` faces first.
3. **No write-normalization yet.** `workflow-reconcile` journal replay writes raw `"done"`/`"in-progress"` and tests assert those stored values.

## Verification

- Clean `tsc -p tsconfig.extensions.json --noEmit --incremental false`.
- 89 targeted tests green: status-guards (incl. new `toStatus`/single-source tests), state-transition-matrix (incl. new `isLegalEdge` tests), new recovery-classification test, event-replay idempotency (the alias-write path), orchestrator characterization/parity, complete/reopen/undo flows, and the **single-writer structural invariant** (write SQL only under `db/writers/`).
- `/simplify` pass ran (4 review agents): 2 findings applied, 7 skipped with documented reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator `advance()` and all generic status write paths; behavior is intended to be neutral this pass, but incorrect phase telemetry or status-guard regressions could affect auto-loop progression or milestone reopen semantics.
> 
> **Overview**
> Implements **ADR-030**: GSD’s state machine is enforced at two altitudes with a shared status vocabulary, instead of an unused phase matrix and scattered raw SQL status writes.
> 
> **Row altitude:** New `applyStatusTransition` in `db/writers/status.ts` is the chokepoint for task/slice/milestone status updates. `updateTaskStatus`, `updateSliceStatus`, and `updateMilestoneStatus` delegate to it with **no call-site churn**; the milestone closed→open guard moves into the core (still milestone-only; task/slice generalization deferred).
> 
> **Vocabulary:** `status-guards.ts` adds canonical `Status`, `toStatus()` (alias mapping + quarantine unknowns), and `RAW_CLOSED_STATUSES` as the single source for `isClosedStatus()` and derived `TERMINAL_STATUS_SQL`.
> 
> **Phase altitude:** `isLegalEdge` and `IllegalPhaseTransitionError` wire `state-transition-matrix.ts` into production. `advance()` tracks `lastDerivedPhase` (reset on start/resume/stop) and, after reconciliation, runs an **advisory** phase-edge check (`phase-transition-advisory` telemetry only until the matrix is complete). Recovery Classification gains `illegal-transition` (escalate) when `IllegalPhaseTransitionError` is thrown in the future.
> 
> Documentation: `CONTEXT.md` and new `docs/dev/ADR-030-two-altitude-state-machine.md` record landed vs deferred work (write-normalization, full phase enforcement).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99095026c90e3276d6c3f981442a44c37179310e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783632288&installation_id=134682257&pr_number=624&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F624&signature=392027f06ce9e0e6d17f22dbb766db7131f0fa18aad768aaac9d56124a15088e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->