### PR TITLE
fix(gsd): parse bare UAT Type declarations instead of defaulting to artifact-driven

### DIFF
--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -671,33 +671,54 @@ export function parseTaskPlanIO(content: string): { inputFiles: string[]; output
  */
 export type UatType = 'artifact-driven' | 'live-runtime' | 'human-experience' | 'mixed' | 'browser-executable' | 'runtime-executable';
 
+/** Canonical list of recognised UAT types — uat-policy.ts re-exports this as UAT_TYPES. */
+export const UAT_TYPE_KEYWORDS: readonly UatType[] = [
+  'artifact-driven',
+  'browser-executable',
+  'runtime-executable',
+  'live-runtime',
+  'mixed',
+  'human-experience',
+];
+
+/** Match a value against the recognised UAT type keywords (leading-keyword-only). */
+function matchUatTypeKeyword(value: string): UatType | undefined {
+  const normalized = value.trim().toLowerCase();
+  return UAT_TYPE_KEYWORDS.find(keyword => normalized.startsWith(keyword));
+}
+
 /**
  * Extract the UAT type from a UAT file's raw content.
  *
  * UAT files have no YAML frontmatter - pass raw file content directly.
  * Classification is leading-keyword-only: e.g. `mixed (artifact-driven + live-runtime)` → `'mixed'`.
  *
+ * The canonical form is a `- UAT mode: <type>` bullet under `## UAT Type`
+ * (case-insensitive prefix, `**bold**` tolerated). When no such line exists,
+ * a line that itself starts with a recognised keyword — e.g. a bare
+ * `browser-executable` under the heading — is accepted, so agent-authored
+ * format drift does not silently fall back to artifact-driven.
+ *
  * Returns `undefined` when:
  * - the `## UAT Type` section is absent
- * - no `UAT mode:` bullet is found in the section
- * - the value does not start with a recognised keyword
+ * - a `UAT mode:` line exists but its value starts with no recognised keyword
+ * - no line in the section starts with `UAT mode:` or a recognised keyword
  */
 export function extractUatType(content: string): UatType | undefined {
   const sectionText = extractSection(content, 'UAT Type');
   if (!sectionText) return undefined;
 
-  const bullets = parseBullets(sectionText);
-  const modeBullet = bullets.find(b => b.startsWith('UAT mode:'));
-  if (!modeBullet) return undefined;
+  const lines = parseBullets(sectionText).map(line => line.replace(/\*\*/g, ''));
 
-  const rawValue = modeBullet.slice('UAT mode:'.length).trim().toLowerCase();
+  for (const line of lines) {
+    const declared = /^uat mode:\s*(.*)$/i.exec(line);
+    if (declared) return matchUatTypeKeyword(declared[1]);
+  }
 
-  if (rawValue.startsWith('artifact-driven')) return 'artifact-driven';
-  if (rawValue.startsWith('browser-executable')) return 'browser-executable';
-  if (rawValue.startsWith('runtime-executable')) return 'runtime-executable';
-  if (rawValue.startsWith('live-runtime')) return 'live-runtime';
-  if (rawValue.startsWith('human-experience')) return 'human-experience';
-  if (rawValue.startsWith('mixed')) return 'mixed';
+  for (const line of lines) {
+    const matched = matchUatTypeKeyword(line);
+    if (matched) return matched;
+  }
 
   return undefined;
 }

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -36,7 +36,7 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 8. Address every Gate to Close. Q8 = **Operational Readiness**: health signal, failure signal, recovery, monitoring gaps. Omit empty sections.
 9. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
 10. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
-11. Draft concrete UAT with preconditions, steps, expected outcomes, edge cases, and UAT Type.
+11. Draft concrete UAT with preconditions, steps, expected outcomes, edge cases, and UAT Type. Declare the type as a bullet under a `## UAT Type` heading, exactly like `- UAT mode: browser-executable`.
     **Web apps:** when inlined Web App UAT guidance is present, declare `browser-executable` or `runtime-executable` (not `artifact-driven`) for localhost/browser/screenshot steps; include dev-server preconditions and name Playwright specs when they exist.
 12. Review the inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions and gotchas. Read full `*-SUMMARY.md` only if needed. Capture with `capture_thought`; do not append knowledge files.
 13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes.

--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -258,6 +258,48 @@ describe('complete-slice verification gate (#3580)', () => {
     }
   });
 
+  test('allows a browser UAT declared as a bare keyword under ## UAT Type (M006/S01 format drift)', async () => {
+    // Regression: the agent wrote `## UAT Type\nbrowser-executable` (no
+    // `- UAT mode:` bullet). The old parser defaulted that to artifact-driven
+    // and the gate rejected the slice in a loop.
+    const body = [
+      '## UAT Type',
+      'browser-executable',
+      '',
+      '## Smoke Test',
+      '1. Open the page in a browser and perform add/edit/complete/delete once.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    if ('error' in result) {
+      assert.doesNotMatch(
+        result.error,
+        /requires browser verification/i,
+        `bare browser-executable declaration must pass the browser gate, got: ${result.error}`,
+      );
+    }
+  });
+
+  test('explains the missing declaration when a browser UAT has no parseable UAT mode', async () => {
+    // When nothing was declared, the error must not claim the agent
+    // "declared artifact-driven" — it must show the expected bullet format.
+    const body = [
+      '## Smoke Test',
+      '1. Open the page in a browser and perform add/edit/complete/delete once.',
+    ].join('\n');
+    const result = await handleCompleteSlice(
+      makeParams({ uatContent: body }),
+      basePath,
+    );
+    assert.ok('error' in result, 'expected handler to reject an undeclared browser UAT');
+    const error = (result as { error: string }).error;
+    assert.match(error, /no parseable UAT mode declaration/i);
+    assert.match(error, /- UAT mode: browser-executable/);
+    assert.doesNotMatch(error, /but declares "UAT mode: artifact-driven"/);
+  });
+
   test('allows a browser UAT when it is declared mixed (mixed receives browser tools)', async () => {
     const body = BROWSER_UAT_BODY.replace('artifact-driven', 'mixed (artifact-driven + browser)');
     const result = await handleCompleteSlice(

--- a/src/resources/extensions/gsd/tests/uat-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-policy.test.ts
@@ -24,6 +24,47 @@ describe("uat-policy", () => {
     assert.equal(getDeclaredUatType("# UAT\n\nCheck generated files."), "artifact-driven");
   });
 
+  it("parses a bare keyword under ## UAT Type (M006/S01 agent format drift)", () => {
+    const content = [
+      "# S01 UAT",
+      "",
+      "## UAT Type",
+      "browser-executable",
+      "",
+      "## Preconditions",
+      "- Open the app at http://127.0.0.1:4173.",
+    ].join("\n");
+    assert.equal(getDeclaredUatType(content), "browser-executable");
+    assert.equal(shouldEscalateArtifactUatToBrowser(content), false);
+  });
+
+  it("parses a UAT mode line case-insensitively with bold markers", () => {
+    const content = [
+      "## UAT Type",
+      "- **UAT Mode:** Runtime-Executable (npx playwright test)",
+    ].join("\n");
+    assert.equal(getDeclaredUatType(content), "runtime-executable");
+  });
+
+  it("does not parse prose in the section as a mode declaration", () => {
+    const content = [
+      "## UAT Type",
+      "- Why this mode is sufficient: static checks cover the schema.",
+    ].join("\n");
+    assert.equal(getDeclaredUatType(content), "artifact-driven");
+  });
+
+  it("treats an explicit UAT mode line with an unrecognised value as undeclared", () => {
+    const content = [
+      "## UAT Type",
+      "- UAT mode: manual-spot-check",
+      "- browser-executable would also work",
+    ].join("\n");
+    // The explicit declaration wins (and fails to parse) — the stray keyword
+    // bullet below it must not be promoted to the declared mode.
+    assert.equal(getDeclaredUatType(content), "artifact-driven");
+  });
+
   it("escalates artifact-driven UAT to browser-executable when the spec requires browser work", () => {
     const content = [
       "## UAT Type",
@@ -38,6 +79,7 @@ describe("uat-policy", () => {
     assert.equal(shouldDispatchUatForContent(content, undefined), true);
     assert.deepEqual(classifyUatContent(content), {
       declaredType: "artifact-driven",
+      modeDeclared: true,
       effectiveType: "browser-executable",
       browserRequired: true,
       shouldDispatchByDefault: true,

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -26,7 +26,7 @@ import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../path
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
-import { getDeclaredUatType, shouldEscalateArtifactUatToBrowser } from "../uat-policy.js";
+import { classifyUatContent, escalatesArtifactUatToBrowser } from "../uat-policy.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb } from "../markdown-renderer.js";
 import { parseRoadmap } from "../parsers-legacy.js";
@@ -355,10 +355,18 @@ export async function handleCompleteSlice(
   // `npx playwright test` via gsd_uat_exec, and live-runtime/mixed/
   // browser-executable receive browser tools (UAT_MODE_POLICIES).
   const uatContent = params.uatContent || "";
-  const declaredUatMode = getDeclaredUatType(uatContent);
-  if (shouldEscalateArtifactUatToBrowser(uatContent)) {
+  const uatPolicy = classifyUatContent(uatContent);
+  if (escalatesArtifactUatToBrowser(uatPolicy)) {
+    // Distinguish an explicit artifact-driven declaration from a missing or
+    // unparseable one that merely *defaulted* to artifact-driven — telling an
+    // agent it "declared artifact-driven" when its declaration simply failed
+    // to parse sends it into a rewrite loop with the same unparseable format.
+    const staticOnlyClause = `which only runs static/file checks and would defer the browser work to a human`;
+    const modeClause = uatPolicy.modeDeclared
+      ? `declares "UAT mode: artifact-driven", ${staticOnlyClause}`
+      : `has no parseable UAT mode declaration in its "## UAT Type" section (the declaration must be a bullet exactly like "- UAT mode: browser-executable"), so it defaults to "artifact-driven", ${staticOnlyClause}`;
     return {
-      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but declares "UAT mode: artifact-driven", which only runs static/file checks and would defer the browser work to a human. Use a mode that actually verifies the UI: "browser-executable" (interactive browser tools), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
+      error: `UAT requires browser verification (opening a page in a browser, navigating to a page or localhost, screenshots) but ${modeClause}. Use a mode that actually verifies the UI: "browser-executable" (interactive browser tools), "runtime-executable" (a browser test command such as playwright), or a browser-inclusive "mixed"/"live-runtime". Re-author the UAT Type section and complete the slice again.`,
     };
   }
 

--- a/src/resources/extensions/gsd/uat-policy.ts
+++ b/src/resources/extensions/gsd/uat-policy.ts
@@ -2,7 +2,7 @@
 // File Purpose: Central UAT mode policy for dispatch, tool presentation, and result validation.
 
 import { hasBrowserContractPrefix } from "../shared/browser-contract.js";
-import { extractUatType } from "./files.js";
+import { extractUatType, UAT_TYPE_KEYWORDS } from "./files.js";
 import type { UatType } from "./files.js";
 import { hasBrowserRequiredText } from "./browser-evidence.js";
 import { parseMcpToolName } from "./mcp-tool-name.js";
@@ -28,19 +28,14 @@ export interface UatModePolicy {
 
 export interface UatContentPolicy {
   declaredType: UatType;
+  /** False when no parseable `UAT mode:` declaration exists and declaredType defaulted to artifact-driven. */
+  modeDeclared: boolean;
   effectiveType: UatType;
   browserRequired: boolean;
   shouldDispatchByDefault: boolean;
 }
 
-export const UAT_TYPES: readonly UatType[] = [
-  "artifact-driven",
-  "browser-executable",
-  "runtime-executable",
-  "live-runtime",
-  "mixed",
-  "human-experience",
-] as const;
+export const UAT_TYPES: readonly UatType[] = UAT_TYPE_KEYWORDS;
 
 export const UAT_MODE_POLICIES: Readonly<Record<UatType, UatModePolicy>> = {
   "artifact-driven": {
@@ -90,7 +85,8 @@ export function getDeclaredUatType(content: string): UatType {
 }
 
 export function classifyUatContent(content: string): UatContentPolicy {
-  const declaredType = getDeclaredUatType(content);
+  const parsedType = extractUatType(content);
+  const declaredType = parsedType ?? "artifact-driven";
   const browserRequired = hasBrowserRequiredText(content);
   const effectiveType = declaredType === "artifact-driven" && browserRequired
     ? "browser-executable"
@@ -98,15 +94,19 @@ export function classifyUatContent(content: string): UatContentPolicy {
 
   return {
     declaredType,
+    modeDeclared: parsedType !== undefined,
     effectiveType,
     browserRequired,
     shouldDispatchByDefault: effectiveType !== "artifact-driven" || browserRequired,
   };
 }
 
-export function shouldEscalateArtifactUatToBrowser(content: string): boolean {
-  const policy = classifyUatContent(content);
+export function escalatesArtifactUatToBrowser(policy: UatContentPolicy): boolean {
   return policy.declaredType === "artifact-driven" && policy.browserRequired;
+}
+
+export function shouldEscalateArtifactUatToBrowser(content: string): boolean {
+  return escalatesArtifactUatToBrowser(classifyUatContent(content));
 }
 
 export function resolveEffectiveUatType(content: string): UatType {


### PR DESCRIPTION
## Summary
- Accept bare recognised UAT mode keywords under `## UAT Type` (not only `- UAT mode:` bullets)
- Expose `modeDeclared` so complete-slice can distinguish declared vs defaulted artifact-driven mode
- Fix rejection message and document the expected declaration format in the complete-slice prompt

Fixes the M006 rewrite loop where `browser-executable` authored as a bare keyword silently defaulted to `artifact-driven`, causing complete-slice to reject the UAT and reopen the slice repeatedly.

## Test plan
- [x] `uat-policy.test.ts` — bare keyword, case-insensitive prefix, bold markers, unrecognised explicit values
- [x] `complete-slice-verification-gate.test.ts` — gate regression for declared vs defaulted modes


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->