### PR TITLE
docs(dev): document session_switch clearing pending auto-start on /clear or /new

### DIFF
--- a/docs/dev/new-milestone-discuss-flow.md
+++ b/docs/dev/new-milestone-discuss-flow.md
@@ -72,6 +72,8 @@ Tools are scoped to the discuss allowlist for `discuss-milestone` (see `DISCUSS_
 
 **Re-dispatch guard:** If `hasPendingAutoStart(basePath)` and discussion is still in flight, `showSmartEntry` returns early (“Discussion already in progress”) unless the pending entry is stale (>30s, no CONTEXT/ROADMAP/manifest).
 
+`/clear` and `/new` destroy the conversation holding the interview, so its pending handoff can never be answered. The `session_switch` hook (`bootstrap/register-hooks.ts`) calls `clearPendingAutoStart(basePath)` when `event.reason === "new"`, deterministically removing the entry — without this, a discussion interrupted **after** its CONTEXT file was written stays pinned forever (the >30s staleness heuristic requires CONTEXT to be absent), dead-ending every later `/gsd` on “Discussion already in progress”. `reason === "resume"` keeps the entry because the restored transcript still contains the question. Auto-mode’s own `newSession()` calls are unaffected: the handoff consumes the entry on `agent_end` before any dispatch.
+
 ## Established project interview (intended)
 
 Applies when M001+ already exist (typical “Start new milestone” after shipping work).
@@ -219,6 +221,7 @@ If two bubbles share one timestamp → model sub-turn (prompt compliance). If tw
 | `src/resources/extensions/gsd/prompts/guided-discuss-milestone.md` | Established milestone interview |
 | `src/resources/extensions/gsd/prompts/discuss.md` | Greenfield bootstrap discuss |
 | `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts` | Post-turn guards |
+| `src/resources/extensions/gsd/bootstrap/register-hooks.ts` | `session_switch` clears `pendingAutoStart` on `/clear`/`/new` |
 | `packages/gsd-agent-modes/.../chat-controller.ts` | Sub-turn → multiple UI segments |
 | `src/resources/extensions/gsd/tests/new-milestone-discuss-routing.test.ts` | Routing regression tests |
 


### PR DESCRIPTION
## Summary

Follow-up to #629 — documents the new `session_switch` behavior in `docs/dev/new-milestone-discuss-flow.md`: `/clear` and `/new` deterministically clear the pending discuss→auto handoff entry (the interview conversation is gone), `resume` keeps it, and auto-mode's own `newSession()` calls are unaffected. Also adds the `register-hooks.ts` row to the file map.

Salvaged from the no-mistakes document step of the superseded #630 (its code commits landed via #629).

## Test plan

- [x] Docs-only change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783642846&installation_id=134682257&pr_number=631&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F631&signature=a938d8c02a653ce356f402c7472f380eb70cfe492d2869fc5d26b5d064e1d7b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or test modifications.
> 
> **Overview**
> Docs-only follow-up to **#629**: **`new-milestone-discuss-flow.md`** now explains how **`/clear`** and **`/new`** interact with the discuss→auto **`pendingAutoStart`** handoff.
> 
> The new **Re-dispatch guard** note describes **`session_switch`** in **`register-hooks.ts`** calling **`clearPendingAutoStart`** when **`reason === "new"`**, so a killed interview cannot leave a permanent “Discussion already in progress” block (including the case where CONTEXT was already written and the >30s staleness rule does not apply). **`resume`** keeps the entry; auto-mode **`newSession()`** is called out as unaffected because the handoff is consumed on **`agent_end`**.
> 
> The **Key files** table adds a row for **`register-hooks.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8862b4a8cc99b6ec32ff46803c0ddca1fd2cfdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->