### PR TITLE
fix(issue): [Bug]: TUI streaming renderer duplicates the prose line before a code fence (mid-buffer reflow misclassified as tail append; scrollback-clamp re-emits boundary line)

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -1402,6 +1402,18 @@ export class TUI extends Container {
 		const previousContentViewportTop = getViewportTop(this.previousLines.length);
 		let clampedToViewport = false;
 		if (firstChanged < previousContentViewportTop) {
+			// When a mid-buffer reflow inserts a line above the live viewport AND the buffer grew,
+			// the scrollback-clamp fast path would re-emit the shifted boundary line (stale copy in
+			// frozen scrollback + fresh copy in the repainted viewport → verbatim duplicate).
+			// Fall back to a full clean repaint to avoid this, the same escape hatch used when
+			// extraLines > height.
+			if (newLines.length > this.previousLines.length) {
+				logRedraw(
+					`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop}) with buffer growth — full repaint to avoid scrollback duplicate`,
+				);
+				fullRender(true);
+				return;
+			}
 			const newViewportTop = getViewportTop(newLines.length);
 			const clampedFirst = Math.max(0, Math.min(previousContentViewportTop, newViewportTop));
 			logRedraw(

--- a/packages/pi-tui/test/tui-render.test.ts
+++ b/packages/pi-tui/test/tui-render.test.ts
@@ -589,3 +589,63 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI scrollback duplicate regression (#592)", () => {
+	it("full re-renders when buffer grows with a change before the viewport (mid-buffer reflow)", async () => {
+		// Regression for: scrollback-clamp path re-emitted the viewport boundary line when a
+		// mid-stream code-fence reflow inserted a line above the live viewport and grew the buffer.
+		// Fix: newLines.length > previousLines.length in the firstChanged < viewportTop branch
+		// bails out to fullRender(true) instead of the partial repaint.
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// 8 lines — more than the 5-row terminal height, so 3 lines live in scrollback.
+		// After render: viewport top = 8 - 5 = 3, viewport shows lines 3-7.
+		component.lines = ["Line 0", "Line 1", "Line 2", "Line 3", "Line 4", "Line 5", "Line 6", "Line 7"];
+		tui.start();
+		await terminal.waitForRender();
+
+		const initialRedraws = tui.fullRedraws;
+
+		// Insert a new line at position 1 (before the viewport top at 3).
+		// newLines.length = 9 > previousLines.length = 8 → buffer grew.
+		// firstChanged = 1 < previousContentViewportTop = 3 → change is above the live viewport.
+		// Without the fix the clamped partial-repaint path would re-emit "Line 3" (the viewport
+		// boundary) producing a duplicate: stale copy frozen in scrollback + fresh copy from repaint.
+		// With the fix a clean fullRender(true) is issued instead.
+		component.lines = [
+			"Line 0",
+			"INSERTED",
+			"Line 1",
+			"Line 2",
+			"Line 3",
+			"Line 4",
+			"Line 5",
+			"Line 6",
+			"Line 7",
+		];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(tui.fullRedraws > initialRedraws, "Buffer growth before viewport top must trigger a full redraw");
+
+		// New viewport top = 9 - 5 = 4, so viewport shows lines 4-8 of the new content.
+		const viewport = terminal.getViewport();
+		assert.deepStrictEqual(
+			viewport,
+			["Line 3", "Line 4", "Line 5", "Line 6", "Line 7"],
+			"Viewport must show the correct five lines with no duplicates after mid-buffer reflow",
+		);
+
+		// "Line 3" is the former boundary line — it must appear exactly once (not duplicated).
+		assert.strictEqual(
+			viewport.filter((l) => l.trim() === "Line 3").length,
+			1,
+			"Viewport boundary line must not be duplicated after buffer-growth reflow",
+		);
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Summary
- Added a buffer-growth guard in tui.ts at the scrollback-clamp path so mid-stream code-fence reflows that grow the buffer trigger fullRender(true) instead of the partial repaint that left a stale duplicate line in scrollback.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #592
- [#592 [Bug]: TUI streaming renderer duplicates the prose line before a code fence (mid-buffer reflow misclassified as tail append; scrollback-clamp re-emits boundary line)](https://github.com/open-gsd/gsd-pi/issues/592)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/592-bug-tui-streaming-renderer-duplicates-th-1781184305`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776550&installation_id=134682257&pr_number=674&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F674&signature=2601494399191c330186fcc7c1dfa1621c3f3d6d67b425183018762672bb87a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to differential render escape logic in pi-tui with a dedicated regression test; may trigger extra full redraws only when content grows with edits above the viewport.
> 
> **Overview**
> Fixes **duplicate lines in the TUI** when streaming content reflows mid-buffer (e.g. opening a code fence) and **grows the line buffer above the live viewport**.
> 
> In the scrollback-clamp branch (`firstChanged < viewportTop`), a **buffer-growth guard** now calls **`fullRender(true)`** instead of the clamped partial repaint when `newLines.length > previousLines.length`. That avoids re-emitting the viewport boundary line (stale scrollback copy plus fresh repaint).
> 
> Adds a **regression test** for #592: insert a line before viewport top with a 5-row terminal and assert a full redraw and no duplicate boundary line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d9c5ff48e69dae2ef641508e31915844a4f2ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->