### PR TITLE
fix(gsd): discuss-handoff dead-end from clobbered write-gate state + duplicate discuss dispatch

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -13,7 +13,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
 import { buildMilestoneFileName, clearPathCache, milestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { applyAskUserQuestionsGateResult, canonicalToolName, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, isMilestoneDepthVerified, isQueuePhaseActive, markApprovalGateVerified, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
+import { applyAskUserQuestionsGateResult, canonicalToolName, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, isApprovalGateVerifiedInSnapshot, isMilestoneDepthVerified, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, loadWriteGateSnapshot, markApprovalGateVerified, markDepthVerified, refreshWriteGateStateFromDisk, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
@@ -572,8 +572,14 @@ function isShellExecutionTool(canonicalName: string): boolean {
 
 function activateDeferredApprovalGate(basePath: string): void {
   if (deferredApprovalGate?.basePath !== basePath) return;
-  setPendingGate(deferredApprovalGate.gateId, basePath);
+  const gateId = deferredApprovalGate.gateId;
   deferredApprovalGate = null;
+  refreshWriteGateStateFromDisk(basePath);
+  const snapshot = loadWriteGateSnapshot(basePath);
+  const milestoneId = extractDepthVerificationMilestoneId(gateId);
+  if (isApprovalGateVerifiedInSnapshot(snapshot, gateId)) return;
+  if (milestoneId && isMilestoneDepthVerifiedInSnapshot(snapshot, milestoneId)) return;
+  setPendingGate(gateId, basePath);
 }
 
 function extractGateQuestionId(input: unknown): string | undefined {

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -244,6 +244,23 @@ export function loadWriteGateSnapshot(basePath: string): WriteGateSnapshot {
   }
 }
 
+/**
+ * Merge the persisted write-gate snapshot into the in-process Map entry.
+ * The workflow MCP server runs in a child process and records depth
+ * verification there; without this refresh the extension host keeps stale
+ * pending-gate memory and `activateDeferredApprovalGate` can re-arm a gate
+ * that the subprocess already cleared on disk.
+ */
+export function refreshWriteGateStateFromDisk(basePath: string): void {
+  if (!shouldPersistWriteGateSnapshot()) return;
+  const snapshot = loadWriteGateSnapshot(basePath);
+  const state = getWriteGateState(basePath);
+  state.pendingGateId = snapshot.pendingGateId;
+  state.activeQueuePhase = snapshot.activeQueuePhase;
+  state.verifiedDepthMilestones = new Set(snapshot.verifiedDepthMilestones);
+  state.verifiedApprovalGates = new Set(snapshot.verifiedApprovalGates ?? []);
+}
+
 export function isDepthVerified(basePath: string = process.cwd()): boolean {
   return getWriteGateState(basePath).verifiedDepthMilestones.size > 0;
 }
@@ -256,6 +273,7 @@ export function isMilestoneDepthVerified(
   basePath: string = process.cwd(),
 ): boolean {
   if (!milestoneId) return false;
+  refreshWriteGateStateFromDisk(basePath);
   return getWriteGateState(basePath).verifiedDepthMilestones.has(milestoneId);
 }
 
@@ -357,6 +375,7 @@ export function clearPendingGate(basePath: string): void {
  * Get the currently pending gate, if any.
  */
 export function getPendingGate(basePath: string = process.cwd()): string | null {
+  refreshWriteGateStateFromDisk(basePath);
   return getWriteGateState(basePath).pendingGateId;
 }
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1594,8 +1594,9 @@ function isAgentTurnInFlight(ctx: ExtensionCommandContext): boolean {
     if (typeof ctx.isIdle === "function" && !ctx.isIdle()) return true;
     if (typeof ctx.hasPendingMessages === "function" && ctx.hasPendingMessages()) return true;
   } catch {
-    // assertActive() throws on a stale runner context — cannot prove a turn
-    // is in flight, so fall through to the artifact/age staleness signals.
+    // assertActive() throws on a stale runner context; fall through to
+    // artifact/age staleness signals.
+    logWarning("guided", "isAgentTurnInFlight: ctx method threw (stale runner); assuming no turn in flight");
   }
   return false;
 }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1582,6 +1582,24 @@ function selfHealRuntimeRecords(basePath: string, ctx: ExtensionContext): { clea
   }
 }
 
+/**
+ * True when an agent turn is currently streaming or a dispatched message is
+ * still queued waiting to trigger one. Used by the pending-auto-start stale
+ * check: a live discuss turn can run for minutes before writing its first
+ * artifact, and deleting its entry as "stale" re-dispatches the workflow —
+ * resetting the interview and producing a duplicate completion turn.
+ */
+function isAgentTurnInFlight(ctx: ExtensionCommandContext): boolean {
+  try {
+    if (typeof ctx.isIdle === "function" && !ctx.isIdle()) return true;
+    if (typeof ctx.hasPendingMessages === "function" && ctx.hasPendingMessages()) return true;
+  } catch {
+    // assertActive() throws on a stale runner context — cannot prove a turn
+    // is in flight, so fall through to the artifact/age staleness signals.
+  }
+  return false;
+}
+
 // ─── Milestone Actions Submenu ──────────────────────────────────────────────
 
 /**
@@ -1911,12 +1929,18 @@ export async function showSmartEntry(
     // and fires another dispatchWorkflow, resetting the conversation mid-interview.
     if (hasPendingAutoStart(basePath)) {
       // #3274: If /clear interrupted the discussion, the pending entry is stale.
-      // Detect staleness: no manifest, no milestone CONTEXT artifact, AND entry is older than
-      // 30s (avoids race between .set() and LLM writing first artifact).
+      // Detect staleness: no manifest, no milestone CONTEXT/CONTEXT-DRAFT artifact,
+      // the entry is older than 30s (avoids race between .set() and LLM writing the
+      // first artifact), AND no agent turn is in flight. A dispatched discuss turn
+      // can think for well over 30s before its first question round writes any
+      // artifact; deleting the entry while that turn is live re-dispatches the
+      // workflow, which both resets the interview and queues a duplicate turn that
+      // replays the final "context written" message after the real one.
       const entry = _getPendingAutoStart(basePath)!;
       const ageMs = Date.now() - (entry.createdAt || 0);
       const manifestExists = existsSync(join(gsdRoot(basePath), "DISCUSSION-MANIFEST.json"));
       const milestoneHasContext = !!resolveMilestoneFile(basePath, entry.milestoneId, "CONTEXT");
+      const milestoneHasDraft = !!resolveMilestoneFile(basePath, entry.milestoneId, "CONTEXT-DRAFT");
       const milestoneHasRoadmap = !!resolveMilestoneFile(basePath, entry.milestoneId, "ROADMAP");
       const milestoneRow = isDbAvailable() ? getMilestone(entry.milestoneId) : null;
       const discussPlanComplete = milestoneHasRoadmap && !!milestoneRow && milestoneRow.status !== "queued";
@@ -1924,7 +1948,13 @@ export async function showSmartEntry(
         // The discuss flow already completed, but pending auto-start cleanup handshake did not run.
         // Clear stale in-memory guard and continue through normal active-milestone routing.
         deletePendingAutoStart(basePath);
-      } else if (!manifestExists && !milestoneHasContext && ageMs > 30_000) {
+      } else if (
+        !manifestExists &&
+        !milestoneHasContext &&
+        !milestoneHasDraft &&
+        ageMs > 30_000 &&
+        !isAgentTurnInFlight(ctx)
+      ) {
         // Stale entry from an interrupted discussion — clear and continue
         deletePendingAutoStart(basePath);
       } else {

--- a/src/resources/extensions/gsd/tests/clear-stale-autostart.test.ts
+++ b/src/resources/extensions/gsd/tests/clear-stale-autostart.test.ts
@@ -73,4 +73,26 @@ describe("clear stale pending auto-start (#3667)", () => {
       "pending auto-start gate must clear stale map entries for completed discussions",
     );
   });
+
+  test("guided-flow does not treat a live discuss turn as a stale pending entry", () => {
+    const source = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
+    assert.ok(
+      source.includes("!isAgentTurnInFlight(ctx)"),
+      "stale-entry deletion must be gated on no agent turn being in flight — a dispatched " +
+      "discuss turn can think for over 30s before writing its first artifact, and deleting " +
+      "its entry re-dispatches the workflow (duplicate interview + duplicate completion message)",
+    );
+    assert.ok(
+      source.includes('const milestoneHasDraft = !!resolveMilestoneFile(basePath, entry.milestoneId, "CONTEXT-DRAFT");'),
+      "stale-entry check must treat an existing CONTEXT-DRAFT as proof of an in-progress interview",
+    );
+    assert.ok(
+      source.includes("!milestoneHasDraft"),
+      "stale-entry deletion must require the CONTEXT-DRAFT to be absent",
+    );
+    assert.ok(
+      source.includes("ctx.hasPendingMessages"),
+      "in-flight detection must also cover dispatched-but-not-yet-started queued messages",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -13,7 +13,9 @@ import { closeDatabase, getMilestone } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
 import {
   getPendingGate,
+  loadWriteGateSnapshot,
   resetWriteGateState,
+  setPendingGate,
   shouldBlockContextArtifactSave,
 } from "../bootstrap/write-gate.ts";
 import { classifyCommand } from "../safety/destructive-guard.ts";
@@ -801,4 +803,92 @@ test("register-hooks message_update does NOT pause while an interactive elicitat
     true,
     "prose-only approval with no elicitation in flight must still arm the pause notice",
   );
+});
+
+test("register-hooks agent_end does not re-arm deferred gate after workflow MCP verified write-gate on disk", async (t) => {
+  const dir = makeTempDir("mcp-disk-sync");
+  const originalCwd = process.cwd();
+  const originalEnv = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+  process.chdir(dir);
+  resetWriteGateState(dir);
+  clearPendingAutoStart(dir);
+  process.env.GSD_PERSIST_WRITE_GATE_STATE = "1";
+
+  const gateId = "depth_verification_M005_confirm";
+  const statePath = join(dir, ".gsd", "runtime", "write-gate-state.json");
+
+  t.after(() => {
+    try {
+      resetWriteGateState(dir);
+      clearPendingAutoStart(dir);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+      } else {
+        process.env.GSD_PERSIST_WRITE_GATE_STATE = originalEnv;
+      }
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  const ctx = {
+    cwd: dir,
+    ui: { notify: () => undefined },
+  } as any;
+
+  registerHooks(pi, []);
+
+  setPendingAutoStart(dir, {
+    basePath: dir,
+    milestoneId: "M005",
+    ctx,
+    pi: { sendMessage: () => undefined } as any,
+  });
+
+  const approvalMessage = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Did I capture the depth right?" },
+    ],
+  };
+
+  for (const handler of handlers.get("message_update") ?? []) {
+    await handler({ message: approvalMessage }, ctx);
+  }
+
+  setPendingGate(gateId, dir);
+  mkdirSync(join(dir, ".gsd", "runtime"), { recursive: true });
+  writeFileSync(statePath, JSON.stringify({
+    verifiedDepthMilestones: ["M005"],
+    verifiedApprovalGates: [gateId],
+    activeQueuePhase: false,
+    pendingGateId: null,
+  }, null, 2), "utf-8");
+
+  for (const handler of handlers.get("agent_end") ?? []) {
+    await handler({ messages: [] }, ctx);
+  }
+
+  assert.equal(getPendingGate(dir), null, "agent_end must not re-arm a gate the MCP subprocess already verified");
+  assert.equal(
+    shouldBlockContextArtifactSave("CONTEXT", "M005", null, dir).block,
+    false,
+    "verified milestone context writes must stay unlocked after agent_end",
+  );
+  assert.deepEqual(loadWriteGateSnapshot(dir), {
+    verifiedDepthMilestones: ["M005"],
+    verifiedApprovalGates: [gateId],
+    activeQueuePhase: false,
+    pendingGateId: null,
+  });
 });

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -803,3 +803,45 @@ test('write-gate: resetWriteGateState persists through dangling .gsd symlink', (
     } catch { /* swallow */ }
   }
 });
+
+// ─── Scenario 31: hydrate in-memory gate state from persisted snapshot (MCP subprocess) ──
+
+test('write-gate: getPendingGate hydrates from disk when workflow MCP verified gate in child process', () => {
+  const base = join(tmpdir(), `gsd-write-gate-mcp-hydrate-${randomUUID()}`);
+  const stateFilePath = join(base, '.gsd', 'runtime', 'write-gate-state.json');
+  const originalEnv = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+  const gateId = 'depth_verification_M005_confirm';
+
+  try {
+    process.env.GSD_PERSIST_WRITE_GATE_STATE = '1';
+    mkdirSync(join(base, '.gsd', 'runtime'), { recursive: true });
+    clearDiscussionFlowState(base);
+    setPendingGate(gateId, base);
+
+    writeFileSync(stateFilePath, JSON.stringify({
+      verifiedDepthMilestones: ['M005'],
+      verifiedApprovalGates: [gateId],
+      activeQueuePhase: false,
+      pendingGateId: null,
+    }, null, 2), 'utf-8');
+
+    assert.strictEqual(getPendingGate(base), null, 'stale in-memory pending must refresh from disk');
+    assert.strictEqual(isMilestoneDepthVerified('M005', base), true, 'verified milestone must hydrate from disk');
+    assert.deepEqual(loadWriteGateSnapshot(base), {
+      verifiedDepthMilestones: ['M005'],
+      verifiedApprovalGates: [gateId],
+      activeQueuePhase: false,
+      pendingGateId: null,
+    });
+  } finally {
+    if (originalEnv === undefined) {
+      delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+    } else {
+      process.env.GSD_PERSIST_WRITE_GATE_STATE = originalEnv;
+    }
+    clearDiscussionFlowState(base);
+    try {
+      rmSync(base, { recursive: true, force: true });
+    } catch { /* swallow */ }
+  }
+});


### PR DESCRIPTION
## Summary

Fixes two bugs observed together in a live discuss session (M005 interview in a Claude Code session): a permanent **"Discussion already in progress" dead-end** after a completed milestone discussion, and a **duplicate "M00X context written." turn** from a double-dispatched discuss workflow.

### Bug 1 — write-gate verification clobbered at agent_end (dead-end)

The depth-verification write gate has two writers — the extension host and the workflow MCP child process — synced via the `.gsd/runtime/write-gate-state.json` snapshot (whole-file, last-write-wins). When the user answered the depth question through the MCP `ask_user_questions` tool, the child verified + cleared the gate on disk, but the host's `activateDeferredApprovalGate` re-armed it at `agent_end` from stale in-memory state. `setPendingGate` also deletes the verified-milestone/gate marks when persisting, so the re-arm wiped the child's verification.

Downstream cascade: `checkAutoStartAfterDiscuss` → `hasBlockingDepthGate` silently blocked the discuss→auto handoff forever → the milestone never got a DB row → false markdown/DB drift warning (`5M/5S/16T` vs `3M/5S/16T`) and every `/gsd` hit the in-progress guard.

**Fix:** `refreshWriteGateStateFromDisk` hydrates host memory from the persisted snapshot in `getPendingGate` / `isMilestoneDepthVerified`, and `activateDeferredApprovalGate` consults the disk snapshot and skips the re-arm when the gate or its milestone depth is already verified.

### Bug 2 — live discussion reaped as stale → duplicate dispatch

`showSmartEntry`'s stale-pending-auto-start heuristic deleted the entry after 30s with no manifest/CONTEXT on disk. A dispatched discuss turn can think for well over 30s before its first question round writes anything, so a second `/gsd` in that window deleted the live entry and re-dispatched the workflow. The duplicate queued turn ran after the real interview finished and replayed the mandated final line — two identical "M005 context written." messages.

**Fix:** stale deletion now also requires that no agent turn is in flight (`ctx.isIdle()` / `ctx.hasPendingMessages()`) and that no `CONTEXT-DRAFT` exists (question rounds write the draft, proving an in-progress interview). Genuinely interrupted discussions (post-`/clear`: idle, no artifacts) are reaped exactly as before.

## Test plan

- [x] `write-gate.test.ts` — new scenario 31: `getPendingGate` hydrates from disk when the MCP child verified the gate in another process (37 pass)
- [x] `register-hooks-depth-verification.test.ts` — new test: `agent_end` must not re-arm a deferred gate the subprocess already verified on disk (11 pass)
- [x] `clear-stale-autostart.test.ts` — new test locking in the in-flight/draft staleness guards (4 pass)
- [x] Related suites standalone: guided-flow, pending-autostart-scope, session-isolation, check-auto-start gates, auto-start bootstrap — all pass
- [x] `tsc --noEmit --incremental false -p tsconfig.extensions.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783632501&installation_id=134682257&pr_number=625&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F625&signature=d99b72b4a5454329a500c2642067b1954a56dffe6aabd6fa70bd157ea43c7066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches discuss handoff, depth-verification gates, and multi-process write-gate persistence—workflow-critical paths with nuanced timing, though changes are narrowly scoped and well-tested.
> 
> **Overview**
> Fixes **cross-process write-gate drift** and **over-aggressive stale pending-auto-start cleanup** that together broke discuss→auto handoff and could re-dispatch a live interview.
> 
> **Write gate (extension host vs workflow MCP child):** Adds `refreshWriteGateStateFromDisk` to hydrate in-memory gate state from `.gsd/runtime/write-gate-state.json` before `getPendingGate` / `isMilestoneDepthVerified`. At `agent_end`, `activateDeferredApprovalGate` refreshes from disk and **skips re-arming** when the snapshot already shows the approval gate or milestone depth verified—so MCP subprocess verification is not clobbered by stale host memory.
> 
> **Guided flow:** Stale `pendingAutoStart` removal (30s + no manifest/CONTEXT) now also requires **no `CONTEXT-DRAFT`**, and **`!isAgentTurnInFlight(ctx)`** (`isIdle` / `hasPendingMessages`) so long-thinking discuss turns are not mistaken for interrupted sessions and re-dispatched (duplicate completion message).
> 
> Tests lock in disk hydration, `agent_end` non-re-arm, and in-flight/draft staleness guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099908bdab831c20806de2fdc6248172acb6a5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->