### PR TITLE
feat(gsd): centralize user notices and guidance into shared modules

### DIFF
--- a/docs/dev/FILE-SYSTEM-MAP.md
+++ b/docs/dev/FILE-SYSTEM-MAP.md
@@ -76,6 +76,7 @@
 | src/bundled-extension-paths.ts | Extension Registry | Serializes/parses bundled extension directory paths |
 | src/bundled-resource-path.ts | Loader/Bootstrap, Extension Registry | Resolves bundled raw resource files from package root |
 | src/cli.ts | CLI | Main CLI entry point — arg parsing, mode detection, plugin init |
+| src/cli-style.ts | CLI | Terminal presentation helpers for CLI-side stderr notices (tags, warnings, hints, banner lines) |
 | src/cli-web-branch.ts | CLI, Web Mode | Web CLI branch; session dir resolution, legacy migration |
 | src/extension-discovery.ts | Extension Registry | Discovers extension entry points from FS and package.json |
 | src/extension-registry.ts | Extension Registry | Extension manifests, registry persistence, enable/disable |
@@ -528,6 +529,8 @@
 | gsd/export-html.ts | GSD Workflow | HTML export of milestone reports |
 | gsd/reports.ts | GSD Workflow | Report generation and summaries |
 | gsd/notifications.ts | GSD Workflow | User notification and messaging |
+| gsd/guidance.ts | GSD Workflow, Doctor/Diagnostics | Single catalog mapping typed findings (recovery kinds, milestone blockers, doctor issue codes, crash unit classes) to remediation prose |
+| gsd/stop-notice.ts | Auto Engine, Headless Mode | Single owner of auto/step-mode stop/pause notice vocabulary — formatters and headless exit-code classifiers |
 | gsd/triage-ui.ts | GSD Workflow | Triage interface for issue categorization |
 | gsd/guided-flow.ts | GSD Workflow | User-guided workflow orchestration |
 | gsd/env-utils.ts | GSD Workflow | Environment variable utilities |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -162,6 +162,8 @@ Phase skipping (from token profile) gates steps 2-3: if a phase is skipped, the 
 | `state.ts` | DB-authoritative state derivation with explicit legacy markdown fallback for tests/recovery |
 | `session-lock.ts` | OS-level exclusive session locking (proper-lockfile) |
 | `crash-recovery.ts` | Lock file management for crash detection and recovery |
+| `guidance.ts` | Single catalog mapping typed findings (recovery kinds, milestone blockers, doctor issue codes, crash unit classes) to user-facing remediation prose |
+| `stop-notice.ts` | Single owner of the auto/step-mode stop/pause notice vocabulary — formatters and headless exit-code classifiers stay in lockstep |
 | `preferences.ts` | Preference loading, merging, validation |
 | `git-service.ts` | Git operations — commit, merge, worktree sync, completed-units cross-boundary sync |
 | `unit-id.ts` | Centralized `parseUnitId()` — milestone/slice/task extraction from unit IDs |

--- a/src/cli-style.ts
+++ b/src/cli-style.ts
@@ -1,9 +1,9 @@
 /**
- * Terminal presentation module for CLI-side notices — the single vocabulary
- * for how the gsd CLI styles warnings, hints, and names on stderr.
- * Pairs with the extension-side glyph set in resources/extensions/shared/ui.ts;
- * this module covers the pre-session CLI surfaces (banners, update checks,
- * worktree commands) that render with chalk directly.
+ * Terminal presentation helpers for CLI-side notices on stderr — warnings,
+ * hints, and names. Pairs with the extension-side glyph set in
+ * resources/extensions/shared/ui.ts. Adopt incrementally: banner-shaped CLI
+ * surfaces (worktree banners today; update checks et al. as they're touched)
+ * should render through these instead of ad-hoc chalk.
  */
 
 import chalk from 'chalk'

--- a/src/cli-style.ts
+++ b/src/cli-style.ts
@@ -1,0 +1,34 @@
+/**
+ * Terminal presentation module for CLI-side notices — the single vocabulary
+ * for how the gsd CLI styles warnings, hints, and names on stderr.
+ * Pairs with the extension-side glyph set in resources/extensions/shared/ui.ts;
+ * this module covers the pre-session CLI surfaces (banners, update checks,
+ * worktree commands) that render with chalk directly.
+ */
+
+import chalk from 'chalk'
+
+/** Dim "[gsd] " line tag that prefixes CLI banner lines. */
+export function gsdTag(): string {
+  return chalk.dim('[gsd] ')
+}
+
+/** A yellow warning fragment. */
+export function warn(text: string): string {
+  return chalk.yellow(text)
+}
+
+/** A dim "what to do next" hint fragment. */
+export function hint(text: string): string {
+  return chalk.dim(text)
+}
+
+/** A cyan user-supplied name (worktree, branch, file). */
+export function name(text: string): string {
+  return chalk.cyan(text)
+}
+
+/** One banner line: tagged warning followed by a tagged hint line. */
+export function bannerLines(warning: string, hintText: string): string {
+  return gsdTag() + warning + '\n' + gsdTag() + hint(hintText) + '\n\n'
+}

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -12,8 +12,6 @@
  */
 
 import {
-  PAUSED_NOTICE_PREFIXES,
-  TERMINAL_NOTICE_PREFIXES,
   isBlockedNoticeMessage,
   isManualResolutionNotice,
   isPauseNotice,
@@ -83,8 +81,6 @@ export function mapStatusToExitCode(status: string): number {
  *
  * Blocked detection is separate — checked via isBlockedNotification.
  */
-export const PAUSED_PREFIXES: readonly string[] = PAUSED_NOTICE_PREFIXES
-export const TERMINAL_PREFIXES: readonly string[] = TERMINAL_NOTICE_PREFIXES
 export const IDLE_TIMEOUT_MS = 15_000
 // new-milestone is a long-running creative task where the LLM may pause
 // between tool calls (e.g. after mkdir, before writing files). Use a

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -5,7 +5,20 @@
  * and classifies commands as quick (single-turn) vs long-running.
  *
  * Also defines exit code constants and the status→exit-code mapping function.
+ *
+ * The stop/pause notice vocabulary itself (prefixes + message classifiers)
+ * lives in the Stop Notice module — the same module the emitters format with,
+ * so wording stays in lockstep with detection.
  */
+
+import {
+  PAUSED_NOTICE_PREFIXES,
+  TERMINAL_NOTICE_PREFIXES,
+  isBlockedNoticeMessage,
+  isManualResolutionNotice,
+  isPauseNotice,
+  isTerminalNotice,
+} from './resources/extensions/gsd/stop-notice.js'
 
 // ---------------------------------------------------------------------------
 // Exit Code Constants
@@ -70,14 +83,8 @@ export function mapStatusToExitCode(status: string): number {
  *
  * Blocked detection is separate — checked via isBlockedNotification.
  */
-export const PAUSED_PREFIXES = ['auto-mode paused', 'step-mode paused']
-export const TERMINAL_PREFIXES = [
-  'auto-mode stopped',
-  'step-mode stopped',
-  'auto-mode complete',
-  'no active milestone',
-  'auto-mode idle',
-]
+export const PAUSED_PREFIXES: readonly string[] = PAUSED_NOTICE_PREFIXES
+export const TERMINAL_PREFIXES: readonly string[] = TERMINAL_NOTICE_PREFIXES
 export const IDLE_TIMEOUT_MS = 15_000
 // new-milestone is a long-running creative task where the LLM may pause
 // between tool calls (e.g. after mkdir, before writing files). Use a
@@ -90,26 +97,6 @@ export function canonicalHeadlessToolName(toolName: string | undefined): string 
   if (!name.startsWith('mcp__')) return name
   const toolSeparator = name.indexOf('__', 'mcp__'.length)
   return toolSeparator >= 0 ? name.slice(toolSeparator + 2) : name
-}
-
-function isManualResolutionNotification(message: string): boolean {
-  return (
-    message.includes('resolve manually and re-run /gsd auto') ||
-    message.includes('resolve conflicts manually and run /gsd auto to resume') ||
-    message.includes('resolve and run /gsd auto to resume')
-  )
-}
-
-function isNonBlockingPauseNotification(message: string): boolean {
-  return message.includes('idempotent advance: unit already active')
-}
-
-function isPauseNotification(message: string): boolean {
-  return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix))
-}
-
-function isPauseNotificationRequiringIntervention(message: string): boolean {
-  return isPauseNotification(message) && !isNonBlockingPauseNotification(message)
 }
 
 function getCommandBlockContent(event: Record<string, unknown>): string | null {
@@ -136,23 +123,14 @@ export function isTerminalNotification(event: Record<string, unknown>): boolean 
   if (isBlockingCommandBlock(event)) return true
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()
-  return (
-    TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix)) ||
-    isPauseNotification(message) ||
-    isManualResolutionNotification(message)
-  )
+  return isTerminalNotice(message) || isPauseNotice(message) || isManualResolutionNotice(message)
 }
 
 export function isBlockedNotification(event: Record<string, unknown>): boolean {
   if (isBlockingCommandBlock(event)) return true
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
-  const message = String(event.message ?? '').toLowerCase()
   // Recoverable pauses need operator intervention in headless mode.
-  return (
-    message.includes('blocked:') ||
-    isPauseNotificationRequiringIntervention(message) ||
-    isManualResolutionNotification(message)
-  )
+  return isBlockedNoticeMessage(String(event.message ?? '').toLowerCase())
 }
 
 export function isMilestoneReadyNotification(event: Record<string, unknown>): boolean {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -360,8 +360,7 @@ export function formatAutoStopNotification(prefix: string, totals: { cost: numbe
   ].join("\n");
 }
 
-const formatAutoStopDisplayReason = stopNoticeDisplayReason;
-export const formatAutoStopNotificationPrefix = formatStopNoticePrefix;
+export { formatStopNoticePrefix as formatAutoStopNotificationPrefix } from "./stop-notice.js";
 
 function clearSessionModelOverrideForCommandSession(ctx?: ExtensionContext | null): void {
   const sessionId =
@@ -1459,8 +1458,8 @@ export async function stopAuto(
 ): Promise<void> {
   if (!s.active && !s.paused) return;
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
-  const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
-  const displayReason = formatAutoStopDisplayReason(reason);
+  const stopNotificationPrefix = formatStopNoticePrefix(reason);
+  const displayReason = stopNoticeDisplayReason(reason);
   const isHeadlessStop = process.env.GSD_HEADLESS === "1";
   const completionStopRequested = Boolean(options.completionWidget);
   const preserveCloseoutTranscript = !isHeadlessStop && (

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -331,6 +331,11 @@ import {
 } from "./db/auto-workers.js";
 import { releaseMilestoneLease } from "./db/milestone-leases.js";
 import { normalizeRealPath } from "./paths.js";
+import {
+  formatStopNoticePrefix,
+  isBlockedStopReason,
+  stopNoticeDisplayReason,
+} from "./stop-notice.js";
 
 // ── ENCAPSULATION INVARIANT ─────────────────────────────────────────────────
 // ALL mutable auto-mode state lives in the AutoSession class (auto/session.ts).
@@ -355,19 +360,8 @@ export function formatAutoStopNotification(prefix: string, totals: { cost: numbe
   ].join("\n");
 }
 
-function isBlockedStopReason(reason?: string | null): boolean {
-  return /^Blocked:\s*/i.test(reason ?? "");
-}
-
-function formatAutoStopDisplayReason(reason?: string | null): string {
-  return (reason ?? "").replace(/^Blocked:\s*/i, "").trim();
-}
-
-export function formatAutoStopNotificationPrefix(reason?: string | null): string {
-  const displayReason = formatAutoStopDisplayReason(reason);
-  const prefix = isBlockedStopReason(reason) ? "Auto-mode blocked" : "Auto-mode stopped";
-  return displayReason ? `${prefix} — ${displayReason}` : prefix;
-}
+const formatAutoStopDisplayReason = stopNoticeDisplayReason;
+export const formatAutoStopNotificationPrefix = formatStopNoticePrefix;
 
 function clearSessionModelOverrideForCommandSession(ctx?: ExtensionContext | null): void {
   const sessionId =

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -43,10 +43,8 @@ import {
 } from "../error-classifier.js";
 import { blockModel, isModelBlocked } from "../blocked-models.js";
 import { getProjectGSDPreferencesPath } from "../preferences.js";
-import {
-  formatProviderErrorGuidance,
-  resolveProviderErrorGuidance,
-} from "../provider-error-guidance.js";
+import { resolveProviderErrorGuidance } from "../provider-error-guidance.js";
+import { formatGuidance } from "../guidance.js";
 
 const retryState = createRetryState();
 const MAX_NETWORK_RETRIES = 2;
@@ -627,7 +625,7 @@ export async function handleAgentEnd(
         preferencesPath: dash.basePath ? getProjectGSDPreferencesPath(dash.basePath) : undefined,
         hasConfiguredFallbacks: (modelConfig?.fallbacks.length ?? 0) > 0,
       });
-      const guidanceText = formatProviderErrorGuidance(guidance);
+      const guidanceText = formatGuidance(guidance);
 
       await pauseForProviderModelRejection(ctx, pi, {
         errorDetail,

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -39,6 +39,7 @@ import { markLatestActiveForWorkerCanceled, type DispatchStatus } from "./db/uni
 import { getRuntimeKv, setRuntimeKv, deleteRuntimeKv } from "./db/runtime-kv.js";
 import { _getAdapter, isDbAvailable } from "./gsd-db.js";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
+import { crashResumeHint } from "./guidance.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { effectiveLockFile } from "./session-lock.js";
 import { isInFlightRuntimePhase, listUnitRuntimeRecords, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
@@ -321,15 +322,8 @@ export function formatCrashInfo(lock: LockData): string {
     `  PID: ${lock.pid}`,
   ];
 
-  if (lock.unitType === "starting" && lock.unitId === "bootstrap") {
-    lines.push(`No work was lost. Run /gsd auto to restart.`);
-  } else if (lock.unitType.includes("research") || lock.unitType.includes("plan")) {
-    lines.push(`The ${lock.unitType} unit may be incomplete. Run /gsd auto to re-run it.`);
-  } else if (lock.unitType.includes("execute")) {
-    lines.push(`Task execution was interrupted. Run /gsd auto to resume — completed work is preserved.`);
-  } else if (lock.unitType.includes("complete")) {
-    lines.push(`Slice/milestone completion was interrupted. Run /gsd auto to finish.`);
-  }
+  const hint = crashResumeHint(lock.unitType, lock.unitId);
+  if (hint) lines.push(hint);
 
   return lines.join("\n");
 }

--- a/src/resources/extensions/gsd/doctor-format.ts
+++ b/src/resources/extensions/gsd/doctor-format.ts
@@ -1,4 +1,9 @@
-import type { DoctorIssue, DoctorIssueCode, DoctorReport, DoctorSummary } from "./doctor-types.js";
+import type { DoctorIssue, DoctorIssueCode, DoctorReport, DoctorSummary, DoctorSeverity } from "./doctor-types.js";
+import { doctorFixHint } from "./guidance.js";
+
+function severityTag(severity: DoctorSeverity): string {
+  return severity === "error" ? "ERROR" : severity === "warning" ? "WARN" : "INFO";
+}
 
 function matchesScope(unitId: string, scope?: string): boolean {
   if (!scope) return true;
@@ -53,8 +58,9 @@ export function formatDoctorReport(
   if (scopedIssues.length > 0) {
     lines.push("Priority issues:");
     for (const issue of scopedIssues.slice(0, maxIssues)) {
-      const prefix = issue.severity === "error" ? "ERROR" : issue.severity === "warning" ? "WARN" : "INFO";
-      lines.push(`- [${prefix}] ${issue.unitId}: ${issue.message}${issue.file ? ` (${issue.file})` : ""}`);
+      lines.push(`- [${severityTag(issue.severity)}] ${issue.unitId}: ${issue.message}${issue.file ? ` (${issue.file})` : ""}`);
+      const hint = doctorFixHint(issue.code);
+      if (hint && issue.severity !== "info") lines.push(`  Fix: ${hint}`);
     }
     if (scopedIssues.length > maxIssues) {
       lines.push(`- ...and ${scopedIssues.length - maxIssues} more in scope`);
@@ -72,10 +78,9 @@ export function formatDoctorReport(
 
 export function formatDoctorIssuesForPrompt(issues: DoctorIssue[]): string {
   if (issues.length === 0) return "- No remaining issues in scope.";
-  return issues.map(issue => {
-    const prefix = issue.severity === "error" ? "ERROR" : issue.severity === "warning" ? "WARN" : "INFO";
-    return `- [${prefix}] ${issue.unitId} | ${issue.code} | ${issue.message}${issue.file ? ` | file: ${issue.file}` : ""} | fixable: ${issue.fixable ? "yes" : "no"}`;
-  }).join("\n");
+  return issues.map(issue =>
+    `- [${severityTag(issue.severity)}] ${issue.unitId} | ${issue.code} | ${issue.message}${issue.file ? ` | file: ${issue.file}` : ""} | fixable: ${issue.fixable ? "yes" : "no"}`
+  ).join("\n");
 }
 
 /**

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -1,0 +1,139 @@
+// Project/App: gsd-pi
+// File Purpose: Guidance module — the single catalog mapping typed findings
+// (Recovery kinds, milestone blocker kinds, doctor issue codes, crash unit
+// classes) to user-facing remediation: what happened and what to do next.
+//
+// Emit sites pass the typed finding; phrasing, command names, and step
+// ordering live here. A missing catalog row is a visible gap, not a silent
+// omission scattered across call sites.
+
+import type { RecoveryFailureKind } from "./recovery-classification.js";
+import type { DoctorIssueCode } from "./doctor-types.js";
+
+// ─── Shape ──────────────────────────────────────────────────────────────
+
+export interface Guidance {
+  summary: string;
+  steps: string[];
+}
+
+/** Flatten guidance into a notification / pause-banner string. */
+export function formatGuidance(guidance: Guidance): string {
+  if (guidance.steps.length === 0) return guidance.summary;
+  const numbered = guidance.steps.map((step, index) => `${index + 1}. ${step}`).join("\n");
+  return `${guidance.summary}\n\n${numbered}`;
+}
+
+// ─── Recovery Classification remediation ────────────────────────────────
+// Keyed by RecoveryFailureKind. The provider kind is split by transience,
+// which Recovery Classification resolves before looking up guidance.
+
+export type RecoveryGuidanceKey =
+  | Exclude<RecoveryFailureKind, "provider">
+  | "provider-transient"
+  | "provider-permanent";
+
+const RECOVERY_REMEDIATION: Record<RecoveryGuidanceKey, string> = {
+  "tool-schema": "Fix the Unit Tool Contract or tool schema before retrying.",
+  "tool-contract":
+    "Fix the Unit Tool Contract or prompt so the Unit is only asked to use tools owned by its phase.",
+  "tool-unavailable":
+    "The tool surface had not finished registering when the Unit called it (workflow MCP startup race). Retry after the surface is ready; escalate if the tool never appears.",
+  "deterministic-policy": "Resolve the policy blocker; retrying the same Unit will repeat the failure.",
+  "lifecycle-progression":
+    "Route to the required owning Unit or restore the missing artifact before advancing lifecycle state.",
+  "stale-worker":
+    "Run `/gsd doctor` to detect and clear the stale worker or lock, then run `/gsd auto` to resume.",
+  "worktree-invalid":
+    "Run `/gsd doctor` to diagnose the milestone worktree (`gsd worktree list` shows its state). Repair it, or merge salvageable work with `gsd worktree merge <name>` before recreating — recreating discards uncommitted work.",
+  "verification-drift":
+    "Run `/gsd status` to see the verification finding, fix or re-run the verification, then run `/gsd auto` to resume. `/gsd doctor` can repair stale state files.",
+  "reconciliation-drift":
+    "Run `/gsd doctor` to surface the persistent or repair-failed drift kinds, apply its fixes, then run `/gsd auto` to resume.",
+  "illegal-transition":
+    "A derived Phase edge rejected by the Phase Transition Invariant survived reconciliation; inspect deriveState and the State Reconciliation Module before resuming.",
+  "runtime-unknown": "Inspect the runtime error and add a dedicated classification if it is repeatable.",
+  "provider-transient": "Retry after the provider/network condition clears.",
+  "provider-permanent": "Inspect provider credentials, model entitlement, or request shape.",
+};
+
+export function recoveryRemediation(key: RecoveryGuidanceKey): string {
+  return RECOVERY_REMEDIATION[key];
+}
+
+// ─── Milestone validation blockers ──────────────────────────────────────
+// NOTE: the first line of each blocker is load-bearing — validation-block-guard
+// matches /milestone validation returned needs-(?:attention|remediation)/i.
+// Keep that phrase intact when editing.
+
+export function needsAttentionBlockerGuidance(milestoneId: string): string {
+  return [
+    `Milestone ${milestoneId} is blocked because milestone validation returned needs-attention.`,
+    `Fix options:`,
+    `1. Review the validation details: \`/gsd status\``,
+    `2. If you fixed the missing evidence or issue, re-run milestone validation: \`/gsd validate-milestone\``,
+    `3. If the finding is acceptable, override it: \`/gsd verdict pass --rationale "why this is okay"\``,
+    `4. If this should wait, defer it explicitly: \`/gsd park ${milestoneId}\``,
+    `After validation or override passes, run \`/gsd auto\` to complete and merge the milestone.`,
+  ].join("\n");
+}
+
+export function needsRemediationBlockerGuidance(milestoneId: string): string {
+  return [
+    `Milestone ${milestoneId} is blocked because milestone validation returned needs-remediation, but all slices are complete.`,
+    `Fix options:`,
+    `1. Run \`/gsd dispatch reassess\` to add remediation slices, then run \`/gsd auto\``,
+    `2. If the finding is acceptable, override it: \`/gsd verdict pass --rationale "why this is okay"\``,
+    `3. If this should wait, defer it explicitly: \`/gsd park ${milestoneId}\``,
+  ].join("\n");
+}
+
+// ─── Crash recovery resume hints ────────────────────────────────────────
+
+/** Resume hint for an interrupted auto-mode unit, by unit class. */
+export function crashResumeHint(unitType: string, unitId: string): string | undefined {
+  if (unitType === "starting" && unitId === "bootstrap") {
+    return `No work was lost. Run /gsd auto to restart.`;
+  }
+  if (unitType.includes("research") || unitType.includes("plan")) {
+    return `The ${unitType} unit may be incomplete. Run /gsd auto to re-run it.`;
+  }
+  if (unitType.includes("execute")) {
+    return `Task execution was interrupted. Run /gsd auto to resume — completed work is preserved.`;
+  }
+  if (unitType.includes("complete")) {
+    return `Slice/milestone completion was interrupted. Run /gsd auto to finish.`;
+  }
+  return undefined;
+}
+
+// ─── Doctor issue fix hints ─────────────────────────────────────────────
+// Partial by design: codes without a row render no hint. Add rows here as
+// guidance is authored — the gap is visible in one place.
+
+const DOCTOR_FIX_HINTS: Partial<Record<DoctorIssueCode, string>> = {
+  db_unavailable:
+    "The workflow database could not be opened — state derivation is degraded. Restart the session; if it persists, run `/gsd doctor` from the project root.",
+  stale_crash_lock: "Run `/gsd doctor` to clear the stale lock, then `/gsd auto` to resume.",
+  stale_parallel_session: "Run `/gsd doctor` to clear the stale session registration.",
+  unresolved_git_conflicts:
+    "Resolve the conflict markers, commit, then re-run `/gsd auto`.",
+  conflict_markers_in_tracked_files:
+    "Search the listed files for `<<<<<<<` markers, resolve, and commit.",
+  worktree_dirty:
+    "Commit or merge the worktree's changes (`gsd worktree merge <name>`) before removing it.",
+  worktree_branch_merged: "The branch is merged — remove the worktree to reclaim space.",
+  orphaned_auto_worktree: "Run `/gsd doctor` to fix, or merge salvageable work with `gsd worktree merge <name>`.",
+  gitignore_missing_patterns: "Run `/gsd doctor` to append the missing .gitignore patterns.",
+  invalid_preferences: "Edit .gsd/PREFERENCES.md to fix the invalid field, then re-run the command.",
+  provider_key_missing: "Add the provider API key to your environment or provider config, then retry.",
+  provider_key_backedoff: "The key is cooling down after repeated failures — wait, or switch the phase model in .gsd/PREFERENCES.md.",
+  state_file_stale: "Run `/gsd doctor` to rebuild the projection from the database.",
+  state_file_missing: "Run `/gsd doctor` to rebuild the projection from the database.",
+  projection_drift: "Run `/gsd doctor` to rebuild markdown projections from the database (DB is the source of truth).",
+  uat_retry_exhausted: "Review the failing UAT criteria via `/gsd status`, fix the issue, then re-run `/gsd auto`.",
+};
+
+export function doctorFixHint(code: DoctorIssueCode): string | undefined {
+  return DOCTOR_FIX_HINTS[code];
+}

--- a/src/resources/extensions/gsd/memory-consolidation-scanner.ts
+++ b/src/resources/extensions/gsd/memory-consolidation-scanner.ts
@@ -264,7 +264,7 @@ export function reportConsolidationGaps(basePath: string): ConsolidationGapRepor
   try {
     const report = scanConsolidationGaps(basePath);
     if (report.totalGaps === 0) return report;
-    appendNotification(report.summary, "warning", "workflow-logger");
+    appendNotification(report.summary, "warning", "workflow-logger", { kind: "memory-consolidation" });
     logWarning("memory-consolidation", report.summary);
     return report;
   } catch (e) {

--- a/src/resources/extensions/gsd/notification-store.ts
+++ b/src/resources/extensions/gsd/notification-store.ts
@@ -126,9 +126,9 @@ export function appendNotification(
 export function readNotifications(basePath?: string, filter?: NotificationMeta): NotificationEntry[] {
   const bp = basePath ?? _basePath;
   if (!bp) return [];
-  let entries = _readEntriesFromDisk(bp);
-  if (filter?.kind) entries = entries.filter((e) => e.kind === filter.kind);
-  if (filter?.scope) entries = entries.filter((e) => e.scope === filter.scope);
+  const entries = _readEntriesFromDisk(bp).filter(
+    (e) => (!filter?.kind || e.kind === filter.kind) && (!filter?.scope || e.scope === filter.scope),
+  );
   return entries.reverse();
 }
 

--- a/src/resources/extensions/gsd/notification-store.ts
+++ b/src/resources/extensions/gsd/notification-store.ts
@@ -12,6 +12,17 @@ import { randomUUID } from "node:crypto";
 export type NotifySeverity = "info" | "success" | "warning" | "error";
 export type NotificationSource = "notify" | "workflow-logger";
 
+/**
+ * Optional structured identity for a notification. When present, `kind`
+ * (a stable machine name like "auto-stop" or "provider-error-pause") plus
+ * `scope` (e.g. a milestone/slice id) — not the prose — key deduplication,
+ * and consumers can filter without parsing message text.
+ */
+export interface NotificationMeta {
+  kind?: string;
+  scope?: string;
+}
+
 export interface NotificationEntry {
   id: string;
   ts: string;
@@ -19,6 +30,8 @@ export interface NotificationEntry {
   message: string;
   source: NotificationSource;
   read: boolean;
+  kind?: string;
+  scope?: string;
 }
 
 // ─── Constants ──────────────────────────────────────────────────────────
@@ -60,11 +73,15 @@ export function appendNotification(
   message: string,
   severity: NotifySeverity,
   source: NotificationSource = "notify",
+  meta?: NotificationMeta,
 ): void {
   if (!_basePath) return;
   if (_suppressCount > 0) return;
   const persistedMessage = message.length > 500 ? message.slice(0, 500) + "…" : message;
-  const dedupKey = `${_basePath}:${severity}:${source}:${persistedMessage}`;
+  // Structured identity (kind + scope) keys dedup when present, so a rephrased
+  // message of the same event still dedups; otherwise fall back to the prose.
+  const identity = meta?.kind ? `${meta.kind}:${meta.scope ?? ""}` : persistedMessage;
+  const dedupKey = `${_basePath}:${severity}:${source}:${identity}`;
   const now = Date.now();
   const lastSeen = _recentMessageTimestamps.get(dedupKey);
   if (lastSeen !== undefined && now - lastSeen < DEDUP_WINDOW_MS) return;
@@ -82,6 +99,8 @@ export function appendNotification(
     message: persistedMessage,
     source,
     read: false,
+    ...(meta?.kind ? { kind: meta.kind } : {}),
+    ...(meta?.scope ? { scope: meta.scope } : {}),
   };
 
   try {
@@ -102,11 +121,15 @@ export function appendNotification(
 
 /**
  * Read all notification entries from disk. Returns newest-first.
+ * An optional filter narrows by structured identity (kind and/or scope).
  */
-export function readNotifications(basePath?: string): NotificationEntry[] {
+export function readNotifications(basePath?: string, filter?: NotificationMeta): NotificationEntry[] {
   const bp = basePath ?? _basePath;
   if (!bp) return [];
-  return _readEntriesFromDisk(bp).reverse();
+  let entries = _readEntriesFromDisk(bp);
+  if (filter?.kind) entries = entries.filter((e) => e.kind === filter.kind);
+  if (filter?.scope) entries = entries.filter((e) => e.scope === filter.scope);
+  return entries.reverse();
 }
 
 /**

--- a/src/resources/extensions/gsd/provider-error-guidance.ts
+++ b/src/resources/extensions/gsd/provider-error-guidance.ts
@@ -1,6 +1,9 @@
 /**
  * Actionable remediation hints when auto-mode pauses on provider/model errors.
+ * Render with formatGuidance from the Guidance module.
  */
+
+import type { Guidance } from "./guidance.js";
 
 export interface ProviderErrorGuidanceInput {
   errorMsg: string;
@@ -11,8 +14,6 @@ export interface ProviderErrorGuidanceInput {
   preferencesPath?: string;
   hasConfiguredFallbacks?: boolean;
 }
-
-import { formatGuidance, type Guidance } from "./guidance.js";
 
 export type ProviderErrorGuidance = Guidance;
 
@@ -128,7 +129,3 @@ export function resolveProviderErrorGuidance(input: ProviderErrorGuidanceInput):
   return { summary, steps };
 }
 
-/** Flatten guidance into a pause banner / notification string. */
-export function formatProviderErrorGuidance(guidance: ProviderErrorGuidance): string {
-  return formatGuidance(guidance);
-}

--- a/src/resources/extensions/gsd/provider-error-guidance.ts
+++ b/src/resources/extensions/gsd/provider-error-guidance.ts
@@ -12,10 +12,9 @@ export interface ProviderErrorGuidanceInput {
   hasConfiguredFallbacks?: boolean;
 }
 
-export interface ProviderErrorGuidance {
-  summary: string;
-  steps: string[];
-}
+import { formatGuidance, type Guidance } from "./guidance.js";
+
+export type ProviderErrorGuidance = Guidance;
 
 /** Map auto unit types to the `models:` key in PREFERENCES.md. */
 export function unitTypeToPrefsPhaseKey(unitType: string | undefined): string | undefined {
@@ -131,6 +130,5 @@ export function resolveProviderErrorGuidance(input: ProviderErrorGuidanceInput):
 
 /** Flatten guidance into a pause banner / notification string. */
 export function formatProviderErrorGuidance(guidance: ProviderErrorGuidance): string {
-  const numbered = guidance.steps.map((step, index) => `${index + 1}. ${step}`).join("\n");
-  return `${guidance.summary}\n\n${numbered}`;
+  return formatGuidance(guidance);
 }

--- a/src/resources/extensions/gsd/provider-switch-observer.ts
+++ b/src/resources/extensions/gsd/provider-switch-observer.ts
@@ -128,7 +128,7 @@ function emitAudit(report: ProviderSwitchReport): void {
 
 function emitNotification(report: ProviderSwitchReport): void {
   try {
-    appendNotification(summarize(report), "warning", "workflow-logger");
+    appendNotification(summarize(report), "warning", "workflow-logger", { kind: "provider-switch" });
   } catch {
     // Notification persistence is best-effort.
   }

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -3,6 +3,7 @@
 
 import { isToolUnavailableError } from "./auto-tool-tracking.js";
 import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
+import { recoveryRemediation } from "./guidance.js";
 import { ReconciliationFailedError } from "./state-reconciliation.js";
 import { IllegalPhaseTransitionError } from "./state-transition-matrix.js";
 
@@ -51,113 +52,46 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         ? "illegal-transition"
         : input.failureKind ?? inferFailureKind(message);
 
-  switch (failureKind) {
-    case "tool-schema":
-      return {
-        failureKind,
-        action: "stop",
-        reason: `Tool schema failure${unitSuffix(input)}: ${message}`,
-        exitReason: "tool-schema",
-        remediation: "Fix the Unit Tool Contract or tool schema before retrying.",
-      };
-    case "tool-contract":
-      return {
-        failureKind,
-        action: "stop",
-        reason: `Tool Contract failure${unitSuffix(input)}: ${message}`,
-        exitReason: "tool-contract",
-        remediation: "Fix the Unit Tool Contract or prompt so the Unit is only asked to use tools owned by its phase.",
-      };
-    case "tool-unavailable":
-      return {
-        failureKind,
-        action: "retry",
-        reason: `Tool unavailable${unitSuffix(input)}: ${message}`,
-        exitReason: "tool-unavailable",
-        remediation:
-          "The tool surface had not finished registering when the Unit called it (workflow MCP startup race). Retry after the surface is ready; escalate if the tool never appears.",
-      };
-    case "deterministic-policy":
-      return {
-        failureKind,
-        action: "stop",
-        reason: `Deterministic policy failure${unitSuffix(input)}: ${message}`,
-        exitReason: "deterministic-policy",
-        remediation: "Resolve the policy blocker; retrying the same Unit will repeat the failure.",
-      };
-    case "lifecycle-progression":
-      return {
-        failureKind,
-        action: "stop",
-        reason: `Lifecycle progression failure${unitSuffix(input)}: ${message}`,
-        exitReason: "lifecycle-progression",
-        remediation: "Route to the required owning Unit or restore the missing artifact before advancing lifecycle state.",
-      };
-    case "stale-worker":
-      return {
-        failureKind,
-        action: "stop",
-        reason: `Stale worker failure${unitSuffix(input)}: ${message}`,
-        exitReason: "stale-worker",
-        remediation: "Clear or reconcile the stale worker before dispatching another Unit.",
-      };
-    case "worktree-invalid":
-      return {
-        failureKind,
-        action: "stop",
-        reason: `Worktree invalid${unitSuffix(input)}: ${message}`,
-        exitReason: "worktree-invalid",
-        remediation: "Repair or recreate the milestone worktree before launching source-writing Units.",
-      };
-    case "verification-drift":
-      return {
-        failureKind,
-        action: "escalate",
-        reason: `Verification drift${unitSuffix(input)}: ${message}`,
-        exitReason: "verification-drift",
-        remediation: "Inspect the verification artifact and reconcile the state snapshot before resuming.",
-      };
-    case "reconciliation-drift":
-      return {
-        failureKind,
-        action: "escalate",
-        reason: `Reconciliation drift${unitSuffix(input)}: ${message}`,
-        exitReason: "reconciliation-drift",
-        remediation:
-          "Inspect the persistent or repair-failed drift kinds reported by the State Reconciliation Module before resuming.",
-      };
-    case "illegal-transition":
-      return {
-        failureKind,
-        action: "escalate",
-        reason: `Illegal phase transition${unitSuffix(input)}: ${message}`,
-        exitReason: "illegal-transition",
-        remediation:
-          "A derived Phase edge rejected by the Phase Transition Invariant survived reconciliation; inspect deriveState and the State Reconciliation Module before resuming.",
-      };
-    case "provider": {
-      const providerClass = classifyError(message, input.retryAfterMs);
-      return {
-        failureKind,
-        action: isTransient(providerClass) ? "retry" : "escalate",
-        reason: message,
-        exitReason: `provider-${providerClass.kind}`,
-        remediation: isTransient(providerClass)
-          ? "Retry after the provider/network condition clears."
-          : "Inspect provider credentials, model entitlement, or request shape.",
-        providerClass: providerClass.kind,
-      };
-    }
-    case "runtime-unknown":
-      return {
-        failureKind,
-        action: "escalate",
-        reason: message,
-        exitReason: "runtime-unknown",
-        remediation: "Inspect the runtime error and add a dedicated classification if it is repeatable.",
-      };
+  if (failureKind === "provider") {
+    const providerClass = classifyError(message, input.retryAfterMs);
+    const transient = isTransient(providerClass);
+    return {
+      failureKind,
+      action: transient ? "retry" : "escalate",
+      reason: message,
+      exitReason: `provider-${providerClass.kind}`,
+      remediation: recoveryRemediation(transient ? "provider-transient" : "provider-permanent"),
+      providerClass: providerClass.kind,
+    };
   }
+
+  const { action, label } = FAILURE_TAXONOMY[failureKind];
+  return {
+    failureKind,
+    action,
+    reason: label ? `${label}${unitSuffix(input)}: ${message}` : message,
+    exitReason: failureKind,
+    remediation: recoveryRemediation(failureKind),
+  };
 }
+
+/** Per-kind action and reason label. Remediation lives in the Guidance module. */
+const FAILURE_TAXONOMY: Record<
+  Exclude<RecoveryFailureKind, "provider">,
+  { action: RecoveryAction; label: string | null }
+> = {
+  "tool-schema": { action: "stop", label: "Tool schema failure" },
+  "tool-contract": { action: "stop", label: "Tool Contract failure" },
+  "tool-unavailable": { action: "retry", label: "Tool unavailable" },
+  "deterministic-policy": { action: "stop", label: "Deterministic policy failure" },
+  "lifecycle-progression": { action: "stop", label: "Lifecycle progression failure" },
+  "stale-worker": { action: "stop", label: "Stale worker failure" },
+  "worktree-invalid": { action: "stop", label: "Worktree invalid" },
+  "verification-drift": { action: "escalate", label: "Verification drift" },
+  "reconciliation-drift": { action: "escalate", label: "Reconciliation drift" },
+  "illegal-transition": { action: "escalate", label: "Illegal phase transition" },
+  "runtime-unknown": { action: "escalate", label: null },
+};
 
 function inferFailureKind(message: string): RecoveryFailureKind {
   if (isToolUnavailableError(message)) return "tool-unavailable";

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -71,27 +71,10 @@ import {
   readinessNeedsDiscussion,
 } from './milestone-readiness.js';
 
-function formatNeedsAttentionBlocker(milestoneId: string): string {
-  return [
-    `Milestone ${milestoneId} is blocked because milestone validation returned needs-attention.`,
-    `Fix options:`,
-    `1. Review the validation details: \`/gsd status\``,
-    `2. If you fixed the missing evidence or issue, re-run milestone validation: \`/gsd validate-milestone\``,
-    `3. If the finding is acceptable, override it: \`/gsd verdict pass --rationale "why this is okay"\``,
-    `4. If this should wait, defer it explicitly: \`/gsd park ${milestoneId}\``,
-    `After validation or override passes, run \`/gsd auto\` to complete and merge the milestone.`,
-  ].join("\n");
-}
-
-function formatNeedsRemediationBlocker(milestoneId: string): string {
-  return [
-    `Milestone ${milestoneId} is blocked because milestone validation returned needs-remediation, but all slices are complete.`,
-    `Fix options:`,
-    `1. Run \`/gsd dispatch reassess\` to add remediation slices, then run \`/gsd auto\``,
-    `2. If the finding is acceptable, override it: \`/gsd verdict pass --rationale "why this is okay"\``,
-    `3. If this should wait, defer it explicitly: \`/gsd park ${milestoneId}\``,
-  ].join("\n");
-}
+import {
+  needsAttentionBlockerGuidance as formatNeedsAttentionBlocker,
+  needsRemediationBlockerGuidance as formatNeedsRemediationBlocker,
+} from './guidance.js';
 
 /**
  * A "ghost" milestone directory contains only META.json (and no substantive

--- a/src/resources/extensions/gsd/stop-notice.ts
+++ b/src/resources/extensions/gsd/stop-notice.ts
@@ -1,0 +1,75 @@
+// Project/App: gsd-pi
+// File Purpose: Stop Notice module — single owner of the auto/step-mode
+// stop/pause notice vocabulary. Both sides of the wire live here: the
+// formatters that produce the canonical prefixes (used by stopAuto/pauseAuto)
+// and the classifiers that recognize them (used by the headless host to pick
+// exit codes). Wording changes in this file keep emitter and detector in
+// lockstep; round-trip tests enforce it.
+
+export type StopNoticeKind = "stopped" | "blocked";
+
+/** A reason string of the form "Blocked: …" marks a blocked stop. */
+export function isBlockedStopReason(reason?: string | null): boolean {
+  return /^Blocked:\s*/i.test(reason ?? "");
+}
+
+/** Strip the "Blocked: " marker for display. */
+export function stopNoticeDisplayReason(reason?: string | null): string {
+  return (reason ?? "").replace(/^Blocked:\s*/i, "").trim();
+}
+
+export function stopNoticeKind(reason?: string | null): StopNoticeKind {
+  return isBlockedStopReason(reason) ? "blocked" : "stopped";
+}
+
+/** Canonical stop-notice prefix: "Auto-mode blocked — reason" / "Auto-mode stopped". */
+export function formatStopNoticePrefix(reason?: string | null): string {
+  const displayReason = stopNoticeDisplayReason(reason);
+  const prefix = stopNoticeKind(reason) === "blocked" ? "Auto-mode blocked" : "Auto-mode stopped";
+  return displayReason ? `${prefix} — ${displayReason}` : prefix;
+}
+
+// ─── Classification (headless host side) ────────────────────────────────
+// The canonical lowercase prefixes the headless event loop recognizes in
+// notify messages. Emitters above and ad-hoc emitters elsewhere must start
+// their terminal notices with one of these.
+
+export const PAUSED_NOTICE_PREFIXES = ["auto-mode paused", "step-mode paused"] as const;
+
+export const TERMINAL_NOTICE_PREFIXES = [
+  "auto-mode stopped",
+  "step-mode stopped",
+  "auto-mode complete",
+  "no active milestone",
+  "auto-mode idle",
+] as const;
+
+/** Manual-resolution notices emitted before auto-mode can formally pause/stop. */
+export function isManualResolutionNotice(message: string): boolean {
+  return (
+    message.includes("resolve manually and re-run /gsd auto") ||
+    message.includes("resolve conflicts manually and run /gsd auto to resume") ||
+    message.includes("resolve and run /gsd auto to resume")
+  );
+}
+
+export function isPauseNotice(message: string): boolean {
+  return PAUSED_NOTICE_PREFIXES.some((prefix) => message.startsWith(prefix));
+}
+
+export function isTerminalNotice(message: string): boolean {
+  return TERMINAL_NOTICE_PREFIXES.some((prefix) => message.startsWith(prefix));
+}
+
+/** Pauses that do not require operator intervention in headless mode. */
+export function isNonBlockingPauseNotice(message: string): boolean {
+  return message.includes("idempotent advance: unit already active");
+}
+
+export function isBlockedNoticeMessage(message: string): boolean {
+  return (
+    message.includes("blocked:") ||
+    (isPauseNotice(message) && !isNonBlockingPauseNotice(message)) ||
+    isManualResolutionNotice(message)
+  );
+}

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -472,18 +472,19 @@ test("auto-dispatch needs-attention pause message references /gsd verdict", asyn
   }
 });
 
-test("state.ts needs-remediation blocker messages reference /gsd verdict", async () => {
+test("guidance.ts needs-remediation blocker messages reference /gsd verdict", async () => {
   // We don't need to invoke deriveState — just assert the substring is in the
-  // source. The blocker strings are constructed inline and shipped to the user
-  // verbatim, so a static check is sufficient and avoids fragile DB setup.
-  const stateSource = readFileSync(
-    new URL("../state.ts", import.meta.url).pathname,
+  // source. The blocker strings are constructed in the guidance catalog and
+  // shipped to the user verbatim, so a static check is sufficient and avoids
+  // fragile DB setup.
+  const guidanceSource = readFileSync(
+    new URL("../guidance.ts", import.meta.url).pathname,
     "utf-8",
   );
-  const occurrences = stateSource.match(/`\/gsd verdict /g) ?? [];
+  const occurrences = guidanceSource.match(/`\/gsd verdict /g) ?? [];
   assert.ok(
     occurrences.length >= 2,
-    `expected at least 2 references to /gsd verdict in state.ts blockers, found ${occurrences.length}`,
+    `expected at least 2 references to /gsd verdict in guidance.ts blockers, found ${occurrences.length}`,
   );
 });
 

--- a/src/resources/extensions/gsd/tests/guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/guidance.test.ts
@@ -1,0 +1,125 @@
+// GSD Extension — Guidance module tests
+// The catalog is the test surface: every typed finding must resolve to
+// non-empty remediation, and load-bearing phrases must survive edits.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatGuidance,
+  recoveryRemediation,
+  needsAttentionBlockerGuidance,
+  needsRemediationBlockerGuidance,
+  crashResumeHint,
+  doctorFixHint,
+  type RecoveryGuidanceKey,
+} from "../guidance.js";
+import { classifyFailure, type RecoveryFailureKind } from "../recovery-classification.js";
+import { isValidationBlockedState } from "../validation-block-guard.js";
+import type { GSDState } from "../types.js";
+
+const RECOVERY_KEYS: RecoveryGuidanceKey[] = [
+  "tool-schema",
+  "tool-contract",
+  "tool-unavailable",
+  "deterministic-policy",
+  "lifecycle-progression",
+  "stale-worker",
+  "worktree-invalid",
+  "verification-drift",
+  "reconciliation-drift",
+  "illegal-transition",
+  "runtime-unknown",
+  "provider-transient",
+  "provider-permanent",
+];
+
+describe("guidance catalog", () => {
+  test("every recovery guidance key resolves to non-empty remediation", () => {
+    for (const key of RECOVERY_KEYS) {
+      const remediation = recoveryRemediation(key);
+      assert.ok(remediation.length > 0, `empty remediation for ${key}`);
+    }
+  });
+
+  test("classifyFailure carries catalog remediation for every failure kind", () => {
+    const kinds: RecoveryFailureKind[] = [
+      "tool-schema",
+      "tool-contract",
+      "deterministic-policy",
+      "lifecycle-progression",
+      "stale-worker",
+      "worktree-invalid",
+      "verification-drift",
+      "reconciliation-drift",
+      "runtime-unknown",
+    ];
+    for (const kind of kinds) {
+      const result = classifyFailure({ error: new Error("boom"), failureKind: kind });
+      assert.equal(result.failureKind, kind);
+      assert.equal(result.exitReason, kind);
+      assert.ok(result.remediation.length > 0, `empty remediation for ${kind}`);
+    }
+  });
+
+  test("escalation kinds with weak guidance now name a concrete command", () => {
+    for (const key of ["stale-worker", "worktree-invalid", "verification-drift", "reconciliation-drift"] as const) {
+      assert.match(recoveryRemediation(key), /\/gsd /, `no command in remediation for ${key}`);
+    }
+  });
+
+  test("formatGuidance numbers steps under the summary", () => {
+    const text = formatGuidance({ summary: "It broke.", steps: ["Fix it.", "Retry."] });
+    assert.equal(text, "It broke.\n\n1. Fix it.\n2. Retry.");
+  });
+
+  test("formatGuidance with no steps is just the summary", () => {
+    assert.equal(formatGuidance({ summary: "All good.", steps: [] }), "All good.");
+  });
+});
+
+describe("milestone blocker guidance", () => {
+  test("needs-attention blocker keeps the phrase the validation-block guard matches", () => {
+    const state = { phase: "blocked", blockers: [needsAttentionBlockerGuidance("M005")] } as unknown as GSDState;
+    assert.ok(isValidationBlockedState(state));
+  });
+
+  test("needs-remediation blocker keeps the phrase the validation-block guard matches", () => {
+    const state = { phase: "blocked", blockers: [needsRemediationBlockerGuidance("M005")] } as unknown as GSDState;
+    assert.ok(isValidationBlockedState(state));
+  });
+
+  test("blockers carry the milestone id and concrete fix commands", () => {
+    const text = needsAttentionBlockerGuidance("M007");
+    assert.match(text, /M007/);
+    assert.match(text, /\/gsd status/);
+    assert.match(text, /\/gsd validate-milestone/);
+  });
+});
+
+describe("crash resume hints", () => {
+  test("bootstrap crash reports no work lost", () => {
+    assert.match(crashResumeHint("starting", "bootstrap") ?? "", /No work was lost/);
+  });
+
+  test("unit classes map to their resume hints", () => {
+    assert.match(crashResumeHint("research-milestone", "M001") ?? "", /may be incomplete/);
+    assert.match(crashResumeHint("execute-task", "T001") ?? "", /completed work is preserved/);
+    assert.match(crashResumeHint("complete-slice", "S001") ?? "", /interrupted/);
+  });
+
+  test("unknown unit types yield no hint", () => {
+    assert.equal(crashResumeHint("triage-captures", "X"), undefined);
+  });
+});
+
+describe("doctor fix hints", () => {
+  test("known codes resolve to a hint", () => {
+    assert.ok(doctorFixHint("stale_crash_lock"));
+    assert.ok(doctorFixHint("db_unavailable"));
+  });
+
+  test("codes without authored guidance resolve to undefined", () => {
+    assert.equal(doctorFixHint("delimiter_in_title"), undefined);
+  });
+});

--- a/src/resources/extensions/gsd/tests/notification-store.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-store.test.ts
@@ -306,6 +306,38 @@ describe("notification-store", () => {
     rmSync(lockPath, { force: true });
   });
 
+  test("structured meta persists kind and scope on the entry", () => {
+    initNotificationStore(tmp);
+    appendNotification("Auto-mode blocked — validation gate", "warning", "notify", { kind: "auto-stop", scope: "M005" });
+
+    const entries = readNotifications();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].kind, "auto-stop");
+    assert.equal(entries[0].scope, "M005");
+  });
+
+  test("dedup keys on kind+scope when present, not on prose", () => {
+    initNotificationStore(tmp);
+    appendNotification("Auto-mode blocked — validation gate", "warning", "notify", { kind: "auto-stop", scope: "M005" });
+    // Rephrased message, same structured identity → deduped within the window
+    appendNotification("Auto-mode blocked — gate rejected", "warning", "notify", { kind: "auto-stop", scope: "M005" });
+    // Same kind, different scope → distinct
+    appendNotification("Auto-mode blocked — validation gate", "warning", "notify", { kind: "auto-stop", scope: "M006" });
+
+    assert.equal(readNotifications().length, 2);
+  });
+
+  test("readNotifications filters by kind and scope", () => {
+    initNotificationStore(tmp);
+    appendNotification("a", "info", "notify", { kind: "auto-stop", scope: "M005" });
+    appendNotification("b", "info", "notify", { kind: "provider-error-pause", scope: "M005" });
+    appendNotification("c", "info");
+
+    assert.equal(readNotifications(tmp, { kind: "auto-stop" }).length, 1);
+    assert.equal(readNotifications(tmp, { scope: "M005" }).length, 2);
+    assert.equal(readNotifications(tmp, { kind: "provider-error-pause", scope: "M005" })[0].message, "b");
+  });
+
   test("listeners are notified on append, markAllRead, and clear", () => {
     initNotificationStore(tmp);
     let calls = 0;

--- a/src/resources/extensions/gsd/tests/provider-error-guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-error-guidance.test.ts
@@ -3,10 +3,10 @@ import assert from "node:assert/strict";
 
 import { classifyError, isTransient } from "../error-classifier.ts";
 import {
-  formatProviderErrorGuidance,
   resolveProviderErrorGuidance,
   unitTypeToPrefsPhaseKey,
 } from "../provider-error-guidance.ts";
+import { formatGuidance } from "../guidance.ts";
 
 test("classifyError: Cloud Code Assist 400 invalid argument is model-error", () => {
   const result = classifyError(
@@ -75,8 +75,8 @@ test("resolveProviderErrorGuidance suggests gemini-3-flash for antigravity pro-h
   assert.ok(guidance.steps.some((step) => step.includes("fallbacks")));
 });
 
-test("formatProviderErrorGuidance numbers steps", () => {
-  const text = formatProviderErrorGuidance({
+test("formatGuidance numbers steps", () => {
+  const text = formatGuidance({
     summary: "Provider error on test/model.",
     steps: ["Change model", "Run /gsd next"],
   });

--- a/src/resources/extensions/gsd/tests/stop-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-notice.test.ts
@@ -1,0 +1,70 @@
+// GSD Extension — Stop Notice module tests
+// Locks the emitter↔detector round-trip: every notice the formatters produce
+// must be recognized by the classifiers the headless host uses for exit codes.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatStopNoticePrefix,
+  isBlockedStopReason,
+  stopNoticeDisplayReason,
+  stopNoticeKind,
+  isTerminalNotice,
+  isPauseNotice,
+  isBlockedNoticeMessage,
+  isManualResolutionNotice,
+  PAUSED_NOTICE_PREFIXES,
+  TERMINAL_NOTICE_PREFIXES,
+} from "../stop-notice.js";
+
+describe("stop notice formatting", () => {
+  test("plain stop has no reason suffix", () => {
+    assert.equal(formatStopNoticePrefix(), "Auto-mode stopped");
+    assert.equal(formatStopNoticePrefix(null), "Auto-mode stopped");
+  });
+
+  test("reason is appended after an em-dash", () => {
+    assert.equal(formatStopNoticePrefix("user request"), "Auto-mode stopped — user request");
+  });
+
+  test("Blocked: marker switches the prefix and is stripped from display", () => {
+    assert.equal(formatStopNoticePrefix("Blocked: validation gate"), "Auto-mode blocked — validation gate");
+    assert.equal(stopNoticeKind("Blocked: x"), "blocked");
+    assert.equal(stopNoticeKind("stop"), "stopped");
+    assert.ok(isBlockedStopReason("blocked: lowercase too"));
+    assert.equal(stopNoticeDisplayReason("Blocked:  spaced "), "spaced");
+  });
+});
+
+describe("emitter↔detector round-trip", () => {
+  test("formatted stop notices classify as terminal", () => {
+    for (const reason of [undefined, "user request"]) {
+      const message = formatStopNoticePrefix(reason).toLowerCase();
+      assert.ok(isTerminalNotice(message), `not terminal: ${message}`);
+    }
+  });
+
+  test("pause prefixes classify as pause and as blocked (operator intervention)", () => {
+    for (const prefix of PAUSED_NOTICE_PREFIXES) {
+      assert.ok(isPauseNotice(`${prefix}: provider error`));
+      assert.ok(isBlockedNoticeMessage(`${prefix}: provider error`));
+    }
+  });
+
+  test("idempotent-advance pauses are non-blocking", () => {
+    assert.equal(isBlockedNoticeMessage("auto-mode paused (idempotent advance: unit already active)"), false);
+  });
+
+  test("manual-resolution notices classify as blocked", () => {
+    const message = "merge conflict — resolve manually and re-run /gsd auto";
+    assert.ok(isManualResolutionNotice(message));
+    assert.ok(isBlockedNoticeMessage(message));
+  });
+
+  test("terminal prefixes cover the known stop vocabulary", () => {
+    for (const message of ["auto-mode stopped.", "auto-mode complete", "auto-mode idle", "no active milestone"]) {
+      assert.ok(TERMINAL_NOTICE_PREFIXES.some((prefix) => message.startsWith(prefix)), message);
+    }
+  });
+});

--- a/src/resources/extensions/gsd/unit-closeout.ts
+++ b/src/resources/extensions/gsd/unit-closeout.ts
@@ -90,7 +90,7 @@ const defaultDeps: UnitCloseoutDeps = {
     }
   },
   commit: (basePath, unitType, unitId) => autoCommitCurrentBranch(basePath, unitType, unitId),
-  notify: (message, severity) => appendNotification(message, severity, "notify", { kind: "unit-closeout" }),
+  notify: (message, severity) => appendNotification(message, severity),
 };
 
 export function closeUnit(request: UnitCloseoutRequest, deps: UnitCloseoutDeps = defaultDeps): UnitCloseoutResult {

--- a/src/resources/extensions/gsd/unit-closeout.ts
+++ b/src/resources/extensions/gsd/unit-closeout.ts
@@ -90,7 +90,7 @@ const defaultDeps: UnitCloseoutDeps = {
     }
   },
   commit: (basePath, unitType, unitId) => autoCommitCurrentBranch(basePath, unitType, unitId),
-  notify: (message, severity) => appendNotification(message, severity),
+  notify: (message, severity) => appendNotification(message, severity, "notify", { kind: "unit-closeout" }),
 };
 
 export function closeUnit(request: UnitCloseoutRequest, deps: UnitCloseoutDeps = defaultDeps): UnitCloseoutResult {

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -19,6 +19,7 @@
  */
 
 import chalk from 'chalk'
+import { bannerLines, name as styledName, warn } from './cli-style.js'
 import { createJiti } from '@mariozechner/jiti'
 import { fileURLToPath } from 'node:url'
 import { generateWorktreeName } from './worktree-name-gen.js'
@@ -387,13 +388,12 @@ async function handleStatusBanner(basePath: string): Promise<void> {
 
   if (withChanges.length === 0) return
 
-  const names = withChanges.map(w => chalk.cyan(w.name)).join(', ')
+  const names = withChanges.map(w => styledName(w.name)).join(', ')
   process.stderr.write(
-    chalk.dim('[gsd] ') +
-    chalk.yellow(`${withChanges.length} worktree${withChanges.length === 1 ? '' : 's'} with unmerged changes: `) +
-    names + '\n' +
-    chalk.dim('[gsd] ') +
-    chalk.dim('Resume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list\n\n'),
+    bannerLines(
+      warn(`${withChanges.length} worktree${withChanges.length === 1 ? '' : 's'} with unmerged changes: `) + names,
+      'Resume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list',
+    ),
   )
 }
 

--- a/src/worktree-status-banner.ts
+++ b/src/worktree-status-banner.ts
@@ -2,7 +2,7 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
 import { resolve, sep } from 'node:path'
-import chalk from 'chalk'
+import { bannerLines, name, warn } from './cli-style.js'
 import { worktreesDirs } from './resources/extensions/gsd/worktree-placement.js'
 
 interface WorktreeEntry {
@@ -139,12 +139,11 @@ export function showWorktreeStatusBanner(basePath: string): void {
   const withChanges = worktrees.filter((worktree) => branchHasChanges(basePath, mainBranch, worktree.branch))
   if (withChanges.length === 0) return
 
-  const names = withChanges.map((worktree) => chalk.cyan(worktree.name)).join(', ')
+  const names = withChanges.map((worktree) => name(worktree.name)).join(', ')
   process.stderr.write(
-    chalk.dim('[gsd] ') +
-    chalk.yellow(`${withChanges.length} worktree${withChanges.length === 1 ? '' : 's'} with unmerged changes: `) +
-    names + '\n' +
-    chalk.dim('[gsd] ') +
-    chalk.dim('Resume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list\n\n'),
+    bannerLines(
+      warn(`${withChanges.length} worktree${withChanges.length === 1 ? '' : 's'} with unmerged changes: `) + names,
+      'Resume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list',
+    ),
   )
 }


### PR DESCRIPTION
## Intent

Architecture deepening of the user-facing notices/alerts & guidance surfaces, requested via an /improve-codebase-architecture review the user approved in full ('do them all'). Five deliberate deepenings: (1) new Guidance module (guidance.ts) — single catalog mapping typed findings (Recovery kinds, milestone blocker kinds, doctor issue codes, crash unit classes) to remediation text; recovery-classification, state.ts blockers, crash-recovery, and provider-error-guidance now resolve prose through it, and the four previously-vague escalation remediations (stale-worker, worktree-invalid, verification-drift, reconciliation-drift) now name concrete /gsd commands — those wording changes are intentional improvements, not regressions. (2) new Stop Notice module (stop-notice.ts) owning the auto/step-mode stop/pause notice vocabulary on both sides of the wire: auto.ts formatters and headless-events.ts exit-code classifiers both delegate to it (behavior-preserving move; round-trip tested). (3) doctor-format renders a 'Fix:' hint per issue code from the Guidance catalog (partial catalog by design — missing codes render nothing). (4) notification-store gains optional structured identity (kind+scope) that keys dedup instead of prose when present, adopted at the three direct producers (unit-closeout, provider-switch-observer, memory-consolidation-scanner); the ctx.ui.notify interceptor path intentionally remains unstructured for incremental adoption. (5) new cli-style.ts terminal presentation helpers adopted by the two duplicate worktree unmerged-changes banners. The blocker text 'milestone validation returned needs-attention/remediation' is load-bearing (matched by validation-block-guard regex) and was intentionally kept verbatim. The legacy formatProviderErrorGuidance wrapper was deliberately deleted in favor of formatGuidance.

## What Changed

- Added a `guidance.ts` catalog that maps typed findings (recovery kinds, milestone blocker kinds, doctor issue codes, crash unit classes) to remediation prose; recovery-classification, `state.ts` blockers, crash-recovery, and provider-error-guidance now resolve text through it, and four previously-vague escalation remediations (stale-worker, worktree-invalid, verification-drift, reconciliation-drift) now name concrete `/gsd` commands. The legacy `formatProviderErrorGuidance` wrapper was dropped in favor of `formatGuidance`.
- Extracted a `stop-notice.ts` module owning the auto/step-mode stop/pause notice vocabulary, with `auto.ts` formatters and `headless-events.ts` exit-code classifiers both delegating to it; `doctor-format` now renders a per-issue-code `Fix:` hint from the guidance catalog.
- Gave `notification-store` optional structured identity (`kind`+`scope`) that keys dedup when present, adopted at the unit-closeout, provider-switch, and memory-consolidation producers, and moved the duplicate worktree unmerged-changes banners onto new `cli-style.ts` terminal helpers; added test suites for guidance, stop-notice, and notification-store.

## Risk Assessment

✅ Low: Behavior-preserving consolidation refactor whose moved logic I verified is logically identical to the originals, with no dangling references and the one prior-round finding already resolved via revert.

## Testing

After fixing a setup gap (no node_modules, contracts/native/pi package dists, or dist-test present — installed deps and ran build:contracts/build:pi/test:compile per the CI order), I ran the four changed/new suites (54/54 pass) plus 16 related suites covering recovery, doctor, headless stop/blocked, provider/memory observers, and worktree banners (268/268 pass). Beyond green tests, I rendered the real user-facing output from the compiled modules — recovery remediation now naming concrete /gsd commands, the preserved milestone-blocker phrase, crash resume hints, the stop/pause emitter↔detector round-trip, the doctor report showing per-code 'Fix:' hints (and correctly omitting uncatalogued codes), provider-error guidance via formatGuidance, and the shared worktree banner with identical ANSI styling — captured as CLI transcripts. A diff of headless-events.ts/auto.ts confirms the Stop Notice move is a byte-identical extraction. Transient build artifacts are gitignored and the two build-touched generated files were reverted; tracked tree is clean.

<details>
<summary>Evidence: User-facing notices &amp; guidance transcript</summary>

<code>1. Recovery remediation — escalation kinds now name commands:&#10;• stale-worker: Run `/gsd doctor` to detect and clear the stale worker or lock, then run `/gsd auto` to resume.&#10;• worktree-invalid: Run `/gsd doctor` to diagnose the milestone worktree (`gsd worktree list` ...). Repair it, or merge salvageable work with `gsd worktree merge &lt;name&gt;` before recreating ...&#10;&#10;5. Doctor report &#39;Fix:&#39; hints (from Guidance catalog):&#10;- [ERROR] M005: Stale crash lock held by dead PID 4123&#10;Fix: Run `/gsd doctor` to clear the stale lock, then `/gsd auto` to resume.&#10;- [WARN] M005: Title contains a reserved delimiter (delimiter_in_title has no catalog row → no Fix line, by design)</code>

```text

══════════ 1. Recovery remediation — the four escalation kinds now name concrete /gsd commands ══════════
• stale-worker:
    Run `/gsd doctor` to detect and clear the stale worker or lock, then run `/gsd auto` to resume.
• worktree-invalid:
    Run `/gsd doctor` to diagnose the milestone worktree (`gsd worktree list` shows its state). Repair it, or merge salvageable work with `gsd worktree merge <name>` before recreating — recreating discards uncommitted work.
• verification-drift:
    Run `/gsd status` to see the verification finding, fix or re-run the verification, then run `/gsd auto` to resume. `/gsd doctor` can repair stale state files.
• reconciliation-drift:
    Run `/gsd doctor` to surface the persistent or repair-failed drift kinds, apply its fixes, then run `/gsd auto` to resume.

  (other kinds, for context)
• tool-unavailable: The tool surface had not finished registering when the Unit called it (workflow MCP startup race). Retry after the surface is ready; escalate if the tool never appears.
• provider-transient: Retry after the provider/network condition clears.
• provider-permanent: Inspect provider credentials, model entitlement, or request shape.

══════════ 2. Milestone validation blocker guidance (load-bearing phrase preserved) ══════════
Milestone M005 is blocked because milestone validation returned needs-attention.
Fix options:
1. Review the validation details: `/gsd status`
2. If you fixed the missing evidence or issue, re-run milestone validation: `/gsd validate-milestone`
3. If the finding is acceptable, override it: `/gsd verdict pass --rationale "why this is okay"`
4. If this should wait, defer it explicitly: `/gsd park M005`
After validation or override passes, run `/gsd auto` to complete and merge the milestone.

Milestone M005 is blocked because milestone validation returned needs-remediation, but all slices are complete.
Fix options:
1. Run `/gsd dispatch reassess` to add remediation slices, then run `/gsd auto`
2. If the finding is acceptable, override it: `/gsd verdict pass --rationale "why this is okay"`
3. If this should wait, defer it explicitly: `/gsd park M005`

══════════ 3. Crash resume hints by unit class ══════════
• starting/bootstrap → No work was lost. Run /gsd auto to restart.
• research-milestone/M001 → The research-milestone unit may be incomplete. Run /gsd auto to re-run it.
• execute-task/T001 → Task execution was interrupted. Run /gsd auto to resume — completed work is preserved.
• complete-slice/S001 → Slice/milestone completion was interrupted. Run /gsd auto to finish.
• triage-captures/X → (no hint)

══════════ 4. Stop / pause notices — emitter output + headless classification round-trip ══════════
emit: "Auto-mode stopped"
   → terminal=true blocked=false
emit: "Auto-mode stopped — user request"
   → terminal=true blocked=false
emit: "Auto-mode blocked — validation gate"
   → terminal=false blocked=false
emit: "auto-mode paused: provider error"
   → pause=true blocked=true

══════════ 5. Doctor report rendering a 'Fix:' hint per issue code (from the Guidance catalog) ══════════
GSD doctor found blocking issues.
Scope: M005
Issues: 4 total · 2 error(s) · 2 warning(s) · 2 fixable
Top issue types:
- delimiter_in_title: 1
- provider_key_missing: 1
- stale_crash_lock: 1
- worktree_dirty: 1
Priority issues:
- [ERROR] M005: Stale crash lock held by dead PID 4123
  Fix: Run `/gsd doctor` to clear the stale lock, then `/gsd auto` to resume.
- [WARN] M005: Worktree has uncommitted changes (.gsd/worktrees/M005)
  Fix: Commit or merge the worktree's changes (`gsd worktree merge <name>`) before removing it.
- [ERROR] M005: No API key for configured provider
  Fix: Add the provider API key to your environment or provider config, then retry.
- [WARN] M005: Title contains a reserved delimiter

  (note: 'delimiter_in_title' has no catalog row → renders no Fix line, by design)

══════════ 6. Provider-error guidance resolved through formatGuidance (legacy wrapper removed) ══════════
Provider error on google-antigravity/gemini-3.1-pro-high during research-milestone. The provider rejected the request as an invalid argument — often a model/config mismatch rather than auth or rate limits. Antigravity Gemini 3.1 Pro High/Low frequently hits this when thinking is disabled.

1. Edit /tmp/project/.gsd/PREFERENCES.md and set models.research to google-antigravity/gemini-3-flash (or another model that works in this project).
2. Optional: add fallbacks under models.research so GSD can switch automatically on the next failure.
3. Run /gsd next to resume the paused unit.
```
</details>
<details>
<summary>Evidence: Shared worktree unmerged-changes banner (ANSI + plain)</summary>

<code>=== ANSI (cat -v) ===&#10;^[[2m[gsd] ^[[22m^[[33m2 worktrees with unmerged changes: ^[[39m^[[36mfeature-login^[[39m, ^[[36mfix-crash^[[39m&#10;^[[2m[gsd] ^[[22m^[[2mResume: gsd -w &lt;name&gt; | Merge: gsd worktree merge &lt;name&gt; | List: gsd worktree list^[[22m&#10;=== plain ===&#10;[gsd] 2 worktrees with unmerged changes: feature-login, fix-crash&#10;[gsd] Resume: gsd -w &lt;name&gt; | Merge: gsd worktree merge &lt;name&gt; | List: gsd worktree list</code>

```text
=== worktree unmerged-changes banner — ANSI codes (cat -v) ===
^[[2m[gsd] ^[[22m^[[33m2 worktrees with unmerged changes: ^[[39m^[[36mfeature-login^[[39m, ^[[36mfix-crash^[[39m
^[[2m[gsd] ^[[22m^[[2mResume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list^[[22m


=== plain ===
[gsd] 2 worktrees with unmerged changes: feature-login, fix-crash
[gsd] Resume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/resources/extensions/gsd/unit-closeout.ts:93` - notification-store.ts now keys dedup on kind+scope when kind is present (line ~84). unit-closeout.ts:93 passes {kind: &#34;unit-closeout&#34;} with no scope, and the notify closure has no access to request.unitId to supply one. All unit-closeout notifications of a given severity now collapse to the dedup key &#39;…:notify:unit-closeout:&#39; within the 30s window. The messages embed distinct unitIds (commit-failed-for-&lt;id&gt;, milestone-&lt;id&gt;-completed), so previously prose-keyed dedup never merged distinct units; now the second of two distinct closeout notices within 30s is silently dropped, losing per-unit detail. Pass scope: request.unitId (plumbing unitId into the notify dep) to preserve old granularity. Unlike provider-switch/memory-consolidation (recurring same-event reports), closeout notices are inherently per-unit.

🔧 Fix: revert unit-closeout notify to prose-keyed dedup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile; pnpm run build:contracts; pnpm run build:pi; pnpm run test:compile (env setup — deps and package dists were absent)`
- `node --import ./scripts/dist-test-resolve.mjs --test on the four changed/new suites: guidance.test.js, stop-notice.test.js, notification-store.test.js, provider-error-guidance.test.js — 54/54 pass`
- `node --import ./scripts/dist-test-resolve.mjs --test on 16 related suites (recovery-classification-illegal-transition, state-reconciliation-drift, auto-recovery, crash-recovery, closeout-recovery, doctor-fix-flag, doctor-runtime-checks, auto-stop-notification, auto-blocked-remediation-message, auto-start-validation-block, provider-switch-observer, memory-consolidation-scanner, unit-closeout, worktree-expected-warnings, provider-errors, plan-gate-failed-doctor-heal-hint) — 268/268 pass`
- `Manual render of the actual user-facing surfaces (recovery remediation, milestone blocker guidance, crash resume hints, stop/pause notice round-trip, doctor report with Fix: hints, provider-error guidance) via render-notices-evidence.mjs against the compiled modules`
- `Manual render of the shared worktree unmerged-changes banner (with and without color) via render-banner.mjs, confirming ANSI styling matches the pre-refactor inline chalk`
- `git diff 8b07cb7d..6818af9a of headless-events.ts and auto.ts to confirm the Stop Notice extraction is behavior-preserving`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783718420&installation_id=134682257&pr_number=661&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F661&signature=9cb50e3e6468f1db5edb77c1181b6684a09893a24533dfc1fe009cd63012e116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a behavior-preserving refactor of notice wording and classification wiring; intentional remediation text changes are user-facing but covered by new tests and headless/stop-notice lockstep.
> 
> **Overview**
> Centralizes **user-facing notices and remediation** into shared modules so emitters and detectors stay aligned, with docs updated to match.
> 
> **`guidance.ts`** becomes the single catalog for recovery kinds, milestone validation blockers, doctor fix hints, and crash-resume copy. Call sites in recovery classification, `state.ts`, crash recovery, provider-error guidance, and agent-end recovery now route through `formatGuidance` / catalog helpers; several escalation remediations intentionally gain concrete `/gsd` commands. **`stop-notice.ts`** owns auto/step stop/pause prefixes and classifiers; **`auto.ts`** and **`headless-events.ts`** delegate to it.
> 
> **`notification-store`** adds optional `kind`/`scope` on entries (dedup by identity when `kind` is set, filter on read); adopted at memory-consolidation and provider-switch producers. **`doctor-format`** prints per-issue **Fix:** lines from the guidance catalog. **`cli-style.ts`** unifies the duplicate worktree unmerged-changes stderr banners.
> 
> New tests cover guidance, stop-notice round-trip, and notification-store meta/dedup; `formatProviderErrorGuidance` is removed in favor of `formatGuidance`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f2814ec7203101524a13342ecc6e38b314e00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->