### PR TITLE
fix(browser-tools): satisfy contract tools browser_click/type/verify/reload via gsd-browser translations

### DIFF
--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -14,6 +14,8 @@ interface ManagedBrowserToolDetails {
   server: string;
   tool: string;
   mcpTool: string;
+  /** All MCP tools invoked, in order, when a translation made multiple calls. */
+  mcpTools?: string[];
   sessionName?: string;
   projectRoot?: string;
   truncated?: boolean;
@@ -38,9 +40,28 @@ interface McpContentItem {
   [key: string]: unknown;
 }
 
+interface ManagedTranslatedCall {
+  mcpTool: string;
+  args: Record<string, unknown>;
+  /** Best-effort call: a failure adds no evidence but does not fail the tool. */
+  optional?: boolean;
+}
+
+interface ManagedToolTranslation {
+  /** Every MCP tool build() can emit; all must be served for contract coverage. */
+  requires: readonly string[];
+  /** Expand the Pi contract args into one or more sequential gsd-browser MCP calls. */
+  build(args: Record<string, unknown>): ManagedTranslatedCall[];
+}
+
 interface ManagedBrowserToolSpec {
   /** gsd-browser MCP tool candidates, tried in order. Defaults to the contract name itself. */
   mcpTools?: string[];
+  /**
+   * Param-shape translation for contract tools gsd-browser does not serve
+   * under any name. Takes precedence over mcpTools/name-based dispatch.
+   */
+  translate?: ManagedToolTranslation;
   label: string;
   description: string;
   parameters: TSchema;
@@ -52,6 +73,7 @@ const connections = new Map<string, ManagedConnection>();
 const pendingConnections = new Map<string, Promise<ManagedConnection>>();
 const DEFAULT_MAX_LINES = 2_000;
 const DEFAULT_MAX_BYTES = 50 * 1024;
+const MCP_CALL_TIMEOUT_MS = 60_000;
 
 const AssertionCheck = Type.Object({
   kind: Type.String({ description: "Assertion kind, e.g. url_contains, text_visible, selector_visible, no_console_errors, no_failed_requests." }),
@@ -86,7 +108,7 @@ const BatchStep = Type.Object({
  */
 export const MANAGED_GSD_BROWSER_TOOL_NAMES = BROWSER_CONTRACT_TOOL_NAMES;
 
-const MANAGED_BROWSER_TOOL_SPECS: Record<BrowserContractToolName, ManagedBrowserToolSpec> = {
+export const MANAGED_BROWSER_TOOL_SPECS: Record<BrowserContractToolName, ManagedBrowserToolSpec> = {
   browser_navigate: {
     label: "Browser Navigate",
     description: "Navigate the managed gsd-browser session to a URL and return page state. Use for local web app verification and UAT evidence.",
@@ -96,6 +118,13 @@ const MANAGED_BROWSER_TOOL_SPECS: Record<BrowserContractToolName, ManagedBrowser
     }, { additionalProperties: true }),
   },
   browser_click: {
+    translate: {
+      requires: ["browser_batch"],
+      build: (args) => [{
+        mcpTool: "browser_batch",
+        args: { steps: [{ action: "click", ...args }] },
+      }],
+    },
     label: "Browser Click",
     description: "Click an element in the managed gsd-browser session by selector or coordinates.",
     parameters: Type.Object({
@@ -105,6 +134,13 @@ const MANAGED_BROWSER_TOOL_SPECS: Record<BrowserContractToolName, ManagedBrowser
     }, { additionalProperties: true }),
   },
   browser_type: {
+    translate: {
+      requires: ["browser_batch"],
+      build: (args) => [{
+        mcpTool: "browser_batch",
+        args: { steps: [{ action: "type", ...args }] },
+      }],
+    },
     label: "Browser Type",
     description: "Type or fill text into an input in the managed gsd-browser session.",
     parameters: Type.Object({
@@ -164,6 +200,38 @@ const MANAGED_BROWSER_TOOL_SPECS: Record<BrowserContractToolName, ManagedBrowser
     }, { additionalProperties: true }),
   },
   browser_verify: {
+    translate: {
+      requires: ["browser_navigate", "browser_assert", "browser_screenshot"],
+      build: (args) => {
+        const calls: ManagedTranslatedCall[] = [
+          {
+            mcpTool: "browser_navigate",
+            args: { url: args.url, ...(args.timeout === undefined ? {} : { timeout: args.timeout }) },
+          },
+        ];
+        const verifyChecks = Array.isArray(args.checks) ? args.checks as Array<Record<string, unknown>> : [];
+        const assertChecks: Array<Record<string, unknown>> = [];
+        for (const check of verifyChecks) {
+          if (typeof check.expectedText === "string") {
+            assertChecks.push({ kind: "text_visible", text: check.expectedText });
+          }
+          if (typeof check.selector === "string") {
+            if (check.expectedVisible === false) {
+              assertChecks.push({ kind: "selector_hidden", selector: check.selector });
+            } else if (check.expectedVisible === true || check.expectedText === undefined) {
+              assertChecks.push({ kind: "selector_visible", selector: check.selector });
+            }
+          }
+        }
+        if (assertChecks.length > 0) {
+          calls.push({ mcpTool: "browser_assert", args: { checks: assertChecks } });
+        }
+        if (verifyChecks.some((check) => check.screenshot === true)) {
+          calls.push({ mcpTool: "browser_screenshot", args: {}, optional: true });
+        }
+        return calls;
+      },
+    },
     label: "Browser Verify",
     description: "Run a structured browser verification flow and return evidence from the managed gsd-browser session.",
     parameters: Type.Object({
@@ -236,6 +304,16 @@ const MANAGED_BROWSER_TOOL_SPECS: Record<BrowserContractToolName, ManagedBrowser
     }, { additionalProperties: true }),
   },
   browser_reload: {
+    // gsd-browser's daemon has a reload command but does not expose it over
+    // MCP, so reload rides browser_evaluate. The network-idle settle is
+    // best-effort: pages with persistent connections never go idle.
+    translate: {
+      requires: ["browser_evaluate", "browser_wait_for"],
+      build: () => [
+        { mcpTool: "browser_evaluate", args: { expression: "location.reload()" } },
+        { mcpTool: "browser_wait_for", args: { condition: "network_idle", timeout: 3_000 }, optional: true },
+      ],
+    },
     label: "Browser Reload",
     description: "Reload the current page in the managed gsd-browser session.",
     parameters: Type.Object({}, { additionalProperties: true }),
@@ -351,10 +429,26 @@ function isUnknownMcpToolError(error: unknown): boolean {
   return /unknown tool|tool .*not found|tool not found|not registered|does not exist/i.test(message);
 }
 
-function normalizeManagedArgs(piToolName: string, args: Record<string, unknown>): Record<string, unknown> {
+function normalizeBatchStep(step: unknown): unknown {
+  if (!step || typeof step !== "object") return step;
+  const { clearFirst, ...rest } = step as Record<string, unknown>;
+  return clearFirst === undefined ? step : { ...rest, clear_first: clearFirst };
+}
+
+export function normalizeManagedArgs(piToolName: string, args: Record<string, unknown>): Record<string, unknown> {
   if (piToolName === "browser_snapshot_refs") {
     const { interactiveOnly: _interactiveOnly, ...snapshotArgs } = args;
     return snapshotArgs;
+  }
+  if (piToolName === "browser_batch") {
+    // gsd-browser's MCP batch tool reads snake_case option and step keys.
+    const { stopOnFailure, finalSummaryOnly, steps, ...rest } = args;
+    return {
+      ...rest,
+      ...(Array.isArray(steps) ? { steps: steps.map(normalizeBatchStep) } : {}),
+      ...(stopOnFailure === undefined ? {} : { stop_on_failure: stopOnFailure }),
+      ...(finalSummaryOnly === undefined ? {} : { summary_only: finalSummaryOnly }),
+    };
   }
   return args;
 }
@@ -433,43 +527,104 @@ function truncateHeadText(
   };
 }
 
+type McpToolCallResult = {
+  content?: unknown;
+  structuredContent?: unknown;
+  isError?: boolean;
+};
+
+function callGsdBrowserMcp(
+  connection: ManagedConnection,
+  mcpTool: string,
+  args: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<McpToolCallResult> {
+  return connection.client.callTool(
+    { name: mcpTool, arguments: args },
+    undefined,
+    { signal, timeout: MCP_CALL_TIMEOUT_MS },
+  ) as Promise<McpToolCallResult>;
+}
+
+function buildManagedToolResult(
+  connection: ManagedConnection,
+  piToolName: string,
+  mcpToolsUsed: string[],
+  contentItems: McpContentItem[],
+  lastResult: McpToolCallResult,
+): ManagedBrowserToolResult {
+  const serialized = serializeMcpContent(contentItems);
+  return {
+    content: serialized.content,
+    details: {
+      engine: "gsd-browser",
+      server: connection.launch.serverName,
+      tool: piToolName,
+      mcpTool: mcpToolsUsed[mcpToolsUsed.length - 1] ?? piToolName,
+      ...(mcpToolsUsed.length > 1 ? { mcpTools: mcpToolsUsed } : {}),
+      sessionName: connection.launch.sessionName,
+      projectRoot: connection.launch.projectRoot,
+      truncated: serialized.truncated,
+      outputLines: serialized.outputLines,
+      outputBytes: serialized.outputBytes,
+      structuredContent: lastResult.structuredContent,
+      mcpIsError: Boolean(lastResult.isError),
+    },
+    isError: Boolean(lastResult.isError),
+  };
+}
+
+async function callTranslatedGsdBrowserTool(
+  connection: ManagedConnection,
+  piToolName: string,
+  translation: ManagedToolTranslation,
+  args: Record<string, unknown>,
+  options: { signal?: AbortSignal },
+): Promise<ManagedBrowserToolResult> {
+  const calls = translation.build(args);
+  const contentItems: McpContentItem[] = [];
+  const toolsUsed: string[] = [];
+  let lastResult: McpToolCallResult = {};
+
+  for (const call of calls) {
+    let result: McpToolCallResult;
+    try {
+      result = await callGsdBrowserMcp(connection, call.mcpTool, normalizeManagedArgs(call.mcpTool, call.args), options.signal);
+    } catch (error) {
+      if (call.optional) continue;
+      throw error;
+    }
+    if (call.optional && result.isError) continue;
+    toolsUsed.push(call.mcpTool);
+    if (Array.isArray(result.content)) contentItems.push(...result.content as McpContentItem[]);
+    lastResult = result;
+    // Later calls assume the earlier ones took effect (e.g. assert after a
+    // failed navigation would report misleading evidence), so stop here.
+    if (lastResult.isError) break;
+  }
+
+  return buildManagedToolResult(connection, piToolName, toolsUsed, contentItems, lastResult);
+}
+
 async function callManagedGsdBrowserTool(
   piToolName: string,
-  mcpTools: string[],
+  spec: ManagedBrowserToolSpec,
   args: Record<string, unknown>,
   options: { signal?: AbortSignal; ctx?: ExtensionContext },
 ): Promise<ManagedBrowserToolResult> {
   const connection = await getOrConnectManagedGsdBrowser(options.ctx, options.signal);
   const normalizedArgs = normalizeManagedArgs(piToolName, args);
+
+  if (spec.translate) {
+    return callTranslatedGsdBrowserTool(connection, piToolName, spec.translate, normalizedArgs, options);
+  }
+
   let lastError: unknown;
-
-  for (const mcpTool of mcpTools) {
+  for (const mcpTool of spec.mcpTools ?? [piToolName]) {
     try {
-      const result = await connection.client.callTool(
-        { name: mcpTool, arguments: normalizedArgs },
-        undefined,
-        { signal: options.signal, timeout: 60000 },
-      );
+      const result = await callGsdBrowserMcp(connection, mcpTool, normalizedArgs, options.signal);
       const contentItems = Array.isArray(result.content) ? result.content as McpContentItem[] : [];
-      const serialized = serializeMcpContent(contentItems);
-
-      return {
-        content: serialized.content,
-        details: {
-          engine: "gsd-browser",
-          server: connection.launch.serverName,
-          tool: piToolName,
-          mcpTool,
-          sessionName: connection.launch.sessionName,
-          projectRoot: connection.launch.projectRoot,
-          truncated: serialized.truncated,
-          outputLines: serialized.outputLines,
-          outputBytes: serialized.outputBytes,
-          structuredContent: (result as { structuredContent?: unknown }).structuredContent,
-          mcpIsError: Boolean((result as { isError?: boolean }).isError),
-        },
-        isError: Boolean((result as { isError?: boolean }).isError),
-      };
+      return buildManagedToolResult(connection, piToolName, [mcpTool], contentItems, result);
     } catch (error) {
       lastError = error;
       if (!isUnknownMcpToolError(error)) break;
@@ -492,12 +647,16 @@ function formatManagedBrowserError(toolName: string, error: unknown): string {
 
 /**
  * Contract tools the server's advertised tool list cannot satisfy through any
- * of their declared MCP candidates.
+ * of their declared MCP candidates or translations.
  */
 export function findMissingContractCoverage(servedToolNames: Iterable<string>): BrowserContractToolName[] {
   const served = new Set(servedToolNames);
   return BROWSER_CONTRACT_TOOL_NAMES.filter((name) => {
-    const candidates = MANAGED_BROWSER_TOOL_SPECS[name].mcpTools ?? [name];
+    const spec = MANAGED_BROWSER_TOOL_SPECS[name];
+    if (spec.translate) {
+      return !spec.translate.requires.every((required) => served.has(required));
+    }
+    const candidates = spec.mcpTools ?? [name];
     return !candidates.some((candidate) => served.has(candidate));
   });
 }
@@ -560,7 +719,7 @@ export function registerManagedGsdBrowserTools(pi: ExtensionAPI): void {
         try {
           return await callManagedGsdBrowserTool(
             name,
-            tool.mcpTools ?? [name],
+            tool,
             params as Record<string, unknown>,
             { signal, ctx },
           );
@@ -572,7 +731,7 @@ export function registerManagedGsdBrowserTools(pi: ExtensionAPI): void {
               engine: "gsd-browser",
               server: "gsd-browser",
               tool: name,
-              mcpTool: tool.mcpTools?.[0] ?? name,
+              mcpTool: tool.translate?.requires[0] ?? tool.mcpTools?.[0] ?? name,
               error: error instanceof Error ? error.message : String(error),
             },
             isError: true,

--- a/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
@@ -2,10 +2,32 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 const {
+  MANAGED_BROWSER_TOOL_SPECS,
   MANAGED_GSD_BROWSER_TOOL_NAMES,
   findMissingContractCoverage,
+  normalizeManagedArgs,
   registerManagedGsdBrowserTools,
 } = await import("../engine/managed-gsd-browser.ts");
+
+// The tools @opengsd/gsd-browser actually serves over MCP (subset relevant to
+// the contract). Notably absent: browser_click, browser_type, browser_verify,
+// browser_reload — those are satisfied through translations.
+const GSD_BROWSER_SERVED_TOOLS = [
+  "browser_navigate",
+  "browser_snapshot",
+  "browser_click_ref",
+  "browser_fill_ref",
+  "browser_fill_form",
+  "browser_wait_for",
+  "browser_assert",
+  "browser_screenshot",
+  "browser_find_element",
+  "browser_console",
+  "browser_network",
+  "browser_evaluate",
+  "browser_batch",
+  "browser_act",
+];
 
 describe("registerManagedGsdBrowserTools", () => {
   it("registers the curated Pi browser contract", () => {
@@ -34,19 +56,114 @@ describe("registerManagedGsdBrowserTools", () => {
 });
 
 describe("findMissingContractCoverage", () => {
-  it("reports nothing when every contract tool has a served candidate", () => {
-    // browser_snapshot_refs is served via its browser_snapshot alias here.
-    const served = [...MANAGED_GSD_BROWSER_TOOL_NAMES].filter((name) => name !== "browser_snapshot_refs");
-    served.push("browser_snapshot");
-    assert.deepEqual(findMissingContractCoverage(served), []);
+  it("reports nothing for the tool list gsd-browser actually serves", () => {
+    assert.deepEqual(findMissingContractCoverage(GSD_BROWSER_SERVED_TOOLS), []);
   });
 
   it("reports contract tools none of whose MCP candidates are served", () => {
-    const served = [...MANAGED_GSD_BROWSER_TOOL_NAMES].filter(
-      (name) => name !== "browser_assert" && name !== "browser_evaluate",
-    );
-    // browser_evaluate is still satisfied through its browser_eval alias.
-    served.push("browser_eval");
-    assert.deepEqual(findMissingContractCoverage(served), ["browser_assert"]);
+    const served = GSD_BROWSER_SERVED_TOOLS.filter((name) => name !== "browser_assert");
+    // browser_verify also depends on browser_assert through its translation.
+    assert.deepEqual(findMissingContractCoverage(served), ["browser_assert", "browser_verify"]);
+  });
+
+  it("reports translated tools when a required MCP tool is missing", () => {
+    const served = GSD_BROWSER_SERVED_TOOLS.filter((name) => name !== "browser_batch");
+    assert.deepEqual(findMissingContractCoverage(served), ["browser_click", "browser_type", "browser_batch"]);
+  });
+});
+
+describe("contract tool translations", () => {
+  it("translates browser_click into a single-step batch call", () => {
+    const calls = MANAGED_BROWSER_TOOL_SPECS.browser_click.translate.build({ selector: "#save" });
+    assert.deepEqual(calls, [{
+      mcpTool: "browser_batch",
+      args: { steps: [{ action: "click", selector: "#save" }] },
+    }]);
+  });
+
+  it("translates browser_type into a single-step batch call", () => {
+    const calls = MANAGED_BROWSER_TOOL_SPECS.browser_type.translate.build({
+      selector: "#name",
+      text: "hello",
+      clearFirst: true,
+      submit: true,
+    });
+    assert.deepEqual(calls, [{
+      mcpTool: "browser_batch",
+      args: { steps: [{ action: "type", selector: "#name", text: "hello", clearFirst: true, submit: true }] },
+    }]);
+  });
+
+  it("normalizes batch options and step keys to the daemon's snake_case", () => {
+    const normalized = normalizeManagedArgs("browser_batch", {
+      steps: [{ action: "type", selector: "#name", text: "hi", clearFirst: true }],
+      stopOnFailure: false,
+      finalSummaryOnly: true,
+    });
+    assert.deepEqual(normalized, {
+      steps: [{ action: "type", selector: "#name", text: "hi", clear_first: true }],
+      stop_on_failure: false,
+      summary_only: true,
+    });
+  });
+
+  it("translates browser_verify into navigate, assert, and screenshot calls", () => {
+    const calls = MANAGED_BROWSER_TOOL_SPECS.browser_verify.translate.build({
+      url: "http://localhost:3000",
+      timeout: 5000,
+      checks: [
+        { description: "heading shows", selector: "h1", expectedText: "Welcome" },
+        { description: "spinner gone", selector: ".spinner", expectedVisible: false },
+        { description: "evidence", selector: "main", expectedVisible: true, screenshot: true },
+      ],
+    });
+    assert.deepEqual(calls, [
+      { mcpTool: "browser_navigate", args: { url: "http://localhost:3000", timeout: 5000 } },
+      {
+        mcpTool: "browser_assert",
+        args: {
+          checks: [
+            { kind: "text_visible", text: "Welcome" },
+            { kind: "selector_hidden", selector: ".spinner" },
+            { kind: "selector_visible", selector: "main" },
+          ],
+        },
+      },
+      { mcpTool: "browser_screenshot", args: {}, optional: true },
+    ]);
+  });
+
+  it("declares every tool a translation can emit in its coverage requirements", () => {
+    for (const [name, spec] of Object.entries(MANAGED_BROWSER_TOOL_SPECS)) {
+      if (!spec.translate) continue;
+      const maximalArgs = {
+        url: "http://localhost:3000",
+        timeout: 5000,
+        selector: "#el",
+        text: "hi",
+        clearFirst: true,
+        checks: [{ description: "d", selector: "#el", expectedText: "hi", expectedVisible: true, screenshot: true }],
+      };
+      const emitted = spec.translate.build(maximalArgs).map((call) => call.mcpTool);
+      for (const mcpTool of emitted) {
+        assert.ok(
+          spec.translate.requires.includes(mcpTool),
+          `${name} translation emits ${mcpTool} but does not require it for coverage`,
+        );
+      }
+    }
+  });
+
+  it("translates browser_verify without checks into navigation only", () => {
+    const calls = MANAGED_BROWSER_TOOL_SPECS.browser_verify.translate.build({ url: "http://localhost:3000", checks: [] });
+    assert.deepEqual(calls, [{ mcpTool: "browser_navigate", args: { url: "http://localhost:3000" } }]);
+  });
+
+  it("translates browser_reload into evaluate plus best-effort network-idle wait", () => {
+    const calls = MANAGED_BROWSER_TOOL_SPECS.browser_reload.translate.build({});
+    assert.deepEqual(calls, [
+      { mcpTool: "browser_evaluate", args: { expression: "location.reload()" } },
+      { mcpTool: "browser_wait_for", args: { condition: "network_idle", timeout: 3_000 }, optional: true },
+    ]);
   });
 });


### PR DESCRIPTION
## Linked issue

Closes #<!-- issue number — required -->

- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fixes the managed gsd-browser adapter so four Browser Automation Contract tools (browser_click, browser_type, browser_verify, browser_reload) no longer error on first use.
**Why:** The tools had no valid MCP alias, so every session emitted a coverage warning and the tools threw "unknown tool" at call time.
**How:** Adds a `translate` hook on tool specs that maps each contract tool to the gsd-browser MCP tools it actually serves via composite/translated calls.

## What

Changed files:
- `src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts`
- `src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs`

## Why

`warmUpManagedGsdBrowser` emits a per-session warning for every contract tool that has no served MCP candidate, and `callManagedGsdBrowserTool` throws "unknown tool" on first use. The gsd-browser MCP server (verified against the Rust source in `@opengsd/gsd-browser@0.1.27`) has never served `browser_click`, `browser_type`, `browser_verify`, or `browser_reload` under those names — it uses ref-based interaction and batch steps instead.

## How

**`translate` field on `ManagedBrowserToolSpec`** — a translation declares:
- `requires: string[]` — every MCP tool `build()` can emit; checked by `findMissingContractCoverage` at warm-up
- `build(args): ManagedTranslatedCall[]` — expands Pi contract args into sequential gsd-browser MCP calls; calls with `optional: true` contribute evidence but never fail the tool

**Translations:**
- `browser_click` → single-step `browser_batch { action: "click", ...args }`
- `browser_type` → single-step `browser_batch { action: "type", ...args }`
- `browser_verify` → `browser_navigate` (forwarding `timeout`) + `browser_assert` (checks mapped to daemon kinds: `expectedText`→`text_visible`, `expectedVisible: false`→`selector_hidden`, otherwise `selector_visible`) + optional `browser_screenshot`
- `browser_reload` → `browser_evaluate("location.reload()")` + optional 3 s `network_idle` wait (best-effort; the gsd-browser daemon implements reload but doesn't expose it over MCP yet — tracked separately)

**Also fixes a latent `browser_batch` arg-shape mismatch** — Pi's camelCase (`stopOnFailure`, `finalSummaryOnly`, step `clearFirst`) were silently ignored by the server, which reads snake_case. `normalizeManagedArgs` now handles the rename, and translated calls are routed through the same normalization so the mapping lives once.

**Details type** — `ManagedBrowserToolDetails` gains `mcpTools?: string[]` for composite calls; the scalar `mcpTool` is set to the last tool used rather than a synthetic join string.

**Extracted shared helper** — `callGsdBrowserMcp` consolidates the `client.callTool` invocation (with `MCP_CALL_TIMEOUT_MS` constant) so the direct and translated dispatch paths share one call site.

**Alternative considered:** collapsing `browser_verify` into a single `browser_batch` call. Rejected because separate navigate/assert calls surface navigation failures independently and navigation latency dominates anyway.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

Covers:
- Each translation's `build()` output (browser_click, browser_type, browser_verify — including timeout forwarding and optional screenshot — browser_reload)
- `normalizeManagedArgs` snake_case conversion for batch args and step keys
- `findMissingContractCoverage` with the real gsd-browser served-tool list produces zero missing tools
- Coverage check correctly reports translated tools as missing when a required MCP tool is absent
- Invariant asserting every tool a translation emits appears in its `requires` (guards against the `requires`/`build()` drift that shipped with `browser_screenshot` missing from `browser_verify`)

## AI disclosure

- [x] This PR includes AI-assisted code — generated with Claude Code (Fable 5); all translations verified against gsd-browser Rust source; tests run clean with no failures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772448&installation_id=134682257&pr_number=667&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F667&signature=2504c4d683e9c66e63affb6f940b5a1745d7cb2c7354337e54f432919d6f9628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser automation dispatch and verification flows; mistakes in translation or arg mapping could alter UAT behavior, though scope is limited to the gsd-browser adapter and is well covered by tests.
> 
> **Overview**
> Adds a **`translate`** path on managed gsd-browser tool specs so contract tools that gsd-browser does not expose under the same names are implemented as **one or more sequential MCP calls**, with optional steps that do not fail the tool.
> 
> **`browser_click` / `browser_type`** map to single-step **`browser_batch`** steps. **`browser_verify`** chains **`browser_navigate`**, **`browser_assert`** (verify checks rewritten to daemon assertion kinds), and an optional **`browser_screenshot`**. **`browser_reload`** uses **`browser_evaluate`** (`location.reload()`) plus an optional **`browser_wait_for`** network-idle settle.
> 
> Dispatch is refactored around **`callGsdBrowserMcp`**, **`callTranslatedGsdBrowserTool`**, and **`buildManagedToolResult`**; tool details can record **`mcpTools[]`** for composite invocations. **`findMissingContractCoverage`** treats translated tools as satisfied when all **`requires`** MCP tools are advertised.
> 
> **`normalizeManagedArgs`** now renames **`browser_batch`** Pi camelCase (`stopOnFailure`, `finalSummaryOnly`, step `clearFirst`) to the daemon’s snake_case so batch options are not silently ignored. Tests cover translation `build()` output, coverage against the real gsd-browser tool list, and the requires/emits invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2388654e59c89c4c25f60ba21f03aff5fb95ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->