### PR TITLE
refactor(tests): consolidate integration and e2e test fixtures

### DIFF
--- a/src/resources/extensions/gsd/tests/browser-automation-contract-fixture.ts
+++ b/src/resources/extensions/gsd/tests/browser-automation-contract-fixture.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+import {
+	getUatBrowserToolSupportError,
+	hasUatBrowserToolSurface,
+	type UatType,
+} from "../uat-policy.ts";
+
+export const BROWSER_AUTOMATION_CONTRACT_TOOLS = {
+	piProvider: ["read", "browser_navigate"],
+	externalMcpClient: ["read", "mcp__gsd-browser__browser_navigate"],
+	externalMcpWildcard: ["read", "mcp__gsd-browser__*"],
+	otherBrowserMcp: ["read", "mcp__browser-uat__*"],
+	workflowOnly: ["read", "mcp__gsd-workflow__*"],
+	withoutBrowser: ["read", "gsd_uat_exec"],
+} as const;
+
+export function assertBrowserAutomationContractAvailable(tools: readonly string[]): void {
+	assert.equal(hasUatBrowserToolSurface(tools), true, `${tools.join(", ")} should satisfy the Browser Automation Contract`);
+}
+
+export function assertBrowserAutomationContractMissing(tools: readonly string[] | undefined): void {
+	assert.equal(hasUatBrowserToolSurface(tools), false, `${tools?.join(", ") ?? "undefined"} should not satisfy the Browser Automation Contract`);
+}
+
+export function assertBrowserBackedUatCanDispatch(options: {
+	uatType: UatType;
+	activeTools: readonly string[] | undefined;
+	registeredTools?: readonly string[];
+}): void {
+	assert.equal(
+		getUatBrowserToolSupportError({
+			...options,
+			milestoneId: "M001",
+			sliceId: "S01",
+		}),
+		null,
+	);
+}

--- a/src/resources/extensions/gsd/tests/dispatch-run-uat-browser-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-run-uat-browser-tools.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 
 import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
 import type { GSDState } from "../types.ts";
+import { BROWSER_AUTOMATION_CONTRACT_TOOLS } from "./browser-automation-contract-fixture.ts";
 
 type DispatchRuleEntry = (typeof DISPATCH_RULES)[number];
 
@@ -80,7 +81,7 @@ test("run-uat browser preflight uses registered tools when the active surface is
   assert.match(blocked?.action === "stop" ? blocked.reason : "", /run-uat tool surface has none/);
 
   const dispatched = await runUatRule().match(makeContext(basePath, {
-    registeredTools: ["browser_navigate"],
+    registeredTools: [...BROWSER_AUTOMATION_CONTRACT_TOOLS.piProvider],
   }));
   assert.equal(dispatched?.action, "dispatch");
   assert.equal(dispatched?.action === "dispatch" ? dispatched.unitType : undefined, "run-uat");

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -35,6 +35,7 @@ import {
   insertTask,
   openDatabase,
 } from "../../gsd-db.ts";
+import { createGsdIntegrationProject } from "./gsd-integration-fixture.ts";
 
 function run(cmd: string, cwd: string): string {
   // Safe: all inputs are hardcoded test strings, not user input
@@ -42,17 +43,12 @@ function run(cmd: string, cwd: string): string {
 }
 
 function createTempRepo(): string {
-  const dir = realpathSync(mkdtempSync(join(tmpdir(), "wt-ms-merge-test-")));
-  run("git init", dir);
-  run("git config user.email test@test.com", dir);
-  run("git config user.name Test", dir);
-  writeFileSync(join(dir, "README.md"), "# test\n");
-  mkdirSync(join(dir, ".gsd"), { recursive: true });
-  writeFileSync(join(dir, ".gsd", "STATE.md"), "# State\n");
-  run("git add .", dir);
-  run("git commit -m init", dir);
-  run("git branch -M main", dir);
-  return dir;
+  return createGsdIntegrationProject({
+    prefix: "wt-ms-merge-test-",
+    initialFiles: {
+      ".gsd/STATE.md": "# State\n",
+    },
+  }).root;
 }
 
 function createTempRepoWithExternalGsd(): { repo: string; externalState: string } {

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
@@ -11,6 +11,11 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
+import {
+  commitAll,
+  createGsdIntegrationProject,
+  writeGsdMilestoneContext,
+} from "./gsd-integration-fixture.ts";
 
 import {
   createAutoWorktree,
@@ -32,17 +37,12 @@ function run(command: string, cwd: string): string {
 }
 
 function createTempRepo(): string {
-  const dir = realpathSync(mkdtempSync(join(tmpdir(), "auto-wt-test-")));
-  run("git init", dir);
-  run("git config user.email test@test.com", dir);
-  run("git config user.name Test", dir);
-  // Create initial commit on main
-  writeFileSync(join(dir, "README.md"), "# test\n");
-  run("git add .", dir);
-  run("git commit -m init", dir);
-  // Ensure branch is called main
-  run("git branch -M main", dir);
-  return dir;
+  return createGsdIntegrationProject("auto-wt-test-").root;
+}
+
+function commitMilestoneContext(repo: string, milestoneId: string): void {
+  writeGsdMilestoneContext(repo, milestoneId);
+  commitAll(repo, "add milestone");
 }
 
 describe("auto-worktree lifecycle", () => {
@@ -59,13 +59,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("create → detect → teardown", () => {
     tempDir = createTempRepo();
-
-    // Create .gsd/milestones/M003 with a dummy file (simulates planning artifacts)
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     // ─── createAutoWorktree ──────────────────────────────────────────
     const wtPath = createAutoWorktree(tempDir, "M003");
@@ -112,11 +106,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("re-entry: create again, exit without teardown, re-enter", () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     const wtPath2 = createAutoWorktree(tempDir, "M003");
     assert.ok(existsSync(wtPath2), "worktree re-created");
@@ -247,11 +237,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("coexistence with manual worktree", async () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     // Import createWorktree directly for manual worktree
     const { createWorktree } = await import("../../worktree-manager.ts");
@@ -274,11 +260,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("split-brain prevention: originalBase cleared after teardown", () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     createAutoWorktree(tempDir, "M003");
     teardownAutoWorktree(tempDir, "M003");
@@ -288,11 +270,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("#1526: getMainBranch returns milestone/<MID> in auto-worktree", async () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M005");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M005 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M005");
 
     const { GitServiceImpl } = await import("../../git-service.ts");
 
@@ -312,11 +290,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("#1713: stale worktree directory without .git file", async () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M010");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M010 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M010");
 
     // Simulate a crash leaving a stale directory with no .git file.
     const { worktreePath } = await import("../../worktree-manager.ts");
@@ -337,11 +311,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("#778: re-attach does not reconcile plan checkboxes into a worktree-local .gsd projection", async () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     const planRelPath = join(".gsd", "milestones", "M004", "slices", "S01", "S01-PLAN.md");
     const planDir = join(tempDir, ".gsd", "milestones", "M004", "slices", "S01");
@@ -401,11 +371,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("#2791: mcp.json is not copied into worktree on creation after copyPlanningArtifacts removal", () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     // Create mcp.json in .gsd/ AFTER the commit (untracked, like real usage).
     // Phase C removed copyPlanningArtifacts, so creation should not seed a
@@ -430,11 +396,7 @@ describe("auto-worktree lifecycle", () => {
 
   test("#2791: mcp.json synced via syncGsdStateToWorktree (ROOT_STATE_FILES)", () => {
     tempDir = createTempRepo();
-    const msDir = join(tempDir, ".gsd", "milestones", "M003");
-    mkdirSync(msDir, { recursive: true });
-    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
-    run("git add .", tempDir);
-    run("git commit -m \"add milestone\"", tempDir);
+    commitMilestoneContext(tempDir, "M003");
 
     // Create worktree first (no mcp.json yet)
     const wtPath = createAutoWorktree(tempDir, "M003");

--- a/src/resources/extensions/gsd/tests/integration/gsd-integration-fixture.ts
+++ b/src/resources/extensions/gsd/tests/integration/gsd-integration-fixture.ts
@@ -1,0 +1,80 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type GsdIntegrationProject = {
+  root: string;
+};
+
+export type CreateGsdIntegrationProjectOptions = {
+  prefix?: string;
+  initialFiles?: Record<string, string>;
+};
+
+export function projectRoot(project: GsdIntegrationProject | string): string {
+  return typeof project === "string" ? project : project.root;
+}
+
+export function git(project: GsdIntegrationProject | string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: projectRoot(project),
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+export function createGsdIntegrationProject(
+  options: CreateGsdIntegrationProjectOptions | string = {},
+): GsdIntegrationProject {
+  const resolvedOptions = typeof options === "string" ? { prefix: options } : options;
+  const prefix = resolvedOptions.prefix ?? "gsd-integration-";
+  const root = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+
+  git(root, "init");
+  git(root, "config", "user.email", "test@test.com");
+  git(root, "config", "user.name", "Test");
+  git(root, "config", "core.autocrlf", "false");
+
+  writeProjectFile(root, "README.md", "# test\n");
+  for (const [relativePath, content] of Object.entries(resolvedOptions.initialFiles ?? {})) {
+    writeProjectFile(root, relativePath, content);
+  }
+  git(root, "add", ".");
+  git(root, "commit", "-m", "init");
+  git(root, "branch", "-M", "main");
+
+  return { root };
+}
+
+export function writeProjectFile(
+  project: GsdIntegrationProject | string,
+  relativePath: string,
+  content: string,
+): string {
+  const filePath = join(projectRoot(project), relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+export function writeGsdMilestoneContext(
+  project: GsdIntegrationProject | string,
+  milestoneId: string,
+  content = `# ${milestoneId} Context\n`,
+): string {
+  return writeProjectFile(
+    project,
+    join(".gsd", "milestones", milestoneId, "CONTEXT.md"),
+    content,
+  );
+}
+
+export function commitAll(project: GsdIntegrationProject | string, message: string): void {
+  git(project, "add", ".");
+  git(project, "commit", "-m", message);
+}
+
+export function cleanupGsdIntegrationProject(project: GsdIntegrationProject | string): void {
+  rmSync(projectRoot(project), { recursive: true, force: true });
+}

--- a/src/resources/extensions/gsd/tests/uat-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-policy.test.ts
@@ -5,7 +5,6 @@ import {
   classifyUatContent,
   getDeclaredUatType,
   getUatBrowserToolSupportError,
-  hasUatBrowserToolSurface,
   isPartialEligibleUatType,
   resolveEffectiveUatType,
   shouldDispatchUatForContent,
@@ -13,6 +12,12 @@ import {
   uatTypeIncludesBrowser,
   validateUatModePolicy,
 } from "../uat-policy.ts";
+import {
+  assertBrowserAutomationContractAvailable,
+  assertBrowserAutomationContractMissing,
+  assertBrowserBackedUatCanDispatch,
+  BROWSER_AUTOMATION_CONTRACT_TOOLS,
+} from "./browser-automation-contract-fixture.ts";
 
 describe("uat-policy", () => {
   it("defaults missing UAT mode to artifact-driven", () => {
@@ -63,14 +68,14 @@ describe("uat-policy", () => {
     }
   });
 
-  it("detects direct and MCP-shaped browser tool surfaces", () => {
-    assert.equal(hasUatBrowserToolSurface(["read", "browser_navigate"]), true);
-    assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-browser__browser_navigate"]), true);
-    assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-browser__*"]), true);
-    assert.equal(hasUatBrowserToolSurface(["read", "mcp__browser-uat__*"]), true);
-    assert.equal(hasUatBrowserToolSurface(["read", "mcp__gsd-workflow__*"]), false);
-    assert.equal(hasUatBrowserToolSurface(["read", "gsd_uat_exec"]), false);
-    assert.equal(hasUatBrowserToolSurface(undefined), false);
+  it("detects Browser Automation Contract capability across adapters", () => {
+    assertBrowserAutomationContractAvailable(BROWSER_AUTOMATION_CONTRACT_TOOLS.piProvider);
+    assertBrowserAutomationContractAvailable(BROWSER_AUTOMATION_CONTRACT_TOOLS.externalMcpClient);
+    assertBrowserAutomationContractAvailable(BROWSER_AUTOMATION_CONTRACT_TOOLS.externalMcpWildcard);
+    assertBrowserAutomationContractAvailable(BROWSER_AUTOMATION_CONTRACT_TOOLS.otherBrowserMcp);
+    assertBrowserAutomationContractMissing(BROWSER_AUTOMATION_CONTRACT_TOOLS.workflowOnly);
+    assertBrowserAutomationContractMissing(BROWSER_AUTOMATION_CONTRACT_TOOLS.withoutBrowser);
+    assertBrowserAutomationContractMissing(undefined);
   });
 
   it("reports missing browser tools only for browser-backed UAT with a known tool snapshot", () => {
@@ -92,26 +97,16 @@ describe("uat-policy", () => {
       }),
       null,
     );
-    assert.equal(
-      getUatBrowserToolSupportError({
-        uatType: "human-experience",
-        activeTools: ["read", "gsd_uat_exec"],
-        registeredTools: ["browser_navigate"],
-        milestoneId: "M001",
-        sliceId: "S01",
-      }),
-      null,
-    );
-    assert.equal(
-      getUatBrowserToolSupportError({
-        uatType: "human-experience",
-        activeTools: ["read", "gsd_uat_exec"],
-        registeredTools: ["mcp__gsd-browser__*"],
-        milestoneId: "M001",
-        sliceId: "S01",
-      }),
-      null,
-    );
+    assertBrowserBackedUatCanDispatch({
+      uatType: "human-experience",
+      activeTools: BROWSER_AUTOMATION_CONTRACT_TOOLS.withoutBrowser,
+      registeredTools: BROWSER_AUTOMATION_CONTRACT_TOOLS.piProvider,
+    });
+    assertBrowserBackedUatCanDispatch({
+      uatType: "human-experience",
+      activeTools: BROWSER_AUTOMATION_CONTRACT_TOOLS.withoutBrowser,
+      registeredTools: BROWSER_AUTOMATION_CONTRACT_TOOLS.externalMcpWildcard,
+    });
 
     const error = getUatBrowserToolSupportError({
       uatType: "browser-executable",

--- a/src/tests/integration/cli-process.ts
+++ b/src/tests/integration/cli-process.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { killChildProcess } from "./child-process-guard.ts";
+
+export type RunResult = {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  timedOut: boolean;
+};
+
+export const projectRoot = process.cwd();
+export const loaderPath = join(projectRoot, "dist", "loader.js");
+
+export function ensureBuiltLoader(): void {
+  if (!existsSync(loaderPath)) {
+    throw new Error("dist/loader.js not found — run: npm run build");
+  }
+}
+
+export function runGsd(
+  args: string[],
+  timeoutMs = 8_000,
+  env: NodeJS.ProcessEnv = {},
+  cwd: string = projectRoot,
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const child = spawn("node", [loaderPath, ...args], {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.stdin.end();
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killChildProcess(child, "SIGTERM");
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code, timedOut });
+    });
+  });
+}
+
+export function spawnGsd(
+  args: string[],
+  timeoutMs = 30_000,
+  env: NodeJS.ProcessEnv = {},
+  cwd: string = projectRoot,
+): { child: ReturnType<typeof spawn>; result: Promise<RunResult> } {
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+
+  const child = spawn("node", [loaderPath, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  child.stdin.end();
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    killChildProcess(child, "SIGTERM");
+  }, timeoutMs);
+
+  const result = new Promise<RunResult>((resolve) => {
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code, timedOut });
+    });
+  });
+
+  return { child, result };
+}
+
+export function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
+}
+
+export function createTempGitRepo(prefix: string): string {
+  const dir = createTempDir(prefix);
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+export function createTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export function createTempWithGsd(prefix: string): string {
+  const dir = createTempDir(prefix);
+  mkdirSync(join(dir, ".gsd", "milestones"), { recursive: true });
+  mkdirSync(join(dir, ".gsd", "runtime"), { recursive: true });
+  return dir;
+}
+
+export function assertNoCrashMarkers(output: string): void {
+  const crashMarkers = [
+    "SyntaxError:",
+    "ReferenceError:",
+    "TypeError: Cannot read",
+    "FATAL ERROR",
+    "ERR_MODULE_NOT_FOUND",
+    "Error: Cannot find module",
+    "SIGSEGV",
+    "SIGABRT",
+  ];
+
+  for (const marker of crashMarkers) {
+    assert.ok(
+      !output.includes(marker),
+      `output should not contain crash marker '${marker}':\n${output.slice(0, 500)}`,
+    );
+  }
+}

--- a/src/tests/integration/e2e-headless.test.ts
+++ b/src/tests/integration/e2e-headless.test.ts
@@ -18,141 +18,18 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { killChildProcess } from "./child-process-guard.ts";
+import { rmSync } from "node:fs";
 
-const projectRoot = process.cwd();
-const loaderPath = join(projectRoot, "dist", "loader.js");
+import {
+  assertNoCrashMarkers,
+  createTempWithGsd,
+  ensureBuiltLoader,
+  runGsd,
+  spawnGsd,
+  stripAnsi,
+} from "./cli-process.ts";
 
-if (!existsSync(loaderPath)) {
-  throw new Error("dist/loader.js not found — run: npm run build");
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-type RunResult = {
-  stdout: string;
-  stderr: string;
-  code: number | null;
-  timedOut: boolean;
-};
-
-/**
- * Spawn `node dist/loader.js ...args` and collect output.
- */
-function runGsd(
-  args: string[],
-  timeoutMs = 30_000,
-  env: NodeJS.ProcessEnv = {},
-  cwd: string = projectRoot,
-): Promise<RunResult> {
-  return new Promise((resolve) => {
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-
-    const child = spawn("node", [loaderPath, ...args], {
-      cwd,
-      env: { ...process.env, ...env },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
-    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
-
-    child.stdin.end();
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      killChildProcess(child, "SIGTERM");
-    }, timeoutMs);
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve({ stdout, stderr, code, timedOut });
-    });
-  });
-}
-
-/**
- * Spawn a child process with the ability to send signals mid-flight.
- * Returns both the child and a promise that resolves with the result.
- */
-function spawnGsd(
-  args: string[],
-  timeoutMs = 30_000,
-  env: NodeJS.ProcessEnv = {},
-  cwd: string = projectRoot,
-): { child: ReturnType<typeof spawn>; result: Promise<RunResult> } {
-  let stdout = "";
-  let stderr = "";
-  let timedOut = false;
-
-  const child = spawn("node", [loaderPath, ...args], {
-    cwd,
-    env: { ...process.env, ...env },
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-
-  child.stdout!.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
-  child.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
-
-  child.stdin!.end();
-
-  const timer = setTimeout(() => {
-    timedOut = true;
-    killChildProcess(child, "SIGTERM");
-  }, timeoutMs);
-
-  const result = new Promise<RunResult>((resolve) => {
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve({ stdout, stderr, code, timedOut });
-    });
-  });
-
-  return { child, result };
-}
-
-/** Strip ANSI escape codes from a string. */
-function stripAnsi(s: string): string {
-  // eslint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
-}
-
-/** Bootstrap a temp directory with .gsd/ structure (milestones + runtime). */
-function createTempWithGsd(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  mkdirSync(join(dir, ".gsd", "milestones"), { recursive: true });
-  mkdirSync(join(dir, ".gsd", "runtime"), { recursive: true });
-  return dir;
-}
-
-/** Assert no crash markers in output. */
-function assertNoCrashMarkers(output: string): void {
-  const crashMarkers = [
-    "SyntaxError:",
-    "ReferenceError:",
-    "TypeError: Cannot read",
-    "FATAL ERROR",
-    "ERR_MODULE_NOT_FOUND",
-    "Error: Cannot find module",
-    "SIGSEGV",
-    "SIGABRT",
-  ];
-
-  for (const marker of crashMarkers) {
-    assert.ok(
-      !output.includes(marker),
-      `output should not contain crash marker '${marker}':\n${output.slice(0, 500)}`,
-    );
-  }
-}
+ensureBuiltLoader();
 
 // ===========================================================================
 // 1. JSON batch mode suppresses streaming — stdout is a single JSON result

--- a/src/tests/integration/e2e-smoke.test.ts
+++ b/src/tests/integration/e2e-smoke.test.ts
@@ -16,87 +16,18 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
-import { killChildProcess } from "./child-process-guard.ts";
+import {
+  assertNoCrashMarkers,
+  createTempDir,
+  createTempGitRepo,
+  ensureBuiltLoader,
+  runGsd,
+  stripAnsi,
+} from "./cli-process.ts";
 
-const projectRoot = process.cwd();
-const loaderPath = join(projectRoot, "dist", "loader.js");
-
-if (!existsSync(loaderPath)) {
-  throw new Error("dist/loader.js not found — run: npm run build");
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-type RunResult = {
-  stdout: string;
-  stderr: string;
-  code: number | null;
-  timedOut: boolean;
-};
-
-/**
- * Spawn `node dist/loader.js ...args` and collect output.
- *
- * @param args    CLI arguments to pass after the script path
- * @param timeoutMs  Maximum time to wait before SIGTERM (default 8 s)
- * @param env     Additional / override environment variables
- * @param cwd     Working directory for the child process (default: projectRoot)
- */
-function runGsd(
-  args: string[],
-  timeoutMs = 8_000,
-  env: NodeJS.ProcessEnv = {},
-  cwd: string = projectRoot,
-): Promise<RunResult> {
-  return new Promise((resolve) => {
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-
-    const child = spawn("node", [loaderPath, ...args], {
-      cwd,
-      env: { ...process.env, ...env },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
-    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
-
-    // Close stdin so the process sees a non-TTY environment.
-    child.stdin.end();
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      killChildProcess(child, "SIGTERM");
-    }, timeoutMs);
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve({ stdout, stderr, code, timedOut });
-    });
-  });
-}
-
-/** Strip ANSI escape codes from a string. */
-function stripAnsi(s: string): string {
-  // eslint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
-}
-
-function createTempGitRepo(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "pipe" });
-  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir, stdio: "pipe" });
-  execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir, stdio: "pipe" });
-  return dir;
-}
+ensureBuiltLoader();
 
 // ---------------------------------------------------------------------------
 // 1. gsd --version outputs a semver string and exits 0
@@ -423,7 +354,7 @@ test("gsd -h is equivalent to --help", async () => {
 // ---------------------------------------------------------------------------
 
 test("gsd headless without .gsd/ directory exits 1 with clean error", async (t) => {
-  const tmpDir = mkdtempSync(join(tmpdir(), "gsd-e2e-no-gsd-"));
+  const tmpDir = createTempDir("gsd-e2e-no-gsd-");
 
   t.after(() => { rmSync(tmpDir, { recursive: true, force: true }); });
 
@@ -446,7 +377,7 @@ test("gsd headless without .gsd/ directory exits 1 with clean error", async (t) 
 // ---------------------------------------------------------------------------
 
 test("gsd headless new-milestone without --context exits 1", async (t) => {
-  const tmpDir = mkdtempSync(join(tmpdir(), "gsd-e2e-no-ctx-"));
+  const tmpDir = createTempDir("gsd-e2e-no-ctx-");
 
   t.after(() => { rmSync(tmpDir, { recursive: true, force: true }); });
 
@@ -469,7 +400,7 @@ test("gsd headless new-milestone without --context exits 1", async (t) => {
 // ---------------------------------------------------------------------------
 
 test("gsd headless --timeout with invalid value exits 1", async (t) => {
-  const tmpDir = mkdtempSync(join(tmpdir(), "gsd-e2e-bad-timeout-"));
+  const tmpDir = createTempDir("gsd-e2e-bad-timeout-");
 
   t.after(() => { rmSync(tmpDir, { recursive: true, force: true }); });
 
@@ -497,7 +428,7 @@ test("gsd headless --timeout with invalid value exits 1", async (t) => {
 // ---------------------------------------------------------------------------
 
 test("gsd headless --timeout with negative value exits 1", async (t) => {
-  const tmpDir = mkdtempSync(join(tmpdir(), "gsd-e2e-neg-timeout-"));
+  const tmpDir = createTempDir("gsd-e2e-neg-timeout-");
 
   t.after(() => { rmSync(tmpDir, { recursive: true, force: true }); });
 
@@ -650,27 +581,3 @@ test("gsd headless help (positional) exits cleanly", async () => {
   assert.strictEqual(result.code, 0, `expected exit 0, got ${result.code}`);
   assert.ok(!result.timedOut, "process should not time out");
 });
-
-// ---------------------------------------------------------------------------
-// Shared crash marker assertion
-// ---------------------------------------------------------------------------
-
-function assertNoCrashMarkers(output: string): void {
-  const crashMarkers = [
-    "SyntaxError:",
-    "ReferenceError:",
-    "TypeError: Cannot read",
-    "FATAL ERROR",
-    "ERR_MODULE_NOT_FOUND",
-    "Error: Cannot find module",
-    "SIGSEGV",
-    "SIGABRT",
-  ];
-
-  for (const marker of crashMarkers) {
-    assert.ok(
-      !output.includes(marker),
-      `output should not contain crash marker '${marker}':\n${output.slice(0, 500)}`,
-    );
-  }
-}

--- a/src/tests/integration/web-bridge-runtime-fixture.ts
+++ b/src/tests/integration/web-bridge-runtime-fixture.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+export class FakeRpcChild extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  exitCode: number | null = null;
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    if (this.exitCode === null) {
+      this.exitCode = 0;
+    }
+    queueMicrotask(() => {
+      this.emit("exit", this.exitCode, signal);
+    });
+    return true;
+  }
+}
+
+export function serializeJsonLine(value: unknown): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+export function attachJsonLineReader(stream: PassThrough, onLine: (line: string) => void): void {
+  const decoder = new StringDecoder("utf8");
+  let buffer = "";
+
+  stream.on("data", (chunk: string | Buffer) => {
+    buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
+    while (true) {
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) return;
+      const line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+    }
+  });
+}
+
+export function makeWorkspaceFixture(): { projectCwd: string; sessionsDir: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "gsd-web-assembled-"));
+  const projectCwd = join(root, "project");
+  const sessionsDir = join(root, "sessions");
+  const milestoneDir = join(projectCwd, ".gsd", "milestones", "M001");
+  const sliceDir = join(milestoneDir, "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+
+  mkdirSync(tasksDir, { recursive: true });
+  mkdirSync(sessionsDir, { recursive: true });
+
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    "# M001: Demo\n\n## Slices\n- [ ] **S01: Demo** `risk:low` `depends:[]`\n",
+  );
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    "# S01: Demo\n\n**Goal:** Demo\n**Demo:** Demo\n\n## Tasks\n- [ ] **T01: Work** `est:5m`\n",
+  );
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01: Work\n\n## Steps\n- do it\n");
+
+  return {
+    projectCwd,
+    sessionsDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+export function createSessionFile(projectCwd: string, sessionsDir: string, sessionId: string, name: string): string {
+  const sessionPath = join(sessionsDir, `2026-03-14T18-00-00-000Z_${sessionId}.jsonl`);
+  writeFileSync(
+    sessionPath,
+    [
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-03-14T18:00:00.000Z",
+        cwd: projectCwd,
+      }),
+      JSON.stringify({
+        type: "session_info",
+        id: "info-1",
+        parentId: null,
+        timestamp: "2026-03-14T18:00:01.000Z",
+        name,
+      }),
+    ].join("\n") + "\n",
+  );
+  return sessionPath;
+}
+
+export function fakeAutoDashboardData(): Record<string, unknown> {
+  return {
+    active: false,
+    paused: false,
+    stepMode: false,
+    startTime: 0,
+    elapsed: 0,
+    currentUnit: null,
+    completedUnits: [],
+    basePath: "",
+    totalCost: 0,
+    totalTokens: 0,
+  };
+}
+
+export function fakeWorkspaceIndex(): Record<string, unknown> {
+  return {
+    milestones: [
+      {
+        id: "M001",
+        title: "Demo",
+        roadmapPath: ".gsd/milestones/M001/M001-ROADMAP.md",
+        slices: [
+          {
+            id: "S01",
+            title: "Demo",
+            done: false,
+            planPath: ".gsd/milestones/M001/slices/S01/S01-PLAN.md",
+            tasksDir: ".gsd/milestones/M001/slices/S01/tasks",
+            tasks: [{ id: "T01", title: "Work", done: false, planPath: ".gsd/milestones/M001/slices/S01/tasks/T01-PLAN.md" }],
+          },
+        ],
+      },
+    ],
+    active: { milestoneId: "M001", sliceId: "S01", taskId: "T01", phase: "executing" },
+    scopes: [{ scope: "project", label: "project", kind: "project" }],
+    validationIssues: [],
+  };
+}
+
+export function fakeSessionState(sessionId: string, sessionPath: string): Record<string, unknown> {
+  return {
+    sessionId,
+    sessionFile: sessionPath,
+    thinkingLevel: "off",
+    isStreaming: false,
+    isCompacting: false,
+    steeringMode: "all",
+    followUpMode: "all",
+    autoCompactionEnabled: false,
+    autoRetryEnabled: false,
+    retryInProgress: false,
+    retryAttempt: 0,
+    messageCount: 0,
+    pendingMessageCount: 0,
+  };
+}
+
+export function waitForMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+export async function readSseEvents(response: Response, count: number, perReadTimeoutMs = 3_000): Promise<any[]> {
+  const reader = response.body?.getReader();
+  assert.ok(reader, "SSE response has a body reader");
+  const decoder = new TextDecoder();
+  const events: any[] = [];
+  let buffer = "";
+
+  while (events.length < count) {
+    let timedOut = false;
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<{ done: true; value: undefined }>((resolve) => {
+        setTimeout(() => {
+          timedOut = true;
+          resolve({ done: true, value: undefined });
+        }, perReadTimeoutMs);
+      }),
+    ]);
+
+    if (timedOut || result.done) break;
+    buffer += decoder.decode(result.value as Uint8Array, { stream: true });
+
+    while (true) {
+      const boundary = buffer.indexOf("\n\n");
+      if (boundary === -1) break;
+      const chunk = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
+      if (!dataLine) continue;
+      events.push(JSON.parse(dataLine.slice(6)));
+    }
+  }
+
+  await reader.cancel();
+  return events;
+}

--- a/src/tests/integration/web-mode-assembled.test.ts
+++ b/src/tests/integration/web-mode-assembled.test.ts
@@ -1,11 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { EventEmitter } from "node:events";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { PassThrough } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
+import { writeFileSync } from "node:fs";
+import {
+  attachJsonLineReader,
+  createSessionFile,
+  fakeAutoDashboardData,
+  FakeRpcChild,
+  fakeSessionState,
+  fakeWorkspaceIndex,
+  makeWorkspaceFixture,
+  readSseEvents,
+  serializeJsonLine,
+  waitForMicrotasks,
+} from "./web-bridge-runtime-fixture.ts";
 
 const repoRoot = process.cwd();
 
@@ -21,203 +28,6 @@ const {
   getBrowserSlashCommandTerminalNotice,
 } = await import("../../../web/lib/browser-slash-command-dispatch.ts");
 const { AuthStorage } = await import("@gsd/pi-coding-agent");
-
-// ---------------------------------------------------------------------------
-// Test infrastructure (shared with web-mode-onboarding.test.ts)
-// ---------------------------------------------------------------------------
-
-class FakeRpcChild extends EventEmitter {
-  stdin = new PassThrough();
-  stdout = new PassThrough();
-  stderr = new PassThrough();
-  exitCode: number | null = null;
-
-  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
-    if (this.exitCode === null) {
-      this.exitCode = 0;
-    }
-    queueMicrotask(() => {
-      this.emit("exit", this.exitCode, signal);
-    });
-    return true;
-  }
-}
-
-function serializeJsonLine(value: unknown): string {
-  return `${JSON.stringify(value)}\n`;
-}
-
-function attachJsonLineReader(stream: PassThrough, onLine: (line: string) => void): void {
-  const decoder = new StringDecoder("utf8");
-  let buffer = "";
-
-  stream.on("data", (chunk: string | Buffer) => {
-    buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
-    while (true) {
-      const newlineIndex = buffer.indexOf("\n");
-      if (newlineIndex === -1) return;
-      const line = buffer.slice(0, newlineIndex);
-      buffer = buffer.slice(newlineIndex + 1);
-      onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
-    }
-  });
-}
-
-function makeWorkspaceFixture(): { projectCwd: string; sessionsDir: string; cleanup: () => void } {
-  const root = mkdtempSync(join(tmpdir(), "gsd-web-assembled-"));
-  const projectCwd = join(root, "project");
-  const sessionsDir = join(root, "sessions");
-  const milestoneDir = join(projectCwd, ".gsd", "milestones", "M001");
-  const sliceDir = join(milestoneDir, "slices", "S01");
-  const tasksDir = join(sliceDir, "tasks");
-
-  mkdirSync(tasksDir, { recursive: true });
-  mkdirSync(sessionsDir, { recursive: true });
-
-  writeFileSync(
-    join(milestoneDir, "M001-ROADMAP.md"),
-    `# M001: Demo\n\n## Slices\n- [ ] **S01: Demo** \`risk:low\` \`depends:[]\`\n`,
-  );
-  writeFileSync(
-    join(sliceDir, "S01-PLAN.md"),
-    `# S01: Demo\n\n**Goal:** Demo\n**Demo:** Demo\n\n## Tasks\n- [ ] **T01: Work** \`est:5m\`\n`,
-  );
-  writeFileSync(join(tasksDir, "T01-PLAN.md"), `# T01: Work\n\n## Steps\n- do it\n`);
-
-  return {
-    projectCwd,
-    sessionsDir,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
-  };
-}
-
-function createSessionFile(projectCwd: string, sessionsDir: string, sessionId: string, name: string): string {
-  const sessionPath = join(sessionsDir, `2026-03-14T18-00-00-000Z_${sessionId}.jsonl`);
-  writeFileSync(
-    sessionPath,
-    [
-      JSON.stringify({
-        type: "session",
-        version: 3,
-        id: sessionId,
-        timestamp: "2026-03-14T18:00:00.000Z",
-        cwd: projectCwd,
-      }),
-      JSON.stringify({
-        type: "session_info",
-        id: "info-1",
-        parentId: null,
-        timestamp: "2026-03-14T18:00:01.000Z",
-        name,
-      }),
-    ].join("\n") + "\n",
-  );
-  return sessionPath;
-}
-
-function fakeAutoDashboardData() {
-  return {
-    active: false,
-    paused: false,
-    stepMode: false,
-    startTime: 0,
-    elapsed: 0,
-    currentUnit: null,
-    completedUnits: [],
-    basePath: "",
-    totalCost: 0,
-    totalTokens: 0,
-  };
-}
-
-function fakeWorkspaceIndex() {
-  return {
-    milestones: [
-      {
-        id: "M001",
-        title: "Demo",
-        roadmapPath: ".gsd/milestones/M001/M001-ROADMAP.md",
-        slices: [
-          {
-            id: "S01",
-            title: "Demo",
-            done: false,
-            planPath: ".gsd/milestones/M001/slices/S01/S01-PLAN.md",
-            tasksDir: ".gsd/milestones/M001/slices/S01/tasks",
-            tasks: [{ id: "T01", title: "Work", done: false, planPath: ".gsd/milestones/M001/slices/S01/tasks/T01-PLAN.md" }],
-          },
-        ],
-      },
-    ],
-    active: { milestoneId: "M001", sliceId: "S01", taskId: "T01", phase: "executing" },
-    scopes: [{ scope: "project", label: "project", kind: "project" }],
-    validationIssues: [],
-  };
-}
-
-function fakeSessionState(sessionId: string, sessionPath: string) {
-  return {
-    sessionId,
-    sessionFile: sessionPath,
-    thinkingLevel: "off",
-    isStreaming: false,
-    isCompacting: false,
-    steeringMode: "all",
-    followUpMode: "all",
-    autoCompactionEnabled: false,
-    autoRetryEnabled: false,
-    retryInProgress: false,
-    retryAttempt: 0,
-    messageCount: 0,
-    pendingMessageCount: 0,
-  };
-}
-
-function waitForMicrotasks(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-/**
- * Read SSE events from a Response stream, collecting up to `count` events.
- * Returns early (without throwing) if no new data arrives within `perReadTimeoutMs`.
- * This allows tests to request a generous count without failing on exact event counts.
- */
-async function readSseEvents(response: Response, count: number, perReadTimeoutMs = 3_000): Promise<any[]> {
-  const reader = response.body?.getReader();
-  assert.ok(reader, "SSE response has a body reader");
-  const decoder = new TextDecoder();
-  const events: any[] = [];
-  let buffer = "";
-
-  while (events.length < count) {
-    let timedOut = false;
-    const result = await Promise.race([
-      reader.read(),
-      new Promise<{ done: true; value: undefined }>((resolve) => {
-        setTimeout(() => {
-          timedOut = true;
-          resolve({ done: true, value: undefined });
-        }, perReadTimeoutMs);
-      }),
-    ]);
-
-    if (timedOut || result.done) break;
-    buffer += decoder.decode(result.value as Uint8Array, { stream: true });
-
-    while (true) {
-      const boundary = buffer.indexOf("\n\n");
-      if (boundary === -1) break;
-      const chunk = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
-      const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
-      if (!dataLine) continue;
-      events.push(JSON.parse(dataLine.slice(6)));
-    }
-  }
-
-  await reader.cancel();
-  return events;
-}
 
 // ---------------------------------------------------------------------------
 // Assembled lifecycle test

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -73,6 +73,10 @@ describe("my feature", () => {
 - **`artifacts.ts`** — `artifactsFor(testSlug)` returns `{ dir, write }`.
   Use it to dump logs/screenshots/traces from a test that's about to fail
   so CI can upload them.
+- **`workflow-scenario.ts`** — shared fake-LLM workflow scenario helpers:
+  transcript turn builders, git commit helpers, DB scalar reads, notification
+  extraction, and `WorkflowOutcomeProbe` assertions for full headless
+  milestone flows.
 
 ## Anti-patterns to avoid
 

--- a/tests/e2e/_shared/index.ts
+++ b/tests/e2e/_shared/index.ts
@@ -10,3 +10,4 @@ export * from "./spawn.ts";
 export * from "./tmp-project.ts";
 export * from "./artifacts.ts";
 export * from "./fake-llm.ts";
+export * from "./workflow-scenario.ts";

--- a/tests/e2e/_shared/workflow-scenario.ts
+++ b/tests/e2e/_shared/workflow-scenario.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import type { TranscriptTurn } from "./fake-llm.ts";
+
+export type JsonEvent = Record<string, unknown>;
+
+export function smokeBinaryAvailable(): { ok: boolean; reason?: string } {
+	const bin = process.env.GSD_SMOKE_BINARY;
+	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
+	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
+	return { ok: true };
+}
+
+export function commitProjectFiles(dir: string, files: readonly string[], message: string): void {
+	execFileSync("git", ["add", ...files], { cwd: dir, stdio: "pipe" });
+	execFileSync("git", ["commit", "-m", message], { cwd: dir, stdio: "pipe" });
+}
+
+export function notificationMessages(events: readonly JsonEvent[]): string[] {
+	return events
+		.filter((event) => event.type === "extension_ui_request" && event.method === "notify")
+		.map((event) => String(event.message ?? ""));
+}
+
+export function toolNames(events: readonly JsonEvent[]): string[] {
+	return events
+		.filter((event) => event.type === "tool_execution_end")
+		.map((event) => String(event.toolName ?? ""));
+}
+
+export function toolErrors(events: readonly JsonEvent[]): string[] {
+	return events
+		.filter((event) => event.type === "tool_execution_end")
+		.filter((event) => event.isError === true || (event.result as { isError?: boolean } | undefined)?.isError === true)
+		.map((event) => `${String(event.toolName ?? "unknown")}: ${JSON.stringify(event.result ?? {})}`);
+}
+
+export function scalar(
+	db: DatabaseSync,
+	sql: string,
+	params: Record<string, string> = {},
+): string | null {
+	const row = db.prepare(sql).get(params) as { value?: string | number | null } | undefined;
+	return row?.value == null ? null : String(row.value);
+}
+
+export class WorkflowOutcomeProbe {
+	readonly projectDir: string;
+	readonly events: readonly JsonEvent[];
+	readonly notifications: string[];
+
+	constructor(
+		projectDir: string,
+		events: readonly JsonEvent[],
+	) {
+		this.projectDir = projectDir;
+		this.events = events;
+		this.notifications = notificationMessages(events);
+	}
+
+	assertNoOperatorFailures(): void {
+		const badOperatorSignals = this.notifications.filter((message) =>
+			/blocked:|failed|cannot complete|cannot validate|stopped with an issue/i.test(message),
+		);
+		assert.deepEqual(badOperatorSignals, [], `unexpected blocked/error operator signals: ${badOperatorSignals.join("\n")}`);
+	}
+
+	assertNoToolErrors(): void {
+		const errors = toolErrors(this.events);
+		assert.deepEqual(errors, [], `unexpected tool errors:\n${errors.join("\n")}`);
+	}
+
+	assertCompletionNotification(pattern: RegExp): void {
+		assert.ok(
+			this.notifications.some((message) => /auto-mode stopped/i.test(message) && pattern.test(message)),
+			`expected terminal auto-mode completion notification, got:\n${this.notifications.join("\n")}`,
+		);
+	}
+
+	assertArtifact(relativePath: string, message: string): void {
+		assert.ok(existsSync(join(this.projectDir, relativePath)), message);
+	}
+
+	openDb(t: { after: (fn: () => void) => void }): DatabaseSync {
+		const db = new DatabaseSync(join(this.projectDir, ".gsd", "gsd.db"));
+		t.after(() => db.close());
+		return db;
+	}
+}
+
+export class WorkflowTranscriptBuilder {
+	private readonly turns: TranscriptTurn[] = [];
+
+	addTool(
+		name: string,
+		input: Record<string, unknown>,
+		id: string,
+		expect?: TranscriptTurn["expect"],
+	): this {
+		appendToolTurn(this.turns, name, input, id, expect);
+		return this;
+	}
+
+	addText(text: string, expect?: TranscriptTurn["expect"]): this {
+		appendTextTurn(this.turns, text, expect);
+		return this;
+	}
+
+	toTurns(): TranscriptTurn[] {
+		return this.turns;
+	}
+}
+
+export function appendToolTurn(
+	turns: TranscriptTurn[],
+	name: string,
+	input: Record<string, unknown>,
+	id: string,
+	expect?: TranscriptTurn["expect"],
+): void {
+	turns.push({
+		turn: turns.length + 1,
+		...(expect ? { expect } : {}),
+		emit: { kind: "tool_use", calls: [{ id, name, input }] },
+	});
+}
+
+export function appendTextTurn(
+	turns: TranscriptTurn[],
+	text: string,
+	expect?: TranscriptTurn["expect"],
+): void {
+	turns.push({
+		turn: turns.length + 1,
+		...(expect ? { expect } : {}),
+		emit: { kind: "text", text },
+	});
+}

--- a/tests/e2e/multi-milestone-sequence.e2e.test.ts
+++ b/tests/e2e/multi-milestone-sequence.e2e.test.ts
@@ -5,55 +5,30 @@ import { execFileSync } from "node:child_process";
 import assert from "node:assert/strict";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 
 import {
+	appendTextTurn,
+	appendToolTurn,
 	artifactsFor,
 	createTmpProject,
 	gsdSync,
 	parseJsonEvents,
+	commitProjectFiles,
+	scalar,
+	smokeBinaryAvailable,
 	type TranscriptTurn,
+	toolNames,
+	WorkflowOutcomeProbe,
 	writeTranscript,
 } from "./_shared/index.ts";
 
-function binaryAvailable(): { ok: boolean; reason?: string } {
-	const bin = process.env.GSD_SMOKE_BINARY;
-	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
-	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
-	return { ok: true };
-}
-
 function commitFixture(dir: string): void {
-	execFileSync("git", ["add", "package.json", "src/answer.js", "src/status.js", "test/answer.test.js", "test/status.test.js"], { cwd: dir, stdio: "pipe" });
-	execFileSync("git", ["commit", "-m", "test: seed multi-milestone fixture"], { cwd: dir, stdio: "pipe" });
-}
-
-function scalar(db: DatabaseSync, sql: string, params: Record<string, string> = {}): string | null {
-	const row = db.prepare(sql).get(params) as { value?: string | number | null } | undefined;
-	return row?.value == null ? null : String(row.value);
-}
-
-function pushTool(
-	turns: TranscriptTurn[],
-	name: string,
-	input: Record<string, unknown>,
-	id: string,
-	expect?: TranscriptTurn["expect"],
-): void {
-	turns.push({
-		turn: turns.length + 1,
-		...(expect ? { expect } : {}),
-		emit: { kind: "tool_use", calls: [{ id, name, input }] },
-	});
-}
-
-function pushText(turns: TranscriptTurn[], text: string, expect?: TranscriptTurn["expect"]): void {
-	turns.push({
-		turn: turns.length + 1,
-		...(expect ? { expect } : {}),
-		emit: { kind: "text", text },
-	});
+	commitProjectFiles(
+		dir,
+		["package.json", "src/answer.js", "src/status.js", "test/answer.test.js", "test/status.test.js"],
+		"test: seed multi-milestone fixture",
+	);
 }
 
 function slicePlanInput(file: string, verify: string, expected: string): Record<string, unknown> {
@@ -172,9 +147,9 @@ function completionInput(
 function buildTranscript(): string {
 	const turns: TranscriptTurn[] = [];
 
-	pushTool(turns, "gsd_milestone_generate_id", {}, "generate-m001", { modelId: "gsd-fake-model", lastUserText: "Headless Milestone Creation" });
-	pushTool(turns, "gsd_milestone_generate_id", {}, "generate-m002", { hasToolResultFor: "gsd_milestone_generate_id" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_milestone_generate_id", {}, "generate-m001", { modelId: "gsd-fake-model", lastUserText: "Headless Milestone Creation" });
+	appendToolTurn(turns, "gsd_milestone_generate_id", {}, "generate-m002", { hasToolResultFor: "gsd_milestone_generate_id" });
+	appendToolTurn(turns, "gsd_summary_save", {
 		artifact_type: "PROJECT",
 		content: [
 			"# Project",
@@ -188,7 +163,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "project", { hasToolResultFor: "gsd_milestone_generate_id" });
-	pushTool(turns, "gsd_requirement_save", {
+	appendToolTurn(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The answer module returns the requested ready value.",
 		why: "M001 needs one observable source behavior change.",
@@ -199,7 +174,7 @@ function buildTranscript(): string {
 		validation: "The focused answer verification command exits 0.",
 		notes: "Multi-milestone e2e fixture.",
 	}, "answer-requirement", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_requirement_save", {
+	appendToolTurn(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The status module returns the requested done value after M001 completes.",
 		why: "M002 proves downstream work remains queued after M001 closeout.",
@@ -210,11 +185,11 @@ function buildTranscript(): string {
 		validation: "The full fixture test command exits 0.",
 		notes: "Multi-milestone e2e fixture.",
 	}, "status-requirement", { hasToolResultFor: "gsd_requirement_save" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		artifact_type: "REQUIREMENTS",
 		content: "# Requirements\n",
 	}, "requirements", { hasToolResultFor: "gsd_requirement_save" });
-	pushTool(turns, "ask_user_questions", {
+	appendToolTurn(turns, "ask_user_questions", {
 		questions: [{
 			id: "depth_verification_M001_confirm",
 			header: "Depth Check",
@@ -231,7 +206,7 @@ function buildTranscript(): string {
 			],
 		}],
 	}, "depth-check", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		artifact_type: "CONTEXT",
 		content: [
@@ -247,7 +222,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "m001-context", { hasToolResultFor: "ask_user_questions" });
-	pushTool(turns, "gsd_plan_milestone", {
+	appendToolTurn(turns, "gsd_plan_milestone", {
 		milestoneId: "M001",
 		title: "Answer Ready",
 		vision: "Trivial source behavior change to establish the first milestone.",
@@ -282,7 +257,7 @@ function buildTranscript(): string {
 		requirementCoverage: "R001 is owned by M001/S01.",
 		boundaryMapMarkdown: "| Boundary | Decision |\n| --- | --- |\n| M001 -> M002 | M002 depends on M001 completion. |\n",
 	}, "m001-roadmap", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "ask_user_questions", {
+	appendToolTurn(turns, "ask_user_questions", {
 		questions: [{
 			id: "depth_verification_M002_confirm",
 			header: "Depth Check",
@@ -299,7 +274,7 @@ function buildTranscript(): string {
 			],
 		}],
 	}, "m002-depth-check", { hasToolResultFor: "gsd_plan_milestone" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M002",
 		artifact_type: "CONTEXT",
 		content: [
@@ -319,7 +294,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "m002-context", { hasToolResultFor: "ask_user_questions" });
-	pushTool(turns, "write", {
+	appendToolTurn(turns, "write", {
 		path: ".gsd/DISCUSSION-MANIFEST.json",
 		content: JSON.stringify({
 			primary: "M001",
@@ -331,48 +306,48 @@ function buildTranscript(): string {
 			gates_completed: 2,
 		}, null, 2) + "\n",
 	}, "discussion-manifest", { hasToolResultFor: "gsd_summary_save" });
-	pushText(turns, "Milestone M001 ready.", { hasToolResultFor: "write" });
+	appendTextTurn(turns, "Milestone M001 ready.", { hasToolResultFor: "write" });
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		slice_id: "S01",
 		artifact_type: "RESEARCH",
 		content: "# S01 - Research\n\nUse `src/answer.js` and verify with `node --test test/answer.test.js`.\n",
 	}, "m001-s01-research");
-	pushText(turns, "M001/S01 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "m001-s01-plan");
-	pushText(turns, "M001/S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
-	pushTool(turns, "write", {
+	appendTextTurn(turns, "M001/S01 researched.", { hasToolResultFor: "gsd_summary_save" });
+	appendToolTurn(turns, "gsd_plan_slice", slicePlanInput("src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "m001-s01-plan");
+	appendTextTurn(turns, "M001/S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
+	appendToolTurn(turns, "write", {
 		path: "src/answer.js",
 		content: "export function answer() {\n\treturn \"ready\";\n}\n",
 	}, "write-answer");
-	pushTool(turns, "bash", {
+	appendToolTurn(turns, "bash", {
 		command: "node --test test/answer.test.js",
 		timeout: 30,
 	}, "verify-answer", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "m001-task", { hasToolResultFor: "bash" });
-	pushText(turns, "M001/S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "m001-slice");
-	pushText(turns, "M001/S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
-	pushTool(turns, "gsd_validate_milestone", validationInput(
+	appendToolTurn(turns, "gsd_task_complete", completeTaskInput("src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "m001-task", { hasToolResultFor: "bash" });
+	appendTextTurn(turns, "M001/S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
+	appendToolTurn(turns, "gsd_slice_complete", completeSliceInput("Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "m001-slice");
+	appendTextTurn(turns, "M001/S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
+	appendToolTurn(turns, "gsd_validate_milestone", validationInput(
 		"- PASS: answer() returns ready.\n- PASS: M001 stops before M002 planning.",
 		"M001 is a focused source change; M002 remains queued for a later command.",
 		"R001 is covered by M001/S01/T01.",
 	), "m001-validation");
-	pushText(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
-	pushTool(turns, "gsd_complete_milestone", completionInput(
+	appendTextTurn(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
+	appendToolTurn(turns, "gsd_complete_milestone", completionInput(
 		"Answer Ready",
 		"Updated answer() to return ready and validated M001.",
 		"M001 completed its source change, focused verification, slice closeout, milestone validation, and milestone completion before M002 work began.",
 		"src/answer.js",
 	), "m001-complete");
-	pushText(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
+	appendTextTurn(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
 
 	return writeTranscript(turns);
 }
 
 describe("multi-milestone sequence e2e (fake LLM)", () => {
-	const avail = binaryAvailable();
+	const avail = smokeBinaryAvailable();
 	const skipReason = avail.ok ? null : avail.reason;
 
 	test("headless new-milestone --auto stops at M001 closeout before M002", { skip: skipReason ?? false, timeout: 300_000 }, (t) => {
@@ -458,54 +433,39 @@ describe("multi-milestone sequence e2e (fake LLM)", () => {
 		assert.ok(!result.timedOut, "headless multi-milestone run must not time out");
 
 		const events = parseJsonEvents(result.stdoutClean);
-		const notifyMessages = events
-			.filter((event) => event.type === "extension_ui_request" && event.method === "notify")
-			.map((event) => String(event.message ?? ""));
-		const badOperatorSignals = notifyMessages.filter((message) =>
-			/blocked:|failed|cannot complete|cannot validate|stopped with an issue/i.test(message),
-		);
-		const toolErrors = events
-			.filter((event) => event.type === "tool_execution_end")
-			.filter((event) => event.isError === true || (event.result as { isError?: boolean } | undefined)?.isError === true)
-			.map((event) => `${String(event.toolName ?? "unknown")}: ${JSON.stringify(event.result ?? {})}`);
-		const toolNames = events
-			.filter((event) => event.type === "tool_execution_end")
-			.map((event) => String(event.toolName ?? ""));
+		const outcome = new WorkflowOutcomeProbe(project.dir, events);
+		const completedToolNames = toolNames(events);
 		const discussionManifestWrites = events.filter((event) =>
 			event.type === "tool_execution_end" &&
 			event.toolName === "write" &&
 			event.toolCallId === "discussion-manifest",
 		);
 
-		assert.deepEqual(badOperatorSignals, [], `unexpected blocked/error operator signals: ${badOperatorSignals.join("\n")}`);
-		assert.deepEqual(toolErrors, [], `unexpected tool errors:\n${toolErrors.join("\n")}`);
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_milestone_generate_id").length, 2, "multi-milestone planning must generate two IDs");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_plan_milestone").length, 1, "auto stops at M001 closeout before planning M002");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_validate_milestone").length, 1, "auto validates only M001 before stopping");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_complete_milestone").length, 1, "auto completes only M001 before stopping");
+		outcome.assertNoOperatorFailures();
+		outcome.assertNoToolErrors();
+		assert.equal(completedToolNames.filter((toolName) => toolName === "gsd_milestone_generate_id").length, 2, "multi-milestone planning must generate two IDs");
+		assert.equal(completedToolNames.filter((toolName) => toolName === "gsd_plan_milestone").length, 1, "auto stops at M001 closeout before planning M002");
+		assert.equal(completedToolNames.filter((toolName) => toolName === "gsd_validate_milestone").length, 1, "auto validates only M001 before stopping");
+		assert.equal(completedToolNames.filter((toolName) => toolName === "gsd_complete_milestone").length, 1, "auto completes only M001 before stopping");
 		assert.equal(discussionManifestWrites.length, 1, "multi-milestone discussion manifest must be written before auto execution");
-		assert.ok(
-			notifyMessages.some((message) => /auto-mode stopped/i.test(message) && /milestone m001 complete/i.test(message)),
-			`expected M001 closeout stop notification, got:\n${notifyMessages.join("\n")}`,
-		);
+		outcome.assertCompletionNotification(/milestone m001 complete/i);
 		assert.doesNotThrow(
 			() => execFileSync("node", ["--test", "test/answer.test.js"], { cwd: project.dir, stdio: "pipe" }),
 			"M001 focused verification command must pass after closeout",
 		);
 
 		for (const milestoneId of ["M001"]) {
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-CONTEXT.md`)), `${milestoneId} context artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-ROADMAP.md`)), `${milestoneId} roadmap artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-VALIDATION.md`)), `${milestoneId} validation artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, `${milestoneId}-SUMMARY.md`)), `${milestoneId} summary artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, "slices", "S01", "S01-SUMMARY.md")), `${milestoneId}/S01 summary artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", milestoneId, "slices", "S01", "tasks", "T01-SUMMARY.md")), `${milestoneId}/S01/T01 summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/${milestoneId}/${milestoneId}-CONTEXT.md`, `${milestoneId} context artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/${milestoneId}/${milestoneId}-ROADMAP.md`, `${milestoneId} roadmap artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/${milestoneId}/${milestoneId}-VALIDATION.md`, `${milestoneId} validation artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/${milestoneId}/${milestoneId}-SUMMARY.md`, `${milestoneId} summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/${milestoneId}/slices/S01/S01-SUMMARY.md`, `${milestoneId}/S01 summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/${milestoneId}/slices/S01/tasks/T01-SUMMARY.md`, `${milestoneId}/S01/T01 summary artifact is present`);
 		}
 		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M002", "M002-CONTEXT.md")), "M002 context artifact is queued");
 		assert.equal(existsSync(join(project.dir, ".gsd", "milestones", "M002", "M002-ROADMAP.md")), false, "M002 roadmap is not planned before the next command");
 
-		const db = new DatabaseSync(join(project.dir, ".gsd", "gsd.db"));
-		t.after(() => db.close());
+		const db = outcome.openDb(t);
 		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM milestones WHERE status = 'complete'"), "1");
 		assert.equal(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M001" }), "complete");
 		assert.notEqual(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M002" }), "complete");

--- a/tests/e2e/multi-slice-milestone-closeout.e2e.test.ts
+++ b/tests/e2e/multi-slice-milestone-closeout.e2e.test.ts
@@ -2,58 +2,32 @@
 // File Purpose: E2E gate for multi-slice headless milestone closeout agreement.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import assert from "node:assert/strict";
-import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 
 import {
+	appendTextTurn,
+	appendToolTurn,
 	artifactsFor,
 	createTmpProject,
 	gsdSync,
 	parseJsonEvents,
+	commitProjectFiles,
+	scalar,
+	smokeBinaryAvailable,
 	type TranscriptTurn,
+	WorkflowOutcomeProbe,
 	writeTranscript,
 } from "./_shared/index.ts";
 
-function binaryAvailable(): { ok: boolean; reason?: string } {
-	const bin = process.env.GSD_SMOKE_BINARY;
-	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
-	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
-	return { ok: true };
-}
-
 function commitFixture(dir: string): void {
-	execFileSync("git", ["add", "package.json", "src/answer.js", "src/status.js", "test/answer.test.js", "test/status.test.js"], { cwd: dir, stdio: "pipe" });
-	execFileSync("git", ["commit", "-m", "test: seed multi-slice fixture"], { cwd: dir, stdio: "pipe" });
-}
-
-function scalar(db: DatabaseSync, sql: string, params: Record<string, string>): string | null {
-	const row = db.prepare(sql).get(params) as { value?: string | number | null } | undefined;
-	return row?.value == null ? null : String(row.value);
-}
-
-function pushTool(
-	turns: TranscriptTurn[],
-	name: string,
-	input: Record<string, unknown>,
-	id: string,
-	expect?: TranscriptTurn["expect"],
-): void {
-	turns.push({
-		turn: turns.length + 1,
-		...(expect ? { expect } : {}),
-		emit: { kind: "tool_use", calls: [{ id, name, input }] },
-	});
-}
-
-function pushText(turns: TranscriptTurn[], text: string, expect?: TranscriptTurn["expect"]): void {
-	turns.push({
-		turn: turns.length + 1,
-		...(expect ? { expect } : {}),
-		emit: { kind: "text", text },
-	});
+	commitProjectFiles(
+		dir,
+		["package.json", "src/answer.js", "src/status.js", "test/answer.test.js", "test/status.test.js"],
+		"test: seed multi-slice fixture",
+	);
 }
 
 function slicePlanInput(
@@ -139,7 +113,7 @@ function completeSliceInput(
 function buildTranscript(): string {
 	const turns: TranscriptTurn[] = [];
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		artifact_type: "PROJECT",
 		content: [
 			"# Project",
@@ -152,7 +126,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "project", { modelId: "gsd-fake-model", lastUserText: "Headless Milestone Creation" });
-	pushTool(turns, "gsd_requirement_save", {
+	appendToolTurn(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The answer module returns the requested ready value.",
 		why: "S01 needs one observable source behavior change.",
@@ -163,7 +137,7 @@ function buildTranscript(): string {
 		validation: "The answer verification command exits 0.",
 		notes: "Multi-slice closeout e2e fixture.",
 	}, "answer-requirement", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_requirement_save", {
+	appendToolTurn(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The status module returns the requested done value.",
 		why: "S02 proves the workflow can continue after one completed slice.",
@@ -174,11 +148,11 @@ function buildTranscript(): string {
 		validation: "The full fixture test command exits 0.",
 		notes: "Multi-slice closeout e2e fixture.",
 	}, "status-requirement", { hasToolResultFor: "gsd_requirement_save" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		artifact_type: "REQUIREMENTS",
 		content: "# Requirements\n",
 	}, "requirements", { hasToolResultFor: "gsd_requirement_save" });
-	pushTool(turns, "ask_user_questions", {
+	appendToolTurn(turns, "ask_user_questions", {
 		questions: [{
 			id: "depth_verification_M001_confirm",
 			header: "Depth Check",
@@ -195,7 +169,7 @@ function buildTranscript(): string {
 			],
 		}],
 	}, "depth-check", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		artifact_type: "CONTEXT",
 		content: [
@@ -215,7 +189,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "context", { hasToolResultFor: "ask_user_questions" });
-	pushTool(turns, "gsd_plan_milestone", {
+	appendToolTurn(turns, "gsd_plan_milestone", {
 		milestoneId: "M001",
 		title: "Multi Slice Closeout Agreement",
 		vision: "Two sequential source changes complete cleanly and close the milestone with all state surfaces in agreement.",
@@ -273,53 +247,53 @@ function buildTranscript(): string {
 		requirementCoverage: "R001 is owned by S01; R002 is owned by S02.",
 		boundaryMapMarkdown: "| Boundary | Decision |\n| --- | --- |\n| S01 -> S02 | S02 depends on S01 remaining green under the full test command. |\n",
 	}, "roadmap", { hasToolResultFor: "gsd_summary_save" });
-	pushText(turns, "Milestone M001 ready.", { hasToolResultFor: "gsd_plan_milestone" });
+	appendTextTurn(turns, "Milestone M001 ready.", { hasToolResultFor: "gsd_plan_milestone" });
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		slice_id: "S01",
 		artifact_type: "RESEARCH",
 		content: "# S01 - Research\n\nUse `src/answer.js` and verify with `node --test test/answer.test.js`.\n",
 	}, "s01-research");
-	pushText(turns, "Slice S01 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("S01", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "s01-plan");
-	pushText(turns, "Slice S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
-	pushTool(turns, "write", {
+	appendTextTurn(turns, "Slice S01 researched.", { hasToolResultFor: "gsd_summary_save" });
+	appendToolTurn(turns, "gsd_plan_slice", slicePlanInput("S01", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "s01-plan");
+	appendTextTurn(turns, "Slice S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
+	appendToolTurn(turns, "write", {
 		path: "src/answer.js",
 		content: "export function answer() {\n\treturn \"ready\";\n}\n",
 	}, "write-answer");
-	pushTool(turns, "bash", {
+	appendToolTurn(turns, "bash", {
 		command: "node --test test/answer.test.js",
 		timeout: 30,
 	}, "verify-answer", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("S01", "src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "s01-task", { hasToolResultFor: "bash" });
-	pushText(turns, "S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("S01", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "s01-complete");
-	pushText(turns, "Slice S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
+	appendToolTurn(turns, "gsd_task_complete", completeTaskInput("S01", "src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "s01-task", { hasToolResultFor: "bash" });
+	appendTextTurn(turns, "S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
+	appendToolTurn(turns, "gsd_slice_complete", completeSliceInput("S01", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "s01-complete");
+	appendTextTurn(turns, "Slice S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		slice_id: "S02",
 		artifact_type: "RESEARCH",
 		content: "# S02 - Research\n\nUse `src/status.js` and verify the whole fixture with `npm test`.\n",
 	}, "s02-research");
-	pushText(turns, "Slice S02 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("S02", "Update status module", "src/status.js", "npm test", "status() returns done."), "s02-plan");
-	pushText(turns, "Slice S02 planned.", { hasToolResultFor: "gsd_plan_slice" });
-	pushTool(turns, "write", {
+	appendTextTurn(turns, "Slice S02 researched.", { hasToolResultFor: "gsd_summary_save" });
+	appendToolTurn(turns, "gsd_plan_slice", slicePlanInput("S02", "Update status module", "src/status.js", "npm test", "status() returns done."), "s02-plan");
+	appendTextTurn(turns, "Slice S02 planned.", { hasToolResultFor: "gsd_plan_slice" });
+	appendToolTurn(turns, "write", {
 		path: "src/status.js",
 		content: "export function status() {\n\treturn \"done\";\n}\n",
 	}, "write-status");
-	pushTool(turns, "bash", {
+	appendToolTurn(turns, "bash", {
 		command: "npm test",
 		timeout: 30,
 	}, "verify-status", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("S02", "src/status.js", "npm test", "Updated status() to return done."), "s02-task", { hasToolResultFor: "bash" });
-	pushText(turns, "S02/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("S02", "Update status module", "src/status.js", "npm test", "status() now returns done."), "s02-complete");
-	pushText(turns, "Slice S02 complete.", { hasToolResultFor: "gsd_slice_complete" });
+	appendToolTurn(turns, "gsd_task_complete", completeTaskInput("S02", "src/status.js", "npm test", "Updated status() to return done."), "s02-task", { hasToolResultFor: "bash" });
+	appendTextTurn(turns, "S02/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
+	appendToolTurn(turns, "gsd_slice_complete", completeSliceInput("S02", "Update status module", "src/status.js", "npm test", "status() now returns done."), "s02-complete");
+	appendTextTurn(turns, "Slice S02 complete.", { hasToolResultFor: "gsd_slice_complete" });
 
-	pushTool(turns, "gsd_validate_milestone", {
+	appendToolTurn(turns, "gsd_validate_milestone", {
 		milestoneId: "M001",
 		verdict: "pass",
 		remediationRound: 0,
@@ -330,8 +304,8 @@ function buildTranscript(): string {
 		verificationClasses: "| Class | Planned Check | Evidence | Verdict |\n| --- | --- | --- | --- |\n| Contract | Focused and full node:test commands exit 0. | `node --test test/answer.test.js` and `npm test` exited 0. | PASS |\n| Integration | Both modules are verified together. | S02 `npm test` exercised both tests after both source changes. | PASS |\n| Operational | Headless process exits cleanly. | No blocked/error operator notification was emitted. | PASS |\n| UAT | Slice UAT summaries pass. | S01 and S02 closeout UAT content recorded PASS. | PASS |",
 		verdictRationale: "All planned slices, requirements, verification classes, and closeout surfaces passed.",
 	}, "validate-milestone");
-	pushText(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
-	pushTool(turns, "gsd_complete_milestone", {
+	appendTextTurn(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
+	appendToolTurn(turns, "gsd_complete_milestone", {
 		milestoneId: "M001",
 		title: "Multi Slice Closeout Agreement",
 		oneLiner: "Updated two source modules across two slices and verified the full fixture.",
@@ -346,13 +320,13 @@ function buildTranscript(): string {
 		followUps: "None.",
 		deviations: "None.",
 	}, "complete-milestone");
-	pushText(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
+	appendTextTurn(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
 
 	return writeTranscript(turns);
 }
 
 describe("multi-slice milestone closeout e2e (fake LLM)", () => {
-	const avail = binaryAvailable();
+	const avail = smokeBinaryAvailable();
 	const skipReason = avail.ok ? null : avail.reason;
 
 	test("headless new-milestone --auto completes two slices with closeout state agreement", { skip: skipReason ?? false, timeout: 240_000 }, (t) => {
@@ -436,37 +410,23 @@ describe("multi-slice milestone closeout e2e (fake LLM)", () => {
 		assert.ok(!result.timedOut, "headless milestone run must not time out");
 
 		const events = parseJsonEvents(result.stdoutClean);
-		const notifyMessages = events
-			.filter((event) => event.type === "extension_ui_request" && event.method === "notify")
-			.map((event) => String(event.message ?? ""));
-		const badOperatorSignals = notifyMessages.filter((message) =>
-			/blocked:|failed|cannot complete|cannot validate|stopped with an issue/i.test(message),
-		);
-		const toolErrors = events
-			.filter((event) => event.type === "tool_execution_end")
-			.filter((event) => event.isError === true || (event.result as { isError?: boolean } | undefined)?.isError === true)
-			.map((event) => `${String(event.toolName ?? "unknown")}: ${JSON.stringify(event.result ?? {})}`);
-
-		assert.deepEqual(badOperatorSignals, [], `unexpected blocked/error operator signals: ${badOperatorSignals.join("\n")}`);
-		assert.deepEqual(toolErrors, [], `unexpected tool errors:\n${toolErrors.join("\n")}`);
-		assert.ok(
-			notifyMessages.some((message) => /auto-mode stopped/i.test(message) && /milestone m001 complete|all milestones complete/i.test(message)),
-			`expected terminal auto-mode completion notification, got:\n${notifyMessages.join("\n")}`,
-		);
+		const outcome = new WorkflowOutcomeProbe(project.dir, events);
+		outcome.assertNoOperatorFailures();
+		outcome.assertNoToolErrors();
+		outcome.assertCompletionNotification(/milestone m001 complete|all milestones complete/i);
 		assert.doesNotThrow(
 			() => execFileSync("npm", ["test"], { cwd: project.dir, stdio: "pipe" }),
 			"full fixture verification command must pass after milestone completion",
 		);
 
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "M001-VALIDATION.md")), "milestone validation artifact is present");
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "M001-SUMMARY.md")), "milestone summary artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/M001-VALIDATION.md", "milestone validation artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/M001-SUMMARY.md", "milestone summary artifact is present");
 		for (const sliceId of ["S01", "S02"]) {
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", sliceId, `${sliceId}-SUMMARY.md`)), `${sliceId} summary artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", sliceId, "tasks", "T01-SUMMARY.md")), `${sliceId}/T01 summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/M001/slices/${sliceId}/${sliceId}-SUMMARY.md`, `${sliceId} summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/M001/slices/${sliceId}/tasks/T01-SUMMARY.md`, `${sliceId}/T01 summary artifact is present`);
 		}
 
-		const db = new DatabaseSync(join(project.dir, ".gsd", "gsd.db"));
-		t.after(() => db.close());
+		const db = outcome.openDb(t);
 		assert.equal(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M001" }), "complete");
 		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM slices WHERE milestone_id = :mid AND status = 'complete'", { mid: "M001" }), "2");
 		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM tasks WHERE milestone_id = :mid AND status = 'complete'", { mid: "M001" }), "2");

--- a/tests/e2e/remediation-milestone-closeout.e2e.test.ts
+++ b/tests/e2e/remediation-milestone-closeout.e2e.test.ts
@@ -3,57 +3,32 @@
 
 import { execFileSync } from "node:child_process";
 import assert from "node:assert/strict";
-import { existsSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 
 import {
+	appendTextTurn,
+	appendToolTurn,
 	artifactsFor,
 	createTmpProject,
 	gsdSync,
 	parseJsonEvents,
+	commitProjectFiles,
+	scalar,
+	smokeBinaryAvailable,
 	type TranscriptTurn,
+	toolNames,
+	WorkflowOutcomeProbe,
 	writeTranscript,
 } from "./_shared/index.ts";
 
-function binaryAvailable(): { ok: boolean; reason?: string } {
-	const bin = process.env.GSD_SMOKE_BINARY;
-	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
-	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
-	return { ok: true };
-}
-
 function commitFixture(dir: string): void {
-	execFileSync("git", ["add", "package.json", "src/answer.js", "src/status.js", "test/answer.test.js", "test/status.test.js"], { cwd: dir, stdio: "pipe" });
-	execFileSync("git", ["commit", "-m", "test: seed remediation fixture"], { cwd: dir, stdio: "pipe" });
-}
-
-function scalar(db: DatabaseSync, sql: string, params: Record<string, string>): string | null {
-	const row = db.prepare(sql).get(params) as { value?: string | number | null } | undefined;
-	return row?.value == null ? null : String(row.value);
-}
-
-function pushTool(
-	turns: TranscriptTurn[],
-	name: string,
-	input: Record<string, unknown>,
-	id: string,
-	expect?: TranscriptTurn["expect"],
-): void {
-	turns.push({
-		turn: turns.length + 1,
-		...(expect ? { expect } : {}),
-		emit: { kind: "tool_use", calls: [{ id, name, input }] },
-	});
-}
-
-function pushText(turns: TranscriptTurn[], text: string, expect?: TranscriptTurn["expect"]): void {
-	turns.push({
-		turn: turns.length + 1,
-		...(expect ? { expect } : {}),
-		emit: { kind: "text", text },
-	});
+	commitProjectFiles(
+		dir,
+		["package.json", "src/answer.js", "src/status.js", "test/answer.test.js", "test/status.test.js"],
+		"test: seed remediation fixture",
+	);
 }
 
 function slicePlanInput(sliceId: "S01" | "S02", file: string, verify: string, expected: string): Record<string, unknown> {
@@ -122,7 +97,7 @@ function completeSliceInput(sliceId: "S01" | "S02", title: string, file: string,
 function buildTranscript(): string {
 	const turns: TranscriptTurn[] = [];
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		artifact_type: "PROJECT",
 		content: [
 			"# Project",
@@ -135,7 +110,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "project", { modelId: "gsd-fake-model", lastUserText: "Headless Milestone Creation" });
-	pushTool(turns, "gsd_requirement_save", {
+	appendToolTurn(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The answer module returns the requested ready value.",
 		why: "The initial slice needs one observable source behavior change.",
@@ -146,7 +121,7 @@ function buildTranscript(): string {
 		validation: "The focused answer verification command exits 0.",
 		notes: "Remediation closeout e2e fixture.",
 	}, "answer-requirement", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_requirement_save", {
+	appendToolTurn(turns, "gsd_requirement_save", {
 		class: "core-capability",
 		description: "The status module returns the requested done value before milestone closeout.",
 		why: "Milestone validation must be able to add and complete remediation work.",
@@ -157,11 +132,11 @@ function buildTranscript(): string {
 		validation: "The full fixture test command exits 0.",
 		notes: "Intentionally left uncovered by the initial roadmap.",
 	}, "status-requirement", { hasToolResultFor: "gsd_requirement_save" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		artifact_type: "REQUIREMENTS",
 		content: "# Requirements\n",
 	}, "requirements", { hasToolResultFor: "gsd_requirement_save" });
-	pushTool(turns, "ask_user_questions", {
+	appendToolTurn(turns, "ask_user_questions", {
 		questions: [{
 			id: "depth_verification_M001_confirm",
 			header: "Depth Check",
@@ -178,7 +153,7 @@ function buildTranscript(): string {
 			],
 		}],
 	}, "depth-check", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		artifact_type: "CONTEXT",
 		content: [
@@ -195,7 +170,7 @@ function buildTranscript(): string {
 			"",
 		].join("\n"),
 	}, "context", { hasToolResultFor: "ask_user_questions" });
-	pushTool(turns, "gsd_plan_milestone", {
+	appendToolTurn(turns, "gsd_plan_milestone", {
 		milestoneId: "M001",
 		title: "Remediation Closeout",
 		vision: "A validation gap is remediated through a real added slice before milestone completion.",
@@ -238,31 +213,31 @@ function buildTranscript(): string {
 		requirementCoverage: "R001 is owned by S01. R002 will be covered by remediation slice S02.",
 		boundaryMapMarkdown: "| Boundary | Decision |\n| --- | --- |\n| Validation -> remediation | A needs-remediation verdict must add S02 before closeout. |\n",
 	}, "roadmap", { hasToolResultFor: "gsd_summary_save" });
-	pushText(turns, "Milestone M001 ready.", { hasToolResultFor: "gsd_plan_milestone" });
+	appendTextTurn(turns, "Milestone M001 ready.", { hasToolResultFor: "gsd_plan_milestone" });
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		slice_id: "S01",
 		artifact_type: "RESEARCH",
 		content: "# S01 - Research\n\nUse `src/answer.js` and verify with `node --test test/answer.test.js`.\n",
 	}, "s01-research");
-	pushText(turns, "Slice S01 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("S01", "src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "s01-plan");
-	pushText(turns, "Slice S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
-	pushTool(turns, "write", {
+	appendTextTurn(turns, "Slice S01 researched.", { hasToolResultFor: "gsd_summary_save" });
+	appendToolTurn(turns, "gsd_plan_slice", slicePlanInput("S01", "src/answer.js", "node --test test/answer.test.js", "answer() returns ready."), "s01-plan");
+	appendTextTurn(turns, "Slice S01 planned.", { hasToolResultFor: "gsd_plan_slice" });
+	appendToolTurn(turns, "write", {
 		path: "src/answer.js",
 		content: "export function answer() {\n\treturn \"ready\";\n}\n",
 	}, "write-answer");
-	pushTool(turns, "bash", {
+	appendToolTurn(turns, "bash", {
 		command: "node --test test/answer.test.js",
 		timeout: 30,
 	}, "verify-answer", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("S01", "src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "s01-task", { hasToolResultFor: "bash" });
-	pushText(turns, "S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("S01", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "s01-complete");
-	pushText(turns, "Slice S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
+	appendToolTurn(turns, "gsd_task_complete", completeTaskInput("S01", "src/answer.js", "node --test test/answer.test.js", "Updated answer() to return ready."), "s01-task", { hasToolResultFor: "bash" });
+	appendTextTurn(turns, "S01/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
+	appendToolTurn(turns, "gsd_slice_complete", completeSliceInput("S01", "Update answer module", "src/answer.js", "node --test test/answer.test.js", "answer() now returns ready."), "s01-complete");
+	appendTextTurn(turns, "Slice S01 complete.", { hasToolResultFor: "gsd_slice_complete" });
 
-	pushTool(turns, "gsd_validate_milestone", {
+	appendToolTurn(turns, "gsd_validate_milestone", {
 		milestoneId: "M001",
 		verdict: "needs-remediation",
 		remediationRound: 0,
@@ -274,7 +249,7 @@ function buildTranscript(): string {
 		verdictRationale: "The initial slice passed, but milestone success requires status() to return done before closeout.",
 		remediationPlan: "Add S02 to update src/status.js and run npm test.",
 	}, "validate-remediation");
-	pushTool(turns, "gsd_reassess_roadmap", {
+	appendToolTurn(turns, "gsd_reassess_roadmap", {
 		milestoneId: "M001",
 		completedSliceId: "S01",
 		verdict: "roadmap-adjusted",
@@ -291,31 +266,31 @@ function buildTranscript(): string {
 			removed: [],
 		},
 	}, "add-remediation-slice", { hasToolResultFor: "gsd_validate_milestone" });
-	pushText(turns, "Remediation slice S02 added.", { hasToolResultFor: "gsd_reassess_roadmap" });
+	appendTextTurn(turns, "Remediation slice S02 added.", { hasToolResultFor: "gsd_reassess_roadmap" });
 
-	pushTool(turns, "gsd_summary_save", {
+	appendToolTurn(turns, "gsd_summary_save", {
 		milestone_id: "M001",
 		slice_id: "S02",
 		artifact_type: "RESEARCH",
 		content: "# S02 - Research\n\nUse `src/status.js` and verify both modules with `npm test`.\n",
 	}, "s02-research");
-	pushText(turns, "Slice S02 researched.", { hasToolResultFor: "gsd_summary_save" });
-	pushTool(turns, "gsd_plan_slice", slicePlanInput("S02", "src/status.js", "npm test", "status() returns done."), "s02-plan");
-	pushText(turns, "Slice S02 planned.", { hasToolResultFor: "gsd_plan_slice" });
-	pushTool(turns, "write", {
+	appendTextTurn(turns, "Slice S02 researched.", { hasToolResultFor: "gsd_summary_save" });
+	appendToolTurn(turns, "gsd_plan_slice", slicePlanInput("S02", "src/status.js", "npm test", "status() returns done."), "s02-plan");
+	appendTextTurn(turns, "Slice S02 planned.", { hasToolResultFor: "gsd_plan_slice" });
+	appendToolTurn(turns, "write", {
 		path: "src/status.js",
 		content: "export function status() {\n\treturn \"done\";\n}\n",
 	}, "write-status");
-	pushTool(turns, "bash", {
+	appendToolTurn(turns, "bash", {
 		command: "npm test",
 		timeout: 30,
 	}, "verify-status", { hasToolResultFor: "write" });
-	pushTool(turns, "gsd_task_complete", completeTaskInput("S02", "src/status.js", "npm test", "Updated status() to return done."), "s02-task", { hasToolResultFor: "bash" });
-	pushText(turns, "S02/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
-	pushTool(turns, "gsd_slice_complete", completeSliceInput("S02", "Remediate status module", "src/status.js", "npm test", "status() now returns done."), "s02-complete");
-	pushText(turns, "Slice S02 complete.", { hasToolResultFor: "gsd_slice_complete" });
+	appendToolTurn(turns, "gsd_task_complete", completeTaskInput("S02", "src/status.js", "npm test", "Updated status() to return done."), "s02-task", { hasToolResultFor: "bash" });
+	appendTextTurn(turns, "S02/T01 complete.", { hasToolResultFor: "gsd_task_complete" });
+	appendToolTurn(turns, "gsd_slice_complete", completeSliceInput("S02", "Remediate status module", "src/status.js", "npm test", "status() now returns done."), "s02-complete");
+	appendTextTurn(turns, "Slice S02 complete.", { hasToolResultFor: "gsd_slice_complete" });
 
-	pushTool(turns, "gsd_validate_milestone", {
+	appendToolTurn(turns, "gsd_validate_milestone", {
 		milestoneId: "M001",
 		verdict: "pass",
 		remediationRound: 1,
@@ -326,8 +301,8 @@ function buildTranscript(): string {
 		verificationClasses: "| Class | Planned Check | Evidence | Verdict |\n| --- | --- | --- | --- |\n| Contract | Focused and full node:test commands exit 0. | `node --test test/answer.test.js` and `npm test` exited 0. | PASS |\n| Integration | Both modules are verified together. | S02 `npm test` exercised both tests after remediation. | PASS |\n| Operational | Headless process exits cleanly. | No blocked/error operator notification was emitted. | PASS |\n| UAT | Slice UAT summaries pass. | S01 and S02 closeout UAT content recorded PASS. | PASS |",
 		verdictRationale: "The remediation slice covered the previously missing status behavior and the full fixture test now passes.",
 	}, "validate-pass");
-	pushText(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
-	pushTool(turns, "gsd_complete_milestone", {
+	appendTextTurn(turns, "Milestone M001 validation complete - verdict: pass.", { hasToolResultFor: "gsd_validate_milestone" });
+	appendToolTurn(turns, "gsd_complete_milestone", {
 		milestoneId: "M001",
 		title: "Remediation Closeout",
 		oneLiner: "Completed initial work, added remediation from validation, and verified the full fixture.",
@@ -342,13 +317,13 @@ function buildTranscript(): string {
 		followUps: "None.",
 		deviations: "The roadmap intentionally started with S01 only so validation could add S02.",
 	}, "complete-milestone");
-	pushText(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
+	appendTextTurn(turns, "Milestone M001 complete.", { hasToolResultFor: "gsd_complete_milestone" });
 
 	return writeTranscript(turns);
 }
 
 describe("remediation milestone closeout e2e (fake LLM)", () => {
-	const avail = binaryAvailable();
+	const avail = smokeBinaryAvailable();
 	const skipReason = avail.ok ? null : avail.reason;
 
 	test("headless new-milestone --auto remediates validation gaps before completion", { skip: skipReason ?? false, timeout: 240_000 }, (t) => {
@@ -431,43 +406,28 @@ describe("remediation milestone closeout e2e (fake LLM)", () => {
 		assert.ok(!result.timedOut, "headless remediation run must not time out");
 
 		const events = parseJsonEvents(result.stdoutClean);
-		const notifyMessages = events
-			.filter((event) => event.type === "extension_ui_request" && event.method === "notify")
-			.map((event) => String(event.message ?? ""));
-		const badOperatorSignals = notifyMessages.filter((message) =>
-			/blocked:|failed|cannot complete|cannot validate|stopped with an issue/i.test(message),
-		);
-		const toolErrors = events
-			.filter((event) => event.type === "tool_execution_end")
-			.filter((event) => event.isError === true || (event.result as { isError?: boolean } | undefined)?.isError === true)
-			.map((event) => `${String(event.toolName ?? "unknown")}: ${JSON.stringify(event.result ?? {})}`);
-		const toolNames = events
-			.filter((event) => event.type === "tool_execution_end")
-			.map((event) => String(event.toolName ?? ""));
+		const outcome = new WorkflowOutcomeProbe(project.dir, events);
+		const completedToolNames = toolNames(events);
 
-		assert.deepEqual(badOperatorSignals, [], `unexpected blocked/error operator signals: ${badOperatorSignals.join("\n")}`);
-		assert.deepEqual(toolErrors, [], `unexpected tool errors:\n${toolErrors.join("\n")}`);
-		assert.ok(toolNames.includes("gsd_reassess_roadmap"), "remediation must add a roadmap slice through gsd_reassess_roadmap");
-		assert.equal(toolNames.filter((toolName) => toolName === "gsd_validate_milestone").length, 2, "validation must run before and after remediation");
-		assert.ok(
-			notifyMessages.some((message) => /auto-mode stopped/i.test(message) && /milestone m001 complete|all milestones complete/i.test(message)),
-			`expected terminal auto-mode completion notification, got:\n${notifyMessages.join("\n")}`,
-		);
+		outcome.assertNoOperatorFailures();
+		outcome.assertNoToolErrors();
+		assert.ok(completedToolNames.includes("gsd_reassess_roadmap"), "remediation must add a roadmap slice through gsd_reassess_roadmap");
+		assert.equal(completedToolNames.filter((toolName) => toolName === "gsd_validate_milestone").length, 2, "validation must run before and after remediation");
+		outcome.assertCompletionNotification(/milestone m001 complete|all milestones complete/i);
 		assert.doesNotThrow(
 			() => execFileSync("npm", ["test"], { cwd: project.dir, stdio: "pipe" }),
 			"full fixture verification command must pass after remediation completion",
 		);
 
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "M001-VALIDATION.md")), "final milestone validation artifact is present");
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "M001-SUMMARY.md")), "milestone summary artifact is present");
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", "S01", "S01-ASSESSMENT.md")), "roadmap reassessment artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/M001-VALIDATION.md", "final milestone validation artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/M001-SUMMARY.md", "milestone summary artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/slices/S01/S01-ASSESSMENT.md", "roadmap reassessment artifact is present");
 		for (const sliceId of ["S01", "S02"]) {
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", sliceId, `${sliceId}-SUMMARY.md`)), `${sliceId} summary artifact is present`);
-			assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", sliceId, "tasks", "T01-SUMMARY.md")), `${sliceId}/T01 summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/M001/slices/${sliceId}/${sliceId}-SUMMARY.md`, `${sliceId} summary artifact is present`);
+			outcome.assertArtifact(`.gsd/milestones/M001/slices/${sliceId}/tasks/T01-SUMMARY.md`, `${sliceId}/T01 summary artifact is present`);
 		}
 
-		const db = new DatabaseSync(join(project.dir, ".gsd", "gsd.db"));
-		t.after(() => db.close());
+		const db = outcome.openDb(t);
 		assert.equal(scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M001" }), "complete");
 		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM slices WHERE milestone_id = :mid AND status = 'complete'", { mid: "M001" }), "2");
 		assert.equal(scalar(db, "SELECT COUNT(*) AS value FROM tasks WHERE milestone_id = :mid AND status = 'complete'", { mid: "M001" }), "2");

--- a/tests/e2e/tiny-milestone-completion.e2e.test.ts
+++ b/tests/e2e/tiny-milestone-completion.e2e.test.ts
@@ -2,10 +2,9 @@
 // File Purpose: E2E gate for headless tiny milestone completion through auto-mode.
 
 import { execFileSync } from "node:child_process";
-import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -13,24 +12,15 @@ import {
 	createTmpProject,
 	gsdSync,
 	parseJsonEvents,
+	commitProjectFiles,
+	scalar,
+	smokeBinaryAvailable,
+	WorkflowOutcomeProbe,
 	writeTranscript,
 } from "./_shared/index.ts";
 
-function binaryAvailable(): { ok: boolean; reason?: string } {
-	const bin = process.env.GSD_SMOKE_BINARY;
-	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
-	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
-	return { ok: true };
-}
-
 function commitFixture(dir: string): void {
-	execFileSync("git", ["add", "package.json", "src/answer.js", "test/answer.test.js"], { cwd: dir, stdio: "pipe" });
-	execFileSync("git", ["commit", "-m", "test: seed tiny fixture"], { cwd: dir, stdio: "pipe" });
-}
-
-function scalar(db: DatabaseSync, sql: string, params: Record<string, string>): string | null {
-	const row = db.prepare(sql).get(params) as { value?: string | null } | undefined;
-	return row?.value ?? null;
+	commitProjectFiles(dir, ["package.json", "src/answer.js", "test/answer.test.js"], "test: seed tiny fixture");
 }
 
 function buildTranscript(): string {
@@ -432,7 +422,7 @@ function buildTranscript(): string {
 }
 
 describe("tiny milestone completion e2e (fake LLM)", () => {
-	const avail = binaryAvailable();
+	const avail = smokeBinaryAvailable();
 	const skipReason = avail.ok ? null : avail.reason;
 
 	test("headless new-milestone --auto completes a verified source change", { skip: skipReason ?? false, timeout: 180_000 }, (t) => {
@@ -502,28 +492,19 @@ describe("tiny milestone completion e2e (fake LLM)", () => {
 		assert.ok(!result.timedOut, "headless milestone run must not time out");
 
 		const events = parseJsonEvents(result.stdoutClean);
-		const notifyMessages = events
-			.filter((event) => event.type === "extension_ui_request" && event.method === "notify")
-			.map((event) => String(event.message ?? ""));
-		const badOperatorSignals = notifyMessages.filter((message) =>
-			/blocked:|failed|cannot complete|cannot validate|stopped with an issue/i.test(message),
-		);
-		assert.deepEqual(badOperatorSignals, [], `unexpected blocked/error operator signals: ${badOperatorSignals.join("\n")}`);
-		assert.ok(
-			notifyMessages.some((message) => /auto-mode stopped/i.test(message) && /milestone m001 complete|all milestones complete/i.test(message)),
-			`expected terminal auto-mode completion notification, got:\n${notifyMessages.join("\n")}`,
-		);
+		const outcome = new WorkflowOutcomeProbe(project.dir, events);
+		outcome.assertNoOperatorFailures();
+		outcome.assertCompletionNotification(/milestone m001 complete|all milestones complete/i);
 
 		assert.doesNotThrow(
 			() => execFileSync("node", ["--test", "test/answer.test.js"], { cwd: project.dir, stdio: "pipe" }),
 			"fixture verification command must pass after milestone completion",
 		);
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "M001-SUMMARY.md")), "milestone summary artifact is present");
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md")), "slice summary artifact is present");
-		assert.ok(existsSync(join(project.dir, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md")), "task summary artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/M001-SUMMARY.md", "milestone summary artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/slices/S01/S01-SUMMARY.md", "slice summary artifact is present");
+		outcome.assertArtifact(".gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md", "task summary artifact is present");
 
-		const db = new DatabaseSync(join(project.dir, ".gsd", "gsd.db"));
-		t.after(() => db.close());
+		const db = outcome.openDb(t);
 		assert.equal(
 			scalar(db, "SELECT status AS value FROM milestones WHERE id = :id", { id: "M001" }),
 			"complete",


### PR DESCRIPTION
## TL;DR

**What:** Consolidates repeated integration and e2e test fixture code into shared helpers.
**Why:** Keeps the test suites easier to maintain while preserving existing behavioral coverage.
**How:** Extracts common workspace, CLI, web bridge, browser-contract, and workflow-scenario helpers, then rewires the affected tests to use them.

## What

- Extracted shared test helpers for GSD integration fixtures, web bridge runtime fixtures, CLI process handling, browser automation contracts, and e2e workflow scenarios.
- Reworked the affected GSD extension, integration, and e2e suites to use those helpers instead of per-file fixture copies.
- Updated `tests/e2e/README.md` to document the shared workflow scenario harness.
- Kept the change test-only; no production runtime paths are changed.

## Why

The affected tests had repeated setup for fake RPC children, temporary workspaces, SSE readers, browser tool surfaces, CLI process handling, and milestone workflow transcripts. Centralizing that setup reduces maintenance drift while keeping the same workflows covered.

## How

- Added shared helpers in `src/resources/extensions/gsd/tests/`, `src/tests/integration/`, and `tests/e2e/_shared/`.
- Replaced inline setup in the changed suites with imports from those helpers.
- Preserved existing assertions around operator notifications, tool errors, terminal completion, and persisted `.gsd/gsd.db` state.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/uat-policy.test.ts src/resources/extensions/gsd/tests/dispatch-run-uat-browser-tools.test.ts src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/integration/e2e-headless.test.ts src/tests/integration/e2e-smoke.test.ts src/tests/integration/web-mode-assembled.test.ts`
- `GSD_SMOKE_BINARY=$(pwd)/dist/loader.js node --experimental-strip-types --test --test-concurrency=1 tests/e2e/tiny-milestone-completion.e2e.test.ts tests/e2e/multi-milestone-sequence.e2e.test.ts tests/e2e/multi-slice-milestone-closeout.e2e.test.ts tests/e2e/remediation-milestone-closeout.e2e.test.ts`
