### PR TITLE
fix(gsd): fail loud on missing workflow tools

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -17,6 +17,7 @@ import { registerHooks } from "./register-hooks.js";
 import { registerShortcuts } from "./register-shortcuts.js";
 import { writeCrashLog } from "./crash-log.js";
 import { logWarning } from "../workflow-logger.js";
+import { UNIT_TOOL_CONTRACTS } from "../unit-tool-contracts.js";
 // Static import so cmux event listeners are registered synchronously during
 // extension bootstrap. Prior implementation used `void import().then()` which
 // queued listener registration as a microtask — any CMUX_CHANNELS emit fired
@@ -36,6 +37,12 @@ const EPIPE_STORM_THRESHOLD = 100;
 const EPIPE_STORM_WINDOW_MS = 10_000;
 let epipeCount = 0;
 let epipeWindowStart = 0;
+
+export const CRITICAL_GSD_WORKFLOW_TOOL_NAMES = [...new Set(
+  Object.values(UNIT_TOOL_CONTRACTS)
+    .flatMap((contract) => contract.requiredWorkflowTools)
+    .filter((toolName) => toolName.startsWith("gsd_")),
+)].sort();
 
 /** Write to stderr without ever re-throwing — stderr can EPIPE too, which would
  *  re-enter this handler and re-loop. */
@@ -133,6 +140,21 @@ export function installEpipeGuard(): void {
   }
 }
 
+function assertCriticalGsdWorkflowToolsRegistered(pi: ExtensionAPI): void {
+  if (typeof pi.getAllTools !== "function") return;
+
+  const registered = new Set(pi.getAllTools().map((tool) => tool.name));
+  const missing = CRITICAL_GSD_WORKFLOW_TOOL_NAMES.filter((toolName) => !registered.has(toolName));
+  if (missing.length === 0) return;
+
+  const message = [
+    `Critical GSD workflow tool registration failed; missing required tool(s): ${missing.join(", ")}.`,
+    "Check earlier bootstrap warnings for the registration slot that failed.",
+  ].join(" ");
+  logWarning("bootstrap", message);
+  throw new Error(message);
+}
+
 export function registerGsdExtension(pi: ExtensionAPI): void {
   // Note: registerGSDCommand is called by index.ts before this function,
   // so we intentionally skip it here to avoid double-registration.
@@ -214,4 +236,6 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
       );
     }
   }
+
+  assertCriticalGsdWorkflowToolsRegistered(pi);
 }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -65,6 +65,7 @@ import { RUN_UAT_READ_ONLY_TOOL_NAMES, RUN_UAT_WORKFLOW_TOOL_NAMES } from "../to
 import { supportsSourceObservationsForUnit } from "../source-observations.js";
 import { clearPendingAutoStart } from "../pending-auto-start.js";
 import { resolveWorkflowToolBasePath } from "./dynamic-tools.js";
+import { getRequiredWorkflowToolsForUnit } from "../unit-tool-contracts.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -262,6 +263,7 @@ export function buildMinimalAutoGsdToolSet(
   activeToolNames: readonly string[],
   unitType: string | undefined,
   registeredToolNames: readonly string[] = activeToolNames,
+  warnOnUnresolvedRequiredTools = registeredToolNames !== activeToolNames,
 ): string[] {
   if (unitType === "run-uat") {
     return buildRunUatGsdToolSet(activeToolNames, registeredToolNames);
@@ -277,7 +279,36 @@ export function buildMinimalAutoGsdToolSet(
     [...activeToolNames, ...registeredToolNames],
     [...MINIMAL_GSD_TOOL_NAMES, ...unitTools],
   );
-  return withPreservedShimTools([...new Set([...preserved, ...scoped])]);
+  const result = withPreservedShimTools([...new Set([...preserved, ...scoped])]);
+  warnIfRequiredWorkflowToolsUnresolved(unitType, result, warnOnUnresolvedRequiredTools);
+  return result;
+}
+
+function hasResolvedWorkflowTool(
+  resolvedToolNames: readonly string[],
+  requiredToolName: string,
+): boolean {
+  return resolvedToolNames.some(
+    (name) => name === requiredToolName || mcpToolMatchesBaseName(name, requiredToolName),
+  );
+}
+
+function warnIfRequiredWorkflowToolsUnresolved(
+  unitType: string | undefined,
+  scopedToolNames: readonly string[],
+  shouldWarn: boolean,
+): void {
+  if (!unitType || !shouldWarn) return;
+
+  const unresolved = getRequiredWorkflowToolsForUnit(unitType).filter(
+    (toolName) => !hasResolvedWorkflowTool(scopedToolNames, toolName),
+  );
+  if (unresolved.length === 0) return;
+
+  safetyLogWarning(
+    "bootstrap",
+    `buildMinimalAutoGsdToolSet(${unitType}): required workflow tool(s) not in active/registered surface after scoping: ${unresolved.join(", ")}. Tool registration may have partially failed, provider filtering may have removed a required tool, or workflow MCP may be disconnected.`,
+  );
 }
 
 export function buildRunUatGsdToolSet(
@@ -330,6 +361,7 @@ export function buildRequestScopedGsdToolSet(
   requestCustomMessages: readonly { customType?: string }[] | undefined,
   registeredToolNames: readonly string[] = activeToolNames,
   guidedUnitType?: string,
+  warnOnUnresolvedRequiredTools = registeredToolNames !== activeToolNames,
 ): string[] | undefined {
   for (let index = (requestCustomMessages?.length ?? 0) - 1; index >= 0; index--) {
     const currentCustomType = requestCustomMessages?.[index]?.customType;
@@ -340,7 +372,12 @@ export function buildRequestScopedGsdToolSet(
       currentCustomType === "gsd-triage"
     ) {
       if (guidedUnitType) {
-        return buildMinimalAutoGsdToolSet(activeToolNames, guidedUnitType, registeredToolNames);
+        return buildMinimalAutoGsdToolSet(
+          activeToolNames,
+          guidedUnitType,
+          registeredToolNames,
+          warnOnUnresolvedRequiredTools,
+        );
       }
       return buildMinimalGsdWorkflowToolSet(activeToolNames, registeredToolNames);
     }
@@ -389,11 +426,13 @@ function applyMinimalGsdToolSurface(pi: ExtensionAPI): void {
   const dash = getAutoRuntimeSnapshot();
   if (dash.active && dash.currentUnit) {
     const currentToolNames = pi.getActiveTools();
+    const hasRegisteredSurface = typeof pi.getAllTools === "function";
     const registeredToolNames = resolveRegisteredToolNames(pi, currentToolNames);
     const scopedToolNames = buildMinimalAutoGsdToolSet(
       currentToolNames,
       dash.currentUnit.type,
       registeredToolNames,
+      hasRegisteredSurface,
     );
     recordAutoToolSurfaceSnapshot({
       source: "runtime-scope",
@@ -415,9 +454,10 @@ export function scopeGsdWorkflowToolsForDispatch(
 ): ScopedGsdWorkflowState | null {
   if (isFullGsdToolSurfaceRequested()) return null;
   const current = pi.getActiveTools();
+  const hasRegisteredSurface = typeof pi.getAllTools === "function";
   const registeredToolNames = resolveRegisteredToolNames(pi, current);
   const scoped = unitType
-    ? buildMinimalAutoGsdToolSet(current, unitType, registeredToolNames)
+    ? buildMinimalAutoGsdToolSet(current, unitType, registeredToolNames, hasRegisteredSurface)
     : buildMinimalGsdWorkflowToolSet(current, registeredToolNames);
   recordAutoToolSurfaceSnapshot({
     source: "dispatch-scope",
@@ -1581,6 +1621,7 @@ export function registerHooks(
       return surfaceReduced ? { toolNames: providerCompatible } : undefined;
     }
     const registeredToolNames = resolveRegisteredToolNames(pi, event.activeToolNames);
+    const hasRegisteredSurface = typeof pi.getAllTools === "function";
     const compatibleRegisteredToolNames = filterToolsForProvider(
       registeredToolNames,
       event.selectedModelApi,
@@ -1595,6 +1636,7 @@ export function registerHooks(
       event.requestCustomMessages,
       requestRegisteredToolNames,
       guidedUnit?.unitType,
+      hasRegisteredSurface,
     );
     if (requestScoped) {
       recordAutoToolSurfaceSnapshot({
@@ -1615,6 +1657,7 @@ export function registerHooks(
         dash.currentUnit.type === "run-uat" ? aliasFilteredCompatible : providerCompatible,
         dash.currentUnit.type,
         registeredForUnit,
+        hasRegisteredSurface,
       );
       recordAutoToolSurfaceSnapshot({
         source: "provider-adjustment",

--- a/src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts
@@ -117,7 +117,8 @@ describe("extension bootstrap isolation (#4168, #4172)", () => {
 // registration is wrapped in its own try/catch so one failure does not
 // prevent siblings from loading.
 
-import { registerGsdExtension } from "../bootstrap/register-extension.ts";
+import { CRITICAL_GSD_WORKFLOW_TOOL_NAMES, registerGsdExtension } from "../bootstrap/register-extension.ts";
+import { drainLogs } from "../workflow-logger.ts";
 
 describe("registerGsdExtension defensive registration", () => {
   test("a failing shortcut registration does not prevent kill command registration", async () => {
@@ -160,5 +161,38 @@ describe("registerGsdExtension defensive registration", () => {
       !registered.includes("gsd"),
       `registerGsdExtension must NOT register 'gsd' (it is registered separately by index.ts), got ${JSON.stringify(registered)}`,
     );
+  });
+
+  test("critical workflow tool list includes lifecycle planning and completion tools", () => {
+    assert.ok(CRITICAL_GSD_WORKFLOW_TOOL_NAMES.includes("gsd_plan_slice"));
+    assert.ok(CRITICAL_GSD_WORKFLOW_TOOL_NAMES.includes("gsd_slice_complete"));
+    assert.ok(CRITICAL_GSD_WORKFLOW_TOOL_NAMES.includes("gsd_validate_milestone"));
+    assert.ok(CRITICAL_GSD_WORKFLOW_TOOL_NAMES.includes("gsd_complete_milestone"));
+  });
+
+  test("partial db-tools registration fails visibly when critical tools are missing", () => {
+    drainLogs();
+    const registeredTools: string[] = [];
+    const pi = {
+      registerCommand: () => {},
+      registerTool: (tool: { name: string }) => {
+        if (tool.name === "gsd_plan_slice") {
+          throw new Error("simulated db-tools partial registration failure");
+        }
+        registeredTools.push(tool.name);
+      },
+      registerHook: () => {},
+      registerShortcut: () => {},
+      events: { on: () => {}, off: () => {}, emit: () => {} },
+      getAllTools: () => registeredTools.map((name) => ({ name })),
+    };
+
+    assert.throws(
+      () => registerGsdExtension(pi as any),
+      /Critical GSD workflow tool registration failed; missing required tool\(s\): .*gsd_plan_slice/,
+    );
+    assert.ok(registeredTools.includes("gsd_plan_milestone"));
+    assert.ok(!registeredTools.includes("gsd_plan_slice"));
+    drainLogs();
   });
 });

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -10,6 +10,7 @@ import { DISCUSS_TOOLS_ALLOWLIST } from "../constants.ts";
 import { buildMinimalAutoGsdToolSet, buildMinimalGsdToolSet, buildMinimalGsdWorkflowToolSet, buildRequestScopedGsdToolSet, MINIMAL_AUTO_BASE_TOOL_NAMES, MINIMAL_GSD_TOOL_NAMES, requestHasGsdCustomType, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "../bootstrap/register-hooks.ts";
 import { filterToolsForProvider } from "../model-router.ts";
 import { applyUnitSkillVisibility } from "../skill-scope.ts";
+import { drainLogs } from "../workflow-logger.ts";
 
 test("buildMinimalGsdToolSet preserves non-GSD tools and replaces broad GSD surface", () => {
   const result = buildMinimalGsdToolSet([
@@ -101,6 +102,40 @@ test("buildMinimalAutoGsdToolSet keeps unit-specific completion tools without al
   assert.ok(!result.includes("gsd_complete_task"));
   assert.ok(!result.includes("gsd_slice_complete"));
   assert.ok(!result.includes("gsd_complete_slice"));
+});
+
+test("buildMinimalAutoGsdToolSet warns when plan-milestone required tools are unresolved", () => {
+  drainLogs();
+  const result = buildMinimalAutoGsdToolSet(
+    [
+      "ask_user_questions",
+      "bash",
+      "read",
+      "gsd_milestone_status",
+      "gsd_plan_milestone",
+    ],
+    "plan-milestone",
+    [
+      "ask_user_questions",
+      "bash",
+      "read",
+      "gsd_milestone_status",
+      "gsd_plan_milestone",
+    ],
+  );
+
+  assert.ok(result.includes("gsd_plan_milestone"));
+  assert.ok(!result.includes("gsd_plan_slice"));
+
+  const logs = drainLogs();
+  assert.ok(
+    logs.some((entry) =>
+      entry.component === "bootstrap" &&
+      entry.message.includes("buildMinimalAutoGsdToolSet(plan-milestone)") &&
+      entry.message.includes("gsd_plan_slice")
+    ),
+    `expected missing gsd_plan_slice bootstrap warning, got ${JSON.stringify(logs)}`,
+  );
 });
 
 test("buildMinimalAutoGsdToolSet scopes run-uat to UAT-specific and read-only tools", () => {


### PR DESCRIPTION
## TL;DR

**What:** Makes missing required GSD workflow tools visible at bootstrap and during per-unit tool scoping.
**Why:** A partial `db-tools` registration failure could drop tools like `gsd_plan_slice`, then auto-mode would stall later with an opaque missing-tool loop.
**How:** Derives critical workflow tools from the unit tool contracts, asserts they registered after bootstrap, and warns when scoping loses a unit's required workflow tools.

## What

- Added a critical GSD workflow tool registration check after extension bootstrap registration completes.
- Added per-unit scoping diagnostics when required workflow tools are unresolved after active/registered tool surface resolution.
- Covered the partial `db-tools` registration path and the `plan-milestone` missing `gsd_plan_slice` scoping path with focused regression tests.

Closes #568

## Why

Issue #568 described a failure mode where `registerDbTools` could abort partway through registration, leaving `gsd_plan_milestone` present but `gsd_plan_slice` absent. The unit scoper then silently dropped the missing required tool, so the real bootstrap failure surfaced much later as a plan-milestone dispatch loop.

## How

- `register-extension.ts` now derives required `gsd_*` workflow tools from `UNIT_TOOL_CONTRACTS`, checks `pi.getAllTools()` after registration, logs the missing tools, and throws a visible bootstrap setup error while preserving the separate `/gsd` command bootstrap guard.
- `register-hooks.ts` now compares the scoped tool surface with the unit's required workflow tools when a real registered-tool surface is available, including MCP-scoped tool names.
- Existing `run-uat` scoping behavior stays unchanged.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/token-tool-gating.test.ts src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts`
- `pnpm run test:changed:src`
- `pnpm run verify:fast`
- `pnpm run verify:pr`

## Impact analysis

- Blast radius: moderate. The change touches GSD extension bootstrap and auto/guided workflow tool scoping, but does not alter the unit tool contracts or tool execution semantics.
- Affected workflows: extension startup, auto-mode runtime scoping, guided GSD workflow requests, and provider-adjusted tool surfaces.
- Compatibility notes: the hard bootstrap assertion only runs when `pi.getAllTools()` is available; the top-level extension wrapper still preserves the core `/gsd` command if full setup fails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783770645&installation_id=134682257&pr_number=666&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F666&signature=d41c6f762f23b38b53d613abed556df9a1f7e13eb4db59bff5fc455dcb5307c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GSD extension bootstrap and auto/guided tool scoping; a hard throw after registration can fail full setup when tools are missing, though `/gsd` isolation and the no-`getAllTools` skip limit blast radius.
> 
> **Overview**
> Makes missing required GSD workflow tools visible at **extension bootstrap** and during **per-unit tool scoping**, instead of failing later in opaque auto-mode loops.
> 
> After non-critical registrations finish, bootstrap derives **`CRITICAL_GSD_WORKFLOW_TOOL_NAMES`** from `UNIT_TOOL_CONTRACTS`, checks `pi.getAllTools()` when available, logs, and **throws** if any required `gsd_*` workflow tool is absent (e.g. partial `db-tools` registration dropping `gsd_plan_slice`).
> 
> **`buildMinimalAutoGsdToolSet`** and related scoping paths now warn when a unit’s contract-required workflow tools are missing from the scoped surface (including MCP-scoped names), gated on having a real registered-tool surface via `getAllTools`. Regression tests cover the bootstrap assertion and the `plan-milestone` / missing `gsd_plan_slice` warning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4d6c9920dcc9b44f6311b9a73ce99fbcc8f5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->