### PR TITLE
fix(web): restore ! prefix for raw shell commands

### DIFF
--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -124,7 +124,7 @@ export type RpcCommand =
 	| { id?: string; type: "set_auto_compaction"; enabled: boolean }
 	| { id?: string; type: "set_auto_retry"; enabled: boolean }
 	| { id?: string; type: "abort_retry" }
-	| { id?: string; type: "bash"; command: string }
+	| { id?: string; type: "bash"; command: string; excludeFromContext?: boolean }
 	| { id?: string; type: "abort_bash" }
 	| { id?: string; type: "get_session_stats" }
 	| { id?: string; type: "export_html"; outputPath?: string }

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/input-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/input-controller.ts
@@ -19,6 +19,16 @@ function markEditorSubmitLatency(host: InteractiveModeStateHost, images: ImageCo
 	host.session.markTurnLatency?.("tui.editor_submit", { images: images?.length ?? 0 });
 }
 
+function wireEditorSubmitHandler(
+	host: InteractiveModeStateHost & { editor: { onSubmit?: (text: string) => void | Promise<void> } },
+	handler: (text: string) => Promise<void>,
+): void {
+	host.defaultEditor.onSubmit = handler;
+	if (host.editor !== host.defaultEditor) {
+		host.editor.onSubmit = handler;
+	}
+}
+
 export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 	getSlashCommandContext: () => any;
 	handleBashCommand: (command: string, excludeFromContext?: boolean) => Promise<void>;
@@ -35,7 +45,7 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 	getContextPercent: () => number | undefined;
 	options?: { submitPromptsDirectly?: boolean };
 }): void {
-	host.defaultEditor.onSubmit = async (text: string) => {
+	const onSubmit = async (text: string) => {
 		text = text.trim();
 		if (!text) return;
 
@@ -146,6 +156,8 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 			host.showError(errorMessage);
 		}
 	};
+
+	wireEditorSubmitHandler(host, onSubmit);
 }
 
 /**

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-mode.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-mode.ts
@@ -668,7 +668,9 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			// =================================================================
 
 			case "bash": {
-				const result = await session.executeBash(command.command);
+				const result = await session.executeBash(command.command, undefined, {
+					excludeFromContext: command.excludeFromContext,
+				});
 				return success(id, "bash", result);
 			}
 

--- a/src/tests/integration/web-command-parity-contract.test.ts
+++ b/src/tests/integration/web-command-parity-contract.test.ts
@@ -151,6 +151,31 @@ test("browser-local aliases and legacy helpers stay explicit", async (t) => {
   })
 })
 
+test("bash-prefixed input dispatches to rpc bash instead of prompt", async (t) => {
+  await t.test("!command routes to bash RPC", () => {
+    const outcome = dispatchBrowserSlashCommand("! ls -la")
+    assert.equal(outcome.kind, "bash")
+    if (outcome.kind !== "bash") return
+    assert.equal(outcome.command.type, "bash")
+    assert.equal(outcome.command.command, "ls -la")
+    assert.equal(outcome.command.excludeFromContext, undefined)
+  })
+
+  await t.test("!!command excludes output from model context", () => {
+    const outcome = dispatchBrowserSlashCommand("!! git status")
+    assert.equal(outcome.kind, "bash")
+    if (outcome.kind !== "bash") return
+    assert.equal(outcome.command.command, "git status")
+    assert.equal(outcome.command.excludeFromContext, true)
+  })
+
+  await t.test("bare ! falls through to prompt", () => {
+    const outcome = dispatchBrowserSlashCommand("!")
+    assert.equal(outcome.kind, "prompt")
+    assert.equal(outcome.command.message, "!")
+  })
+})
+
 test("registered GSD command roots stay on the prompt/extension path", async () => {
   const registeredRoots = await collectRegisteredGsdCommandRoots()
   assert.deepEqual(

--- a/web/components/gsd/terminal.tsx
+++ b/web/components/gsd/terminal.tsx
@@ -41,7 +41,7 @@ function inputModePlaceholder(mode: InputMode, state: ReturnType<typeof useGSDWo
     case "follow_up":
       return "Agent is active — type a follow-up or /state"
     case "prompt":
-      return "Type a prompt, /state, /new, or /clear"
+      return "Type a prompt, !command for shell, /state, /new, or /clear"
   }
 }
 

--- a/web/lib/browser-slash-command-dispatch.ts
+++ b/web/lib/browser-slash-command-dispatch.ts
@@ -45,7 +45,18 @@ export interface BrowserSlashCommandDispatchOptions {
   isStreaming?: boolean
 }
 
+export type BrowserBashBridgeCommand = {
+  type: "bash"
+  command: string
+  excludeFromContext?: boolean
+}
+
 export type BrowserSlashCommandDispatchResult =
+  | {
+      kind: "bash"
+      input: string
+      command: BrowserBashBridgeCommand
+    }
   | {
       kind: "prompt"
       input: string
@@ -242,6 +253,21 @@ function dispatchGSDSubcommand(
   }
 }
 
+/**
+ * Parse `!command` / `!!command` input matching the interactive TUI bash prefix.
+ * Returns null when the input is not a bash-prefixed command or has no command body.
+ */
+export function parseBashPrefixedInput(input: string): { command: string; excludeFromContext: boolean } | null {
+  const trimmed = input.trim()
+  if (!trimmed.startsWith("!")) return null
+
+  const excludeFromContext = trimmed.startsWith("!!")
+  const command = excludeFromContext ? trimmed.slice(2).trim() : trimmed.slice(1).trim()
+  if (!command) return null
+
+  return { command, excludeFromContext }
+}
+
 function parseSlashCommand(input: string): { name: string; args: string } | null {
   if (!input.startsWith("/")) return null
   const body = input.slice(1).trim()
@@ -286,6 +312,19 @@ export function dispatchBrowserSlashCommand(
   options: BrowserSlashCommandDispatchOptions = {},
 ): BrowserSlashCommandDispatchResult {
   const trimmed = input.trim()
+  const bashInput = parseBashPrefixedInput(trimmed)
+  if (bashInput) {
+    return {
+      kind: "bash",
+      input: trimmed,
+      command: {
+        type: "bash",
+        command: bashInput.command,
+        ...(bashInput.excludeFromContext ? { excludeFromContext: true } : {}),
+      },
+    }
+  }
+
   const parsed = parseSlashCommand(trimmed)
 
   if (trimmed === "/clear") {

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -1030,6 +1030,22 @@ function responseToLine(response: WorkspaceCommandResponse): WorkspaceTerminalLi
       return createTerminalLine("success", "Prompt accepted by the live bridge")
     case "follow_up":
       return createTerminalLine("success", "Follow-up queued on the live bridge")
+    case "bash": {
+      const data = response.data as
+        | { output?: string; exitCode?: number; cancelled?: boolean }
+        | undefined
+      if (data?.output?.trim()) {
+        return createTerminalLine("output", data.output.trimEnd())
+      }
+      if (data?.cancelled) {
+        return createTerminalLine("system", "Bash command cancelled")
+      }
+      const exitCode = data?.exitCode ?? 0
+      return createTerminalLine(
+        exitCode === 0 ? "success" : "error",
+        exitCode === 0 ? "Bash command completed" : `Bash command exited with code ${exitCode}`,
+      )
+    }
     default:
       return createTerminalLine("success", `Command accepted (${response.command})`)
   }
@@ -3834,6 +3850,9 @@ export class GSDWorkspaceStore {
     }
 
     switch (outcome.kind) {
+      case "bash":
+        await this.sendCommand(outcome.command, { displayInput: trimmed })
+        return outcome
       case "prompt":
       case "rpc": {
         const imagePayload = images?.map((i) => ({ type: "image" as const, data: i.data, mimeType: i.mimeType }))


### PR DESCRIPTION
## Summary

- Route `!command` and `!!command` through the browser bridge bash RPC instead of sending them to the model as prompts
- Display bash output in the web terminal log and support `excludeFromContext` for double-bang commands
- Wire TUI submit handler to both default and active editors when a custom editor is in use

## Test plan

- [x] `bash-prefixed input dispatches to rpc bash instead of prompt` integration tests pass
- [x] `input-controller` unit tests pass
- [ ] In web Chat mode, `! pwd` runs locally and shows output
- [ ] `!! git status` runs without adding output to model context
- [ ] Native TUI / xterm paths still accept `!` as before


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783824573&installation_id=134682257&pr_number=684&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F684&signature=5632263c2e53cb503d3168cedb638ae73653f3ce4e5133c4e75c9390608269f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->