### PR TITLE
fix(gsd): close the workflow MCP startup race — tool surface readiness at two altitudes (ADR-036)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,9 @@
 - **Worktree State Projection**: directional flow of state files between the project root and the auto-worktree, where one side is authoritative per file class (e.g., project root is authoritative for `completed-units.json` after crash recovery; worktree is authoritative for in-flight artifacts).
 - **Drift**: a state-shape mismatch between DB rows, disk artifacts, and in-memory state that has a known repair. Distinct from a `blocker`, which describes a terminal condition needing human attention or recovery escalation.
 - **Drift catalog**: the discriminated union of drift kinds the State Reconciliation Module recognizes and can repair.
+- **Tool Surface Readiness**: the Tool Contract module's runtime face — verification at SDK session init that the live tool surface (registered tools + MCP server statuses) covers the Unit's required workflow tools, aborting before the first model turn when it does not. Complements the static pre-dispatch gate (`getWorkflowTransportSupportError`), which only proves the MCP launch config is discoverable; the workflow server connects asynchronously after session start, so only the init message can prove registration. See `docs/dev/ADR-036-tool-surface-readiness.md`.
+- **`tool-unavailable` (Recovery kind)**: the Recovery Classification failure kind for a tool call that raced the workflow MCP server's registration (`No such tool available` / a Tool Surface Readiness abort). Transient — action `retry` with bounded attempts and its own exit reason; distinct from `tool-schema`/`tool-contract`, which are deterministic stops. The system retries; the model must never improvise a fallback around a missing workflow tool.
+- **Workflow Bridge Warm-up**: the stdio MCP server's eager load + shape-check of the executor and write-gate bridges at startup. A broken bridge fails the spawn with the actionable error (fail closed) instead of advertising tools that error on first call; a healthy spawn pre-pays the bridge import.
 
 ## Architecture terms adopted for this area
 
@@ -153,6 +156,10 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
   See `docs/dev/ADR-030-two-altitude-state-machine.md`.
 
 - Foreground `/gsd next` and `/gsd auto` runs follow **Closeout Boundary Stop**: after the first durable task, slice, or milestone closeout boundary, the foreground terminal preserves the closeout transcript as the final visible surface instead of replacing it with a terminal roll-up widget. Headless runs may still emit durable terminal completion notifications/widgets for automation.
+
+- Tool availability is enforced at **two altitudes**: the static pre-dispatch gate (launch-config discoverability, name membership) stays at dispatch sites, and **Tool Surface Readiness** verifies the live surface at SDK init before the first model turn. The startup race classifies as the transient `tool-unavailable` Recovery kind (bounded retry), the MCP server fails closed on a broken bridge (Workflow Bridge Warm-up), and per-Unit tool name lists are typed against the `CanonicalWorkflowToolName` literal union so drift fails typecheck. The fold of the four static-gate call sites into one helper is deferred.
+
+  See `docs/dev/ADR-036-tool-surface-readiness.md`.
 
 - Worktree placement deepens behind the **Worktree Placement module**: new worktrees are created at the Canonical Worktree Container (`<projectRoot>/.gsd-worktrees/<MID>`), the Legacy Worktree Container stays recognized for in-flight worktrees, and `findWorktreeSegment` (worktree-root.ts) is the only marker-matching implementation — new layouts are taught in exactly two places (placement forward, worktree-root reverse). ADR-002's "no external state directory exists" closure is amended: the External State Layout shipped.
 

--- a/docs/dev/ADR-036-tool-surface-readiness.md
+++ b/docs/dev/ADR-036-tool-surface-readiness.md
@@ -1,0 +1,52 @@
+# ADR-036: Tool Surface Readiness — close the MCP startup race at two altitudes
+
+**Status:** Accepted (implemented)
+**Date:** 2026-06-10
+**Deciders:** Jeremy McSpadden
+**Related:** ADR-008 (workflow tools over MCP for provider parity), ADR-015 (runtime invariant modules: Tool Contract, Recovery Classification)
+
+## Context
+
+The workflow MCP server (`packages/mcp-server`) registers the 29-tool workflow surface for SDK-driven Claude Code sessions, but it connects **asynchronously after session start**. A Unit whose prompt requires `gsd_uat_exec` could begin its first model turn before the server finished registering; the model then hit `No such tool available: mcp__gsd-workflow__gsd_uat_exec` mid-Unit and improvised (e.g. running UAT checks through Bash, silently skipping the typed evidence and journal writes that `gsd_uat_exec` owns).
+
+Four independent gaps let the race through:
+
+1. The ADR-008 phase-5 pre-dispatch gate (`getWorkflowTransportSupportError`) is **static** — it proves the MCP launch config is discoverable and the required names belong to a compiled-in surface list. It never observes the live session's registered tools, because at pre-dispatch time the session does not exist yet.
+2. `"No such tool available"` was pattern-matched (`auto-tool-tracking.ts`) but lumped into the **deterministic** invocation-error bucket: auto-mode paused with "retrying cannot resolve this deterministic failure" — exactly backwards for a transient startup race. Recovery Classification had no kind for it.
+3. The MCP server **lazy-loaded** its executor and write-gate bridges on first tool call, so a broken bridge connected cleanly and advertised tools that all error mid-Unit.
+4. Tool **naming knowledge** was spread across four homes (contracts package, hand-maintained per-Unit string lists, two MCP-prefix parser implementations, hardcoded test strings), so drift between a Unit's required list and the real surface failed at runtime, not typecheck.
+
+## Decision
+
+Enforce tool availability at **two altitudes**, classify the race as **transient**, and make the server **fail closed**:
+
+1. **Static altitude (unchanged seam).** `getWorkflowTransportSupportError` stays the pre-dispatch fast path: launch-config discoverability and name membership.
+2. **Runtime altitude — Tool Surface Readiness.** The Tool Contract module gains a runtime face, `getToolSurfaceReadinessError` (`tool-surface-readiness.ts`). The claude-code stream adapter checks the SDK init message's live `tools` and `mcp_servers` statuses against the Unit's required workflow tools and **aborts before the first model turn** when the workflow server failed or has not registered a required tool. The init message is the one observation point where the session reports its live surface.
+3. **`tool-unavailable` Recovery kind.** The readiness abort and the raw `No such tool available` error both classify as `tool-unavailable` → `retry` (own exit reason / telemetry bucket). `error-classifier` treats the readiness phrase as transient (same-model retry, short delay); post-unit verification routes the raw error into the existing **bounded** verification retry instead of pausing. The system retries; the model never improvises.
+4. **Workflow bridge warm-up (fail closed).** The stdio CLI eagerly loads and shape-checks the executor and write-gate bridges at startup (`warmWorkflowToolBridges`). A broken bridge fails the spawn with the actionable bridge error — visible in the SDK's MCP server status, where the runtime gate (2) turns it into a typed pre-turn failure. A healthy spawn pre-pays the bridge import, shrinking the race window.
+5. **One naming seam.** Per-Unit tool lists are typed against the literal `CanonicalWorkflowToolName` union derived from `WORKFLOW_TOOL_CONTRACTS`, so name drift fails `tsc`. MCP tool-name parsing has one implementation (`@gsd/pi-ai`); the gsd extension re-exports a typed face over it.
+
+The cross-module phrase contract (`workflow tool surface not ready` recognized by `isToolUnavailableError`, `classifyError`, and `classifyFailure`) is pinned by `tests/tool-surface-readiness.test.ts`.
+
+## Why this decision
+
+- **The interface is the test surface.** Readiness is testable with fake observations (`{tools, mcpServers}`) — no live SDK session needed. The classification chain is table-driven.
+- **Deletion test.** Deleting the readiness face re-scatters availability knowledge across the stream adapter, four dispatch sites, and post-unit recovery — where it lived before, as bugs.
+- **Fail closed matches the Worktree Safety posture** (ADR-016): a server that cannot execute its advertised mutation tools must not present that surface.
+- A retry-after-abort costs one session spawn; an improvised mid-Unit fallback costs silent evidence loss and a human triage loop.
+
+## Trade-offs accepted
+
+- If the SDK reports the workflow server as pending/failed at init but would have connected later in the same session, the gate aborts and retries a fresh session. Bounded retries absorb this; the alternative (waiting mid-session) has no SDK surface to wait on.
+- The stdio CLI now refuses to start when the workflow bridge is unloadable, even for read-only/session-control use. Every supported launch path (stream-adapter env injection, `gsd mcp init` config, repo checkout, built package) has a loadable bridge; a hand-rolled config without one gets the actionable remediation at spawn time instead of a dead tool surface.
+- The four static-gate call sites are not folded into one helper this pass — they share `getWorkflowTransportSupportError` already; folding their option-plumbing is cosmetic and touches four hot dispatch paths. Deferred.
+
+## Implementation status
+
+| Piece | Status | Evidence |
+|---|---|---|
+| Tool Surface Readiness gate | ✅ | `src/resources/extensions/gsd/tool-surface-readiness.ts`; wired in `claude-code-cli/stream-adapter.ts` (`case "system"`) |
+| `tool-unavailable` Recovery kind | ✅ | `recovery-classification.ts`; transient routing in `auto-post-unit.ts`; `error-classifier.ts` |
+| Workflow bridge warm-up | ✅ | `packages/mcp-server/src/workflow-tools.ts` (`warmWorkflowToolBridges`); `cli.ts` fails spawn on broken bridge |
+| Typed naming seam | ✅ | `@opengsd/contracts` `CanonicalWorkflowToolName`; `unit-tool-contracts.ts` typed lists; parser delegated to `@gsd/pi-ai` |
+| Static-gate call-site fold | ⏸ deferred | see trade-offs |

--- a/packages/contracts/src/workflow.ts
+++ b/packages/contracts/src/workflow.ts
@@ -255,6 +255,12 @@ export const WORKFLOW_TOOL_CONTRACTS = [
 	},
 ] as const satisfies readonly WorkflowToolContractMetadata[];
 
+/** Literal union of canonical workflow tool names. Typing a name list with this union makes drift from WORKFLOW_TOOL_CONTRACTS a compile error. */
+export type CanonicalWorkflowToolName = (typeof WORKFLOW_TOOL_CONTRACTS)[number]["canonicalName"];
+
+/** Literal union of backwards-compatibility alias names. */
+export type WorkflowToolAliasName = (typeof WORKFLOW_TOOL_CONTRACTS)[number]["aliases"][number];
+
 export const WORKFLOW_TOOL_NAMES = WORKFLOW_TOOL_CONTRACTS.flatMap((tool) => [
 	tool.canonicalName,
 	...tool.aliases,

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -9,6 +9,7 @@ import { SessionManager } from './session-manager.js';
 import { createMcpServer } from './server.js';
 import { installGlobalErrorHandlers } from './cli-errors.js';
 import { loadStoredCredentialEnvKeys } from './tool-credentials.js';
+import { warmWorkflowToolBridges } from './workflow-tools.js';
 
 const MCP_PKG = '@modelcontextprotocol/sdk';
 
@@ -52,10 +53,12 @@ async function main(): Promise<void> {
   // Handle stdin end — MCP client disconnected
   process.stdin.on('end', () => void cleanup());
 
-  // Connect and start serving
+  // Connect and start serving. The workflow bridges are warmed eagerly so a
+  // broken executor/write-gate module fails the spawn with an actionable
+  // error instead of advertising tools that error on their first call.
   try {
-    await server.connect(transport);
-    process.stderr.write('[gsd-mcp-server] MCP server started on stdio\n');
+    await Promise.all([server.connect(transport), warmWorkflowToolBridges()]);
+    process.stderr.write('[gsd-mcp-server] MCP server started on stdio; workflow bridges ready\n');
   } catch (err) {
     process.stderr.write(
       `[gsd-mcp-server] Fatal: failed to start — ${err instanceof Error ? err.message : String(err)}\n`

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -184,6 +184,32 @@ process.env.GSD_WORKFLOW_WRITE_GATE_MODULE ??= fileURLToPath(new URL(
   import.meta.url,
 ));
 
+describe("warmWorkflowToolBridges", () => {
+  it("resolves when the executor and write-gate bridges load and shape-check", async () => {
+    const { warmWorkflowToolBridges: freshWarm } = await import(
+      cacheBustedWorkflowToolsImport("warm-ok")
+    );
+    await freshWarm();
+  });
+
+  it("rejects with an actionable error when the executor module config is broken", async () => {
+    const prevModule = process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
+    try {
+      process.env.GSD_WORKFLOW_EXECUTORS_MODULE = "data:text/javascript,export default {}";
+      const { warmWorkflowToolBridges: freshWarm } = await import(
+        cacheBustedWorkflowToolsImport("warm-broken")
+      );
+      await assert.rejects(freshWarm(), /only supports file: URLs or filesystem paths/);
+    } finally {
+      if (prevModule === undefined) {
+        delete process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
+      } else {
+        process.env.GSD_WORKFLOW_EXECUTORS_MODULE = prevModule;
+      }
+    }
+  });
+});
+
 describe("workflow MCP tools", () => {
   it("registers the full headless-safe workflow tool surface", () => {
     const server = makeMockServer();

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -735,6 +735,18 @@ async function getWorkflowToolExecutors(): Promise<WorkflowToolExecutors> {
   return workflowToolExecutorsPromise;
 }
 
+/**
+ * Eagerly load and shape-check the workflow executor and write-gate bridges.
+ * The stdio CLI awaits this at startup so a broken bridge fails the spawn
+ * with an actionable error instead of presenting an available-looking tool
+ * surface that errors on the first call. Shares the cached promises the tool
+ * handlers use, so a successful warm-up also removes first-call import latency.
+ */
+export async function warmWorkflowToolBridges(): Promise<void> {
+  await getWorkflowToolExecutors();
+  await getWorkflowWriteGateModule();
+}
+
 async function getWorkflowWriteGateModule(): Promise<WorkflowWriteGateModule> {
   if (!workflowWriteGatePromise) {
     workflowWriteGatePromise = (async () => {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -59,6 +59,7 @@ import {
 	computeMcpDisallowedTools,
 } from "../gsd/mcp-filter.js";
 import { RUN_UAT_CLAUDE_NATIVE_TOOL_NAMES, RUN_UAT_FORBIDDEN_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES, resolveToolPresentationPlan } from "../gsd/tool-presentation-plan.js";
+import { getToolSurfaceReadinessError } from "../gsd/tool-surface-readiness.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
 	SDKAssistantMessage,
@@ -2041,7 +2042,34 @@ async function pumpSdkMessages(
 			switch (msg.type) {
 				// -- Init --
 				case "system": {
-					// Nothing to emit — the stream is already started.
+					// Tool Surface Readiness gate: the init message is the first (and
+					// only) point where the session reports its live tool surface and
+					// MCP server statuses. If the workflow server failed or has not
+					// registered this Unit's required tools, abort before the first
+					// model turn with a transient, recovery-classifiable error
+					// (tool-unavailable → retry) instead of letting the model hit
+					// "No such tool available" mid-Unit and improvise around it.
+					const init = msg as unknown as {
+						subtype?: string;
+						tools?: string[];
+						mcp_servers?: { name: string; status: string }[];
+					};
+					if (init.subtype === "init") {
+						const readinessError = getToolSurfaceReadinessError({
+							unitType: gsdPhase,
+							workflowServerName: workflowMcpServerNameFromAllowedTools(sdkOpts.allowedTools),
+							observation: { tools: init.tools ?? [], mcpServers: init.mcp_servers ?? [] },
+						});
+						if (readinessError) {
+							controller.abort();
+							stream.push({
+								type: "error",
+								reason: "error",
+								error: makeErrorMessage(modelId, readinessError),
+							});
+							return;
+						}
+					}
 					break;
 				}
 

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1999,8 +1999,9 @@ async function pumpSdkMessages(
 					: {}),
 			},
 		);
+		const workflowMcpServerName = workflowMcpServerNameFromAllowedTools(sdkOpts.allowedTools);
 		const prompt = buildPromptFromContext(context, {
-			workflowMcpServerName: workflowMcpServerNameFromAllowedTools(sdkOpts.allowedTools),
+			workflowMcpServerName,
 			browserMcpServerName: browserMcpServerNameFromAllowedTools(sdkOpts.allowedTools),
 		});
 		const queryPrompt = buildSdkQueryPrompt(context, prompt);
@@ -2057,7 +2058,7 @@ async function pumpSdkMessages(
 					if (init.subtype === "init") {
 						const readinessError = getToolSurfaceReadinessError({
 							unitType: gsdPhase,
-							workflowServerName: workflowMcpServerNameFromAllowedTools(sdkOpts.allowedTools),
+							workflowServerName: workflowMcpServerName,
 							observation: { tools: init.tools ?? [], mcpServers: init.mcp_servers ?? [] },
 						});
 						if (readinessError) {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -88,7 +88,7 @@ import { writeTurnGitTransaction } from "./uok/gitops.js";
 import { isClosedStatus } from "./status-guards.js";
 import { detectAbandonMilestone } from "./abandon-detect.js";
 import { getPendingGate } from "./bootstrap/write-gate.js";
-import { isDeterministicPolicyError } from "./auto-tool-tracking.js";
+import { isDeterministicPolicyError, isToolUnavailableError } from "./auto-tool-tracking.js";
 import { formatConnectedStepStack, formatPostUnitStatusCard } from "./auto-status-message.js";
 import {
   clearProjectResearchInflightMarker,
@@ -2022,7 +2022,18 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           "error",
         );
       } else if (!triggerArtifactVerified) {
-        if (s.lastToolInvocationError) {
+        if (s.lastToolInvocationError && isToolUnavailableError(s.lastToolInvocationError)) {
+          // Tool-unavailable is the one transient invocation error: the
+          // workflow MCP server registers its surface asynchronously, so a
+          // Unit's first call can race the registration. Fall through to the
+          // bounded verification retry instead of pausing.
+          debugLog("postUnit", { phase: "tool-unavailable-retry", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
+          ctx.ui.notify(
+            `Tool unavailable for ${s.currentUnit.type}: ${s.lastToolInvocationError}. The tool surface may still be registering — retrying.`,
+            "warning",
+          );
+          s.lastToolInvocationError = null;
+        } else if (s.lastToolInvocationError) {
           const isUserSkip = /queued user message/i.test(s.lastToolInvocationError);
           const errMsg = isUserSkip
             ? `Tool skipped for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Queued user message interrupted the turn — pausing auto-mode.`

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -139,7 +139,7 @@ const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd que
  * Unit's first tool call can race the registration. Callers should retry
  * (bounded) instead of breaking the loop.
  */
-const TOOL_UNAVAILABLE_ERROR_RE = /No such tool available/i;
+const TOOL_UNAVAILABLE_ERROR_RE = /No such tool available|workflow tool surface not ready/i;
 
 /**
  * Returns true if the error message indicates a deterministic invocation or

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -133,12 +133,30 @@ const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation er
 const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
 
 /**
+ * Matches the runtime's "tool not registered" error. Unlike the deterministic
+ * invocation failures above, this one is usually transient: the workflow MCP
+ * server registers its tool surface asynchronously after session start, so a
+ * Unit's first tool call can race the registration. Callers should retry
+ * (bounded) instead of breaking the loop.
+ */
+const TOOL_UNAVAILABLE_ERROR_RE = /No such tool available/i;
+
+/**
  * Returns true if the error message indicates a deterministic invocation or
  * policy failure (as opposed to a normal tool execution error).
  */
 export function isToolInvocationError(errorMsg: string): boolean {
   if (!errorMsg) return false;
   return TOOL_INVOCATION_ERROR_RE.test(errorMsg) || isDeterministicPolicyError(errorMsg);
+}
+
+/**
+ * Returns true if the error message indicates the called tool was not on the
+ * session's tool surface (MCP startup race — see TOOL_UNAVAILABLE_ERROR_RE).
+ */
+export function isToolUnavailableError(errorMsg: string): boolean {
+  if (!errorMsg) return false;
+  return TOOL_UNAVAILABLE_ERROR_RE.test(errorMsg);
 }
 
 /**

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -5,6 +5,7 @@
  */
 
 import { stripMcpToolPrefix } from "@gsd/pi-ai";
+import { TOOL_SURFACE_NOT_READY } from "./tool-surface-readiness.js";
 
 interface InFlightTool {
   startedAt: number;
@@ -139,7 +140,7 @@ const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd que
  * Unit's first tool call can race the registration. Callers should retry
  * (bounded) instead of breaking the loop.
  */
-const TOOL_UNAVAILABLE_ERROR_RE = /No such tool available|workflow tool surface not ready/i;
+const TOOL_UNAVAILABLE_ERROR_RE = new RegExp(`No such tool available|${TOOL_SURFACE_NOT_READY}`, "i");
 
 /**
  * Returns true if the error message indicates a deterministic invocation or

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -70,6 +70,10 @@ const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side close
 const STREAM_RE = /in JSON at position \d+|Unexpected end of JSON|SyntaxError.*JSON/i;
 const RESET_DELAY_RE = /reset in (\d+)s/i;
 const TOOL_SCHEMA_RE = /schema overload|consecutive tool validation failures/i;
+// GSD tool-surface readiness abort (claude-code stream adapter): the workflow
+// MCP server had not registered the Unit's required tools at SDK init. The
+// server typically finishes connecting within seconds — same-model retry.
+const TOOL_SURFACE_NOT_READY_RE = /workflow tool surface not ready/i;
 // Provider rejected the request shape for the selected model (400 bad request,
 // grammar limits, etc.). Not transient — try a different model/fallback.
 // Context-window 400s stay in SERVER_RE (checked earlier).
@@ -106,6 +110,11 @@ export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorCla
   // Checked early to prevent misclassification as unknown/provider error.
   if (TOOL_SCHEMA_RE.test(errorMsg)) {
     return { kind: "tool-schema", retryAfterMs: 0 };
+  }
+
+  // Tool-surface readiness abort — transient; retry the same model shortly.
+  if (TOOL_SURFACE_NOT_READY_RE.test(errorMsg)) {
+    return { kind: "network", retryAfterMs: retryAfterMs ?? 3_000 };
   }
 
   const isPermanent = PERMANENT_RE.test(errorMsg);

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -10,6 +10,8 @@
  * @see https://github.com/open-gsd/gsd-pi/issues/2577
  */
 
+import { TOOL_SURFACE_NOT_READY } from "./tool-surface-readiness.js";
+
 // ── ErrorClass discriminated union ──────────────────────────────────────────
 
 export type ErrorClass =
@@ -73,7 +75,7 @@ const TOOL_SCHEMA_RE = /schema overload|consecutive tool validation failures/i;
 // GSD tool-surface readiness abort (claude-code stream adapter): the workflow
 // MCP server had not registered the Unit's required tools at SDK init. The
 // server typically finishes connecting within seconds — same-model retry.
-const TOOL_SURFACE_NOT_READY_RE = /workflow tool surface not ready/i;
+const TOOL_SURFACE_NOT_READY_RE = new RegExp(TOOL_SURFACE_NOT_READY, "i");
 // Provider rejected the request shape for the selected model (400 bad request,
 // grammar limits, etc.). Not transient — try a different model/fallback.
 // Context-window 400s stay in SERVER_RE (checked earlier).

--- a/src/resources/extensions/gsd/mcp-tool-name.ts
+++ b/src/resources/extensions/gsd/mcp-tool-name.ts
@@ -1,5 +1,7 @@
 // Project/App: gsd-pi
-// File Purpose: Shared parsing and formatting helpers for MCP-scoped tool names.
+// File Purpose: GSD-facing face over the shared @gsd/pi-ai MCP tool-name helpers.
+
+import { parseMcpToolName as parsePiAiMcpToolName, stripMcpToolPrefix } from "@gsd/pi-ai";
 
 const MCP_TOOL_PREFIX = "mcp__";
 
@@ -9,18 +11,11 @@ export interface ParsedMcpToolName {
 }
 
 export function parseMcpToolName(toolName: string): ParsedMcpToolName | null {
-  if (!toolName.startsWith(MCP_TOOL_PREFIX)) return null;
-  const toolSeparator = toolName.indexOf("__", MCP_TOOL_PREFIX.length);
-  if (toolSeparator < 0) return null;
-  return {
-    serverName: toolName.slice(MCP_TOOL_PREFIX.length, toolSeparator),
-    toolName: toolName.slice(toolSeparator + 2),
-  };
+  const parsed = parsePiAiMcpToolName(toolName);
+  return parsed ? { serverName: parsed.server, toolName: parsed.tool } : null;
 }
 
-export function stripMcpToolPrefix(toolName: string): string {
-  return parseMcpToolName(toolName)?.toolName ?? toolName;
-}
+export { stripMcpToolPrefix };
 
 export function toMcpToolName(serverName: string, toolName: string): string {
   return `${MCP_TOOL_PREFIX}${serverName}__${toolName}`;

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -1,6 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: ADR-015 Recovery Classification module for runtime failure taxonomy.
 
+import { isToolUnavailableError } from "./auto-tool-tracking.js";
 import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
 import { ReconciliationFailedError } from "./state-reconciliation.js";
 import { IllegalPhaseTransitionError } from "./state-transition-matrix.js";
@@ -8,6 +9,7 @@ import { IllegalPhaseTransitionError } from "./state-transition-matrix.js";
 export type RecoveryFailureKind =
   | "tool-schema"
   | "tool-contract"
+  | "tool-unavailable"
   | "deterministic-policy"
   | "lifecycle-progression"
   | "stale-worker"
@@ -65,6 +67,15 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         reason: `Tool Contract failure${unitSuffix(input)}: ${message}`,
         exitReason: "tool-contract",
         remediation: "Fix the Unit Tool Contract or prompt so the Unit is only asked to use tools owned by its phase.",
+      };
+    case "tool-unavailable":
+      return {
+        failureKind,
+        action: "retry",
+        reason: `Tool unavailable${unitSuffix(input)}: ${message}`,
+        exitReason: "tool-unavailable",
+        remediation:
+          "The tool surface had not finished registering when the Unit called it (workflow MCP startup race). Retry after the surface is ready; escalate if the tool never appears.",
       };
     case "deterministic-policy":
       return {
@@ -149,6 +160,7 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
 }
 
 function inferFailureKind(message: string): RecoveryFailureKind {
+  if (isToolUnavailableError(message)) return "tool-unavailable";
   if (/tool contract|auto-unit tool scope|phase-boundary gate|not permitted.*own/i.test(message)) return "tool-contract";
   if (/lifecycle progression|required artifact|missing .*assessment|missing .*closeout|cannot legally (?:advance|progress)/i.test(message)) return "lifecycle-progression";
   if (/schema|invalid.*tool|tool.*invalid|enum/i.test(message)) return "tool-schema";

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -164,6 +164,7 @@ test("Recovery Classification covers ADR-015 failure families", () => {
   const cases = [
     ["invalid tool schema enum", "tool-schema", "stop"],
     ["Tool Contract failure: complete-slice cannot use gsd_uat_result_save", "tool-contract", "stop"],
+    ["No such tool available: mcp__gsd-workflow__gsd_uat_exec", "tool-unavailable", "retry"],
     ["deterministic policy rejection", "deterministic-policy", "stop"],
     ["cannot legally advance because required UAT Assessment artifact is missing", "lifecycle-progression", "stop"],
     ["stale worker lease", "stale-worker", "stop"],

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -48,6 +48,7 @@ import {
   isDeterministicPolicyError,
   isPendingUserApprovalGateError,
   isToolInvocationError,
+  isToolUnavailableError,
   isQueuedUserMessageSkip,
 } from "../auto-tool-tracking.ts";
 import {
@@ -119,6 +120,13 @@ describe("#2883: isToolInvocationError classification", () => {
 
   test("detects 'No such tool available' error", () => {
     assert.equal(isToolInvocationError("No such tool available: mcp__gsd-workflow__memory_query"), true);
+  });
+
+  test("isToolUnavailableError singles out the startup-race error as transient", () => {
+    assert.equal(isToolUnavailableError("No such tool available: mcp__gsd-workflow__gsd_uat_exec"), true);
+    assert.equal(isToolUnavailableError("Validation failed for tool gsd_complete_slice"), false);
+    assert.equal(isToolUnavailableError("Unexpected end of JSON input"), false);
+    assert.equal(isToolUnavailableError(""), false);
   });
 
   test("detects ESM export-link errors", () => {

--- a/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
@@ -1,0 +1,119 @@
+// Project/App: gsd-pi
+// File Purpose: Contract coverage for the Tool Surface Readiness gate and its recovery classification.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { getToolSurfaceReadinessError } from "../tool-surface-readiness.ts";
+import { isToolUnavailableError } from "../auto-tool-tracking.ts";
+import { classifyError, isTransient } from "../error-classifier.ts";
+import { classifyFailure } from "../recovery-classification.ts";
+
+const SERVER = "gsd-workflow";
+
+function prefixed(tool: string): string {
+  return `mcp__${SERVER}__${tool}`;
+}
+
+const RUN_UAT_TOOLS = [
+  "gsd_uat_exec",
+  "gsd_uat_result_save",
+  "gsd_resume",
+  "gsd_milestone_status",
+  "gsd_journal_query",
+];
+
+describe("getToolSurfaceReadinessError", () => {
+  test("returns null when no unit type or no workflow server is in play", () => {
+    const observation = { tools: [], mcpServers: [] };
+    assert.equal(
+      getToolSurfaceReadinessError({ unitType: undefined, workflowServerName: SERVER, observation }),
+      null,
+    );
+    assert.equal(
+      getToolSurfaceReadinessError({ unitType: "run-uat", workflowServerName: undefined, observation }),
+      null,
+    );
+  });
+
+  test("returns null for units with no required workflow tools", () => {
+    const error = getToolSurfaceReadinessError({
+      unitType: "rewrite-docs",
+      workflowServerName: SERVER,
+      observation: { tools: [], mcpServers: [{ name: SERVER, status: "failed" }] },
+    });
+    assert.equal(error, null);
+  });
+
+  test("returns null when the workflow server is not part of the session", () => {
+    const error = getToolSurfaceReadinessError({
+      unitType: "run-uat",
+      workflowServerName: SERVER,
+      observation: { tools: ["read", "bash"], mcpServers: [{ name: "other-server", status: "connected" }] },
+    });
+    assert.equal(error, null);
+  });
+
+  test("returns null when all required tools are registered under the MCP prefix", () => {
+    const error = getToolSurfaceReadinessError({
+      unitType: "run-uat",
+      workflowServerName: SERVER,
+      observation: {
+        tools: ["read", ...RUN_UAT_TOOLS.map(prefixed)],
+        mcpServers: [{ name: SERVER, status: "connected" }],
+      },
+    });
+    assert.equal(error, null);
+  });
+
+  test("reports the failed server and the missing tools when the surface never registered", () => {
+    const error = getToolSurfaceReadinessError({
+      unitType: "run-uat",
+      workflowServerName: SERVER,
+      observation: { tools: ["read", "bash"], mcpServers: [{ name: SERVER, status: "failed" }] },
+    });
+    assert.ok(error, "expected a readiness error");
+    assert.match(error, /workflow tool surface not ready for run-uat/);
+    assert.match(error, /status is "failed"/);
+    assert.match(error, /gsd_uat_exec/);
+  });
+
+  test("reports partially-registered surfaces even when the server says connected", () => {
+    const error = getToolSurfaceReadinessError({
+      unitType: "run-uat",
+      workflowServerName: SERVER,
+      observation: {
+        tools: [prefixed("gsd_uat_exec")],
+        mcpServers: [{ name: SERVER, status: "connected" }],
+      },
+    });
+    assert.ok(error, "expected a readiness error");
+    assert.match(error, /connected but has not registered/);
+    assert.match(error, /gsd_uat_result_save/);
+    assert.doesNotMatch(error, /gsd_uat_exec,/);
+  });
+});
+
+describe("readiness error classification contract", () => {
+  const readinessError = getToolSurfaceReadinessError({
+    unitType: "run-uat",
+    workflowServerName: SERVER,
+    observation: { tools: [], mcpServers: [{ name: SERVER, status: "pending" }] },
+  })!;
+
+  test("auto-tool-tracking treats the readiness error as tool-unavailable", () => {
+    assert.equal(isToolUnavailableError(readinessError), true);
+  });
+
+  test("error-classifier treats the readiness error as transient", () => {
+    const cls = classifyError(`Claude Code error: ${readinessError}`);
+    assert.equal(isTransient(cls), true);
+  });
+
+  test("Recovery Classification maps the readiness error to tool-unavailable → retry", () => {
+    const recovery = classifyFailure({ error: new Error(readinessError), unitType: "run-uat", unitId: "M001" });
+    assert.equal(recovery.failureKind, "tool-unavailable");
+    assert.equal(recovery.action, "retry");
+    assert.equal(recovery.exitReason, "tool-unavailable");
+  });
+});

--- a/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
@@ -46,13 +46,16 @@ describe("getToolSurfaceReadinessError", () => {
     assert.equal(error, null);
   });
 
-  test("returns null when the workflow server is not part of the session", () => {
+  test("returns an error when the expected workflow server is absent from the init surface", () => {
     const error = getToolSurfaceReadinessError({
       unitType: "run-uat",
       workflowServerName: SERVER,
       observation: { tools: ["read", "bash"], mcpServers: [{ name: "other-server", status: "connected" }] },
     });
-    assert.equal(error, null);
+    assert.ok(error, "expected a readiness error when the workflow server is absent");
+    assert.match(error, /workflow tool surface not ready for run-uat/);
+    assert.match(error, /absent from the init surface/);
+    assert.match(error, /gsd_uat_exec/);
   });
 
   test("returns null when all required tools are registered under the MCP prefix", () => {

--- a/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
@@ -7,12 +7,13 @@ import assert from "node:assert/strict";
 import { getToolSurfaceReadinessError } from "../tool-surface-readiness.ts";
 import { isToolUnavailableError } from "../auto-tool-tracking.ts";
 import { classifyError, isTransient } from "../error-classifier.ts";
+import { toMcpToolName } from "../mcp-tool-name.ts";
 import { classifyFailure } from "../recovery-classification.ts";
 
 const SERVER = "gsd-workflow";
 
 function prefixed(tool: string): string {
-  return `mcp__${SERVER}__${tool}`;
+  return toMcpToolName(SERVER, tool);
 }
 
 const RUN_UAT_TOOLS = [

--- a/src/resources/extensions/gsd/tool-surface-readiness.ts
+++ b/src/resources/extensions/gsd/tool-surface-readiness.ts
@@ -1,0 +1,60 @@
+// Project/App: gsd-pi
+// File Purpose: Tool Contract module's runtime face — verify the live SDK tool surface covers a Unit's required workflow tools.
+
+import { mcpToolMatchesBaseName } from "./mcp-tool-name.js";
+import { getRequiredWorkflowToolsForUnit } from "./unit-tool-contracts.js";
+import { isWorkflowToolSurfaceName } from "./workflow-tool-surface.js";
+
+/**
+ * Stable phrase recognized as transient by auto-tool-tracking's
+ * isToolUnavailableError and error-classifier's transient buckets —
+ * keep the three in sync.
+ */
+export const TOOL_SURFACE_NOT_READY = "workflow tool surface not ready";
+
+export interface LiveToolSurfaceObservation {
+  /** Tool names the session reported at init (MCP tools appear as mcp__<server>__<tool>). */
+  tools: readonly string[];
+  /** MCP server connection statuses the session reported at init. */
+  mcpServers: readonly { name: string; status: string }[];
+}
+
+/**
+ * Verify the live tool surface observed at SDK session init covers the Unit's
+ * required workflow tools. Complements the static pre-dispatch gate
+ * (getWorkflowTransportSupportError), which only proves the MCP launch config
+ * is discoverable — the workflow server connects asynchronously after session
+ * start, so the static gate cannot see whether the tools actually registered.
+ *
+ * Returns a transient, recovery-classifiable error (kind tool-unavailable →
+ * retry) when the workflow server failed or has not yet registered a required
+ * tool, so dispatch aborts before the first model turn instead of letting the
+ * Unit improvise around "No such tool available". Returns null when no
+ * workflow server is part of this session (native tool path), when the Unit
+ * requires no workflow tools, or when the surface is ready.
+ */
+export function getToolSurfaceReadinessError(input: {
+  unitType: string | undefined;
+  workflowServerName: string | undefined;
+  observation: LiveToolSurfaceObservation;
+}): string | null {
+  const { unitType, workflowServerName, observation } = input;
+  if (!unitType || !workflowServerName) return null;
+
+  const required = getRequiredWorkflowToolsForUnit(unitType).filter(isWorkflowToolSurfaceName);
+  if (required.length === 0) return null;
+
+  const server = observation.mcpServers.find((entry) => entry.name === workflowServerName);
+  if (!server) return null;
+
+  const missing = required.filter(
+    (tool) => !observation.tools.some((name) => name === tool || mcpToolMatchesBaseName(name, tool)),
+  );
+  if (missing.length === 0) return null;
+
+  const serverDetail =
+    server.status === "connected"
+      ? `MCP server "${workflowServerName}" is connected but has not registered`
+      : `MCP server "${workflowServerName}" status is "${server.status}" and it has not registered`;
+  return `${TOOL_SURFACE_NOT_READY} for ${unitType}: ${serverDetail}: ${missing.join(", ")}`;
+}

--- a/src/resources/extensions/gsd/tool-surface-readiness.ts
+++ b/src/resources/extensions/gsd/tool-surface-readiness.ts
@@ -7,8 +7,8 @@ import { isWorkflowToolSurfaceName } from "./workflow-tool-surface.js";
 
 /**
  * Stable phrase recognized as transient by auto-tool-tracking's
- * isToolUnavailableError and error-classifier's transient buckets —
- * keep the three in sync.
+ * isToolUnavailableError and error-classifier's transient buckets,
+ * which build their matchers from this constant.
  */
 export const TOOL_SURFACE_NOT_READY = "workflow tool surface not ready";
 

--- a/src/resources/extensions/gsd/tool-surface-readiness.ts
+++ b/src/resources/extensions/gsd/tool-surface-readiness.ts
@@ -45,7 +45,9 @@ export function getToolSurfaceReadinessError(input: {
   if (required.length === 0) return null;
 
   const server = observation.mcpServers.find((entry) => entry.name === workflowServerName);
-  if (!server) return null;
+  if (!server) {
+    return `${TOOL_SURFACE_NOT_READY} for ${unitType}: MCP server "${workflowServerName}" is absent from the init surface (not yet connected): ${required.join(", ")}`;
+  }
 
   const missing = required.filter(
     (tool) => !observation.tools.some((name) => name === tool || mcpToolMatchesBaseName(name, tool)),

--- a/src/resources/extensions/gsd/unit-tool-contracts.ts
+++ b/src/resources/extensions/gsd/unit-tool-contracts.ts
@@ -210,7 +210,7 @@ export function getUnitToolSurfaceContract(unitType: string): UnitToolSurfaceCon
   return UNIT_TOOL_CONTRACTS[unitType];
 }
 
-export function getRequiredWorkflowToolsForUnit(unitType: string): string[] {
+export function getRequiredWorkflowToolsForUnit(unitType: string): UnitWorkflowToolName[] {
   return [...(UNIT_TOOL_CONTRACTS[unitType]?.requiredWorkflowTools ?? [])];
 }
 

--- a/src/resources/extensions/gsd/unit-tool-contracts.ts
+++ b/src/resources/extensions/gsd/unit-tool-contracts.ts
@@ -1,9 +1,17 @@
 // Project/App: gsd-pi
 // File Purpose: Central Unit-to-tool contracts for phase-aware GSD tool surfaces.
 
+import type { CanonicalWorkflowToolName } from "@opengsd/contracts";
+import type { WorkflowMcpAdapterToolName } from "./workflow-tool-surface.js";
+
+/** Workflow-surface names a Unit contract may reference. Drift from WORKFLOW_TOOL_CONTRACTS fails typecheck. */
+export type UnitWorkflowToolName = CanonicalWorkflowToolName | WorkflowMcpAdapterToolName;
+
+export type UnitGsdToolName = UnitWorkflowToolName | "subagent";
+
 export interface UnitToolSurfaceContract {
-  allowedGsdTools: readonly string[];
-  requiredWorkflowTools: readonly string[];
+  allowedGsdTools: readonly UnitGsdToolName[];
+  requiredWorkflowTools: readonly UnitWorkflowToolName[];
   forbiddenGsdTools?: Readonly<Record<string, string>>;
 }
 

--- a/src/resources/extensions/gsd/workflow-tool-surface.ts
+++ b/src/resources/extensions/gsd/workflow-tool-surface.ts
@@ -28,7 +28,7 @@ export const WORKFLOW_TOOL_ALIAS_PAIRS: readonly WorkflowToolAliasPair[] =
 export const WORKFLOW_TOOL_ALIAS_TO_CANONICAL: Readonly<Record<string, string>> =
   Object.fromEntries(WORKFLOW_TOOL_ALIAS_PAIRS.map(({ alias, canonical }) => [alias, canonical]));
 
-const WORKFLOW_MCP_ADAPTER_TOOL_NAMES = [
+export const WORKFLOW_MCP_ADAPTER_TOOL_NAMES = [
   "gsd_cancel",
   "gsd_captures",
   "ask_user_questions",
@@ -44,6 +44,9 @@ const WORKFLOW_MCP_ADAPTER_TOOL_NAMES = [
   "gsd_roadmap",
   "gsd_status",
 ] as const;
+
+/** Session-orchestration tools exposed by the workflow MCP adapter alongside the contract tools. */
+export type WorkflowMcpAdapterToolName = (typeof WORKFLOW_MCP_ADAPTER_TOOL_NAMES)[number];
 
 export const WORKFLOW_TOOL_SURFACE_NAMES = [
   ...WORKFLOW_MCP_ADAPTER_TOOL_NAMES,


### PR DESCRIPTION
## Linked issue

Closes #646

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Closes the workflow MCP startup race — tool availability is now enforced at two altitudes (static pre-dispatch + live surface at SDK init), the race classifies as a transient `tool-unavailable` Recovery kind, the MCP server fails closed on a broken bridge, and per-Unit tool name lists are typed against the contracts package.
**Why:** A Unit's first tool call could race the workflow MCP server's async registration; the model hit `No such tool available: mcp__gsd-workflow__gsd_uat_exec` mid-Unit and improvised Bash fallbacks, silently skipping typed UAT evidence writes.
**How:** New Tool Surface Readiness gate checked at the SDK init message before the first model turn, a `tool-unavailable` kind in Recovery Classification routed to bounded retry, eager `warmWorkflowToolBridges()` at stdio startup, and `CanonicalWorkflowToolName` literal-union typing in `unit-tool-contracts.ts`.

## What

- `src/resources/extensions/gsd/tool-surface-readiness.ts` (new) — the Tool Contract module's runtime face; wired into `claude-code-cli/stream-adapter.ts` at `case "system"` (init message).
- `recovery-classification.ts` — new `tool-unavailable` failure kind (action `retry`, own exit reason); `auto-tool-tracking.ts` exports `isToolUnavailableError`; `auto-post-unit.ts` routes the race into the existing bounded verification retry instead of pausing; `error-classifier.ts` treats the readiness phrase as transient (same-model retry).
- `packages/mcp-server` — `warmWorkflowToolBridges()` loads + shape-checks the executor and write-gate bridges at stdio startup; a broken bridge fails the spawn with the actionable error instead of advertising dead tools.
- `packages/contracts` — exports `CanonicalWorkflowToolName` / `WorkflowToolAliasName` literal unions; `unit-tool-contracts.ts` types its lists with them; MCP tool-name parsing delegated to the single `@gsd/pi-ai` implementation.
- `docs/dev/ADR-036-tool-surface-readiness.md` + CONTEXT.md glossary/decision entries.

## Why

Observed during S03 UAT (see #646). Four gaps compounded: the ADR-008 phase-5 gate is static (cannot see the live session surface), the error classified as deterministic (pause, not retry), the executor bridge lazy-loaded (broken bridge = clean connect, dead tools), and tool-name knowledge lived in four homes (drift failed at runtime, not typecheck).

## How

Two-altitude enforcement: the static gate stays at the four dispatch sites (fast path); the readiness gate runs where the live surface is first observable — the SDK init message — and aborts before burning a model turn. The abort phrase (`workflow tool surface not ready`, exported constant) is recognized transient end-to-end: `error-classifier` → bounded same-model retry; `classifyFailure` → `tool-unavailable` → retry. Cross-module phrase contract pinned by `tests/tool-surface-readiness.test.ts`.

Deliberate decisions (recorded in ADR-036): fail-closed server spawn (matches Worktree Safety posture; every supported launch path has a loadable bridge); no dedicated `ErrorClass` kind (the domain taxonomy already owns `tool-unavailable`; `ErrorClass` is the provider-transport layer); the four static-gate call sites are not folded this pass (deferred). ADR numbered 036 because ADR-032..035 are owned by parallel in-flight work.

## Change type

- [x] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `docs` — Documentation only

## Testing

- New: `tests/tool-surface-readiness.test.ts` (9 tests incl. cross-module classification contract), `warmWorkflowToolBridges` tests (2), `tool-unavailable` rows in the ADR-015 taxonomy table and invocation-error classifier tests.
- Full unit suite: 10,424 passed, 0 failed. `tsc` clean on main + extensions configs (`--incremental false`). mcp-server package tests 54/54.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783684572&installation_id=134682257&pr_number=647&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F647&signature=b10437da6817364034fe5cb34b2f96a15d175ed305b484ee4e97242452212e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-mode dispatch, recovery classification, and MCP stdio startup on a critical tool path; behavior change is intentional (retry vs pause) with new tests pinning the cross-module phrase contract.
> 
> **Overview**
> Closes the **workflow MCP startup race** where Units could start before async tool registration, leading to mid-Unit `No such tool available` and improvised fallbacks (e.g. Bash instead of typed UAT tools).
> 
> **Runtime gate:** Adds **Tool Surface Readiness** (`getToolSurfaceReadinessError`) and wires it into the Claude Code stream adapter on the SDK **init** message so required workflow tools and MCP server status are checked **before the first model turn**, aborting with a stable `workflow tool surface not ready` phrase when the surface is incomplete.
> 
> **Recovery:** Introduces **`tool-unavailable`** (retry, own exit reason). `isToolUnavailableError` splits startup-race errors from deterministic invocation failures; post-unit verification retries bounded instead of pausing; `error-classifier` treats readiness aborts as transient.
> 
> **MCP server:** **Workflow bridge warm-up** (`warmWorkflowToolBridges`) runs at stdio startup alongside connect so broken executor/write-gate modules **fail the spawn** instead of advertising dead tools.
> 
> **Typing / seams:** `CanonicalWorkflowToolName` in contracts; unit tool lists typed in `unit-tool-contracts.ts`; MCP name parsing delegated to `@gsd/pi-ai` via `mcp-tool-name.ts`. ADR-036 and CONTEXT glossary/decision entries document the two-altitude model (static pre-dispatch unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07e01a67ae016d77ed27ba06b29818cb7b564d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->