### PR TITLE
fix(auth): prefer OAuth subscription routes over platform API keys

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-auth.ts
@@ -71,10 +71,12 @@ function getApiKeyProviderDisplayName(host: InteractiveModeDelegateHost, provide
 
 export function buildLoginProviderOptions(host: InteractiveModeDelegateHost): AuthSelectorProvider[] {
 	const modelRegistry = host.session.modelRegistry;
-	const oauthProviders = modelRegistry.authStorage
-		.getOAuthProviders()
-		.filter((provider) => isBrowserOAuthProviderAllowed(provider.id));
+	const allOAuthProviders = modelRegistry.authStorage.getOAuthProviders();
+	const oauthProviders = allOAuthProviders.filter((provider) => isBrowserOAuthProviderAllowed(provider.id));
 	const oauthProviderIds = new Set(oauthProviders.map((provider) => provider.id));
+	const apiKeyOnlyOAuthProviderIds = new Set(
+		allOAuthProviders.filter((provider) => !isBrowserOAuthProviderAllowed(provider.id)).map((provider) => provider.id),
+	);
 	const modelProviderIds = Array.from(new Set(modelRegistry.getAll().map((model) => model.provider))).sort();
 
 	const externalCliProviders = modelProviderIds
@@ -87,7 +89,10 @@ export function buildLoginProviderOptions(host: InteractiveModeDelegateHost): Au
 		}));
 
 	const apiKeyProviders = modelProviderIds
-		.filter((providerId) => modelRegistry.getProviderAuthMode(providerId) === "apiKey")
+		.filter(
+			(providerId) =>
+				modelRegistry.getProviderAuthMode(providerId) === "apiKey" || apiKeyOnlyOAuthProviderIds.has(providerId),
+		)
 		.filter((providerId) => !oauthProviderIds.has(providerId))
 		.map((providerId) => ({
 			id: providerId,

--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -506,8 +506,8 @@ export class AuthStorage {
 	 * Get API key for a provider.
 	 * Priority:
 	 * 1. Runtime override (CLI --api-key)
-	 * 2. API key from auth.json
-	 * 3. OAuth token from auth.json (auto-refreshed with locking)
+	 * 2. OAuth token from auth.json (when provider supports OAuth login)
+	 * 3. API key from auth.json
 	 * 4. Environment variable
 	 * 5. Fallback resolver (models.json custom providers)
 	 */
@@ -521,7 +521,13 @@ export class AuthStorage {
 		const creds = this.getCredentialsForProvider(providerId);
 		const apiKeyCredential = creds.find(isUsableApiKeyCredential);
 		const oauthCredential = creds.find((entry) => entry.type === "oauth");
-		const cred = apiKeyCredential ?? oauthCredential;
+		// Prefer OAuth for providers that support subscription login (anthropic,
+		// github-copilot, openai-codex). Users often have both OAuth and a stale
+		// API key on disk; subscription auth should win unless --api-key overrides.
+		const cred =
+			oauthCredential && getOAuthProvider(providerId)
+				? oauthCredential
+				: (apiKeyCredential ?? oauthCredential);
 
 		if (cred?.type === "api_key") {
 			return resolveConfigValue(cred.key);

--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -507,7 +507,7 @@ export class AuthStorage {
 	 * Priority:
 	 * 1. Runtime override (CLI --api-key)
 	 * 2. OAuth token from auth.json (when provider supports OAuth login)
-	 * 3. API key from auth.json
+	 * 3. API key from auth.json (including fallback when OAuth refresh fails)
 	 * 4. Environment variable
 	 * 5. Fallback resolver (models.json custom providers)
 	 */
@@ -540,6 +540,9 @@ export class AuthStorage {
 				return undefined;
 			}
 
+			const resolveStoredApiKey = (): string | undefined =>
+				apiKeyCredential ? resolveConfigValue(apiKeyCredential.key) : undefined;
+
 			// Check if token needs refresh
 			const needsRefresh = Date.now() >= cred.expires;
 
@@ -552,20 +555,21 @@ export class AuthStorage {
 					}
 				} catch (error) {
 					this.recordError(error);
-					// Refresh failed - re-read file to check if another instance succeeded
-					this.reload();
-					const updatedCred = this.getCredentialsForProvider(providerId).find(
-						(entry) => entry.type === "oauth",
-					);
+				}
 
-					if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
-						// Another instance refreshed successfully, use those credentials
-						return provider.getApiKey(updatedCred);
-					}
+				// Refresh failed or returned nothing - re-read file to check if another instance succeeded
+				this.reload();
+				const updatedCred = this.getCredentialsForProvider(providerId).find(
+					(entry) => entry.type === "oauth",
+				);
 
-					// Refresh truly failed - return undefined so model discovery skips this provider
-					// User can /login to re-authenticate (credentials preserved for retry)
-					return undefined;
+				if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
+					return provider.getApiKey(updatedCred);
+				}
+
+				const storedApiKey = resolveStoredApiKey();
+				if (storedApiKey) {
+					return storedApiKey;
 				}
 			} else {
 				// Token not expired, use current access token

--- a/packages/pi-coding-agent/src/core/provider-readiness.ts
+++ b/packages/pi-coding-agent/src/core/provider-readiness.ts
@@ -2,6 +2,7 @@
  * Provider readiness policy extracted from ModelRegistry.
  */
 
+import { getOAuthProviders } from "@gsd/pi-ai/oauth";
 import type { AuthStorage } from "./auth-storage.js";
 
 export type ProviderAuthMode = "apiKey" | "oauth" | "none" | "externalCli";
@@ -23,10 +24,17 @@ export interface ProviderReadinessDeps {
 export function getProviderAuthMode(deps: ProviderReadinessDeps, provider: string): ProviderAuthMode {
 	if (provider === "gsd-fake") return "none";
 	const config = deps.registeredProviders.get(provider);
-	if (!config) return "apiKey";
-	if (config.authMode) return config.authMode;
-	if (config.oauth) return "oauth";
-	if (config.apiKey) return "apiKey";
+	if (config) {
+		if (config.authMode) return config.authMode;
+		if (config.oauth) return "oauth";
+		if (config.apiKey) return "apiKey";
+		return "apiKey";
+	}
+	// Built-in OAuth providers (openai-codex, github-copilot, …) are not
+	// registered via registerProvider(), but still authenticate via OAuth.
+	if (getOAuthProviders().some((oauthProvider) => oauthProvider.id === provider)) {
+		return "oauth";
+	}
 	return "apiKey";
 }
 

--- a/packages/pi-coding-agent/test/auth-storage.test.ts
+++ b/packages/pi-coding-agent/test/auth-storage.test.ts
@@ -483,6 +483,23 @@ describe("AuthStorage", () => {
 			expect(authStorage.hasAuth("custom-provider")).toBe(false);
 			expect(authStorage.getAuthStatus("custom-provider")).toEqual({ configured: false });
 		});
+
+		test("prefers OAuth over stored API key for OAuth-capable providers", async () => {
+			authStorage = AuthStorage.inMemory({
+				anthropic: [
+					{ type: "api_key", key: "sk-ant-stored-api-key" },
+					{
+						type: "oauth",
+						access: "oauth-access-token",
+						refresh: "oauth-refresh-token",
+						expires: Date.now() + 60_000,
+					},
+				],
+			});
+
+			const apiKey = await authStorage.getApiKey("anthropic");
+			expect(apiKey).toBe("oauth-access-token");
+		});
 	});
 
 	describe("runtime overrides", () => {

--- a/packages/pi-coding-agent/test/auth-storage.test.ts
+++ b/packages/pi-coding-agent/test/auth-storage.test.ts
@@ -500,6 +500,70 @@ describe("AuthStorage", () => {
 			const apiKey = await authStorage.getApiKey("anthropic");
 			expect(apiKey).toBe("oauth-access-token");
 		});
+
+		test("falls back to stored API key when OAuth refresh fails", async () => {
+			const providerId = `test-oauth-api-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth API Fallback",
+				async login() {
+					throw new Error("Not used in this test");
+				},
+				async refreshToken() {
+					throw new Error("refresh failed");
+				},
+				getApiKey(credentials) {
+					return credentials.access;
+				},
+			});
+
+			authStorage = AuthStorage.inMemory({
+				[providerId]: [
+					{ type: "api_key", key: "sk-fallback-api-key" },
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "refresh-token",
+						expires: Date.now() - 10_000,
+					},
+				],
+			});
+
+			const apiKey = await authStorage.getApiKey(providerId);
+			expect(apiKey).toBe("sk-fallback-api-key");
+		});
+
+		test("falls back to stored API key when OAuth refresh returns nothing", async () => {
+			const providerId = `test-oauth-null-refresh-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Null Refresh",
+				async login() {
+					throw new Error("Not used in this test");
+				},
+				async refreshToken() {
+					return null as never;
+				},
+				getApiKey(credentials) {
+					return credentials.access;
+				},
+			});
+
+			authStorage = AuthStorage.inMemory({
+				[providerId]: [
+					{ type: "api_key", key: "sk-null-refresh-fallback" },
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "refresh-token",
+						expires: Date.now() - 10_000,
+					},
+				],
+			});
+
+			const apiKey = await authStorage.getApiKey(providerId);
+			expect(apiKey).toBe("sk-null-refresh-fallback");
+		});
 	});
 
 	describe("runtime overrides", () => {

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -1041,15 +1041,35 @@ export function resolveModelId<T extends { id: string; provider: string }>(
     if (providerMatch) return providerMatch;
   }
 
-  // Prefer "anthropic" as the canonical provider for Anthropic models.
-  // Transport-specific tiebreaker (ADR-012): intentionally keys on provider,
-  // not api — we want the plain Anthropic transport when multiple are available.
-  const anthropicMatch = candidates.find(m => m.provider === "anthropic");
-  if (anthropicMatch) return anthropicMatch;
+  // Subscription/OAuth routes beat pay-per-token API when the same model ID
+  // exists on multiple providers. Order matters — first match wins.
+  for (const provider of BARE_ID_SUBSCRIPTION_PROVIDER_PRECEDENCE) {
+    const match = candidates.find(m => m.provider === provider);
+    if (match) return match;
+  }
 
   // Fall back to first non-extension candidate, or any candidate
   return candidates.find(m => !EXTENSION_PROVIDERS.has(m.provider)) ?? candidates[0];
 }
+
+/**
+ * When a bare model ID exists on multiple providers, prefer subscription/OAuth
+ * routes over pay-per-token API keys. Matches PROVIDER_ROUTES in doctor-providers
+ * but applies when *both* sides are authenticated.
+ *
+ * Order rationale:
+ * - openai-codex before github-copilot: ChatGPT-native for shared GPT IDs
+ * - google-gemini-cli before github-copilot: first-party Gemini CLI
+ * - anthropic before github-copilot: first-party Claude API/OAuth over Copilot
+ * - github-copilot before openai/google: Copilot OAuth over platform API keys
+ */
+export const BARE_ID_SUBSCRIPTION_PROVIDER_PRECEDENCE = [
+  "openai-codex",
+  "google-gemini-cli",
+  "anthropic",
+  "github-copilot",
+  "google-antigravity",
+] as const;
 
 /**
  * Flat-rate providers charge the same per request regardless of model.

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -857,3 +857,25 @@ test("resolveModelId: claude-code wins when session is claude-code regardless of
   assert.ok(result, "should resolve a model");
   assert.equal(result.provider, "claude-code", "claude-code must win when it is the session provider");
 });
+
+test("resolveModelId: openai-codex wins over openai for bare GPT IDs when both are available", () => {
+  const availableModels = [
+    { id: "gpt-5.5", provider: "openai" },
+    { id: "gpt-5.5", provider: "openai-codex" },
+  ];
+
+  const result = resolveModelId("gpt-5.5", availableModels, undefined);
+  assert.ok(result, "should resolve a model");
+  assert.equal(result.provider, "openai-codex", "ChatGPT OAuth must win over platform API for bare IDs");
+});
+
+test("resolveModelId: github-copilot wins over openai when both offer the same GPT model", () => {
+  const availableModels = [
+    { id: "gpt-5.5", provider: "openai" },
+    { id: "gpt-5.5", provider: "github-copilot" },
+  ];
+
+  const result = resolveModelId("gpt-5.5", availableModels, undefined);
+  assert.ok(result);
+  assert.equal(result.provider, "github-copilot");
+});

--- a/src/resources/extensions/gsd/tests/oauth-api-model-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/oauth-api-model-routing.test.ts
@@ -1,0 +1,167 @@
+/**
+ * OAuth/subscription vs pay-per-token API routing for bare model IDs.
+ *
+ * When the same model ID (e.g. gpt-5.5) exists on multiple providers, resolveModelId
+ * must prefer subscription/OAuth routes over platform API keys.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { MODELS } from "../../../../../packages/pi-ai/dist/models.generated.js";
+import {
+  BARE_ID_SUBSCRIPTION_PROVIDER_PRECEDENCE,
+  resolveModelId,
+} from "../auto-model-selection.js";
+
+type ModelRef = { id: string; provider: string };
+
+function modelsForProviders(modelId: string, providers: string[]): ModelRef[] {
+  return providers.map((provider) => ({ id: modelId, provider }));
+}
+
+/** Table-driven precedence cases — one row per conflict shape, not per model ID. */
+const PRECEDENCE_CASES: Array<{
+  label: string;
+  modelId: string;
+  providers: string[];
+  expected: string;
+  currentProvider?: string;
+}> = [
+  {
+    label: "ChatGPT OAuth beats OpenAI API (gpt-5.5)",
+    modelId: "gpt-5.5",
+    providers: ["openai", "openai-codex"],
+    expected: "openai-codex",
+  },
+  {
+    label: "Codex beats Copilot beats OpenAI API (gpt-5.5 triple)",
+    modelId: "gpt-5.5",
+    providers: ["openai", "github-copilot", "openai-codex"],
+    expected: "openai-codex",
+  },
+  {
+    label: "Copilot OAuth beats OpenAI API when no Codex (gpt-5.5)",
+    modelId: "gpt-5.5",
+    providers: ["openai", "github-copilot"],
+    expected: "github-copilot",
+  },
+  {
+    label: "Copilot OAuth beats OpenAI API (gpt-5-mini)",
+    modelId: "gpt-5-mini",
+    providers: ["openai", "github-copilot"],
+    expected: "github-copilot",
+  },
+  {
+    label: "Anthropic beats Copilot for Claude (claude-sonnet-4-6)",
+    modelId: "claude-sonnet-4-6",
+    providers: ["anthropic", "github-copilot"],
+    expected: "anthropic",
+  },
+  {
+    label: "Copilot beats Google API for Gemini (gemini-2.5-pro)",
+    modelId: "gemini-2.5-pro",
+    providers: ["google", "github-copilot"],
+    expected: "github-copilot",
+  },
+  {
+    label: "Gemini CLI beats Google API (gemini-2.5-pro)",
+    modelId: "gemini-2.5-pro",
+    providers: ["google", "google-gemini-cli"],
+    expected: "google-gemini-cli",
+  },
+  {
+    label: "Gemini CLI beats Copilot beats Google API",
+    modelId: "gemini-2.5-pro",
+    providers: ["google", "github-copilot", "google-gemini-cli"],
+    expected: "google-gemini-cli",
+  },
+  {
+    label: "Session provider still wins (openai-codex explicit)",
+    modelId: "gpt-5.5",
+    providers: ["openai", "openai-codex", "github-copilot"],
+    expected: "github-copilot",
+    currentProvider: "github-copilot",
+  },
+  {
+    label: "claude-code session beats anthropic (#3772)",
+    modelId: "claude-sonnet-4-6",
+    providers: ["anthropic", "claude-code"],
+    expected: "claude-code",
+    currentProvider: "claude-code",
+  },
+];
+
+for (const row of PRECEDENCE_CASES) {
+  test(`resolveModelId precedence: ${row.label}`, () => {
+    const available = modelsForProviders(row.modelId, row.providers);
+    const result = resolveModelId(row.modelId, available, row.currentProvider);
+    assert.ok(result, `expected a match for ${row.modelId}`);
+    assert.equal(result.provider, row.expected);
+  });
+}
+
+test("BARE_ID_SUBSCRIPTION_PROVIDER_PRECEDENCE covers known OAuth/subscription providers", () => {
+  const expected = [
+    "openai-codex",
+    "google-gemini-cli",
+    "anthropic",
+    "github-copilot",
+    "google-antigravity",
+  ];
+  assert.deepEqual([...BARE_ID_SUBSCRIPTION_PROVIDER_PRECEDENCE], expected);
+});
+
+test("every catalog overlap with OAuth/subscription + API resolves to subscription route", () => {
+  const oauthProviders = new Set(["anthropic", "github-copilot", "openai-codex"]);
+  const subscriptionCli = new Set(["google-gemini-cli", "google-antigravity", "claude-code"]);
+  const apiPayPerToken = new Set(["openai", "google", "azure-openai-responses"]);
+
+  const byId = new Map<string, Set<string>>();
+  for (const [provider, models] of Object.entries(MODELS)) {
+    for (const id of Object.keys(models)) {
+      if (!byId.has(id)) byId.set(id, new Set());
+      byId.get(id)!.add(provider);
+    }
+  }
+
+  const failures: string[] = [];
+
+  for (const [modelId, providers] of byId) {
+    if (providers.size < 2) continue;
+
+    const hasApi = [...providers].some((p) => apiPayPerToken.has(p));
+    const subscriptionCandidates = [...providers].filter(
+      (p) => oauthProviders.has(p) || subscriptionCli.has(p),
+    );
+    if (!hasApi || subscriptionCandidates.length === 0) continue;
+
+    const testProviders = new Set<string>(subscriptionCandidates);
+    for (const p of providers) {
+      if (apiPayPerToken.has(p)) testProviders.add(p);
+    }
+
+    const available = modelsForProviders(modelId, [...testProviders]);
+    const result = resolveModelId(modelId, available, undefined);
+    if (!result) {
+      failures.push(`${modelId}: no resolution among ${[...testProviders].join(", ")}`);
+      continue;
+    }
+
+    const winnerIsSubscription =
+      oauthProviders.has(result.provider) ||
+      subscriptionCli.has(result.provider) ||
+      result.provider === "anthropic";
+
+    if (!winnerIsSubscription) {
+      failures.push(
+        `${modelId}: got ${result.provider}, expected subscription route among ${[...testProviders].join(", ")}`,
+      );
+    }
+  }
+
+  assert.equal(
+    failures.length,
+    0,
+    `catalog overlap routing failures:\n${failures.join("\n")}`,
+  );
+});


### PR DESCRIPTION
## Summary

- Bare model IDs (e.g. `gpt-5.5`) that exist on both subscription and API providers now resolve to OAuth/subscription routes (`openai-codex`, `github-copilot`, `google-gemini-cli`, etc.) instead of silently falling through to `openai`/`google` when `OPENAI_API_KEY` is also set.
- Built-in OAuth providers (`openai-codex`, `github-copilot`) now report `authMode: oauth` in the UI instead of incorrectly showing "API key".
- Stored OAuth tokens take precedence over stale API keys in `auth.json` for OAuth-capable providers (anthropic, copilot, codex).
- When OAuth refresh fails or returns nothing, `getApiKey()` falls back to a stored `api_key` instead of leaving the provider unauthenticated (cross-instance refresh success is still checked first).

## Test plan

- [x] `oauth-api-model-routing.test.ts` — 12 precedence cases + catalog overlap sweep
- [x] `auto-model-selection.test.ts` — codex and copilot precedence cases
- [x] `auth-storage.test.ts` — OAuth preferred over stored API key; fallback when refresh fails or returns null
- [ ] Manual: confirm `/gsd keys list` shows OAuth badge for openai-codex
- [ ] Manual: bare `gpt-5.5` in PREFERENCES.md routes to ChatGPT OAuth when both Codex OAuth and `OPENAI_API_KEY` are configured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication credential priority and model routing for users with both OAuth and API keys; incorrect precedence could send requests to the wrong provider or billable route, though behavior is heavily tested and runtime `--api-key` still overrides.
> 
> **Overview**
> **Subscription/OAuth auth and routing now win over platform API keys** when both are configured, so bare model IDs and stored credentials no longer silently use pay-per-token routes.
> 
> `AuthStorage.getApiKey()` prefers OAuth for providers that support subscription login (unless `--api-key` overrides), and after a failed or empty OAuth refresh it falls back to a stored `api_key` instead of leaving the provider unauthenticated. Built-in OAuth providers (`openai-codex`, `github-copilot`, etc.) report `authMode: oauth` in readiness/UI even when not registered on the model registry. The login selector lists browser-blocked OAuth providers (e.g. anthropic) under API key login.
> 
> Bare model resolution in `resolveModelId` uses `BARE_ID_SUBSCRIPTION_PROVIDER_PRECEDENCE` (codex → gemini-cli → anthropic → copilot → antigravity) instead of always preferring `anthropic`, while keeping session `claude-code` and explicit current-provider behavior. Tests cover precedence tables, catalog overlap, and OAuth/API key fallback in auth storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e629bb40fd5ed798b421c909fdd581596852950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->