### PR TITLE
fix(issue): [Bug]: Error: 400 {"error":{"message":"The use of the web search tool is not supported.","code":"unsupported_value"}}

### DIFF
--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -243,9 +243,11 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
       // Anthropic-only tool never leaks into OpenAI Responses requests.
       isAnthropic = isAnthropicProvider && payloadLooksAnthropic !== false;
     } else {
-      // Last resort: session-restore paths where the SDK doesn't pass model.
-      // The model-name prefix is best-effort and assumes direct Anthropic.
-      isAnthropic = payloadLooksAnthropic === true;
+      // No authoritative provider info available (no event.model, no model_select).
+      // Do NOT inject native web_search — guessing on model name alone causes 400
+      // "unsupported_value" errors when the actual provider (copilot, openrouter,
+      // proxy, etc.) doesn't expose the server-side search tool (#648).
+      isAnthropic = false;
     }
     if (!isAnthropic) return;
 

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -101,11 +101,14 @@ test("before_provider_request injects web_search for claude models", async () =>
   assert.equal(nativeTool.max_uses, 5, "Should set max_uses to 5 to prevent search loops (#817)");
 });
 
-test("before_provider_request injects web_search for claude models even without model_select", async () => {
+test("before_provider_request does NOT inject web_search without model_select or event.model provider (#648)", async () => {
   const pi = createMockPI();
   registerNativeSearchHooks(pi);
 
-  // NO model_select fired — simulates session restore where modelsAreEqual suppresses the event
+  // NO model_select fired, NO event.model with provider info — simulates startup
+  // or a third-party proxy where the SDK omits provider details. Injecting
+  // web_search_20250305 without confirmed provider causes 400 "unsupported_value"
+  // errors on non-Anthropic endpoints that serve Claude-named models (#648).
   const payload: Record<string, unknown> = {
     model: "claude-opus-4-8",
     tools: [
@@ -120,13 +123,12 @@ test("before_provider_request injects web_search for claude models even without 
     payload,
   });
 
-  const tools = ((result as any)?.tools ?? payload.tools) as any[];
-  const names = tools.map((t: any) => t.name ?? t.type);
-
-  assert.ok(names.includes("web_search"), "Should inject native web_search based on model name");
-  assert.ok(!names.includes("search-the-web"), "Should remove search-the-web");
-  assert.ok(!names.includes("google_search"), "Should remove google_search");
-  assert.ok(names.includes("bash"), "Should keep non-search tools");
+  assert.equal(result, undefined, "Should not modify payload without authoritative provider info");
+  const tools = payload.tools as any[];
+  assert.ok(
+    !tools.some((t: any) => t.type === "web_search_20250305"),
+    "web_search_20250305 must NOT be injected without confirmed provider — causes 400 on proxies/copilot"
+  );
 });
 
 test("before_provider_request does NOT inject for non-claude models", async () => {


### PR DESCRIPTION
## Summary
- Fixed the 400 "web search tool not supported" error by replacing the model-name-based Anthropic guess in the last-resort path of `before_provider_request` with `false`, preventing web_search injection when no authoritative provider info is available; updated the corresponding test to validate the corrected behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #648
- [#648 [Bug]: Error: 400 {"error":{"message":"The use of the web search tool is not supported.","code":"unsupported_value"}}](https://github.com/open-gsd/gsd-pi/issues/648)

## User
- @mgerdov-igt

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/648-bug-error-400-error-message-the-use-of-t-1781183631`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776170&installation_id=134682257&pr_number=673&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F673&signature=87a9f48afb918ab999b35542e136359c31d70b33db4a0bc9038c722ce9bc9fb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider-detection for native search injection; real Anthropic sessions without `event.model` may lose native search until `model_select` fires, but avoids breaking third-party Claude routes.
> 
> **Overview**
> Stops injecting Anthropic's native **`web_search_20250305`** tool when the request has no confirmed provider (`event.model` / `model_select`). The previous last-resort path treated a **`claude-*`** payload model name as enough to inject native search, which broke proxies, Copilot, OpenRouter, and similar endpoints that reject the server-side search tool with **400 `unsupported_value`** (#648).
> 
> **`before_provider_request`** now skips native search injection in that case instead of guessing from the model string. Custom search tools stay on the payload unchanged. A unit test was flipped to assert no injection and no payload mutation when only a Claude-looking model name is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24d280d6bfa609803ea932196cb62afe3a2eb38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->