### PR TITLE
fix(gsd): honor PREFERENCES.md models over session default in /gsd auto

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -994,12 +994,14 @@ export async function bootstrapAutoSession(
   // phase-specific planning model for a discuss turn (#2829).
   //
   // Precedence:
-  // 1) Explicit session override via /gsd model (this session)
-  // 2) Current session model from settings/session restore (if provider ready)
-  // 3) GSD model preferences from PREFERENCES.md (validated against live auth)
+  // 1) Explicit session override via /gsd model or /gsd auto --model (this session)
+  // 2) GSD model preferences from PREFERENCES.md (validated against live auth)
+  // 3) Current session model from settings/session restore (if provider ready)
   //
-  // This preserves #3517 defaults while honoring explicit runtime model
-  // selection for subsequent /gsd runs in the same session.
+  // PREFERENCES.md wins over the ambient session default (#3517) so /gsd auto
+  // does not stick on claude-code/claude-sonnet-4-6 when the user configured
+  // models via /gsd workflow-preferences or PREFERENCES.md. Custom providers
+  // still skip PREFERENCES.md entirely (#4122).
   //
   // Exception (#4122): when the session provider is a custom provider declared
   // in ~/.gsd/agent/models.json (Ollama, vLLM, OpenAI-compatible proxy, etc.),
@@ -1011,7 +1013,7 @@ export async function bootstrapAutoSession(
   const sessionProviderIsCustom = isCustomProvider(ctx.model?.provider);
   const preferredModel = sessionProviderIsCustom
     ? null
-    : resolveDefaultSessionModel(ctx.model?.provider);
+    : resolveDefaultSessionModel(ctx.model?.provider, base);
   // Validate the preferred model against the live registry + provider auth so
   // an unconfigured PREFERENCES.md entry (no API key / OAuth) can't become the
   // start-model snapshot. Without this, every subsequent unit would try to
@@ -1041,8 +1043,8 @@ export async function bootstrapAutoSession(
     : null;
   const startThinkingSnapshot = pi.getThinkingLevel();
   const startModelSnapshot = manualSessionOverride
-    ?? currentSessionModel
     ?? validatedPreferredModel
+    ?? currentSessionModel
     ?? null;
 
   try {

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -185,8 +185,9 @@ export function resolveThinkingLevelForUnit(unitType: string): GSDThinkingLevel 
  */
 export function resolveDefaultSessionModel(
   sessionProvider?: string,
+  basePath?: string,
 ): { provider: string; id: string } | undefined {
-  const prefs = loadEffectiveGSDPreferences(undefined, { availableModelIds: [] });
+  const prefs = loadEffectiveGSDPreferences(basePath, { availableModelIds: [] });
   const models = prefs?.preferences?.models;
   if (!models) return undefined;
 

--- a/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
+++ b/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { resolveExpectedArtifactPath } from "../auto-artifact-paths.ts";
 import { unitPhaseLabel, unitVerb } from "../auto-dashboard.ts";
 import { classifyUnitPhase } from "../metrics.ts";
-import { resolveModelWithFallbacksForUnit } from "../preferences-models.ts";
+import { resolveDefaultSessionModel, resolveModelWithFallbacksForUnit } from "../preferences-models.ts";
 import { KNOWN_UNIT_LABELS } from "../preferences-types.ts";
 
 function withModelPreferences<T>(fn: () => T): T {
@@ -89,6 +89,37 @@ test("run-uat falls back to completion when uat bucket is not configured", () =>
     if (oldHome === undefined) delete process.env.GSD_HOME;
     else process.env.GSD_HOME = oldHome;
     rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("default session model resolves from the explicit project base path", () => {
+  const oldHome = process.env.GSD_HOME;
+  const originalCwd = process.cwd();
+  const home = mkdtempSync(join(tmpdir(), "gsd-model-map-home-"));
+  const base = mkdtempSync(join(tmpdir(), "gsd-model-map-project-"));
+
+  try {
+    process.env.GSD_HOME = home;
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "PREFERENCES.md"), [
+      "---",
+      "models:",
+      "  execution: gpt-5.5",
+      "---",
+      "",
+    ].join("\n"));
+    process.chdir(home);
+
+    assert.deepEqual(resolveDefaultSessionModel("openai-codex", base), {
+      provider: "openai-codex",
+      id: "gpt-5.5",
+    });
+  } finally {
+    process.chdir(originalCwd);
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(base, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Fixes `/gsd auto` bootstrap preferring the ambient session model (often `claude-code/claude-sonnet-4-6`) over models configured in PREFERENCES.md via `/gsd` workflow-preferences.
- Restores documented precedence: `/gsd model` pin → PREFERENCES.md → session default (#3517).
- Loads project preferences from the auto `base` path so `.gsd/PREFERENCES.md` resolves reliably at bootstrap.

## Test plan
- [x] `model-isolation.test.ts` precedence cases pass
- [ ] Start `/gsd auto` with PREFERENCES.md `models.execution` set to a non-session model; confirm startup banner shows the configured model, not `claude-code/claude-sonnet-4-6`
- [ ] Confirm `/gsd model <provider/model>` still overrides PREFERENCES.md for the session
- [ ] Confirm custom providers (Ollama, etc.) still skip PREFERENCES.md (#4122)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783824601&installation_id=134682257&pr_number=685&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F685&signature=22352e22e1214fda42fd2e45968c88fc6e03d4e3c2a522fc37bfde98e0653556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->