### PR TITLE
fix(gsd): make destructive-command HARD BLOCK escapable via confirmation

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -13,7 +13,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
 import { buildMilestoneFileName, clearPathCache, milestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { applyAskUserQuestionsGateResult, canonicalToolName, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, isApprovalGateVerifiedInSnapshot, isMilestoneDepthVerified, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, loadWriteGateSnapshot, markApprovalGateVerified, markDepthVerified, refreshWriteGateStateFromDisk, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
+import { applyAskUserQuestionsGateResult, canonicalToolName, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, isApprovalGateVerifiedInSnapshot, isDepthConfirmationAnswer, isMilestoneDepthVerified, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, loadWriteGateSnapshot, markApprovalGateVerified, markDepthVerified, refreshWriteGateStateFromDisk, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
@@ -39,6 +39,12 @@ import { saveActivityLog } from "../activity-log.js";
 import { recordToolCall as safetyRecordToolCall, recordToolResult as safetyRecordToolResult, saveEvidenceToDisk } from "../safety/evidence-collector.js";
 import { parseUnitId } from "../unit-id.js";
 import { classifyCommand } from "../safety/destructive-guard.js";
+import {
+  confirmDestructiveCommand,
+  consumeDestructiveConfirmation,
+  isDestructiveConfirmGateId,
+  requestDestructiveConfirmation,
+} from "../safety/destructive-confirmation.js";
 import { logWarning as safetyLogWarning } from "../workflow-logger.js";
 import { isUnitCloseoutTool, runInteractiveUnitCloseout } from "../unit-closeout.js";
 import { installNotifyInterceptor } from "./notify-interceptor.js";
@@ -1390,23 +1396,39 @@ export function registerHooks(
 
     // Destructive command classification + hard gate in all modes.
     if (isToolCallEventType("bash", event)) {
-      const classification = classifyCommand(event.input.command);
+      const command = event.input.command;
+      const classification = classifyCommand(command);
       if (classification.destructive) {
+        const guardBasePath = contextBasePath(ctx);
+        // Escape hatch: if the user already confirmed this exact command via a
+        // destructive_confirm gate, consume the one-shot token and let it run.
+        // Without this, the block below loops forever — the model cannot satisfy
+        // "confirm in the current turn" because nothing ever clears the gate.
+        if (consumeDestructiveConfirmation(command, guardBasePath)) {
+          safetyLogWarning("safety", `destructive command confirmed: ${classification.labels.join(", ")}`, {
+            command: String(command).slice(0, 200),
+          });
+          return;
+        }
+        // Record the command as pending so an affirmative answer to a
+        // destructive_confirm gate (handled in tool_result) can confirm it.
+        requestDestructiveConfirmation(command, guardBasePath);
         const reason = [
           "HARD BLOCK: destructive Bash command requires explicit human confirmation.",
           `Detected: ${classification.labels.join(", ")}`,
-          "Run this via ask_user_questions, wait for the user's response,",
-          "then issue the command only when confirmed in the current turn.",
+          "Call ask_user_questions with a question id containing \"destructive_confirm\"",
+          "and a first option that affirms the action; wait for the user's response,",
+          "then re-issue this exact command in the same turn to run it once.",
         ].join(" ");
         safetyLogWarning("safety", `destructive command: ${classification.labels.join(", ")}`, {
-          command: String(event.input.command).slice(0, 200),
+          command: String(command).slice(0, 200),
         });
         if (ctx) {
           await maybePauseAutoForApprovalGate(
             ctx,
             pi,
             isAutoActive(),
-            "Depth confirmation is waiting for your answer — pausing auto-mode.",
+            "Destructive-command confirmation is waiting for your answer — pausing auto-mode.",
           );
         }
         return { block: true, reason };
@@ -1495,6 +1517,24 @@ export function registerHooks(
     }
 
     if (details?.cancelled || !details?.response) return;
+
+    // Destructive-command confirmation: an affirmative answer to a
+    // destructive_confirm gate promotes the pending blocked command to a
+    // one-shot confirmed token, which the bash tool_call guard consumes on the
+    // next attempt. Rejecting/declining leaves the command blocked.
+    // (Depth-verification gate handling now lives in
+    // applyAskUserQuestionsGateResult above; only the destructive-confirm gate
+    // is handled inline here.)
+    for (const question of questions) {
+      if (isDestructiveConfirmGateId(question?.id)) {
+        const answer = details.response?.answers?.[question.id];
+        if (isDepthConfirmationAnswer(answer?.selected, question.options)) {
+          confirmDestructiveCommand(basePath);
+        }
+        break;
+      }
+    }
+
     if (!milestoneId) return;
     await saveDiscussionQuestionRound(basePath, milestoneId, questions, details);
   });

--- a/src/resources/extensions/gsd/safety/destructive-confirmation.ts
+++ b/src/resources/extensions/gsd/safety/destructive-confirmation.ts
@@ -1,0 +1,134 @@
+/**
+ * One-shot confirmation token for destructive bash commands.
+ *
+ * The destructive-command guard hard-blocks classified commands (force push,
+ * rm -rf, SQL drop, etc.) in all modes. The block instructs the model to
+ * confirm via ask_user_questions and re-issue the command. This module is the
+ * missing escape hatch: it records the user's confirmation and lets the exact
+ * confirmed command through exactly once.
+ *
+ * Design constraints:
+ *  - In-memory only, never persisted. A confirmation token written to disk
+ *    could silently auto-approve a destructive command in a later session —
+ *    confirmation must be re-obtained every process lifetime.
+ *  - One-shot. Consuming a token clears it, so a second destructive command
+ *    (even an identical one) re-blocks and re-prompts.
+ *  - Command-bound. The token only matches the exact (normalized) command
+ *    string the user confirmed. A reworded command re-blocks, which is safe.
+ *  - Per basePath, so concurrent workspaces in one process never share tokens.
+ *
+ * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+ */
+
+import { resolve } from "node:path";
+
+/**
+ * Question-id substring that marks an ask_user_questions call as a
+ * destructive-command confirmation. The tool_result handler promotes the
+ * pending command to a confirmed token when an affirmative answer arrives for
+ * a question whose id contains this marker.
+ */
+export const DESTRUCTIVE_CONFIRM_GATE_MARKER = "destructive_confirm";
+
+interface DestructiveConfirmationState {
+  /** Command awaiting confirmation, captured when the guard blocked it. */
+  pendingCommand: string | null;
+  /** Confirmed command cleared on first matching consume. */
+  confirmedCommand: string | null;
+}
+
+const statesByBasePath = new Map<string, DestructiveConfirmationState>();
+
+function stateKey(basePath: string): string {
+  return resolve(basePath);
+}
+
+function getState(basePath: string): DestructiveConfirmationState {
+  const key = stateKey(basePath);
+  let state = statesByBasePath.get(key);
+  if (!state) {
+    state = { pendingCommand: null, confirmedCommand: null };
+    statesByBasePath.set(key, state);
+  }
+  return state;
+}
+
+/**
+ * Normalize a command for stable matching across block → confirm → retry.
+ * Trims surrounding whitespace and collapses internal runs of whitespace so
+ * cosmetic reformatting of the same command still matches the token.
+ */
+export function normalizeDestructiveCommand(command: string): string {
+  return command.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Whether an ask_user_questions question id is a destructive-confirm gate.
+ */
+export function isDestructiveConfirmGateId(questionId: unknown): boolean {
+  return typeof questionId === "string" && questionId.includes(DESTRUCTIVE_CONFIRM_GATE_MARKER);
+}
+
+/**
+ * Record that a destructive command was blocked and is awaiting confirmation.
+ * Called by the guard at block time. Overwrites any prior pending command —
+ * only the most recently blocked command can be confirmed.
+ */
+export function requestDestructiveConfirmation(
+  command: string,
+  basePath: string = process.cwd(),
+): void {
+  const state = getState(basePath);
+  state.pendingCommand = normalizeDestructiveCommand(command);
+  // A fresh request invalidates any stale confirmed token for a different
+  // command so confirmation cannot leak across distinct destructive actions.
+  state.confirmedCommand = null;
+}
+
+/**
+ * Promote the pending command to a confirmed, one-shot token. Called by the
+ * tool_result handler when the user gives an affirmative answer to a
+ * destructive-confirm gate. Returns the confirmed command, or null if there
+ * was nothing pending (e.g. confirmation arrived without a preceding block).
+ */
+export function confirmDestructiveCommand(
+  basePath: string = process.cwd(),
+): string | null {
+  const state = getState(basePath);
+  if (!state.pendingCommand) return null;
+  state.confirmedCommand = state.pendingCommand;
+  state.pendingCommand = null;
+  return state.confirmedCommand;
+}
+
+/**
+ * Check whether the given command has been confirmed, consuming the token if
+ * so. Returns true exactly once per confirmation; subsequent calls (or a
+ * non-matching command) return false. Called by the guard before blocking.
+ */
+export function consumeDestructiveConfirmation(
+  command: string,
+  basePath: string = process.cwd(),
+): boolean {
+  const state = getState(basePath);
+  if (!state.confirmedCommand) return false;
+  if (state.confirmedCommand !== normalizeDestructiveCommand(command)) return false;
+  state.confirmedCommand = null;
+  return true;
+}
+
+/**
+ * Inspect the pending command without consuming it (diagnostics/tests).
+ */
+export function peekPendingDestructiveCommand(
+  basePath: string = process.cwd(),
+): string | null {
+  return getState(basePath).pendingCommand;
+}
+
+/**
+ * Clear all destructive-confirmation state for a basePath (tests / flow reset).
+ */
+export function resetDestructiveConfirmation(basePath: string = process.cwd()): void {
+  statesByBasePath.delete(stateKey(basePath));
+}

--- a/src/resources/extensions/gsd/tests/destructive-confirmation.test.ts
+++ b/src/resources/extensions/gsd/tests/destructive-confirmation.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the destructive-command confirmation escape hatch.
+ *
+ * Regression target: the destructive-guard hard block had no confirmation
+ * path. Re-issuing a force push after confirming via ask_user_questions hit
+ * the identical HARD BLOCK every time — an unwinnable loop. These tests pin
+ * the block → confirm → allow-once flow and its safety invariants.
+ *
+ * Two layers of coverage:
+ *  1. Unit — the confirmation-token module in isolation (block/confirm/consume
+ *     and every safety invariant).
+ *  2. Integration — the real registerHooks() bash tool_call guard +
+ *     ask_user_questions tool_result handler driven end-to-end, proving the
+ *     loop is escapable through the actual wiring, not just the helper module.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { classifyCommand } from "../safety/destructive-guard.ts";
+import {
+  DESTRUCTIVE_CONFIRM_GATE_MARKER,
+  confirmDestructiveCommand,
+  consumeDestructiveConfirmation,
+  isDestructiveConfirmGateId,
+  normalizeDestructiveCommand,
+  peekPendingDestructiveCommand,
+  requestDestructiveConfirmation,
+  resetDestructiveConfirmation,
+} from "../safety/destructive-confirmation.ts";
+
+const BASE = "/tmp/gsd-destructive-confirm-test";
+const FORCE_PUSH = "git push --force-with-lease origin feature/PO-566-chart-supply-chain";
+
+function blocked(command: string, basePath: string): boolean {
+  // Mirror the guard's decision: a classified-destructive command is blocked
+  // unless a matching confirmation token is consumed in this same check.
+  if (!classifyCommand(command).destructive) return false;
+  return !consumeDestructiveConfirmation(command, basePath);
+}
+
+test("repro: destructive command loops forever without confirmation", () => {
+  resetDestructiveConfirmation(BASE);
+  // Every attempt blocks — this is the bug the escape hatch fixes.
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "first attempt blocks");
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "retry still blocks");
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "and again — unwinnable loop");
+});
+
+test("block then confirm then retry allows the exact command once", () => {
+  resetDestructiveConfirmation(BASE);
+
+  // 1. Guard blocks and records the pending command.
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "initial attempt blocks");
+  requestDestructiveConfirmation(FORCE_PUSH, BASE);
+  assert.equal(peekPendingDestructiveCommand(BASE), normalizeDestructiveCommand(FORCE_PUSH));
+
+  // 2. User confirms via ask_user_questions affirmative answer.
+  const confirmed = confirmDestructiveCommand(BASE);
+  assert.equal(confirmed, normalizeDestructiveCommand(FORCE_PUSH));
+
+  // 3. Retry in the same turn now passes.
+  assert.equal(blocked(FORCE_PUSH, BASE), false, "confirmed command passes once");
+});
+
+test("confirmation is one-shot — a second destructive command re-blocks", () => {
+  resetDestructiveConfirmation(BASE);
+
+  requestDestructiveConfirmation(FORCE_PUSH, BASE);
+  confirmDestructiveCommand(BASE);
+  assert.equal(blocked(FORCE_PUSH, BASE), false, "first run consumes the token");
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "identical second run re-blocks");
+});
+
+test("confirmation is command-bound — a different command is not approved", () => {
+  resetDestructiveConfirmation(BASE);
+
+  requestDestructiveConfirmation(FORCE_PUSH, BASE);
+  confirmDestructiveCommand(BASE);
+
+  // A different destructive command must not ride the force-push confirmation.
+  assert.equal(blocked("rm -rf node_modules", BASE), true, "unrelated destructive cmd re-blocks");
+  // The original token is still intact for its exact command.
+  assert.equal(blocked(FORCE_PUSH, BASE), false, "original confirmed command still passes once");
+});
+
+test("cosmetic whitespace reformatting still matches the confirmed token", () => {
+  resetDestructiveConfirmation(BASE);
+
+  requestDestructiveConfirmation("git push   --force  origin   main", BASE);
+  confirmDestructiveCommand(BASE);
+  assert.equal(blocked("git push --force origin main", BASE), false, "whitespace-normalized match passes");
+});
+
+test("requesting a new confirmation invalidates a stale confirmed token", () => {
+  resetDestructiveConfirmation(BASE);
+
+  requestDestructiveConfirmation(FORCE_PUSH, BASE);
+  confirmDestructiveCommand(BASE);
+  // New block for a different command before the first was consumed.
+  requestDestructiveConfirmation("git reset --hard HEAD~3", BASE);
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "old confirmation no longer valid after new request");
+});
+
+test("confirm with nothing pending returns null and approves nothing", () => {
+  resetDestructiveConfirmation(BASE);
+  assert.equal(confirmDestructiveCommand(BASE), null, "no pending command -> null");
+  assert.equal(blocked(FORCE_PUSH, BASE), true, "no spurious approval");
+});
+
+test("tokens are isolated per basePath", () => {
+  const a = "/tmp/gsd-confirm-ws-a";
+  const b = "/tmp/gsd-confirm-ws-b";
+  resetDestructiveConfirmation(a);
+  resetDestructiveConfirmation(b);
+
+  requestDestructiveConfirmation(FORCE_PUSH, a);
+  confirmDestructiveCommand(a);
+
+  assert.equal(blocked(FORCE_PUSH, b), true, "workspace B is unaffected by workspace A's confirmation");
+  assert.equal(blocked(FORCE_PUSH, a), false, "workspace A still passes once");
+});
+
+test("gate id marker detection", () => {
+  assert.equal(isDestructiveConfirmGateId(`${DESTRUCTIVE_CONFIRM_GATE_MARKER}_push`), true);
+  assert.equal(isDestructiveConfirmGateId("depth_verification_M001"), false);
+  assert.equal(isDestructiveConfirmGateId(undefined), false);
+  assert.equal(isDestructiveConfirmGateId(123), false);
+});
+
+test("non-destructive commands are never gated regardless of token state", () => {
+  resetDestructiveConfirmation(BASE);
+  assert.equal(blocked("git status", BASE), false);
+  assert.equal(blocked("ls -la", BASE), false);
+});
+
+// ─── Integration: real registerHooks() wiring, driven end-to-end ────────────
+// The unit tests above exercise the token module directly. These drive the
+// actual registered bash tool_call guard and ask_user_questions tool_result
+// handler, proving the loop the user hit is escapable through the real hooks —
+// not just the helper. Mirrors the harness in
+// register-hooks-depth-verification.test.ts.
+
+type Handler = (event: any, ctx?: any) => Promise<any> | any;
+
+function makeHookHarness(): {
+  handlers: Map<string, Handler[]>;
+  pi: any;
+} {
+  const handlers = new Map<string, Handler[]>();
+  const pi = {
+    on(event: string, handler: Handler) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+  return { handlers, pi };
+}
+
+/** Run every bash tool_call guard and return the first block result, if any. */
+async function runBashGuard(
+  handlers: Map<string, Handler[]>,
+  command: string,
+  ctx: any,
+): Promise<{ block?: boolean; reason?: string } | undefined> {
+  let block: { block?: boolean; reason?: string } | undefined;
+  for (const handler of handlers.get("tool_call") ?? []) {
+    const result = await handler(
+      { toolCallId: "bash-1", toolName: "bash", input: { command } },
+      ctx,
+    );
+    if (result?.block) block = result;
+  }
+  return block;
+}
+
+/** Deliver an affirmative ask_user_questions answer for a destructive gate. */
+async function answerConfirmGate(
+  handlers: Map<string, Handler[]>,
+  questionId: string,
+  ctx: any,
+): Promise<void> {
+  const questions = [
+    {
+      id: questionId,
+      question: "Run this destructive command?",
+      options: [{ label: "Yes, run it (Recommended)" }, { label: "No, cancel" }],
+    },
+  ];
+  for (const handler of handlers.get("tool_result") ?? []) {
+    await handler(
+      {
+        toolName: "ask_user_questions",
+        input: { questions },
+        details: {
+          response: { answers: { [questionId]: { selected: "Yes, run it (Recommended)" } } },
+        },
+      },
+      ctx,
+    );
+  }
+}
+
+test("integration: real hooks block a force push, then allow it once after confirmation", async (t) => {
+  const dir = "/tmp/gsd-destructive-confirm-int-allow";
+  const ctx = { cwd: dir, ui: { notify: () => undefined } } as any;
+  resetDestructiveConfirmation(dir);
+  t.after(() => resetDestructiveConfirmation(dir));
+
+  const { handlers, pi } = makeHookHarness();
+  registerHooks(pi, []);
+
+  // 1. First attempt is hard-blocked by the real guard, with instructions that
+  //    name the destructive_confirm gate.
+  const firstBlock = await runBashGuard(handlers, FORCE_PUSH, ctx);
+  assert.equal(firstBlock?.block, true, "real guard blocks the first attempt");
+  assert.match(firstBlock?.reason ?? "", /HARD BLOCK: destructive Bash command/);
+  assert.match(firstBlock?.reason ?? "", /force push/);
+  assert.match(firstBlock?.reason ?? "", /destructive_confirm/);
+
+  // 2. User answers an affirmative destructive_confirm gate.
+  await answerConfirmGate(handlers, "destructive_confirm_force_push", ctx);
+
+  // 3. Re-issuing the exact command in the same turn now runs once (no block).
+  const secondAttempt = await runBashGuard(handlers, FORCE_PUSH, ctx);
+  assert.equal(secondAttempt, undefined, "confirmed command passes the real guard once");
+
+  // 4. One-shot: an immediate identical third attempt re-blocks.
+  const thirdAttempt = await runBashGuard(handlers, FORCE_PUSH, ctx);
+  assert.equal(thirdAttempt?.block, true, "second run of the same command re-blocks (one-shot)");
+});
+
+test("integration: declining the confirm gate leaves the command blocked", async (t) => {
+  const dir = "/tmp/gsd-destructive-confirm-int-decline";
+  const ctx = { cwd: dir, ui: { notify: () => undefined } } as any;
+  resetDestructiveConfirmation(dir);
+  t.after(() => resetDestructiveConfirmation(dir));
+
+  const { handlers, pi } = makeHookHarness();
+  registerHooks(pi, []);
+
+  assert.equal((await runBashGuard(handlers, FORCE_PUSH, ctx))?.block, true, "first attempt blocks");
+
+  // Decline: the non-affirmative (non-first) option must NOT promote a token.
+  const questions = [
+    {
+      id: "destructive_confirm_force_push",
+      question: "Run this destructive command?",
+      options: [{ label: "Yes, run it (Recommended)" }, { label: "No, cancel" }],
+    },
+  ];
+  for (const handler of handlers.get("tool_result") ?? []) {
+    await handler(
+      {
+        toolName: "ask_user_questions",
+        input: { questions },
+        details: {
+          response: { answers: { "destructive_confirm_force_push": { selected: "No, cancel" } } },
+        },
+      },
+      ctx,
+    );
+  }
+
+  assert.equal(
+    (await runBashGuard(handlers, FORCE_PUSH, ctx))?.block,
+    true,
+    "declined command stays blocked",
+  );
+});
+
+test("integration: a confirm token does not leak to a different destructive command", async (t) => {
+  const dir = "/tmp/gsd-destructive-confirm-int-bound";
+  const ctx = { cwd: dir, ui: { notify: () => undefined } } as any;
+  resetDestructiveConfirmation(dir);
+  t.after(() => resetDestructiveConfirmation(dir));
+
+  const { handlers, pi } = makeHookHarness();
+  registerHooks(pi, []);
+
+  await runBashGuard(handlers, FORCE_PUSH, ctx);
+  await answerConfirmGate(handlers, "destructive_confirm_force_push", ctx);
+
+  // A different destructive command must not ride the force-push confirmation.
+  // In the real guard, blocking this command also records it as pending, which
+  // invalidates the stale force-push token (stale-token safety invariant) — so
+  // the original confirmation is consumed/cleared, not left dangling.
+  assert.equal(
+    (await runBashGuard(handlers, "rm -rf build", ctx))?.block,
+    true,
+    "unrelated destructive command is still blocked",
+  );
+  // Because the unrelated block invalidated the stale token, the original
+  // force-push now re-blocks too: a confirmation never survives an intervening
+  // destructive command. This is stricter (safer) than per-command isolation.
+  assert.equal(
+    (await runBashGuard(handlers, FORCE_PUSH, ctx))?.block,
+    true,
+    "force-push token was invalidated by the intervening destructive block",
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #678

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Make the destructive-command HARD BLOCK escapable via an explicit one-shot confirmation token instead of an unwinnable loop.
**Why:** Confirming a destructive command via `ask_user_questions` never cleared the gate, so re-issuing it hit the identical block forever (regression from `06212d00`).
**How:** A new in-memory, command-bound, per-basePath confirmation token: the guard records the blocked command and blocks; an affirmative `destructive_confirm` gate answer promotes it; the next matching bash call consumes it and runs once.

## What

Adds the missing confirmation path for the destructive-command safety guard.

- **`src/resources/extensions/gsd/safety/destructive-confirmation.ts`** (new) — one-shot confirmation token module: `requestDestructiveConfirmation` (record pending at block time), `confirmDestructiveCommand` (promote pending → confirmed on affirmative answer), `consumeDestructiveConfirmation` (allow the exact command through once), plus `normalizeDestructiveCommand`, `isDestructiveConfirmGateId`, and test/diagnostic helpers.
- **`src/resources/extensions/gsd/bootstrap/register-hooks.ts`** — wires the token in:
  1. bash `tool_call` guard: consume a matching token (allow once) before blocking; otherwise record the command as pending and block with corrected instructions (use a question id containing `destructive_confirm` whose first option affirms the action).
  2. `ask_user_questions` `tool_result` handler: an affirmative answer to a `destructive_confirm` gate promotes the pending command to a confirmed token. Reuses the existing fail-closed `isDepthConfirmationAnswer` predicate.
- **`src/resources/extensions/gsd/tests/destructive-confirmation.test.ts`** (new) — 13 tests across two layers: **10 unit** (loop repro, block→confirm→allow-once, one-shot re-block, command-binding, whitespace-normalization, stale-token invalidation, per-basePath isolation, gate-id detection, non-destructive passthrough) and **3 integration** that drive the real `registerHooks()` bash guard + `ask_user_questions` handler end-to-end (block→confirm→allow-once, decline-stays-blocked, and stale-token invalidation on an intervening destructive command).

The hard block remains in all modes; it is now *escapable* rather than *unwinnable*.

## Why

The bash `tool_call` guard returned `{ block: true }` unconditionally for any classified-destructive command, with no state tracking user confirmation. The error told the model to confirm via `ask_user_questions` and re-issue "in the current turn", but nothing ever detected that confirmation — an unwinnable loop (observed on a `git push --force-with-lease`).

Regression from `06212d00` (closing #373), whose message claimed "auto-only & warn-only" but whose diff removed the `isAutoActive()` guard and replaced `ctx.ui.notify` with a hard block in all modes.

## How

A one-shot, command-bound confirmation token with these safety invariants (each pinned by a test):

- **In-memory only** — never persisted. A token on disk could silently auto-approve a destructive command in a later session; confirmation must be re-obtained every process lifetime.
- **One-shot** — consuming a token clears it, so a second destructive command (even identical) re-blocks and re-prompts.
- **Command-bound** — only the exact whitespace-normalized command the user confirmed matches; a reworded command re-blocks.
- **Per basePath** — concurrent workspaces in one process never share tokens.

The `destructive_confirm` gate id is intentionally distinct from the `depth_verification` gate patterns (the only entries in `GATE_QUESTION_PATTERNS`), so the two gate systems do not interfere — a `destructive_confirm` answer never trips the depth-gate's early "waiting" return, and the confirm handler is always reached. The guard and the `tool_result` handler both derive basePath from `contextBasePath(ctx)`, so token write/lookup keys match.

Alternatives considered: (a) reverting `06212d00` to warn-only — rejected, it would re-open #373's self-executing-destructive-next-step problem; (b) persisting the token — rejected for the silent-auto-approve-in-later-session risk above.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

(The destructive guard's user-visible block message changed wording to instruct the new `destructive_confirm` gate flow; behavior is strictly more permissive — previously-blocked confirmed commands now run once.)

## Test plan

- [x] New/updated tests included — `destructive-confirmation.test.ts` (13 tests). The `repro:` unit test and the `integration: real hooks block a force push, then allow it once after confirmation` test both fail without the escape hatch and pass with it.
- [x] `destructive-confirmation.test.ts` → **13/13 pass** (10 unit + 3 integration) via the TS-strip resolver.
- [x] Adjacent write-gate / depth-verification suites → **159/159 pass** (no regression from the rebase).
- [x] `typecheck:extensions` → **0 errors** (run after `build:core`; a stale `@opengsd/contracts` dist otherwise reports a pre-existing error in the untouched `unit-registry.ts`).
- [x] Full `test:unit` → 10510 pass / 15 fail. **All 15 failures reproduce verbatim on a clean `origin/main` checkout** (onboarding-state, cost-spike telemetry, `/gsd discuss` routing, `shared/mod.ts` import, dev-CLI `GSD_BIN_PATH` — one even references a sibling worktree path). They are pre-existing / environmental and untouched by this 3-file change.
- [x] Manual: the live guard in this very session still emitted the **old** unfixed block message on a `rm` symlink cleanup, confirming the bug is active on the base and this PR is the fix.

## AI disclosure

- [x] This PR includes AI-assisted code. Investigation, implementation, and tests were AI-assisted and verified locally (full suite run, root-cause traced to `06212d00`, regression test confirmed to fail pre-fix / pass post-fix).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->