### PR TITLE
refactor(gsd): route worktree placement call sites through the seam and restore legacy coverage

### DIFF
--- a/docs/dev/ADR-031-worktree-placement.md
+++ b/docs/dev/ADR-031-worktree-placement.md
@@ -43,7 +43,9 @@ In-flight milestones must survive upgrades. The legacy container (`<projectRoot>
 
 `worktree-placement.ts` owns the forward direction (project root + name → physical path): `CANONICAL_WORKTREES_DIRNAME`, `canonicalWorktreesDir`, `legacyWorktreesDir`, `worktreesDirs`, `worktreePathFor`. `worktree-manager.ts` re-exports basePath-resolving wrappers (`worktreesDir`, `allWorktreesDirs`, `worktreePath`).
 
-The reverse direction (path → project identity) stays in `worktree-root.ts`: `findWorktreeSegment` is the **only** marker-matching implementation, now recognizing three layouts — canonical (`/.gsd-worktrees/`), legacy direct (`/.gsd/worktrees/`), and external-state (`~/.gsd/projects/<hash>/worktrees/`). The duplicate detectors listed in Context were deleted and routed through this seam.
+The reverse direction (path → project identity) stays in `worktree-root.ts`: `findWorktreeSegment` is the **only** marker-matching implementation, now recognizing three layouts — canonical (`/.gsd-worktrees/`), legacy direct (`/.gsd/worktrees/`), and external-state (`~/.gsd/projects/<hash>/worktrees/`). `projectRootFromWorktreePath` is the thin path→root-prefix helper over it; the duplicate detectors listed in Context (`escapeStaleWorktree`, `parseWorktreeBase`, `doctor-environment`, `captures`, `worktree-session-state`) were deleted and routed through it.
+
+Two consumers cannot import the seam and keep deliberate, comment-pinned copies that must be hand-synchronized when a layout changes: `bg-shell/utilities.ts` mirrors the reverse marker regexes (bg-shell does not import the gsd extension), and `packages/mcp-server`'s `worktreeContainers` mirrors the forward container pair (the MCP server cannot statically import the extension tree).
 
 ### 4. Decision-record reconciliation
 
@@ -60,6 +62,6 @@ Documented here because they were previously undocumented load-bearing behavior:
 
 - New milestone worktrees appear at `<projectRoot>/.gsd-worktrees/<MID>` — visible, findable, project-local.
 - Existing legacy worktrees keep working: resolution, safety validation, merge, teardown, and doctor repair all accept both containers. No migration step is required; legacy worktrees age out as milestones complete.
-- A new layout (if ever needed) is taught in exactly two places: `worktree-placement.ts` (forward) and `findWorktreeSegment` (reverse).
+- A new layout (if ever needed) is taught in two seam files — `worktree-placement.ts` (forward) and `findWorktreeSegment` (reverse) — plus the two comment-pinned boundary copies that cannot import the seam: `bg-shell/utilities.ts` (reverse) and `packages/mcp-server`'s `worktreeContainers` (forward).
 - The HOME-detection guard in `worktree-root.ts` and the stale-worktree escape heuristic remain for legacy paths; they are dead weight for canonical paths and can be retired with the legacy layout.
 - `.gitignore` in existing projects gains the `.gsd-worktrees/` entry via the idempotent `ensureGitignore` bootstrap; the doctor flags it when missing.


### PR DESCRIPTION
## Intent

Follow-up to merged PR #637 (worktree placement seam). Two commits: (1) simplify-pass cleanups found by a 4-angle review of the placement diff — export projectRootFromWorktreePath from worktree-root and route the five hand-rolled normalize→findWorktreeSegment→slice call sites through it (captures, doctor-environment, worktree-session-state, escapeStaleWorktree, exec-tool); restore shell completion's zero-I/O fast path for non-worktree cwds (resolveWorktreeProjectRoot's directory-walk fallback was added to every TAB keypress); resolve the worktree path once per worker per 5s tick in the parallel monitor overlay instead of three times; getAutoWorktreePath calls worktreePathFor directly instead of re-resolving the project root; worktree-status-banner and migrate/safety use the placement seam instead of inlining the container pair; mcp-server's boundary copy and bg-shell's regexes get sync-pinning comments naming the seam (deliberate: mcp-server cannot statically import the extension tree, bg-shell does not import the gsd extension); drop the checkoutBranchWithStashGuard re-export shim — auto-start and the stash-guard test import worktree-git-recovery directly; auto-start's container predicate recognizes the external-state container dir again (case dropped during the seam migration); remove a leftover bare block in doctor-runtime-checks. (2) restore legacy external-state worktree regression coverage: integration tests that create legacy .gsd/worktrees/ worktrees explicitly with raw git (canonical creation never crosses the symlink) covering merge cleanup (#2156/#1852) and detection after module state reset.

## What Changed

- Exported `projectRootFromWorktreePath` from `worktree-root` and routed the five hand-rolled `normalize → findWorktreeSegment → slice` call sites (captures, doctor-environment, worktree-session-state, escapeStaleWorktree, exec-tool) through it; `worktree-status-banner` and `migrate/safety` now call the placement seam instead of inlining the container pair, `getAutoWorktreePath` calls `worktreePathFor` directly, and the parallel monitor overlay resolves the worktree path once per worker per tick.
- Restored shell-completion's zero-I/O fast path for non-worktree cwds, dropped the `checkoutBranchWithStashGuard` re-export shim (auto-start and the stash-guard test import `worktree-git-recovery` directly), re-recognized the external-state container dir in auto-start's predicate, removed a leftover bare block in doctor-runtime-checks, and added sync-pinning comments naming the seam to the mcp-server and bg-shell boundary copies that cannot import the gsd extension tree.
- Restored legacy external-state worktree regression coverage: integration tests that create `.gsd/worktrees/` worktrees with raw git to cover merge cleanup (#2156/#1852) and detection after module state reset, and synced ADR-031 with the boundary-copy follow-ups.

## Risk Assessment

✅ Low: Well-bounded, behavior-preserving refactor whose tricky equivalences (projectRootFromWorktreePath slicing, getAutoWorktreePath double-resolution, restored auto-start container predicate) all check out, plus added regression coverage rather than changed behavior.

## Testing

<code>Installed deps and built workspace packages, then ran the two new regression integration tests plus the existing test suites for every refactored module (worktree-root/placement seam, stash-guard, captures, exec-tool, parallel-monitor, migrate, skill-catalog, auto-start). All passed. The two restored legacy tests directly demonstrate the user intent: each creates a legacy `.gsd/worktrees/&lt;MID&gt;` worktree with raw git, asserts git registered it under external `.gsd` state (the symlink-resolved layout canonical creation never produces), then confirms merge cleanup removes it (#2156/#1852) and structural detection finds it after a module-state reset. Evidence is a CLI transcript of the focused legacy-test runs; no UI surface is involved (this is a CLI/library-internal worktree placement change), so no visual artifact applies. Build regenerated two tracked `.generated.ts` files as a side effect — reverted to leave the tree clean.</code>

<details>
<summary>Evidence: Legacy external-state worktree regression test transcript</summary>

<code>--- detection after module state reset ---&#10;✔ legacy symlink-resolved auto worktree is detected after module state reset (260.7ms)&#10;ℹ tests 1 pass 1 fail 0&#10;--- merge cleanup (#2156/#1852) ---&#10;✔ #2156 (legacy): mergeMilestoneToMain removes external-state worktrees created under .gsd/worktrees/ (940.0ms)&#10;ℹ tests 1 pass 1 fail 0</code>

```text
=== Restored legacy external-state worktree regression coverage (commit 0dcd8950) ===

--- auto-worktree.test.ts: detection after module state reset ---
  ✔ legacy symlink-resolved auto worktree is detected after module state reset (260.73875ms)
✔ auto-worktree lifecycle (261.775084ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0

--- auto-worktree-milestone-merge.test.ts: merge cleanup (#2156/#1852) ---
  ✔ #2156 (legacy): mergeMilestoneToMain removes external-state worktrees created under .gsd/worktrees/ (940.061709ms)
✔ auto-worktree-milestone-merge (941.372541ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/mcp-server/src/workflow-tools.ts:421` - Two boundary copies of the container layout are duplicated outside the placement seam and protected only by sync-pinning comments: packages/mcp-server/src/workflow-tools.ts:421 worktreeContainers() hand-lists [&#39;.gsd-worktrees&#39;, &#39;.gsd/worktrees&#39;] (mcp-server cannot import the extension tree), and src/resources/extensions/bg-shell/utilities.ts:46 mirrors findWorktreeSegment&#39;s regexes. If the worktree layout changes, these must be updated by hand. The comments now name the seam, which is the right mitigation, but the divergence risk remains by design.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts` — 12/12 pass, including new `legacy symlink-resolved auto worktree is detected after module state reset`</code>
- <code>`node --test src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts` — 27/27 pass, including new `#2156 (legacy): mergeMilestoneToMain removes external-state worktrees created under .gsd/worktrees/`</code>
- <code>`--test-name-pattern` focused runs isolating the two restored legacy tests (1/1 pass each) → saved as evidence transcript</code>
- <code>`checkout-branch-stash-guard.test.ts`, `worktree-placement.test.ts`, `worktree-root.test.ts`, `worktree-root-resolution.test.ts` — 17/17 pass (seam + dropped re-export shim import path)</code>
- <code>`captures.test.ts`, `exec-tool.test.ts`, `parallel-monitor-overlay.test.ts`, `migrate-external-worktree.test.ts`, `migrate-safety-audit.test.ts`, `skill-catalog.test.ts` — 73/73 pass (other rerouted call sites)</code>
- <code>`auto-start-orphan-bootstrap.test.ts`, `auto-start-worktree-db-path.test.ts` — 7/7 pass (external-state container predicate)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783680829&installation_id=134682257&pr_number=643&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F643&signature=28ffc262d4ad6286e7a3ca1b0b321605746e6738a20bd5d39536eef4781275cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ADR edits with no runtime behavior change in this diff.
> 
> **Overview**
> **ADR-031** is updated to match the worktree placement seam follow-up: the reverse path→root flow is spelled out as `projectRootFromWorktreePath` over `findWorktreeSegment`, with the former hand-rolled detectors (`escapeStaleWorktree`, `parseWorktreeBase`, `doctor-environment`, `captures`, `worktree-session-state`) noted as removed in favor of that helper.
> 
> The ADR now calls out **two deliberate boundary copies** that cannot import the seam—`bg-shell/utilities.ts` (reverse marker regexes) and `packages/mcp-server`'s `worktreeContainers` (forward container pair)—and revises the “new layout” consequence so changes must stay in sync across the two seam files **plus** those pinned copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5631181174b502a6322aabfe7824e09438325ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->