### PR TITLE
fix(gsd): avoid full requirements fallback on empty DB query

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -972,7 +972,7 @@ export async function inlineDecisionsFromDb(
 
 /**
  * Inline requirements with optional milestone and slice scoping from the DB.
- * Falls back to filesystem via inlineGsdRootFile when DB unavailable or empty.
+ * Falls back to filesystem via inlineGsdRootFile only when DB is unavailable.
  */
 export async function inlineRequirementsFromDb(
   base: string, milestoneId?: string, sliceId?: string, level?: InlineLevel,
@@ -982,14 +982,21 @@ export async function inlineRequirementsFromDb(
     const { isDbAvailable } = await import("./gsd-db.js");
     if (isDbAvailable()) {
       const { queryRequirements, formatRequirementsForPrompt } = await import("./context-store.js");
-      const requirements = queryRequirements({ milestoneId, sliceId });
+      let requirements = queryRequirements({ milestoneId, sliceId });
+      if (requirements.length === 0 && sliceId) {
+        requirements = queryRequirements({ milestoneId });
+      }
+      if (requirements.length === 0 && milestoneId) {
+        requirements = queryRequirements({ status: "active" });
+      }
       if (requirements.length > 0) {
         // Use compact format for non-full levels to save ~40% tokens
-        const formatted = inlineLevel !== "full"
+        const formatted = inlineLevel !== "full" || !sliceId
           ? formatRequirementsCompact(requirements)
           : formatRequirementsForPrompt(requirements);
         return `### Requirements\nSource: \`.gsd/REQUIREMENTS.md\`\n\n${formatted}`;
       }
+      return null;
     }
   } catch (err) {
     logWarning("prompt", `inlineRequirementsFromDb failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -983,15 +983,22 @@ export async function inlineRequirementsFromDb(
     if (isDbAvailable()) {
       const { queryRequirements, formatRequirementsForPrompt } = await import("./context-store.js");
       let requirements = queryRequirements({ milestoneId, sliceId });
+      let broadenedScope = false;
       if (requirements.length === 0 && sliceId) {
         requirements = queryRequirements({ milestoneId });
+        broadenedScope = true;
       }
       if (requirements.length === 0 && milestoneId) {
         requirements = queryRequirements({ status: "active" });
+        broadenedScope = true;
       }
       if (requirements.length > 0) {
-        // Use compact format for non-full levels to save ~40% tokens
-        const formatted = inlineLevel !== "full" || !sliceId
+        // Use compact format for non-full levels, milestone-scoped calls, and
+        // any cascade stage that broadened past the originally requested scope —
+        // a slice-scoped "full" call that fell through to the project-wide
+        // active fallback must not format those rows as full requirements.
+        const useCompact = inlineLevel !== "full" || !sliceId || broadenedScope;
+        const formatted = useCompact
           ? formatRequirementsCompact(requirements)
           : formatRequirementsForPrompt(requirements);
         return `### Requirements\nSource: \`.gsd/REQUIREMENTS.md\`\n\n${formatted}`;

--- a/src/resources/extensions/gsd/tests/prompt-db.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-db.test.ts
@@ -263,6 +263,49 @@ test('prompt-db: inlineRequirementsFromDb cascades from empty milestone query to
   }
 });
 
+test('prompt-db: inlineRequirementsFromDb keeps active fallback compact for slice-scoped full calls', async () => {
+  const { tmpDir } = createDbProjectWithRequirements(
+    '# Requirements\n\nFULL FILE SHOULD NOT BE INLINED\n',
+  );
+  try {
+    insertRequirement({
+      id: 'R001',
+      class: 'functional',
+      status: 'active',
+      description: 'active requirement for another milestone',
+      why: 'needed',
+      source: 'M001',
+      primary_owner: 'M001/S01',
+      supporting_slices: '',
+      validation: 'test',
+      notes: '',
+      full_content: '',
+      superseded_by: null,
+    });
+
+    // Slice-scoped call at inlineLevel "full" with no matching rows for the
+    // milestone+slice or milestone-only queries. The cascade should land on
+    // status: "active" rows from another milestone, and those project-wide
+    // active rows must be formatted compactly even though sliceId is set —
+    // otherwise the full per-requirement markdown would be inlined for every
+    // active row across the project.
+    const inlined = await inlineRequirementsFromDb(tmpDir, 'M999', 'S99', 'full');
+
+    assert.ok(inlined);
+    assert.match(inlined, /### Requirements/);
+    assert.match(inlined, /# Requirements \(compact\)/);
+    assert.match(inlined, /R001/);
+    // Full per-requirement markdown is forbidden here — its hallmark fields
+    // (Class:/Status:/Why: as bolded list items) are emitted only by
+    // formatRequirementsForPrompt, never by formatRequirementsCompact.
+    assert.doesNotMatch(inlined, /\*\*Class:\*\*/);
+    assert.doesNotMatch(inlined, /FULL FILE SHOULD NOT BE INLINED/);
+  } finally {
+    closeDatabase();
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // prompt-db: scoped filtering reduces content vs unscoped
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/prompt-db.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-db.test.ts
@@ -7,6 +7,9 @@
 
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   openDatabase,
   closeDatabase,
@@ -22,6 +25,17 @@ import {
   formatDecisionsForPrompt,
   formatRequirementsForPrompt,
 } from '../context-store.ts';
+import { inlineRequirementsFromDb } from '../auto-prompts.ts';
+import { migrateFromMarkdown } from '../md-importer.ts';
+
+function createDbProjectWithRequirements(content: string): { tmpDir: string; gsdDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'prompt-db-requirements-'));
+  const gsdDir = join(tmpDir, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+  writeFileSync(join(gsdDir, 'REQUIREMENTS.md'), content);
+  openDatabase(join(gsdDir, 'gsd.db'));
+  return { tmpDir, gsdDir };
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // prompt-db: DB-aware decisions helper returns scoped content
@@ -183,6 +197,73 @@ console.log('\n=== prompt-db: fallback when DB unavailable ===');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// prompt-db: DB-aware requirements helper does not fall back on empty DB rows
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('prompt-db: inlineRequirementsFromDb returns null instead of full file when DB query is empty', async () => {
+  const { tmpDir } = createDbProjectWithRequirements(
+    `# Requirements\n\nFULL FILE SHOULD NOT BE INLINED\n\n${'large requirement body\n'.repeat(500)}`,
+  );
+  try {
+    const inlined = await inlineRequirementsFromDb(tmpDir, 'M999', undefined, 'full');
+
+    assert.equal(inlined, null);
+  } finally {
+    closeDatabase();
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('prompt-db: inlineRequirementsFromDb cascades from empty milestone query to active requirements', async () => {
+  const { tmpDir } = createDbProjectWithRequirements(
+    '# Requirements\n\nFULL FILE SHOULD NOT BE INLINED\n',
+  );
+  try {
+    insertRequirement({
+      id: 'R001',
+      class: 'functional',
+      status: 'active',
+      description: 'active requirement for another milestone',
+      why: 'needed',
+      source: 'M001',
+      primary_owner: 'M001/S01',
+      supporting_slices: '',
+      validation: 'test',
+      notes: '',
+      full_content: '',
+      superseded_by: null,
+    });
+    insertRequirement({
+      id: 'R002',
+      class: 'functional',
+      status: 'validated',
+      description: 'validated requirement should not be active fallback',
+      why: 'already done',
+      source: 'M001',
+      primary_owner: 'M001/S02',
+      supporting_slices: '',
+      validation: 'done',
+      notes: '',
+      full_content: '',
+      superseded_by: null,
+    });
+
+    const inlined = await inlineRequirementsFromDb(tmpDir, 'M999', undefined, 'full');
+
+    assert.ok(inlined);
+    assert.match(inlined, /### Requirements/);
+    assert.match(inlined, /# Requirements \(compact\)/);
+    assert.match(inlined, /R001/);
+    assert.match(inlined, /active requirement for another milestone/);
+    assert.doesNotMatch(inlined, /R002/);
+    assert.doesNotMatch(inlined, /FULL FILE SHOULD NOT BE INLINED/);
+  } finally {
+    closeDatabase();
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // prompt-db: scoped filtering reduces content vs unscoped
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -315,12 +396,6 @@ console.log('\n=== prompt-db: DB helpers wrapper format matches expected pattern
 // ═══════════════════════════════════════════════════════════════════════════
 // prompt-db: re-import updates DB when source markdown changes
 // ═══════════════════════════════════════════════════════════════════════════
-
-import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { migrateFromMarkdown } from '../md-importer.ts';
-
 
 describe('prompt-db', () => {
 test('prompt-db: re-import updates DB when source markdown changes', () => {


### PR DESCRIPTION
## TL;DR

**What:** Prevent requirements prompt inlining from reading the full `.gsd/REQUIREMENTS.md` file after an empty DB-backed scoped query.
**Why:** New milestones and sparse slice ownership can otherwise inject very large requirements files into planning prompts and spike token costs.
**How:** Mirror the decisions helper cascade, keep DB-success empty results as `null`, and preserve filesystem fallback only for DB-unavailable/error cases.

## What

Updates `inlineRequirementsFromDb` so requirements lookup cascades from scoped milestone/slice rows to milestone rows, then compact active requirements for new milestones. If the DB is available and those queries return no relevant rows, the helper returns `null` instead of falling through to the on-disk requirements file.

Adds regression coverage around the real helper to prove a large on-disk `REQUIREMENTS.md` is not inlined when the DB succeeds with no rows, and that the active-requirements fallback stays compact and excludes validated rows.

## Why

Closes #689. The prior fallback treated an empty scoped DB result the same as DB unavailability, which could dump a large root requirements artifact into every affected planning, validation, or completion prompt.

## How

The implementation follows the existing `inlineDecisionsFromDb` contract: DB-backed empty results are intentional and do not fall back to markdown, while genuine DB-unavailable/error cases still use the filesystem fallback. For milestone-level new work, compact active requirements are used so agents still see the capability contract without paying for the entire rendered artifact.

## Verification

- [x] `pnpm run build:core`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-db.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/context-store.test.ts src/resources/extensions/gsd/tests/structured-data-formatter.test.ts`
- [x] `pnpm run verify:fast`
- [ ] `pnpm run verify:pr`

## Impact analysis

- Blast radius: moderate. The helper feeds multiple milestone and slice prompt builders, but the change is limited to requirements context selection.
- Affected workflows: `plan-milestone`, `discuss-milestone`, `validate-milestone`, `complete-milestone`, and slice-scoped prompt composition that requests requirements context.
- Risks or compatibility notes: DB-unavailable fallback behavior is preserved. DB-available empty queries now omit requirements context instead of using stale or oversized markdown fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes requirements context selection across multiple milestone/slice prompt builders; agents may see no inlined requirements where they previously got oversized markdown, though DB-unavailable behavior is unchanged.
> 
> **Overview**
> **`inlineRequirementsFromDb`** now matches **`inlineDecisionsFromDb`**: when the DB is available, scoped queries **cascade** from milestone+slice → milestone-only → **`status: "active"`**, and a successful query with **no rows returns `null`** instead of inlining the full on-disk **`.gsd/REQUIREMENTS.md`**. Filesystem fallback via **`inlineGsdRootFile`** is limited to DB-unavailable or error paths.
> 
> For milestone-level prompts (no **`sliceId`**), requirements are rendered with **`formatRequirementsCompact`** even at **`full`** inline level, so new milestones still get a small active-requirements contract without dumping the whole artifact.
> 
> **`prompt-db.test.ts`** adds integration tests: empty scoped DB results must not pull a large **`REQUIREMENTS.md`**, and the active-requirements cascade must stay compact and exclude non-active rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8807ddeb3cec820cf4fd4568f29f5f1518a39c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->