### PR TITLE
docs(gsd): update worktree-git-recovery header for broadened collision resolver

### DIFF
--- a/src/resources/extensions/gsd/worktree-git-recovery.ts
+++ b/src/resources/extensions/gsd/worktree-git-recovery.ts
@@ -8,8 +8,9 @@
  * git operations during worktree transitions:
  *
  *   - `checkoutBranchWithStashGuard` — branch switch with stash protection,
- *     including the stash-pop EEXIST collision recovery for `.gsd/` runtime
- *     files (force-checkout + targeted stash drop).
+ *     including the stash-pop EEXIST collision recovery for untracked files
+ *     (force-checkout + targeted stash drop; #645 broadened it beyond `.gsd/`,
+ *     guarded by "no non-.gsd unmerged entries remain").
  *   - `removeMergeStateFiles` — clears SQUASH_MSG / MERGE_HEAD / etc. left by
  *     a failed merge so subsequent merges don't fail on stale state.
  *   - `cleanupConflictState` — merge-abort + index reset + state-file cleanup


### PR DESCRIPTION
## Intent

One-line documentation fix: PR #645 broadened checkoutBranchWithStashGuard's untracked-collision resolver beyond .gsd/ files (closes #642), but the worktree-git-recovery.ts module header doc comment still described the recovery as scoped to .gsd/ runtime files. This updates the header to match the merged behavior. No code changes — comment only.

## What Changed

- Updated the `worktree-git-recovery.ts` module header doc comment so the `checkoutBranchWithStashGuard` entry describes the stash-pop EEXIST recovery as covering untracked files generally, rather than `.gsd/` runtime files specifically.
- Noted that #645 broadened the resolver beyond `.gsd/` and that it remains guarded by "no non-`.gsd` unmerged entries remain", matching the merged implementation. Comment-only; no code or behavior change.

## Risk Assessment

✅ Low: Documentation-only change to a module header comment that accurately reflects the existing code's broadened untracked-collision recovery and its non-.gsd guard; no behavioral risk.

## Testing

Ran the relevant unit suite after fixing a setup gap (dependencies were not installed — `pnpm install --frozen-lockfile`). All 8 `checkoutBranchWithStashGuard` tests pass, two of which directly exercise non-`.gsd/` untracked-collision recovery, demonstrating the behavior the updated header now documents. I also read the resolver code to confirm the new comment accurately describes it. This is a comment-only change with no end-user UI surface, so the appropriate reviewer-visible evidence is the test transcript rather than a screenshot. Working tree is clean and node_modules is gitignored, so nothing transient will be committed.

<details>
<summary>Evidence: checkoutBranchWithStashGuard test transcript (8/8 pass, incl. non-.gsd collision tests)</summary>

<code>✔ auto-resolves combined non-.gsd untracked collision and .gsd index conflict&#10;✔ auto-resolves non-.gsd untracked restore collisions (e.g. harness config outside .gsd/)&#10;ℹ tests 8 ℹ pass 8 ℹ fail 0</code>

```text
▶ checkoutBranchWithStashGuard
  ✔ restores dirty working tree after successful checkout (267.305584ms)
  ✔ restores dirty working tree when checkout throws (183.078166ms)
  ✔ surfaces distinct error when checkout succeeds but stash pop conflicts (269.461167ms)
  ✔ accepts target branch .gsd files when untracked stash restore collides (282.072125ms)
  ✔ clears tracked .gsd JSONL conflict markers when untracked stash restore collides (314.395333ms)
  ✔ auto-resolves .gsd untracked restore collisions after checkout (288.356083ms)
  ✔ auto-resolves combined non-.gsd untracked collision and .gsd index conflict (312.950459ms)
  ✔ auto-resolves non-.gsd untracked restore collisions (e.g. harness config outside .gsd/) (242.483416ms)
✔ checkoutBranchWithStashGuard (2160.966666ms)
ℹ tests 8
ℹ suites 1
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2307.464125
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts` — all 8 tests pass, including `auto-resolves non-.gsd untracked restore collisions (e.g. harness config outside .gsd/)` and `auto-resolves combined non-.gsd untracked collision and .gsd index conflict`, which demonstrate the broadened-beyond-`.gsd/` behavior the new header documents</code>
- <code>Read `worktree-git-recovery.ts:263-305` to confirm the resolver resolves arbitrary untracked collisions and is guarded by `nonGsdUnmerged.length === 0`, matching the new comment text</code>
- <code>`pnpm install --frozen-lockfile` to resolve a missing-dependency setup issue (no node_modules) before running tests</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783687518&installation_id=134682257&pr_number=649&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F649&signature=fde109221f583aae1adbe4f2a48c18012b800f15f9ea55fd1cf2334217ec0859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change; no code or behavior is modified.
> 
> **Overview**
> Updates the **`worktree-git-recovery.ts`** module header so **`checkoutBranchWithStashGuard`** is documented as recovering from stash-pop **untracked-file** collisions in general, not only **`.gsd/`** runtime files.
> 
> The comment now references **#645** and states the resolver stays gated on **no non-`.gsd` unmerged entries**—matching the existing force-checkout + targeted stash-drop path. **No runtime or test changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e564fd1c05617ba33becbbb6f804045ee320cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->