### PR TITLE
chore(pi-ai): decouple model generation from build

### DIFF
--- a/packages/pi-ai/README.md
+++ b/packages/pi-ai/README.md
@@ -1326,6 +1326,7 @@ Create a new provider file (for example `amazon-bedrock.ts`) that exports:
 - Map chat/tool-capable provider model data to the standardized `Model` interface via `scripts/generate-models.ts`
 - Map image-generation provider model data to the standardized `ImagesModel` interface via `scripts/generate-image-models.ts`
 - Handle provider-specific quirks (pricing format, capability flags, model ID transformations)
+- Run `pnpm run generate` from `packages/pi-ai` when changing model generation; `pnpm run build` compiles the committed generated catalogs without refreshing them.
 
 #### 5. Tests (`test/`)
 

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -72,7 +72,8 @@
     "clean": "node ../../scripts/clean-package-dist.cjs",
     "generate-models": "node scripts/generate-models.ts",
     "generate-image-models": "node scripts/generate-image-models.ts",
-    "build": "node ../../scripts/clean-package-dist.cjs && node scripts/generate-models.ts && node scripts/generate-image-models.ts && tsc -p tsconfig.json --incremental false",
+    "generate": "pnpm run generate-models && pnpm run generate-image-models",
+    "build": "pnpm run clean && tsc -p tsconfig.json --incremental false",
     "test": "vitest --run",
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },


### PR DESCRIPTION
## What Changed
- Decoupled `@gsd/pi-ai` model catalog generation from the package build so `build` runs clean TypeScript compilation without rewriting generated model snapshots.
- Added an explicit package `generate` command that runs both text and image model catalog generation when catalog refreshes are intended.
- Documented the explicit generation workflow in the package README.

## Risk Assessment

✅ Low: The change is limited to decoupling @gsd/pi-ai model generation from the package build script while leaving tracked generated sources in place and adding an explicit generate script.

## Testing

After dependency setup with a non-blocking optional postinstall warning, I verified the end-user developer flow: `@gsd/pi-ai` build compiled without regenerating committed model catalogs, explicit `generate` fetched and rewrote the catalogs, the generated-model regression test passed when run directly, and the worktree was cleaned back to a clean state.

<details>
<summary>Evidence: Build did not regenerate catalogs</summary>

```text
## command: pnpm --filter @gsd/pi-ai build
## before generated catalog checksums
571ef7f062c010233ac4bc03d927c50d708e1043  packages/pi-ai/src/models.generated.ts
6334645e64dc422f68bdf4043892bebeec44de40  packages/pi-ai/src/image-models.generated.ts

> @gsd/pi-ai@1.2.0 build /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai
> pnpm run clean && tsc -p tsconfig.json --incremental false


> @gsd/pi-ai@1.2.0 clean /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai
> node ../../scripts/clean-package-dist.cjs

## build_exit_status=0
## after generated catalog checksums
571ef7f062c010233ac4bc03d927c50d708e1043  packages/pi-ai/src/models.generated.ts
6334645e64dc422f68bdf4043892bebeec44de40  packages/pi-ai/src/image-models.generated.ts
## generated catalog git status after build
```
</details>
<details>
<summary>Evidence: Explicit generate refreshed catalogs</summary>

```text
## command: pnpm --filter @gsd/pi-ai generate

> @gsd/pi-ai@1.2.0 generate /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai
> pnpm run generate-models && pnpm run generate-image-models


> @gsd/pi-ai@1.2.0 generate-models /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai
> node scripts/generate-models.ts

Fetching models from models.dev API...
Loaded 475 tool-capable models from models.dev
Fetching models from OpenRouter API...
Fetched 252 tool-capable models from OpenRouter
Fetching models from Vercel AI Gateway API...
Fetched 166 tool-capable models from Vercel AI Gateway
Generated src/models.generated.ts

Model Statistics:
  Total tool-capable models: 955
  Reasoning-capable models: 696
  amazon-bedrock: 98 models
  anthropic: 25 models
  anthropic-vertex: 12 models
  google: 16 models
  openai: 42 models
  groq: 7 models
  cerebras: 2 models
  cloudflare-workers-ai: 11 models
  cloudflare-ai-gateway: 37 models
  xai: 7 models
  zai: 5 models
  mistral: 30 models
  huggingface: 22 models
  fireworks: 13 models
  together: 17 models
  opencode: 45 models
  opencode-go: 14 models
  github-copilot: 23 models
  minimax: 3 models
  minimax-cn: 3 models
  kimi-coding: 2 models
  moonshotai: 7 models
  moonshotai-cn: 7 models
  xiaomi: 6 models
  xiaomi-token-plan-cn: 6 models
  xiaomi-token-plan-ams: 6 models
  xiaomi-token-plan-sgp: 6 models
  openrouter: 253 models
  vercel-ai-gateway: 166 models
  deepseek: 2 models
  openai-codex: 6 models
  google-vertex: 13 models
  azure-openai-responses: 42 models

> @gsd/pi-ai@1.2.0 generate-image-models /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai
> node scripts/generate-image-models.ts

Fetching image models from OpenRouter API...
Fetched 32 image models from OpenRouter
Generated /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai/src/image-models.generated.ts
## generate_exit_status=0
## generated catalog git status after explicit generate
 M packages/pi-ai/src/image-models.generated.ts
 M packages/pi-ai/src/models.generated.ts
```
</details>
<details>
<summary>Evidence: Focused generated models test</summary>

```text
## command: pnpm --dir packages/pi-ai exec vitest --run test/generated-models.test.ts

 RUN  v4.1.0 /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  10:35:44
   Duration  274ms (transform 150ms, setup 0ms, import 169ms, tests 3ms, environment 0ms)

## test_exit_status=0
```
</details>
<details>
<summary>Evidence: Initial broad pi-ai test failure</summary>

```text
## command: pnpm --filter @gsd/pi-ai test -- test/generated-models.test.ts

> @gsd/pi-ai@1.2.0 test /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai
> vitest --run -- test/generated-models.test.ts


 RUN  v4.1.0 /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai

 ❯ test/faux-provider.test.ts (22 tests | 1 failed) 215ms
     × unregisters the provider 12ms
 ❯ test/google-shared-gemini3-unsigned-tool-call.test.ts (4 tests | 3 failed) 9ms
     × does not add skip_thought_signature_validator for unsigned Google Gen AI tool calls 7ms
     × does not add skip_thought_signature_validator for unsigned Vertex tool calls 1ms
     × preserves valid thoughtSignature when present for the same provider and model 1ms
 ❯ test/anthropic-adaptive-thinking-models.test.ts (1 test | 1 failed) 13ms
     × marks exactly the built-in Anthropic API models that use adaptive thinking 12ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/anthropic-adaptive-thinking-models.test.ts > Anthropic adaptive thinking model metadata > marks exactly the built-in Anthropic API models that use adaptive thinking
AssertionError: expected [ …(28) ] to deeply equal [ …(24) ]

- Expected
+ Received

@@ -1,14 +1,17 @@
  [
+   "anthropic-vertex/claude-fable-5",
    "anthropic-vertex/claude-opus-4-6",
    "anthropic-vertex/claude-opus-4-7",
    "anthropic-vertex/claude-opus-4-8",
    "anthropic-vertex/claude-sonnet-4-6",
+   "anthropic/claude-fable-5",
    "anthropic/claude-opus-4-6",
    "anthropic/claude-opus-4-7",
    "anthropic/claude-opus-4-8",
    "anthropic/claude-sonnet-4-6",
+   "cloudflare-ai-gateway/claude-fable-5",
    "cloudflare-ai-gateway/claude-opus-4-6",
    "cloudflare-ai-gateway/claude-opus-4-7",
    "cloudflare-ai-gateway/claude-opus-4-8",
    "cloudflare-ai-gateway/claude-sonnet-4-6",
    "github-copilot/claude-opus-4.6",
@@ -17,10 +20,11 @@
    "github-copilot/claude-sonnet-4.6",
    "opencode/claude-opus-4-6",
    "opencode/claude-opus-4-7",
    "opencode/claude-opus-4-8",
    "opencode/claude-sonnet-4-6",
+   "vercel-ai-gateway/anthropic/claude-fable-5",
    "vercel-ai-gateway/anthropic/claude-opus-4.6",
    "vercel-ai-gateway/anthropic/claude-opus-4.7",
    "vercel-ai-gateway/anthropic/claude-opus-4.8",
    "vercel-ai-gateway/anthropic/claude-sonnet-4.6",
  ]

 ❯ test/anthropic-adaptive-thinking-models.test.ts:44:25
     42|    .sort();
     43|
     44|   expect(flaggedModels).toEqual([...EXPECTED_ADAPTIVE_THINKING_MODELS]…
       |                         ^
     45|  });
     46| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  test/faux-provider.test.ts > faux provider > unregisters the provider
AssertionError: expected [Function] to throw error including 'No API provider registered for api: f…' but got 'No API provider registered for provid…'

Expected: "No API provider registered for api: faux:1781278523763:k8bw788dnb9"
Received: "No API provider registered for provider/api: faux/faux:1781278523763:k8bw788dnb9"

 ❯ test/faux-provider.test.ts:595:3
    593|   await expect(
    594|    complete(registration.getModel(), { messages: [{ role: "user", cont…
    595|   ).rejects.toThrow(`No API provider registered for api: ${registratio…
       |   ^
    596|  });
    597| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  test/google-shared-gemini3-unsigned-tool-call.test.ts > google-shared convertMessages — Gemini 3 unsigned tool calls > does not add skip_thought_signature_validator for unsigned Google Gen AI tool calls
AssertionError: expected 'skip_thought_signature_validator' to be undefined

- Expected:
undefined

+ Received:
"skip_thought_signature_validator"

 ❯ test/google-shared-gemini3-unsigned-tool-call.test.ts:74:50
     72|   const functionCallParts = modelTurn?.parts?.filter((p) => p.function…
     73|   expect(functionCallParts).toHaveLength(2);
     74|   expect(functionCallParts[0]?.thoughtSignature).toBeUndefined();
       |                                                  ^
     75|   expect(functionCallParts[1]?.thoughtSignature).toBeUndefined();
     76|   expect(JSON.stringify(modelTurn)).not.toContain("skip_thought_signat…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  test/google-shared-gemini3-unsigned-tool-call.test.ts > google-shared convertMessages — Gemini 3 unsigned tool calls > does not add skip_thought_signature_validator for unsigned Vertex tool calls
AssertionError: expected 'skip_thought_signature_validator' to be undefined

- Expected:
undefined

+ Received:
"skip_thought_signature_validator"

 ❯ test/google-shared-gemini3-unsigned-tool-call.test.ts:90:50
     88|
     89|   expect(functionCallParts).toHaveLength(2);
     90|   expect(functionCallParts[0]?.thoughtSignature).toBeUndefined();
       |                                                  ^
     91|   expect(functionCallParts[1]?.thoughtSignature).toBeUndefined();
     92|   expect(JSON.stringify(modelTurn)).not.toContain("skip_thought_signat…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

 FAIL  test/google-shared-gemini3-unsigned-tool-call.test.ts > google-shared convertMessages — Gemini 3 unsigned tool calls > preserves valid thoughtSignature when present for the same provider and model
AssertionError: expected 'skip_thought_signature_validator' to be undefined

- Expected:
undefined

+ Received:
"skip_thought_signature_validator"

 ❯ test/google-shared-gemini3-unsigned-tool-call.test.ts:104:50
    102|   expect(functionCallParts).toHaveLength(2);
    103|   expect(functionCallParts[0]?.thoughtSignature).toBe(validSig);
    104|   expect(functionCallParts[1]?.thoughtSignature).toBeUndefined();
       |                                                  ^
    105|  });
    106|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/5]⎯


 Test Files  3 failed | 50 passed | 25 skipped (78)
      Tests  5 failed | 295 passed | 716 skipped (1016)
   Start at  10:35:22
   Duration  6.31s (transform 3.21s, setup 0ms, import 14.24s, tests 7.51s, environment 9ms)

/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KTY6VZM5DY9181SJCG35Q851/packages/pi-ai:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @gsd/pi-ai@1.2.0 test: `vitest --run -- test/generated-models.test.ts`
Exit status 1
## test_exit_status=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git merge-base --is-ancestor HEAD origin/main; printf &#39;head_ancestor_origin_main=%s\n&#39; $?` confirmed the target worktree was not already merged.</code>
- <code>`pnpm install --frozen-lockfile` installed workspace dependencies; postinstall warned optional runtime dependencies could not be materialized, but package scripts were usable.</code>
- <code>`pnpm --filter @gsd/pi-ai build` with before/after `shasum packages/pi-ai/src/models.generated.ts packages/pi-ai/src/image-models.generated.ts` confirmed build ran `clean` + `tsc` and left both generated catalog checksums unchanged.</code>
- <code>`pnpm --filter @gsd/pi-ai generate` confirmed the new explicit command ran `generate-models` and `generate-image-models`, fetched live catalogs, and rewrote both generated catalog files intentionally.</code>
- <code>`git restore -- packages/pi-ai/src/models.generated.ts packages/pi-ai/src/image-models.generated.ts` restored the reviewed generated snapshots after the explicit generate evidence run.</code>
- <code>`pnpm --filter @gsd/pi-ai test -- test/generated-models.test.ts` expanded into a broad package test run and failed in unrelated existing pi-ai tests; transcript captured for audit.</code>
- <code>`pnpm --dir packages/pi-ai exec vitest --run test/generated-models.test.ts` passed the focused generated-model catalog regression test.</code>
- <code>Removed test-created ignored dependency/build artifacts from the worktree and verified `git status --short` was clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to the pi-ai package; developers who relied on `build` to refresh catalogs must run `generate` explicitly instead.
> 
> **Overview**
> **`@gsd/pi-ai` build no longer refreshes model catalogs** — `build` is now `clean` + `tsc` only, so committed `models.generated.ts` / `image-models.generated.ts` stay unchanged during normal compiles.
> 
> A new **`pnpm run generate`** script chains `generate-models` and `generate-image-models` for intentional catalog updates. The README **Adding a New Provider** section documents that workflow: run **`generate`** when changing generation logic; use **`build`** when you only need TypeScript output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9afdbf2161291f91eb94e0d684e0ba50da7cd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->