### PR TITLE
fix(issue): [Bug]: Installation Failure: @opengsd/gsd-pi missing from npm and broken mirror in pnpm-lock.yaml

### DIFF
--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -202,6 +202,30 @@ source ~/.zshrc
 - Missing workspace packages — fixed in v2.10.4+
 - `postinstall` hangs on Linux (Playwright `--with-deps` triggering sudo) — fixed in v2.3.6+
 - Node.js version too old — requires ≥ 22.0.0
+- `ETARGET: No matching version found` / `notarget` — the `@opengsd/gsd-pi` package has not been published to the npm registry yet for the requested version (see below)
+
+**If you see `ETARGET` or `notarget` (package not found on npm):**
+
+The `@opengsd/gsd-pi` package is published to npm from tagged releases. If a release is in progress or you are on a pre-release branch, the package may not yet be available on the public npm registry.
+
+Options:
+
+1. **Wait and retry** — check [npm for @opengsd/gsd-pi](https://www.npmjs.com/package/@opengsd/gsd-pi) to confirm whether a release has landed, then retry.
+
+2. **Use `npx` instead of a global install** — `npx @opengsd/gsd-pi@latest` fetches the package on demand and may pick up the most recently published version without a local cache:
+   ```bash
+   npx @opengsd/gsd-pi@latest
+   ```
+
+3. **Build from source** — clone the repository and build locally:
+   ```bash
+   git clone https://github.com/open-gsd/gsd-pi.git
+   cd gsd-pi
+   pnpm install --frozen-lockfile
+   pnpm run build
+   npm install -g .
+   ```
+   Requires Node.js ≥ 22.0.0 and pnpm. If `pnpm` is not installed: `npm install -g pnpm`.
 
 ### Provider errors during auto mode
 


### PR DESCRIPTION
## Summary
- Added ETARGET/notarget troubleshooting guidance with build-from-source fallback to troubleshooting.md; confirmed pnpm-lock.yaml already has no npmmirror references and requires no further changes.

## Bugs Addressed
- [x] **Package @opengsd/gsd-pi not published to npm registry**
- [ ] **pnpm-lock.yaml hardcodes npmmirror.com mirror causing 404 on pnpm install** _(skipped: pnpm-lock.yaml already contains zero references to registry.npmmirror.com; the lockfile was previously repaired in commit 87a37b52 and now resolves all packages through the default npm registry.)_

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #669
- [#669 [Bug]: Installation Failure: @opengsd/gsd-pi missing from npm and broken mirror in pnpm-lock.yaml](https://github.com/open-gsd/gsd-pi/issues/669)

## User
- @ducphamhoang

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/669-bug-installation-failure-opengsd-gsd-pi--1781183038`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing documentation only; no runtime, registry, or lockfile behavior changes in this diff.
> 
> **Overview**
> **Docs:** Expands the **`npm install -g @opengsd/gsd-pi@latest` fails** section in `troubleshooting.md` for when the package is not on npm yet.
> 
> Adds **`ETARGET` / `notarget`** as a documented cause and a short subsection explaining release timing. Workarounds are **wait and check npm**, **`npx @opengsd/gsd-pi@latest`**, or **clone, `pnpm` build, and `npm install -g .`** (Node ≥ 22, pnpm install note included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d06c710bac91862a85b384f21d2cd80116dd792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783775345&installation_id=134682257&pr_number=672&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F672&signature=aeb955f800db646aafd77d8cf8d5008a4062512155f0d032d770f88190eccd35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->