### PR TITLE
fix(gsd): honor stranded branch recovery on milestone re-entry under worktree isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 ## [Unreleased]
 
 ### Fixed
+- **gsd**: honor an adopted stranded-milestone branch when auto mode re-enters the milestone — resuming saved milestone work no longer fails worktree creation with "already in use by another worktree" and stops emitting a degraded-isolation warning on every re-entry; configured worktree isolation is restored for the next milestone once the recovered one merges
 - **skills**: quote the gsd-browser SKILL.md description so the skill loads in Claude Code — an unquoted colon in the description was parsed as a nested YAML mapping and rejected the frontmatter
 - **gsd**: make undo's slice reset atomic — an interrupted reset can no longer leave a slice partially reset (tasks reset but slice status not, or vice versa)
 - **claude-code-cli**: keep in-flight ask_user_questions elicitation alive through the foreground approval pause

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -638,12 +638,21 @@ type AutoIsolationMode = ReturnType<typeof getIsolationMode>;
 export function _resolveEffectiveUnitIsolationModeForTest(
   configuredMode: AutoIsolationMode,
   isolationDegraded: boolean,
+  strandedRecoveryIsolationMode: "worktree" | "branch" | null = null,
 ): AutoIsolationMode {
-  return resolveEffectiveUnitIsolationMode(configuredMode, isolationDegraded);
+  return resolveEffectiveUnitIsolationMode(
+    configuredMode,
+    isolationDegraded,
+    strandedRecoveryIsolationMode,
+  );
 }
 
 function getEffectiveUnitIsolationMode(basePath: string): AutoIsolationMode {
-  return resolveEffectiveUnitIsolationMode(getIsolationMode(basePath), s.isolationDegraded);
+  return resolveEffectiveUnitIsolationMode(
+    getIsolationMode(basePath),
+    s.isolationDegraded,
+    s.strandedRecoveryIsolationMode,
+  );
 }
 
 /** Crash recovery prompt — set by startAuto, consumed by the main loop */

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -617,7 +617,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   // ── WorktreeAdapter (folded) ─────────────────────────────────────────────
 
   private getEffectiveUnitIsolationMode(basePath: string): ReturnType<typeof getIsolationMode> {
-    return resolveEffectiveUnitIsolationMode(getIsolationMode(basePath), this.s.isolationDegraded);
+    return resolveEffectiveUnitIsolationMode(
+      getIsolationMode(basePath),
+      this.s.isolationDegraded,
+      this.s.strandedRecoveryIsolationMode,
+    );
   }
 
   private buildLifecycle(): WorktreeLifecycle {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -365,10 +365,12 @@ async function validateSourceWriteWorktreeSafety(
   const projectRoot = s.canonicalProjectRoot ?? resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
   // A degraded session already fell back to the milestone branch in the
   // project root — validating against the canonical worktree root there
-  // would fail every dispatch with a false invalid-root.
+  // would fail every dispatch with a false invalid-root. The same applies
+  // to a stranded-recovery session that adopted the milestone branch.
   const isolationMode = resolveEffectiveUnitIsolationMode(
     deps.getIsolationMode(projectRoot),
     s.isolationDegraded,
+    s.strandedRecoveryIsolationMode,
   );
   if (isolationMode !== "worktree") return null;
 

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -871,13 +871,18 @@ export function getIsolationMode(basePath?: string): "none" | "worktree" | "bran
  * Resolve the isolation mode a unit actually runs under. A session whose
  * worktree isolation has degraded (worktree creation failed) falls back to
  * the milestone branch in the project root, so configured "worktree" becomes
- * effective "branch".
+ * effective "branch". A stranded-work recovery session likewise runs under
+ * the adopted mode (`strandedRecoveryIsolationMode`) rather than the
+ * configured one until the recovered milestone merges — adopting the
+ * milestone branch in the project root is intentional, not degraded.
  */
 export function resolveEffectiveUnitIsolationMode(
   configuredMode: ReturnType<typeof getIsolationMode>,
   isolationDegraded: boolean,
+  strandedRecoveryIsolationMode: "worktree" | "branch" | null = null,
 ): ReturnType<typeof getIsolationMode> {
-  return configuredMode === "worktree" && isolationDegraded ? "branch" : configuredMode;
+  if (configuredMode === "worktree" && isolationDegraded) return "branch";
+  return strandedRecoveryIsolationMode ?? configuredMode;
 }
 
 export function resolveParallelConfig(prefs: GSDPreferences | undefined): import("./types.js").ParallelConfig {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -5578,6 +5578,68 @@ test("dispatch Worktree Safety honors degraded branch fallback instead of demand
   assert.ok(!deps.callLog.includes("stopAuto"), "auto-mode must not stop on the degraded fallback");
 });
 
+test("dispatch Worktree Safety honors stranded branch recovery instead of demanding the canonical worktree root", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const notifications: string[] = [];
+  ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+
+  // Bootstrap adopted stranded work by checking out the milestone branch in
+  // the project root (strandedRecoveryIsolationMode = "branch"). Isolation is
+  // NOT degraded — the adoption is intentional. The safety gate must validate
+  // against the effective branch mode, not the configured worktree mode.
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-wt-safety-stranded-"));
+  t.after(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+  const s = makeLoopSession({
+    basePath: projectRoot,
+    originalBasePath: projectRoot,
+    canonicalProjectRoot: projectRoot,
+    strandedRecoveryIsolationMode: "branch",
+  });
+  const deps = makeMockDeps({
+    getIsolationMode: () => "worktree",
+  });
+  const result = await runDispatch(
+    {
+      ctx,
+      pi,
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "test-flow",
+      nextSeq: () => 1,
+    },
+    {
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any,
+      mid: "M001",
+      midTitle: "Test",
+    },
+    {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    },
+  );
+
+  assert.equal(result.action, "next", "dispatch must proceed under stranded branch recovery");
+  assert.ok(
+    !notifications.some((n) => n.includes("Worktree Safety failed")),
+    "stranded branch recovery must not trip a false invalid-root",
+  );
+  assert.ok(!deps.callLog.includes("stopAuto"), "auto-mode must not stop on stranded branch recovery");
+});
+
 test("runDispatch runs stuck detection while artifact verification retry is pending (#5719)", async (t) => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -240,6 +240,43 @@ test("adoptStrandedMilestone forces branch recovery even when normal preferences
   assert.equal(currentBranch, "milestone/M001");
 });
 
+test("enterMilestone honors stranded branch recovery instead of recreating the worktree", (t) => {
+  // Regression: after adoptStrandedMilestone checks out milestone/M001 in
+  // the project root, a plain enterMilestone under isolation:worktree used
+  // to attempt `git worktree add`, which git refuses ("branch is already in
+  // use by another worktree" — the root checkout IS the conflicting
+  // worktree), tripping a creation-failed warning and degrading isolation.
+  // The recovery override must keep re-entries in branch mode.
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "worktree" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+
+  const s = makeSession({ basePath: base, originalBasePath: base });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const adopted = lifecycle.adoptStrandedMilestone("M001", base, ctx, {
+    mode: "branch",
+  });
+  assert.equal(adopted.ok, true, `expected adopt ok:true, got: ${JSON.stringify(adopted)}`);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true, `expected ok:true, got: ${JSON.stringify(result)}`);
+  if (result.ok) {
+    assert.equal(result.mode, "branch");
+    assert.equal(result.path, base);
+  }
+  assert.equal(s.basePath, base);
+  assert.equal(s.isolationDegraded, false, "intentional branch adoption must not degrade isolation");
+  assert.equal(
+    ctx.messages.some((m) => m.msg.includes("creation for M001 failed")),
+    false,
+    "re-entry must not attempt (and fail) canonical worktree creation",
+  );
+});
+
 test("enterMilestone returns ok:false reason:isolation-degraded when session degraded", () => {
   const s = makeSession({ isolationDegraded: true });
   const deps = makeDeps({ getIsolationMode: () => "branch" });

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -675,7 +675,16 @@ export function _enterMilestoneCore(
   // Handles the case where originalBasePath is falsy and basePath is itself
   // a worktree path — prevents double-nested worktree paths (#3729).
   const basePath = resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
-  const mode = opts.modeOverride ?? getIsolationMode(basePath);
+  // A stranded-recovery session that adopted the milestone branch in the
+  // project root must keep re-entering in that mode: the root checkout holds
+  // the branch, so creating the canonical worktree would fail with "already
+  // in use by another worktree". The override clears when the recovered
+  // milestone merges (_mergeAndExit), restoring configured isolation for
+  // subsequent milestones.
+  const mode =
+    opts.modeOverride ??
+    s.strandedRecoveryIsolationMode ??
+    getIsolationMode(basePath);
 
   if (s.isolationDegraded) {
     if (mode === "worktree") {


### PR DESCRIPTION
## Intent

Fix the stranded-work recovery vs worktree-isolation conflict in gsd auto/step mode. When bootstrap resumes saved milestone work it adopts the milestone branch (milestone/M001) in the project root and records s.strandedRecoveryIsolationMode='branch', but every subsequent WorktreeLifecycle.enterMilestone under git.isolation=worktree ignored that override, tried to create .gsd/worktrees/<mid>, and git refused with 'Branch milestone/M001 is already in use by another worktree' (the root checkout IS the conflicting worktree); the session only recovered via the degraded-isolation fallback, emitting a creation-failed warning each time. The user asked to reconcile this at the source rather than relying on the degraded fallback. Deliberate decisions: (1) honor the existing session-scoped strandedRecoveryIsolationMode override in _enterMilestoneCore's mode resolution (modeOverride ?? strandedRecoveryIsolationMode ?? getIsolationMode) instead of setting s.isolationDegraded, because adoption is intentional, the merge path already honors this override, and it self-clears in _mergeAndExit so the NEXT milestone regains full worktree isolation — setting isolationDegraded would stick for the whole session; (2) thread the override as an optional third parameter into resolveEffectiveUnitIsolationMode and its three call sites (auto.ts and orchestrator.ts getEffectiveUnitIsolationMode, phases.ts validateSourceWriteWorktreeSafety) so the dispatch Worktree Safety gates from PR #634 validate against the effective branch mode instead of demanding the canonical worktree root; degraded check deliberately takes precedence over the override; (3) the override is intentionally NOT persisted across sessions because the stranded-work audit re-runs on every auto start and re-derives it; (4) the _resolveEffectiveUnitIsolationModeForTest wrapper was extended to forward the new param. Regression coverage was explicitly requested: a worktree-lifecycle test proving enterMilestone after adoptStrandedMilestone(branch) re-enters branch mode without attempting worktree creation or degrading isolation (verified red before the fix with the exact creation-failed error), and an auto-loop dispatch test mirroring the existing 'degraded branch fallback' Worktree Safety test but with strandedRecoveryIsolationMode='branch' and isolationDegraded=false. Test duplication with the adjacent degraded test is the file's established idiom.

## What Changed

- `_enterMilestoneCore` now resolves isolation as `modeOverride ?? strandedRecoveryIsolationMode ?? getIsolationMode(basePath)`, so a milestone re-entered after stranded-work adoption stays in the adopted branch mode instead of attempting a `.gsd/worktrees/<mid>` worktree that git rejects (branch already in use) and falling back to degraded isolation; the override self-clears in `_mergeAndExit`, so the next milestone regains full worktree isolation.
- Threaded the optional stranded-recovery override into `resolveEffectiveUnitIsolationMode` and its call sites (`auto.ts`/`orchestrator.ts` `getEffectiveUnitIsolationMode`, `phases.ts` dispatch Worktree Safety, and the `_resolveEffectiveUnitIsolationModeForTest` wrapper) so the PR #634 safety gates validate against the effective branch mode, while the degraded-isolation check still takes precedence.
- Added a worktree-lifecycle regression test (re-entry after `adoptStrandedMilestone('branch')` stays in branch mode without worktree creation or degradation) and an auto-loop dispatch test mirroring the degraded-fallback case with `strandedRecoveryIsolationMode='branch'` / `isolationDegraded=false`; updated CHANGELOG.

## Risk Assessment

✅ Low: A well-bounded, session-scoped override threaded through existing mode-resolution paths with matching regression tests; the override self-clears on merge/failure and the only edge case is a narrow degraded+recovery combination that the design otherwise prevents.

## Testing

Baseline build/test infra had to be provisioned (deps install plus building the native and contracts workspace packages and esbuild test compile) before any test could run. I then ran the two compiled regression suites the author added: worktree-lifecycle (43/43) and auto-loop (116/116), both fully green including the new stranded-branch-recovery cases. To demonstrate the user intent at the behavioral level, I reverted the mode-resolution override in the compiled artifacts only (source untouched) and reproduced the exact pre-fix failure — enterMilestone returning {"ok":false,"reason":"creation-failed"} from the doomed git worktree add, and the dispatch gate refusing to proceed — then restored the override and reconfirmed both tests pass. Transient gitignored build outputs (dist-test and the three package dist dirs) were removed; the working tree carries only the intended source/test changes.

<details>
<summary>Evidence: Red/green proof: stranded-recovery regression tests fail pre-fix, pass post-fix</summary>

<code>PRE-FIX (override removed) — RED:&#10;✖ enterMilestone honors stranded branch recovery instead of recreating the worktree&#10;AssertionError: expected ok:true, got: {&#34;ok&#34;:false,&#34;reason&#34;:&#34;creation-failed&#34;,&#34;cause&#34;:{&#34;code&#34;:&#34;GSD_LOCK_HELD&#34;}}&#10;✖ dispatch Worktree Safety honors stranded branch recovery instead of demanding the canonical worktree root&#10;AssertionError: dispatch must proceed under stranded branch recovery&#10;&#10;POST-FIX (override restored) — GREEN:&#10;✔ enterMilestone honors stranded branch recovery instead of recreating the worktree&#10;✔ dispatch Worktree Safety honors degraded branch fallback instead of demanding the canonical worktree root&#10;✔ dispatch Worktree Safety honors stranded branch recovery instead of demanding the canonical worktree root</code>

```text
==== PRE-FIX (override removed in compiled artifacts) — expect RED ====
--- worktree-lifecycle: enterMilestone honors stranded branch recovery ---
✖ enterMilestone honors stranded branch recovery instead of recreating the worktree (2601.067625ms)
✔ enterMilestone returns ok:false reason:isolation-degraded when session degraded (2.076041ms)
✖ enterMilestone honors stranded branch recovery instead of recreating the worktree (2601.067625ms)
  AssertionError [ERR_ASSERTION]: expected ok:true, got: {"ok":false,"reason":"creation-failed","cause":{"code":"GSD_LOCK_HELD","name":"GSDError"}}

--- auto-loop: dispatch Worktree Safety honors stranded branch recovery ---
✖ dispatch Worktree Safety honors stranded branch recovery instead of demanding the canonical worktree root (3.768459ms)
✖ dispatch Worktree Safety honors stranded branch recovery instead of demanding the canonical worktree root (3.768459ms)
  AssertionError [ERR_ASSERTION]: dispatch must proceed under stranded branch recovery

==== POST-FIX (override restored) — expect GREEN ====
✔ enterMilestone honors stranded branch recovery instead of recreating the worktree (6083.330542ms)
✔ dispatch Worktree Safety honors degraded branch fallback instead of demanding the canonical worktree root (4.378083ms)
✔ dispatch Worktree Safety honors stranded branch recovery instead of demanding the canonical worktree root (5.411833ms)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/resources/extensions/gsd/worktree-lifecycle.ts:684` - _enterMilestoneCore resolves `mode = modeOverride ?? strandedRecoveryIsolationMode ?? getIsolationMode(basePath)` independently of `resolveEffectiveUnitIsolationMode`, so the degraded-precedence handling differs. If a branch re-entry fails mid-recovery (line 797 sets s.isolationDegraded=true while strandedRecoveryIsolationMode stays &#39;branch&#39;), the next enterMilestone resolves mode=&#39;branch&#39;, enters the `if (s.isolationDegraded)` block, fails the `if (mode === &#39;worktree&#39;)` guard, and returns ok:false reason:&#39;isolation-degraded&#39; without re-attempting the branch fallback. This is a narrow path (requires a branch-checkout failure during recovery, which the PR&#39;s design otherwise avoids) and is consistent with existing handling for an already-degraded branch session, so no change is required — just flagging the interaction.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/worktree-lifecycle.test.js` (43/43 pass, incl. `enterMilestone honors stranded branch recovery instead of recreating the worktree`)</code>
- <code>`node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/auto-loop.test.js` (116/116 pass, incl. `dispatch Worktree Safety honors stranded branch recovery`)</code>
- <code>Red/green proof: reverted `?? s.strandedRecoveryIsolationMode` (worktree-lifecycle.js) and `strandedRecoveryIsolationMode ?? configuredMode` (preferences.js) in compiled dist-test only → confirmed both new tests fail (creation-failed / dispatch must proceed), then restored → confirmed green</code>
- <code>Setup: `pnpm install`, `pnpm run build:native-pkg`, `pnpm run build:contracts`, `pnpm run test:compile` to produce runnable compiled tests</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783651160&installation_id=134682257&pr_number=636&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F636&signature=14a77edb44caddb8ed5a681f28da7183d1ea313c59fb1057fd651dee5e5cb1d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session-scoped override in existing isolation resolution paths with regression tests; override clears on merge and does not persist across sessions.
> 
> **Overview**
> Fixes auto-mode **stranded-work recovery** when `git.isolation` is **worktree**: after bootstrap adopts the milestone branch in the project root (`strandedRecoveryIsolationMode = 'branch'`), **re-entering the milestone** no longer tries to add `.gsd/worktrees/<mid>` (git error: branch already in use) or falls through to **degraded isolation** with repeated creation-failed warnings.
> 
> **`enterMilestone`** resolves isolation as `modeOverride ?? strandedRecoveryIsolationMode ?? getIsolationMode`, so intentional branch adoption is honored until the recovered milestone merges. **`resolveEffectiveUnitIsolationMode`** gains an optional third argument for that override (degraded isolation still wins); it is threaded through dispatch **Worktree Safety** and orchestrator effective-mode helpers so validation uses **branch** semantics instead of demanding the canonical worktree root.
> 
> Regression tests cover lifecycle re-entry after `adoptStrandedMilestone('branch')` and dispatch safety with `strandedRecoveryIsolationMode` set and `isolationDegraded` false; CHANGELOG updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f394217b8b2e2278a8566e3d67e0f82f90b1e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->