### PR TITLE
fix: add package.json to src/resources/shared to mark compiled output as ESM

### DIFF
--- a/src/resources/shared/package.json
+++ b/src/resources/shared/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Problem

At runtime, importing `isPnpmInstall` from `../../shared/package-manager-detection.js` inside `extensions/gsd/commands-handlers.js` throws:

```
Named export 'isPnpmInstall' not found. The requested module
'../../shared/package-manager-detection.js' is a CommonJS module,
which may not support all module.exports as named exports.
```

## Root cause

`dist/resources/extensions/` has a `package.json` with `"type": "module"` (copied from `src/resources/extensions/package.json`), so all JS files there are treated as ESM. However, `dist/resources/shared/` has no `package.json` in its directory or any ancestor within the package — Node.js therefore defaults to **CommonJS** for those files. The compiled `package-manager-detection.js` uses ES `export` syntax, but a CommonJS-typed module can't expose named exports to ESM importers via static `import { ... }` syntax.

## Fix

Add `src/resources/shared/package.json` with `{"type": "module"}`. The existing `copy-resources.cjs` build step already copies all `package.json` files from `src/resources/` into `dist/resources/`, so this file will be present in the built output and Node.js will correctly treat `dist/resources/shared/*.js` as ESM.

## Change

```
src/resources/shared/package.json  (new file)
{"type": "module"}
```

One file, three lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783690687&installation_id=134682257&pr_number=653&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F653&signature=a6a82cd872047d8aec533d5f0946f516812dbe881a537641687af32a91b014df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->