### PR TITLE
fix(gsd): stop run-uat context-mode guidance steering to forbidden gsd_exec

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -24,6 +24,7 @@ import type {
   UnitContextManifest,
 } from "../unit-context-manifest.ts";
 import { KNOWN_UNIT_TYPES, UNIT_MANIFESTS } from "../unit-context-manifest.ts";
+import { getUnitToolSurfaceContract } from "../unit-tool-contracts.ts";
 import {
   buildExecuteTaskPrompt,
   buildGateEvaluatePrompt,
@@ -165,10 +166,30 @@ test("Context Mode composer: every known eligible unit renders its configured la
     }
     assert.ok(out.startsWith("## Context Mode"), `${unitType} should render standalone Context Mode heading`);
     assert.match(out, new RegExp(`Lane: \\*\\*${laneLabelByMode[manifest.contextMode]} lane\\*\\*\\.`, "i"));
-    assert.match(out, /`gsd_exec`/, `${unitType} should mention gsd_exec`);
-    assert.match(out, /`gsd_exec_search`/, `${unitType} should mention gsd_exec_search`);
+    const forbidden = getUnitToolSurfaceContract(unitType)?.forbiddenGsdTools ?? {};
+    if ("gsd_exec" in forbidden) {
+      // Units that forbid gsd_exec (run-uat) have it stripped from their
+      // Claude Code dispatch surface; guidance steering to it produces
+      // "No such tool available" loops in the dispatched agent.
+      assert.doesNotMatch(out, /`gsd_exec`/, `${unitType} forbids gsd_exec; guidance must not steer to it`);
+      assert.doesNotMatch(out, /`gsd_exec_search`/, `${unitType} guidance must not steer to gsd_exec_search`);
+      assert.match(out, /`gsd_uat_exec`/, `${unitType} guidance should steer to gsd_uat_exec instead`);
+    } else {
+      assert.match(out, /`gsd_exec`/, `${unitType} should mention gsd_exec`);
+      assert.match(out, /`gsd_exec_search`/, `${unitType} should mention gsd_exec_search`);
+    }
     assert.match(out, /`gsd_resume`/, `${unitType} should mention gsd_resume`);
   }
+});
+
+test("Context Mode composer: run-uat guidance steers to gsd_uat_exec in both render modes", () => {
+  const nested = composeContextModeInstructions("run-uat", { enabled: true, renderMode: "nested" });
+  assert.match(nested, /^Context Mode \(verification lane\): /);
+  assert.match(nested, /`gsd_uat_exec`/);
+  assert.doesNotMatch(nested, /`gsd_exec`/);
+  const standalone = composeContextModeInstructions("run-uat", { enabled: true, renderMode: "standalone" });
+  assert.match(standalone, /`gsd_uat_exec`/);
+  assert.doesNotMatch(standalone, /`gsd_exec`/);
 });
 
 test("Context Mode composer: workflow-preferences and research-decision render no Context Mode block", () => {

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -133,6 +133,16 @@ const CONTEXT_MODE_GUIDANCE_BY_LANE: Record<Exclude<ContextModePolicy, "none">, 
     "Use `gsd_resume` for prior context, `gsd_exec_search` for saved evidence, and `gsd_exec` for noisy doc validation commands.",
 };
 
+// Per-unit overrides win over the lane default. run-uat's tool contract
+// forbids `gsd_exec`/`gsd_exec_search` (acceptance evidence must flow through
+// `gsd_uat_exec`) and Claude Code dispatch strips the tools entirely, so the
+// shared verification-lane guidance would steer the agent into calling an
+// unavailable tool.
+const CONTEXT_MODE_GUIDANCE_BY_UNIT: Record<string, string> = {
+  "run-uat":
+    "Use `gsd_uat_exec` for acceptance checks so evidence is typed as UAT-owned, and `gsd_resume` after compaction or resume.",
+};
+
 /**
  * Render the Context Mode instruction lane for a unit type. Unknown unit
  * types, disabled config, and explicit `contextMode: "none"` all omit the
@@ -147,7 +157,8 @@ export function composeContextModeInstructions(
   if (!manifest || manifest.contextMode === "none") return "";
 
   const lane = CONTEXT_MODE_LANE_LABELS[manifest.contextMode];
-  const guidance = CONTEXT_MODE_GUIDANCE_BY_LANE[manifest.contextMode];
+  const guidance =
+    CONTEXT_MODE_GUIDANCE_BY_UNIT[unitType] ?? CONTEXT_MODE_GUIDANCE_BY_LANE[manifest.contextMode];
   if (opts.renderMode === "nested") {
     return `Context Mode (${lane} lane): ${guidance}`;
   }


### PR DESCRIPTION
## Summary
- The run-uat unit's context-mode guidance steered the agent toward `gsd_exec`, which is forbidden for that unit's tool surface. This updates the unit context composer so run-uat guidance no longer references it.

## Test plan
- unit-context-composer tests pass (29 tests), including new coverage for the run-uat guidance.
- Clean `build:core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783708922&installation_id=134682257&pr_number=660&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F660&signature=a94da3672f257b39efbfa3d4939d4cccffd5ca67e7f46f8d540803eb44bb513a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt text and unit tests only; no runtime dispatch or auth paths change.
> 
> **Overview**
> **run-uat** Context Mode prompts no longer reuse generic verification-lane copy that names **`gsd_exec`** / **`gsd_exec_search`**. The unit context composer now applies a **per-unit guidance override** for **`run-uat`**, steering acceptance work to **`gsd_uat_exec`** and **`gsd_resume`** so dispatched agents are not told to call tools stripped from their surface.
> 
> Tests now assert alignment with each unit’s **forbidden tool contract** (not only **`run-uat`**), plus dedicated coverage for nested and standalone render modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7651307691ae8e92491127145110900bf4846cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->