### PR TITLE
fix(gsd): preserve bare UAT type declarations

### DIFF
--- a/docs/dev/uat-process.md
+++ b/docs/dev/uat-process.md
@@ -4,7 +4,7 @@ This document names the current UAT contract so prompt, dispatch, browser toolin
 
 ## Pipeline Order
 
-1. `complete-slice` persists the slice summary and UAT spec. It rejects specs that declare `artifact-driven` while requiring browser-observable checks.
+1. `complete-slice` persists the slice summary and UAT spec. It rejects browser-observable specs that declare `artifact-driven` or omit a parseable UAT mode.
 2. `run-uat` runs after slice completion. It classifies the UAT spec through `src/resources/extensions/gsd/uat-policy.ts`, presents the matching tool surface, records typed evidence, and saves one `S##-ASSESSMENT.md` plus a typed attempt record through `gsd_uat_result_save`.
 3. `validate-milestone` runs after all slices close. It dispatches three reviewers in parallel: requirements coverage, cross-slice integration, and assessment/acceptance evidence. It consumes UAT assessments; it is not the UAT producer.
 4. `complete-milestone` runs only after validation records a passing milestone verdict.
@@ -20,6 +20,8 @@ This document names the current UAT contract so prompt, dispatch, browser toolin
 - Result-save requirements such as runtime evidence for `runtime-executable` and browser evidence for `browser-executable`.
 - Dispatch-time browser tool support checks when an active tool snapshot is available.
 
+UAT specs should declare the mode under `## UAT Type` as a bullet, for example `- UAT mode: browser-executable`. The parser is case-insensitive, tolerates bold markers around the label, and also accepts a bare recognized keyword as the first meaningful declaration in that section, such as `browser-executable`, so older agent-authored specs do not silently default to `artifact-driven`.
+
 ## Browser Engine
 
 GSD exposes a product-level Browser Automation Contract with canonical `browser_*` tool names, declared once in `src/resources/extensions/shared/browser-contract.ts`. Per ADR-037, browser-facing projects prefer the managed `gsd-browser` engine when the availability probe proves a CLI exists and a session-start daemon connect succeeds; otherwise (and for non-browser-facing projects) the session falls back to legacy Playwright with a recorded reason. `GSD_BROWSER_ENGINE` remains the explicit override, and `gsd-browser` remains available for External MCP Clients via `/gsd mcp init`.
@@ -28,7 +30,7 @@ GSD exposes a product-level Browser Automation Contract with canonical `browser_
 
 ## Current Guardrails
 
-- `complete-slice` blocks browser-required specs mislabeled as `artifact-driven`.
+- `complete-slice` blocks browser-required specs mislabeled as `artifact-driven` or missing a parseable UAT mode declaration.
 - `run-uat` requires `gsd_uat_result_save` and rejects forbidden summary/gate write substitutes.
 - `src/resources/extensions/gsd/uat-run.ts` owns `gsd_uat_result_save` lifecycle preparation, run IDs, attempt metadata, worktree capture, and assessment rendering.
 - `gsd_uat_result_save` validates objective evidence, fresh UAT-owned exec evidence, canonical tool presentation, and mode-specific evidence before saving the assessment and attempt artifact.

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -671,33 +671,54 @@ export function parseTaskPlanIO(content: string): { inputFiles: string[]; output
  */
 export type UatType = 'artifact-driven' | 'live-runtime' | 'human-experience' | 'mixed' | 'browser-executable' | 'runtime-executable';
 
+/** Canonical list of recognised UAT types — uat-policy.ts re-exports this as UAT_TYPES. */
+export const UAT_TYPE_KEYWORDS: readonly UatType[] = [
+  'artifact-driven',
+  'browser-executable',
+  'runtime-executable',
+  'live-runtime',
+  'mixed',
+  'human-experience',
+];
+
+/** Match a value against the recognised UAT type keywords (leading-keyword-only). */
+function matchUatTypeKeyword(value: string): UatType | undefined {
+  const normalized = value.trim().toLowerCase();
+  return UAT_TYPE_KEYWORDS.find(keyword => normalized.startsWith(keyword));
+}
+
 /**
  * Extract the UAT type from a UAT file's raw content.
  *
  * UAT files have no YAML frontmatter - pass raw file content directly.
  * Classification is leading-keyword-only: e.g. `mixed (artifact-driven + live-runtime)` → `'mixed'`.
  *
+ * The canonical form is a `- UAT mode: <type>` bullet under `## UAT Type`
+ * (case-insensitive prefix, `**bold**` tolerated). When no such line exists,
+ * a line that itself starts with a recognised keyword — e.g. a bare
+ * `browser-executable` under the heading — is accepted, so agent-authored
+ * format drift does not silently fall back to artifact-driven.
+ *
  * Returns `undefined` when:
  * - the `## UAT Type` section is absent
- * - no `UAT mode:` bullet is found in the section
- * - the value does not start with a recognised keyword
+ * - a `UAT mode:` line exists but its value starts with no recognised keyword
+ * - no line in the section starts with `UAT mode:` or a recognised keyword
  */
 export function extractUatType(content: string): UatType | undefined {
   const sectionText = extractSection(content, 'UAT Type');
   if (!sectionText) return undefined;
 
-  const bullets = parseBullets(sectionText);
-  const modeBullet = bullets.find(b => b.startsWith('UAT mode:'));
-  if (!modeBullet) return undefined;
+  const lines = parseBullets(sectionText).map(line => line.replace(/\*\*/g, ''));
 
-  const rawValue = modeBullet.slice('UAT mode:'.length).trim().toLowerCase();
+  for (const line of lines) {
+    const declared = /^uat mode:\s*(.*)$/i.exec(line);
+    if (declared) return matchUatTypeKeyword(declared[1]);
+  }
 
-  if (rawValue.startsWith('artifact-driven')) return 'artifact-driven';
-  if (rawValue.startsWith('browser-executable')) return 'browser-executable';
-  if (rawValue.startsWith('runtime-executable')) return 'runtime-executable';
-  if (rawValue.startsWith('live-runtime')) return 'live-runtime';
-  if (rawValue.startsWith('human-experience')) return 'human-experience';
-  if (rawValue.startsWith('mixed')) return 'mixed';
+  for (const line of lines) {
+    const matched = matchUatTypeKeyword(line);
+    if (matched) return matched;
+  }
 
   return undefined;
 }

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -36,7 +36,7 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 8. Address every Gate to Close. Q8 = **Operational Readiness**: health signal, failure signal, recovery, monitoring gaps. Omit empty sections.
 9. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
 10. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
-11. Draft concrete UAT with preconditions, steps, expected outcomes, edge cases, and UAT Type.
+11. Draft concrete UAT with preconditions, steps, expected outcomes, edge cases, and UAT Type. Declare the type as a bullet under a `## UAT Type` heading, exactly like `- UAT mode: browser-executable`.
     **Web apps:** when inlined Web App UAT guidance is present, declare `browser-executable` or `runtime-executable` (not `artifact-driven`) for localhost/browser/screenshot steps; include dev-server preconditions and name Playwright specs when they exist.
 12. Review the inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions and gotchas. Read full `*-SUMMARY.md` only if needed. Capture with `capture_thought`; do not append knowledge files.
 13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes.

--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -258,6 +258,48 @@ describe('complete-slice verification gate (#3580)', () => {
     }
   });
 
+  test('allows a browser UAT declared as a bare keyword under ## UAT Type (M006/S01 format drift)', async () => {
+    // Regression: the agent wrote `## UAT Type\nbrowser-executable` (no
+    // `- UAT mode:` bullet). The old parser defaulted that to artifact-driven
+    // and the gate rejected the slice in a loop.
+    const body = [
+      '## UAT Type',
+      'browser-executable',
+      '',
+      '## Smoke Test',
+      '1. Open the page in a browser and perform add/edit/complete/delete once.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /requires browser verification/i,
+        `bare browser-executable declaration must pass the browser gate, got: ${result.error}`,
+      );
+    }
+  });
+
+  test('explains the missing declaration when a browser UAT has no parseable UAT mode', async () => {
+    // When nothing was declared, the error must not claim the agent
+    // "declared artifact-driven" — it must show the expected bullet format.
+    const body = [
+      '## Smoke Test',
+      '1. Open the page in a browser and perform add/edit/complete/delete once.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    assert.ok('error' in result, 'expected handler to reject an undeclared browser UAT');
+    const error = (result as { error: string }).error;
+    assert.match(error, /no parseable UAT mode declaration/i);
+    assert.match(error, /- UAT mode: browser-executable/);
+    assert.doesNotMatch(error, /but declares "UAT mode: artifact-driven"/);
+  });
+
   test('allows a browser UAT when it is declared mixed (mixed receives browser tools)', async () => {
     const body = BROWSER_UAT_BODY.replace('artifact-driven', 'mixed (artifact-driven + browser)');
     const result = await handleCompleteSlice(

--- a/src/resources/extensions/gsd/tests/uat-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-policy.test.ts
@@ -24,6 +24,47 @@ describe("uat-policy", () => {
     assert.equal(getDeclaredUatType("# UAT\n\nCheck generated files."), "artifact-driven");
   });
 
+  it("parses a bare keyword under ## UAT Type (M006/S01 agent format drift)", () => {
+    const content = [
+      "# S01 UAT",
+      "",
+      "## UAT Type",
+      "browser-executable",
+      "",
+      "## Preconditions",
+      "- Open the app at http://127.0.0.1:4173.",
+    ].join("\n");
+    assert.equal(getDeclaredUatType(content), "browser-executable");
+    assert.equal(shouldEscalateArtifactUatToBrowser(content), false);
+  });
+
+  it("parses a UAT mode line case-insensitively with bold markers", () => {
+    const content = [
+      "## UAT Type",
+      "- **UAT Mode:** Runtime-Executable (npx playwright test)",
+    ].join("\n");
+    assert.equal(getDeclaredUatType(content), "runtime-executable");
+  });
+
+  it("does not parse prose in the section as a mode declaration", () => {
+    const content = [
+      "## UAT Type",
+      "- Why this mode is sufficient: static checks cover the schema.",
+    ].join("\n");
+    assert.equal(getDeclaredUatType(content), "artifact-driven");
+  });
+
+  it("treats an explicit UAT mode line with an unrecognised value as undeclared", () => {
+    const content = [
+      "## UAT Type",
+      "- UAT mode: manual-spot-check",
+      "- browser-executable would also work",
+    ].join("\n");
+    // The explicit declaration wins (and fails to parse) — the stray keyword
+    // bullet below it must not be promoted to the declared mode.
+    assert.equal(getDeclaredUatType(content), "artifact-driven");
+  });
+
   it("escalates artifact-driven UAT to browser-executable when the spec requires browser work", () => {
     const content = [
       "## UAT Type",
@@ -38,6 +79,7 @@ describe("uat-policy", () => {
     assert.equal(shouldDispatchUatForContent(content, undefined), true);
     assert.deepEqual(classifyUatContent(content), {
       declaredType: "artifact-driven",
+      modeDeclared: true,
       effectiveType: "browser-executable",
       browserRequired: true,
       shouldDispatchByDefault: true,

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -26,7 +26,7 @@ import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../path
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
-import { getDeclaredUatType, shouldEscalateArtifactUatToBrowser } from "../uat-policy.js";
+import { classifyUatContent, escalatesArtifactUatToBrowser } from "../uat-policy.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb } from "../markdown-renderer.js";
 import { parseRoadmap } from "../parsers-legacy.js";
@@ -355,10 +355,18 @@ export async function handleCompleteSlice(
   // `npx playwright test` via gsd_uat_exec, and live-runtime/mixed/
   // browser-executable receive browser tools (UAT_MODE_POLICIES).
   const uatContent = params.uatContent || "";
-  const declaredUatMode = getDeclaredUatType(uatContent);
-  if (shouldEscalateArtifactUatToBrowser(uatContent)) {
+  const uatPolicy = classifyUatContent(uatContent);
+  if (escalatesArtifactUatToBrowser(uatPolicy)) {
+    // Distinguish an explicit artifact-driven declaration from a missing or
+    // unparseable one that merely *defaulted* to artifact-driven — telling an
+    // agent it "declared artifact-driven" when its declaration simply failed
+    // to parse sends it into a rewrite loop with the same unparseable format.
+    const staticOnlyClause = `which only runs static/file checks and would defer the browser work to a human`;
+    const modeClause = uatPolicy.modeDeclared
+      ? `declares "UAT mode: artifact-driven", ${staticOnlyClause}`
+      : `has no parseable UAT mode declaration in its "## UAT Type" section (the declaration must be a bullet exactly like "- UAT mode: browser-executable"), so it defaults to "artifact-driven", ${staticOnlyClause}`;
     return {
-      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but declares "UAT mode: artifact-driven", which only runs static/file checks and would defer the browser work to a human. Use a mode that actually verifies the UI: "browser-executable" (interactive browser tools), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
+      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but ${modeClause}. Use a mode that actually verifies the UI: "browser-executable" (interactive browser tools), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
     };
   }
 

--- a/src/resources/extensions/gsd/uat-policy.ts
+++ b/src/resources/extensions/gsd/uat-policy.ts
@@ -2,7 +2,7 @@
 // File Purpose: Central UAT mode policy for dispatch, tool presentation, and result validation.
 
 import { hasBrowserContractPrefix } from "../shared/browser-contract.js";
-import { extractUatType } from "./files.js";
+import { extractUatType, UAT_TYPE_KEYWORDS } from "./files.js";
 import type { UatType } from "./files.js";
 import { hasBrowserRequiredText } from "./browser-evidence.js";
 import { parseMcpToolName } from "./mcp-tool-name.js";
@@ -28,19 +28,14 @@ export interface UatModePolicy {
 
 export interface UatContentPolicy {
   declaredType: UatType;
+  /** False when no parseable `UAT mode:` declaration exists and declaredType defaulted to artifact-driven. */
+  modeDeclared: boolean;
   effectiveType: UatType;
   browserRequired: boolean;
   shouldDispatchByDefault: boolean;
 }
 
-export const UAT_TYPES: readonly UatType[] = [
-  "artifact-driven",
-  "browser-executable",
-  "runtime-executable",
-  "live-runtime",
-  "mixed",
-  "human-experience",
-] as const;
+export const UAT_TYPES: readonly UatType[] = UAT_TYPE_KEYWORDS;
 
 export const UAT_MODE_POLICIES: Readonly<Record<UatType, UatModePolicy>> = {
   "artifact-driven": {
@@ -90,7 +85,8 @@ export function getDeclaredUatType(content: string): UatType {
 }
 
 export function classifyUatContent(content: string): UatContentPolicy {
-  const declaredType = getDeclaredUatType(content);
+  const parsedType = extractUatType(content);
+  const declaredType = parsedType ?? "artifact-driven";
   const browserRequired = hasBrowserRequiredText(content);
   const effectiveType = declaredType === "artifact-driven" && browserRequired
     ? "browser-executable"
@@ -98,15 +94,19 @@ export function classifyUatContent(content: string): UatContentPolicy {
 
   return {
     declaredType,
+    modeDeclared: parsedType !== undefined,
     effectiveType,
     browserRequired,
     shouldDispatchByDefault: effectiveType !== "artifact-driven" || browserRequired,
   };
 }
 
-export function shouldEscalateArtifactUatToBrowser(content: string): boolean {
-  const policy = classifyUatContent(content);
+export function escalatesArtifactUatToBrowser(policy: UatContentPolicy): boolean {
   return policy.declaredType === "artifact-driven" && policy.browserRequired;
+}
+
+export function shouldEscalateArtifactUatToBrowser(content: string): boolean {
+  return escalatesArtifactUatToBrowser(classifyUatContent(content));
 }
 
 export function resolveEffectiveUatType(content: string): UatType {

--- a/src/resources/extensions/gsd/verdict-parser.ts
+++ b/src/resources/extensions/gsd/verdict-parser.ts
@@ -137,7 +137,7 @@ export function isValidMilestoneVerdict(verdict: string): verdict is ValidationV
  * Extract the UAT type from content, defaulting to `"artifact-driven"`.
  *
  * The `"artifact-driven"` fallback is the original default used throughout
- * the codebase when a UAT file lacks an explicit `## UAT Type` section.
+ * the codebase when a UAT file has no parseable UAT mode declaration.
  */
 export function getUatType(content: string): UatType {
   return getDeclaredUatType(content);


### PR DESCRIPTION
## What Changed
- Teach the GSD UAT policy/parser path to recognize bare `UAT Type:` declarations, so explicit executable/browser/manual modes are preserved instead of falling back to artifact-driven inference.
- Update complete-slice verification gate handling and prompt text so bare browser-executable UAT bodies route through the expected executable-evidence flow.
- Add focused UAT policy and complete-slice gate coverage, and sync the developer UAT process docs with the supported declaration format.

## Risk Assessment

✅ Low: The change is narrowly scoped to UAT type parsing and complete-slice messaging, preserves existing policy paths, and includes focused regression coverage for the new accepted format.

## Testing

Restored dependencies, resolved the fresh-worktree missing-dist setup issue with the repo build chain, reran the focused UAT policy and complete-slice gate tests successfully, and captured a reviewer-facing transcript showing the bare `browser-executable` UAT body is parsed and accepted by `gsd_slice_complete`.

<details>
<summary>Evidence: Bare UAT Type complete-slice evidence</summary>

```text
# Bare UAT Type acceptance evidence

## Input UAT
`` `markdown
## UAT Type
browser-executable

## Smoke Test
1. Open the page in a browser and perform add/edit/complete/delete once.
`` `

## Observed behavior
`` `json
{
  "scenario": "gsd_slice_complete receives a browser UAT whose ## UAT Type section contains only a bare browser-executable value",
  "uatContent": "## UAT Type\nbrowser-executable\n\n## Smoke Test\n1. Open the page in a browser and perform add/edit/complete/delete once.",
  "parsedPolicy": {
    "declaredType": "browser-executable",
    "modeDeclared": true,
    "effectiveType": "browser-executable",
    "browserRequired": true,
    "shouldDispatchByDefault": true
  },
  "shouldEscalateArtifactUatToBrowser": false,
  "acceptedByCompleteSliceBrowserGate": true,
  "toolResult": {
    "summaryPath": "/private/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-uat-evidence-project-FTE3Cw/.gsd/milestones/M001/slices/S01/S01-SUMMARY.md",
    "uatPath": "/private/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-uat-evidence-project-FTE3Cw/.gsd/milestones/M001/slices/S01/S01-UAT.md"
  }
}
`` `
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile --ignore-scripts`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/uat-policy.test.ts src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts` (initial run: parser test passed; complete-slice test hit missing package dist setup issue)</code>
- <code>`pnpm run build:agent-core` (confirmed dependent package dists were missing)</code>
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/uat-policy.test.ts src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module &lt;&lt;&#39;EOF&#39; ... EOF` to capture complete-slice evidence for a bare browser-executable UAT body</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to UAT type parsing, policy classification metadata, and complete-slice validation messaging, with regression tests for the new formats.
> 
> **Overview**
> **UAT mode parsing** no longer treats agent format drift as implicit `artifact-driven` when the `## UAT Type` section uses a bare keyword (e.g. `browser-executable` without `- UAT mode:`). `extractUatType` now prefers a `UAT mode:` bullet (case-insensitive, bold-tolerant), then falls back to bullet lines that start with a recognized keyword; unrecognized explicit `UAT mode:` values stay undeclared so later keyword bullets are not promoted.
> 
> **Policy and complete-slice gate** expose `modeDeclared` on `classifyUatContent` and tailor rejection copy when browser work is required but the effective mode is still `artifact-driven`: missing/unparseable declarations get the expected `- UAT mode: browser-executable` hint instead of blaming an explicit artifact-driven choice.
> 
> **Docs and prompts** align the UAT contract (`uat-process.md`, `complete-slice.md`) with the canonical bullet form while documenting the bare-keyword compatibility path. Focused tests cover drift, prose false positives, and gate error wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77755c468c2045f9c5d76705f982febe138d7b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->