### PR TITLE
fix(issue): [Bug]: Skill docs and workflows reference the wrong project-local skill directory

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -47,7 +47,7 @@ export const BUNDLED_SKILL_TRIGGERS: Array<{ trigger: string; skill: string }> =
   { trigger: "TDD - red-green-refactor vertical slices, never refactor while red, tests survive refactors", skill: "tdd" },
   { trigger: "Draft a milestone brief (M###-CONTEXT.md) or PRD from current conversation context", skill: "write-milestone-brief" },
   { trigger: "Break a plan into vertical-slice roadmap slices (M###-ROADMAP.md) or GitHub issues with dependency ordering", skill: "decompose-into-slices" },
-  { trigger: "Package spike findings into a reusable project-local skill at .claude/skills/", skill: "spike-wrap-up" },
+  { trigger: "Package spike findings into a reusable project-local skill at .agents/skills/", skill: "spike-wrap-up" },
   { trigger: "Block completion claims until verification evidence has been produced in this message", skill: "verify-before-complete" },
   { trigger: "Create a Model Context Protocol (MCP) server — tool design, error handling, Inspector testing, evals", skill: "create-mcp-server" },
   { trigger: "Write documentation, proposals, specs, RFCs, or READMEs for a fresh reader", skill: "write-docs" },

--- a/src/resources/extensions/gsd/tests/system-context-skill-triggers.test.ts
+++ b/src/resources/extensions/gsd/tests/system-context-skill-triggers.test.ts
@@ -1,0 +1,29 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for BUNDLED_SKILL_TRIGGERS path correctness (#668).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { BUNDLED_SKILL_TRIGGERS } from "../bootstrap/system-context.ts";
+
+test("spike-wrap-up trigger references .agents/skills/ not .claude/skills/ (#668)", () => {
+  const entry = BUNDLED_SKILL_TRIGGERS.find((t) => t.skill === "spike-wrap-up");
+  assert.ok(entry, "expected spike-wrap-up entry in BUNDLED_SKILL_TRIGGERS");
+  assert.ok(
+    entry.trigger.includes(".agents/skills/"),
+    `expected trigger to reference .agents/skills/ but got: ${entry.trigger}`,
+  );
+  assert.ok(
+    !entry.trigger.includes(".claude/skills/"),
+    `trigger must not reference legacy .claude/skills/ path: ${entry.trigger}`,
+  );
+});
+
+test("no BUNDLED_SKILL_TRIGGERS entry references .claude/skills/ as a write target", () => {
+  const offenders = BUNDLED_SKILL_TRIGGERS.filter((t) => t.trigger.includes(".claude/skills/"));
+  assert.deepEqual(
+    offenders,
+    [],
+    `these triggers still reference .claude/skills/: ${offenders.map((t) => t.skill).join(", ")}`,
+  );
+});

--- a/src/resources/extensions/gsd/workflow-templates/spike.md
+++ b/src/resources/extensions/gsd/workflow-templates/spike.md
@@ -68,7 +68,7 @@ Use for: technology evaluation, architecture decisions, "should we X?" questions
 4. **Present** the recommendation to the user for discussion
 5. **Offer wrap-up:** If the findings are reusable on future work, offer to run
    the `spike-wrap-up` skill to package them as a project-local skill at
-   `.claude/skills/<name>/SKILL.md`. That skill will auto-load on future
+   `.agents/skills/<name>/SKILL.md`. That skill will auto-load on future
    similar tasks via `skill-discovery.ts`. If the recommendation is
    decision-only (no reusable guidance), suggest appending a one-liner to
    `.gsd/DECISIONS.md` instead.

--- a/src/resources/skills/create-skill/references/executable-code.md
+++ b/src/resources/skills/create-skill/references/executable-code.md
@@ -45,7 +45,7 @@ skill-name/
 **Reference pattern**: In SKILL.md, reference scripts using the `scripts/` path:
 
 ```bash
-python ~/.claude/skills/skill-name/scripts/analyze.py input.har
+python ~/.agents/skills/skill-name/scripts/analyze.py input.har
 ```
 </scripts_directory>
 </file_organization>

--- a/src/resources/skills/create-skill/workflows/add-reference.md
+++ b/src/resources/skills/create-skill/workflows/add-reference.md
@@ -10,7 +10,7 @@
 ## Step 1: Select the Skill
 
 ```bash
-ls ~/.claude/skills/
+ls ~/.agents/skills/
 ```
 
 Present numbered list, ask: "Which skill needs a new reference?"
@@ -18,8 +18,8 @@ Present numbered list, ask: "Which skill needs a new reference?"
 ## Step 2: Analyze Current Structure
 
 ```bash
-cat ~/.claude/skills/{skill-name}/SKILL.md
-ls ~/.claude/skills/{skill-name}/references/ 2>/dev/null
+cat ~/.agents/skills/{skill-name}/SKILL.md
+ls ~/.agents/skills/{skill-name}/references/ 2>/dev/null
 ```
 
 Determine:

--- a/src/resources/skills/create-skill/workflows/add-script.md
+++ b/src/resources/skills/create-skill/workflows/add-script.md
@@ -24,7 +24,7 @@ If not a good fit, suggest alternatives (inline code in workflow, reference exam
 ## Step 3: Create Scripts Directory
 
 ```bash
-mkdir -p ~/.claude/skills/{skill-name}/scripts
+mkdir -p ~/.agents/skills/{skill-name}/scripts
 ```
 
 ## Step 4: Design Script
@@ -58,7 +58,7 @@ set -euo pipefail
 ## Step 6: Make Executable (if bash)
 
 ```bash
-chmod +x ~/.claude/skills/{skill-name}/scripts/{script-name}.sh
+chmod +x ~/.agents/skills/{skill-name}/scripts/{script-name}.sh
 ```
 
 ## Step 7: Update Workflow to Use Script

--- a/src/resources/skills/create-skill/workflows/add-template.md
+++ b/src/resources/skills/create-skill/workflows/add-template.md
@@ -24,7 +24,7 @@ If not a good fit, suggest alternatives (workflow guidance, reference examples).
 ## Step 3: Create Templates Directory
 
 ```bash
-mkdir -p ~/.claude/skills/{skill-name}/templates
+mkdir -p ~/.agents/skills/{skill-name}/templates
 ```
 
 ## Step 4: Design Template Structure

--- a/src/resources/skills/create-skill/workflows/add-workflow.md
+++ b/src/resources/skills/create-skill/workflows/add-workflow.md
@@ -12,7 +12,7 @@
 **DO NOT use AskUserQuestion** - there may be many skills.
 
 ```bash
-ls ~/.claude/skills/
+ls ~/.agents/skills/
 ```
 
 Present numbered list, ask: "Which skill needs a new workflow?"
@@ -21,8 +21,8 @@ Present numbered list, ask: "Which skill needs a new workflow?"
 
 Read the skill:
 ```bash
-cat ~/.claude/skills/{skill-name}/SKILL.md
-ls ~/.claude/skills/{skill-name}/workflows/ 2>/dev/null
+cat ~/.agents/skills/{skill-name}/SKILL.md
+ls ~/.agents/skills/{skill-name}/workflows/ 2>/dev/null
 ```
 
 Determine:

--- a/src/resources/skills/create-skill/workflows/upgrade-to-router.md
+++ b/src/resources/skills/create-skill/workflows/upgrade-to-router.md
@@ -10,7 +10,7 @@
 ## Step 1: Select the Skill
 
 ```bash
-ls ~/.claude/skills/
+ls ~/.agents/skills/
 ```
 
 Present numbered list, ask: "Which skill should be upgraded to the router pattern?"
@@ -19,8 +19,8 @@ Present numbered list, ask: "Which skill should be upgraded to the router patter
 
 Read the skill:
 ```bash
-cat ~/.claude/skills/{skill-name}/SKILL.md
-ls ~/.claude/skills/{skill-name}/
+cat ~/.agents/skills/{skill-name}/SKILL.md
+ls ~/.agents/skills/{skill-name}/
 ```
 
 **Already a router?** (has workflows/ and intake question)
@@ -65,8 +65,8 @@ Ask: "Does this breakdown look right? Any adjustments?"
 ## Step 4: Create Directory Structure
 
 ```bash
-mkdir -p ~/.claude/skills/{skill-name}/workflows
-mkdir -p ~/.claude/skills/{skill-name}/references
+mkdir -p ~/.agents/skills/{skill-name}/workflows
+mkdir -p ~/.agents/skills/{skill-name}/references
 ```
 
 ## Step 5: Extract Workflows

--- a/src/resources/skills/create-skill/workflows/verify-skill.md
+++ b/src/resources/skills/create-skill/workflows/verify-skill.md
@@ -15,7 +15,7 @@ Skills contain claims about external things: APIs, CLI tools, frameworks, servic
 ## Step 1: Select the Skill
 
 ```bash
-ls ~/.claude/skills/
+ls ~/.agents/skills/
 ```
 
 Present numbered list, ask: "Which skill should I verify for accuracy?"
@@ -24,9 +24,9 @@ Present numbered list, ask: "Which skill should I verify for accuracy?"
 
 Read the entire skill (SKILL.md + workflows/ + references/):
 ```bash
-cat ~/.claude/skills/{skill-name}/SKILL.md
-cat ~/.claude/skills/{skill-name}/workflows/*.md 2>/dev/null
-cat ~/.claude/skills/{skill-name}/references/*.md 2>/dev/null
+cat ~/.agents/skills/{skill-name}/SKILL.md
+cat ~/.agents/skills/{skill-name}/workflows/*.md 2>/dev/null
+cat ~/.agents/skills/{skill-name}/references/*.md 2>/dev/null
 ```
 
 Categorize by primary dependency type:

--- a/src/resources/skills/spike-wrap-up/SKILL.md
+++ b/src/resources/skills/spike-wrap-up/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: spike-wrap-up
-description: Package findings from a completed spike into a durable project-local skill that auto-loads on future similar work. Reads the latest `.gsd/workflows/spikes/` dir, interviews the user on what's reusable, then writes `.claude/skills/<name>/SKILL.md`. Use when asked to "wrap up the spike", "package this as a skill", "make this reusable", "turn findings into a skill", or at the synthesize phase of `/gsd start spike`.
+description: Package findings from a completed spike into a durable project-local skill that auto-loads on future similar work. Reads the latest `.gsd/workflows/spikes/` dir, interviews the user on what's reusable, then writes `.agents/skills/<name>/SKILL.md`. Use when asked to "wrap up the spike", "package this as a skill", "make this reusable", "turn findings into a skill", or at the synthesize phase of `/gsd start spike`.
 ---
 
 <objective>
-Convert the output of a research spike (`SCOPE.md`, `research/*.md`, `RECOMMENDATION.md`) into a project-local skill under `.claude/skills/` so that the next time a similar task comes up, the agent loads the skill automatically. This is how throwaway spikes become durable capital.
+Convert the output of a research spike (`SCOPE.md`, `research/*.md`, `RECOMMENDATION.md`) into a project-local skill under `.agents/skills/` so that the next time a similar task comes up, the agent loads the skill automatically. This is how throwaway spikes become durable capital.
 </objective>
 
 <context>
 GSD's spike workflow (`src/resources/extensions/gsd/workflow-templates/spike.md`) produces documents in `.gsd/workflows/spikes/<slug>/`. Those documents are useful once and then forgotten unless something packages them for reuse.
 
-GSD already watches `.claude/skills/` (and `.agents/skills/`) at both user and project levels — see `src/resources/extensions/gsd/skill-discovery.ts`. Any skill written there is picked up on the next session without further wiring. This skill is the bridge from "spike done" to "skill available."
+GSD watches `.agents/skills/` at both user and project levels (and `.claude/skills/` for legacy compatibility) — see `src/resources/extensions/gsd/skill-discovery.ts`. Any skill written to `.agents/skills/` is picked up on the next session without further wiring. This skill is the bridge from "spike done" to "skill available."
 
 Invocation points:
 - End of Phase 3 (synthesize) in `/gsd start spike` — prompt suggests running this skill
@@ -21,7 +21,7 @@ Invocation points:
 <core_principle>
 **NOT EVERY SPIKE DESERVES A SKILL.** If the recommendation was "don't do X," there may be no reusable guidance. Ask the user first; exit without writing if the answer is no.
 
-**PROJECT-LOCAL, NOT USER-GLOBAL.** Write to `.claude/skills/` in the repo, not `~/.claude/skills/`. The skill encodes project-specific choices that should not leak into unrelated projects.
+**PROJECT-LOCAL, NOT USER-GLOBAL.** Write to `.agents/skills/` in the repo, not `~/.agents/skills/`. The skill encodes project-specific choices that should not leak into unrelated projects.
 
 **DESCRIPTION IS THE DISCOVERABILITY SIGNAL.** The `description` field in frontmatter is the primary signal the agent uses to judge relevance and decide whether to load the skill — it is a heuristic, not a deterministic trigger. Write it as keywords the future agent will plausibly encounter, not a summary.
 </core_principle>
@@ -65,7 +65,7 @@ Show this sketch to the user. One round of feedback. Iterate.
 
 ## Step 4: Write the skill
 
-Write to `.claude/skills/<name>/SKILL.md` (create the directory). Match the frontmatter + XML-tag structure used by other bundled skills — see `src/resources/skills/review/SKILL.md` for the canonical shape.
+Write to `.agents/skills/<name>/SKILL.md` (create the directory). Match the frontmatter + XML-tag structure used by other bundled skills — see `src/resources/skills/review/SKILL.md` for the canonical shape.
 
 Minimum structure:
 
@@ -102,7 +102,7 @@ description: <one sentence with trigger keywords>
 </success_criteria>
 ```
 
-If the spike produced a reusable template (a config file, a starter script), copy it into `.claude/skills/<name>/templates/` or `.claude/skills/<name>/references/` and reference it from the skill body.
+If the spike produced a reusable template (a config file, a starter script), copy it into `.agents/skills/<name>/templates/` or `.agents/skills/<name>/references/` and reference it from the skill body.
 
 ## Step 5: Archive the spike, link from the skill
 
@@ -112,13 +112,13 @@ If the spike produced a reusable template (a config file, a starter script), cop
 
 ## Step 6: Confirm pickup
 
-Tell the user the skill will be surfaced on the next session via `skill-discovery.ts`. If they want to use it immediately, they can `Read .claude/skills/<name>/SKILL.md` now.
+Tell the user the skill will be surfaced on the next session via `skill-discovery.ts`. If they want to use it immediately, they can `Read .agents/skills/<name>/SKILL.md` now.
 
 </process>
 
 <anti_patterns>
 
-- **Writing to `~/.claude/skills/`.** That's user-global. Project spikes produce project skills — keep them scoped.
+- **Writing to `~/.agents/skills/`.** That's user-global. Project spikes produce project skills — keep them scoped to `.agents/skills/` in the repo.
 - **Verbose frontmatter description.** The description is an index entry, not a tutorial. Keywords over prose.
 - **Packaging every spike.** If the outcome was "we decided X once," append to DECISIONS.md and move on.
 - **Copy-pasting the spike verbatim into the skill.** The spike is research; the skill is executable guidance. Re-author.
@@ -128,7 +128,7 @@ Tell the user the skill will be surfaced on the next session via `skill-discover
 
 <success_criteria>
 
-- [ ] A new `.claude/skills/<name>/SKILL.md` exists with well-formed frontmatter.
+- [ ] A new `.agents/skills/<name>/SKILL.md` exists with well-formed frontmatter.
 - [ ] The `description` field uses keywords that will plausibly match future agent work.
 - [ ] The skill body is executable on its own without re-reading the originating spike.
 - [ ] The originating spike is referenced from the skill.


### PR DESCRIPTION
## Summary
- Updated four bundled skill files to replace `~/.claude/skills/` (user-global) and `.claude/skills/` (project-local) references with the canonical `~/.agents/skills/` and `.agents/skills/` paths respectively, matching the documented skill directory layout; verified with docs-prompt-injection and skill-reference checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #668
- [#668 [Bug]: Skill docs and workflows reference the wrong project-local skill directory](https://github.com/open-gsd/gsd-pi/issues/668)

## User
- @Seonfx

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/668-bug-skill-docs-and-workflows-reference-t-1781182812`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783774977&installation_id=134682257&pr_number=670&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F670&signature=a351cb229e9680f99e836a8e23bba7b7ef906bdd6df99f228bca4b0252044b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and prompt-string updates only; no runtime discovery or write-path logic changes beyond aligning agent-facing instructions.
> 
> **Overview**
> Aligns bundled skill documentation, workflows, and system prompts with the **canonical** project-local path `.agents/skills/` (and user-global `~/.agents/skills/`) instead of legacy `.claude/skills/` / `~/.claude/skills/` write targets (#668).
> 
> **`spike-wrap-up`** and the spike workflow template now tell agents to package spikes under `.agents/skills/<name>/SKILL.md`. The **`create-skill`** reference and workflow markdown (add script, template, workflow, verify, router upgrade, etc.) update example `ls`, `cat`, and `mkdir` commands to the same paths. **`BUNDLED_SKILL_TRIGGERS`** in `system-context.ts` matches that wording for the spike-wrap-up trigger.
> 
> Adds **`system-context-skill-triggers.test.ts`** so no bundled trigger still advertises `.claude/skills/` as a write target. Runtime discovery still supports `.claude/skills/` for compatibility; docs now steer new skills to `.agents/skills/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4167d10778775bc8e3e585cb0cf2c78ddf9d547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->