### PR TITLE
fix(gsd): discussion-scratch drift false positive + /clear pending-auto-start dead-end

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -818,14 +818,10 @@ export function registerHooks(
     clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState(basePath);
-    // A fresh conversation (/clear, /new) destroys any in-flight discuss→auto
-    // handoff: the interview turns are gone, so the pending entry can never be
-    // answered. Without this, a discussion that already saved CONTEXT is
-    // immortal — the guided-flow staleness heuristic requires the CONTEXT file
-    // to be absent — and every subsequent /gsd dead-ends on "Discussion already
-    // in progress". Resume ("resume" reason) restores the interview transcript,
-    // so the entry stays. Auto-mode's own newSession() calls are safe: the
-    // handoff consumes the entry on agent_end before auto-mode dispatches.
+    // /clear or /new destroys the conversation holding a discuss interview, so
+    // its pending discuss→auto handoff can never be answered — clear it. Resume
+    // restores the interview transcript, so the entry survives. Auto-mode's own
+    // newSession() calls are safe: the handoff consumes the entry on agent_end.
     if (event.reason === "new") {
       clearPendingAutoStart(basePath);
     }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -61,6 +61,7 @@ import { filterToolsForProvider } from "../model-router.js";
 import { mcpToolMatchesBaseName } from "../mcp-tool-name.js";
 import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
 import { supportsSourceObservationsForUnit } from "../source-observations.js";
+import { clearPendingAutoStart } from "../pending-auto-start.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -808,7 +809,7 @@ export function registerHooks(
     }
   });
 
-  pi.on("session_switch", async (_event, ctx) => {
+  pi.on("session_switch", async (event, ctx) => {
     const basePath = contextBasePath(ctx);
     const preserveCloseoutSurface = isAutoCompletionStopInProgress();
     initSessionNotifications(ctx);
@@ -817,6 +818,17 @@ export function registerHooks(
     clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState(basePath);
+    // A fresh conversation (/clear, /new) destroys any in-flight discuss→auto
+    // handoff: the interview turns are gone, so the pending entry can never be
+    // answered. Without this, a discussion that already saved CONTEXT is
+    // immortal — the guided-flow staleness heuristic requires the CONTEXT file
+    // to be absent — and every subsequent /gsd dead-ends on "Discussion already
+    // in progress". Resume ("resume" reason) restores the interview transcript,
+    // so the entry stays. Auto-mode's own newSession() calls are safe: the
+    // handoff consumes the entry on agent_end before auto-mode dispatches.
+    if (event.reason === "new") {
+      clearPendingAutoStart(basePath);
+    }
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -39,6 +39,9 @@ interface HierarchyScan {
   milestones: Set<string>;
   slices: Set<string>;
   tasks: Set<string>;
+  // Markdown milestones whose dir has no ROADMAP (CONTEXT/CONTEXT-DRAFT only
+  // or empty). Always empty for DB scans.
+  milestonesWithoutRoadmap: Set<string>;
 }
 
 function zeroCounts(): HierarchyCounts {
@@ -46,7 +49,13 @@ function zeroCounts(): HierarchyCounts {
 }
 
 function emptyScan(): HierarchyScan {
-  return { counts: zeroCounts(), milestones: new Set(), slices: new Set(), tasks: new Set() };
+  return {
+    counts: zeroCounts(),
+    milestones: new Set(),
+    slices: new Set(),
+    tasks: new Set(),
+    milestonesWithoutRoadmap: new Set(),
+  };
 }
 
 function sameCounts(a: HierarchyCounts, b: HierarchyCounts): boolean {
@@ -109,7 +118,10 @@ export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
     scan.milestones.add(milestoneId);
 
     const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-    if (!roadmapPath || !existsSync(roadmapPath)) continue;
+    if (!roadmapPath || !existsSync(roadmapPath)) {
+      scan.milestonesWithoutRoadmap.add(milestoneId);
+      continue;
+    }
 
     const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
     scan.counts.slices += roadmap.slices.length;
@@ -164,7 +176,6 @@ export async function checkMarkdownHierarchyAgainstDb(
   basePath: string,
 ): Promise<MigrationAutoCheckResult> {
   const markdownScan = scanMarkdownHierarchy(basePath);
-  const markdown = markdownScan.counts;
 
   // Always open the DB before deciding. An empty markdown tree does NOT imply
   // an empty project — the DB may hold authoritative rows whose markdown was
@@ -183,6 +194,20 @@ export async function checkMarkdownHierarchyAgainstDb(
 
   const dbScan = scanDbHierarchy();
   const beforeDb = dbScan.counts;
+
+  // Discussion-phase scratch: a milestone dir with no ROADMAP and no DB row is
+  // a pre-registration discussion artifact (CONTEXT/CONTEXT-DRAFT only — the
+  // queued DB row is inserted only at discussion handoff). Treating it as
+  // drift would warn on every live discussion and recommend
+  // `/gsd recover --confirm`, an import that materializes abandoned-discussion
+  // dirs as ghost active milestones. Exclude such dirs from this comparison
+  // only; recover preflights use the raw scans and still see them.
+  for (const id of markdownScan.milestonesWithoutRoadmap) {
+    if (dbScan.milestones.has(id)) continue;
+    markdownScan.milestones.delete(id);
+    markdownScan.counts.milestones--;
+  }
+  const markdown = markdownScan.counts;
 
   const markdownEmpty = sameCounts(markdown, zeroCounts());
   const dbEmpty = sameCounts(beforeDb, zeroCounts());

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
-import { copyFileSync, mkdtempSync, renameSync, rmSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
@@ -283,6 +283,90 @@ test("migration auto-check refreshes a stale open DB handle before comparing", a
     assert.equal(result.reason, "in-sync");
     assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
     assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+function writeScratchMilestoneDir(base: string, milestoneId: string, file?: string): void {
+  const dir = join(base, ".gsd", "milestones", milestoneId);
+  mkdirSync(dir, { recursive: true });
+  if (file) writeFileSync(join(dir, file), `# ${milestoneId} discussion context\n`);
+}
+
+test("migration auto-check ignores discussion-scratch milestone dirs (CONTEXT only, no DB row)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+    // Mid-discussion artifacts: dirs with no ROADMAP and no DB row. The queued
+    // DB row is only inserted at discussion handoff, so these are expected to
+    // be DB-less — not drift, and recover must not be recommended (it would
+    // import them as ghost active milestones).
+    writeScratchMilestoneDir(base, "M002", "M002-CONTEXT.md");
+    writeScratchMilestoneDir(base, "M003", "M003-CONTEXT-DRAFT.md");
+    writeScratchMilestoneDir(base, "M004"); // empty dir
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check stays quiet mid-first-discussion (scratch dir over empty DB)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    writeScratchMilestoneDir(base, "M001", "M001-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "no-markdown");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check still reports real drift with scratch dirs excluded from counts", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01, DB empty
+    assert.equal(await ensureDbOpen(base), true);
+    writeScratchMilestoneDir(base, "M002", "M002-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "recovery-required");
+    assert.equal(result.reason, "db-empty");
+    assert.equal(result.recoveryCommand, "/gsd recover --confirm");
+    // The scratch dir must not inflate the reported markdown count.
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check still compares a roadmapless milestone that HAS a DB row", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    // Post-handoff queued milestone: CONTEXT-only dir WITH a DB row. It must
+    // stay in the comparison (both sides have it → in-sync).
+    insertMilestone({ id: "M001", title: "M001", status: "queued" });
+    writeScratchMilestoneDir(base, "M001", "M001-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 0, tasks: 0 });
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/session-switch-clears-pending-autostart.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-clears-pending-autostart.test.ts
@@ -1,0 +1,108 @@
+// gsd-pi — A fresh conversation (/clear, /new) must clear pending auto-start.
+//
+// The discuss→auto handoff entry lives in-memory and is consumed on agent_end
+// of the live interview. Once the milestone CONTEXT artifact is saved, the
+// guided-flow staleness heuristic (which requires the CONTEXT file to be
+// absent) can never fire — so a discussion interrupted by /clear left an
+// immortal entry and every subsequent /gsd dead-ended on "Discussion already
+// in progress — answer the question above" with no question above.
+//
+// session_switch with reason "new" means the conversation that contained the
+// interview is gone; the entry must go with it. Reason "resume" restores the
+// interview transcript, so the entry must survive.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import {
+  setPendingAutoStart,
+  clearPendingAutoStart,
+  _getPendingAutoStart,
+} from "../pending-auto-start.ts";
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-session-switch-pas-"));
+  const milestoneDir = join(dir, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  // The post-CONTEXT state that made the entry immortal before the fix.
+  writeFileSync(join(milestoneDir, "M001-CONTEXT.md"), "# M001 Context\n");
+  return dir;
+}
+
+function fakeCtx(base: string): any {
+  return {
+    cwd: base,
+    ui: {
+      notify: () => undefined,
+      setWidget: () => undefined,
+      setStatus: () => undefined,
+    },
+  };
+}
+
+function armPendingAutoStart(base: string): void {
+  setPendingAutoStart(base, {
+    basePath: base,
+    milestoneId: "M001",
+    ctx: { ui: { notify: () => undefined } } as any,
+    pi: { sendMessage: () => undefined } as any,
+  });
+}
+
+describe("session_switch clears pending auto-start on conversation reset", () => {
+  let base: string;
+  const handlers = new Map<string, Function>();
+
+  beforeEach(() => {
+    clearPendingAutoStart();
+    base = makeProjectDir();
+    handlers.clear();
+    registerHooks({ on(event: string, handler: Function) { handlers.set(event, handler); } } as any, []);
+  });
+
+  afterEach(() => {
+    clearPendingAutoStart();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  async function fireSessionSwitch(reason: "new" | "resume"): Promise<void> {
+    const handler = handlers.get("session_switch");
+    assert.ok(handler, "session_switch handler should be registered");
+    try {
+      await handler({ type: "session_switch", reason, previousSessionFile: undefined }, fakeCtx(base));
+    } catch {
+      // The handler also performs session plumbing (MCP prep, service tier
+      // sync) that may throw against the minimal fake ctx. Pending auto-start
+      // is cleared before that plumbing runs, so the assertions below remain
+      // valid either way.
+    }
+  }
+
+  it('reason "new" (/clear, /new) drops the entry even after CONTEXT was saved', async () => {
+    armPendingAutoStart(base);
+    assert.ok(_getPendingAutoStart(base), "entry should be armed");
+
+    await fireSessionSwitch("new");
+
+    assert.equal(
+      _getPendingAutoStart(base),
+      null,
+      "a fresh conversation destroyed the interview — the handoff entry must not outlive it",
+    );
+  });
+
+  it('reason "resume" keeps the entry (the interview transcript is restored)', async () => {
+    armPendingAutoStart(base);
+
+    await fireSessionSwitch("resume");
+
+    assert.ok(
+      _getPendingAutoStart(base),
+      "resuming restores the interview — the in-flight handoff must survive",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two bugs observed together in a live discuss session (M006 interview in test-apps/890): a false **markdown/DB drift warning recommending a destructive recover** on every milestone discussion, and a **permanent "Discussion already in progress" dead-end** after interrupting a discussion with /clear.

### Bug 1 — discussion-scratch milestone dirs flagged as projection drift

A milestone dir holding only `CONTEXT`/`CONTEXT-DRAFT` (no ROADMAP) with no DB row is a *pre-registration discussion artifact* — the queued DB row is only inserted at discussion handoff (`discussion-handoff.ts` R3b). The startup drift check counted such dirs as markdown milestones, so every live (or abandoned) discussion produced:

```
Warning: Markdown planning artifacts (6M/5S/16T) do not match the authoritative DB (3M/5S/16T).
... run `/gsd recover --confirm` if markdown should repopulate the database.
```

Following that recommendation would be harmful: the md-importer imports roadmapless dirs as **active** milestones, so recover materializes abandoned-discussion scratch as ghost milestones in the authoritative DB.

**Fix:** `scanMarkdownHierarchy` now records which milestones lack a ROADMAP, and `checkMarkdownHierarchyAgainstDb` excludes roadmapless+DB-less milestones from the comparison only. The raw scans (`countMarkdownHierarchy`, `recoverWouldDeleteDbRows`) are deliberately untouched — recover preflights must keep seeing exactly what the importer would import.

### Bug 2 — /clear after CONTEXT save leaves an immortal pending auto-start entry

The #3274 staleness heuristic in guided-flow requires the CONTEXT file to be **absent** (`!milestoneHasContext`) before reaping a stale pending auto-start entry. Once a discussion saves CONTEXT, the entry can never be reclaimed — so `/clear` mid-discussion left every subsequent `/gsd` dead-ending on "Discussion already in progress — answer the question above" with no question above.

**Fix:** the `session_switch` hook now clears pending auto-start when `reason === "new"` (/clear, /new destroy the conversation holding the interview). `"resume"` keeps the entry — the restored transcript contains the question. Auto-mode's own `newSession()` calls are unaffected: the handoff consumes the entry on `agent_end` before any dispatch. The 30s heuristic stays as a backstop for other failure modes.

A third symptom from the same session (duplicate "M006 context written." message) was investigated and confirmed to be the model restating its status across two linear turns in the transcript — not a dispatch or render bug, no code change (distinct from the double-dispatch fixed in #625).

## Test plan

- [x] `migration-auto-check.test.ts` — 4 new scenarios: scratch dirs ignored (CONTEXT, CONTEXT-DRAFT, empty); mid-first-discussion quiet over empty DB; real drift still reported with scratch excluded from counts; roadmapless milestone WITH a DB row still compared (13 pass)
- [x] `session-switch-clears-pending-autostart.test.ts` — new: reason "new" drops the entry even after CONTEXT was saved; reason "resume" keeps it (2 pass)
- [x] Related suites standalone post-rebase: guided-flow-session-isolation, pending-autostart-scope — all pass (29 total)
- [x] `tsc --noEmit --project tsconfig.extensions.json` clean; `build:core` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783641650&installation_id=134682257&pr_number=629&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F629&signature=1b5b57a093e027c3238aa91fb744188ac4943f66bf2d1dcc27cb7dc9d748c159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fixes to startup drift comparison and session-switch cleanup; recover preflight paths unchanged; covered by new tests.
> 
> **Overview**
> Fixes two guided-discussion edge cases: **false markdown/DB drift warnings** during live milestone interviews, and a **stuck “Discussion already in progress”** state after `/clear` or `/new`.
> 
> **Migration auto-check** now tracks milestone dirs without a `ROADMAP` and, in `checkMarkdownHierarchyAgainstDb` only, drops roadmapless milestones that also have no DB row from the comparison. That stops pre-handoff `CONTEXT`/`CONTEXT-DRAFT` scratch dirs from inflating counts and recommending destructive `/gsd recover --confirm`. Raw scans used by recover preflights are unchanged.
> 
> **Session lifecycle**: on `session_switch` with `reason === "new"`, the hook calls `clearPendingAutoStart(basePath)` so the in-memory discuss→auto handoff dies with the cleared conversation; `resume` leaves it intact.
> 
> Tests cover scratch-dir drift scenarios and session-switch pending auto-start behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3776334ccb8f1c97b197f03fda9bc54e4986be94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->