### PR TITLE
fix(gsd): stop false drift warnings and dead-ended discussions from scratch milestone state

### DIFF
--- a/docs/dev/new-milestone-discuss-flow.md
+++ b/docs/dev/new-milestone-discuss-flow.md
@@ -72,6 +72,8 @@ Tools are scoped to the discuss allowlist for `discuss-milestone` (see `DISCUSS_
 
 **Re-dispatch guard:** If `hasPendingAutoStart(basePath)` and discussion is still in flight, `showSmartEntry` returns early (“Discussion already in progress”) unless the pending entry is stale (>30s, no CONTEXT/ROADMAP/manifest).
 
+`/clear` and `/new` destroy the conversation holding the interview, so its pending handoff can never be answered. The `session_switch` hook (`bootstrap/register-hooks.ts`) calls `clearPendingAutoStart(basePath)` when `event.reason === "new"`, deterministically removing the entry — without this, a discussion interrupted **after** its CONTEXT file was written stays pinned forever (the >30s staleness heuristic requires CONTEXT to be absent), dead-ending every later `/gsd` on “Discussion already in progress”. `reason === "resume"` keeps the entry because the restored transcript still contains the question. Auto-mode’s own `newSession()` calls are unaffected: the handoff consumes the entry on `agent_end` before any dispatch.
+
 ## Established project interview (intended)
 
 Applies when M001+ already exist (typical “Start new milestone” after shipping work).
@@ -219,6 +221,7 @@ If two bubbles share one timestamp → model sub-turn (prompt compliance). If tw
 | `src/resources/extensions/gsd/prompts/guided-discuss-milestone.md` | Established milestone interview |
 | `src/resources/extensions/gsd/prompts/discuss.md` | Greenfield bootstrap discuss |
 | `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts` | Post-turn guards |
+| `src/resources/extensions/gsd/bootstrap/register-hooks.ts` | `session_switch` clears `pendingAutoStart` on `/clear`/`/new` |
 | `packages/gsd-agent-modes/.../chat-controller.ts` | Sub-turn → multiple UI segments |
 | `src/resources/extensions/gsd/tests/new-milestone-discuss-routing.test.ts` | Routing regression tests |
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -818,14 +818,10 @@ export function registerHooks(
     clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState(basePath);
-    // A fresh conversation (/clear, /new) destroys any in-flight discuss→auto
-    // handoff: the interview turns are gone, so the pending entry can never be
-    // answered. Without this, a discussion that already saved CONTEXT is
-    // immortal — the guided-flow staleness heuristic requires the CONTEXT file
-    // to be absent — and every subsequent /gsd dead-ends on "Discussion already
-    // in progress". Resume ("resume" reason) restores the interview transcript,
-    // so the entry stays. Auto-mode's own newSession() calls are safe: the
-    // handoff consumes the entry on agent_end before auto-mode dispatches.
+    // /clear or /new destroys the conversation holding a discuss interview, so
+    // its pending discuss→auto handoff can never be answered — clear it. Resume
+    // restores the interview transcript, so the entry survives. Auto-mode's own
+    // newSession() calls are safe: the handoff consumes the entry on agent_end.
     if (event.reason === "new") {
       clearPendingAutoStart(basePath);
     }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -61,6 +61,7 @@ import { filterToolsForProvider } from "../model-router.js";
 import { mcpToolMatchesBaseName } from "../mcp-tool-name.js";
 import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../tool-presentation-plan.js";
 import { supportsSourceObservationsForUnit } from "../source-observations.js";
+import { clearPendingAutoStart } from "../pending-auto-start.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -808,7 +809,7 @@ export function registerHooks(
     }
   });
 
-  pi.on("session_switch", async (_event, ctx) => {
+  pi.on("session_switch", async (event, ctx) => {
     const basePath = contextBasePath(ctx);
     const preserveCloseoutSurface = isAutoCompletionStopInProgress();
     initSessionNotifications(ctx);
@@ -817,6 +818,17 @@ export function registerHooks(
     clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState(basePath);
+    // A fresh conversation (/clear, /new) destroys any in-flight discuss→auto
+    // handoff: the interview turns are gone, so the pending entry can never be
+    // answered. Without this, a discussion that already saved CONTEXT is
+    // immortal — the guided-flow staleness heuristic requires the CONTEXT file
+    // to be absent — and every subsequent /gsd dead-ends on "Discussion already
+    // in progress". Resume ("resume" reason) restores the interview transcript,
+    // so the entry stays. Auto-mode's own newSession() calls are safe: the
+    // handoff consumes the entry on agent_end before auto-mode dispatches.
+    if (event.reason === "new") {
+      clearPendingAutoStart(basePath);
+    }
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -39,6 +39,9 @@ interface HierarchyScan {
   milestones: Set<string>;
   slices: Set<string>;
   tasks: Set<string>;
+  // Markdown milestones whose dir has no ROADMAP (CONTEXT/CONTEXT-DRAFT only
+  // or empty). Always empty for DB scans.
+  milestonesWithoutRoadmap: Set<string>;
 }
 
 function zeroCounts(): HierarchyCounts {
@@ -46,7 +49,13 @@ function zeroCounts(): HierarchyCounts {
 }
 
 function emptyScan(): HierarchyScan {
-  return { counts: zeroCounts(), milestones: new Set(), slices: new Set(), tasks: new Set() };
+  return {
+    counts: zeroCounts(),
+    milestones: new Set(),
+    slices: new Set(),
+    tasks: new Set(),
+    milestonesWithoutRoadmap: new Set(),
+  };
 }
 
 function sameCounts(a: HierarchyCounts, b: HierarchyCounts): boolean {
@@ -109,7 +118,10 @@ export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
     scan.milestones.add(milestoneId);
 
     const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-    if (!roadmapPath || !existsSync(roadmapPath)) continue;
+    if (!roadmapPath || !existsSync(roadmapPath)) {
+      scan.milestonesWithoutRoadmap.add(milestoneId);
+      continue;
+    }
 
     const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
     scan.counts.slices += roadmap.slices.length;
@@ -164,7 +176,6 @@ export async function checkMarkdownHierarchyAgainstDb(
   basePath: string,
 ): Promise<MigrationAutoCheckResult> {
   const markdownScan = scanMarkdownHierarchy(basePath);
-  const markdown = markdownScan.counts;
 
   // Always open the DB before deciding. An empty markdown tree does NOT imply
   // an empty project — the DB may hold authoritative rows whose markdown was
@@ -183,6 +194,20 @@ export async function checkMarkdownHierarchyAgainstDb(
 
   const dbScan = scanDbHierarchy();
   const beforeDb = dbScan.counts;
+
+  // Discussion-phase scratch: a milestone dir with no ROADMAP and no DB row is
+  // a pre-registration discussion artifact (CONTEXT/CONTEXT-DRAFT only — the
+  // queued DB row is inserted only at discussion handoff). Treating it as
+  // drift would warn on every live discussion and recommend
+  // `/gsd recover --confirm`, an import that materializes abandoned-discussion
+  // dirs as ghost active milestones. Exclude such dirs from this comparison
+  // only; recover preflights use the raw scans and still see them.
+  for (const id of markdownScan.milestonesWithoutRoadmap) {
+    if (dbScan.milestones.has(id)) continue;
+    markdownScan.milestones.delete(id);
+    markdownScan.counts.milestones--;
+  }
+  const markdown = markdownScan.counts;
 
   const markdownEmpty = sameCounts(markdown, zeroCounts());
   const dbEmpty = sameCounts(beforeDb, zeroCounts());

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
-import { copyFileSync, mkdtempSync, renameSync, rmSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
@@ -283,6 +283,90 @@ test("migration auto-check refreshes a stale open DB handle before comparing", a
     assert.equal(result.reason, "in-sync");
     assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
     assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+function writeScratchMilestoneDir(base: string, milestoneId: string, file?: string): void {
+  const dir = join(base, ".gsd", "milestones", milestoneId);
+  mkdirSync(dir, { recursive: true });
+  if (file) writeFileSync(join(dir, file), `# ${milestoneId} discussion context\n`);
+}
+
+test("migration auto-check ignores discussion-scratch milestone dirs (CONTEXT only, no DB row)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+    // Mid-discussion artifacts: dirs with no ROADMAP and no DB row. The queued
+    // DB row is only inserted at discussion handoff, so these are expected to
+    // be DB-less — not drift, and recover must not be recommended (it would
+    // import them as ghost active milestones).
+    writeScratchMilestoneDir(base, "M002", "M002-CONTEXT.md");
+    writeScratchMilestoneDir(base, "M003", "M003-CONTEXT-DRAFT.md");
+    writeScratchMilestoneDir(base, "M004"); // empty dir
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check stays quiet mid-first-discussion (scratch dir over empty DB)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    writeScratchMilestoneDir(base, "M001", "M001-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "no-markdown");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check still reports real drift with scratch dirs excluded from counts", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base); // markdown: M001 / S01 / T01, DB empty
+    assert.equal(await ensureDbOpen(base), true);
+    writeScratchMilestoneDir(base, "M002", "M002-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "recovery-required");
+    assert.equal(result.reason, "db-empty");
+    assert.equal(result.recoveryCommand, "/gsd recover --confirm");
+    // The scratch dir must not inflate the reported markdown count.
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check still compares a roadmapless milestone that HAS a DB row", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    // Post-handoff queued milestone: CONTEXT-only dir WITH a DB row. It must
+    // stay in the comparison (both sides have it → in-sync).
+    insertMilestone({ id: "M001", title: "M001", status: "queued" });
+    writeScratchMilestoneDir(base, "M001", "M001-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 0, tasks: 0 });
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/session-switch-clears-pending-autostart.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-clears-pending-autostart.test.ts
@@ -1,0 +1,108 @@
+// gsd-pi — A fresh conversation (/clear, /new) must clear pending auto-start.
+//
+// The discuss→auto handoff entry lives in-memory and is consumed on agent_end
+// of the live interview. Once the milestone CONTEXT artifact is saved, the
+// guided-flow staleness heuristic (which requires the CONTEXT file to be
+// absent) can never fire — so a discussion interrupted by /clear left an
+// immortal entry and every subsequent /gsd dead-ended on "Discussion already
+// in progress — answer the question above" with no question above.
+//
+// session_switch with reason "new" means the conversation that contained the
+// interview is gone; the entry must go with it. Reason "resume" restores the
+// interview transcript, so the entry must survive.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import {
+  setPendingAutoStart,
+  clearPendingAutoStart,
+  _getPendingAutoStart,
+} from "../pending-auto-start.ts";
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-session-switch-pas-"));
+  const milestoneDir = join(dir, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  // The post-CONTEXT state that made the entry immortal before the fix.
+  writeFileSync(join(milestoneDir, "M001-CONTEXT.md"), "# M001 Context\n");
+  return dir;
+}
+
+function fakeCtx(base: string): any {
+  return {
+    cwd: base,
+    ui: {
+      notify: () => undefined,
+      setWidget: () => undefined,
+      setStatus: () => undefined,
+    },
+  };
+}
+
+function armPendingAutoStart(base: string): void {
+  setPendingAutoStart(base, {
+    basePath: base,
+    milestoneId: "M001",
+    ctx: { ui: { notify: () => undefined } } as any,
+    pi: { sendMessage: () => undefined } as any,
+  });
+}
+
+describe("session_switch clears pending auto-start on conversation reset", () => {
+  let base: string;
+  const handlers = new Map<string, Function>();
+
+  beforeEach(() => {
+    clearPendingAutoStart();
+    base = makeProjectDir();
+    handlers.clear();
+    registerHooks({ on(event: string, handler: Function) { handlers.set(event, handler); } } as any, []);
+  });
+
+  afterEach(() => {
+    clearPendingAutoStart();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  async function fireSessionSwitch(reason: "new" | "resume"): Promise<void> {
+    const handler = handlers.get("session_switch");
+    assert.ok(handler, "session_switch handler should be registered");
+    try {
+      await handler({ type: "session_switch", reason, previousSessionFile: undefined }, fakeCtx(base));
+    } catch {
+      // The handler also performs session plumbing (MCP prep, service tier
+      // sync) that may throw against the minimal fake ctx. Pending auto-start
+      // is cleared before that plumbing runs, so the assertions below remain
+      // valid either way.
+    }
+  }
+
+  it('reason "new" (/clear, /new) drops the entry even after CONTEXT was saved', async () => {
+    armPendingAutoStart(base);
+    assert.ok(_getPendingAutoStart(base), "entry should be armed");
+
+    await fireSessionSwitch("new");
+
+    assert.equal(
+      _getPendingAutoStart(base),
+      null,
+      "a fresh conversation destroyed the interview — the handoff entry must not outlive it",
+    );
+  });
+
+  it('reason "resume" keeps the entry (the interview transcript is restored)', async () => {
+    armPendingAutoStart(base);
+
+    await fireSessionSwitch("resume");
+
+    assert.ok(
+      _getPendingAutoStart(base),
+      "resuming restores the interview — the in-flight handoff must survive",
+    );
+  });
+});


### PR DESCRIPTION
## Intent

Fix two GSD runtime bugs diagnosed from a live test session (test-apps/890): (1) The startup drift check (checkMarkdownHierarchyAgainstDb) counted milestone dirs holding only CONTEXT/CONTEXT-DRAFT (no ROADMAP, no DB row) as markdown milestones. These are pre-registration discussion artifacts — the queued DB row is only inserted at discussion handoff — so every live or abandoned milestone discussion produced a false 'recovery-required' warning recommending '/gsd recover --confirm', an import that would materialize abandoned-discussion scratch dirs as ghost active milestones in the authoritative DB. Fix: filter such dirs from the comparison inside checkMarkdownHierarchyAgainstDb only, deliberately leaving the raw scans (countMarkdownHierarchy, recoverWouldDeleteDbRows — used by recover preflights, which must see what the importer would import) untouched. Deliberately did NOT change the md-importer or insert DB rows at ID-reservation time, to keep blast radius small. (2) A discussion interrupted by /clear after its CONTEXT artifact was saved became an immortal pending auto-start entry: the #3274 staleness heuristic in guided-flow requires the CONTEXT file to be ABSENT, so every subsequent /gsd dead-ended on 'Discussion already in progress — answer the question above' with no question above. Fix: deterministically clear the in-memory pending auto-start entry in the session_switch hook when reason is 'new' (/clear, /new destroy the conversation holding the interview); reason 'resume' keeps the entry because the restored transcript contains the question. The 30s heuristic is intentionally kept as a backstop for other failure modes. Auto-mode's own newSession() calls are safe because the handoff consumes the entry on agent_end before any dispatch. Tests added for both: 4 drift-check scenarios and a session_switch handler test (new clears, resume keeps). A third investigated symptom (duplicate 'M006 context written.' message) was confirmed to be the model restating its status across two turns — not a harness bug, no code change. NOTE: two previous runs of this head died on provider infrastructure errors, not findings: run 01KTQC2BD2Z683BEDBE60AM7H6 passed review with 0 findings and its test agent validated both fixes end-to-end (all 15 tests passed) before crashing on an API socket error; run 01KTQCY4EVJM28D2X468F53Y32 crashed mid-review stream. This is retry #3.

## What Changed

- Filter pre-registration discussion dirs (those holding only `CONTEXT`/`CONTEXT-DRAFT` with no `ROADMAP` and no queued DB row) out of the comparison inside `checkMarkdownHierarchyAgainstDb`, so abandoned or in-flight milestone discussions no longer trigger a false `recovery-required` warning recommending `/gsd recover --confirm`. The raw scans used by recover preflights are left untouched.
- Clear the in-memory pending auto-start entry in the `session_switch` hook when the reason is `new` (`/clear`, `/new`), preventing an interrupted post-CONTEXT discussion from becoming an immortal entry that dead-ends every subsequent `/gsd` on "Discussion already in progress"; `resume` keeps the entry since the restored transcript still holds the question.
- Add tests for both fixes (4 discussion-scratch drift scenarios, plus a session_switch handler test covering new-clears and resume-keeps) and document the `session_switch` clearing behavior in the new-milestone discuss-flow doc.

## Risk Assessment

✅ Low: Two tightly-scoped GSD bugfixes whose key safety invariants I verified against the surrounding code (newSession emits session_switch reason "new" but the handoff consumes the pending entry on agent_end first; basePath keying is consistent via ctx.cwd; raw drift scans left untouched), each backed by accurate targeted tests.

## Testing

The worktree arrived without node_modules or built package dist, so I installed deps and built packages plus test:compile as a setup prerequisite, then ran the two changed test files from dist-test with all 15 tests passing. Beyond the unit tests I wrote and ran a driver that invokes the actual production functions on a test-apps fixture and captured a CLI transcript: the startup check returns action none and reason in-sync with no recovery banner for discussion-scratch dirs while still flagging genuine drift, and the session_switch hook clears the pending handoff on reason new but keeps it on resume. No product failures were found; build-regenerated pi-ai generated files were reverted to keep the tree clean.

<details>
<summary>Evidence: End-to-end CLI transcript of both fixes against real production functions</summary>

```text
══════════════════════════════════════════════════════════════════════
 BUG 1 — startup drift check vs. live/abandoned discussion scratch dirs
══════════════════════════════════════════════════════════════════════
Scenario (test-apps/890): a healthy project (M001 in markdown AND DB)
plus three discussion artifacts mid-flight — dirs holding only CONTEXT
with NO ROADMAP and NO queued DB row (the row is inserted at handoff):
  • M002/M002-CONTEXT.md      (live discussion)
  • M003/M003-CONTEXT-DRAFT.md (abandoned draft)
  • M004/                      (empty scratch dir)

raw scanMarkdownHierarchy() sees milestones: [M001, M002, M003, M004]
  → roadmapless (scratch) dirs the recover preflight must still import: [M002, M003, M004]
  (raw scan deliberately UNCHANGED — recover preflights need to see these)

startup checkMarkdownHierarchyAgainstDb() → what the user's startup sees:
  action          : none
  reason          : in-sync
  recoveryCommand : (none — no banner shown)
  counted markdown: {"milestones":1,"slices":1,"tasks":1}

✅ RESULT: NO false 'recovery-required' warning, NO '/gsd recover --confirm'.
   Before the fix: action=recovery-required, banner urged /gsd recover,
   which would have imported M002/M003/M004 as ghost active milestones.

── sub-check: a REAL drift (markdown M001 tree, empty DB) still warns ──
  action=recovery-required  reason=db-empty  recoveryCommand=/gsd recover --confirm  markdown={"milestones":1,"slices":1,"tasks":1}
✅ Genuine drift is still caught — and the scratch dir did NOT inflate the count (M002 excluded).

══════════════════════════════════════════════════════════════════════
 BUG 2 — /clear must clear the immortal pending auto-start handoff entry
══════════════════════════════════════════════════════════════════════
Scenario: a discuss interview saved its CONTEXT artifact, then the user
ran /clear. The 30s staleness heuristic requires CONTEXT to be ABSENT,
so the in-memory handoff entry became immortal and every later /gsd
dead-ended on 'Discussion already in progress — answer the question
above' with no question above.

reason "new"   (/clear, /new): armed before=true  pending after=false
reason "resume"             : armed before=true  pending after=true

✅ RESULT: /clear (reason 'new') drops the stranded handoff entry, so the
   next /gsd starts clean instead of dead-ending. 'resume' keeps it because
   the restored transcript still contains the question.

All scenarios completed.
```
</details>
<details>
<summary>Evidence: Evidence driver source harness</summary>

```text
// Evidence driver — reproduces the live test-apps/890 scenario against the
// REAL production startup-drift functions and the REAL session_switch hook.
// Prints the banner/result an end user would actually experience.

import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
import { join } from "node:path";
import { tmpdir } from "node:os";

import { ensureDbOpen } from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTQD1641X8W5JFCVK613BFQ8/dist-test/src/resources/extensions/gsd/bootstrap/dynamic-tools.js";
import { closeDatabase, insertMilestone, insertSlice, insertTask } from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTQD1641X8W5JFCVK613BFQ8/dist-test/src/resources/extensions/gsd/gsd-db.js";
import {
  checkMarkdownHierarchyAgainstDb,
  scanMarkdownHierarchy,
} from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTQD1641X8W5JFCVK613BFQ8/dist-test/src/resources/extensions/gsd/migration-auto-check.js";
import { writeGSDDirectory } from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTQD1641X8W5JFCVK613BFQ8/dist-test/src/resources/extensions/gsd/migrate/writer.js";
import { registerHooks } from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTQD1641X8W5JFCVK613BFQ8/dist-test/src/resources/extensions/gsd/bootstrap/register-hooks.js";
import { setPendingAutoStart, clearPendingAutoStart, hasPendingAutoStart } from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTQD1641X8W5JFCVK613BFQ8/dist-test/src/resources/extensions/gsd/pending-auto-start.js";

function scratch(base, id, file) {
  const dir = join(base, ".gsd", "milestones", id);
  mkdirSync(dir, { recursive: true });
  if (file) writeFileSync(join(dir, file), `# ${id} discussion context\n`);
}

const line = (s = "") => process.stdout.write(s + "\n");

// ───────────────────────────────────────────────────────────────────────────
line("══════════════════════════════════════════════════════════════════════");
line(" BUG 1 — startup drift check vs. live/abandoned discussion scratch dirs");
line("══════════════════════════════════════════════════════════════════════");
line("Scenario (test-apps/890): a healthy project (M001 in markdown AND DB)");
line("plus three discussion artifacts mid-flight — dirs holding only CONTEXT");
line("with NO ROADMAP and NO queued DB row (the row is inserted at handoff):");
line("  • M002/M002-CONTEXT.md      (live discussion)");
line("  • M003/M003-CONTEXT-DRAFT.md (abandoned draft)");
line("  • M004/                      (empty scratch dir)");
line("");

const base1 = mkdtempSync(join(tmpdir(), "evidence-drift-"));
try {
  await writeGSDDirectory(
    {
      projectContent: "# Legacy Project\n",
      decisionsContent: "",
      requirements: [],
      milestones: [
        {
          id: "M001", title: "Legacy Milestone", vision: "v", successCriteria: ["x"],
          research: null, boundaryMap: [],
          slices: [{
            id: "S01", title: "Legacy Slice", risk: "medium", depends: [], done: false,
            demo: "d", goal: "d", research: null, summary: null,
            tasks: [{ id: "T01", title: "Legacy Task", description: "", done: false, estimate: "", files: ["src/index.ts"], mustHaves: [], summary: null }],
          }],
        },
      ],
    },
    base1,
  );
  await ensureDbOpen(base1);
  insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
  insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "d", sequence: 1 });
  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });

  scratch(base1, "M002", "M002-CONTEXT.md");
  scratch(base1, "M003", "M003-CONTEXT-DRAFT.md");
  scratch(base1, "M004");

  const raw = scanMarkdownHierarchy(base1);
  line(`raw scanMarkdownHierarchy() sees milestones: [${[...raw.milestones].sort().join(", ")}]`);
  line(`  → roadmapless (scratch) dirs the recover preflight must still import: [${[...raw.milestonesWithoutRoadmap].sort().join(", ")}]`);
  line("  (raw scan deliberately UNCHANGED — recover preflights need to see these)");
  line("");

  const result = await checkMarkdownHierarchyAgainstDb(base1);
  line("startup checkMarkdownHierarchyAgainstDb() → what the user's startup sees:");
  line(`  action          : ${result.action}`);
  line(`  reason          : ${result.reason}`);
  line(`  recoveryCommand : ${result.recoveryCommand ?? "(none — no banner shown)"}`);
  line(`  counted markdown: ${JSON.stringify(result.markdown)}`);
  line("");
  if (result.action === "none" && !result.recoveryCommand) {
    line("✅ RESULT: NO false 'recovery-required' warning, NO '/gsd recover --confirm'.");
    line("   Before the fix: action=recovery-required, banner urged /gsd recover,");
    line("   which would have imported M002/M003/M004 as ghost active milestones.");
  } else {
    line("❌ UNEXPECTED: a recovery banner was produced for scratch dirs.");
    process.exitCode = 1;
  }
} finally {
  closeDatabase();
  rmSync(base1, { recursive: true, force: true });
}

line("");
line("── sub-check: a REAL drift (markdown M001 tree, empty DB) still warns ──");
const base1b = mkdtempSync(join(tmpdir(), "evidence-drift-real-"));
try {
  await writeGSDDirectory(
    {
      projectContent: "# P\n", decisionsContent: "", requirements: [],
      milestones: [{
        id: "M001", title: "M001", vision: "v", successCriteria: ["x"], research: null, boundaryMap: [],
        slices: [{ id: "S01", title: "S", risk: "medium", depends: [], done: false, demo: "d", goal: "d", research: null, summary: null,
          tasks: [{ id: "T01", title: "T", description: "", done: false, estimate: "", files: ["a"], mustHaves: [], summary: null }] }],
      }],
    },
    base1b,
  );
  await ensureDbOpen(base1b); // DB left empty
  scratch(base1b, "M002", "M002-CONTEXT.md"); // scratch dir alongside the real drift
  const r = await checkMarkdownHierarchyAgainstDb(base1b);
  line(`  action=${r.action}  reason=${r.reason}  recoveryCommand=${r.recoveryCommand}  markdown=${JSON.stringify(r.markdown)}`);
  if (r.action === "recovery-required" && r.recoveryCommand === "/gsd recover --confirm") {
    line("✅ Genuine drift is still caught — and the scratch dir did NOT inflate the count (M002 excluded).");
  } else {
    line("❌ UNEXPECTED: real drift no longer detected.");
    process.exitCode = 1;
  }
} finally {
  closeDatabase();
  rmSync(base1b, { recursive: true, force: true });
}

// ───────────────────────────────────────────────────────────────────────────
line("");
line("══════════════════════════════════════════════════════════════════════");
line(" BUG 2 — /clear must clear the immortal pending auto-start handoff entry");
line("══════════════════════════════════════════════════════════════════════");
line("Scenario: a discuss interview saved its CONTEXT artifact, then the user");
line("ran /clear. The 30s staleness heuristic requires CONTEXT to be ABSENT,");
line("so the in-memory handoff entry became immortal and every later /gsd");
line("dead-ended on 'Discussion already in progress — answer the question");
line("above' with no question above.");
line("");

const base2 = mkdtempSync(join(tmpdir(), "evidence-autostart-"));
mkdirSync(join(base2, ".gsd", "milestones", "M001"), { recursive: true });
writeFileSync(join(base2, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001 Context\n");

const handlers = new Map();
registerHooks({ on(ev, h) { handlers.set(ev, h); } }, []);
const sessionSwitch = handlers.get("session_switch");
const fakeCtx = { cwd: base2, ui: { notify: () => {}, setWidget: () => {}, setStatus: () => {} } };

async function fire(reason) {
  clearPendingAutoStart();
  setPendingAutoStart(base2, {
    basePath: base2, milestoneId: "M001",
    ctx: { ui: { notify: () => {} } }, pi: { sendMessage: () => {} },
  });
  const armed = hasPendingAutoStart(base2);
  try {
    await sessionSwitch({ type: "session_switch", reason, previousSessionFile: undefined }, fakeCtx);
  } catch { /* session plumbing may throw on the minimal fake ctx; clear runs first */ }
  return { armed, after: hasPendingAutoStart(base2) };
}

const newRun = await fire("new");
line(`reason "new"   (/clear, /new): armed before=${newRun.armed}  pending after=${newRun.after}`);
const resumeRun = await fire("resume");
line(`reason "resume"             : armed before=${resumeRun.armed}  pending after=${resumeRun.after}`);
line("");
if (newRun.armed && !newRun.after && resumeRun.armed && resumeRun.after) {
  line("✅ RESULT: /clear (reason 'new') drops the stranded handoff entry, so the");
  line("   next /gsd starts clean instead of dead-ending. 'resume' keeps it because");
  line("   the restored transcript still contains the question.");
} else {
  line("❌ UNEXPECTED: clear/keep behavior did not match the fix.");
  process.exitCode = 1;
}
clearPendingAutoStart();
rmSync(base2, { recursive: true, force: true });

line("");
line("All scenarios completed.");
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `migration-auto-check test 13 of 13 pass including 4 new discussion-scratch drift scenarios`
- `session-switch test 2 of 2 pass, new clears and resume keeps`
- `reproduction driver invoking real checkMarkdownHierarchyAgainstDb, scanMarkdownHierarchy, and the registered session_switch hook on a test-apps fixture, exit 0`
- `prerequisite build: pnpm install, build:pi, native build, test:compile`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped startup-comparison and session-hook changes with tests; recover preflights and resume behavior are explicitly preserved.
> 
> **Overview**
> Fixes two GSD runtime edge cases around milestone discussion scratch state.
> 
> **Startup drift check:** `checkMarkdownHierarchyAgainstDb` now drops markdown milestone dirs that have no `ROADMAP` and no matching DB row from the comparison (pre-registration `CONTEXT` / `CONTEXT-DRAFT` only). That stops false `recovery-required` banners and `/gsd recover --confirm` during live or abandoned discussions. Raw `scanMarkdownHierarchy` / recover preflights are unchanged so importers still see scratch dirs.
> 
> **Pending discuss handoff:** On `session_switch` with `reason === "new"` (`/clear`, `/new`), `clearPendingAutoStart(basePath)` runs so an in-memory discuss→auto entry cannot outlive the cleared interview (especially after `CONTEXT` was written, when the 30s staleness heuristic no longer applies). `resume` leaves the entry intact.
> 
> Adds regression tests for both behaviors and documents the `/clear` behavior in the new-milestone discuss-flow doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a306046b564499050aacdc0f1ccc1eb4d6ee1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783642616&installation_id=134682257&pr_number=630&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F630&signature=c4df8ef9b95af4a6ee3d72648604c9ccbb37e8ca5d0c0428f7a4d97122efbb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->