### PR TITLE
refactor(gsd): worktree placement seam — canonical .gsd-worktrees/ location off the state symlink

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,10 @@
 - **Worktree Safety module**: module that validates project root, worktree registration, lease ownership, and git health before a source-writing Unit runs.
 - **Worktree Lifecycle module**: module that owns worktree create/enter/teardown/merge verbs, `s.basePath` mutation, and `process.chdir` discipline. Sole owner of these mutations across single-loop and parallel callers.
 - **Worktree State Projection module**: module that owns the direction-and-rules of state file flow between project root and auto-worktree. Encodes the bug-hardened invariants (additive milestone copy, ASSESSMENT verdict overwrite, completed-units forward-sync, WAL/SHM cleanup) that `syncProjectRootToWorktree` and `syncStateToProjectRoot` carry today.
+- **Worktree Placement module**: module (`worktree-placement.ts`) that owns WHERE a worktree physically lives — the forward direction (project root + name → path). Creation always targets the Canonical Worktree Container; resolution prefers an existing worktree's actual location. The reverse direction (path → project identity) is owned by `worktree-root.ts`'s `findWorktreeSegment`, the single marker-matching seam. See `docs/dev/ADR-031-worktree-placement.md`.
+- **Canonical Worktree Container**: `<projectRoot>/.gsd-worktrees/` — a real directory sibling of `.gsd` that never crosses the external-state symlink, so the working copy stays at the project root. Requires its own `.gitignore` entry (a blanket `.gsd` pattern does not cover it).
+- **Legacy Worktree Container**: `<projectRoot>/.gsd/worktrees/` — the pre-ADR-031 location, which crosses the `.gsd → ~/.gsd/projects/<hash>/` symlink and materialises worktrees in the home directory. Stays recognized for in-flight worktrees: scans, containment, and safety checks accept both containers; new worktrees are never created here.
+- **External State Layout**: the shipped `.gsd → ~/.gsd/projects/<hash>/` symlink arrangement managed by `repo-identity.ts` (ADR-002's closure note said it didn't exist; ADR-031 amends the record). Env contracts: `GSD_PROJECT_ROOT` (worker-process root override), `GSD_STATE_DIR` (overrides `~/.gsd` as the external-state parent).
 - **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, runtime, and reconciliation-drift failures to a Recovery decision.
 - **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, source-observation invariants, and pre-dispatch validation aligned.
 - **Task Output Contract**: the concrete files a planned Task promises to create or overwrite. Distinct from task inputs, verification commands, and human-readable success outcomes.
@@ -149,6 +153,10 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
   See `docs/dev/ADR-030-two-altitude-state-machine.md`.
 
 - Foreground `/gsd next` and `/gsd auto` runs follow **Closeout Boundary Stop**: after the first durable task, slice, or milestone closeout boundary, the foreground terminal preserves the closeout transcript as the final visible surface instead of replacing it with a terminal roll-up widget. Headless runs may still emit durable terminal completion notifications/widgets for automation.
+
+- Worktree placement deepens behind the **Worktree Placement module**: new worktrees are created at the Canonical Worktree Container (`<projectRoot>/.gsd-worktrees/<MID>`), the Legacy Worktree Container stays recognized for in-flight worktrees, and `findWorktreeSegment` (worktree-root.ts) is the only marker-matching implementation — new layouts are taught in exactly two places (placement forward, worktree-root reverse). ADR-002's "no external state directory exists" closure is amended: the External State Layout shipped.
+
+  See `docs/dev/ADR-031-worktree-placement.md`.
 
 ## Current implementation snapshot (phase 1)
 

--- a/docs/dev/ADR-002-external-state-directory.md
+++ b/docs/dev/ADR-002-external-state-directory.md
@@ -22,3 +22,7 @@ The worktree-level concerns this ADR would have touched were addressed by:
 
 - Cross-references to "ADR-002" from ADR-001 and ADR-003 should be read as "the work that became ADR-016/017."
 - No external state directory exists or is planned. `.gsd/` artifacts remain inside the working tree as projections.
+
+## Amendment (2026-06-09, see ADR-031)
+
+The closure statement above did not survive contact with the codebase: an external state directory **was** subsequently shipped. `repo-identity.ts` manages the `<project>/.gsd → ~/.gsd/projects/<hash>/` symlink and `migrate-external.ts` migrates in-tree `.gsd/` state into it. The DB-authoritative model holds (markdown stays projection-only), but the physical `.gsd` directory may live externally behind the symlink. ADR-031 documents the shipped layout, its environment contracts (`GSD_PROJECT_ROOT`, `GSD_STATE_DIR`), and moves worktree placement out from under the symlink to the canonical `<projectRoot>/.gsd-worktrees/` sibling.

--- a/docs/dev/ADR-016-worktree-safety-fail-closed.md
+++ b/docs/dev/ADR-016-worktree-safety-fail-closed.md
@@ -23,7 +23,7 @@ A source-writing Unit is any Unit whose Tool Contract permits writes outside `.g
 Worktree Safety validates:
 
 - the milestone id is present and path-safe
-- the Unit root is the canonical `<projectRoot>/.gsd/worktrees/<milestone>` path
+- the Unit root is the canonical `<projectRoot>/.gsd-worktrees/<milestone>` path (amended by ADR-031; the legacy `<projectRoot>/.gsd/worktrees/<milestone>` path is also accepted for worktrees created before the placement change)
 - the worktree root exists
 - `.git` is a worktree file, not a standalone `.git` directory
 - the root is registered by `git worktree list`

--- a/docs/dev/ADR-031-worktree-placement.md
+++ b/docs/dev/ADR-031-worktree-placement.md
@@ -1,0 +1,65 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: ADR for the Worktree Placement module and the canonical .gsd-worktrees/ location. -->
+
+# ADR-031: Worktree Placement — Canonical `.gsd-worktrees/` Sibling and One Placement Seam
+
+**Status:** Accepted
+**Date:** 2026-06-09
+**Author:** GSD architecture review
+**Related:** ADR-002 (external state directory — closure note amended by this ADR), ADR-015 (Worktree Safety module), ADR-016 trio (worktree lifecycle/projection split, fail-closed safety), ADR-017 (drift-driven reconciliation)
+
+## Context
+
+### The shipped reality ADR-002 does not record
+
+ADR-002 closed "Not Adopted" with the statement *"No external state directory exists or is planned."* That statement is contradicted by the shipped code: `repo-identity.ts` computes a per-repo identity hash, resolves an external `~/.gsd/projects/<hash>/` state directory, and manages the `<project>/.gsd → external` symlink; `migrate-external.ts` migrates in-tree `.gsd/` directories into that layout. The external state directory exists, ships, and is in active use.
+
+### The consequence: worktrees materialize in the home directory
+
+Worktrees were placed at `<projectRoot>/.gsd/worktrees/<MID>`. When `.gsd` is the external-state symlink, that logical path crosses the symlink and the worktree **physically materializes** at `~/.gsd/projects/<hash>/worktrees/<MID>`. After `process.chdir`, the realpath the agent — and the user — sees is an opaque hash path in the home directory. User-facing symptoms: work appears to happen "in a `~/.gsd/XXXX` folder", IDEs and file pickers can't find the working copy, and relative tooling breaks.
+
+### The architectural cost
+
+Because the placement decision leaked, every consumer had to reverse-engineer project identity from a path string. At the time of this ADR the codebase carried **six** independent implementations of "is this path a GSD worktree / where is its project root": `worktree-root.ts` (authoritative, 3 marker regexes + env fallbacks + a HOME-detection guard), `paths.ts` (`isInsideGsdWorktree`), `auto-worktree.ts` (`escapeStaleWorktree` string-slice), `commands/catalog.ts` (verbatim copies of `findWorktreeSegment` and `resolveProjectRootFromGitFile`), `doctor-environment.ts`, and `tools/exec-tool.ts` (`parseWorktreeBase`) — plus marker regexes in `bg-shell/utilities.ts`, `auto-start.ts`, `captures.ts`, and `worktree-session-state.ts`. Several of these did not recognize the external-state layout at all.
+
+## Decision
+
+### 1. Canonical placement: `<projectRoot>/.gsd-worktrees/<name>`
+
+New worktrees are created under a **real directory sibling** of `.gsd`, never under it. `repo-identity.ts` symlinks only `.gsd`, so the canonical container never crosses the symlink: the working copy stays at the project root regardless of where `.gsd` state lives. This kills the `~/.gsd/<hash>/worktrees/<MID>` symptom at the source.
+
+`.gsd-worktrees/` is **not** covered by a blanket `.gsd` gitignore entry. It gets its own entry in `BASELINE_PATTERNS` and `GSD_RUNTIME_PATTERNS` (gitignore.ts — canonical source of truth), `RUNTIME_EXCLUSION_PATHS` (git-service.ts), the worktree-diff `SKIP_PATHS` (worktree-manager.ts), and the doctor's critical-pattern check (which requires it independently of the blanket check).
+
+### 2. Legacy placement stays recognized — resolution prefers existing worktrees
+
+In-flight milestones must survive upgrades. The legacy container (`<projectRoot>/.gsd/worktrees/`, possibly resolving through the symlink to `~/.gsd/projects/<hash>/worktrees/`) remains a recognized layout:
+
+- **Creation** always uses the canonical container (including re-creation after a stale legacy directory is cleaned up).
+- **Resolution** (`worktreePathFor`) returns an existing worktree's actual location — canonical first, then legacy — and falls back to canonical for new ones.
+- **Containment and safety checks** (`isInsideWorktreesDir`, the write-gate, Worktree Safety's expected-root validation) accept membership in either container.
+- **Scans** (listing, reentry, doctor orphan checks, parallel worker discovery) enumerate both containers.
+
+### 3. One placement seam: the Worktree Placement module
+
+`worktree-placement.ts` owns the forward direction (project root + name → physical path): `CANONICAL_WORKTREES_DIRNAME`, `canonicalWorktreesDir`, `legacyWorktreesDir`, `worktreesDirs`, `worktreePathFor`. `worktree-manager.ts` re-exports basePath-resolving wrappers (`worktreesDir`, `allWorktreesDirs`, `worktreePath`).
+
+The reverse direction (path → project identity) stays in `worktree-root.ts`: `findWorktreeSegment` is the **only** marker-matching implementation, now recognizing three layouts — canonical (`/.gsd-worktrees/`), legacy direct (`/.gsd/worktrees/`), and external-state (`~/.gsd/projects/<hash>/worktrees/`). The duplicate detectors listed in Context were deleted and routed through this seam.
+
+### 4. Decision-record reconciliation
+
+ADR-002's closure note is amended to record that the external state directory **was** subsequently shipped (repo-identity symlink layout) and that worktree placement no longer depends on it. ADR-016 (fail-closed) is amended: the canonical Unit root for source-writing Units is `<projectRoot>/.gsd-worktrees/<milestone>`, with the legacy path accepted for pre-existing worktrees.
+
+## Environment contracts
+
+Documented here because they were previously undocumented load-bearing behavior:
+
+- **`GSD_PROJECT_ROOT`** — worker-process override for project-root resolution. `resolveWorktreeProjectRoot` honors it only when the base path is a recognized worktree path; shell-completion honors it unconditionally.
+- **`GSD_STATE_DIR`** — overrides `~/.gsd` as the parent of the external-state `projects/` directory during layout detection.
+
+## Consequences
+
+- New milestone worktrees appear at `<projectRoot>/.gsd-worktrees/<MID>` — visible, findable, project-local.
+- Existing legacy worktrees keep working: resolution, safety validation, merge, teardown, and doctor repair all accept both containers. No migration step is required; legacy worktrees age out as milestones complete.
+- A new layout (if ever needed) is taught in exactly two places: `worktree-placement.ts` (forward) and `findWorktreeSegment` (reverse).
+- The HOME-detection guard in `worktree-root.ts` and the stale-worktree escape heuristic remain for legacy paths; they are dead weight for canonical paths and can be retired with the legacy layout.
+- `.gitignore` in existing projects gains the `.gsd-worktrees/` entry via the idempotent `ensureGitignore` bootstrap; the doctor flags it when missing.

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -418,36 +418,48 @@ function extractMilestoneId(parsed: Record<string, unknown>): string | null {
  * the shared project `.gsd/` and auto-mode's verifyExpectedArtifact (which
  * uses the worktree `.gsd/`) fails, triggering a guaranteed retry per unit.
  */
+/** Containers a GSD worktree may live in: canonical .gsd-worktrees/ first, legacy .gsd/worktrees/ second. */
+function worktreeContainers(projectRoot: string): string[] {
+  return [join(projectRoot, ".gsd-worktrees"), join(projectRoot, ".gsd", "worktrees")];
+}
+
 function resolveActiveWorktreeBasePath(
   projectRoot: string,
   milestoneId: string | null,
 ): string | null {
   if (!milestoneId) return null;
-  const wtPath = join(projectRoot, ".gsd", "worktrees", milestoneId);
-  if (!existsSync(wtPath)) return null;
-  // Sanity check: a real git worktree has a `.git` file with a gitdir pointer.
-  // Bare directories without it shouldn't hijack the write path.
-  if (!existsSync(join(wtPath, ".git"))) return null;
-  return wtPath;
+  for (const container of worktreeContainers(projectRoot)) {
+    const wtPath = join(container, milestoneId);
+    if (!existsSync(wtPath)) continue;
+    // Sanity check: a real git worktree has a `.git` file with a gitdir pointer.
+    // Bare directories without it shouldn't hijack the write path.
+    if (!existsSync(join(wtPath, ".git"))) continue;
+    return wtPath;
+  }
+  return null;
 }
 
 /**
  * Fallback when the tool call has no milestoneId: if exactly one auto-worktree
- * exists under `<projectRoot>/.gsd/worktrees/`, treat it as the active one.
+ * exists across the project's worktree containers, treat it as the active one.
  * Multiple worktrees → ambiguous, return null and let writes go to project root.
  */
 function resolveSoleActiveWorktree(projectRoot: string): string | null {
-  const worktreesDir = join(projectRoot, ".gsd", "worktrees");
-  if (!existsSync(worktreesDir)) return null;
-  let entries: string[];
-  try {
-    entries = readdirSync(worktreesDir);
-  } catch {
-    return null;
+  const live: string[] = [];
+  for (const worktreesDir of worktreeContainers(projectRoot)) {
+    if (!existsSync(worktreesDir)) continue;
+    let entries: string[];
+    try {
+      entries = readdirSync(worktreesDir);
+    } catch {
+      continue;
+    }
+    live.push(
+      ...entries
+        .map((name) => join(worktreesDir, name))
+        .filter((p) => existsSync(join(p, ".git"))),
+    );
   }
-  const live = entries
-    .map((name) => join(worktreesDir, name))
-    .filter((p) => existsSync(join(p, ".git")));
   if (live.length !== 1) return null;
   return live[0];
 }

--- a/src/resources/extensions/bg-shell/utilities.ts
+++ b/src/resources/extensions/bg-shell/utilities.ts
@@ -45,7 +45,7 @@ export function formatTimeAgo(timestamp: number): string {
 
 function deriveProjectRootFromAutoWorktree(cachedCwd?: string): string | undefined {
 	if (!cachedCwd) return undefined;
-	const match = cachedCwd.match(/^(.*?)[\\/]\.gsd[\\/]worktrees[\\/][^\\/]+(?:[\\/].*)?$/);
+	const match = cachedCwd.match(/^(.*?)[\\/]\.gsd(?:-worktrees|[\\/]worktrees)[\\/][^\\/]+(?:[\\/].*)?$/);
 	return match?.[1];
 }
 
@@ -84,7 +84,7 @@ export function resolveBgShellPersistenceCwd(
 	pathExists: (path: string) => boolean = existsSync,
 ): string {
 	const resolvedLiveCwd = liveCwd ?? getBgShellLiveCwd(cachedCwd, pathExists);
-	const cachedIsAutoWorktree = /(?:^|[\\/])\.gsd[\\/]worktrees[\\/]/.test(cachedCwd);
+	const cachedIsAutoWorktree = /(?:^|[\\/])\.gsd(?:-worktrees|[\\/]worktrees)[\\/]/.test(cachedCwd);
 	if (!cachedIsAutoWorktree) return cachedCwd;
 	if (cachedCwd === resolvedLiveCwd && pathExists(cachedCwd)) return cachedCwd;
 	if (!pathExists(cachedCwd)) return resolvedLiveCwd;

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -16,6 +16,7 @@ import type {
   ExtensionCommandContext,
 } from "@gsd/pi-coding-agent";
 import { deriveState } from "./state.js";
+import { findWorktreeSegment, isGsdWorktreePath } from "./worktree-root.js";
 import { loadFile, getManifestStatus } from "./files.js";
 import type { InterruptedSessionAssessment } from "./interrupted-session.js";
 import {
@@ -96,7 +97,6 @@ import {
   rmSync,
 } from "node:fs";
 import { join } from "node:path";
-import { sep as pathSep } from "node:path";
 
 import { validateDirectory } from "./validate-directory.js";
 import {
@@ -601,7 +601,7 @@ export function auditOrphanedMilestoneBranches(
               warnings.push(`Failed to remove worktree directory for ${milestoneId}: ${err2 instanceof Error ? err2.message : String(err2)}`);
             }
           } else {
-            warnings.push(`Orphaned worktree directory for ${milestoneId} is outside .gsd/worktrees/ — skipping removal for safety.`);
+            warnings.push(`Orphaned worktree directory for ${milestoneId} is outside the GSD worktrees containers — skipping removal for safety.`);
           }
         } else {
           pushAction({
@@ -717,7 +717,7 @@ export function auditOrphanedMilestoneBranches(
     if (!existsSync(wtDir)) continue;
     if (!isInsideWorktreesDir(basePath, wtDir)) {
       warnings.push(
-        `Orphaned worktree directory for ${m.id} is outside .gsd/worktrees/ — skipping removal for safety.`,
+        `Orphaned worktree directory for ${m.id} is outside the GSD worktrees containers — skipping removal for safety.`,
       );
       continue;
     }
@@ -1325,7 +1325,7 @@ export async function bootstrapAutoSession(
       (state.phase === "pre-planning" || state.phase === "complete") &&
       survivorIsolationMode !== "none" &&
       !detectWorktreeName(base) &&
-      !base.includes(`${pathSep}.gsd${pathSep}worktrees${pathSep}`)
+      !isGsdWorktreePath(base)
     ) {
       const milestoneBranch = `milestone/${survivorMilestoneId}`;
       const { nativeBranchExists } = await import("./native-git-bridge.js");
@@ -1610,16 +1610,10 @@ export async function bootstrapAutoSession(
     // live here is gone.
 
     const isUnderGsdWorktrees = (p: string): boolean => {
-      // Direct layout: /.gsd/worktrees/
-      const marker = `${pathSep}.gsd${pathSep}worktrees${pathSep}`;
-      if (p.includes(marker)) return true;
-      const worktreesSuffix = `${pathSep}.gsd${pathSep}worktrees`;
-      if (p.endsWith(worktreesSuffix)) return true;
-      // Symlink-resolved layout: /.gsd/projects/<hash>/worktrees/
-      const symlinkRe = new RegExp(
-        `\\${pathSep}\\.gsd\\${pathSep}projects\\${pathSep}[a-f0-9]+\\${pathSep}worktrees(?:\\${pathSep}|$)`,
-      );
-      return symlinkRe.test(p);
+      const normalized = p.replaceAll("\\", "/");
+      if (findWorktreeSegment(normalized) !== null) return true;
+      // The container directory itself (no trailing worktree name).
+      return normalized.endsWith("/.gsd/worktrees") || normalized.endsWith("/.gsd-worktrees");
     };
 
     if (

--- a/src/resources/extensions/gsd/auto-worktree-repair.ts
+++ b/src/resources/extensions/gsd/auto-worktree-repair.ts
@@ -5,6 +5,7 @@ import { existsSync, lstatSync, readdirSync, type Stats } from "node:fs";
 import { join } from "node:path";
 
 import { worktreePath } from "./worktree-manager.js";
+import { worktreesDirs } from "./worktree-placement.js";
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
 import type { WorktreeSafetyResult } from "./worktree-safety.js";
 
@@ -37,6 +38,16 @@ export function expectedAutoWorktreePath(
   const id = milestoneId?.trim();
   if (!id || !isValidMilestoneId(id)) return null;
   return worktreePath(projectRoot, id);
+}
+
+/** Every path the milestone worktree may legitimately live at (canonical + legacy). */
+function candidateAutoWorktreePaths(
+  projectRoot: string,
+  milestoneId: string | null | undefined,
+): string[] {
+  const id = milestoneId?.trim();
+  if (!id || !isValidMilestoneId(id)) return [];
+  return worktreesDirs(projectRoot).map((dir) => join(dir, id));
 }
 
 export function resolvePausedAutoWorktreePath(input: {
@@ -82,8 +93,8 @@ export function assessAutoWorktreeRepairTarget(input: {
   if (!expectedPath) {
     return { ok: false, reason: "missing expected worktree path" };
   }
-  const computedExpectedPath = expectedAutoWorktreePath(input.projectRoot, input.milestoneId);
-  if (!computedExpectedPath || !samePath(expectedPath, computedExpectedPath)) {
+  const candidatePaths = candidateAutoWorktreePaths(input.projectRoot, input.milestoneId);
+  if (candidatePaths.length === 0 || !candidatePaths.some((candidate) => samePath(expectedPath, candidate))) {
     return { ok: false, reason: "expected worktree path does not match milestone" };
   }
   if (!samePath(input.activeRoot, input.projectRoot) && !samePath(input.activeRoot, expectedPath)) {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -63,6 +63,19 @@ import {
 } from "./pull-request-process.js";
 import { debugLog } from "./debug-logger.js";
 import { logWarning, logError } from "./workflow-logger.js";
+import {
+  checkoutBranchWithStashGuard,
+  cleanupConflictState,
+  gsdJsonlFilesWithConflictMarkers,
+  hasConflictMarkers,
+  popStashByRef,
+  removeMergeStateFiles,
+  stashAlreadyExistsFilesFromError,
+  stashRefFromError,
+} from "./worktree-git-recovery.js";
+
+// Re-export for existing callers/tests (auto-start.ts, checkout-branch-stash-guard.test.ts).
+export { checkoutBranchWithStashGuard } from "./worktree-git-recovery.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import { runWorktreePostCreateHook } from "./worktree-post-create-hook.js";
@@ -86,7 +99,6 @@ import {
   nativeDiffNumstat,
   nativeUpdateRef,
   nativeIsAncestor,
-  nativeMergeAbort,
   nativeWorktreeList,
   nativeLsFiles,
 } from "./native-git-bridge.js";
@@ -132,111 +144,6 @@ const ROOT_STATE_FILES = [
   // Back-sync (worktree → main) must NEVER overwrite the project root's copy
   // because the project root is authoritative for preferences (#2684).
 ] as const;
-
-/**
- * Pop a stash entry by tracking the unique marker embedded in its message so
- * concurrent stash operations against the same project root cannot cause us to
- * pop the wrong entry.
- *
- * If `stashMarker` is null or no longer present in the stash list (e.g. a
- * concurrent process popped/dropped it), leaves the stash list untouched and
- * returns null.
- *
- * Throws on pop failure so callers can handle conflict cases the same way
- * they would with the prior `git stash pop` form. When throwing after a
- * targeted pop attempt, the error is annotated with the targeted stash ref.
- *
- * (Issue #4980 HIGH-6)
- */
-function popStashByRef(basePath: string, stashMarker: string | null): string | null {
-  let popArg: string | null = null;
-  if (stashMarker) {
-    try {
-      const list = execFileSync("git", ["stash", "list", "--format=%gd%x00%s"], {
-        cwd: basePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      }).trim().split("\n").filter(Boolean);
-      for (const entry of list) {
-        const [ref, subject] = entry.split("\0");
-        if (ref && subject?.includes(stashMarker)) {
-          popArg = ref;
-          break;
-        }
-      }
-    } catch (err) {
-      logWarning("worktree", `stash list lookup failed; leaving stash untouched: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-  if (!popArg) {
-    logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic pop");
-    return null;
-  }
-  try {
-    execFileSync("git", ["stash", "pop", popArg], {
-      cwd: basePath,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-  } catch (err) {
-    if (err && typeof err === "object") {
-      (err as { stashRef?: string }).stashRef = popArg;
-    }
-    throw err;
-  }
-  return popArg;
-}
-
-/**
- * Extract a stash ref annotation injected by popStashByRef() when git stash
- * pop fails and we need to conditionally drop the exact stash entry later.
- */
-function stashRefFromError(err: unknown): string | null {
-  if (!err || typeof err !== "object") return null;
-  const stashRef = (err as { stashRef?: unknown }).stashRef;
-  return typeof stashRef === "string" && stashRef.length > 0 ? stashRef : null;
-}
-
-function stashAlreadyExistsFilesFromError(err: unknown): string[] {
-  if (!err || typeof err !== "object") return [];
-  const stderr = (err as { stderr?: unknown }).stderr;
-  const stderrText = typeof stderr === "string"
-    ? stderr
-    : stderr instanceof Uint8Array
-      ? Buffer.from(stderr).toString("utf-8")
-      : "";
-  const message = err instanceof Error ? err.message : String(err);
-  const text = `${stderrText}\n${message}`;
-  const files = new Set<string>();
-  for (const line of text.split("\n")) {
-    const m = line.match(/^(.*?)\s+already exists, no checkout\s*$/i);
-    if (!m) continue;
-    const filePath = m[1]?.trim();
-    if (filePath) files.add(filePath);
-  }
-  return [...files];
-}
-
-/**
- * Detect whether an on-disk file still contains unresolved merge conflict
- * markers from a failed stash-pop or merge attempt.
- *
- * Returns false when the file cannot be read.
- */
-function hasConflictMarkers(filePath: string): boolean {
-  try {
-    const content = readFileSync(filePath, "utf-8");
-    return content.includes("<<<<<<<") && content.includes("=======") && content.includes(">>>>>>>");
-  } catch {
-    return false;
-  }
-}
-
-function gsdJsonlFilesWithConflictMarkers(basePath: string): string[] {
-  return nativeLsFiles(basePath, ".gsd/*.jsonl").filter((f) =>
-    hasConflictMarkers(join(basePath, f)),
-  );
-}
 
 /**
  * Check if two filesystem paths resolve to the same real location.
@@ -524,49 +431,6 @@ export const SAFE_AUTO_RESOLVE_PATTERNS: RegExp[] = [
 export const isSafeToAutoResolve = (filePath: string): boolean =>
   filePath.startsWith(".gsd/") ||
   SAFE_AUTO_RESOLVE_PATTERNS.some((re) => re.test(filePath));
-
-function removeMergeStateFiles(basePath: string, contextLabel: string): void {
-  try {
-    for (const f of ["SQUASH_MSG", "MERGE_MSG", "MERGE_MODE", "MERGE_HEAD", "AUTO_MERGE"]) {
-      const rawPath = execFileSync("git", ["rev-parse", "--git-path", f], {
-        cwd: basePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      }).trim();
-      const p = rawPath.length > 0
-        ? (isAbsolute(rawPath) ? rawPath : resolve(basePath, rawPath))
-        : join(resolveGitDir(basePath), f);
-      if (existsSync(p)) unlinkSync(p);
-    }
-  } catch (err) {
-    logError("worktree", `${contextLabel} merge state cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-}
-
-function cleanupConflictState(basePath: string): void {
-  // Merge conflicts can leave unmerged index entries; merge-abort alone is not
-  // enough for squash merges (MERGE_HEAD is never written). Reset the merge
-  // index, then remove merge message files that native/libgit2 paths may have
-  // created.
-  try {
-    nativeMergeAbort(basePath);
-  } catch (err) {
-    // MERGE_HEAD absent (squash merge path) — abort is a no-op, which is fine.
-    debugLog("conflict-cleanup:merge-abort-skipped", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-  try {
-    execFileSync("git", ["reset", "--merge"], {
-      cwd: basePath,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-  } catch (err) {
-    logError("worktree", `git reset --merge failed after merge conflict: ${err instanceof Error ? err.message : String(err)}`);
-  }
-  removeMergeStateFiles(basePath, "conflict");
-}
 
 // ─── Dispatch-Level Sync (project root ↔ worktree) ──────────────────────────
 
@@ -1056,122 +920,6 @@ export function enterBranchModeForMilestone(
   }
 
   checkoutBranchWithStashGuard(basePath, branch, `enter-branch-mode:${milestoneId}`);
-}
-
-export function checkoutBranchWithStashGuard(
-  basePath: string,
-  branch: string,
-  reason: string,
-): void {
-  let stashMarker: string | null = null;
-  let stashed = false;
-
-  const status = nativeWorkingTreeStatus(basePath).trim();
-  if (status.length > 0) {
-    stashMarker = `gsd-checkout-stash:${reason}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
-    const stashListBefore = execFileSync("git", ["stash", "list"], {
-      cwd: basePath,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-    execFileSync(
-      "git",
-      ["stash", "push", "--include-untracked", "-m", `gsd: checkout stash [${stashMarker}]`],
-      {
-        cwd: basePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      },
-    );
-    const stashListAfter = execFileSync("git", ["stash", "list"], {
-      cwd: basePath,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-    stashed = stashListAfter !== stashListBefore;
-  }
-
-  // Checkout and stash-restore are split so we can distinguish two failure
-  // modes: (a) checkout failed → HEAD did not move, restore stash and rethrow;
-  // (b) checkout succeeded but stash pop failed → HEAD moved to `branch` but
-  // the working-tree changes remain in the stash list. We surface a distinct
-  // error in case (b) so callers don't assume the branch switch was rolled back.
-  try {
-    nativeCheckoutBranch(basePath, branch);
-  } catch (checkoutErr) {
-    if (stashed) {
-      try {
-        popStashByRef(basePath, stashMarker);
-      } catch (restoreErr) {
-        logWarning("worktree", `git stash pop failed during checkout restore: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
-      }
-    }
-    throw checkoutErr;
-  }
-
-  if (stashed) {
-    try {
-      popStashByRef(basePath, stashMarker);
-    } catch (popErr) {
-      const msg = popErr instanceof Error ? popErr.message : String(popErr);
-      const stderr = popErr && typeof popErr === "object"
-        ? (popErr as { stderr?: unknown }).stderr
-        : undefined;
-      const stderrText = typeof stderr === "string"
-        ? stderr
-        : stderr instanceof Uint8Array
-          ? Buffer.from(stderr).toString("utf-8")
-          : "";
-      const stashPopMessage = `${stderrText}\n${msg}`.trim();
-      const alreadyExists = stashAlreadyExistsFilesFromError(popErr);
-      const gsdAlreadyExists = alreadyExists.filter((f) => f.startsWith(".gsd/"));
-      const nonGsdAlreadyExists = alreadyExists.filter((f) => !f.startsWith(".gsd/"));
-      const isUntrackedRestoreFailure = stashPopMessage.includes("could not restore untracked files from stash");
-      const stashRefForDrop = stashRefFromError(popErr);
-      const nonGsdUnmerged = nativeConflictFiles(basePath).filter((f) => !f.startsWith(".gsd/"));
-      const gsdContentConflicts = isUntrackedRestoreFailure
-        ? gsdJsonlFilesWithConflictMarkers(basePath)
-        : [];
-      const gsdConflictFiles = [...new Set([...gsdAlreadyExists, ...gsdContentConflicts])];
-
-      if (
-        isUntrackedRestoreFailure &&
-        gsdConflictFiles.length > 0 &&
-        nonGsdAlreadyExists.length === 0 &&
-        nonGsdUnmerged.length === 0
-      ) {
-        for (const f of gsdConflictFiles) {
-          execFileSync("git", ["checkout", "HEAD", "--", f], {
-            cwd: basePath,
-            stdio: ["ignore", "pipe", "pipe"],
-            encoding: "utf-8",
-          });
-          nativeAddPaths(basePath, [f]);
-        }
-
-        if (stashRefForDrop) {
-          try {
-            execFileSync("git", ["stash", "drop", stashRefForDrop], {
-              cwd: basePath,
-              stdio: ["ignore", "pipe", "pipe"],
-              encoding: "utf-8",
-            });
-          } catch (err) { /* stash may already be consumed */
-            logWarning("worktree", `git stash drop failed: ${err instanceof Error ? err.message : String(err)}`);
-          }
-        } else {
-          logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic drop");
-        }
-        return;
-      }
-
-      const wrapped = new Error(
-        `checkout to '${branch}' succeeded but stash restore failed; working tree changes remain in the stash list. Original error: ${msg}`,
-      );
-      if (stashRefForDrop) (wrapped as { stashRef?: string }).stashRef = stashRefForDrop;
-      throw wrapped;
-    }
-  }
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -20,7 +20,7 @@ import {
   unlinkSync,
   lstatSync as lstatSyncFn,
 } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve, sep as pathSep } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { GSDError, GSD_IO_ERROR, GSD_GIT_ERROR } from "./errors.js";
 import {
   reconcileWorktreeDb,
@@ -50,6 +50,7 @@ import {
   nudgeGitBranchCache,
 } from "./worktree.js";
 import {
+  findWorktreeSegment,
   isGsdWorktreePath,
   normalizeWorktreePathForCompare,
   resolveWorktreeProjectRoot,
@@ -655,21 +656,12 @@ export function checkResourcesStale(
  * Returns the corrected base path.
  */
 export function escapeStaleWorktree(base: string): string {
-  // Direct layout: /.gsd/worktrees/
-  const directMarker = `${pathSep}.gsd${pathSep}worktrees${pathSep}`;
-  let idx = base.indexOf(directMarker);
-  if (idx === -1) {
-    // Symlink-resolved layout: /.gsd/projects/<hash>/worktrees/
-    const symlinkRe = new RegExp(
-      `\\${pathSep}\\.gsd\\${pathSep}projects\\${pathSep}[a-f0-9]+\\${pathSep}worktrees\\${pathSep}`,
-    );
-    const match = base.match(symlinkRe);
-    if (!match || match.index === undefined) return base;
-    idx = match.index;
-  }
+  const segment = findWorktreeSegment(base.replaceAll("\\", "/"));
+  if (!segment) return base;
 
-  // base is inside .gsd/worktrees/<something> — extract the project root
-  const projectRoot = base.slice(0, idx);
+  // base is inside .gsd/worktrees/<something> — extract the project root.
+  // Normalization is 1:1 on characters, so the segment index is valid in `base`.
+  const projectRoot = base.slice(0, segment.gsdIdx);
 
   // Guard: If the candidate project root's .gsd IS the user-level ~/.gsd,
   // the string-slice heuristic matched the wrong /.gsd/ boundary. This happens

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -12,6 +12,7 @@ import { logWarning } from "../workflow-logger.js";
 import { openWorkflowDatabase } from "../db-workspace.js";
 import { getAutoWorktreePath } from "../auto-worktree.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
+import { worktreesDirs } from "../worktree-placement.js";
 
 export function safeWorkspaceCwd(): string {
   try {
@@ -46,13 +47,15 @@ export function resolveWorkflowToolBasePath(
     const worktree = getAutoWorktreePath(projectRoot, milestoneId);
     if (worktree) return worktree;
   } else {
-    const worktreesDir = join(projectRoot, ".gsd", "worktrees");
-    if (existsSync(worktreesDir)) {
+    const live: string[] = [];
+    for (const worktreesDir of worktreesDirs(projectRoot)) {
+      if (!existsSync(worktreesDir)) continue;
       try {
-        const live = readdirSync(worktreesDir)
-          .map((name) => join(worktreesDir, name))
-          .filter((p) => existsSync(join(p, ".git")));
-        if (live.length === 1) return live[0]!;
+        live.push(
+          ...readdirSync(worktreesDir)
+            .map((name) => join(worktreesDir, name))
+            .filter((p) => existsSync(join(p, ".git"))),
+        );
       } catch (err) {
         logWarning(
           "bootstrap",
@@ -60,6 +63,7 @@ export function resolveWorkflowToolBasePath(
         );
       }
     }
+    if (live.length === 1) return live[0]!;
   }
   return cwd;
 }

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -10,6 +10,7 @@ import { getIsolationMode } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "../worktree-root.js";
+import { worktreesDirs } from "../worktree-placement.js";
 
 /**
  * Regex matching milestone CONTEXT.md file names in both legacy M001
@@ -1157,10 +1158,12 @@ export function shouldBlockWorktreeWrite(
   const realTarget = realpathOrResolve(absTarget);
   const realRoot = realpathOrResolve(projectRoot);
   const realGsd = realpathOrResolve(join(projectRoot, ".gsd"));
-  const realWorktreesDir = realpathOrResolve(join(projectRoot, ".gsd", "worktrees"));
 
-  // Allow writes inside the legitimate worktrees subtree.
-  if (isPathContained(realTarget, realWorktreesDir)) return { block: false };
+  // Allow writes inside a legitimate worktrees subtree (canonical
+  // .gsd-worktrees/ or legacy .gsd/worktrees/).
+  for (const container of worktreesDirs(projectRoot)) {
+    if (isPathContained(realTarget, realpathOrResolve(container))) return { block: false };
+  }
 
   // Allow writes to .gsd/ planning artifacts, but reject siblings whose name
   // starts with "worktrees" (the worktrees-extra prefix trick — case 4).

--- a/src/resources/extensions/gsd/captures.ts
+++ b/src/resources/extensions/gsd/captures.ts
@@ -9,9 +9,10 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { gsdRoot } from "./paths.js";
+import { findWorktreeSegment } from "./worktree-root.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -60,20 +61,10 @@ const VALID_CLASSIFICATIONS: readonly string[] = [
  */
 export function resolveCapturesPath(basePath: string): string {
   const resolved = resolve(basePath);
-  // Direct layout: /.gsd/worktrees/
-  const worktreeMarker = `${sep}.gsd${sep}worktrees${sep}`;
-  let idx = resolved.indexOf(worktreeMarker);
-  if (idx === -1) {
-    // Symlink-resolved layout: /.gsd/projects/<hash>/worktrees/
-    const symlinkRe = new RegExp(
-      `\\${sep}\\.gsd\\${sep}projects\\${sep}[a-f0-9]+\\${sep}worktrees\\${sep}`,
-    );
-    const match = resolved.match(symlinkRe);
-    if (match && match.index !== undefined) idx = match.index;
-  }
-  if (idx !== -1) {
+  const segment = findWorktreeSegment(resolved.replaceAll("\\", "/"));
+  if (segment) {
     // basePath is inside a worktree — resolve to project root
-    const projectRoot = resolved.slice(0, idx);
+    const projectRoot = resolved.slice(0, segment.gsdIdx);
     return join(projectRoot, ".gsd", CAPTURES_FILENAME);
   }
   return join(gsdRoot(basePath), CAPTURES_FILENAME);

--- a/src/resources/extensions/gsd/closeout-recovery.ts
+++ b/src/resources/extensions/gsd/closeout-recovery.ts
@@ -10,6 +10,7 @@ import { runTurnGitAction, type TurnGitActionMode, type TurnGitActionResult } fr
 import { _getAdapter, upsertTurnGitTransaction } from "./gsd-db.js";
 import { probeGitConflictState } from "./git-conflict-state.js";
 import { parseUnitId } from "./unit-id.js";
+import { worktreePathFor } from "./worktree-placement.js";
 
 export interface CloseoutFailureRecord {
   traceId: string;
@@ -156,7 +157,7 @@ export function resolveCloseoutRecoveryBasePath(projectRoot: string, record: Clo
   const parsed = parseUnitId(record.unitId);
   const milestoneId = parsed.milestone ?? (/^M\d+(?:-[a-z0-9]{6})?/.exec(record.unitId)?.[0] ?? "");
   if (milestoneId) {
-    const worktreePath = existingRealPath(join(projectRoot, ".gsd", "worktrees", milestoneId));
+    const worktreePath = existingRealPath(worktreePathFor(projectRoot, milestoneId));
     if (worktreePath) return worktreePath;
   }
 

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import { loadRegistry } from "../workflow-templates.js";
 import { gsdHome } from "../gsd-home.js";
+import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { VISUAL_BRIEF_MODES } from "../../visual-brief/prompts.js";
 
 
@@ -396,75 +397,12 @@ function getExtensionCompletions(prefix: string, action: string) {
   }
 }
 
-function normalizePathForCompare(path: string): string {
-  return path.replaceAll("\\", "/").replace(/\/+$/, "");
-}
-
-function findWorktreeSegment(normalizedPath: string): { gsdIdx: number; afterWorktrees: number } | null {
-  const directMarker = "/.gsd/worktrees/";
-  const directIdx = normalizedPath.indexOf(directMarker);
-  if (directIdx !== -1) {
-    return { gsdIdx: directIdx, afterWorktrees: directIdx + directMarker.length };
-  }
-
-  const symlinkMatch = normalizedPath.match(/\/\.gsd\/projects\/[a-f0-9]+\/worktrees\//);
-  if (symlinkMatch?.index !== undefined) {
-    return { gsdIdx: symlinkMatch.index, afterWorktrees: symlinkMatch.index + symlinkMatch[0].length };
-  }
-
-  return null;
-}
-
-function resolveProjectRootFromGitFile(worktreePath: string): string | null {
-  try {
-    let dir = worktreePath;
-    for (let i = 0; i < 30; i++) {
-      const gitPath = join(dir, ".git");
-      if (existsSync(gitPath)) {
-        const content = readFileSync(gitPath, "utf8").trim();
-        if (content.startsWith("gitdir: ")) {
-          const gitDir = resolve(dir, content.slice(8));
-          const dotGitDir = resolve(gitDir, "..", "..");
-          if (dotGitDir.endsWith(".git") || dotGitDir.endsWith(".git/") || dotGitDir.endsWith(".git\\")) {
-            return resolve(dotGitDir, "..");
-          }
-          const commonDirPath = join(gitDir, "commondir");
-          if (existsSync(commonDirPath)) {
-            const commonDir = readFileSync(commonDirPath, "utf8").trim();
-            return resolve(resolve(gitDir, commonDir), "..");
-          }
-        }
-        break;
-      }
-      const parent = resolve(dir, "..");
-      if (parent === dir) break;
-      dir = parent;
-    }
-  } catch {
-    // Completion must stay best-effort.
-  }
-  return null;
-}
-
 function resolveProjectRootForCompletion(basePath: string): string {
+  // Completion honors GSD_PROJECT_ROOT unconditionally (worker processes may
+  // complete from any cwd); resolveWorktreeProjectRoot only honors it for
+  // worktree paths.
   if (process.env.GSD_PROJECT_ROOT) return process.env.GSD_PROJECT_ROOT;
-
-  const normalizedPath = normalizePathForCompare(basePath);
-  const segment = findWorktreeSegment(normalizedPath);
-  if (!segment) return basePath;
-
-  const separator = basePath.includes("\\") ? "\\" : "/";
-  const gsdMarker = `${separator}.gsd${separator}`;
-  const gsdIdx = basePath.indexOf(gsdMarker);
-  const candidate = gsdIdx !== -1 ? basePath.slice(0, gsdIdx) : basePath.slice(0, segment.gsdIdx);
-
-  const normalizedGsdHome = normalizePathForCompare(gsdHome());
-  const candidateGsdPath = normalizePathForCompare(join(candidate, ".gsd"));
-  if (candidateGsdPath === normalizedGsdHome || candidateGsdPath.startsWith(`${normalizedGsdHome}/`)) {
-    return resolveProjectRootFromGitFile(basePath) ?? basePath;
-  }
-
-  return candidate;
+  return resolveWorktreeProjectRoot(basePath);
 }
 
 export function getGsdArgumentCompletions(prefix: string) {

--- a/src/resources/extensions/gsd/doctor-environment.ts
+++ b/src/resources/extensions/gsd/doctor-environment.ts
@@ -15,6 +15,7 @@ import { join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { detectPythonExecutable } from "./python-resolver.js";
+import { findWorktreeSegment } from "./worktree-root.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -38,27 +39,23 @@ const CMD_TIMEOUT = 5_000;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-/** Worktree sentinel — path segment that marks an auto-worktree directory. */
-const WORKTREE_PATH_SEGMENT = `${join(".gsd", "worktrees")}/`;
-
 /**
- * Resolve the project root when running inside a `.gsd/worktrees/<name>/`
- * auto-worktree. Returns `null` if not in a worktree.
+ * Resolve the project root when running inside a GSD auto-worktree.
+ * Returns `null` if not in a worktree.
  *
  * Detection order:
  *   1. `GSD_WORKTREE` env var (set by the worktree launcher)
- *   2. `.gsd/worktrees/` segment in basePath
+ *   2. worktree segment in basePath (via worktree-root's layout matching)
  */
 function resolveWorktreeProjectRoot(basePath: string): string | null {
   const envRoot = process.env.GSD_WORKTREE;
   if (envRoot) return envRoot;
 
-  const normalised = basePath.replace(/\\/g, "/");
-  const idx = normalised.indexOf(WORKTREE_PATH_SEGMENT.replace(/\\/g, "/"));
-  if (idx === -1) return null;
+  const segment = findWorktreeSegment(basePath.replace(/\\/g, "/"));
+  if (!segment) return null;
 
-  // Everything before `.gsd/worktrees/` is the project root
-  return basePath.slice(0, idx);
+  // Everything before the worktree segment is the project root
+  return basePath.slice(0, segment.gsdIdx);
 }
 
 function tryExec(cmd: string, cwd: string): string | null {

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -9,7 +9,7 @@ import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
 import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { resolveMilestoneFile } from "./paths.js";
 import { deriveState, isMilestoneComplete } from "./state.js";
-import { createWorktree, listWorktrees, resolveGitDir, worktreesDir } from "./worktree-manager.js";
+import { allWorktreesDirs, createWorktree, listWorktrees, resolveGitDir } from "./worktree-manager.js";
 import { abortAndReset } from "./git-self-heal.js";
 import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegrationBranch } from "./git-service.js";
 import { nativeIsRepo, nativeWorktreeList, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeAddTracked, nativeCommit } from "./native-git-bridge.js";
@@ -496,8 +496,8 @@ export async function checkGitHealth(
   // that is no longer registered with git. These orphaned dirs cause
   // "already exists" errors when re-creating the same worktree name.
   try {
-    const wtDir = worktreesDir(basePath);
-    if (existsSync(wtDir)) {
+    for (const wtDir of allWorktreesDirs(basePath)) {
+      if (!existsSync(wtDir)) continue;
       // Resolve symlinks and normalize separators so that symlinked .gsd
       // paths (e.g. ~/.gsd/projects/<hash>/worktrees/…) match the paths
       // returned by `git worktree list`.

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -414,11 +414,18 @@ export async function checkRuntimeHealth(
         ".gsd/event-log.jsonl",
       ];
 
-      // If blanket .gsd/ or .gsd is present, all patterns are covered
+      // If blanket .gsd/ or .gsd is present, all .gsd/* patterns are covered —
+      // but NOT the .gsd-worktrees/ sibling, which always needs its own entry.
       const hasBlanketIgnore = existingLines.has(".gsd/") || existingLines.has(".gsd");
-
+      const missing: string[] = [];
+      if (!existingLines.has(".gsd-worktrees/") && !existingLines.has(".gsd-worktrees")) {
+        missing.push(".gsd-worktrees/");
+      }
       if (!hasBlanketIgnore) {
-        const missing = criticalPatterns.filter(p => !existingLines.has(p));
+        missing.push(...criticalPatterns.filter(p => !existingLines.has(p)));
+      }
+
+      {
         if (missing.length > 0) {
           issues.push({
             severity: "warning",

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -359,6 +359,7 @@ export interface PreMergeCheckResult {
  * This array must stay synchronized with it.
  */
 export const RUNTIME_EXCLUSION_PATHS: readonly string[] = [
+  ".gsd-worktrees/",
   ".gsd/activity/",
   ".gsd/audit/",
   ".gsd/forensics/",

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -25,6 +25,7 @@ import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
  * but retained for backwards compatibility during migration.
  */
 const GSD_RUNTIME_PATTERNS = [
+  ".gsd-worktrees/",
   ".gsd/activity/",
   ".gsd/audit/",
   ".gsd/forensics/",
@@ -48,6 +49,8 @@ const GSD_RUNTIME_PATTERNS = [
 const BASELINE_PATTERNS = [
   // ── GSD state directory (symlink to external storage) ──
   ".gsd",
+  // Worktree container sibling — NOT covered by the ".gsd" pattern above.
+  ".gsd-worktrees/",
   ".gsd-id",
   ".mcp.json",
   ".bg-shell/",

--- a/src/resources/extensions/gsd/migrate/safety.ts
+++ b/src/resources/extensions/gsd/migrate/safety.ts
@@ -106,14 +106,22 @@ export function assertMigrationHasSlices(preview: MigrationPreview): void {
 }
 
 function hasWorktreeState(targetRoot: string): boolean {
-  const worktreesDir = join(gsdRoot(targetRoot), "worktrees");
-  if (!existsSync(worktreesDir)) return false;
-  try {
-    return readdirSync(worktreesDir, { withFileTypes: true })
-      .some((entry) => entry.isDirectory() || entry.isFile());
-  } catch {
-    return true;
+  const containers = [
+    join(targetRoot, ".gsd-worktrees"),
+    join(gsdRoot(targetRoot), "worktrees"),
+  ];
+  for (const worktreesDir of containers) {
+    if (!existsSync(worktreesDir)) continue;
+    try {
+      if (readdirSync(worktreesDir, { withFileTypes: true })
+        .some((entry) => entry.isDirectory() || entry.isFile())) {
+        return true;
+      }
+    } catch {
+      return true;
+    }
   }
+  return false;
 }
 
 export async function assertMigrationTargetAvailable(targetRoot: string): Promise<void> {

--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -9,6 +9,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { resolveGsdPathContract } from "./paths.js";
+import { worktreePathFor, worktreesDirs } from "./worktree-placement.js";
 import { getAutoWorktreePath } from "./auto-worktree.js";
 import { buildWorktreeLifecycleDeps } from "./auto.js";
 import {
@@ -42,7 +43,7 @@ export type MergeOrder = "sequential" | "by-completion";
  * Returns true when milestones.status = 'complete' in project gsd.db.
  */
 export function isMilestoneCompleteInProjectDb(basePath: string, mid: string): boolean {
-  const workRoot = join(basePath, ".gsd", "worktrees", mid);
+  const workRoot = worktreePathFor(basePath, mid);
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return false;
 
@@ -65,15 +66,17 @@ export function isMilestoneCompleteInProjectDb(basePath: string, mid: string): b
  */
 function discoverDbCompletedMilestones(basePath: string): Set<string> {
   const completed = new Set<string>();
-  const worktreeDir = join(basePath, ".gsd", "worktrees");
-  try {
-    for (const entry of readdirSync(worktreeDir)) {
-      if (entry.startsWith("M") && isMilestoneCompleteInProjectDb(basePath, entry)) {
-        completed.add(entry);
+  for (const worktreeDir of worktreesDirs(basePath)) {
+    if (!existsSync(worktreeDir)) continue;
+    try {
+      for (const entry of readdirSync(worktreeDir)) {
+        if (entry.startsWith("M") && isMilestoneCompleteInProjectDb(basePath, entry)) {
+          completed.add(entry);
+        }
       }
+    } catch (e) {
+      logWarning("parallel", `readdirSync for completed set failed: ${(e as Error).message}`);
     }
-  } catch (e) {
-    logWarning("parallel", `readdirSync for completed set failed: ${(e as Error).message}`);
   }
   return completed;
 }
@@ -120,7 +123,7 @@ export function determineMergeOrder(
         title: mid,
         pid: 0,
         process: null,
-        worktreePath: basePath ? join(basePath, ".gsd", "worktrees", mid) : "",
+        worktreePath: basePath ? worktreePathFor(basePath, mid) : "",
         startedAt: 0,
         state: "stopped",
         cost: 0,

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -11,6 +11,7 @@ import { matchesKey, Key } from "@gsd/pi-tui";
 import { formatDuration } from "../shared/mod.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { resolveGsdPathContract } from "./paths.js";
+import { worktreePathFor, worktreesDirs } from "./worktree-placement.js";
 import {
   renderBar,
   renderDialogFrame,
@@ -101,7 +102,6 @@ function tailRead(filePath: string, maxBytes: number): string {
 
 function discoverWorkers(basePath: string): string[] {
   const parallelDir = join(basePath, ".gsd", "parallel");
-  const worktreeDir = join(basePath, ".gsd", "worktrees");
   const mids = new Set<string>();
 
   if (existsSync(parallelDir)) {
@@ -114,7 +114,8 @@ function discoverWorkers(basePath: string): string[] {
     } catch { /* skip */ }
   }
 
-  if (existsSync(worktreeDir)) {
+  for (const worktreeDir of worktreesDirs(basePath)) {
+    if (!existsSync(worktreeDir)) continue;
     try {
       for (const d of readdirSync(worktreeDir)) {
         if (d.startsWith("M") && existsSync(join(worktreeDir, d, ".gsd", "auto.lock"))) {
@@ -128,7 +129,7 @@ function discoverWorkers(basePath: string): string[] {
 }
 
 function querySliceProgress(basePath: string, mid: string): SliceProgress[] {
-  const workRoot = join(basePath, ".gsd", "worktrees", mid);
+  const workRoot = worktreePathFor(basePath, mid);
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
 
@@ -169,7 +170,7 @@ function extractCostFromNdjson(basePath: string, mid: string): number {
 }
 
 function queryRecentCompletions(basePath: string, mid: string): string[] {
-  const workRoot = join(basePath, ".gsd", "worktrees", mid);
+  const workRoot = worktreePathFor(basePath, mid);
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
   try {
@@ -193,7 +194,7 @@ function collectWorkerData(basePath: string): WorkerView[] {
 
   for (const mid of mids) {
     const status = readJsonSafe<StatusJson>(join(parallelDir, `${mid}.status.json`));
-    const lock = readJsonSafe<AutoLock>(join(basePath, ".gsd", "worktrees", mid, ".gsd", "auto.lock"));
+    const lock = readJsonSafe<AutoLock>(join(worktreePathFor(basePath, mid), ".gsd", "auto.lock"));
     const slices = querySliceProgress(basePath, mid);
 
     const pid = lock?.pid || status?.pid || 0;

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -17,7 +17,7 @@ import { spawnSync } from "node:child_process";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
 import { DIR_CACHE_MAX } from "./constants.js";
 import { gsdHome } from "./gsd-home.js";
-import { isGsdWorktreePath, resolveExternalStateProjectGsdFromWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
+import { findWorktreeSegment, isGsdWorktreePath, resolveExternalStateProjectGsdFromWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
@@ -458,29 +458,16 @@ function assertNotGlobalGsdHome(basePath: string, result: string): void {
  * When gsdRoot() is called with such a path, we must NOT walk up to the
  * project root's .gsd — each worktree manages its own .gsd state (#2594).
  *
- * Matches both forward-slash and platform-native separators to handle
- * Windows paths (path.sep = '\\') and normalized Unix paths.
+ * Layout matching is owned by worktree-root's findWorktreeSegment; this
+ * only adds the requirement that a non-empty worktree name follows the
+ * marker (the worktrees container dir itself is not a worktree).
  */
 function isInsideGsdWorktree(p: string): boolean {
-  // Match /.gsd/worktrees/<name> where <name> is the final segment or
-  // followed by a separator. The <name> segment must be non-empty.
-  const sepFwd = "/";
-  const sepNative = "\\";
-  const markers = [
-    `${sepFwd}.gsd${sepFwd}worktrees${sepFwd}`,
-    `${sepNative}.gsd${sepNative}worktrees${sepNative}`,
-  ];
-  for (const marker of markers) {
-    const idx = p.indexOf(marker);
-    if (idx === -1) continue;
-    // Verify there's a non-empty worktree name after the marker
-    const afterMarker = p.slice(idx + marker.length);
-    // The name is everything up to the next separator (or end of string)
-    const nameEnd = afterMarker.search(/[/\\]/);
-    const name = nameEnd === -1 ? afterMarker : afterMarker.slice(0, nameEnd);
-    if (name.length > 0) return true;
-  }
-  return false;
+  const normalized = p.replaceAll("\\", "/");
+  const segment = findWorktreeSegment(normalized);
+  if (!segment) return false;
+  const name = normalized.slice(segment.afterWorktrees).split("/")[0];
+  return name.length > 0;
 }
 
 function probeGsdRoot(rawBasePath: string): string {

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -306,7 +306,9 @@ test("pauseAuto records the expected worktree path when paused from project root
 
     const meta = readPausedSessionMetadata(base);
     assert.ok(meta);
-    assert.equal(meta.worktreePath, join(base, ".gsd", "worktrees", "M001"));
+    // No worktree exists yet, so the recorded path is the canonical
+    // .gsd-worktrees/ creation location (worktree-placement seam).
+    assert.equal(meta.worktreePath, join(base, ".gsd-worktrees", "M001"));
   } finally {
     autoSession.reset();
     try {

--- a/src/resources/extensions/gsd/tests/auto-worktree-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-registry.test.ts
@@ -184,7 +184,7 @@ describe("auto-worktree workspace registry", () => {
     git(["commit", "-m", "add milestone"], tempDir);
 
     createAutoWorktree(tempDir, "M003");
-    const wtDir = join(tempDir, ".gsd", "worktrees", "M003");
+    const wtDir = join(tempDir, ".gsd-worktrees", "M003");
     writeFileSync(join(wtDir, "feature.txt"), "implemented\n");
     git(["add", "feature.txt"], wtDir);
     git(["commit", "-m", "feat: implement M003"], wtDir);
@@ -216,7 +216,7 @@ describe("auto-worktree workspace registry", () => {
     git(["commit", "-m", "add milestone"], tempDir);
 
     createAutoWorktree(tempDir, "M004");
-    const wtDir = join(tempDir, ".gsd", "worktrees", "M004");
+    const wtDir = join(tempDir, ".gsd-worktrees", "M004");
     writeFileSync(join(wtDir, "feature.txt"), "implemented\n");
     git(["add", "feature.txt"], wtDir);
     git(["commit", "-m", "feat: implement M004"], wtDir);

--- a/src/resources/extensions/gsd/tests/auto-worktree-repair.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-repair.test.ts
@@ -35,7 +35,8 @@ test("repair target accepts a missing expected milestone worktree", () => {
 
     assert.equal(result.ok, true);
     if (result.ok) {
-      assert.equal(result.expectedPath, join(base, ".gsd", "worktrees", "M001"));
+      // No worktree exists yet, so the expected path is the canonical container.
+      assert.equal(result.expectedPath, join(base, ".gsd-worktrees", "M001"));
     }
   } finally {
     cleanup(base);
@@ -192,7 +193,8 @@ test("paused metadata path resolves to the expected worktree while paused at pro
       baseIsAutoWorktree: false,
     });
 
-    assert.equal(result, join(base, ".gsd", "worktrees", "M001"));
+    // No worktree exists yet, so resolution lands at the canonical container.
+    assert.equal(result, join(base, ".gsd-worktrees", "M001"));
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -746,7 +746,7 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
   });
 
   test("#2156: mergeMilestoneToMain removes external-state worktrees using the milestone branch name", () => {
-    const { repo, externalState } = freshRepoWithExternalGsd();
+    const { repo } = freshRepoWithExternalGsd();
     const wtPath = createAutoWorktree(repo, "M215");
 
     addSliceToMilestone(repo, wtPath, "M215", "S01", "External cleanup", [
@@ -754,9 +754,10 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
     ]);
 
     const realWtPath = realpathSync(wtPath);
-    assert.ok(
-      realWtPath.startsWith(externalState),
-      `worktree should be registered under external .gsd state, got ${realWtPath}`,
+    assert.equal(
+      realWtPath,
+      join(repo, ".gsd-worktrees", "M215"),
+      `worktree should use canonical path under project root, got ${realWtPath}`,
     );
 
     // Recreate the exact divergence from #1852: local .gsd/ is replaced with a

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
@@ -157,7 +157,7 @@ describe("auto-worktree lifecycle", () => {
     try {
       const wtPath = createAutoWorktree(tempDir, "M001");
       const realWtPath = realpathSync(wtPath);
-      assert.ok(realWtPath.startsWith(storage), "git registered the symlink-resolved worktree path");
+      assert.equal(realWtPath, join(tempDir, ".gsd-worktrees", "M001"), "worktree uses canonical path under project root, not through the .gsd symlink");
 
       _resetAutoWorktreeOriginalBaseForTests();
       process.chdir(realWtPath);

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -293,11 +293,12 @@ describe('git-service', async () => {
 
   assert.deepStrictEqual(
     RUNTIME_EXCLUSION_PATHS.length,
-    16,
-    "exactly 16 runtime exclusion paths"
+    17,
+    "exactly 17 runtime exclusion paths"
   );
 
   const expectedPaths = [
+    ".gsd-worktrees/",
     ".gsd/activity/",
     ".gsd/audit/",
     ".gsd/forensics/",

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -161,13 +161,13 @@ test("enterMilestone returns ok:true mode:worktree on successful create", (t) =>
   if (result.ok) {
     assert.equal(result.mode, "worktree");
     assert.ok(
-      result.path.endsWith("/.gsd/worktrees/M001"),
-      `expected path to end with /.gsd/worktrees/M001, got ${result.path}`,
+      result.path.endsWith("/.gsd-worktrees/M001"),
+      `expected path to end with /.gsd-worktrees/M001, got ${result.path}`,
     );
   }
   assert.ok(
-    s.basePath.endsWith("/.gsd/worktrees/M001"),
-    `expected s.basePath to end with /.gsd/worktrees/M001, got ${s.basePath}`,
+    s.basePath.endsWith("/.gsd-worktrees/M001"),
+    `expected s.basePath to end with /.gsd-worktrees/M001, got ${s.basePath}`,
   );
   // After C3 (#5626) `invalidateAllCaches` is inlined; assertion against
   // `deps.calls` for cache invalidation is no longer possible.

--- a/src/resources/extensions/gsd/tests/worktree-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-manager.test.ts
@@ -180,7 +180,7 @@ describe("createWorktree — branch cleanup on add failure", () => {
 
     // Make the worktrees parent directory non-writable so `git worktree add`
     // fails after the branch has already been force-reset.
-    const parentDir = join(base, ".gsd", "worktrees");
+    const parentDir = join(base, ".gsd-worktrees");
     mkdirSync(parentDir, { recursive: true });
     run(`chmod 555 "${parentDir}"`, base);
 

--- a/src/resources/extensions/gsd/tests/worktree-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-manager.test.ts
@@ -142,6 +142,27 @@ describe("createWorktree", () => {
     run("git rev-parse --git-dir", info.path);
     assert.ok(!existsSync(join(info.path, "orphan.txt")), "stale file removed by recovery");
   });
+
+  test("removes stale canonical directory when legacy orphan is cleaned and canonical target is stale", () => {
+    // Scenario: a stale .gsd-worktrees/M020 directory (no .git — aborted prior
+    // creation) coexists with an orphaned .gsd/worktrees/M020 dir (.git file not
+    // registered with git). worktreePathFor returns the legacy path (canonical has
+    // no .git marker), so only the legacy path was previously cleaned — the stale
+    // canonical blocked git worktree add. The fix ensures createWorktree also
+    // removes the stale canonical before calling git worktree add.
+    const canonicalDir = join(base, ".gsd-worktrees", "M020");
+    const legacyDir = join(base, ".gsd", "worktrees", "M020");
+
+    mkdirSync(canonicalDir, { recursive: true });  // stale canonical: exists, no .git
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, ".git"), "gitdir: ../../../../.git/worktrees/M020\n", "utf-8");
+
+    const info = createWorktree(base, "M020");
+    assert.strictEqual(info.name, "M020");
+    assert.ok(existsSync(info.path), "worktree path should exist after creation");
+    assert.ok(existsSync(join(info.path, ".git")), "new worktree has .git marker");
+    run("git rev-parse --git-dir", info.path);
+  });
 });
 
 describe("createWorktree — duplicate rejection", () => {

--- a/src/resources/extensions/gsd/tests/worktree-placement.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-placement.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for worktreePathFor — the forward seam (project + name → path).
+ *
+ * Key invariant: a stale canonical directory (no .git marker) must NOT
+ * shadow a live legacy worktree (.gsd/worktrees/<name> with .git).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { worktreePathFor, canonicalWorktreesDir, legacyWorktreesDir } from "../worktree-placement.ts";
+
+function makeTmpRoot(): string {
+  const root = join(tmpdir(), `gsd-placement-test-${randomUUID()}`);
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function cleanup(root: string): void {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* */ }
+}
+
+function makeCanonicalDir(root: string, name: string): string {
+  const p = join(canonicalWorktreesDir(root), name);
+  mkdirSync(p, { recursive: true });
+  return p;
+}
+
+function makeLiveCanonical(root: string, name: string): string {
+  const p = makeCanonicalDir(root, name);
+  writeFileSync(join(p, ".git"), `gitdir: ${join(root, ".git", "worktrees", name)}\n`);
+  return p;
+}
+
+function makeLiveLegacy(root: string, name: string): string {
+  const p = join(legacyWorktreesDir(root), name);
+  mkdirSync(p, { recursive: true });
+  writeFileSync(join(p, ".git"), `gitdir: ${join(root, ".git", "worktrees", name)}\n`);
+  return p;
+}
+
+test("returns canonical path when canonical has .git marker", () => {
+  const root = makeTmpRoot();
+  try {
+    const canonical = makeLiveCanonical(root, "M001");
+    assert.equal(worktreePathFor(root, "M001"), canonical);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("returns legacy path when only legacy exists with .git marker", () => {
+  const root = makeTmpRoot();
+  try {
+    const legacy = makeLiveLegacy(root, "M001");
+    assert.equal(worktreePathFor(root, "M001"), legacy);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("returns legacy path when canonical dir exists but has no .git (stale canonical)", () => {
+  const root = makeTmpRoot();
+  try {
+    makeCanonicalDir(root, "M001"); // stale: dir exists, no .git
+    const legacy = makeLiveLegacy(root, "M001");
+    assert.equal(
+      worktreePathFor(root, "M001"),
+      legacy,
+      "stale canonical must not shadow live legacy worktree",
+    );
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("returns canonical path for new-worktree creation when neither path exists", () => {
+  const root = makeTmpRoot();
+  try {
+    const expected = join(canonicalWorktreesDir(root), "M001");
+    assert.equal(worktreePathFor(root, "M001"), expected);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("prefers live canonical over live legacy when both exist", () => {
+  const root = makeTmpRoot();
+  try {
+    const canonical = makeLiveCanonical(root, "M001");
+    makeLiveLegacy(root, "M001");
+    assert.equal(worktreePathFor(root, "M001"), canonical);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("returns legacy when canonical is stale and legacy has no .git (both stale)", () => {
+  const root = makeTmpRoot();
+  try {
+    makeCanonicalDir(root, "M001"); // stale canonical
+    const legacy = join(legacyWorktreesDir(root), "M001");
+    mkdirSync(legacy, { recursive: true }); // stale legacy (no .git)
+    // Falls through to legacy existsSync since canonical has no .git
+    assert.equal(worktreePathFor(root, "M001"), legacy);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/src/resources/extensions/gsd/tests/worktree-reentry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-reentry.test.ts
@@ -65,7 +65,7 @@ describe("reenterActiveWorktreeIfNeeded", () => {
     const entered = await reenterActiveWorktreeIfNeeded(dir);
     assert.ok(entered, "re-entry returned a worktree path");
     assert.strictEqual(realpathSync(process.cwd()), realpathSync(entered!), "cwd moved into the worktree");
-    assert.strictEqual(entered, join(dir, ".gsd", "worktrees", "M001"));
+    assert.strictEqual(entered, join(dir, ".gsd-worktrees", "M001"));
   });
 
   test("no-op when already inside a worktree", async (t) => {

--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -126,7 +126,9 @@ describe("Worktree Safety module", () => {
     assert.equal(result.ok, false);
     assert.equal(result.kind, "invalid-root");
     assert.equal(result.details?.unitRoot, outsideRoot);
-    assert.equal(result.details?.expectedRoot, unitRoot);
+    // The reported expected root is the canonical container; the legacy
+    // .gsd/worktrees/ location is also accepted but not surfaced here.
+    assert.equal(result.details?.expectedRoot, join(projectRoot, ".gsd-worktrees", "M001"));
   });
 
   test("accepts project root for source-writing Unit when isolation mode is none", () => {

--- a/src/resources/extensions/gsd/tests/worktree-symlink-removal.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-symlink-removal.test.ts
@@ -8,6 +8,11 @@
  *
  * Fix: removeWorktree should query `git worktree list` to find the actual
  * registered path when the computed path doesn't match.
+ *
+ * New worktrees are created at the canonical `.gsd-worktrees/` sibling and
+ * never cross the symlink, so this scenario only applies to LEGACY worktrees
+ * (created under `.gsd/worktrees/` by older versions). The test creates the
+ * worktree at the legacy location directly to keep that coverage.
  */
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, unlinkSync, writeFileSync, existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
@@ -15,7 +20,6 @@ import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
 import {
-  createWorktree,
   removeWorktree,
   listWorktrees,
   worktreePath,
@@ -64,13 +68,15 @@ test('worktree-symlink-removal removes the git-registered symlink target safely'
   run("git add .", base);
   run('git commit -m "init"', base);
 
-  // Create a worktree — git will resolve the symlink and register
-  // the worktree at the external path
-  const info = createWorktree(base, "M002", { branch: "milestone/M002" });
-  assert.ok(info.exists, "worktree created");
+  // Create a LEGACY worktree through the symlinked .gsd path — git resolves
+  // the symlink and registers the worktree at the external path. (Current
+  // createWorktree() uses the canonical .gsd-worktrees/ sibling instead.)
+  const legacyPath = join(base, ".gsd", "worktrees", "M002");
+  run(`git worktree add -b milestone/M002 "${legacyPath}"`, base);
+  assert.ok(existsSync(legacyPath), "worktree created");
 
   // Verify worktree was created at the resolved (external) path
-  const realWtPath = realpathSync(info.path);
+  const realWtPath = realpathSync(legacyPath);
   assert.ok(
     realWtPath.startsWith(externalState),
     `worktree real path (${realWtPath}) is under external state dir`,

--- a/src/resources/extensions/gsd/tests/worktree-teardown-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-teardown-safety.test.ts
@@ -116,8 +116,8 @@ describe("worktree-teardown-safety", () => {
 
     const wtPathResult = worktreePath(tempDir, "anything");
     assertTrue(
-      wtPathResult.startsWith(join(tempDir, ".gsd", "worktrees")),
-      "worktreePath returns path under .gsd/worktrees/",
+      wtPathResult.startsWith(join(tempDir, ".gsd-worktrees")),
+      "worktreePath returns path under the canonical .gsd-worktrees/ container",
     );
   });
 

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -11,6 +11,7 @@ import {
 import { realpathSync } from "node:fs";
 import path from "node:path";
 import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
+import { findWorktreeSegment } from "../worktree-root.js";
 import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
 
 export interface ExecToolParams {
@@ -201,11 +202,10 @@ function normalizeScanPath(value: string): string {
 
 function parseWorktreeBase(baseDir: string): { originalRoot: string; worktreeRoot: string } | null {
   const normalizedBase = normalizeScanPath(baseDir);
-  const marker = "/.gsd/worktrees/";
-  const markerIndex = normalizedBase.indexOf(marker);
-  if (markerIndex <= 0) return null;
+  const segment = findWorktreeSegment(normalizedBase);
+  if (!segment || segment.gsdIdx <= 0) return null;
   return {
-    originalRoot: normalizedBase.slice(0, markerIndex),
+    originalRoot: normalizedBase.slice(0, segment.gsdIdx),
     worktreeRoot: normalizedBase,
   };
 }
@@ -297,7 +297,7 @@ function scriptReferencesOriginalRootFromWorktree(script: string, baseDir: strin
   const normalizedScript = script.replace(/\\/g, "/");
   return comparablePathVariants(parsed.originalRoot).some((originalRoot) => {
     const originalRootPattern = new RegExp(
-      `${escapeRegExp(originalRoot)}(?=$|[\\s'"\\\`;)&|<>]|/(?!\\.gsd/worktrees(?:/|$)))`,
+      `${escapeRegExp(originalRoot)}(?=$|[\\s'"\\\`;)&|<>]|/(?!\\.gsd(?:-worktrees|/worktrees)(?:/|$)))`,
     );
     return originalRootPattern.test(normalizedScript);
   });

--- a/src/resources/extensions/gsd/worktree-git-recovery.ts
+++ b/src/resources/extensions/gsd/worktree-git-recovery.ts
@@ -1,0 +1,308 @@
+// Project/App: gsd-pi
+// File Purpose: Git checkout/stash/merge-state recovery primitives for worktree operations.
+
+/**
+ * Worktree Git Recovery — the recurring-bug hot spot, in one place.
+ *
+ * Owns the verbs that recover a repository from interrupted or conflicting
+ * git operations during worktree transitions:
+ *
+ *   - `checkoutBranchWithStashGuard` — branch switch with stash protection,
+ *     including the stash-pop EEXIST collision recovery for `.gsd/` runtime
+ *     files (force-checkout + targeted stash drop).
+ *   - `removeMergeStateFiles` — clears SQUASH_MSG / MERGE_HEAD / etc. left by
+ *     a failed merge so subsequent merges don't fail on stale state.
+ *   - `cleanupConflictState` — merge-abort + index reset + state-file cleanup
+ *     after a conflicted (including squash) merge.
+ *   - stash helpers (`popStashByRef`, `stashRefFromError`,
+ *     `stashAlreadyExistsFilesFromError`, `gsdJsonlFilesWithConflictMarkers`)
+ *     used by the merge pipeline in auto-worktree.ts.
+ *
+ * Extracted from auto-worktree.ts so recovery fixes land here instead of as
+ * embedded special cases in a 2,600-line orchestration module, and so the
+ * rules can be tested against scripted git states.
+ *
+ * The State Reconciliation drift repair (`state-reconciliation/drift/
+ * merge-state.ts`) keeps its own merge-state primitive by design — drift
+ * repairs own their raw primitives (see CONTEXT.md, Drift repair).
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+
+import { debugLog } from "./debug-logger.js";
+import { logError, logWarning } from "./workflow-logger.js";
+import {
+  nativeAddPaths,
+  nativeCheckoutBranch,
+  nativeConflictFiles,
+  nativeLsFiles,
+  nativeMergeAbort,
+  nativeWorkingTreeStatus,
+} from "./native-git-bridge.js";
+import { resolveGitDir } from "./worktree-manager.js";
+
+/**
+ * Pop the stash entry created with `stashMarker` in its subject, resolving it
+ * to a concrete `stash@{n}` ref first so a concurrent stash push cannot make
+ * `git stash pop` grab the wrong entry.
+ *
+ * If `stashMarker` is null or no longer present in the stash list (e.g. a
+ * concurrent process popped/dropped it), leaves the stash list untouched and
+ * returns null.
+ *
+ * Throws on pop failure so callers can handle conflict cases the same way
+ * they would with the prior `git stash pop` form. When throwing after a
+ * targeted pop attempt, the error is annotated with the targeted stash ref.
+ *
+ * (Issue #4980 HIGH-6)
+ */
+export function popStashByRef(basePath: string, stashMarker: string | null): string | null {
+  let popArg: string | null = null;
+  if (stashMarker) {
+    try {
+      const list = execFileSync("git", ["stash", "list", "--format=%gd%x00%s"], {
+        cwd: basePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+      }).trim().split("\n").filter(Boolean);
+      for (const entry of list) {
+        const [ref, subject] = entry.split("\0");
+        if (ref && subject?.includes(stashMarker)) {
+          popArg = ref;
+          break;
+        }
+      }
+    } catch (err) {
+      logWarning("worktree", `stash list lookup failed; leaving stash untouched: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (!popArg) {
+    logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic pop");
+    return null;
+  }
+  try {
+    execFileSync("git", ["stash", "pop", popArg], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+  } catch (err) {
+    if (err && typeof err === "object") {
+      (err as { stashRef?: string }).stashRef = popArg;
+    }
+    throw err;
+  }
+  return popArg;
+}
+
+/**
+ * Extract a stash ref annotation injected by popStashByRef() when git stash
+ * pop fails and we need to conditionally drop the exact stash entry later.
+ */
+export function stashRefFromError(err: unknown): string | null {
+  if (!err || typeof err !== "object") return null;
+  const stashRef = (err as { stashRef?: unknown }).stashRef;
+  return typeof stashRef === "string" && stashRef.length > 0 ? stashRef : null;
+}
+
+export function stashAlreadyExistsFilesFromError(err: unknown): string[] {
+  if (!err || typeof err !== "object") return [];
+  const stderr = (err as { stderr?: unknown }).stderr;
+  const stderrText = typeof stderr === "string"
+    ? stderr
+    : stderr instanceof Uint8Array
+      ? Buffer.from(stderr).toString("utf-8")
+      : "";
+  const message = err instanceof Error ? err.message : String(err);
+  const text = `${stderrText}\n${message}`;
+  const files = new Set<string>();
+  for (const line of text.split("\n")) {
+    const m = line.match(/^(.*?)\s+already exists, no checkout\s*$/i);
+    if (!m) continue;
+    const filePath = m[1]?.trim();
+    if (filePath) files.add(filePath);
+  }
+  return [...files];
+}
+
+/**
+ * Detect whether an on-disk file still contains unresolved merge conflict
+ * markers from a failed stash-pop or merge attempt.
+ *
+ * Returns false when the file cannot be read.
+ */
+export function hasConflictMarkers(filePath: string): boolean {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    return content.includes("<<<<<<<") && content.includes("=======") && content.includes(">>>>>>>");
+  } catch {
+    return false;
+  }
+}
+
+export function gsdJsonlFilesWithConflictMarkers(basePath: string): string[] {
+  return nativeLsFiles(basePath, ".gsd/*.jsonl").filter((f) =>
+    hasConflictMarkers(join(basePath, f)),
+  );
+}
+
+export function removeMergeStateFiles(basePath: string, contextLabel: string): void {
+  try {
+    for (const f of ["SQUASH_MSG", "MERGE_MSG", "MERGE_MODE", "MERGE_HEAD", "AUTO_MERGE"]) {
+      const rawPath = execFileSync("git", ["rev-parse", "--git-path", f], {
+        cwd: basePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+      }).trim();
+      const p = rawPath.length > 0
+        ? (isAbsolute(rawPath) ? rawPath : resolve(basePath, rawPath))
+        : join(resolveGitDir(basePath), f);
+      if (existsSync(p)) unlinkSync(p);
+    }
+  } catch (err) {
+    logError("worktree", `${contextLabel} merge state cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function cleanupConflictState(basePath: string): void {
+  // Merge conflicts can leave unmerged index entries; merge-abort alone is not
+  // enough for squash merges (MERGE_HEAD is never written). Reset the merge
+  // index, then remove merge message files that native/libgit2 paths may have
+  // created.
+  try {
+    nativeMergeAbort(basePath);
+  } catch (err) {
+    // MERGE_HEAD absent (squash merge path) — abort is a no-op, which is fine.
+    debugLog("conflict-cleanup:merge-abort-skipped", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    execFileSync("git", ["reset", "--merge"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+  } catch (err) {
+    logError("worktree", `git reset --merge failed after merge conflict: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  removeMergeStateFiles(basePath, "conflict");
+}
+
+export function checkoutBranchWithStashGuard(
+  basePath: string,
+  branch: string,
+  reason: string,
+): void {
+  let stashMarker: string | null = null;
+  let stashed = false;
+
+  const status = nativeWorkingTreeStatus(basePath).trim();
+  if (status.length > 0) {
+    stashMarker = `gsd-checkout-stash:${reason}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
+    const stashListBefore = execFileSync("git", ["stash", "list"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    execFileSync(
+      "git",
+      ["stash", "push", "--include-untracked", "-m", `gsd: checkout stash [${stashMarker}]`],
+      {
+        cwd: basePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+      },
+    );
+    const stashListAfter = execFileSync("git", ["stash", "list"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    stashed = stashListAfter !== stashListBefore;
+  }
+
+  // Checkout and stash-restore are split so we can distinguish two failure
+  // modes: (a) checkout failed → HEAD did not move, restore stash and rethrow;
+  // (b) checkout succeeded but stash pop failed → HEAD moved to `branch` but
+  // the working-tree changes remain in the stash list. We surface a distinct
+  // error in case (b) so callers don't assume the branch switch was rolled back.
+  try {
+    nativeCheckoutBranch(basePath, branch);
+  } catch (checkoutErr) {
+    if (stashed) {
+      try {
+        popStashByRef(basePath, stashMarker);
+      } catch (restoreErr) {
+        logWarning("worktree", `git stash pop failed during checkout restore: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
+      }
+    }
+    throw checkoutErr;
+  }
+
+  if (stashed) {
+    try {
+      popStashByRef(basePath, stashMarker);
+    } catch (popErr) {
+      const msg = popErr instanceof Error ? popErr.message : String(popErr);
+      const stderr = popErr && typeof popErr === "object"
+        ? (popErr as { stderr?: unknown }).stderr
+        : undefined;
+      const stderrText = typeof stderr === "string"
+        ? stderr
+        : stderr instanceof Uint8Array
+          ? Buffer.from(stderr).toString("utf-8")
+          : "";
+      const stashPopMessage = `${stderrText}\n${msg}`.trim();
+      const alreadyExists = stashAlreadyExistsFilesFromError(popErr);
+      const gsdAlreadyExists = alreadyExists.filter((f) => f.startsWith(".gsd/"));
+      const nonGsdAlreadyExists = alreadyExists.filter((f) => !f.startsWith(".gsd/"));
+      const isUntrackedRestoreFailure = stashPopMessage.includes("could not restore untracked files from stash");
+      const stashRefForDrop = stashRefFromError(popErr);
+      const nonGsdUnmerged = nativeConflictFiles(basePath).filter((f) => !f.startsWith(".gsd/"));
+      const gsdContentConflicts = isUntrackedRestoreFailure
+        ? gsdJsonlFilesWithConflictMarkers(basePath)
+        : [];
+      const gsdConflictFiles = [...new Set([...gsdAlreadyExists, ...gsdContentConflicts])];
+
+      if (
+        isUntrackedRestoreFailure &&
+        gsdConflictFiles.length > 0 &&
+        nonGsdAlreadyExists.length === 0 &&
+        nonGsdUnmerged.length === 0
+      ) {
+        for (const f of gsdConflictFiles) {
+          execFileSync("git", ["checkout", "HEAD", "--", f], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+          });
+          nativeAddPaths(basePath, [f]);
+        }
+
+        if (stashRefForDrop) {
+          try {
+            execFileSync("git", ["stash", "drop", stashRefForDrop], {
+              cwd: basePath,
+              stdio: ["ignore", "pipe", "pipe"],
+              encoding: "utf-8",
+            });
+          } catch (err) { /* stash may already be consumed */
+            logWarning("worktree", `git stash drop failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        } else {
+          logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic drop");
+        }
+        return;
+      }
+
+      const wrapped = new Error(
+        `checkout to '${branch}' succeeded but stash restore failed; working tree changes remain in the stash list. Original error: ${msg}`,
+      );
+      if (stashRefForDrop) (wrapped as { stashRef?: string }).stashRef = stashRefForDrop;
+      throw wrapped;
+    }
+  }
+}

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -4,7 +4,8 @@
 /**
  * GSD Worktree Manager
  *
- * Creates and manages git worktrees under .gsd/worktrees/<name>/.
+ * Creates and manages git worktrees under .gsd-worktrees/<name>/ (canonical;
+ * legacy .gsd/worktrees/<name>/ stays recognized — see worktree-placement.ts).
  * Each worktree gets its own branch (worktree/<name>) and a full
  * working copy of the project, enabling parallel work streams.
  *
@@ -12,7 +13,7 @@
  * the main branch, then dispatches an LLM-guided merge flow.
  *
  * Flow:
- *   1. create()  — git worktree add .gsd/worktrees/<name> -b worktree/<name>
+ *   1. create()  — git worktree add .gsd-worktrees/<name> -b worktree/<name>
  *   2. user works in the worktree (new plans, milestones, etc.)
  *   3. merge()   — LLM-guided reconciliation of .gsd/ artifacts back to main
  *   4. remove()  — git worktree remove + branch cleanup
@@ -48,6 +49,7 @@ import {
   normalizeWorktreePathForCompare,
   resolveWorktreeProjectRoot,
 } from "./worktree-root.js";
+import { canonicalWorktreesDir, worktreePathFor, worktreesDirs } from "./worktree-placement.js";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -138,12 +140,20 @@ export function resolveGitDir(basePath: string): string {
   return gitPath;
 }
 
+/** Canonical container for new worktrees. For scans that must also see legacy
+ *  worktrees, use allWorktreesDirs(). */
 export function worktreesDir(basePath: string): string {
-  return join(resolveWorktreeProjectRoot(basePath), ".gsd", "worktrees");
+  return canonicalWorktreesDir(resolveWorktreeProjectRoot(basePath));
 }
 
+/** Every container a GSD worktree may live in (canonical + legacy), canonical first. */
+export function allWorktreesDirs(basePath: string): string[] {
+  return worktreesDirs(resolveWorktreeProjectRoot(basePath));
+}
+
+/** Path for worktree `name` — an existing legacy worktree keeps its location. */
 export function worktreePath(basePath: string, name: string): string {
-  return join(worktreesDir(basePath), name);
+  return worktreePathFor(resolveWorktreeProjectRoot(basePath), name);
 }
 
 export function worktreeBranchName(name: string): string {
@@ -151,20 +161,22 @@ export function worktreeBranchName(name: string): string {
 }
 
 /**
- * Validate that a path is inside the .gsd/worktrees/ directory.
- * Resolves symlinks and normalizes ".." traversals before comparison
- * so that a symlink-resolved or crafted path cannot escape containment.
+ * Validate that a path is inside a GSD worktrees container (canonical
+ * .gsd-worktrees/ or legacy .gsd/worktrees/). Resolves symlinks and
+ * normalizes ".." traversals before comparison so that a symlink-resolved
+ * or crafted path cannot escape containment.
  *
  * Used as a safety gate before any destructive operation (rmSync,
  * nativeWorktreeRemove --force) to prevent #2365-style data loss.
  */
 export function isInsideWorktreesDir(basePath: string, targetPath: string): boolean {
-  const wtDirPath = worktreesDir(basePath);
-  const wtDir = existsSync(wtDirPath) ? realpathSync(wtDirPath) : resolve(wtDirPath);
   const resolved = existsSync(targetPath) ? realpathSync(targetPath) : resolve(targetPath);
-  // The resolved path must start with the worktrees dir followed by a separator,
-  // not merely be a prefix match (e.g. ".gsd/worktrees-extra" must not match).
-  return resolved === wtDir || resolved.startsWith(wtDir + sep);
+  return allWorktreesDirs(basePath).some((wtDirPath) => {
+    const wtDir = existsSync(wtDirPath) ? realpathSync(wtDirPath) : resolve(wtDirPath);
+    // The resolved path must start with the worktrees dir followed by a separator,
+    // not merely be a prefix match (e.g. ".gsd/worktrees-extra" must not match).
+    return resolved === wtDir || resolved.startsWith(wtDir + sep);
+  });
 }
 
 function isRegisteredGitWorktreeAtPath(basePath: string, wtPath: string): boolean {
@@ -277,12 +289,12 @@ export function buildManualValidationGuidance(
 ): string | null {
   if (!milestoneId) return null;
   const validationRoot = resolveCanonicalMilestoneRoot(basePath, milestoneId);
-  const inWorktree = validationRoot.includes(`${sep}.gsd${sep}worktrees${sep}`);
+  const inWorktree = isGsdWorktreePath(validationRoot);
   const lines: string[] = [`Validate the work here: ${validationRoot}`];
   if (inWorktree) {
     lines.push(
-      "This milestone runs in a git worktree, so the code lives under the hidden " +
-        `\`.gsd/worktrees/\` path. Open it with: cd "${validationRoot}"`,
+      "This milestone runs in a git worktree, so the code lives under the " +
+        `GSD worktrees directory. Open it with: cd "${validationRoot}"`,
     );
   }
   if (opts.uatPath) {
@@ -307,22 +319,24 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
     throw new GSDError(GSD_PARSE_ERROR, `Invalid worktree name "${name}". Use only letters, numbers, hyphens, and underscores.`);
   }
 
-  const wtPath = worktreePath(basePath, name);
+  const existingPath = worktreePath(basePath, name);
   const branch = opts.branch ?? worktreeBranchName(name);
 
-  if (existsSync(wtPath)) {
+  if (existsSync(existingPath)) {
     // A valid git worktree is registered in `git worktree list` and has a .git
     // *file* with a gitdir: pointer. Leftover directories (no .git, a standalone
     // .git directory from accidental `git init`, or an orphan pointer) block
     // creation unless removed.
-    if (isRegisteredGitWorktreeAtPath(basePath, wtPath)) {
-      throw new GSDError(GSD_STALE_STATE, `Worktree "${name}" already exists at ${wtPath}`);
+    if (isRegisteredGitWorktreeAtPath(basePath, existingPath)) {
+      throw new GSDError(GSD_STALE_STATE, `Worktree "${name}" already exists at ${existingPath}`);
     }
-    removeStaleWorktreeDirectory(wtPath, name);
+    removeStaleWorktreeDirectory(existingPath, name);
   }
 
-  // Ensure the .gsd/worktrees/ directory exists
+  // New worktrees always land in the canonical container, even when a stale
+  // legacy directory was just cleaned up.
   const wtDir = worktreesDir(basePath);
+  const wtPath = join(wtDir, name);
   mkdirSync(wtDir, { recursive: true });
 
   // Prune any stale worktree entries from a previous removal
@@ -405,7 +419,8 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
 
 /**
  * List all GSD-managed worktrees.
- * Uses native worktree list and filters to those under .gsd/worktrees/.
+ * Uses native worktree list and filters to those under a GSD worktrees
+ * container (canonical .gsd-worktrees/ or legacy .gsd/worktrees/).
  */
 export function listWorktrees(basePath: string): WorktreeInfo[] {
   basePath = normalizeBasePathForWorktreeOps(basePath);
@@ -416,12 +431,8 @@ export function listWorktrees(basePath: string): WorktreeInfo[] {
   }
   const seenRoots = new Set<string>();
   const worktreeRoots = baseVariants
-    .map(baseVariant => {
-      const path = join(baseVariant, ".gsd", "worktrees");
-      return {
-        normalized: normalizePathForComparison(path),
-      };
-    })
+    .flatMap(baseVariant => worktreesDirs(baseVariant))
+    .map(path => ({ normalized: normalizePathForComparison(path) }))
     .filter(root => {
       if (seenRoots.has(root.normalized)) return false;
       seenRoots.add(root.normalized);
@@ -794,6 +805,7 @@ export function removeWorktree(
  * This module uses a split representation (paths/exact/prefixes) for efficient matching.
  */
 const SKIP_PATHS = [
+  ".gsd-worktrees/",
   ".gsd/worktrees/",
   ".gsd/runtime/",
   ".gsd/activity/",

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -339,6 +339,13 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
   const wtPath = join(wtDir, name);
   mkdirSync(wtDir, { recursive: true });
 
+  // When existingPath resolved to a legacy location, the canonical target may
+  // still hold a stale directory from a prior aborted creation (no .git marker).
+  // Remove it so git worktree add does not fail with "path already exists".
+  if (existingPath !== wtPath && existsSync(wtPath) && !isRegisteredGitWorktreeAtPath(basePath, wtPath)) {
+    removeStaleWorktreeDirectory(wtPath, name);
+  }
+
   // Prune any stale worktree entries from a previous removal
   nativeWorktreePrune(basePath);
 

--- a/src/resources/extensions/gsd/worktree-placement.ts
+++ b/src/resources/extensions/gsd/worktree-placement.ts
@@ -1,0 +1,61 @@
+/**
+ * Worktree Placement module — owns WHERE GSD worktrees physically live.
+ *
+ * Canonical placement: `<projectRoot>/.gsd-worktrees/<name>` — a real
+ * directory that never crosses the `.gsd` symlink managed by repo-identity.
+ * Under the external-state layout (`.gsd → ~/.gsd/projects/<hash>/`), the
+ * legacy `.gsd/worktrees/` location materialised worktrees inside the user's
+ * home directory behind an opaque hash path; the canonical sibling keeps the
+ * working copy at the project root regardless of where `.gsd` state lives.
+ *
+ * Legacy placement (`<projectRoot>/.gsd/worktrees/<name>`, possibly resolving
+ * through the symlink to `~/.gsd/projects/<hash>/worktrees/<name>`) stays
+ * recognized so in-flight milestones keep working across upgrades:
+ *   - creation always uses the canonical location;
+ *   - resolution prefers an existing legacy worktree for the same name;
+ *   - containment checks accept membership in either location.
+ *
+ * Path → project identification lives in worktree-root.ts; this module owns
+ * only the forward direction (project + name → physical path).
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** Directory name of the canonical worktrees container at the project root. */
+export const CANONICAL_WORKTREES_DIRNAME = ".gsd-worktrees";
+
+/** Canonical container for newly created worktrees. Never crosses the `.gsd` symlink. */
+export function canonicalWorktreesDir(projectRoot: string): string {
+  return join(projectRoot, CANONICAL_WORKTREES_DIRNAME);
+}
+
+/** Legacy container (`.gsd/worktrees/`) — may resolve through the external-state symlink. */
+export function legacyWorktreesDir(projectRoot: string): string {
+  return join(projectRoot, ".gsd", "worktrees");
+}
+
+/**
+ * All containers a GSD worktree may live in, canonical first.
+ * Use for listing, scanning, and containment checks.
+ */
+export function worktreesDirs(projectRoot: string): string[] {
+  return [canonicalWorktreesDir(projectRoot), legacyWorktreesDir(projectRoot)];
+}
+
+/**
+ * Physical path for the worktree `name` under `projectRoot`.
+ *
+ * An existing worktree directory keeps its location (canonical or legacy);
+ * otherwise the canonical location is returned for creation. The legacy
+ * check is a plain existsSync so a stale legacy directory still resolves —
+ * callers that need a *registered* worktree validate the `.git` marker
+ * themselves (resolveCanonicalMilestoneRoot, Worktree Safety).
+ */
+export function worktreePathFor(projectRoot: string, name: string): string {
+  const canonical = join(canonicalWorktreesDir(projectRoot), name);
+  if (existsSync(canonical)) return canonical;
+  const legacy = join(legacyWorktreesDir(projectRoot), name);
+  if (existsSync(legacy)) return legacy;
+  return canonical;
+}

--- a/src/resources/extensions/gsd/worktree-placement.ts
+++ b/src/resources/extensions/gsd/worktree-placement.ts
@@ -46,15 +46,17 @@ export function worktreesDirs(projectRoot: string): string[] {
 /**
  * Physical path for the worktree `name` under `projectRoot`.
  *
- * An existing worktree directory keeps its location (canonical or legacy);
- * otherwise the canonical location is returned for creation. The legacy
- * check is a plain existsSync so a stale legacy directory still resolves —
+ * Canonical wins only when it has a `.git` marker (i.e. is a live worktree).
+ * A bare directory with no `.git` — a stale leftover from an aborted create
+ * or a partial cleanup — does not shadow an existing legacy worktree, so the
+ * legacy path is tried next. The legacy check remains a plain existsSync;
  * callers that need a *registered* worktree validate the `.git` marker
- * themselves (resolveCanonicalMilestoneRoot, Worktree Safety).
+ * themselves (resolveCanonicalMilestoneRoot, getAutoWorktreePath).
+ * Falls back to canonical for new-worktree creation when neither path exists.
  */
 export function worktreePathFor(projectRoot: string, name: string): string {
   const canonical = join(canonicalWorktreesDir(projectRoot), name);
-  if (existsSync(canonical)) return canonical;
+  if (existsSync(canonical) && existsSync(join(canonical, ".git"))) return canonical;
   const legacy = join(legacyWorktreesDir(projectRoot), name);
   if (existsSync(legacy)) return legacy;
   return canonical;

--- a/src/resources/extensions/gsd/worktree-reentry.ts
+++ b/src/resources/extensions/gsd/worktree-reentry.ts
@@ -10,7 +10,7 @@ import { readdirSync } from "node:fs";
 
 import { enterAutoWorktree, getAutoWorktreePath } from "./auto-worktree.js";
 import { getIsolationMode } from "./preferences.js";
-import { worktreesDir } from "./worktree-manager.js";
+import { allWorktreesDirs } from "./worktree-manager.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 interface LiveWorktree {
@@ -19,15 +19,18 @@ interface LiveWorktree {
 }
 
 /**
- * Enumerate the live (valid git) auto-worktrees under <projectRoot>/.gsd/worktrees/.
+ * Enumerate the live (valid git) auto-worktrees in the project's worktree
+ * containers (canonical .gsd-worktrees/ and legacy .gsd/worktrees/).
  * Reuses getAutoWorktreePath's validation so stray directories are ignored.
  */
 function liveMilestoneWorktrees(projectRoot: string): LiveWorktree[] {
-  let names: string[];
-  try {
-    names = readdirSync(worktreesDir(projectRoot));
-  } catch {
-    return [];
+  const names = new Set<string>();
+  for (const dir of allWorktreesDirs(projectRoot)) {
+    try {
+      for (const name of readdirSync(dir)) names.add(name);
+    } catch {
+      // container absent — skip
+    }
   }
   const live: LiveWorktree[] = [];
   for (const id of names) {

--- a/src/resources/extensions/gsd/worktree-root.ts
+++ b/src/resources/extensions/gsd/worktree-root.ts
@@ -20,10 +20,17 @@ export function normalizeWorktreePathForCompare(path: string): string {
 }
 
 /**
- * Find the GSD worktree segment in both direct project layout and the
- * symlink-resolved external-state layout used by ~/.gsd/projects/<hash>.
+ * Find the GSD worktree segment in the canonical layout (.gsd-worktrees/),
+ * the legacy direct layout (.gsd/worktrees/), and the symlink-resolved
+ * external-state layout used by ~/.gsd/projects/<hash>.
  */
 export function findWorktreeSegment(normalizedPath: string): WorktreeSegment | null {
+  const canonicalMarker = "/.gsd-worktrees/";
+  const canonicalIdx = normalizedPath.indexOf(canonicalMarker);
+  if (canonicalIdx !== -1) {
+    return { gsdIdx: canonicalIdx, afterWorktrees: canonicalIdx + canonicalMarker.length };
+  }
+
   const directMarker = "/.gsd/worktrees/";
   const directIdx = normalizedPath.indexOf(directMarker);
   if (directIdx !== -1) {
@@ -72,7 +79,8 @@ export function isGsdWorktreePath(path: string): boolean {
 export function resolveExternalStateProjectGsdFromWorktreePath(projectPath: string): string | null {
   const normalized = resolve(projectPath).replaceAll("\\", "/");
 
-  // Direct layout — parent state is resolved via repoIdentity(git root).
+  // Canonical/direct layouts — parent state is resolved via repoIdentity(git root).
+  if (normalized.includes("/.gsd-worktrees/")) return null;
   if (normalized.includes("/.gsd/worktrees/") && !normalized.includes("/.gsd/projects/")) {
     return null;
   }
@@ -139,12 +147,15 @@ function resolveProjectRootFromPath(path: string): string {
     return resolveNearestBootstrappedGsdRoot(path) ?? resolveGitWorkingTreeRoot(path) ?? path;
   }
 
+  // Slice at the first `.gsd` boundary, but never past the worktree segment:
+  // in the canonical layout (`<root>/.gsd-worktrees/<MID>/.gsd/...`) the first
+  // `/.gsd/` occurrence is the worktree-local projection dir, not the project
+  // root's state dir.
   const sepChar = path.includes("\\") ? "\\" : "/";
   const gsdMarker = `${sepChar}.gsd${sepChar}`;
   const markerIdx = path.indexOf(gsdMarker);
-  const candidate = markerIdx !== -1
-    ? path.slice(0, markerIdx)
-    : path.slice(0, segment.gsdIdx);
+  const sliceIdx = markerIdx !== -1 ? Math.min(markerIdx, segment.gsdIdx) : segment.gsdIdx;
+  const candidate = path.slice(0, sliceIdx);
 
   const gsdHomeNorm = normalizeWorktreePathForCompare(gsdHome());
   const candidateGsdPath = normalizeWorktreePathForCompare(join(candidate, ".gsd"));

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -6,6 +6,7 @@ import { execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
+import { worktreesDirs } from "./worktree-placement.js";
 import { listWorktrees } from "./worktree-manager.js";
 import { getCurrentBranch } from "./worktree.js";
 
@@ -158,10 +159,12 @@ export function createWorktreeSafetyModule(
       const projectRoot = resolve(input.projectRoot);
       const unitRoot = resolve(input.unitRoot);
       const isolationMode = input.isolationMode ?? "worktree";
-      const expectedRoot = isolationMode === "worktree"
-        ? join(projectRoot, ".gsd", "worktrees", milestoneId)
-        : projectRoot;
-      if (!samePath(unitRoot, expectedRoot)) {
+      // A milestone worktree may live in the canonical container or the
+      // legacy one (pre-placement-change worktrees keep their location).
+      const expectedRoots = isolationMode === "worktree"
+        ? worktreesDirs(projectRoot).map((dir) => join(dir, milestoneId))
+        : [projectRoot];
+      if (!expectedRoots.some((expectedRoot) => samePath(unitRoot, expectedRoot))) {
         return failure(
           "invalid-root",
           isolationMode === "worktree"
@@ -170,7 +173,7 @@ export function createWorktreeSafetyModule(
           isolationMode === "worktree"
             ? "Prepare the Unit in its canonical milestone worktree before allowing source writes."
             : "Run the Unit from the project root when worktree isolation is disabled.",
-          { expectedRoot, unitRoot },
+          { expectedRoot: expectedRoots[0], unitRoot },
         );
       }
 

--- a/src/resources/extensions/gsd/worktree-session-state.ts
+++ b/src/resources/extensions/gsd/worktree-session-state.ts
@@ -1,4 +1,6 @@
 // GSD worktree session state
+import { findWorktreeSegment } from "./worktree-root.js";
+
 let originalCwd: string | null = null;
 
 export function getWorktreeOriginalCwd(): string | null {
@@ -15,21 +17,21 @@ export function clearWorktreeOriginalCwd(): void {
 
 export function ensureWorktreeOriginalCwdFromPath(cwd: string = process.cwd()): string | null {
   if (originalCwd) return originalCwd;
-  const marker = `${/\\/.test(cwd) ? "\\" : "/"}.gsd${/\\/.test(cwd) ? "\\" : "/"}worktrees${/\\/.test(cwd) ? "\\" : "/"}`;
-  const markerIdx = cwd.indexOf(marker);
-  if (markerIdx !== -1) {
-    originalCwd = cwd.slice(0, markerIdx);
+  const segment = findWorktreeSegment(cwd.replaceAll("\\", "/"));
+  if (segment) {
+    originalCwd = cwd.slice(0, segment.gsdIdx);
   }
   return originalCwd;
 }
 
 export function getActiveWorktreeName(): string | null {
   if (!originalCwd) return null;
-  const cwd = process.cwd();
-  const wtDir = `${originalCwd.replace(/[\\/]+$/, "")}/.gsd/worktrees`.replaceAll("\\", "/");
-  const normalizedCwd = cwd.replaceAll("\\", "/");
-  if (!normalizedCwd.startsWith(`${wtDir}/`)) return null;
-  const rel = normalizedCwd.slice(wtDir.length + 1);
-  const name = rel.split("/")[0];
+  const normalizedCwd = process.cwd().replaceAll("\\", "/");
+  const normalizedOriginal = originalCwd.replace(/[\\/]+$/, "").replaceAll("\\", "/");
+  const segment = findWorktreeSegment(normalizedCwd);
+  if (!segment) return null;
+  // Only treat the cwd as an active worktree of OUR project root.
+  if (normalizedCwd.slice(0, segment.gsdIdx) !== normalizedOriginal) return null;
+  const name = normalizedCwd.slice(segment.afterWorktrees).split("/")[0];
   return name || null;
 }

--- a/src/worktree-status-banner.ts
+++ b/src/worktree-status-banner.ts
@@ -67,7 +67,10 @@ function existingPathVariants(path: string): string[] {
 }
 
 function findGsdWorktrees(basePath: string, entries: WorktreeEntry[]): GsdWorktree[] {
-  const roots = existingPathVariants(join(basePath, '.gsd', 'worktrees'))
+  const roots = [
+    ...existingPathVariants(join(basePath, '.gsd-worktrees')),
+    ...existingPathVariants(join(basePath, '.gsd', 'worktrees')),
+  ]
   const worktrees: GsdWorktree[] = []
 
   for (const entry of entries) {
@@ -126,8 +129,9 @@ function branchHasChanges(basePath: string, mainBranch: string, branch: string):
 }
 
 export function showWorktreeStatusBanner(basePath: string): void {
-  const worktreesDir = join(basePath, '.gsd', 'worktrees')
-  if (!existsSync(worktreesDir)) return
+  const hasWorktreesDir = [join(basePath, '.gsd-worktrees'), join(basePath, '.gsd', 'worktrees')]
+    .some((dir) => existsSync(dir))
+  if (!hasWorktreesDir) return
 
   const entries = parseWorktreeList(gitExec(basePath, ['worktree', 'list', '--porcelain']))
   const worktrees = findGsdWorktrees(basePath, entries)


### PR DESCRIPTION
## Linked issue

<!-- Issue creation is blocked for this session; maintainer to link or create. -->

Closes #

- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Collapses scattered worktree path logic into two seams (placement + identity) and moves the canonical worktree location to `<root>/.gsd-worktrees/`, off the external-state `.gsd` symlink.
**Why:** Three modules independently re-derived "is this a GSD worktree", and worktree creation under the external-state layout materialized working copies inside `~/.gsd/projects/<hash>/` behind an opaque path.
**How:** New `worktree-placement.ts` owns project+name → physical path (canonical-first, legacy-aware); `worktree-root.ts` owns path → project identity and learns the canonical marker; all former ad-hoc call sites route through these seams.

## What

Two commits:

**1. `refactor(gsd): collapse worktree path-identity detection into worktree-root seam`**
`paths.ts` `isInsideGsdWorktree` (own marker matching, missing the external-state layout), `auto-worktree.ts` `escapeStaleWorktree` (string-slice heuristic with a narrower hash regex), and `commands/catalog.ts` (verbatim copies of `findWorktreeSegment` / `resolveProjectRootFromGitFile`) now all route through `worktree-root.ts`.

**2. `refactor(gsd): introduce worktree-placement seam with canonical .gsd-worktrees/ location`**
New `worktree-placement.ts` exports `canonicalWorktreesDir` / `legacyWorktreesDir` / `worktreesDirs` / `worktreePathFor`. Creation always targets `<root>/.gsd-worktrees/<name>`; resolution prefers an existing legacy worktree of the same name; listing, containment checks, doctor checks, safety validation, write-gate, banner, and teardown accept both containers. ~30 call sites across worktree-manager, worktree-safety, doctor, migrate, parallel-merge, exec-tool, bg-shell, mcp-server, and the status banner stop hardcoding `.gsd/worktrees/`.

## Why

Under the external-state layout (`.gsd → ~/.gsd/projects/<hash>/`), the legacy `.gsd/worktrees/<name>` location crosses the symlink: working copies land in the user's home directory behind an opaque hash path, invisible next to the project. The canonical sibling keeps worktrees at the project root regardless of where `.gsd` state lives. Independently, three copies of path-identity logic had already drifted (different markers, narrower regexes) — layout knowledge now lives in one module per direction.

## How

Forward direction (project + name → path) lives in `worktree-placement.ts`; reverse direction (path → project root) stays in `worktree-root.ts`, which gains the `.gsd-worktrees` marker and now slices project roots at the worktree segment so a worktree-local `.gsd` projection dir is not mistaken for the project state dir. Migration is recognition-based rather than data-moving: existing legacy worktrees keep working (resolution, merge, teardown) and only newly created worktrees use the canonical location, so in-flight milestones survive the upgrade with no migration step.

## Change type

- [x] `refactor` — Code restructuring (no behavior change)

Note: placement of *newly created* worktrees does change (`.gsd-worktrees/` instead of `.gsd/worktrees/`); existing worktrees are unaffected.

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

Legacy worktree locations remain fully recognized for resolution, listing, containment, and teardown.

## Test plan

- [x] CI passes
- [x] New/updated tests included

All 8 touched worktree test files pass locally (99 tests across registry, repair, lifecycle, manager, reentry, safety, symlink-removal, teardown-safety), including new canonical-location and legacy-recognition coverage. `tsc --noEmit --incremental false` is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783652190&installation_id=134682257&pr_number=637&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F637&signature=4b6b6441492e5141b7707dc823332e44ac054f6eb2dd369f1fafb717e8a499bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worktree create/resolve, safety validation, write-gate, and MCP tool base paths—core to where agents write code; legacy recognition limits breakage but mis-resolution could still route writes to the wrong root.
> 
> **Overview**
> Introduces **ADR-031** and a **`worktree-placement.ts`** seam so **new** milestone worktrees are created under `<projectRoot>/.gsd-worktrees/<name>` (a sibling of `.gsd` that does not cross the external-state symlink), while **legacy** `<projectRoot>/.gsd/worktrees/` paths stay recognized for resolution, safety, listing, and teardown.
> 
> **`worktree-root.ts`** becomes the sole reverse identity seam: `findWorktreeSegment` learns the canonical marker, and project-root slicing avoids mistaking a worktree-local `.gsd/` dir for the project state dir. Scattered duplicate detectors in `paths.ts`, `auto-worktree.ts`, `commands/catalog.ts`, `captures.ts`, `exec-tool.ts`, bg-shell, MCP workflow tools, and others are removed or routed through these two modules.
> 
> **`worktree-manager.ts`** always creates in the canonical container, resolves paths via `worktreePathFor` (canonical with `.git` wins; stale canonical dirs must not block legacy), scans both containers, and cleans stale canonical dirs before `git worktree add` when legacy was just removed. **Worktree Safety**, write-gate, doctor, parallel merge/monitor, migration guards, and gitignore/runtime exclusion lists are updated for dual-container behavior and a dedicated `.gsd-worktrees/` ignore entry.
> 
> **`worktree-git-recovery.ts`** is extracted from `auto-worktree.ts` (checkout/stash/merge-state recovery); behavior is re-exported for existing callers. Docs amend ADR-002/016 and **CONTEXT.md** to record the shipped external-state layout and placement module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f491420b92e7ba1b54d1858dd7dbf51c2986554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->