### PR TITLE
feat(gsd): fix shell-tool selection — uncapped sync bash, interruptible await, graceful kills

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -674,6 +674,11 @@ export class ToolExecutionComponent extends Container {
 
 	/**
 	 * Finalize a pending tool call as failed/interrupted while preserving any streamed partial output.
+	 *
+	 * Guard: a tool that already produced a settled, non-partial result must NOT be
+	 * touched just because the surrounding turn was aborted (e.g. the user pressed
+	 * ESC during a later tool's await). Only genuinely-incomplete tool calls should
+	 * be marked interrupted.
 	 */
 	completeWithError(message?: string): void {
 		if (this.result && !this.isPartial) {

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -773,3 +773,85 @@ test("handleAgentEvent: agent_end finalizes orphaned pending tool cards", async 
 	assert.doesNotMatch(rendered, /running/, "agent_end must not leave stale running tool cards");
 	assert.match(rendered, /success/, "orphaned tool card should settle as no-result success");
 });
+
+test("handleAgentEvent: aborting a turn does NOT flip an already-completed tool to error (ESC regression)", async () => {
+	// Repro: a background-bash tool finishes successfully, then the user presses
+	// ESC during a later await. The turn ends with stopReason "aborted". The
+	// already-finished tool must stay a success — only genuinely-pending tools
+	// should be marked interrupted.
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const host = createStreamingHost(chatContainer);
+
+	const message = {
+		id: "turn-1",
+		role: "assistant",
+		provider: "claude-code",
+		model: "claude-opus-4-8",
+		timestamp: 1,
+		stopReason: "aborted",
+		content: [{ type: "toolCall", id: "bg-1", name: "async_bash", arguments: { command: "echo hi" } }],
+	};
+
+	await handleAgentEvent(host, {
+		type: "tool_execution_start",
+		toolCallId: "bg-1",
+		toolName: "async_bash",
+		args: { command: "echo hi" },
+	} as any);
+	await handleAgentEvent(host, {
+		type: "tool_execution_end",
+		toolCallId: "bg-1",
+		toolName: "async_bash",
+		result: { content: [{ type: "text", text: "Background job started: bg-1" }], isError: false },
+		isError: false,
+	} as any);
+
+	// Precondition: the completed tool rendered as success before the abort.
+	assert.match(
+		stripAnsi(chatContainer.render(100).join("\n")),
+		/success/,
+		"precondition: completed tool should render success before abort",
+	);
+
+	await handleAgentEvent(host, { type: "message_end", message } as any);
+
+	const rendered = stripAnsi(chatContainer.render(100).join("\n"));
+	assert.match(rendered, /success/, "completed tool must stay green after the turn is aborted");
+	assert.doesNotMatch(
+		rendered,
+		/Operation aborted/,
+		"a completed tool must not be labelled aborted just because the turn was",
+	);
+});
+
+test("handleAgentEvent: aborting a turn DOES mark a still-pending tool as interrupted", async () => {
+	// Counterpart to the regression above: a tool that never produced a result
+	// must still be marked interrupted when the turn aborts.
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const host = createStreamingHost(chatContainer);
+
+	const message = {
+		id: "turn-2",
+		role: "assistant",
+		provider: "claude-code",
+		model: "claude-opus-4-8",
+		timestamp: 1,
+		stopReason: "aborted",
+		content: [{ type: "toolCall", id: "await-1", name: "await_job", arguments: {} }],
+	};
+
+	await handleAgentEvent(host, {
+		type: "tool_execution_start",
+		toolCallId: "await-1",
+		toolName: "await_job",
+		args: {},
+	} as any);
+	// No tool_execution_end — the tool is still pending when the abort lands.
+
+	await handleAgentEvent(host, { type: "message_end", message } as any);
+
+	const rendered = stripAnsi(chatContainer.render(100).join("\n"));
+	assert.match(rendered, /Operation aborted/, "a genuinely-pending tool must be marked interrupted on abort");
+});

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -1371,6 +1371,13 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			const component = host.pendingTools.get(event.toolCallId);
 			if (component) {
 				component.updateResult({ ...event.result, isError: event.isError });
+				// NOTE: the component is intentionally left in host.pendingTools.
+				// The message_end rebuild path relies on finding already-completed
+				// components there to re-attach them; removing it here makes the
+				// rebuild synthesize a fresh empty component that a turn-abort would
+				// then mark errored. The real protection against downgrading a
+				// finished tool lives in ToolExecutionComponent.completeWithError,
+				// which no-ops on an already-successful result.
 				replaceCompactToolRowsWithPhaseSummary(host);
 				host.ui.requestRender();
 			}

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.test.ts
@@ -7,6 +7,7 @@ import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { AssistantMessage } from "@gsd/pi-ai";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { Container } from "@gsd/pi-tui";
+import stripAnsi from "strip-ansi";
 
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { MAX_CHAT_COMPONENTS } from "./interactive-mode-class-constants.js";
@@ -26,6 +27,7 @@ function createHost(): InteractiveModeDelegateHost {
 		getMarkdownThemeWithSettings: () => undefined,
 		getRegisteredToolDefinition: () => undefined,
 		formatWebSearchResult: () => "",
+		toolOutputExpanded: true,
 		session: { retryAttempt: 0 },
 		editor: {},
 		footer: { invalidate() {} },
@@ -99,5 +101,71 @@ describe("interactive chat trimming", () => {
 		assert.ok(firstChild instanceof AssistantMessageComponent);
 		assert.equal(host.chatContainer.children.length, MAX_CHAT_COMPONENTS);
 		assert.equal(connectedToUser(firstChild), false);
+	});
+});
+
+describe("interactive chat replay: aborted turns preserve completed tool results", () => {
+	test("a tool that completed is rendered with its real result even though the turn aborted", () => {
+		// On reload/replay, an aborted assistant turn carries its tool calls, and
+		// each completed tool's result lives in a later `toolResult` message. The
+		// replay must surface that real result instead of discarding it and
+		// painting the row as "Operation aborted".
+		const host = createHost();
+
+		const assistant = {
+			id: "a-abort",
+			role: "assistant",
+			provider: "test",
+			model: "test-model",
+			timestamp: 1,
+			stopReason: "aborted",
+			content: [
+				{ type: "toolCall", id: "bg-1", name: "async_bash", arguments: { command: "echo hi" } },
+			],
+		} as unknown as AgentMessage;
+		const toolResult = {
+			id: "tr-1",
+			role: "toolResult",
+			toolCallId: "bg-1",
+			toolName: "async_bash",
+			timestamp: 2,
+			content: [{ type: "text", text: "UNIQUE_RESULT_TOKEN" }],
+			isError: false,
+		} as unknown as AgentMessage;
+
+		renderSessionContext(host, { messages: [assistant, toolResult] } as any);
+
+		const rendered = stripAnsi(host.chatContainer.render(100).join("\n"));
+		assert.match(rendered, /UNIQUE_RESULT_TOKEN/, "the completed tool's real result must survive replay");
+		assert.doesNotMatch(
+			rendered,
+			/Operation aborted/,
+			"a tool that actually completed must not be shown as aborted on replay",
+		);
+	});
+
+	test("a tool with no result on an aborted turn is still shown as interrupted", () => {
+		const host = createHost();
+
+		const assistant = {
+			id: "a-abort-2",
+			role: "assistant",
+			provider: "test",
+			model: "test-model",
+			timestamp: 1,
+			stopReason: "aborted",
+			content: [
+				{ type: "toolCall", id: "await-1", name: "await_job", arguments: {} },
+			],
+		} as unknown as AgentMessage;
+
+		renderSessionContext(host, { messages: [assistant] } as any);
+
+		const rendered = stripAnsi(host.chatContainer.render(100).join("\n"));
+		assert.match(
+			rendered,
+			/Operation aborted/,
+			"a tool with no result on an aborted turn should render as interrupted",
+		);
 	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.ts
@@ -248,7 +248,22 @@ export function renderSessionContext(host: InteractiveModeDelegateHost,
 						component.setExpanded(host.toolOutputExpanded);
 						host.chatContainer.addChild(component);
 
-						if (message.stopReason === "aborted" || message.stopReason === "error") {
+						// On an aborted/errored turn, only the tool calls that never
+						// produced a result should render as interrupted. A tool that
+						// actually completed has its result in a later `toolResult`
+						// message (keyed by toolCallId) — register it as pending so the
+						// normal toolResult handler below renders the TRUE result with
+						// its real isError flag. Otherwise the successful result would be
+						// silently discarded and the row shown red.
+						const turnAbortedOrErrored =
+							message.stopReason === "aborted" || message.stopReason === "error";
+						const hasRealResult =
+							turnAbortedOrErrored &&
+							sessionContext.messages.some(
+								(m) => m.role === "toolResult" && m.toolCallId === content.id,
+							);
+
+						if (turnAbortedOrErrored && !hasRealResult) {
 							let errorMessage: string;
 							if (message.stopReason === "aborted") {
 								const retryAttempt = host.session.retryAttempt;

--- a/packages/pi-agent-core/src/harness/env/nodejs.ts
+++ b/packages/pi-agent-core/src/harness/env/nodejs.ts
@@ -189,29 +189,60 @@ function getShellEnv(baseEnv?: NodeJS.ProcessEnv, extraEnv?: Record<string, stri
 	};
 }
 
+// Grace period before escalating from SIGTERM to SIGKILL. Deliberately a local
+// mirror of @gsd/pi-coding-agent shell.ts SIGKILL_GRACE_MS: pi-agent-core is the
+// lowest layer and must not depend on pi-coding-agent, so the value cannot be
+// imported. Exported so a higher-layer test can lock it against the canonical
+// source and fail CI on drift (see
+// packages/pi-coding-agent/src/utils/kill-constant-parity.test.ts).
+export const SIGKILL_GRACE_MS = 5_000;
+
+// Note: NodeExecutionEnv.exec does not impose a hard exec deadline — that is intentionally out of
+// scope here; the sync-bash hard deadline in shell.ts covers the agent-facing case. This function
+// only provides graceful SIGTERM→SIGKILL escalation for consistency with the sync-bash kill path.
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
+		// No deliverable graceful signal for hidden console processes; force-kill the
+		// whole tree immediately (matches shell.ts killProcessTree on Windows).
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const tk = spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
 				windowsHide: true,
 			});
+			tk.unref();
 		} catch {
 			// Ignore errors.
 		}
 		return;
 	}
 
+	// Send SIGTERM to the process group first; well-behaved processes exit promptly.
 	try {
-		process.kill(-pid, "SIGKILL");
+		process.kill(-pid, "SIGTERM");
 	} catch {
 		try {
-			process.kill(pid, "SIGKILL");
+			process.kill(pid, "SIGTERM");
 		} catch {
 			// Process already dead.
+			return;
 		}
 	}
+
+	// Escalate to SIGKILL after the grace window for SIGTERM-immune processes.
+	// .unref() so this timer does not prevent the Node.js event loop from exiting.
+	const timer = setTimeout(() => {
+		try {
+			process.kill(-pid, "SIGKILL");
+		} catch {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				// Process already dead.
+			}
+		}
+	}, SIGKILL_GRACE_MS);
+	timer.unref();
 }
 
 export class NodeExecutionEnv implements ExecutionEnv {

--- a/packages/pi-agent-core/src/index.ts
+++ b/packages/pi-agent-core/src/index.ts
@@ -38,6 +38,9 @@ export * from "./harness/system-prompt.js";
 export * from "./harness/types.js";
 export * from "./harness/utils/shell-output.js";
 export * from "./harness/utils/truncate.js";
+// Graceful-kill timing constant (mirror of pi-coding-agent shell.ts; exported so a
+// higher-layer test can lock the two against each other and fail CI on drift).
+export { SIGKILL_GRACE_MS as NODE_ENV_SIGKILL_GRACE_MS } from "./harness/env/nodejs.js";
 // Proxy utilities
 export * from "./proxy.js";
 // Types

--- a/packages/pi-agent-core/test/harness/nodejs-kill-graceful.test.ts
+++ b/packages/pi-agent-core/test/harness/nodejs-kill-graceful.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
+import { createTempDir } from "./session-test-utils.ts";
+
+// Collect abort controllers so afterEach can abort any lingering commands.
+const liveControllers: AbortController[] = [];
+
+afterEach(async () => {
+	for (const ctrl of liveControllers.splice(0)) {
+		ctrl.abort();
+	}
+});
+
+// Spawns POSIX `sleep`/`bash` and asserts SIGTERM-then-SIGKILL escalation, which
+// is Unix-primary; skip on Windows where those commands don't exist and the kill
+// path is taskkill-based.
+describe.skipIf(process.platform === "win32")("NodeExecutionEnv killProcessTree graceful escalation", () => {
+	it("terminates a well-behaved child via SIGTERM when aborted (abort path)", async () => {
+		// A process that does NOT ignore SIGTERM — 'sleep 60' exits promptly when the group receives SIGTERM.
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		const controller = new AbortController();
+		liveControllers.push(controller);
+
+		const started = Date.now();
+		const execPromise = env.exec("sleep 60", { abortSignal: controller.signal });
+
+		// Abort shortly after spawning so the child is running.
+		await new Promise<void>((res) => setTimeout(res, 100));
+		controller.abort();
+
+		const result = await execPromise;
+		const elapsedMs = Date.now() - started;
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe("aborted");
+		}
+		// Must settle well within the SIGKILL grace window (5 s) — SIGTERM alone should suffice.
+		expect(elapsedMs).toBeLessThan(4_000);
+	});
+
+	it("escalates to SIGKILL for a SIGTERM-immune child (timeout path) and does not hang", async () => {
+		// This child ignores SIGTERM, so the test validates that SIGKILL eventually fires.
+		// We use a short timeout so the grace window fires quickly via the exec timeout path.
+		// The exec timeout kills the process; we then assert it settles within a generous band.
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		const controller = new AbortController();
+		liveControllers.push(controller);
+
+		const TIMEOUT_S = 0.2; // exec timeout (seconds) — triggers killProcessTree
+		// Wall-clock guard: if escalation doesn't fire, we'd hang. 8 s is generous.
+		const WALL_CLOCK_LIMIT_MS = 8_000;
+
+		const execPromise = env.exec("bash -c \"trap '' TERM; sleep 60\"", {
+			timeout: TIMEOUT_S,
+			abortSignal: controller.signal,
+		});
+
+		const guardPromise = new Promise<"timeout-guard">((res) =>
+			setTimeout(() => res("timeout-guard"), WALL_CLOCK_LIMIT_MS),
+		);
+
+		const winner = await Promise.race([execPromise.then(() => "exec" as const), guardPromise]);
+
+		// The wall-clock guard must NOT win — exec must settle (SIGKILL should fire after grace).
+		expect(winner).toBe("exec");
+
+		const result = await execPromise;
+		// exec settles with timeout error (the exec-level timeout triggered killProcessTree).
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe("timeout");
+		}
+	});
+});

--- a/packages/pi-coding-agent/src/core/tools/bash-hard-deadline.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash-hard-deadline.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit test for the hard-deadline force-resolve in createLocalBashOperations.
+ *
+ * A true D-state (uninterruptible-sleep) child never emits `close`/`exit` even
+ * after SIGKILL, so `await waitForChildProcess(child)` would hang the sync bash
+ * path forever. The graceful-kill ladder sends the signals but cannot
+ * force-resolve the awaiting caller — the hard deadline must live in the caller.
+ *
+ * Reproducing a real D-state portably is impractical, so we simulate the exact
+ * symptom (child never closes before the deadline) deterministically: a
+ * SIGTERM-ignoring child combined with a LARGE killGraceMs (so the SIGKILL
+ * escalation never fires inside the test window) and a SHORT forceResolveDelayMs.
+ * The child therefore stays open past the hard deadline, forcing the caller to
+ * force-resolve — proving the no-hang guarantee and the (force-killed) marker.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createBashTool, createLocalBashOperations } from "./bash.js";
+
+const isWin = process.platform === "win32";
+
+// Wall-clock guard: reject if the call has not settled by `ms`. Proves no-hang
+// independently of the assertions on timing/markers.
+function wallClockGuard<T>(promise: Promise<T>, ms: number): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<never>((_, reject) => {
+			const t = setTimeout(() => reject(new Error(`Call did not settle within ${ms}ms (hang)`)), ms);
+			if (typeof t === "object" && "unref" in t) t.unref();
+		}),
+	]);
+}
+
+function getTextOutput(result: { content?: Array<{ type: string; text?: string }> }): string {
+	return (
+		result.content
+			?.filter((block) => block.type === "text")
+			.map((block) => block.text ?? "")
+			.join("\n") ?? ""
+	);
+}
+
+// Clean up the detached SIGTERM-ignoring child (and its process group) that the
+// large killGraceMs intentionally leaves alive.
+function cleanupByPidFile(pidFile: string): void {
+	if (!existsSync(pidFile)) return;
+	const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+	if (!Number.isFinite(pid) || pid <= 0) return;
+	if (isWin) {
+		// Best-effort; not exercised on win32 (test is skipped there).
+		return;
+	}
+	try {
+		process.kill(-pid, "SIGKILL");
+	} catch {
+		try {
+			process.kill(pid, "SIGKILL");
+		} catch {
+			// already gone
+		}
+	}
+}
+
+test(
+	"createLocalBashOperations: non-closing (SIGTERM-ignoring) child force-resolves via hard deadline without hanging",
+	{ skip: isWin ? "Unix-primary graceful semantics; force-resolve covered on POSIX" : false, timeout: 20_000 },
+	async (t) => {
+		const dir = mkdtempSync(join(tmpdir(), "bash-hard-deadline-"));
+		const pidFile = join(dir, "child.pid");
+		t.after(() => {
+			cleanupByPidFile(pidFile);
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		// Timing seams: SIGKILL never fires in-window (graceMs huge), so the only way
+		// the call can settle is the hard deadline -> proves the caller-side deadline.
+		const KILL_GRACE_MS = 30_000;
+		const FORCE_RESOLVE_DELAY_MS = 800;
+		// Generous timeout so the SIGTERM trap is reliably installed before the kill
+		// fires, even under heavy parallel test load. With a too-tight timeout the
+		// kill can land before `trap '' TERM` runs, SIGTERM takes its default action,
+		// the child closes on SIGTERM, and the force-resolve path never runs.
+		const TIMEOUT_SECS = 2; // when the kill is initiated
+
+		// Install the SIGTERM trap FIRST so the shell is already immune by the time
+		// the kill fires; then record the shell's PID (process-group leader) for
+		// cleanup and print partial output. The shell loops forever holding its
+		// stdout pipe open. A single SIGTERM kills the current inner `sleep`, but the
+		// loop re-spawns it and bash itself ignores TERM and never exits -> `close`
+		// never fires -> waitForChildProcess hangs -> the caller's hard deadline must
+		// resolve.
+		const command =
+			`trap '' TERM; printf 'PARTIAL_OUTPUT\\n'; echo $$ > '${pidFile}'; while true; do sleep 1; done`;
+
+		const bashTool = createBashTool(dir, {
+			operations: createLocalBashOperations({
+				killGraceMs: KILL_GRACE_MS,
+				forceResolveDelayMs: FORCE_RESOLVE_DELAY_MS,
+			}),
+		});
+
+		const start = Date.now();
+		let settledText = "";
+		await wallClockGuard(
+			(async () => {
+				try {
+					const result = await bashTool.execute("hard-deadline-test", { command, timeout: TIMEOUT_SECS });
+					// Should not reach here — a non-closing child must force-resolve via throw.
+					settledText = getTextOutput(result as any);
+					throw new Error(`Expected force-resolve throw, but resolved with: ${settledText}`);
+				} catch (err) {
+					if (err instanceof Error) settledText = err.message;
+					else throw err;
+				}
+			})(),
+			15_000,
+		);
+		const elapsed = Date.now() - start;
+
+		// (a) Did not hang and settled via the hard deadline, NOT via SIGKILL: the
+		//     SIGKILL grace is 30s, so settling well under it proves the caller-side
+		//     force-resolve fired (not the kill ladder). Bound is the force-resolve
+		//     band plus generous CI slack, kept below the 15s wallClockGuard.
+		assert.ok(
+			elapsed < TIMEOUT_SECS * 1000 + FORCE_RESOLVE_DELAY_MS + 8_000,
+			`Expected force-resolve well before SIGKILL grace (${KILL_GRACE_MS}ms), but took ${elapsed}ms`,
+		);
+		// (b) Settled roughly at timeout + forceResolveDelay (give generous slack).
+		const expectedFloor = TIMEOUT_SECS * 1000; // kill initiated no earlier than this
+		assert.ok(
+			elapsed >= expectedFloor && elapsed <= expectedFloor + FORCE_RESOLVE_DELAY_MS + 8_000,
+			`Expected settle near ${expectedFloor + FORCE_RESOLVE_DELAY_MS}ms, but took ${elapsed}ms`,
+		);
+		// (c) Rendered text preserves partial output AND carries the force-killed marker.
+		assert.match(settledText, /PARTIAL_OUTPUT/, `Expected partial output in:\n${settledText}`);
+		assert.match(settledText, /force-killed/, `Expected force-killed marker in:\n${settledText}`);
+	},
+);

--- a/packages/pi-coding-agent/src/core/tools/bash.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash.ts
@@ -11,7 +11,9 @@ import { waitForChildProcess } from "../../utils/child-process.js";
 import {
 	getShellConfig,
 	getShellEnv,
+	HARD_DEADLINE_MS,
 	killProcessTree,
+	SIGKILL_GRACE_MS,
 	trackDetachedChildPid,
 	untrackDetachedChildPid,
 } from "../../utils/shell.js";
@@ -23,7 +25,7 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult
 
 const bashSchema = Type.Object({
 	command: Type.String({ description: "Bash command to execute" }),
-	timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (optional, no default timeout)" })),
+	timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (optional, no default timeout)." })),
 });
 
 export type BashToolInput = Static<typeof bashSchema>;
@@ -63,7 +65,23 @@ export interface BashOperations {
  * This is useful for extensions that intercept user_bash and still want pi's
  * standard local shell behavior while wrapping or rewriting commands.
  */
-export function createLocalBashOperations(options?: { shellPath?: string; loginShell?: boolean }): BashOperations {
+export function createLocalBashOperations(options?: {
+	shellPath?: string;
+	loginShell?: boolean;
+	/**
+	 * Grace (ms) handed to killProcessTree between SIGTERM and SIGKILL.
+	 * Defaults to SIGKILL_GRACE_MS. Exposed primarily as a test seam.
+	 */
+	killGraceMs?: number;
+	/**
+	 * Delay (ms) AFTER a kill is initiated before the hard deadline force-resolves
+	 * the awaiting exec. Defaults to SIGKILL_GRACE_MS + HARD_DEADLINE_MS so it only
+	 * fires once SIGKILL has had its grace window. Exposed primarily as a test seam.
+	 */
+	forceResolveDelayMs?: number;
+}): BashOperations {
+	const killGraceMs = options?.killGraceMs ?? SIGKILL_GRACE_MS;
+	const forceResolveDelayMs = options?.forceResolveDelayMs ?? SIGKILL_GRACE_MS + HARD_DEADLINE_MS;
 	return {
 		exec: async (command, cwd, { onData, signal, timeout, env }) => {
 			const { shell, args } = getShellConfig(options?.shellPath);
@@ -86,8 +104,31 @@ export function createLocalBashOperations(options?: { shellPath?: string; loginS
 			if (child.pid) trackDetachedChildPid(child.pid);
 			let timedOut = false;
 			let timeoutHandle: NodeJS.Timeout | undefined;
+
+			// Hard deadline: a true D-state (uninterruptible-sleep) child never emits
+			// `exit`/`close`, so waitForChildProcess(child) would hang forever even after
+			// SIGKILL. killProcessTree can send the signals but cannot force-resolve
+			// the awaiting caller — the deadline MUST live here, in the caller. It is only
+			// ARMED once a kill has been initiated (timeout or abort), and fires
+			// `forceResolveDelayMs` later so SIGKILL has had its full grace window first.
+			let deadlineHandle: NodeJS.Timeout | undefined;
+			let resolveDeadline: ((value: { forceKilled: true }) => void) | undefined;
+			const hardDeadlinePromise = new Promise<{ forceKilled: true }>((resolve) => {
+				resolveDeadline = resolve;
+			});
+			const armHardDeadline = () => {
+				if (deadlineHandle) return; // already armed by a prior kill
+				deadlineHandle = setTimeout(() => {
+					resolveDeadline?.({ forceKilled: true });
+				}, forceResolveDelayMs);
+				if (typeof deadlineHandle === "object" && "unref" in deadlineHandle) deadlineHandle.unref();
+			};
+			const initiateKill = () => {
+				if (child.pid) killProcessTree(child.pid, { graceMs: killGraceMs });
+				armHardDeadline();
+			};
 			const onAbort = () => {
-				if (child.pid) killProcessTree(child.pid);
+				initiateKill();
 			};
 
 			try {
@@ -95,7 +136,7 @@ export function createLocalBashOperations(options?: { shellPath?: string; loginS
 				if (timeout !== undefined && timeout > 0) {
 					timeoutHandle = setTimeout(() => {
 						timedOut = true;
-						if (child.pid) killProcessTree(child.pid);
+						initiateKill();
 					}, timeout * 1000);
 				}
 				// Stream stdout and stderr.
@@ -106,19 +147,27 @@ export function createLocalBashOperations(options?: { shellPath?: string; loginS
 					if (signal.aborted) onAbort();
 					else signal.addEventListener("abort", onAbort, { once: true });
 				}
-				// Handle shell spawn errors and wait for the process to terminate without hanging
-				// on inherited stdio handles held by detached descendants.
-				const exitCode = await waitForChildProcess(child);
+				// Race the real termination against the hard deadline. Promise.race ensures
+				// the deadline and the real `close` cannot double-resolve the caller.
+				const exitPromise = waitForChildProcess(child).then((code) => ({ forceKilled: false as const, code }));
+				const raceResult = await Promise.race([exitPromise, hardDeadlinePromise]);
+				if (raceResult.forceKilled) {
+					// Child never closed (D-state symptom). Stop tracking and force-resolve
+					// the awaiting caller with a distinct marker the bash tool renders sanely.
+					if (child.pid) untrackDetachedChildPid(child.pid);
+					throw new Error("force-killed");
+				}
 				if (signal?.aborted) {
 					throw new Error("aborted");
 				}
 				if (timedOut) {
 					throw new Error(`timeout:${timeout}`);
 				}
-				return { exitCode };
+				return { exitCode: raceResult.code };
 			} finally {
 				if (child.pid) untrackDetachedChildPid(child.pid);
 				if (timeoutHandle) clearTimeout(timeoutHandle);
+				if (deadlineHandle) clearTimeout(deadlineHandle);
 				if (signal) signal.removeEventListener("abort", onAbort);
 			}
 		},
@@ -276,7 +325,7 @@ export function createBashToolDefinition(
 	return {
 		name: "bash",
 		label: "bash",
-		description: `Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.`,
+		description: `Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds. No default timeout — pass an explicit timeout or rely on human cancellation.`,
 		promptSnippet: "Execute bash commands (ls, grep, find, etc.)",
 		parameters: bashSchema,
 		async execute(
@@ -388,6 +437,13 @@ export function createBashToolDefinition(
 					if (err instanceof Error && err.message.startsWith("timeout:")) {
 						const timeoutSecs = err.message.split(":")[1];
 						throw new Error(appendStatus(text, `Command timed out after ${timeoutSecs} seconds`));
+					}
+					if (err instanceof Error && err.message === "force-killed") {
+						// Hard-deadline force-resolve: the child never closed even after SIGKILL
+						// (D-state symptom). Surface a distinct marker so an operator/agent can
+						// tell this apart from a clean SIGTERM exit. Partial output is preserved.
+						const suffix = timeout ? `Command timed out after ${timeout} seconds (force-killed)` : "Command force-killed";
+						throw new Error(appendStatus(text, suffix));
 					}
 					throw err;
 				}

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -254,7 +254,13 @@ export { copyToClipboard } from "./utils/clipboard.js";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.js";
 export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.js";
 // Shell utilities
-export { getShellConfig, sanitizeCommand } from "./utils/shell.js";
+export {
+	getShellConfig,
+	sanitizeCommand,
+	killProcessTree,
+	SIGKILL_GRACE_MS,
+	HARD_DEADLINE_MS,
+} from "./utils/shell.js";
 export {
 	SAFE_COMMAND_PREFIXES,
 	getAllowedCommandPrefixes,

--- a/packages/pi-coding-agent/src/utils/kill-constant-parity.test.ts
+++ b/packages/pi-coding-agent/src/utils/kill-constant-parity.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Cross-layer parity lock for the graceful-kill timing constant.
+ *
+ * SIGKILL_GRACE_MS is deliberately duplicated rather than imported in the
+ * lowest layer (`@gsd/pi-agent-core` harness/env/nodejs.ts), because
+ * pi-agent-core must not depend on pi-coding-agent. Duplication invites drift:
+ * someone tunes the canonical 5_000 in shell.ts and the agent-core mirror
+ * silently keeps the old value, so the two kill paths escalate to SIGKILL at
+ * different times.
+ *
+ * This test imports BOTH real values (no source grep, no string scanning) and
+ * asserts they are equal, so any future divergence fails CI here with a clear
+ * message instead of shipping an inconsistent kill ladder.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SIGKILL_GRACE_MS as CANONICAL_GRACE_MS } from "./shell.js";
+import { NODE_ENV_SIGKILL_GRACE_MS } from "@gsd/pi-agent-core";
+
+test("graceful-kill grace period is identical across the canonical and agent-core kill paths", () => {
+	assert.equal(
+		NODE_ENV_SIGKILL_GRACE_MS,
+		CANONICAL_GRACE_MS,
+		`pi-agent-core nodejs.ts SIGKILL_GRACE_MS (${NODE_ENV_SIGKILL_GRACE_MS}) drifted from ` +
+			`the canonical pi-coding-agent shell.ts value (${CANONICAL_GRACE_MS}). ` +
+			`Update the mirror in packages/pi-agent-core/src/harness/env/nodejs.ts to match.`,
+	);
+});
+
+test("canonical grace period is a sane positive duration", () => {
+	assert.ok(
+		Number.isInteger(CANONICAL_GRACE_MS) && CANONICAL_GRACE_MS > 0,
+		`SIGKILL_GRACE_MS must be a positive integer ms value, got ${CANONICAL_GRACE_MS}`,
+	);
+});

--- a/packages/pi-coding-agent/src/utils/kill-process-tree.test.ts
+++ b/packages/pi-coding-agent/src/utils/kill-process-tree.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for killProcessTree graceful escalation ladder.
+ *
+ * Case (a): SIGTERM-cooperative child — exits quickly without needing SIGKILL.
+ * Case (b): SIGTERM-resistant child — survives SIGTERM but is dead after SIGKILL grace.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { killProcessTree } from "./shell.js";
+
+// These tests spawn POSIX `sleep`/`bash` and assert SIGTERM-then-SIGKILL timing,
+// which is Unix-primary; on Windows killProcessTree force-kills via taskkill and
+// the POSIX commands don't exist, so skip there.
+const skipOnWindows = process.platform === "win32" ? "Unix-primary graceful semantics" : false;
+
+// ------------------------------------------------------------------
+// Helper: poll until the process is dead (ESRCH) or deadline exceeded.
+// Returns elapsed ms on success; throws if wall-clock limit exceeded.
+// ------------------------------------------------------------------
+async function waitUntilDead(
+	pid: number,
+	deadlineMs: number,
+	pollIntervalMs = 50,
+): Promise<number> {
+	const start = Date.now();
+	return new Promise<number>((resolve, reject) => {
+		const interval = setInterval(() => {
+			const elapsed = Date.now() - start;
+			try {
+				process.kill(pid, 0); // throws ESRCH when dead
+			} catch {
+				clearInterval(interval);
+				resolve(elapsed);
+				return;
+			}
+			if (elapsed > deadlineMs) {
+				clearInterval(interval);
+				reject(new Error(`Process ${pid} still alive after ${elapsed}ms`));
+			}
+		}, pollIntervalMs);
+		if (typeof interval === "object" && "unref" in interval) interval.unref();
+	});
+}
+
+// ------------------------------------------------------------------
+// Helper: check whether a pid is currently alive.
+// ------------------------------------------------------------------
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ------------------------------------------------------------------
+// Helper: poll until a file exists or the deadline is exceeded. Used as a
+// handshake that a spawned shell has reached a known point in its script
+// (e.g. AFTER installing its SIGTERM trap) — far more robust than a blind
+// fixed sleep, which races shell startup under heavy parallel load.
+// ------------------------------------------------------------------
+async function waitForFile(path: string, deadlineMs: number): Promise<boolean> {
+	const start = Date.now();
+	while (Date.now() - start < deadlineMs) {
+		if (existsSync(path)) return true;
+		await new Promise((r) => setTimeout(r, 20));
+	}
+	return existsSync(path);
+}
+
+// ------------------------------------------------------------------
+// Case (a): SIGTERM-cooperative child exits promptly (no SIGKILL needed)
+// ------------------------------------------------------------------
+test("killProcessTree: SIGTERM-cooperative child exits well under the grace window", { timeout: 8_000, skip: skipOnWindows }, async (t) => {
+	const child = spawn("sleep", ["60"], {
+		detached: true,
+		stdio: "ignore",
+	});
+	child.unref();
+
+	const pid = child.pid!;
+	assert.ok(pid, "child pid should be defined");
+	// Reap the child if an assertion throws before it dies, so a failed run never
+	// leaks a `sleep 60` onto the CI box.
+	t.after(() => {
+		try { process.kill(-pid, "SIGKILL"); } catch { /* already gone */ }
+	});
+
+	// Give the process a moment to fully start
+	await new Promise((r) => setTimeout(r, 100));
+	assert.ok(isAlive(pid), "child should be alive before kill");
+
+	killProcessTree(pid);
+
+	// Should die well before the grace window (1500ms is generous for SIGTERM)
+	const elapsed = await Promise.race([
+		waitUntilDead(pid, 4_000),
+		new Promise<never>((_, reject) => {
+			const t = setTimeout(
+				() => reject(new Error(`Wall-clock guard triggered — child ${pid} still alive after 4s`)),
+				4_000,
+			);
+			if (typeof t === "object" && "unref" in t) t.unref();
+		}),
+	]);
+
+	assert.ok(
+		elapsed < 1_500,
+		`Expected child to die within 1500ms of SIGTERM, but took ${elapsed}ms`,
+	);
+});
+
+// ------------------------------------------------------------------
+// Case (b): SIGTERM-resistant child survives SIGTERM but dies via SIGKILL
+// ------------------------------------------------------------------
+test("killProcessTree: SIGTERM-resistant child dies after grace window but not immediately", { timeout: 10_000, skip: skipOnWindows }, async (t) => {
+	const dir = mkdtempSync(join(tmpdir(), "kill-process-tree-"));
+	const trapReadyFile = join(dir, "trap-ready");
+
+	// Install the SIGTERM trap FIRST, then signal readiness by creating the
+	// handshake file, then loop forever holding the group open. The loop form
+	// (rather than `trap '' TERM; sleep 60`) keeps bash itself — the process-group
+	// leader — the SIGTERM-immune process, instead of relying on bash exec-
+	// optimizing into `sleep` and the SIG_IGN disposition surviving execve.
+	const child = spawn(
+		"bash",
+		["-c", `trap '' TERM; : > '${trapReadyFile}'; while true; do sleep 1; done`],
+		{ detached: true, stdio: "ignore" },
+	);
+	child.unref();
+
+	const pid = child.pid!;
+	assert.ok(pid, "child pid should be defined");
+	// Reap the SIGTERM-immune child if an assertion throws before SIGKILL fires.
+	t.after(() => {
+		try { process.kill(-pid, "SIGKILL"); } catch { /* already gone */ }
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	// Handshake: wait until the child has ACTUALLY installed its SIGTERM trap
+	// (it writes trapReadyFile immediately after `trap`). A blind fixed sleep here
+	// races bash startup under heavy parallel load — if SIGTERM lands before the
+	// trap is set, the child dies on SIGTERM and the "survives SIGTERM" assertion
+	// flakes. Polling the handshake file removes that race.
+	assert.ok(await waitForFile(trapReadyFile, 5_000), "child should install its SIGTERM trap and signal readiness");
+	assert.ok(isAlive(pid), "SIGTERM-resistant child should be alive before kill");
+
+	const GRACE_MS = 600; // short grace keeps the test fast
+	const startMs = Date.now();
+	killProcessTree(pid, { graceMs: GRACE_MS });
+
+	// ~300ms after SIGTERM: the child should still be alive (it ignores SIGTERM).
+	// The trap is guaranteed installed (handshake above), so this is no longer racy.
+	await new Promise((r) => setTimeout(r, 300));
+	const aliveAtMidpoint = isAlive(pid);
+
+	// Wait for death (SIGKILL fires at ~600ms); generous upper bound of 4000ms
+	const elapsed = await Promise.race([
+		waitUntilDead(pid, 4_000),
+		new Promise<never>((_, reject) => {
+			const t = setTimeout(
+				() => reject(new Error(`Wall-clock guard triggered — child ${pid} still alive after 4s post-kill`)),
+				4_000,
+			);
+			if (typeof t === "object" && "unref" in t) t.unref();
+		}),
+	]);
+
+	const totalElapsed = Date.now() - startMs;
+
+	assert.ok(
+		aliveAtMidpoint,
+		"SIGTERM-resistant child should still be alive ~300ms after SIGTERM (before SIGKILL fires)",
+	);
+	// Lower bound proves SIGKILL did NOT fire immediately (it waited for the grace
+	// window); upper bound proves it fired roughly AT the grace window, not just
+	// "eventually". A loose [300ms, 4000ms] band would pass even if SIGKILL slipped
+	// far past GRACE_MS, so the window is tied to GRACE_MS with CI jitter slack.
+	assert.ok(
+		totalElapsed >= GRACE_MS * 0.8 && totalElapsed <= GRACE_MS + 2_000,
+		`Expected child to die in the SIGKILL grace window (~${GRACE_MS}ms), but elapsed=${totalElapsed}ms`,
+	);
+});

--- a/packages/pi-coding-agent/src/utils/shell.ts
+++ b/packages/pi-coding-agent/src/utils/shell.ts
@@ -230,31 +230,75 @@ export function killTrackedDetachedChildren(): void {
 }
 
 /**
- * Kill a process and all its children (cross-platform)
+ * Grace period (ms) between SIGTERM and SIGKILL.
+ * Canonical source of truth for the graceful-kill timing ladder — imported by the
+ * async_bash and GSD exec-sandbox kill paths. The pi-agent-core harness keeps a
+ * deliberate local mirror (it must not depend on this package); a parity test
+ * locks the two. Update both together.
  */
-export function killProcessTree(pid: number): void {
+export const SIGKILL_GRACE_MS = 5_000;
+/** Hard deadline (ms) after SIGKILL to force-resolve the job promise — consumed by the sync-bash, async_bash, and exec-sandbox kill paths. */
+export const HARD_DEADLINE_MS = 3_000;
+
+/**
+ * Kill a process and all its children (cross-platform).
+ *
+ * Returns immediately; the SIGKILL escalation fires asynchronously after `graceMs`,
+ * so the target is not guaranteed dead by the time this returns.
+ *
+ * On Unix: sends SIGTERM immediately, then escalates to SIGKILL after `graceMs`
+ * (default: SIGKILL_GRACE_MS = 5 s). The escalation timer is `.unref()`'d so it
+ * never keeps the event loop alive after the parent process has nothing else to do.
+ *
+ * On Windows: there is no reliable graceful signal for the hidden console
+ * processes pi spawns (`windowsHide: true` means no window to receive WM_CLOSE
+ * and no console for CTRL_BREAK), so `taskkill /T` without /F is a no-op here.
+ * We therefore force-terminate the tree immediately with `taskkill /F /T /PID`.
+ * Graceful (SIGTERM-first) semantics are Unix-primary; `opts.graceMs` is ignored
+ * on Windows.
+ */
+export function killProcessTree(pid: number, opts?: { graceMs?: number }): void {
 	if (process.platform === "win32") {
-		// Use taskkill on Windows to kill process tree
+		// No deliverable graceful signal for hidden console processes — force-kill the
+		// whole tree now. (A delayed /F /T after a no-op /T would only add latency,
+		// regressing the old immediate-kill behavior.) opts.graceMs is intentionally
+		// unused on Windows.
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const tk = spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
 				windowsHide: true,
 			});
+			tk.unref();
 		} catch {
-			// Ignore errors if taskkill fails
+			// Ignore — process may already be gone
 		}
 	} else {
-		// Use SIGKILL on Unix/Linux/Mac
+		// Unix: SIGTERM → grace window → SIGKILL
 		try {
-			process.kill(-pid, "SIGKILL");
+			process.kill(-pid, "SIGTERM");
 		} catch {
-			// Fallback to killing just the child if process group kill fails
+			// -pid (process group) failed — fall back to direct pid
 			try {
-				process.kill(pid, "SIGKILL");
+				process.kill(pid, "SIGTERM");
 			} catch {
-				// Process already dead
+				// Process already dead — no escalation needed
+				return;
 			}
 		}
+		// Escalate to SIGKILL after the grace period.
+		// The timer is unref'd so it never prevents the event loop from exiting.
+		const t = setTimeout(() => {
+			try {
+				process.kill(-pid, "SIGKILL");
+			} catch {
+				try {
+					process.kill(pid, "SIGKILL");
+				} catch {
+					// Process already dead
+				}
+			}
+		}, opts?.graceMs ?? SIGKILL_GRACE_MS);
+		if (typeof t === "object" && "unref" in t) t.unref();
 	}
 }

--- a/src/resources/extensions/async-jobs/async-bash-cancel.test.ts
+++ b/src/resources/extensions/async-jobs/async-bash-cancel.test.ts
@@ -1,0 +1,360 @@
+/**
+ * async-bash-cancel.test.ts — Tests for graceful async_bash cancellation.
+ *
+ * Proves that:
+ *   1. The killProcessTree re-export from @gsd/pi-coding-agent resolves correctly
+ *      (loading async-bash-tool.ts will fail at import-time if the export is missing).
+ *   2. manager.cancel() sets status to 'cancelled' and returns 'cancelled'.
+ *   3. The job promise settles promptly (SIGTERM kills a well-behaved child).
+ *   4. The timeout path force-kills a SIGTERM-immune child via SIGKILL (regression:
+ *      it must not be left running in the background after the timeout fires).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAsyncBashTool } from "./async-bash-tool.ts";
+import { createAwaitTool } from "./await-tool.ts";
+import { AsyncJobManager } from "./job-manager.ts";
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0); // signal 0 probes existence without killing
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// If killProcessTree is missing from the re-export the import above will throw
+// at load time (async-bash-tool.ts destructures it from @gsd/pi-coding-agent).
+// A load-time error surfaces as a test runner parse failure — no explicit
+// assertion needed; the test file simply won't run.
+
+const noopSignal = new AbortController().signal;
+
+test("graceful cancel: manager.cancel returns 'cancelled' and job settles promptly", async () => {
+	const manager = new AsyncJobManager();
+	const tool = createAsyncBashTool(() => manager, () => process.cwd());
+
+	// Launch a long-running well-behaved process (responds to SIGTERM)
+	const result = await tool.execute(
+		"tc-cancel-01",
+		{
+			command: "sleep 30",
+			label: "cancel-test-sleep",
+		},
+		noopSignal,
+		() => {},
+		undefined as never,
+	);
+
+	const text = result.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n");
+	const jobId = text.match(/\*\*(bg_[a-f0-9]+)\*\*/)?.[1];
+	assert.ok(jobId, `Expected a job ID in result text, got: ${text}`);
+
+	const job = manager.getJob(jobId)!;
+	assert.ok(job, "Job should be registered in manager");
+	assert.equal(job.status, "running", "Job should be running before cancel");
+
+	// Cancel — should return 'cancelled' immediately
+	const cancelResult = manager.cancel(jobId);
+	assert.equal(cancelResult, "cancelled", `cancel() should return 'cancelled', got: ${cancelResult}`);
+	assert.equal(job.status, "cancelled", "Job status should flip to 'cancelled'");
+
+	// Job promise should settle promptly — SIGTERM kills sleep quickly
+	const start = Date.now();
+	await Promise.race([
+		job.promise,
+		new Promise<never>((_, reject) => {
+			const t = setTimeout(() => {
+				reject(new Error(
+					`Job promise did not settle within 5s after cancel ` +
+					`(${Date.now() - start}ms elapsed) — graceful cancel may be broken`,
+				));
+			}, 5_000);
+			if (typeof t === "object" && "unref" in t) t.unref();
+		}),
+	]);
+
+	const elapsed = Date.now() - start;
+	assert.ok(elapsed < 5_000, `Job promise should settle under 5s, took ${elapsed}ms`);
+
+	manager.shutdown();
+});
+
+test(
+	"graceful cancel: status STAYS 'cancelled' after the job promise settles (not clobbered to 'completed')",
+	async (t) => {
+		// Regression: async_bash resolves (not rejects) its run promise even when aborted —
+		// safeResolve returns "Command aborted" rather than throwing — so the job-manager
+		// .then branch used to overwrite status back to 'completed', mislabeling a job the
+		// user explicitly cancelled. A cancelled job must also deliver NO follow-up.
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: (j) => delivered.push(j.id) });
+		// Tear down via t.after() so a thrown assertion still cleans up the manager.
+		t.after(() => manager.shutdown());
+		const tool = createAsyncBashTool(() => manager, () => process.cwd());
+
+		const result = await tool.execute(
+			"tc-cancel-status",
+			{ command: "sleep 30", label: "cancel-status-test" },
+			noopSignal,
+			() => {},
+			undefined as never,
+		);
+		const text = result.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n");
+		const jobId = text.match(/\*\*(bg_[a-f0-9]+)\*\*/)?.[1];
+		assert.ok(jobId, `Expected a job ID, got: ${text}`);
+
+		const job = manager.getJob(jobId)!;
+		assert.equal(manager.cancel(jobId), "cancelled");
+		assert.equal(job.status, "cancelled", "status should be 'cancelled' synchronously");
+
+		// Await the run promise settling (SIGTERM kills sleep quickly), THEN re-check status.
+		await job.promise;
+		// Let the deliverResult setTimeout(0) (if any) and microtasks flush.
+		await new Promise((r) => setTimeout(r, 20));
+
+		assert.equal(
+			job.status,
+			"cancelled",
+			`status must REMAIN 'cancelled' after the run promise settles, got '${job.status}' ` +
+				`(the .then branch clobbered the user-cancelled status)`,
+		);
+		assert.equal(
+			delivered.includes(jobId),
+			false,
+			"a cancelled job must not fire an onJobComplete follow-up",
+		);
+	},
+);
+
+test("graceful cancel: killProcessTree re-export resolves (load-time check)", async () => {
+	// This test is a belt-and-suspenders static check. If killProcessTree were
+	// not re-exported, the import at the top of this file would have already
+	// caused the entire test file to fail to load. We do an explicit runtime
+	// check here to make the intent clear and produce a readable assertion failure
+	// rather than a cryptic module-not-found error in the test runner output.
+	const mod = await import("@gsd/pi-coding-agent");
+	assert.ok(
+		typeof (mod as Record<string, unknown>).killProcessTree === "function",
+		"killProcessTree must be exported from @gsd/pi-coding-agent",
+	);
+});
+
+test(
+	"timeout path: SIGTERM-immune job is force-killed (SIGKILL), not left running in the background",
+	// Worst case ~12s (1s timeout + 5s grace + 3s hard-deadline + 3s poll); the
+	// explicit timeout prevents an infinite hang if force-resolve ever regresses.
+	{ skip: process.platform === "win32" ? "Unix-primary graceful semantics" : false, timeout: 20_000 },
+	async (t) => {
+		// Regression: the timeout path previously called a local killTree that only
+		// ever sent SIGTERM (twice), so a `trap '' TERM` child survived its timeout
+		// and ran forever in the background. It now routes through killProcessTree,
+		// which escalates SIGTERM -> grace -> SIGKILL. This proves the child is
+		// actually dead shortly after the 5s grace window, not orphaned.
+		const dir = mkdtempSync(join(tmpdir(), "async-timeout-sigkill-"));
+		const pidFile = join(dir, "pgid.pid");
+		t.after(() => {
+			// Best-effort: kill the process group if the test failed and left it alive.
+			try {
+				const pgid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+				// Guard pgid > 0: process.kill(-0, ...) would signal the test runner's OWN
+				// process group (-0 === 0 === "caller's group" under POSIX).
+				if (Number.isFinite(pgid) && pgid > 0) process.kill(-pgid, "SIGKILL");
+			} catch {
+				/* already gone */
+			}
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		const manager = new AsyncJobManager();
+		const tool = createAsyncBashTool(() => manager, () => process.cwd());
+
+		// echo $$ records the detached shell's PID (process-group leader). The shell
+		// ignores SIGTERM and loops forever, so only SIGKILL can end it.
+		const command = `echo $$ > '${pidFile}'; trap '' TERM; while true; do sleep 1; done`;
+		const result = await tool.execute(
+			"tc-timeout-sigkill",
+			{ command, label: "timeout-sigkill", timeout: 1 },
+			noopSignal,
+			() => {},
+			undefined as never,
+		);
+
+		const text = result.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n");
+		const jobId = text.match(/\*\*(bg_[a-f0-9]+)\*\*/)?.[1];
+		assert.ok(jobId, `Expected a job ID, got: ${text}`);
+
+		// The promise force-resolves at ~timeout + grace + hard-deadline (~1+5+3s).
+		await manager.getJob(jobId)!.promise;
+
+		const pgid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+		assert.ok(Number.isFinite(pgid) && pgid > 0, "child must have recorded a valid positive process-group PID");
+
+		// Poll briefly: SIGKILL was sent at timeout+grace (~6s); give it a moment to reap.
+		const deadlineMs = Date.now() + 3_000;
+		while (isAlive(pgid) && Date.now() < deadlineMs) {
+			await new Promise((r) => setTimeout(r, 100));
+		}
+		assert.equal(
+			isAlive(pgid),
+			false,
+			`SIGTERM-immune timed-out job (pgid ${pgid}) must be SIGKILLed, not left running`,
+		);
+
+		manager.shutdown();
+	},
+);
+
+test("graceful cancel: job promise settles even for node process on cancel", async () => {
+	const manager = new AsyncJobManager();
+	const tool = createAsyncBashTool(() => manager, () => process.cwd());
+
+	// node process that blocks for 30s — responds to SIGTERM
+	const result = await tool.execute(
+		"tc-cancel-02",
+		{
+			command: `node -e "setTimeout(()=>{}, 30000)"`,
+			label: "cancel-test-node",
+		},
+		noopSignal,
+		() => {},
+		undefined as never,
+	);
+
+	const text = result.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n");
+	const jobId = text.match(/\*\*(bg_[a-f0-9]+)\*\*/)?.[1];
+	assert.ok(jobId, "Expected a job ID");
+
+	const job = manager.getJob(jobId)!;
+	assert.equal(job.status, "running");
+
+	const cancelResult = manager.cancel(jobId);
+	assert.equal(cancelResult, "cancelled");
+
+	const start = Date.now();
+	await Promise.race([
+		job.promise,
+		new Promise<never>((_, reject) => {
+			const t = setTimeout(() => {
+				reject(new Error(`Job promise hung after cancel (${Date.now() - start}ms)`));
+			}, 5_000);
+			if (typeof t === "object" && "unref" in t) t.unref();
+		}),
+	]);
+
+	assert.ok(Date.now() - start < 5_000, "Promise should settle quickly after cancel");
+	manager.shutdown();
+});
+
+test(
+	"cancel path: SIGTERM-immune job force-resolves via hard deadline, does not hang",
+	// Worst case ~8s (5s grace + 3s hard-deadline after cancel); explicit timeout
+	// guards against an infinite hang if the abort-path force-resolve regresses.
+	{ skip: process.platform === "win32" ? "Unix-primary graceful semantics" : false, timeout: 20_000 },
+	async () => {
+		// Regression: onAbort (the /jobs cancel path) used to kill the child but arm no
+		// hard deadline, so cancelling a `trap '' TERM` child that never closes left the
+		// job promise dangling forever. It now arms the same hard-deadline force-resolve
+		// the timeout path uses.
+		const manager = new AsyncJobManager();
+		const tool = createAsyncBashTool(() => manager, () => process.cwd());
+
+		const result = await tool.execute(
+			"tc-cancel-dstate",
+			{ command: `trap '' TERM; while true; do sleep 1; done`, label: "cancel-dstate" },
+			noopSignal,
+			() => {},
+			undefined as never,
+		);
+		const text = result.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n");
+		const jobId = text.match(/\*\*(bg_[a-f0-9]+)\*\*/)?.[1];
+		assert.ok(jobId, "Expected a job ID");
+
+		const job = manager.getJob(jobId)!;
+		assert.equal(job.status, "running");
+		assert.equal(manager.cancel(jobId), "cancelled");
+
+		// The promise must settle via the hard deadline (~8s) rather than hang.
+		const start = Date.now();
+		await Promise.race([
+			job.promise,
+			new Promise<never>((_, reject) => {
+				const t = setTimeout(() => {
+					reject(new Error(`Cancelled D-state job hung (${Date.now() - start}ms) — abort-path force-resolve missing`));
+				}, 15_000);
+				if (typeof t === "object" && "unref" in t) t.unref();
+			}),
+		]);
+		assert.ok(Date.now() - start < 15_000, "cancelled D-state job must force-resolve, not hang");
+
+		manager.shutdown();
+	},
+);
+
+test(
+	"ESC during await_job ends the wait but leaves the real background process alive",
+	// End-to-end proof of the headline claim: a real OS subprocess (not a synthetic
+	// in-process job) must survive an aborted await_job. The await tool resolves on
+	// abort; we then confirm the child PID is still alive before cleaning it up.
+	{ skip: process.platform === "win32" ? "Unix-primary graceful semantics" : false, timeout: 20_000 },
+	async (t) => {
+		const dir = mkdtempSync(join(tmpdir(), "await-esc-alive-"));
+		const pidFile = join(dir, "pgid.pid");
+		const manager = new AsyncJobManager();
+		t.after(() => {
+			try {
+				const pgid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+				if (Number.isFinite(pgid) && pgid > 0) process.kill(-pgid, "SIGKILL");
+			} catch {
+				/* already gone */
+			}
+			manager.shutdown();
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		const asyncBash = createAsyncBashTool(() => manager, () => process.cwd());
+		const awaitJob = createAwaitTool(() => manager);
+
+		// Start a real 60s background process that records its process-group PID.
+		const started = await asyncBash.execute(
+			"tc-await-esc",
+			{ command: `echo $$ > '${pidFile}'; sleep 60`, label: "await-esc-sleeper" },
+			noopSignal,
+			() => {},
+			undefined as never,
+		);
+		const jobId = started.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n")
+			.match(/\*\*(bg_[a-f0-9]+)\*\*/)?.[1];
+		assert.ok(jobId, "expected a job id from async_bash");
+
+		// Give the child a moment to write its pidfile.
+		await new Promise((r) => setTimeout(r, 200));
+		const pgid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+		assert.ok(Number.isFinite(pgid) && pgid > 0, "child must record a valid pgid");
+		assert.equal(isAlive(pgid), true, "child should be alive before the await");
+
+		// await_job, then fire ESC (abort) ~100ms in. The wait must end promptly.
+		const ac = new AbortController();
+		const abortTimer = setTimeout(() => ac.abort(), 100);
+		if (typeof abortTimer === "object" && "unref" in abortTimer) (abortTimer as NodeJS.Timeout).unref();
+
+		const waitStart = Date.now();
+		const awaitResult = await awaitJob.execute("tc-await-esc-wait", { jobs: [jobId!] }, ac.signal, () => {}, undefined as never);
+		const elapsed = Date.now() - waitStart;
+		const awaitText = awaitResult.content.map((c: { type: string; text?: string }) => c.text ?? "").join("\n");
+
+		// (a) The wait ended promptly on ESC, not after the 120s default timeout.
+		assert.ok(elapsed < 5_000, `await should end promptly on ESC, took ${elapsed}ms`);
+		assert.match(awaitText, /interrupted/i, "aborted await should report the interruption");
+
+		// (b) The job and its real OS process are both STILL ALIVE — ESC ends the wait,
+		//     it does not kill the job.
+		assert.equal(manager.getJob(jobId!)!.status, "running", "job should still be running after ESC");
+		assert.equal(isAlive(pgid), true, "the real background process must survive an aborted await_job");
+	},
+);

--- a/src/resources/extensions/async-jobs/async-bash-tool.ts
+++ b/src/resources/extensions/async-jobs/async-bash-tool.ts
@@ -10,11 +10,14 @@ import type { ToolDefinition } from "@gsd/pi-coding-agent";
 import {
 	getShellConfig,
 	sanitizeCommand,
+	killProcessTree,
+	SIGKILL_GRACE_MS,
+	HARD_DEADLINE_MS,
 	DEFAULT_MAX_BYTES,
 	DEFAULT_MAX_LINES,
 } from "@gsd/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -37,29 +40,6 @@ function getTempFilePath(): string {
 	return join(tmpdir(), `pi-async-bash-${id}.log`);
 }
 
-/**
- * Kill a process and its children (cross-platform).
- * Uses process group kill on Unix; taskkill /F /T on Windows.
- */
-function killTree(pid: number): void {
-	if (process.platform === "win32") {
-		try {
-			spawnSync("taskkill", ["/F", "/T", "/PID", String(pid)], {
-				timeout: 5_000,
-				stdio: "ignore",
-			});
-		} catch {
-			try { process.kill(pid, "SIGTERM"); } catch { /* already exited */ }
-		}
-	} else {
-		try {
-			process.kill(-pid, "SIGTERM");
-		} catch {
-			try { process.kill(pid, "SIGTERM"); } catch { /* already exited */ }
-		}
-	}
-}
-
 export function createAsyncBashTool(
 	getManager: () => AsyncJobManager,
 	getCwd: () => string,
@@ -73,7 +53,7 @@ export function createAsyncBashTool(
 			`Output is truncated to the last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB.`,
 		promptSnippet: "Run a bash command in the background, returning a job ID immediately.",
 		promptGuidelines: [
-			"Use async_bash for commands that take more than a few seconds (builds, tests, installs, large git operations).",
+			"Use async_bash for long-running builds, tests, installs, or operations that should run in the background so you can continue other work (the job ID lets you await_job later). Sync bash is uncapped — use async_bash when you want non-blocking behavior, not because of a timeout concern.",
 			"After starting async jobs, continue with other work and use await_job when you need the results.",
 			"await_job has a configurable timeout (default 120s) to prevent indefinite blocking — if it times out, jobs keep running and you can check again later.",
 			"For long-running processes (SSH, deploys, training) that may take minutes+, prefer async_bash with periodic await_job polling over a single long await.",
@@ -138,39 +118,27 @@ function executeBashInBackground(
 
 		let timedOut = false;
 		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-		let sigkillHandle: ReturnType<typeof setTimeout> | undefined;
 		let hardDeadlineHandle: ReturnType<typeof setTimeout> | undefined;
-
-		/** Grace period (ms) between SIGTERM and SIGKILL. */
-		const SIGKILL_GRACE_MS = 5_000;
-		/** Hard deadline (ms) after SIGKILL to force-resolve the promise. */
-		const HARD_DEADLINE_MS = 3_000;
 
 		if (timeout !== undefined && timeout > 0) {
 			timeoutHandle = setTimeout(() => {
 				timedOut = true;
-				if (child.pid) killTree(child.pid);
+				// killProcessTree owns the SIGTERM -> grace -> SIGKILL escalation, so a
+				// SIGTERM-immune child is actually force-killed rather than left running.
+				if (child.pid) killProcessTree(child.pid);
 
-				// If the process ignores SIGTERM, escalate to SIGKILL
-				sigkillHandle = setTimeout(() => {
-					if (child.pid) {
-						// killTree already uses taskkill /F /T on Windows
-						killTree(child.pid);
-					}
-
-					// Hard deadline: if even SIGKILL doesn't trigger 'close',
-					// force-resolve so the job doesn't hang forever (#2186).
-					hardDeadlineHandle = setTimeout(() => {
-						const output = Buffer.concat(chunks).toString("utf-8");
-						safeResolve(
-							output
-								? `${output}\n\nCommand timed out after ${timeout} seconds (force-killed)`
-								: `Command timed out after ${timeout} seconds (force-killed)`,
-						);
-					}, HARD_DEADLINE_MS);
-					if (typeof hardDeadlineHandle === "object" && "unref" in hardDeadlineHandle) hardDeadlineHandle.unref();
-				}, SIGKILL_GRACE_MS);
-				if (typeof sigkillHandle === "object" && "unref" in sigkillHandle) sigkillHandle.unref();
+				// Hard deadline: a D-state (uninterruptible-I/O) child never emits 'close'
+				// even after SIGKILL, so force-resolve the promise rather than hang (#2186).
+				// Fires after the full grace window so SIGKILL has had its chance first.
+				hardDeadlineHandle = setTimeout(() => {
+					const output = Buffer.concat(chunks).toString("utf-8");
+					safeResolve(
+						output
+							? `${output}\n\nCommand timed out after ${timeout} seconds (force-killed)`
+							: `Command timed out after ${timeout} seconds (force-killed)`,
+					);
+				}, SIGKILL_GRACE_MS + HARD_DEADLINE_MS);
+				if (typeof hardDeadlineHandle === "object" && "unref" in hardDeadlineHandle) hardDeadlineHandle.unref();
 			}, timeout * 1000);
 		}
 
@@ -202,7 +170,18 @@ function executeBashInBackground(
 		if (child.stderr) child.stderr.on("data", onData);
 
 		const onAbort = () => {
-			if (child.pid) killTree(child.pid);
+			if (child.pid) killProcessTree(child.pid);
+			// Arm the same hard-deadline force-resolve the timeout path uses, so a
+			// cancelled D-state child (never emits 'close' even after SIGKILL) can't
+			// hang the job promise forever. safeResolve is idempotent, so the real
+			// 'close' still wins if the child does exit.
+			if (!hardDeadlineHandle) {
+				hardDeadlineHandle = setTimeout(() => {
+					const output = Buffer.concat(chunks).toString("utf-8");
+					safeResolve(output ? `${output}\n\nCommand aborted (force-killed)` : "Command aborted (force-killed)");
+				}, SIGKILL_GRACE_MS + HARD_DEADLINE_MS);
+				if (typeof hardDeadlineHandle === "object" && "unref" in hardDeadlineHandle) hardDeadlineHandle.unref();
+			}
 		};
 
 		if (signal.aborted) {
@@ -213,7 +192,6 @@ function executeBashInBackground(
 
 		child.on("error", (err) => {
 			if (timeoutHandle) clearTimeout(timeoutHandle);
-			if (sigkillHandle) clearTimeout(sigkillHandle);
 			if (hardDeadlineHandle) clearTimeout(hardDeadlineHandle);
 			signal.removeEventListener("abort", onAbort);
 			safeReject(err);
@@ -221,7 +199,6 @@ function executeBashInBackground(
 
 		child.on("close", (code) => {
 			if (timeoutHandle) clearTimeout(timeoutHandle);
-			if (sigkillHandle) clearTimeout(sigkillHandle);
 			if (hardDeadlineHandle) clearTimeout(hardDeadlineHandle);
 			signal.removeEventListener("abort", onAbort);
 			if (spillStream) spillStream.end();

--- a/src/resources/extensions/async-jobs/await-tool.test.ts
+++ b/src/resources/extensions/async-jobs/await-tool.test.ts
@@ -177,6 +177,145 @@ test("await_job suppresses follow-up for already-completed jobs (cross-turn case
 	manager.shutdown();
 });
 
+test("await_job aborts promptly when signal fires; job keeps running and is not suppressed", async () => {
+	const manager = new AsyncJobManager();
+	const tool = createAwaitTool(() => manager);
+
+	// Register a job that would run for 60s
+	const jobId = manager.register("bash", "long-job", async (_signal) => {
+		return new Promise<string>((resolve) => {
+			const timer = setTimeout(() => resolve("finally done"), 60_000);
+			if (typeof timer === "object" && "unref" in timer) timer.unref();
+		});
+	});
+
+	const ac = new AbortController();
+	// Abort after ~100ms
+	const abortTimer = setTimeout(() => ac.abort(), 100);
+	if (typeof abortTimer === "object" && "unref" in abortTimer) (abortTimer as NodeJS.Timeout).unref();
+
+	const start = Date.now();
+	const result = await tool.execute("tc_abort1", { jobs: [jobId], timeout: 60 }, ac.signal, () => {}, undefined as never);
+	const elapsed = Date.now() - start;
+	const text = getTextFromResult(result);
+
+	// Should abort quickly (within ~100ms + overhead), not wait for full timeout
+	assert.ok(elapsed < 5_000, `Expected abort in ~100ms but took ${elapsed}ms`);
+	assert.match(text, /interrupted/i);
+
+	// Job should still be running (not killed)
+	const job = manager.getJob(jobId)!;
+	assert.equal(job.status, "running", "Job should still be running after abort");
+	// Job should NOT be marked awaited — results must resurface later
+	assert.ok(!job.awaited, "Job should not be suppressed after abort");
+
+	// Cleanup
+	manager.cancel(jobId);
+	manager.shutdown();
+});
+
+test("after abort, a still-running job resurfaces via onJobComplete", async () => {
+	const followUps: string[] = [];
+	const manager = new AsyncJobManager({
+		onJobComplete: (job) => {
+			if (!job.awaited) followUps.push(job.id);
+		},
+	});
+	const tool = createAwaitTool(() => manager);
+
+	// Register a job that resolves after ~150ms
+	const jobId = manager.register("bash", "resurface-job", async () => {
+		return new Promise<string>((resolve) => {
+			const timer = setTimeout(() => resolve("done"), 150);
+			if (typeof timer === "object" && "unref" in timer) (timer as NodeJS.Timeout).unref();
+		});
+	});
+
+	const ac = new AbortController();
+	// Abort the await at ~50ms (before the job completes at ~150ms)
+	const abortTimer = setTimeout(() => ac.abort(), 50);
+	if (typeof abortTimer === "object" && "unref" in abortTimer) (abortTimer as NodeJS.Timeout).unref();
+
+	const result = await tool.execute("tc_abort2", { jobs: [jobId], timeout: 10 }, ac.signal, () => {}, undefined as never);
+	const text = getTextFromResult(result);
+	assert.match(text, /interrupted/i);
+
+	// Wait longer than the job's natural completion time (150ms) + delivery timer (0ms) + buffer
+	await new Promise((r) => setTimeout(r, 350));
+
+	// The job should have completed and the follow-up should have fired
+	// (because we did NOT suppress it on abort)
+	assert.ok(followUps.includes(jobId), `Expected job ${jobId} to resurface via onJobComplete, but got: ${followUps.join(", ")}`);
+
+	manager.shutdown();
+});
+
+test("await_job does not reprint a job whose follow-up was already delivered (no duplicate-in-context)", async () => {
+	// Real cross-turn timing: a job completes in a prior turn, its setTimeout(0)
+	// follow-up FIRES (delivered to context), and only THEN does await_job run in a
+	// later turn. The earlier #3787 test masked this by advancing with setImmediate,
+	// which races ahead of setTimeout(0); a real turn boundary does not. await_job
+	// must acknowledge the already-delivered job tersely instead of reprinting its
+	// full output (which would duplicate it in context).
+	const followUps: string[] = [];
+	const manager = new AsyncJobManager({
+		onJobComplete: (job) => {
+			if (!job.awaited) followUps.push(job.id);
+		},
+	});
+	const tool = createAwaitTool(() => manager);
+
+	const jobId = manager.register("bash", "already-delivered-job", async () => "THE_RESULT_TEXT");
+	await manager.getJob(jobId)!.promise;
+
+	// Real macrotask gap — generously long so the setTimeout(0) delivery fires even
+	// if the CI event loop is briefly starved (a tight 25ms could race the precondition).
+	await new Promise((r) => setTimeout(r, 100));
+	assert.equal(followUps.length, 1, "follow-up should have been delivered before the later-turn await_job");
+
+	const result = await tool.execute("tc_dup", { jobs: [jobId] }, noopSignal, () => {}, undefined as never);
+	const text = getTextFromResult(result);
+
+	// The full output must NOT be reprinted (it is already in context via the follow-up).
+	assert.ok(
+		!text.includes("THE_RESULT_TEXT"),
+		`await_job must not reprint already-delivered output, got:\n${text}`,
+	);
+	// It should still acknowledge the job so the agent knows the wait resolved.
+	assert.match(text, /already-delivered-job/);
+	// Single already-delivered job must use grammatical singular wording, not
+	// the plural form (regression: "These job ... their results ... they completed").
+	assert.match(text, /This job already finished and its result was shown above when it completed/);
+	assert.doesNotMatch(text, /These job\b/);
+
+	manager.shutdown();
+});
+
+test("await_job still renders full output for a job consumed within the same turn (not yet delivered)", async () => {
+	// Within-turn case: await_job wins the race against the delivery timer, so the
+	// follow-up is suppressed and never delivered. Here await_job IS the only place
+	// the result surfaces, so it must render the full output.
+	const followUps: string[] = [];
+	const manager = new AsyncJobManager({
+		onJobComplete: (job) => {
+			if (!job.awaited) followUps.push(job.id);
+		},
+	});
+	const tool = createAwaitTool(() => manager);
+
+	const jobId = manager.register("bash", "within-turn-job", async () => {
+		return new Promise<string>((resolve) => setTimeout(() => resolve("WITHIN_TURN_OUTPUT"), 40));
+	});
+
+	const result = await tool.execute("tc_within", { jobs: [jobId] }, noopSignal, () => {}, undefined as never);
+	const text = getTextFromResult(result);
+
+	assert.equal(followUps.length, 0, "within-turn await must suppress the follow-up");
+	assert.match(text, /WITHIN_TURN_OUTPUT/, "within-turn await must render the full output inline");
+
+	manager.shutdown();
+});
+
 test("unawaited jobs still get follow-up delivery (#2248)", async () => {
 	const followUps: string[] = [];
 	const manager = new AsyncJobManager({

--- a/src/resources/extensions/async-jobs/await-tool.ts
+++ b/src/resources/extensions/async-jobs/await-tool.ts
@@ -33,7 +33,7 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 		description:
 			"Wait for background jobs to complete. Provide specific job IDs or omit to wait for the next job that finishes. Returns results of completed jobs.",
 		parameters: schema,
-		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+		async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
 			const manager = getManager();
 			const { jobs: jobIds, timeout } = params;
 			const timeoutMs = ((timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000);
@@ -66,41 +66,79 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 				}
 			}
 
-			// Suppress follow-up notifications for all watched jobs upfront.
+			// If all watched jobs are already done, suppress follow-up and return immediately.
 			// suppressFollowUp() cancels the pending delivery timer (if any), which
 			// handles both the within-turn case (job completes while we await) and
 			// the cross-turn case (job already completed before await_job was called).
 			// Previously this only set j.awaited = true, which missed the cross-turn
 			// case because the queueMicrotask had already fired (#3787).
-			for (const j of watched) manager.suppressFollowUp(j.id);
-
-			// If all watched jobs are already done, return immediately
 			const running = watched.filter((j) => j.status === "running");
 			if (running.length === 0) {
-				const result = formatResults(watched);
-				return { content: [{ type: "text", text: result }], details: undefined };
+				for (const j of watched) manager.suppressFollowUp(j.id);
+				return { content: [{ type: "text", text: renderCompleted(watched) }], details: undefined };
 			}
 
-			// Wait for at least one to complete, or timeout
+			// Wait for at least one to complete, timeout, or abort signal
 			const TIMEOUT_SENTINEL = Symbol("timeout");
+			const ABORT_SENTINEL = Symbol("abort");
+
+			// The race timer and abort listener are explicitly torn down once the race
+			// settles (below) so a completion- or timeout-won race never leaks a pending
+			// timer or a lingering abort listener — the listener holds a closure over the
+			// race resolver, so { once: true } alone (which only detaches on fire) is not
+			// enough when ESC never happens.
+			let raceTimer: ReturnType<typeof setTimeout> | undefined;
+			let abortListener: (() => void) | undefined;
 			const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
-				const timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
+				raceTimer = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
 				// Allow the process to exit even if the timer is pending
-				if (typeof timer === "object" && "unref" in timer) timer.unref();
+				if (typeof raceTimer === "object" && "unref" in raceTimer) raceTimer.unref();
+			});
+
+			const abortPromise = new Promise<typeof ABORT_SENTINEL>((resolve) => {
+				if (!signal || signal.aborted) {
+					resolve(ABORT_SENTINEL);
+				} else {
+					abortListener = () => resolve(ABORT_SENTINEL);
+					signal.addEventListener("abort", abortListener, { once: true });
+				}
 			});
 
 			const raceResult = await Promise.race([
 				Promise.race(running.map((j) => j.promise)).then(() => "completed" as const),
 				timeoutPromise,
+				abortPromise,
 			]);
 
+			// Tear down race resources now that a winner is decided.
+			if (raceTimer) clearTimeout(raceTimer);
+			if (abortListener && signal) signal.removeEventListener("abort", abortListener);
+
+			const aborted = raceResult === ABORT_SENTINEL;
 			const timedOut = raceResult === TIMEOUT_SENTINEL;
 
 			// Collect all completed results (more may have finished while waiting)
 			const completed = watched.filter((j) => j.status !== "running");
-
 			const stillRunning = watched.filter((j) => j.status === "running");
-			let result = formatResults(completed);
+
+			// Suppress follow-up ONLY for completed jobs — leave stillRunning unsuppressed
+			// so deliverResult/onJobComplete can resurface their results later.
+			for (const j of completed) manager.suppressFollowUp(j.id);
+
+			if (aborted) {
+				// ESC ended the wait, not the jobs: still-running jobs keep going and
+				// resurface via onJobComplete (they were deliberately not suppressed above).
+				const runningDesc = stillRunning.map((j) => `${j.id} (${j.label})`).join(", ");
+				const interrupt = stillRunning.length > 0
+					? `Wait interrupted. Still running: ${runningDesc} — results will surface when complete.`
+					: "Wait interrupted.";
+				const text = completed.length > 0
+					? `${renderCompleted(completed)}\n\n${interrupt}`
+					: interrupt;
+				return { content: [{ type: "text", text }], details: undefined };
+			}
+
+			let result = renderCompleted(completed);
 			if (stillRunning.length > 0) {
 				result += `\n\n**Still running:** ${stillRunning.map((j) => `${j.id} (${j.label})`).join(", ")}`;
 			}
@@ -113,6 +151,38 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 			return { content: [{ type: "text", text: result }], details: undefined };
 		},
 	};
+}
+
+/**
+ * Render completed jobs for the await_job result, de-duplicating against
+ * follow-ups that have already been delivered to context.
+ *
+ * A job's follow-up fires ~immediately (setTimeout(0)) once it settles, so when
+ * await_job runs in a LATER turn the result is already in context. Reprinting it
+ * inline produces the same output twice. Jobs already `delivered` are therefore
+ * acknowledged on a single line instead of having their full output reprinted;
+ * not-yet-delivered jobs (the within-turn case, where suppressFollowUp won the
+ * race) are rendered in full as before.
+ */
+function renderCompleted(jobs: Job[]): string {
+	if (jobs.length === 0) return "No completed jobs.";
+
+	const fresh = jobs.filter((j) => !j.delivered);
+	const alreadyDelivered = jobs.filter((j) => j.delivered);
+
+	const sections: string[] = [];
+	if (fresh.length > 0) sections.push(formatResults(fresh));
+	if (alreadyDelivered.length > 0) {
+		const names = alreadyDelivered
+			.map((j) => `${j.id} (${j.label})`)
+			.join(", ");
+		const sentence =
+			alreadyDelivered.length === 1
+				? `This job already finished and its result was shown above when it completed, so there is nothing new to report: ${names}.`
+				: `These jobs already finished and their results were shown above when they completed, so there is nothing new to report: ${names}.`;
+		sections.push(sentence);
+	}
+	return sections.join("\n\n");
 }
 
 function formatResults(jobs: Job[]): string {

--- a/src/resources/extensions/async-jobs/index.ts
+++ b/src/resources/extensions/async-jobs/index.ts
@@ -117,10 +117,89 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 				return;
 			}
 
+			const ctx = _ctx;
 			const running = manager.getRunningJobs();
 			const recent = manager.getRecentJobs(10);
 			const completed = recent.filter((j) => j.status !== "running");
 
+			// Interactive kill-picker when there are running jobs and a UI is available
+			if (running.length > 0 && ctx.hasUI) {
+				// Kill-picker loop: each iteration shows live running jobs.
+				// Step 1 picks a job (neutral label — selecting does NOT cancel yet);
+				// step 2 confirms before the destructive cancel. Labels deliberately
+				// omit a live elapsed time: ctx.ui.select renders the option strings
+				// once and never refreshes them, so a "(24s)" baked into the label
+				// would freeze and mislead. Accurate elapsed times are shown in the
+				// post-picker summary (rebuilt fresh) instead.
+				const DONE = "Close";
+				while (true) {
+					const liveJobs = manager.getRunningJobs();
+					if (liveJobs.length === 0) break;
+
+					// Map display label -> job id so we never parse ids back out of
+					// free-form label text.
+					const labelToId = new Map<string, string>();
+					for (const j of liveJobs) {
+						labelToId.set(`${j.id} — ${j.label} (running)`, j.id);
+					}
+					const options = [...labelToId.keys(), DONE];
+
+					const choice = await ctx.ui.select(
+						"Background jobs — pick one to cancel, Escape to close",
+						options,
+					);
+
+					// ESC returns undefined; headless may return string[]; DONE closes
+					if (!choice || typeof choice !== "string" || choice === DONE) break;
+
+					const id = labelToId.get(choice);
+					if (!id) break;
+
+					const job = liveJobs.find((j) => j.id === id);
+					const confirmed = await ctx.ui.confirm(
+						"Cancel background job?",
+						`This will stop ${id}${job ? ` — ${job.label}` : ""}. Other jobs keep running.`,
+					);
+					if (!confirmed) continue;
+
+					const r = manager.cancel(id);
+					ctx.ui.notify(
+						r === "cancelled" ? `Job ${id} cancelled.` : `Job ${id}: ${r}`,
+						r === "cancelled" ? "success" : "warning",
+					);
+				}
+
+				// After picker, send a summary of any still-running jobs
+				const stillRunning = manager.getRunningJobs();
+				const summaryLines: string[] = ["## Background Jobs"];
+				if (stillRunning.length > 0) {
+					summaryLines.push("", "### Running");
+					for (const job of stillRunning) {
+						const elapsed = ((Date.now() - job.startTime) / 1000).toFixed(0);
+						summaryLines.push(`- **${job.id}** — ${job.label} (${elapsed}s)`);
+					}
+				}
+				const recentCompleted = manager.getRecentJobs(10).filter((j) => j.status !== "running");
+				if (recentCompleted.length > 0) {
+					summaryLines.push("", "### Recent");
+					for (const job of recentCompleted) {
+						const elapsed = ((Date.now() - job.startTime) / 1000).toFixed(1);
+						summaryLines.push(`- **${job.id}** — ${job.label} (${job.status}, ${elapsed}s)`);
+					}
+				}
+				if (stillRunning.length === 0 && recentCompleted.length === 0) {
+					summaryLines.push("", "No background jobs.");
+				}
+
+				pi.sendMessage({
+					customType: "async_jobs_list",
+					content: summaryLines.join("\n"),
+					display: true,
+				});
+				return;
+			}
+
+			// Text-only display: headless/RPC mode, or no running jobs
 			const lines: string[] = ["## Background Jobs"];
 
 			if (running.length === 0 && completed.length === 0) {

--- a/src/resources/extensions/async-jobs/job-manager.ts
+++ b/src/resources/extensions/async-jobs/job-manager.ts
@@ -25,6 +25,14 @@ export interface Job {
 	/** Set by await_job when results are consumed. Suppresses follow-up delivery. */
 	awaited?: boolean;
 	/**
+	 * Set true once the follow-up notification has actually been delivered via
+	 * onJobComplete. The delivery timer fires ~immediately (setTimeout(0)) after a
+	 * job settles, so by a later LLM turn the follow-up is already in context.
+	 * await_job reads this to avoid rendering the same result inline a second time
+	 * (duplicate-in-context bug): a delivered job is acknowledged tersely, not reprinted.
+	 */
+	delivered?: boolean;
+	/**
 	 * Handle for the pending follow-up delivery timer (set by deliverResult).
 	 * Stored so suppressFollowUp() can cancel it before the notification fires,
 	 * even when await_job is called after the job has already completed (#3787).
@@ -102,6 +110,15 @@ export class AsyncJobManager {
 
 		job.promise = runFn(abortController.signal)
 			.then((resultText) => {
+				if (job.status === "cancelled") {
+					// Already cancelled by cancel(). The runFn resolves (not rejects) even
+					// when aborted — async_bash's safeResolve returns "Command aborted"
+					// rather than throwing — so without this guard the status would be
+					// clobbered back to "completed", mislabeling a user-cancelled job.
+					// Mirrors the symmetric guard in the .catch branch below.
+					this.scheduleEviction(id);
+					return;
+				}
 				job.status = "completed";
 				job.resultText = resultText;
 				this.scheduleEviction(id);
@@ -200,7 +217,10 @@ export class AsyncJobManager {
 		const cb = this.onJobComplete;
 		job.deliveryTimer = setTimeout(() => {
 			job.deliveryTimer = undefined;
-			if (!job.awaited) cb(job);
+			if (!job.awaited) {
+				job.delivered = true;
+				cb(job);
+			}
 		}, 0);
 		// Allow process to exit even if timer is pending
 		if (typeof job.deliveryTimer === "object" && "unref" in job.deliveryTimer) {

--- a/src/resources/extensions/bg-shell/bg-shell-command.ts
+++ b/src/resources/extensions/bg-shell/bg-shell-command.ts
@@ -8,7 +8,7 @@ import { shortcutDesc } from "../shared/terminal.js";
 
 import {
 	processes,
-	killProcess,
+	terminateProcess,
 	getGroupStatus,
 	cleanupAll,
 } from "./process-manager.js";
@@ -150,11 +150,11 @@ export function registerBgShellCommand(pi: ExtensionAPI, state: BgShellSharedSta
 					ctx.ui.notify(`No process with id '${id}'`, "error");
 					return;
 				}
-				killProcess(id, "SIGTERM");
-				await new Promise(r => setTimeout(r, 300));
-				if (bg.alive) {
-					killProcess(id, "SIGKILL");
-					await new Promise(r => setTimeout(r, 200));
+				// Graceful ladder (SIGTERM → grace → SIGKILL) via killProcessTree.
+				terminateProcess(id);
+				const deadline = Date.now() + 6_000; // grace (5s) + slack
+				while (bg.alive && Date.now() < deadline) {
+					await new Promise(r => setTimeout(r, 100));
 				}
 				if (!bg.alive) processes.delete(id);
 				ctx.ui.notify(`Killed process ${id} (${bg.label})`, "info");

--- a/src/resources/extensions/bg-shell/bg-shell-tool.ts
+++ b/src/resources/extensions/bg-shell/bg-shell-tool.ts
@@ -12,6 +12,7 @@ import {
 	processes,
 	startProcess,
 	killProcess,
+	terminateProcess,
 	restartProcess,
 	getInfo,
 	getGroupStatus,
@@ -44,7 +45,8 @@ export function registerBgShellTool(pi: ExtensionAPI, state: BgShellSharedState)
 			"group_status (health of a process group), highlights (significant output lines only).",
 
 		promptGuidelines: [
-			"Use bg_shell to start long-running processes (servers, watchers, builds) that should not block the agent.",
+			"Use bg_shell for processes that STAY ALIVE and you interact with over time: servers, watchers, daemons, REPLs. For a command that runs to completion and exits (terraform apply, migrations, builds, tests, installs), use async_bash or sync bash instead — NOT bg_shell.",
+			"'wait_for_ready' is for long-lived processes that signal readiness (open a port / print a pattern). Never use it on a run-to-completion command: that command exits instead of becoming ready, so a clean exit-0 is reported as 'not ready'. If you see that, switch to async_bash.",
 			"After starting a server, use 'wait_for_ready' to efficiently block until it's listening — avoids polling loops entirely.",
 			"Use 'digest' instead of 'output' when you just need status — it returns a structured ~30-token summary instead of ~2000 tokens of raw output.",
 			"Use 'highlights' to see only significant output (errors, URLs, results) — typically 5-15 lines instead of hundreds.",
@@ -615,11 +617,13 @@ export function registerBgShellTool(pi: ExtensionAPI, state: BgShellSharedState)
 						};
 					}
 
-					const killed = killProcess(params.id, "SIGTERM");
-					await new Promise(r => setTimeout(r, 300));
-					if (bg.alive) {
-						killProcess(params.id, "SIGKILL");
-						await new Promise(r => setTimeout(r, 200));
+					// Graceful termination: SIGTERM → grace → SIGKILL via the shared
+					// killProcessTree ladder (same path bash/async_bash/exec use), so a
+					// stateful process gets a clean-shutdown window instead of a bare kill.
+					const killed = terminateProcess(params.id);
+					const deadline = Date.now() + 6_000; // grace (5s) + slack
+					while (bg.alive && Date.now() < deadline) {
+						await new Promise(r => setTimeout(r, 100));
 					}
 
 					const info = getInfo(bg);

--- a/src/resources/extensions/bg-shell/overlay.ts
+++ b/src/resources/extensions/bg-shell/overlay.ts
@@ -9,7 +9,7 @@ import { ERROR_PATTERNS, WARNING_PATTERNS } from "./types.js";
 import { formatUptime, formatTimeAgo } from "./utilities.js";
 import {
 	processes,
-	killProcess,
+	terminateProcess,
 	cleanupAll,
 	restartProcess,
 } from "./process-manager.js";
@@ -134,16 +134,20 @@ export class BgManagerOverlay {
 			return;
 		}
 
-		// x or d = kill selected
+		// x or d = kill selected (graceful ladder via killProcessTree).
+		// Use a short interactive grace: the user explicitly asked to kill, so give the
+		// process a brief clean-shutdown window then force, and re-render AFTER that grace
+		// plus slack so the row reflects the SIGKILL escalation (a 300ms re-render against
+		// the default 5s grace would show the process still alive).
 		if (data === "x" || data === "d") {
 			const proc = procs[this.selected];
 			if (proc && proc.alive) {
-				killProcess(proc.id, "SIGTERM");
+				const OVERLAY_KILL_GRACE_MS = 500;
+				terminateProcess(proc.id, OVERLAY_KILL_GRACE_MS);
 				setTimeout(() => {
-					if (proc.alive) killProcess(proc.id, "SIGKILL");
 					this.invalidate();
 					this.tui.requestRender();
-				}, 300);
+				}, OVERLAY_KILL_GRACE_MS + 400);
 			}
 			return;
 		}

--- a/src/resources/extensions/bg-shell/process-manager.ts
+++ b/src/resources/extensions/bg-shell/process-manager.ts
@@ -7,7 +7,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { getShellConfig, sanitizeCommand } from "@gsd/pi-coding-agent";
+import { getShellConfig, sanitizeCommand, killProcessTree } from "@gsd/pi-coding-agent";
 import { rewriteCommandWithRtk } from "../shared/rtk.js";
 import type {
 	BgProcess,
@@ -259,6 +259,34 @@ export function startProcess(opts: StartOptions): BgProcess {
 
 // ── Process Kill ───────────────────────────────────────────────────────────
 
+/**
+ * Gracefully terminate a process and its tree using the shared killProcessTree
+ * ladder (SIGTERM → grace window → SIGKILL), the same path bash/async_bash/exec
+ * use. This is the "I want it dead, cleanly" intent — use it for the `kill`
+ * action, `restart`, and session cleanup. For sending a SPECIFIC signal the
+ * agent chose on purpose (SIGINT, SIGHUP, …) use killProcess(), which delivers
+ * that exact signal once and does not escalate.
+ *
+ * `graceMs` overrides the SIGTERM→SIGKILL window (default: killProcessTree's 5s);
+ * session cleanup passes a shorter grace so it stays snappy between units.
+ *
+ * Returns false only when the process is unknown/already dead; the actual
+ * SIGKILL escalation fires asynchronously after the grace window, so callers
+ * should not assume the process is dead the instant this returns.
+ */
+export function terminateProcess(id: string, graceMs?: number): boolean {
+	const bg = processes.get(id);
+	if (!bg) return false;
+	if (!bg.alive) return true;
+	if (!bg.proc.pid) {
+		// No pid to target a tree; fall back to a direct graceful signal.
+		try { bg.proc.kill("SIGTERM"); } catch { /* already gone */ }
+		return true;
+	}
+	killProcessTree(bg.proc.pid, graceMs !== undefined ? { graceMs } : undefined);
+	return true;
+}
+
 export function killProcess(id: string, sig: NodeJS.Signals = "SIGTERM"): boolean {
 	const bg = processes.get(id);
 	if (!bg) return false;
@@ -306,13 +334,14 @@ export async function restartProcess(id: string): Promise<BgProcess | null> {
 	const config = old.startConfig;
 	const restartCount = old.restartCount + 1;
 
-	// Kill old process
+	// Kill old process via the graceful ladder, then wait for it to actually die.
+	// killProcessTree escalates SIGTERM → grace → SIGKILL asynchronously, so poll
+	// for death rather than assuming a fixed sleep is enough.
 	if (old.alive) {
-		killProcess(id, "SIGTERM");
-		await new Promise(r => setTimeout(r, 300));
-		if (old.alive) {
-			killProcess(id, "SIGKILL");
-			await new Promise(r => setTimeout(r, 200));
+		terminateProcess(id);
+		const deadline = Date.now() + 6_000; // grace (5s) + slack
+		while (old.alive && Date.now() < deadline) {
+			await new Promise(r => setTimeout(r, 100));
 		}
 	}
 	processes.delete(id);
@@ -374,23 +403,14 @@ export function pruneDeadProcesses(): void {
 }
 
 export function cleanupAll(): void {
+	// Deliberately a bare, synchronous SIGKILL — not the graceful ladder. This runs
+	// from process 'exit'/signal handlers where timers no longer fire, so a deferred
+	// SIGKILL would never be delivered and children would be orphaned when we vanish.
+	// Immediate force-kill is the correct teardown semantics here.
 	for (const [id, bg] of processes) {
 		if (bg.alive) killProcess(id, "SIGKILL");
 	}
 	processes.clear();
-}
-
-/**
- * Kill all alive, non-persistent bg processes.
- * Called between auto-mode units to prevent orphaned servers from
- * keeping ports bound across task boundaries (#1209).
- */
-export function killSessionProcesses(): void {
-	for (const [id, bg] of processes) {
-		if (bg.alive && !bg.persistAcrossSessions) {
-			killProcess(id, "SIGTERM");
-		}
-	}
 }
 
 async function waitForProcessExit(bg: BgProcess, timeoutMs: number): Promise<boolean> {
@@ -406,6 +426,13 @@ async function waitForProcessExit(bg: BgProcess, timeoutMs: number): Promise<boo
 	return !bg.alive;
 }
 
+/**
+ * Terminate the alive, non-persistent processes owned by a session, gracefully.
+ * Routes through the shared killProcessTree ladder (SIGTERM → grace → SIGKILL)
+ * via terminateProcess, with a short grace (default 300ms) so cleanup between
+ * units stays snappy; killProcessTree handles the SIGKILL escalation itself, so
+ * there is no separate force-kill pass here.
+ */
 export async function cleanupSessionProcesses(
 	sessionFile: string,
 	options?: { graceMs?: number },
@@ -417,13 +444,11 @@ export async function cleanupSessionProcesses(
 	if (matches.length === 0) return [];
 
 	for (const bg of matches) {
-		killProcess(bg.id, "SIGTERM");
+		terminateProcess(bg.id, graceMs);
 	}
 	if (graceMs > 0) {
-		await Promise.all(matches.map((bg) => waitForProcessExit(bg, graceMs)));
-	}
-	for (const bg of matches) {
-		if (bg.alive) killProcess(bg.id, "SIGKILL");
+		// Wait past the grace so the SIGKILL escalation has fired and exits are observed.
+		await Promise.all(matches.map((bg) => waitForProcessExit(bg, graceMs + 200)));
 	}
 	return matches.map((bg) => bg.id);
 }

--- a/src/resources/extensions/bg-shell/readiness-detector.ts
+++ b/src/resources/extensions/bg-shell/readiness-detector.ts
@@ -87,6 +87,18 @@ export async function waitForReady(bg: BgProcess, timeout: number, signal?: Abor
 			return { ready: false, detail: "Cancelled" };
 		}
 		if (!bg.alive) {
+			// A clean exit-0 means the command ran to completion — it was a batch
+			// command (e.g. terraform apply, a migration, a build), not a long-lived
+			// server. That is success, not a readiness failure; say so plainly and
+			// point at the right tool so the agent stops using wait_for_ready here.
+			if (bg.exitCode === 0) {
+				return {
+					ready: false,
+					detail:
+						"Process completed (exit 0) before signaling readiness — it ran to completion rather than staying alive. " +
+						"wait_for_ready is for long-lived servers/watchers; for a run-to-completion command use async_bash (or bg_shell 'run').",
+				};
+			}
 			const stderrLines = bg.output.filter(l => l.stream === "stderr").slice(-5).map(l => l.line);
 			const stderrContext = stderrLines.length > 0 ? `\nstderr:\n${stderrLines.join("\n").slice(0, 500)}` : "";
 			return {

--- a/src/resources/extensions/bg-shell/tests/lifecycle-and-utilities.test.ts
+++ b/src/resources/extensions/bg-shell/tests/lifecycle-and-utilities.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import type { BgProcess } from "../types.ts";
-import { detectProcessType } from "../process-manager.ts";
+import { detectProcessType, startProcess, terminateProcess, processes } from "../process-manager.ts";
 import { waitForReady } from "../readiness-detector.ts";
 import {
   formatTimeAgo,
@@ -108,6 +108,18 @@ describe("bg-shell waitForReady", () => {
     assert.match(result.detail, /137/);
   });
 
+  test("a clean exit-0 reads as completion, not a crash, and points at the right tool", async () => {
+    // Regression: a run-to-completion batch command (e.g. terraform apply) put
+    // under wait_for_ready exits 0 on success. It must NOT be framed as a crash;
+    // it should say it completed and steer toward async_bash.
+    const bg = makeBg({ alive: false, exitCode: 0 });
+    const result = await waitForReady(bg, 1000);
+    assert.equal(result.ready, false);
+    assert.match(result.detail, /completed \(exit 0\)/);
+    assert.match(result.detail, /async_bash/);
+    assert.doesNotMatch(result.detail, /exited before becoming ready/);
+  });
+
   test("reports failure when the process entered an error state", async () => {
     const bg = makeBg({ status: "error", readyPort: 5173 });
     const result = await waitForReady(bg, 1000);
@@ -203,4 +215,39 @@ describe("bg-shell resolveBgShellPersistenceCwd", () => {
     );
     assert.equal(result, "/proj/.gsd/worktrees/feature-b");
   });
+});
+
+describe("bg-shell terminateProcess (graceful kill ladder)", () => {
+  test(
+    "force-kills a SIGTERM-immune process via the shared killProcessTree ladder",
+    { skip: process.platform === "win32" ? "Unix-primary graceful semantics" : false, timeout: 15_000 },
+    async (t) => {
+      // A process that ignores SIGTERM must still die — terminateProcess routes
+      // through killProcessTree, which escalates SIGTERM → grace → SIGKILL. A bare
+      // single-signal kill (the old behavior) would have left this running.
+      const bg = startProcess({
+        command: "trap '' TERM; while true; do sleep 1; done",
+        cwd: "/tmp",
+        label: "sigterm-immune",
+        type: "generic",
+      });
+      t.after(() => {
+        try { if (bg.proc.pid) process.kill(-bg.proc.pid, "SIGKILL"); } catch { /* gone */ }
+        processes.delete(bg.id);
+      });
+
+      // Let the trap install.
+      await new Promise((r) => setTimeout(r, 300));
+      assert.equal(bg.alive, true, "process should be alive before terminate");
+
+      terminateProcess(bg.id);
+
+      // SIGKILL fires after the 5s grace; poll up to grace + slack.
+      const deadline = Date.now() + 9_000;
+      while (bg.alive && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      assert.equal(bg.alive, false, "SIGTERM-immune process must be SIGKILLed via the ladder, not left running");
+    },
+  );
 });

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { createBashTool, createEditTool, createReadTool, createWriteTool } from "@gsd/pi-coding-agent";
 
-import { DEFAULT_BASH_TIMEOUT_SECS } from "../constants.js";
 import { logWarning } from "../workflow-logger.js";
 import { openWorkflowDatabase } from "../db-workspace.js";
 import { getAutoWorktreePath } from "../auto-worktree.js";
@@ -87,8 +86,30 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
   const baseBash = createBashTool(fallbackRoot, {
     spawnHook: (ctx) => ctx,
   });
+  // The auto-mode stalled-tool watchdog only exists in GSD/auto-mode, so the
+  // watchdog verbiage is injected here (the GSD-registered tool) rather than in
+  // core bash.ts, which is reused by non-GSD embeddings that have no watchdog.
+  const WATCHDOG_DETAIL =
+    "Genuine hangs are caught by the auto-mode stalled-tool watchdog (stalled: 5m / idle: 10m / soft: 20m / hard: 30m).";
+  const gsdBashDescription = `${(baseBash as any).description} ${WATCHDOG_DETAIL}`;
+  const gsdBashParameters = (() => {
+    const params: any = (baseBash as any).parameters;
+    if (!params?.properties?.timeout) return params;
+    return {
+      ...params,
+      properties: {
+        ...params.properties,
+        timeout: {
+          ...params.properties.timeout,
+          description: `${params.properties.timeout.description} ${WATCHDOG_DETAIL}`,
+        },
+      },
+    };
+  })();
   const dynamicBash = {
     ...baseBash,
+    description: gsdBashDescription,
+    parameters: gsdBashParameters,
     execute: async (
       toolCallId: string,
       params: { command: string; timeout?: number },
@@ -100,11 +121,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
       const fresh = createBashTool(basePath, {
         spawnHook: (spawnCtx) => ({ ...spawnCtx, cwd: basePath }),
       });
-      const paramsWithTimeout = {
-        ...params,
-        timeout: params.timeout ?? DEFAULT_BASH_TIMEOUT_SECS,
-      };
-      return (fresh as any).execute(toolCallId, paramsWithTimeout, signal, onUpdate, ctx);
+      return (fresh as any).execute(toolCallId, params, signal, onUpdate, ctx);
     },
   };
   pi.registerTool(dynamicBash as any);

--- a/src/resources/extensions/gsd/constants.ts
+++ b/src/resources/extensions/gsd/constants.ts
@@ -9,9 +9,6 @@
 /** Default timeout for verification-gate commands (ms). */
 export const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
-/** Default timeout for the dynamic bash tool (seconds). */
-export const DEFAULT_BASH_TIMEOUT_SECS = 120;
-
 // ─── Cache Sizes ──────────────────────────────────────────────────────────────
 
 /** Max directory-listing cache entries before eviction (#611). */

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -12,6 +12,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
+import { killProcessTree, SIGKILL_GRACE_MS, HARD_DEADLINE_MS } from "@gsd/pi-coding-agent";
 
 export interface ExecSandboxRequest {
   /** Interpreter to use. */
@@ -47,6 +48,17 @@ export interface ExecSandboxOptions {
   now?: () => Date;
   /** Optional override for id generation (tests). */
   generateId?: () => string;
+  /**
+   * Grace period (ms) between SIGTERM and SIGKILL on timeout.
+   * Defaults to SIGKILL_GRACE_MS. Exposed as a test seam.
+   */
+  kill_grace_ms?: number;
+  /**
+   * Delay (ms) after a kill is initiated before the hard-deadline force-resolves
+   * the promise (handles D-state / non-closing children).
+   * Defaults to SIGKILL_GRACE_MS + HARD_DEADLINE_MS. Exposed as a test seam.
+   */
+  force_resolve_delay_ms?: number;
 }
 
 export interface ExecSandboxResult {
@@ -55,6 +67,12 @@ export interface ExecSandboxResult {
   exit_code: number | null;
   signal: NodeJS.Signals | null;
   timed_out: boolean;
+  /**
+   * True when the result came from the hard-deadline force-resolve (a non-closing
+   * D-state child that never emitted 'close') rather than an observed process exit.
+   * In that case `signal` is the synthetic "SIGKILL" marker, not a delivered signal.
+   */
+  force_resolved: boolean;
   duration_ms: number;
   stdout_bytes: number;
   stderr_bytes: number;
@@ -67,6 +85,10 @@ export interface ExecSandboxResult {
 }
 
 const ALWAYS_FORWARD_ENV = ["PATH", "HOME"] as const;
+
+// SIGKILL_GRACE_MS / HARD_DEADLINE_MS are imported from @gsd/pi-coding-agent
+// (shell.ts) — the single source of truth for the graceful-kill timing ladder —
+// so this sandbox can never drift from the canonical kill path it delegates to.
 
 export const EXEC_DEFAULTS = {
   clampTimeoutMs: 600_000,
@@ -180,6 +202,7 @@ export function runExecSandbox(
         exit_code: null,
         signal: null,
         timed_out: false,
+        force_resolved: false,
         duration_ms: duration,
         stdout_bytes: 0,
         stderr_bytes: Buffer.byteLength(`spawn error: ${message}\n`),
@@ -233,23 +256,39 @@ export function runExecSandbox(
       }
     });
 
+    const effectiveGraceMs = opts.kill_grace_ms ?? SIGKILL_GRACE_MS;
+    const effectiveForceResolveDelay = opts.force_resolve_delay_ms ?? (effectiveGraceMs + HARD_DEADLINE_MS);
+
     let timedOut = false;
+    let settled = false;
+    let forceResolveTimer: NodeJS.Timeout | undefined;
+
     const timer = setTimeout(() => {
       timedOut = true;
-      if (useProcessGroup && child.pid != null) {
-        try {
-          process.kill(-child.pid, "SIGKILL");
-        } catch {
-          child.kill("SIGKILL");
-        }
+      // killProcessTree handles both platforms and kills the whole tree: on Unix
+      // it signals the process group (SIGTERM -> grace -> SIGKILL); on Windows it
+      // force-kills the tree via taskkill /F /T. Using child.kill("SIGTERM") here
+      // would only terminate the direct child on Windows, orphaning grandchildren.
+      if (child.pid != null) {
+        killProcessTree(child.pid, { graceMs: effectiveGraceMs });
       } else {
-        child.kill("SIGKILL");
+        child.kill("SIGTERM");
       }
+      // Arm hard-deadline force-resolve in case child never closes (D-state).
+      // The "SIGKILL" here is a synthetic marker (the process may not have actually
+      // received it); force_resolved=true records that this was a deadline, not an exit.
+      forceResolveTimer = setTimeout(() => {
+        finalize(null, "SIGKILL", true);
+      }, effectiveForceResolveDelay);
+      forceResolveTimer.unref?.();
     }, timeoutMs);
     timer.unref?.();
 
-    const finalize = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+    const finalize = (exitCode: number | null, signal: NodeJS.Signals | null, forceResolved = false) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
+      clearTimeout(forceResolveTimer);
       const duration = Date.now() - started;
       const stdoutBuf = Buffer.concat(stdoutChunks);
       const stderrBuf = Buffer.concat(stderrChunks);
@@ -274,6 +313,7 @@ export function runExecSandbox(
         exit_code: exitCode,
         signal,
         timed_out: timedOut,
+        force_resolved: forceResolved,
         duration_ms: duration,
         stdout_bytes: stdoutBytes,
         stderr_bytes: stderrBytes,
@@ -324,6 +364,7 @@ function writeMeta(
     exit_code: result.exit_code,
     signal: result.signal,
     timed_out: result.timed_out,
+    force_resolved: result.force_resolved,
     duration_ms: result.duration_ms,
     stdout_bytes: result.stdout_bytes,
     stderr_bytes: result.stderr_bytes,
@@ -331,7 +372,6 @@ function writeMeta(
     stderr_truncated: result.stderr_truncated,
     stdout_path: result.stdout_path,
     stderr_path: result.stderr_path,
-    ...(request.metadata ? { metadata: request.metadata } : {}),
   };
   writeFileSync(path, `${JSON.stringify(meta, null, 2)}\n`);
 }

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -110,9 +110,12 @@ Templates are in `{{templatesDir}}`.
 
 **External facts:** Use `search-the-web` + `fetch_page`, or `search_and_read`; use `freshness` for recency. Never state current facts from training data without verification.
 
-**Background processes:** Use `bg_shell` `start` + `wait_for_ready` for servers/watchers/daemons. Never use `bash` with `&` or `nohup`; inherited stdout can hang. Never poll with `sleep`; use `wait_for_ready`. For status use `digest`, `highlights` for significant lines, and `output` only when debugging.
+**Choosing a shell tool — decide by how the command runs, not how long it takes:**
 
-**One-shot commands:** Use `async_bash` for builds, tests, and installs. Results are pushed on exit; use `await_job` only to block on a specific job.
+- **Runs and exits (a batch command):** anything that does work and finishes — `terraform apply`, DB migrations, builds, tests, installs, long scripts. Use synchronous `bash` when you want to block and read the result now (uncapped; in auto-mode genuine hangs are caught by the stalled-tool watchdog, interactively they end on human ESC). Use `async_bash` when you want it non-blocking — it returns a job ID immediately and you `await_job` later. **Never** put a run-to-completion command under `bg_shell` `wait_for_ready`: it exits instead of staying alive, so readiness never trips and a clean exit looks like a failure.
+- **Stays alive and you interact with it over time:** servers, watchers, daemons, REPLs. Use `bg_shell` `start`, then `wait_for_ready` (block until it listens/prints its ready pattern), `output`/`digest`/`highlights` to inspect, `send`/`send_and_wait` to drive it, and `kill`/`restart` to manage it. Never use `bash` with `&` or `nohup` (inherited stdout can hang); never poll with `sleep` (use `wait_for_ready`).
+
+Quick rule of thumb: if the command would exit on its own, it's `bash`/`async_bash`; if it would keep running until you stop it, it's `bg_shell`.
 
 **Stale job hygiene:** After editing source to fix a failure, `cancel_job` every in-flight `async_bash` job before rerunning. Changed inputs make in-flight outputs untrusted.
 

--- a/src/resources/extensions/gsd/tests/dynamic-bash-no-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/dynamic-bash-no-cap.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createBashTool } from "@gsd/pi-coding-agent";
+
+import { registerDynamicTools } from "../bootstrap/dynamic-tools.ts";
+import { createAsyncBashTool } from "../../async-jobs/async-bash-tool.ts";
+
+// These tests assert on the runtime tool objects the agent actually receives —
+// the registered GSD bash tool, the core bash tool, and the async_bash tool —
+// not on source text. The behavioral guarantee (an explicit timeout still
+// fires after the silent 120s cap was removed) is exercised by spawning a real
+// process at the bottom of the file.
+
+/** Capture the GSD-registered `bash` tool object from registerDynamicTools. */
+function registerAndCaptureBash(): any {
+  let captured: any = undefined;
+  const pi = {
+    registerTool: (tool: any) => {
+      if (!captured && tool && tool.name === "bash") captured = tool;
+    },
+  };
+  registerDynamicTools(pi as any);
+  assert.ok(captured, "registerDynamicTools must register a tool named 'bash'");
+  return captured;
+}
+
+// 1. Cap removal: the GSD bash tool no longer injects a default timeout. The
+//    schema's timeout stays optional (no `default`), so an omitted timeout
+//    means "no timeout" rather than a silent 120s cap.
+test("GSD bash tool exposes an optional timeout with no injected default", () => {
+  const bash = registerAndCaptureBash();
+  const timeout = bash.parameters?.properties?.timeout;
+  assert.ok(timeout, "bash tool must expose a `timeout` parameter");
+  assert.equal(
+    "default" in timeout,
+    false,
+    "the timeout schema must not carry a default — an omitted timeout means uncapped",
+  );
+  assert.equal(
+    bash.parameters?.required?.includes?.("timeout") ?? false,
+    false,
+    "timeout must remain optional",
+  );
+});
+
+// 2. Watchdog verbiage is GSD-scoped: the core bash tool (reused by non-GSD
+//    embeddings with no watchdog) must NOT claim a watchdog, while the
+//    GSD-registered tool injects it into both description and timeout schema.
+test("core bash tool does not advertise the auto-mode watchdog", () => {
+  const core = createBashTool(process.cwd(), { spawnHook: (c: any) => c });
+  assert.equal(
+    /stalled-tool watchdog/.test(core.description ?? ""),
+    false,
+    "core bash must not advertise a watchdog — non-GSD embeddings have none",
+  );
+  assert.equal(
+    /stalled-tool watchdog/.test(
+      (core.parameters as any)?.properties?.timeout?.description ?? "",
+    ),
+    false,
+    "core bash timeout schema must not advertise a watchdog",
+  );
+});
+
+test("GSD-registered bash tool advertises the stalled-tool watchdog", () => {
+  const bash = registerAndCaptureBash();
+  assert.equal(
+    /stalled-tool watchdog/.test(bash.description ?? ""),
+    true,
+    "the GSD bash description must name the stalled-tool watchdog",
+  );
+  assert.equal(
+    /stalled-tool watchdog/.test(
+      bash.parameters?.properties?.timeout?.description ?? "",
+    ),
+    true,
+    "the GSD bash timeout schema must name the stalled-tool watchdog",
+  );
+});
+
+// 3. async_bash guidance frames itself as a non-blocking/background choice and
+//    no longer implies sync bash is time-capped.
+test("async_bash guidance is non-blocking and drops the sync-cap implication", () => {
+  const asyncTool: any = createAsyncBashTool(
+    () => ({ register: () => "job-0" }) as any,
+    () => process.cwd(),
+  );
+  const guidance = (asyncTool.promptGuidelines ?? []).join("\n");
+  assert.equal(
+    /more than a few seconds/.test(guidance),
+    false,
+    "async_bash guidance must not imply sync bash is time-capped",
+  );
+  assert.equal(
+    /non-blocking/.test(guidance),
+    true,
+    "async_bash guidance must describe itself as non-blocking",
+  );
+});
+
+// 4. Behavioral passthrough: an explicitly-set timeout is still honored after
+//    the cap removal. A 1s timeout on a 5s sleep must fire well under 5s.
+test("GSD bash still forwards an explicit timeout (cap removal did not break passthrough)", async () => {
+  const bash = registerAndCaptureBash();
+
+  const start = Date.now();
+  let resultText = "";
+  try {
+    const result: any = await bash.execute(
+      "t1",
+      { command: "sleep 5", timeout: 1 },
+      undefined,
+      undefined,
+      { cwd: process.cwd() },
+    );
+    resultText = JSON.stringify(result ?? "");
+  } catch (err) {
+    resultText = String(err instanceof Error ? err.message : err);
+  }
+  const elapsed = Date.now() - start;
+
+  assert.equal(
+    /timed out|timeout|exited with code|force-killed/i.test(resultText),
+    true,
+    `explicit 1s timeout should fire before the 5s sleep completes; got: ${resultText}`,
+  );
+  assert.ok(
+    elapsed < 4500,
+    `explicit timeout should fire quickly, not run to completion (elapsed ${elapsed}ms)`,
+  );
+});

--- a/src/resources/extensions/gsd/tests/exec-graceful-kill.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-graceful-kill.test.ts
@@ -1,0 +1,193 @@
+// Project/App: gsd-pi
+// File Purpose: Deterministic timing tests for the exec-sandbox graceful-kill
+// ladder + hard-deadline force-resolve (S04/T02).
+//
+// T01 extended runExecSandbox's timeout path to a graceful
+// SIGTERM -> grace -> SIGKILL ladder (via killProcessTree) plus a caller-side
+// force-resolve hard deadline so a non-closing ("D-state") child can never hang
+// the awaiting promise. A true D-state child is non-portable, so we simulate the
+// exact symptom deterministically:
+//   1. A SIGTERM-cooperative child (trap 'exit 0' TERM) closes promptly on the
+//      first SIGTERM — proving the ladder resolves via `close` well before the
+//      force-resolve deadline.
+//   2. A SIGTERM-ignoring (trap '' TERM) child combined with a LARGE
+//      kill_grace_ms (so SIGKILL never fires in-window) and a SHORT
+//      force_resolve_delay_ms — the only way the promise can settle is the
+//      hard deadline, proving the no-hang guarantee.
+//
+// Unlike the sync bash path (which throws on force-resolve), runExecSandbox
+// always RESOLVES; force-resolve calls finalize(null, "SIGKILL") and preserves
+// timed_out === true so the agent can still distinguish a graceful timeout exit
+// from a forced kill.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { EXEC_DEFAULTS, runExecSandbox, type ExecSandboxOptions } from '../exec-sandbox.ts';
+
+const isWin = process.platform === 'win32';
+
+function freshBase(): string {
+  return mkdtempSync(join(tmpdir(), 'gsd-exec-gracekill-'));
+}
+
+function cleanup(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function baseOpts(base: string, overrides: Partial<ExecSandboxOptions> = {}): ExecSandboxOptions {
+  return {
+    baseDir: base,
+    clamp_timeout_ms: EXEC_DEFAULTS.clampTimeoutMs,
+    default_timeout_ms: 10_000,
+    stdout_cap_bytes: 1_024,
+    stderr_cap_bytes: 1_024,
+    digest_chars: 120,
+    env_allowlist: EXEC_DEFAULTS.envAllowlist,
+    ...overrides,
+  };
+}
+
+// Wall-clock guard: reject if the call has not settled by `ms`. Proves no-hang
+// independently of the assertions on timing/markers.
+function wallClockGuard<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      const t = setTimeout(() => reject(new Error(`Call did not settle within ${ms}ms (hang)`)), ms);
+      if (typeof t === 'object' && 'unref' in t) t.unref();
+    }),
+  ]);
+}
+
+// Clean up a detached child (and its process group) that a large kill_grace_ms
+// intentionally leaves alive past the force-resolve deadline.
+function cleanupByPidFile(pidFile: string): void {
+  if (!existsSync(pidFile)) return;
+  const pid = Number.parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+  if (!Number.isFinite(pid) || pid <= 0) return;
+  if (isWin) return; // best-effort; test is skipped on win32
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // already gone
+    }
+  }
+}
+
+test(
+  'runExecSandbox: SIGTERM-cooperative child exits promptly within grace on timeout',
+  { skip: isWin ? 'Unix-primary graceful semantics' : false, timeout: 20_000 },
+  async (t) => {
+    const base = freshBase();
+    t.after(() => cleanup(base));
+
+    const KILL_GRACE_MS = 5_000;
+    const FORCE_RESOLVE_DELAY_MS = 8_000; // grace + hard-deadline; must NOT be reached
+    const TIMEOUT_MS = 300;
+
+    // Child traps SIGTERM and exits 0, then sleeps long. The first SIGTERM from
+    // the ladder ends it immediately -> `close` fires -> finalize via close,
+    // well before the force-resolve deadline.
+    const script = `trap 'exit 0' TERM; sleep 30`;
+
+    const result = await wallClockGuard(
+      runExecSandbox(
+        { runtime: 'bash', script, timeout_ms: TIMEOUT_MS },
+        baseOpts(base, {
+          kill_grace_ms: KILL_GRACE_MS,
+          force_resolve_delay_ms: FORCE_RESOLVE_DELAY_MS,
+        }),
+      ),
+      15_000,
+    );
+
+    // timed_out is preserved even though the child exited cooperatively.
+    assert.equal(result.timed_out, true, 'timeout fired so timed_out must be true');
+    // Proves SIGTERM (close) resolved it, NOT the force-resolve deadline:
+    // a force-resolve would land at ~TIMEOUT_MS + FORCE_RESOLVE_DELAY_MS (~8.3s).
+    assert.ok(
+      result.duration_ms < KILL_GRACE_MS,
+      `expected prompt close well under grace (${KILL_GRACE_MS}ms), got ${result.duration_ms}ms`,
+    );
+    // A clean SIGTERM-trapped exit resolves via `close` with an exit code,
+    // not the force-resolve sentinel (exit_code null / signal SIGKILL).
+    assert.notEqual(
+      result.signal,
+      'SIGKILL',
+      'cooperative child must not be force-resolved as SIGKILL',
+    );
+    assert.equal(result.force_resolved, false, 'a cooperative close must not be flagged as force-resolved');
+  },
+);
+
+test(
+  'runExecSandbox: SIGTERM-ignoring (non-closing) child force-resolves via hard deadline without hanging',
+  { skip: isWin ? 'Unix-primary graceful semantics; force-resolve covered on POSIX' : false, timeout: 20_000 },
+  async (t) => {
+    const base = freshBase();
+    const pidFile = join(base, 'child.pid');
+    t.after(() => {
+      cleanupByPidFile(pidFile);
+      cleanup(base);
+    });
+
+    // Timing seams: SIGKILL never fires in-window (grace huge), so the only way
+    // the promise can settle is the hard deadline -> proves the caller-side
+    // force-resolve.
+    const KILL_GRACE_MS = 30_000;
+    const FORCE_RESOLVE_DELAY_MS = 800;
+    // Generous timeout so the SIGTERM trap is reliably installed before the kill
+    // fires, even under heavy parallel test load. A too-tight timeout can race
+    // the shell's startup: the kill lands before `trap '' TERM` runs, SIGTERM
+    // takes its default action, the child closes on SIGTERM, and the
+    // force-resolve path never runs (flaky 'SIGTERM' instead of 'SIGKILL').
+    const TIMEOUT_MS = 1_500;
+
+    // Install the SIGTERM trap FIRST (before any other command) so the shell is
+    // already immune by the time the kill fires; then record the detached
+    // shell's PID (process-group leader) for cleanup. The shell loops forever
+    // holding its stdout pipe open -> `close` never fires in-window -> the
+    // caller's hard deadline must force-resolve.
+    const script = `trap '' TERM; echo $$ > '${pidFile}'; while true; do sleep 1; done`;
+
+    const start = Date.now();
+    const result = await wallClockGuard(
+      runExecSandbox(
+        { runtime: 'bash', script, timeout_ms: TIMEOUT_MS },
+        baseOpts(base, {
+          kill_grace_ms: KILL_GRACE_MS,
+          force_resolve_delay_ms: FORCE_RESOLVE_DELAY_MS,
+        }),
+      ),
+      8_000,
+    );
+    const elapsed = Date.now() - start;
+
+    // (a) Did not hang and settled well before the SIGKILL grace would fire.
+    assert.ok(
+      elapsed < KILL_GRACE_MS,
+      `expected force-resolve before SIGKILL grace (${KILL_GRACE_MS}ms), took ${elapsed}ms`,
+    );
+    // (b) Settled in the force-resolve band: >= timeout (kill initiated) and
+    //     roughly timeout + force_resolve_delay (generous CI slack, but kept below
+    //     the 8000ms wallClockGuard so the upper bound is actually reachable).
+    assert.ok(
+      elapsed >= TIMEOUT_MS && elapsed <= TIMEOUT_MS + FORCE_RESOLVE_DELAY_MS + 4_000,
+      `expected settle near ${TIMEOUT_MS + FORCE_RESOLVE_DELAY_MS}ms, took ${elapsed}ms`,
+    );
+    // (c) Force-resolve preserves timed_out and surfaces the SIGKILL sentinel
+    //     (exit_code null) plus the explicit force_resolved flag, so the agent can
+    //     tell a forced kill (D-state hard deadline) from a clean SIGKILL exit.
+    assert.equal(result.timed_out, true, 'force-resolve must preserve timed_out');
+    assert.equal(result.exit_code, null, 'force-resolve exit_code must be null');
+    assert.equal(result.signal, 'SIGKILL', 'force-resolve must mark signal SIGKILL');
+    assert.equal(result.force_resolved, true, 'force-resolve must set force_resolved=true');
+  },
+);

--- a/src/resources/extensions/gsd/tests/exec-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-tool.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { registerExecTools } from "../bootstrap/exec-tools.ts";
-import { executeUatExec } from "../tools/exec-tool.ts";
+import { executeGsdExec, executeUatExec } from "../tools/exec-tool.ts";
 import type { ExecSandboxRequest, ExecSandboxResult } from "../exec-sandbox.ts";
 
 function makeExecResult(request: ExecSandboxRequest): ExecSandboxResult {
@@ -12,6 +12,7 @@ function makeExecResult(request: ExecSandboxRequest): ExecSandboxResult {
     exit_code: 0,
     signal: null,
     timed_out: false,
+    force_resolved: false,
     duration_ms: 1,
     stdout_bytes: 12,
     stderr_bytes: 0,
@@ -49,6 +50,33 @@ test("executeUatExec accepts evidence-mode aliases for intent", async () => {
   assert.equal(result.details?.operation, "gsd_uat_exec");
   assert.equal(result.details?.intent, "uat-artifact-check");
   assert.equal(requests[0]?.metadata?.intent, "uat-artifact-check");
+});
+
+test("gsd_exec surfaces a force-resolved (D-state) kill distinctly from a clean exit", async () => {
+  // A hard-deadline force-resolve sets force_resolved=true with a synthetic SIGKILL
+  // signal and null exit code. The tool result must carry that flag in details and
+  // render it as exit=timeout(force-killed) so the agent can tell it apart from a
+  // normally-exited or cleanly-timed-out command.
+  const result = await executeGsdExec(
+    { runtime: "bash", script: "sleep 60" },
+    {
+      baseDir: "/tmp/gsd-exec-force-resolved-test",
+      preferences: null,
+      run: async (request) => ({
+        ...makeExecResult(request),
+        exit_code: null,
+        signal: "SIGKILL",
+        timed_out: true,
+        force_resolved: true,
+        digest: "[no stdout \u2014 timed out]",
+      }),
+    },
+  );
+
+  assert.equal(result.isError, true, "a force-resolved kill is an error result");
+  assert.equal(result.details?.force_resolved, true, "details must expose force_resolved");
+  const text = result.content.map((c) => c.text ?? "").join("\n");
+  assert.match(text, /exit=timeout\(force-killed\)/, "summary must distinguish a force-killed result");
 });
 
 test("registerExecTools exposes gsd_uat_exec intent as recoverable string schema", () => {

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -424,6 +424,7 @@ function formatResult(result: ExecSandboxResult): ToolExecutionResult {
       exit_code: result.exit_code,
       signal: result.signal,
       timed_out: result.timed_out,
+      force_resolved: result.force_resolved,
       duration_ms: result.duration_ms,
       stdout_bytes: result.stdout_bytes,
       stderr_bytes: result.stderr_bytes,
@@ -438,6 +439,9 @@ function formatResult(result: ExecSandboxResult): ToolExecutionResult {
 }
 
 function formatExit(result: ExecSandboxResult): string {
+  // force_resolved means a non-closing (D-state) child was force-resolved past its
+  // hard deadline rather than observed exiting; distinguish it from a clean timeout.
+  if (result.force_resolved) return "timeout(force-killed)";
   if (result.timed_out) return "timeout";
   if (result.signal) return `signal:${result.signal}`;
   if (result.exit_code === null) return "null";


### PR DESCRIPTION
## Linked issue

Closes #680

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fix how the agent chooses and uses shell tools — stop the reflex of reaching for `async_bash` + an immediate `await_job` (and `bg_shell` for run-to-completion commands) — by making synchronous `bash` genuinely uncapped and the tool verbiage honest about it.
**Why:** The agent defaulted to `async_bash` then immediately blocked on `await_job` for ordinary commands, because the guidance implied sync `bash` was time-limited/risky and a silent 120s cap actually made it so. That's a pointless round-trip, and `await_job` couldn't even be interrupted.
**How:** Remove the silent 120s sync-bash cap, rewrite the bash/async_bash/await_job/bg_shell/system.md guidance around a clear Quick(sync) / One-shot(async_bash) / Background(bg_shell) decision rule, make `await_job` interruptible, and back it with a graceful kill ladder so "sync bash is safe to run uncapped" is actually true.

This is primarily a **behavioral / agent-guidance** change. The kill-safety work exists to make the behavioral change honest and safe — it is the supporting layer, not the headline.

## What this PR does (at a glance)

- Stops the agent reaching for `async_bash` + an immediate `await_job` for ordinary commands
- Removes the hidden 120s cap on synchronous `bash` (the thing that made that habit "rational")
- Rewrites tool guidance into one rule: Quick → `bash`, background → `async_bash`, long-lived → `bg_shell`
- Makes `await_job` interruptible — ESC ends the wait without killing the job
- Stops `bg_shell` / `wait_for_ready` from reporting a clean exit-0 as a failure
- Adds a graceful SIGTERM → grace → SIGKILL kill ladder so the now-uncapped `bash` can't corrupt `terraform apply` / DB migrations on timeout/ESC
- Fixes a real leak: SIGTERM-immune timed-out `async_bash` jobs were left running in the background
- Fixes a TUI bug: pressing ESC during a later await flipped already-finished tool cards red

---

## Why (the root problem)

Two bad agent habits, both caused by tool descriptions that didn't match reality plus a hidden cap:

1. **`async_bash` + immediate `await_job` instead of synchronous `bash`.** The old guidance said *"use async_bash for commands that take more than a few seconds"*, framing async_bash as the safe choice for anything non-trivial. A **silent 120s cap on synchronous `bash`** (injected by the GSD wrapper) made that instinct rational — sync `bash` really was secretly time-limited. So the agent kicked off `async_bash` and then immediately blocked on `await_job`: a non-blocking tool used in a blocking way, adding a pointless round-trip. And `await_job` couldn't be interrupted, so once it blocked it was stuck.

2. **`bg_shell` + `wait_for_ready` for run-to-completion commands.** `wait_for_ready` is for long-lived processes that open a port / print a ready pattern. Run-to-completion commands (`terraform apply`, migrations, builds) exit instead of becoming "ready", so a clean exit-0 was reported as a readiness failure.

The fix: make the tools behave honestly (uncapped, interruptible, graceful) and describe them accurately, so the agent picks the right tool the first time. Removing the cap is only safe if a timeout/ESC can no longer corrupt a long stateful command — hence the graceful kill ladder.

---

## What changed — every change and why

### A. Behavioral fix: tool guidance + uncapped sync bash

| File | What changed | Why |
| --- | --- | --- |
| `gsd/bootstrap/dynamic-tools.ts` | Stopped injecting a default 120s timeout into the GSD `bash` tool. Appends the auto-mode watchdog detail to the bash tool's description and `timeout` param. | Removing the silent cap is the core fix — sync `bash` is now genuinely uncapped, so the agent no longer needs `async_bash` to escape a hidden timeout. The watchdog detail is injected here (GSD-scoped) because only GSD/auto-mode has the watchdog; non-GSD embeddings don't. |
| `gsd/constants.ts` | Deleted `DEFAULT_BASH_TIMEOUT_SECS = 120`. | Dead once the cap injection is gone. |
| `gsd/prompts/system.md` | Replaced the old "Background processes / One-shot commands" prose with a single decision rule: Quick → sync `bash`; one-shot non-blocking → `async_bash` + later `await_job`; long-lived → `bg_shell`. States sync bash is uncapped (hangs owned by the auto-mode watchdog / human ESC). | The agent was choosing tools by *how long* a command takes; the new rule teaches it to choose by *how the command runs*. |
| `pi-coding-agent/src/core/tools/bash.ts` | Tool description now says "No default timeout — pass an explicit timeout or rely on human cancellation." | Makes the core tool's self-description honest for all embeddings. |
| `async-jobs/async-bash-tool.ts` | Rewrote `promptGuidelines`: async_bash is "for non-blocking behavior, not because of a timeout concern." | Directly kills the "async_bash because sync is capped" reasoning. |
| `bg-shell/bg-shell-tool.ts` | Rewrote `promptGuidelines`: use `bg_shell` only for processes that STAY ALIVE; never use `wait_for_ready` on a run-to-completion command. | Stops the second bad habit (bg_shell for batch commands). |
| `bg-shell/readiness-detector.ts` | When a watched process exits 0 before signaling readiness, return a "ran to completion — use async_bash" message instead of a crash/error. | A clean exit was being reported as a readiness failure; now it's reported as success pointing at the right tool. |

### B. Interruptible `await_job` (so blocking on a job is no longer a trap)

| File | What changed | Why |
| --- | --- | --- |
| `async-jobs/await-tool.ts` | ESC/AbortSignal now ends the wait promptly. Moved follow-up suppression from upfront to *after* the race, so only completed jobs are suppressed; an aborted-but-still-running job stays unsuppressed and resurfaces later. Tears down the race timer + abort listener on settle. Renders already-`delivered` jobs as a one-line acknowledgement instead of reprinting. | Previously `await_job` couldn't be interrupted and suppressed follow-ups for *all* watched jobs upfront — so an aborted job's result was lost. Now ESC frees the agent without killing the job. |
| `async-jobs/job-manager.ts` | Added a `delivered` flag set when the follow-up actually fires; **added a `cancelled`-status guard to the `.then` branch** (mirrors the existing `.catch` guard). | `delivered` stops a later-turn `await_job` from reprinting output already in context. The `.then` guard fixes a real bug: async_bash *resolves* (not rejects) even when aborted, so a user-cancelled job's status was clobbered back to `completed`. |
| `async-jobs/index.ts` | `/jobs` is now an interactive pick → confirm → cancel kill-picker (was select-immediately-cancels). Labels drop the baked-in elapsed time (which `ui.select` renders once and freezes); accurate times go in the post-picker summary. Headless falls back to text. | Prevents destroying a job on a single keypress and avoids a misleading frozen "(24s)". |

### C. Graceful kill ladder (the safety net that makes "uncapped" honest)

| File | What changed | Why |
| --- | --- | --- |
| `pi-coding-agent/src/utils/shell.ts` | `killProcessTree` escalates SIGTERM → 5s grace → SIGKILL (was a bare SIGKILL), every timer `.unref()`'d. Windows force-kills the tree via `taskkill /F /T`. Exports `SIGKILL_GRACE_MS` / `HARD_DEADLINE_MS` as the single source of truth. | A bare SIGKILL on timeout/ESC can corrupt a stateful command (`terraform apply`, DB migration). With the cap removed, sync bash runs arbitrarily long, so a clean-shutdown window matters. |
| `pi-coding-agent/src/core/tools/bash.ts` | Added a caller-side hard deadline: after a kill is initiated, race the real `close` against a deadline so a non-closing (D-state) child force-resolves with a distinct `force-killed` marker instead of hanging. | `killProcessTree` can signal but can't force-resolve an awaiting caller; a D-state child never emits `close`, so without this the tool hangs forever even after SIGKILL. |
| `pi-coding-agent/src/index.ts` | Re-export `killProcessTree`, `SIGKILL_GRACE_MS`, `HARD_DEADLINE_MS`. | So the async_bash tool and exec-sandbox use the one canonical kill path + constants instead of redefining them. |
| `async-jobs/async-bash-tool.ts` | Deleted the local `killTree` helper; both kill paths (timeout and onAbort/ESC) now call the shared `killProcessTree`. onAbort arms the same hard deadline. Imports the shared constants. | **Real bug fix:** the old `killTree` only ever sent SIGTERM (even its "escalate" branch re-sent SIGTERM), so a SIGTERM-immune timed-out job was left running in the background while the promise force-resolved. Now it actually escalates to SIGKILL. |
| `gsd/exec-sandbox.ts` | Timeout path uses `killProcessTree` (was `child.kill("SIGTERM")`, which on Windows orphaned grandchildren) + the hard-deadline force-resolve. Added a `force_resolved` flag persisted to the `.meta.json` sidecar. Imports the shared constants. | Closes the identical bare-kill / orphaned-tree hazard on `gsd_exec` / `gsd_uat_exec`, and lets callers tell a hard-deadline force-resolve from a real exit. |
| `gsd/tools/exec-tool.ts` | Surfaces `force_resolved` in tool details; renders `exit=timeout(force-killed)` in the summary. | Operator/agent can distinguish a force-killed D-state child from a clean timeout. |
| `pi-agent-core/src/harness/env/nodejs.ts` | Same SIGTERM→grace→SIGKILL escalation in the local kill helper. Keeps a deliberate local mirror of `SIGKILL_GRACE_MS` (this is the lowest layer and must not import `pi-coding-agent`) and exports it for a parity test. | Consistency on the non-GSD embedding path. Mirror is deliberate; a parity test prevents drift. |
| `pi-agent-core/src/index.ts` | Re-export the mirror as `NODE_ENV_SIGKILL_GRACE_MS`. | Lets a higher-layer test lock it against the canonical value. |
| `bg-shell/process-manager.ts` | Added `terminateProcess` (graceful ladder) for `kill`/`restart`/session cleanup; kept `killProcess` for exact single-signal sends and synchronous `cleanupAll`. Removed unused `killSessionProcesses`. | `kill`/`restart`/cleanup should give a clean-shutdown window; an explicit `signal` send and exit-handler teardown should not (deferred timers don't fire during process exit). |
| `bg-shell/bg-shell-tool.ts`, `bg-shell-command.ts`, `overlay.ts` | Their kill paths call `terminateProcess` and poll for death (grace + slack) instead of a fixed SIGTERM-then-SIGKILL sleep. | Route every bg-shell kill through the one graceful ladder. |

### D. TUI fix (pre-existing bug on the same ESC/await surface)

| File | What changed | Why |
| --- | --- | --- |
| `gsd-agent-modes/.../components/tool-execution.ts` | `completeWithError` no-ops on an already-successful, non-partial result. | Pressing ESC during a *later* await used to flip every still-tracked tool — including already-succeeded ones — to red. |
| `gsd-agent-modes/.../controllers/chat-controller.ts` | Documented why a completed tool component is intentionally left in `pendingTools` (the message_end rebuild relies on it; the real protection is the `completeWithError` no-op). | Prevents a future "fix" from re-introducing the regression. |
| `gsd-agent-modes/.../interactive-chat-render.ts` | On an aborted/errored turn, look ahead for a matching `toolResult` and render the true result instead of discarding it and painting the row aborted. | Session-replay was the worse variant of the same bug — it dropped the real result entirely. |

---

## Change type

- [x] `feat` — uncapped sync bash, interruptible await, decision-rule guidance
- [x] `fix` — SIGTERM-immune async job leak, D-state hang, TUI ESC mis-mark, cancelled-status clobber
- [x] `refactor` — DRY'd the kill-timing constants to one source of truth
- [x] `test` — new behavior-executing tests

## Scope

- [x] `pi-agent-core` — local kill helper only
- [x] `pi-coding-agent` — coding agent
- [x] `gsd extension` — tool guidance, system.md, exec-sandbox, bg-shell
- [x] `pi-tui` — gsd-agent-modes tool cards

## Breaking changes

- [x] Yes

- **Removed the silent 120s synchronous-`bash` cap.** Commands that previously timed out at 120s now run uncapped (hangs owned by the auto-mode watchdog in auto-mode, or human ESC interactively). Behavior change for any embedding that relied on the implicit cap.
- **`pi-agent-core` `nodejs.ts` kill helper:** bare SIGKILL → graceful ladder. Behavior-preserving safety alignment; flagged for reviewer visibility given that package's RFC-sensitivity.
- **Removed the internal `killSessionProcesses` export** (no consumers).

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — described above

Behavior-executing tests only (no source-grep). Local run on the rebased base — **105 tests pass** across the affected suites. New/updated test files, each tied to the change it covers:

| Test file | Verifies |
| --- | --- |
| `gsd/tests/dynamic-bash-no-cap.test.ts` (new) | GSD bash exposes no injected default timeout; advertises the watchdog; async_bash guidance drops the sync-cap implication; explicit timeout still forwarded |
| `bg-shell/tests/lifecycle-and-utilities.test.ts` | clean exit-0 reads as completion (points at async_bash), not a crash; graceful `terminateProcess` force-kills a SIGTERM-immune process |
| `async-jobs/await-tool.test.ts` (new) | await is interruptible; aborted job resurfaces; no duplicate-in-context; suppression only for completed jobs |
| `async-jobs/async-bash-cancel.test.ts` (new) | graceful cancel; SIGTERM-immune timeout-path SIGKILL regression; cancel-path D-state no-hang; **cancelled-status persistence regression** (proven to fail without the `.then` guard) |
| `gsd/tests/exec-graceful-kill.test.ts` (new) | exec-sandbox cooperative/non-closing kill timing, no hang |
| `gsd/tests/exec-tool.test.ts` | `force_resolved` rendered as `timeout(force-killed)` |
| `pi-coding-agent/.../kill-process-tree.test.ts` (new) | SIGTERM-cooperative/resistant escalation timing |
| `pi-coding-agent/.../bash-hard-deadline.test.ts` (new) | D-state child force-resolves, no hang |
| `pi-coding-agent/.../kill-constant-parity.test.ts` (new) | **cross-layer constant parity lock** (proven to fail when the mirror is perturbed) |
| `pi-agent-core/.../nodejs-kill-graceful.test.ts` (new) | SIGTERM→SIGKILL escalation, no hang |
| `gsd-agent-modes/.../chat-controller.test.ts`, `interactive-chat-render.test.ts` | ESC keeps a completed tool green, marks a pending tool interrupted; replay preserves the real result |

`typecheck:extensions`, `build:core`, and the three changed-package typechecks are clean.

Reviewer note: a bare `tsc --noEmit` from `packages/pi-coding-agent/` reports stale-`dist/` dual-module-identity errors in the untouched `package-commands.ts`; the package's real `build` (cleans `dist/` first) is exit 0. Use `pnpm run verify:merge` for the authoritative gate.

## AI disclosure

- [x] This PR includes AI-assisted code. Tooling: GSD-pi agent. All changes tested to the same standard as human-written code (behavior-executing tests, full affected-suite run, two proven regression tests). The AI is not credited as an author or co-author.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783798682&installation_id=134682257&pr_number=681&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F681&signature=6233c908da795c0e0e4bf7a9fc56234dbe3d0de34912ce13d07ad992225917a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->