### PR TITLE
fix(skills): quote gsd-browser SKILL.md description to fix YAML parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 ## [Unreleased]
 
 ### Fixed
+- **skills**: quote the gsd-browser SKILL.md description so the skill loads in Claude Code — an unquoted colon in the description was parsed as a nested YAML mapping and rejected the frontmatter
 - **gsd**: make undo's slice reset atomic — an interrupted reset can no longer leave a slice partially reset (tasks reset but slice status not, or vice versa)
 - **claude-code-cli**: keep in-flight ask_user_questions elicitation alive through the foreground approval pause
 - **claude-code-cli**: stop auto-mode watchdogs from self-cancelling ask_user_questions

--- a/src/resources/skills/gsd-browser/SKILL.md
+++ b/src/resources/skills/gsd-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-browser
-description: Use gsd-browser for browser automation and UAT: navigating local apps, inspecting pages, clicking or filling controls, taking screenshots, asserting UI behavior, collecting console/network diagnostics, visual diffing, and creating evidence bundles. Prefer this over legacy Playwright browser tooling when both are available.
+description: "Use gsd-browser for browser automation and UAT: navigating local apps, inspecting pages, clicking or filling controls, taking screenshots, asserting UI behavior, collecting console/network diagnostics, visual diffing, and creating evidence bundles. Prefer this over legacy Playwright browser tooling when both are available."
 allowed-tools: Bash(gsd-browser:*), Bash(gsd-browser *)
 ---
 


### PR DESCRIPTION
## Intent

The gsd-browser skill failed to load in Claude Code with 'Nested mappings are not allowed in compact mappings' because the description value in src/resources/skills/gsd-browser/SKILL.md frontmatter contained an unquoted colon ('...browser automation and UAT: navigating...'). YAML reads that as an illegal nested mapping, so the installed skill at ~/.gsd/agent/skills/gsd-browser/SKILL.md was rejected at load time. The fix is deliberately minimal: wrap the description value in double quotes — no rewording, no switch to folded scalar style. The user confirmed the skill is authored in gsd-pi (not copied from the upstream gsd-browser repo, whose own SKILL.md already uses the safe 'description: >' folded style), so this one-line fix in gsd-pi is the complete fix. Out-of-scope hardening (CI frontmatter validation, replacing the regex parser in skill-discovery.ts) was intentionally deferred to a separate task.

## What Changed

- Wrapped the `description` value in `src/resources/skills/gsd-browser/SKILL.md` frontmatter in double quotes. The unquoted value contained a colon (`...browser automation and UAT: navigating...`), which YAML parsed as an illegal nested mapping, causing the skill to be rejected at load time with `Nested mappings are not allowed in compact mappings`.
- Added a CHANGELOG.md entry recording the frontmatter parse fix.

## Risk Assessment

✅ Low: A single-line YAML fix that correctly quotes a frontmatter description containing a colon-space sequence, resolving the parse failure with no behavioral or structural side effects.

## Testing

No prebuilt deps were present (node_modules absent), so I installed `yaml@2.8.2` in a throwaway /tmp dir and ran the real loader's parse path against the actual on-disk frontmatter from both commits. The pre-fix file reproduces the exact reported error ("Nested mappings are not allowed in compact mappings"); the post-fix quoted file parses cleanly and yields the correct name/description. This is the closest product-level artifact to the end-user experience (a CLI transcript of the skill loader accepting/rejecting the frontmatter) — no UI surface is involved, as this is a YAML frontmatter parsing fix for a CLI skill loader. Temp install removed; worktree clean.

<details>
<summary>Evidence: YAML parse before/after fix (real loader)</summary>

<code>BEFORE fix (base 50a06a28): PARSE FAILED ❌ error: Nested mappings are not allowed in compact mappings at line 2, column 14&#10;AFTER fix (HEAD 3e1d21f0): PARSED OK ✅ name=&#34;gsd-browser&#34; description=&#34;Use gsd-browser for browser automation and UAT: navigating local apps, inspecting pages, ...&#34;</code>

```text
====================================================
BEFORE fix (base 50a06a28) -> /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KTQFMSJTPS03FAQ3QJ3GWCNQ/SKILL-old.md
  RESULT: PARSE FAILED ❌
  error: Nested mappings are not allowed in compact mappings at line 2, column 14:
====================================================
AFTER fix (HEAD 3e1d21f0) -> /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KTQFMSJTPS03FAQ3QJ3GWCNQ/SKILL-new.md
  RESULT: PARSED OK ✅
  name        = "gsd-browser"
  description = "Use gsd-browser for browser automation and UAT: navigating local apps, inspecting pages, ...
```
</details>
<details>
<summary>Evidence: Extracted SKILL.md frontmatter (pre-fix)</summary>

```text
---
name: gsd-browser
description: Use gsd-browser for browser automation and UAT: navigating local apps, inspecting pages, clicking or filling controls, taking screenshots, asserting UI behavior, collecting console/network diagnostics, visual diffing, and creating evidence bundles. Prefer this over legacy Playwright browser tooling when both are available.
allowed-tools: Bash(gsd-browser:*), Bash(gsd-browser *)
---

# gsd-browser

Use `gsd-browser` as the default browser surface for automated UAT and real UI verification.

## MCP First

When MCP tools are available, prefer the `gsd-browser` server:

- Discovery: `browser_snapshot_refs`, `browser_find`, `browser_get_accessibility_tree`
- Actions: `browser_act`, `browser_batch`, `browser_click_ref`, `browser_fill_ref`
- Verification: `browser_assert`, `browser_screenshot`, `browser_visual_diff`
- Diagnostics: `browser_get_console_logs`, `browser_get_network_logs`, `browser_debug_bundle`

If the host namespaces MCP tools, use names like `mcp__gsd-browser__browser_snapshot_refs`.

## CLI Fallback

The daemon starts automatically on first browser command.

`` `bash
gsd-browser navigate http://localhost:3000
gsd-browser snapshot
gsd-browser click-ref @v1:e1
gsd-browser wait-for --condition network_idle
gsd-browser assert --checks '[{"kind":"url_contains","text":"dashboard"}]'
gsd-browser screenshot --output /tmp/gsd-browser-uat.png --format png
`` `

After any navigation, submit, or dynamic DOM change, take a fresh snapshot before using refs again. Refs are versioned, such as `@v1:e1` and `@v2:e3`, and old refs can become stale.

Use `--json` when parsing output programmatically. Use named sessions for parallel or project-specific work:

`` `bash
gsd-browser --session gsd-pi navigate http://localhost:3000
`` `
```
</details>
<details>
<summary>Evidence: Extracted SKILL.md frontmatter (post-fix)</summary>

```text
---
name: gsd-browser
description: "Use gsd-browser for browser automation and UAT: navigating local apps, inspecting pages, clicking or filling controls, taking screenshots, asserting UI behavior, collecting console/network diagnostics, visual diffing, and creating evidence bundles. Prefer this over legacy Playwright browser tooling when both are available."
allowed-tools: Bash(gsd-browser:*), Bash(gsd-browser *)
---

# gsd-browser

Use `gsd-browser` as the default browser surface for automated UAT and real UI verification.

## MCP First

When MCP tools are available, prefer the `gsd-browser` server:

- Discovery: `browser_snapshot_refs`, `browser_find`, `browser_get_accessibility_tree`
- Actions: `browser_act`, `browser_batch`, `browser_click_ref`, `browser_fill_ref`
- Verification: `browser_assert`, `browser_screenshot`, `browser_visual_diff`
- Diagnostics: `browser_get_console_logs`, `browser_get_network_logs`, `browser_debug_bundle`

If the host namespaces MCP tools, use names like `mcp__gsd-browser__browser_snapshot_refs`.

## CLI Fallback

The daemon starts automatically on first browser command.

`` `bash
gsd-browser navigate http://localhost:3000
gsd-browser snapshot
gsd-browser click-ref @v1:e1
gsd-browser wait-for --condition network_idle
gsd-browser assert --checks '[{"kind":"url_contains","text":"dashboard"}]'
gsd-browser screenshot --output /tmp/gsd-browser-uat.png --format png
`` `

After any navigation, submit, or dynamic DOM change, take a fresh snapshot before using refs again. Refs are versioned, such as `@v1:e1` and `@v2:e3`, and old refs can become stale.

Use `--json` when parsing output programmatically. Use named sessions for parallel or project-specific work:

`` `bash
gsd-browser --session gsd-pi navigate http://localhost:3000
`` `
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Extracted the actual SKILL.md frontmatter at base commit `50a06a28` and target `3e1d21f0` and parsed both with the real eemeli `yaml@2.8.2` parser via a script replicating `packages/pi-coding-agent/src/utils/frontmatter.ts` `parseFrontmatter`</code>
- <code>Confirmed BEFORE = `PARSE FAILED` with `Nested mappings are not allowed in compact mappings at line 2, column 14`</code>
- <code>Confirmed AFTER = `PARSED OK` with `name=gsd-browser` and the full description string extracted</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783644462&installation_id=134682257&pr_number=632&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F632&signature=1d2aca40d93c50268d95ed0db2ba323c28dc7c9c202b6ecf24f089d525bff662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line YAML quoting fix in bundled skill metadata; no runtime logic or security-sensitive code paths.
> 
> **Overview**
> Fixes **gsd-browser** skill load failures in Claude Code by wrapping the `SKILL.md` frontmatter **description** in double quotes. The text includes `UAT: navigating`, which YAML treated as a nested mapping and rejected with *Nested mappings are not allowed in compact mappings*.
> 
> **CHANGELOG** records the skills frontmatter fix. No other skill content or loader behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7273e29240af3f34968a9e91908b256c2b737092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->