### PR TITLE
fix(gsd): add actionable blocker recovery guidance

### DIFF
--- a/docs/dev/uat-process.md
+++ b/docs/dev/uat-process.md
@@ -7,7 +7,7 @@ This document names the current UAT contract so prompt, dispatch, browser toolin
 1. `complete-slice` persists the slice summary and UAT spec. It rejects browser-observable specs that declare `artifact-driven` or omit a parseable UAT mode.
 2. `run-uat` runs after slice completion. It classifies the UAT spec through `src/resources/extensions/gsd/uat-policy.ts`, presents the matching tool surface, records typed evidence, and saves one `S##-ASSESSMENT.md` plus a typed attempt record through `gsd_uat_result_save`.
 3. `validate-milestone` runs after all slices close. It dispatches three reviewers in parallel: requirements coverage, cross-slice integration, and assessment/acceptance evidence. It consumes UAT assessments; it is not the UAT producer.
-4. `complete-milestone` runs only after validation records a passing milestone verdict.
+4. `complete-milestone` runs only after every slice has a UAT assessment with verdict `PASS` and validation records a passing milestone verdict. If a slice is missing a PASS verdict, auto mode stops with recovery guidance to run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, or add remediation slices with `/gsd dispatch reassess`.
 
 ## UAT Mode Policy
 
@@ -34,6 +34,7 @@ GSD exposes a product-level Browser Automation Contract with canonical `browser_
 - `run-uat` requires `gsd_uat_result_save` and rejects forbidden summary/gate write substitutes.
 - `src/resources/extensions/gsd/uat-run.ts` owns `gsd_uat_result_save` lifecycle preparation, run IDs, attempt metadata, worktree capture, and assessment rendering.
 - `gsd_uat_result_save` validates objective evidence, fresh UAT-owned exec evidence, canonical tool presentation, and mode-specific evidence before saving the assessment and attempt artifact.
+- Milestone closeout requires each slice assessment to record `PASS`; missing or non-PASS verdicts block closeout with steps to rerun UAT, inspect `/gsd status`, or dispatch reassessment work.
 - Manual handoff text includes the real worktree path when checks are left as `NEEDS-HUMAN`.
 - Milestone validation downgrades a pass to `needs-attention` when browser-observable acceptance criteria lack persisted browser/runtime evidence.
 

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -13,7 +13,7 @@ Each slice flows through phases automatically:
 ```
 Plan (with integrated research) → Execute (per task) → Complete → Reassess Roadmap → Next Slice
                                                                                       ↓ (all slices done)
-                                                                              Validate Milestone → Complete Milestone
+                                                                      UAT PASS → Validate Milestone → Complete Milestone
 ```
 
 - **Plan** — scouts the codebase, researches relevant docs, and decomposes the slice into tasks with must-haves
@@ -28,7 +28,7 @@ When progressive planning is enabled, GSD fully plans the first slice and may le
 
 Milestone completion is safe to retry. If a `complete-milestone` unit is redispatched after the database already marks the milestone as closed, GSD treats the call as successful instead of returning an error. The existing summary projection is left intact, no duplicate completion event is appended, and the tool response includes `alreadyComplete: true` in its details so operators and integrations can distinguish a retry from the first completion.
 
-`complete-milestone` now also enforces a hard validation prerequisite: the latest `milestone-validation` assessment for that milestone must exist and have verdict `pass`. If the verdict is `fail`, `partial`, or absent, closeout is blocked until `validate-milestone` records a fresh passing verdict.
+`complete-milestone` now also enforces hard closeout prerequisites: each slice must have a UAT assessment with verdict `PASS`, and the latest `milestone-validation` assessment for that milestone must exist with verdict `pass`. If UAT is missing or non-PASS, auto mode stops with guidance to run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, inspect `/gsd status`, or add remediation slices with `/gsd dispatch reassess`. If milestone validation is `fail`, `partial`, or absent, closeout is blocked until `validate-milestone` records a fresh passing verdict.
 
 ### Planning-Only Milestone Closeout
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -154,8 +154,9 @@ Replace the path with the exact global bin directory from your pnpm error messag
 
 **Fix:**
 - Close editors, terminals, or antivirus tools that may be locking `.gsd/worktrees/*` paths.
-- Retry `/gsd auto`; if fallback succeeds, continue in branch mode for that milestone.
-- Run `/gsd doctor` after recovery to verify overall worktree health.
+- If the old worktree has salvageable changes, merge it with `/gsd worktree merge <MID>`.
+- If the old worktree is stale and should be discarded, remove it with `/gsd worktree remove <MID>`.
+- Run `/gsd doctor fix`, then retry `/gsd auto`. If fallback already succeeded, work continues on `milestone/<MID>` in the project root for that milestone.
 
 ### Windows `EPERM` / `EBUSY` while removing stale worktree directories
 

--- a/docs/zh-CN/user-docs/auto-mode.md
+++ b/docs/zh-CN/user-docs/auto-mode.md
@@ -13,7 +13,7 @@
 ```
 Plan (with integrated research) → Execute (per task) → Complete → Reassess Roadmap → Next Slice
                                                                                       ↓ (all slices done)
-                                                                              Validate Milestone → Complete Milestone
+                                                                      UAT PASS → Validate Milestone → Complete Milestone
 ```
 
 - **Plan**：巡检代码库、研究相关文档，把 slice 分解成带 must-have 的 task
@@ -25,6 +25,8 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 ### Milestone 完成的幂等行为
 
 Milestone completion 可以安全重试。如果 `complete-milestone` 单元在数据库已经把该 milestone 标记为关闭后再次派发，GSD 会把这次调用视为成功，而不是返回错误。已有的 summary projection 会保持不变，不会追加重复的 completion event，并且工具响应的 details 中会包含 `alreadyComplete: true`，方便 operator 和集成方区分重试与首次完成。
+
+`complete-milestone` 还会强制执行收尾前置条件：每个 slice 都必须有 verdict 为 `PASS` 的 UAT assessment，并且该 milestone 最新的 `milestone-validation` assessment 必须是 `pass`。如果 UAT 缺失或不是 PASS，自动模式会停止并提示运行 `/gsd dispatch uat`、在需要时请求重新运行指定 slice 的 UAT、查看 `/gsd status`，或用 `/gsd dispatch reassess` 添加补救 slice。若 milestone validation 为 `fail`、`partial` 或缺失，则必须先让 `validate-milestone` 写入新的 passing verdict，才能继续 closeout。
 
 ## 关键特性
 

--- a/docs/zh-CN/user-docs/troubleshooting.md
+++ b/docs/zh-CN/user-docs/troubleshooting.md
@@ -153,6 +153,19 @@ rm -rf "$(dirname .gsd)/.gsd.lock"
 - 先执行 `/gsd doctor fix`，在安全回退很明显时自动改写过期 metadata
 - 如果 GSD 仍然阻塞，则请重新创建缺失 branch，或更新 git 偏好设置，让 `git.main_branch` 指向一个真实存在的 branch
 
+### Milestone entry 因 worktree 隔离降级而被阻塞
+
+**症状：** 自动模式在进入 milestone 时报告 `isolation-degraded`，通常发生在之前的 worktree 创建或清理失败之后，Windows 上更常见。
+
+**原因：** 编辑器、终端、杀毒软件、索引器或 Git 工具仍然占用旧的 `.gsd/worktrees/*` 路径，导致 GSD 无法恢复干净的 worktree 隔离。
+
+**解决：**
+
+- 关闭可能占用旧 worktree 路径的工具
+- 如果旧 worktree 中还有需要保留的更改，运行 `/gsd worktree merge <MID>`
+- 如果旧 worktree 已经无用，运行 `/gsd worktree remove <MID>`
+- 运行 `/gsd doctor fix`，然后用 `/gsd auto` 重试；如果 fallback 已经成功，该 milestone 会继续在项目根目录的 `milestone/<MID>` 分支上运行
+
 ### 写 `.gsd/` 文件时出现瞬时 `EBUSY` / `EPERM` / `EACCES`
 
 **症状：** 在 Windows 上，自动模式或 doctor 在更新 `.gsd/` 文件时偶发 `EBUSY`、`EPERM` 或 `EACCES`。

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -17,7 +17,7 @@ Each slice flows through phases automatically:
 ```
 Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
                                                            ↓ (all done)
-                                                   Validate Milestone
+                                           UAT PASS → Validate Milestone
 ```
 
 - **Plan** — scouts the codebase, researches docs, decomposes the slice into tasks
@@ -25,6 +25,8 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 - **Complete** — writes summary, UAT script, marks roadmap, commits
 - **Reassess** — checks if the roadmap still makes sense after what was learned
 - **Validate** — after all slices, verifies success criteria were actually met
+
+Before milestone closeout, every slice must have a UAT assessment with verdict `PASS`. If a slice is missing a PASS verdict, auto mode stops with guidance to run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, inspect `/gsd status`, or add remediation slices with `/gsd dispatch reassess`.
 
 ## State Authority
 

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -137,13 +137,19 @@ Worktree merge fails on `.gsd/` files.
 
 Auto mode was paused, stopped, or crashed mid-milestone, and the work is still on the `milestone/<MID>` branch in `.gsd/worktrees/<MID>/` — never merged back to main. Next session reports the milestone as incomplete or behaving inconsistently.
 
-**Fix:** As of GSD 2.78, `/gsd auto` bootstrap automatically detects this condition and surfaces a warning naming the branch, commit count, and worktree location. Run `/gsd auto` to re-enter the worktree and resume; or merge `milestone/<MID>` into main manually if abandoning.
+**Fix:** As of GSD 2.78, `/gsd auto` bootstrap automatically detects this condition and surfaces a warning naming the branch, commit count, and worktree location. Run `/gsd auto` to re-enter the worktree and resume. If the worktree must be resolved manually, merge salvageable work with `/gsd worktree merge <MID>` or remove a stale worktree with `/gsd worktree remove <MID>`, then run `/gsd doctor fix`.
 
 **Diagnose:** Run `/gsd forensics` and look at the **Worktree Telemetry** section:
 - `Orphans detected > 0` with reason `in-progress-unmerged` confirms the condition
 - `Unmerged exits > 0` on the producer side confirms which exit type caused it
 
 **Prevent recurrence:** If your milestones are large or sessions are frequently interrupted, consider setting `git.collapse_cadence: "slice"` in preferences — validated slices merge to main immediately, shrinking the orphan window from milestone-size to slice-size. See [Git & Worktrees](../configuration/git-settings.md#collapse-cadence).
+
+### Milestone entry blocked by degraded worktree isolation
+
+Auto mode fails milestone entry with an isolation-degraded warning, often after a previous worktree cleanup or create problem on Windows.
+
+**Fix:** Close editors, terminals, antivirus tools, or Git clients that may be locking `.gsd/worktrees/*` paths. Merge salvageable work with `/gsd worktree merge <MID>` or remove a stale worktree with `/gsd worktree remove <MID>`, then run `/gsd doctor fix` and retry `/gsd auto`. If fallback already succeeded, work continues on `milestone/<MID>` in the project root for that milestone.
 
 ### `orphan_milestone_dir` doctor warning
 

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -10,7 +10,7 @@ Auto mode is a **state machine driven by the GSD database at the project root**.
 ```
 Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
                                                             ↓ (all slices done)
-                                                    Validate → Complete Milestone
+                                            UAT PASS → Validate → Complete Milestone
 ```
 
 - **Plan** — scouts the codebase, researches docs, decomposes the slice into tasks
@@ -21,7 +21,7 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 
 When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in `M###-ROADMAP.md` with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
 
-`complete-milestone` enforces a hard validation prerequisite: the latest `milestone-validation` assessment for the milestone must exist with verdict `pass`. If the latest verdict is `fail`, `partial`, or missing, milestone closeout is blocked until `validate-milestone` records a fresh passing verdict.
+`complete-milestone` enforces hard closeout prerequisites: every slice must have a UAT assessment with verdict `PASS`, and the latest `milestone-validation` assessment for the milestone must exist with verdict `pass`. If UAT is missing or non-PASS, auto mode stops with guidance to run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, inspect `/gsd status`, or add remediation slices with `/gsd dispatch reassess`. If milestone validation is `fail`, `partial`, or missing, closeout is blocked until `validate-milestone` records a fresh passing verdict.
 
 ## Deep planning mode
 

--- a/mintlify-docs/guides/troubleshooting.mdx
+++ b/mintlify-docs/guides/troubleshooting.mdx
@@ -153,6 +153,12 @@ It checks file structure, referential integrity, completion state consistency, g
     **Fix:** Re-run the operation. Close tools holding files open if the error persists. Run `/gsd doctor` to verify repo health.
   </Accordion>
 
+  <Accordion title="Milestone entry blocked by degraded worktree isolation">
+    **Cause:** A previous worktree create or cleanup failure left worktree isolation degraded, often because an editor, terminal, antivirus tool, or Git client still holds the old worktree path.
+
+    **Fix:** Close tools using `.gsd/worktrees/*`. Merge salvageable work with `/gsd worktree merge <MID>` or remove a stale worktree with `/gsd worktree remove <MID>`, then run `/gsd doctor fix` and retry `/gsd auto`. If fallback already succeeded, work continues on `milestone/<MID>` in the project root for that milestone.
+  </Accordion>
+
   <Accordion title="Worktree isolation stopped working after upgrade to v2.45+">
     **Cause:** The default `git.isolation` mode changed from `worktree` to `none` in v2.45.0.
 

--- a/src/resources/GSD-WORKFLOW.md
+++ b/src/resources/GSD-WORKFLOW.md
@@ -470,13 +470,13 @@ key_decisions: []
 
 **After a slice completes:**
 1. Write slice `S##-SUMMARY.md` (compresses all task summaries).
-2. Write slice `S##-UAT.md` — a non-blocking human test script derived from the slice's must-haves and demo sentence. The agent does NOT wait for UAT results.
+2. Write slice `S##-UAT.md` — a human test script derived from the slice's must-haves and demo sentence.
 3. Mark the slice checkbox in `M###-ROADMAP.md` as `[x]`.
 4. Update `STATE.md` with new position.
 5. Update milestone `M###-SUMMARY.md` with the completed slice's contributions.
-6. Continue to next slice immediately. The user tests the UAT whenever convenient.
-7. If the user reports UAT failures later, create fix tasks in the current or a new slice.
-8. If all slices done → milestone complete.
+6. Continue to next slice immediately. UAT can run after slice completion; automatic milestone closure requires each slice assessment to record `PASS`.
+7. If UAT is missing or non-PASS at milestone closeout, run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, or create remediation work with `/gsd dispatch reassess`.
+8. If all slices are done and UAT plus milestone validation pass → milestone complete.
 
 ---
 
@@ -605,6 +605,7 @@ Commit types: `feat`, `fix`, `test`, `refactor`, `docs`, `perf`, `chore`
 |---------|-----|
 | Bad task | Revert the task commit on the active branch |
 | Bad milestone squash | Revert the squash commit on the integration branch |
+| UAT missing or non-PASS at closeout | Run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, or create remediation work with `/gsd dispatch reassess` |
 | UAT failure after merge | Create follow-up fix tasks in the current or next milestone |
 
 ---

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -28,6 +28,7 @@ import { ensureGsdSymlink, isInheritedRepo, validateProjectId } from "./repo-ide
 import { migrateToExternalState, recoverFailedMigration } from "./migrate-external.js";
 import { collectSecretsFromManifest } from "../get-secrets-from-user.js";
 import { gsdRoot, resolveMilestoneFile } from "./paths.js";
+import { milestoneEntryBlockedGuidance } from "./guidance.js";
 import { invalidateAllCaches } from "./cache.js";
 import { writeLock, clearLock, readCrashLock, isLockProcessAlive } from "./crash-recovery.js";
 import {
@@ -1645,14 +1646,9 @@ export async function bootstrapAutoSession(
             `Cannot enter milestone ${s.currentMilestoneId}: lease is held by another worker.`,
             "error",
           );
-        } else if (enterResult.reason === "creation-failed") {
+        } else if (enterResult.reason === "creation-failed" || enterResult.reason === "isolation-degraded") {
           ctx.ui.notify(
-            `Cannot enter milestone ${s.currentMilestoneId}: worktree/branch creation failed. Isolation is degraded.`,
-            "error",
-          );
-        } else if (enterResult.reason === "isolation-degraded") {
-          ctx.ui.notify(
-            `Cannot enter milestone ${s.currentMilestoneId}: isolation is degraded from a prior worktree failure. Close processes locking the worktree and retry, or run /gsd doctor fix.`,
+            milestoneEntryBlockedGuidance(s.currentMilestoneId, enterResult.reason),
             "error",
           );
         } else if (enterResult.reason === "invalid-milestone-id") {

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -102,18 +102,22 @@ export function uatSignoffBlockerGuidance(
     verdict === undefined
       ? `missing UAT PASS verdict for ${sliceId}`
       : `UAT verdict for ${sliceId} is "${verdict}"`;
+  const sliceSpecificRerunStep =
+    `If ${sliceId} is not the most recently completed slice, type a chat request to re-run UAT for ${sliceId}; run-uat will record the verdict through \`gsd_uat_result_save\`.`;
   const steps =
     verdict === undefined
       ? [
-          `1. Run UAT for the slice to record a verdict: \`/gsd dispatch uat\``,
-          `2. Review the UAT criteria and progress: \`/gsd status\``,
-          `3. After UAT records PASS, run \`/gsd auto\` to complete the milestone.`,
+          `1. Run UAT for the most recently completed slice to record a verdict: \`/gsd dispatch uat\``,
+          `2. ${sliceSpecificRerunStep}`,
+          `3. Review the UAT criteria and progress: \`/gsd status\``,
+          `4. After UAT records PASS, run \`/gsd auto\` to complete the milestone.`,
         ]
       : [
           `1. Review the failing UAT findings: \`/gsd status\` (the ${sliceId} ASSESSMENT records what failed)`,
-          `2. Fix the issue, then re-run UAT to record a fresh verdict: \`/gsd dispatch uat\``,
-          `3. If the fix needs new implementation work, add remediation slices: \`/gsd dispatch reassess\``,
-          `4. After UAT records PASS, run \`/gsd auto\` to complete the milestone.`,
+          `2. Fix the issue, then re-run UAT for the most recently completed slice to record a fresh verdict: \`/gsd dispatch uat\``,
+          `3. ${sliceSpecificRerunStep}`,
+          `4. If the fix needs new implementation work, add remediation slices: \`/gsd dispatch reassess\``,
+          `5. After UAT records PASS, run \`/gsd auto\` to complete the milestone.`,
         ];
   return [
     `Cannot complete milestone ${milestoneId}: ${finding}. Manual UAT sign-off (PASS) is required before milestone closure.`,
@@ -133,7 +137,7 @@ function restoreIsolationHint(milestoneId: string): string {
 export function worktreeCreationFailedGuidance(milestoneId: string, error: string): string {
   return [
     `Auto-worktree creation for ${milestoneId} failed: ${error}. Continuing in project root.`,
-    `Worktree isolation is degraded for this session — work continues in the project root.`,
+    `Worktree isolation is degraded for this session.`,
     restoreIsolationHint(milestoneId),
   ].join("\n");
 }

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -88,6 +88,80 @@ export function needsRemediationBlockerGuidance(milestoneId: string): string {
   ].join("\n");
 }
 
+// ─── Milestone closeout UAT sign-off blockers ───────────────────────────
+// The first sentence is the blocker finding; the numbered steps are the
+// resolution path. `verdict` is the recorded non-PASS verdict, or undefined
+// when no verdict has been recorded at all.
+
+export function uatSignoffBlockerGuidance(
+  milestoneId: string,
+  sliceId: string,
+  verdict?: string,
+): string {
+  const finding =
+    verdict === undefined
+      ? `missing UAT PASS verdict for ${sliceId}`
+      : `UAT verdict for ${sliceId} is "${verdict}"`;
+  const steps =
+    verdict === undefined
+      ? [
+          `1. Run UAT for the slice to record a verdict: \`/gsd dispatch uat\``,
+          `2. Review the UAT criteria and progress: \`/gsd status\``,
+          `3. After UAT records PASS, run \`/gsd auto\` to complete the milestone.`,
+        ]
+      : [
+          `1. Review the failing UAT findings: \`/gsd status\` (the ${sliceId} ASSESSMENT records what failed)`,
+          `2. Fix the issue, then re-run UAT to record a fresh verdict: \`/gsd dispatch uat\``,
+          `3. If the fix needs new implementation work, add remediation slices: \`/gsd dispatch reassess\``,
+          `4. After UAT records PASS, run \`/gsd auto\` to complete the milestone.`,
+        ];
+  return [
+    `Cannot complete milestone ${milestoneId}: ${finding}. Manual UAT sign-off (PASS) is required before milestone closure.`,
+    `Fix options:`,
+    ...steps,
+  ].join("\n");
+}
+
+// ─── Worktree isolation degradation ─────────────────────────────────────
+// The first sentence of each notice is load-bearing for log matching and
+// tests — keep it intact and append guidance after it.
+
+function restoreIsolationHint(milestoneId: string): string {
+  return `To restore isolation: close any processes using the old worktree, merge salvageable work with \`/gsd worktree merge ${milestoneId}\` or remove the stale worktree with \`/gsd worktree remove ${milestoneId}\`, then run \`/gsd doctor fix\`.`;
+}
+
+export function worktreeCreationFailedGuidance(milestoneId: string, error: string): string {
+  return [
+    `Auto-worktree creation for ${milestoneId} failed: ${error}. Continuing in project root.`,
+    `Worktree isolation is degraded for this session — work continues in the project root.`,
+    restoreIsolationHint(milestoneId),
+  ].join("\n");
+}
+
+export function isolationDegradedFallbackGuidance(milestoneId: string): string {
+  return [
+    `Worktree isolation is degraded. Fell back to branch milestone/${milestoneId}.`,
+    `Work continues safely on the milestone branch in the project root.`,
+    restoreIsolationHint(milestoneId),
+  ].join("\n");
+}
+
+/** Hard entry blockers from auto-start: bootstrap stopped, user must act. */
+export function milestoneEntryBlockedGuidance(
+  milestoneId: string,
+  reason: "creation-failed" | "isolation-degraded",
+): string {
+  const finding =
+    reason === "creation-failed"
+      ? `worktree/branch creation failed. Isolation is degraded.`
+      : `isolation is degraded from a prior worktree failure.`;
+  return [
+    `Cannot enter milestone ${milestoneId}: ${finding}`,
+    restoreIsolationHint(milestoneId),
+    `Then run \`/gsd auto\` to retry.`,
+  ].join("\n");
+}
+
 // ─── Crash recovery resume hints ────────────────────────────────────────
 
 /** Resume hint for an interrupted auto-mode unit, by unit class. */

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -12,6 +12,7 @@ import { getMilestone, getMilestoneSlices, isDbAvailable } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { runSafely } from "./auto-utils.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
+import { uatSignoffBlockerGuidance } from "./guidance.js";
 import { logWarning } from "./workflow-logger.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 import { buildCompleteMilestonePrompt } from "./auto-prompts.js";
@@ -110,7 +111,7 @@ export async function evaluateCompleteMilestoneDispatch(
       if (!result) {
         return {
           action: "stop",
-          reason: `Cannot complete milestone ${mid}: missing UAT PASS verdict for ${sliceId}. Manual UAT sign-off (PASS) is required before milestone closure.`,
+          reason: uatSignoffBlockerGuidance(mid, sliceId),
           level: "warning",
         };
       }
@@ -118,7 +119,7 @@ export async function evaluateCompleteMilestoneDispatch(
       if (!isAcceptableUatVerdict(verdict, uatType)) {
         return {
           action: "stop",
-          reason: `Cannot complete milestone ${mid}: UAT verdict for ${sliceId} is "${verdict}". Manual UAT sign-off (PASS) is required before milestone closure.`,
+          reason: uatSignoffBlockerGuidance(mid, sliceId, verdict),
           level: "warning",
         };
       }

--- a/src/resources/extensions/gsd/tests/guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/guidance.test.ts
@@ -10,6 +10,8 @@ import {
   recoveryRemediation,
   needsAttentionBlockerGuidance,
   needsRemediationBlockerGuidance,
+  uatSignoffBlockerGuidance,
+  worktreeCreationFailedGuidance,
   crashResumeHint,
   doctorFixHint,
   type RecoveryGuidanceKey,
@@ -94,6 +96,27 @@ describe("milestone blocker guidance", () => {
     assert.match(text, /M007/);
     assert.match(text, /\/gsd status/);
     assert.match(text, /\/gsd validate-milestone/);
+  });
+
+  test("UAT sign-off guidance explains direct dispatch target", () => {
+    const missing = uatSignoffBlockerGuidance("M007", "S02");
+    const failing = uatSignoffBlockerGuidance("M007", "S02", "FAIL");
+
+    for (const text of [missing, failing]) {
+      assert.match(text, /Manual UAT sign-off \(PASS\) is required before milestone closure/);
+      assert.match(text, /\/gsd dispatch uat/);
+      assert.match(text, /most recently completed slice/);
+      assert.match(text, /re-run UAT for S02/);
+      assert.match(text, /gsd_uat_result_save/);
+    }
+  });
+
+  test("worktree creation failure guidance does not claim bootstrap continues", () => {
+    const text = worktreeCreationFailedGuidance("M007", "boom");
+
+    assert.match(text, /Auto-worktree creation for M007 failed: boom\. Continuing in project root\./);
+    assert.match(text, /Worktree isolation is degraded for this session\./);
+    assert.doesNotMatch(text, /work continues in the project root/i);
   });
 });
 

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -47,6 +47,7 @@ import {
 // callers — production wiring previously injected them via deps; the seam
 // added type churn without enabling test variation.
 import { loadEffectiveGSDPreferences, getIsolationMode } from "./preferences.js";
+import { isolationDegradedFallbackGuidance, worktreeCreationFailedGuidance } from "./guidance.js";
 import { invalidateAllCaches } from "./cache.js";
 import { resolveMilestoneFile } from "./paths.js";
 import { getMilestone, insertMilestone, isDbAvailable, updateMilestoneStatus } from "./gsd-db.js";
@@ -693,10 +694,7 @@ export function _enterMilestoneCore(
         s.basePath = basePath;
         rebuildGitService(s, deps);
         invalidateAllCaches();
-        ctx.notify(
-          `Worktree isolation is degraded. Fell back to branch milestone/${milestoneId}.`,
-          "warning",
-        );
+        ctx.notify(isolationDegradedFallbackGuidance(milestoneId), "warning");
         return { ok: true, mode: "branch", path: basePath };
       } catch (err) {
         debugLog("WorktreeLifecycle", {
@@ -883,10 +881,7 @@ export function _enterMilestoneCore(
       eventType: "worktree-create-failed",
       data: { milestoneId, error: msg, fallback: "project-root" },
     });
-    ctx.notify(
-      `Auto-worktree creation for ${milestoneId} failed: ${msg}. Continuing in project root.`,
-      "warning",
-    );
+    ctx.notify(worktreeCreationFailedGuidance(milestoneId, msg), "warning");
     // Degrade isolation for the rest of this session so mergeAndExit
     // doesn't try to merge a nonexistent worktree branch (#2483)
     s.isolationDegraded = true;


### PR DESCRIPTION
## Intent

The developer wanted to improve user-facing notices for blockage scenarios so they include concrete next steps and recovery guidance, consistent with recent centralized notice/guidance work. They specifically pointed at issues like worktree branch-in-use messages and UAT failure pause loops where users were seeing raw stop reasons or generic prompts instead of actionable resolution paths. They expected the implementation to find the existing guidance system, wire the relevant emit sites into it, use accurate command names and wording, and avoid misleading claims about branch/worktree state.

## What Changed

- Routed UAT closeout blockers and degraded worktree startup notices through the centralized GSD guidance catalog so users see concrete recovery steps instead of raw stop reasons.
- Added catalog entries and coverage for UAT sign-off recovery, branch-in-use worktree fallback, and worktree creation failure guidance with wording aligned to the actual dispatch and bootstrap behavior.
- Synced the updated blocker guidance across workflow resources, user docs, GitBook, Mintlify, and Chinese troubleshooting/auto-mode docs.

## Risk Assessment

✅ Low: The changes are narrowly scoped to user-facing guidance strings and their call sites, and the follow-up commit resolves the previously identified misleading UAT dispatch and worktree bootstrap wording without introducing a substantiated behavioral risk.

## Testing

Confirmed the target checkout, reviewed the blast radius, ran focused guidance plus closeout/worktree caller tests, and captured evidence showing the actual UAT closeout stop actions and worktree recovery notice text include concrete commands and next steps; all exercised checks passed.

<details>
<summary>Evidence: User-facing blocker guidance notice transcript</summary>

```text
=== User sees missing UAT PASS closeout blocker ===
Cannot complete milestone M007: missing UAT PASS verdict for S02. Manual UAT sign-off (PASS) is required before milestone closure.
Fix options:
1. Run UAT for the most recently completed slice to record a verdict: `/gsd dispatch uat`
2. If S02 is not the most recently completed slice, type a chat request to re-run UAT for S02; run-uat will record the verdict through `gsd_uat_result_save`.
3. Review the UAT criteria and progress: `/gsd status`
4. After UAT records PASS, run `/gsd auto` to complete the milestone.

=== User sees failing UAT closeout blocker ===
Cannot complete milestone M007: UAT verdict for S02 is "FAIL". Manual UAT sign-off (PASS) is required before milestone closure.
Fix options:
1. Review the failing UAT findings: `/gsd status` (the S02 ASSESSMENT records what failed)
2. Fix the issue, then re-run UAT for the most recently completed slice to record a fresh verdict: `/gsd dispatch uat`
3. If S02 is not the most recently completed slice, type a chat request to re-run UAT for S02; run-uat will record the verdict through `gsd_uat_result_save`.
4. If the fix needs new implementation work, add remediation slices: `/gsd dispatch reassess`
5. After UAT records PASS, run `/gsd auto` to complete the milestone.

=== User sees worktree creation fallback warning ===
Auto-worktree creation for M007 failed: fatal: branch is already checked out elsewhere. Continuing in project root.
Worktree isolation is degraded for this session.
To restore isolation: close any processes using the old worktree, merge salvageable work with `/gsd worktree merge M007` or remove the stale worktree with `/gsd worktree remove M007`, then run `/gsd doctor fix`.

=== User sees degraded isolation fallback warning ===
Worktree isolation is degraded. Fell back to branch milestone/M007.
Work continues safely on the milestone branch in the project root.
To restore isolation: close any processes using the old worktree, merge salvageable work with `/gsd worktree merge M007` or remove the stale worktree with `/gsd worktree remove M007`, then run `/gsd doctor fix`.

=== User sees auto-start hard entry blocker after prior degradation ===
Cannot enter milestone M007: isolation is degraded from a prior worktree failure.
To restore isolation: close any processes using the old worktree, merge salvageable work with `/gsd worktree merge M007` or remove the stale worktree with `/gsd worktree remove M007`, then run `/gsd doctor fix`.
Then run `/gsd auto` to retry.
```
</details>
<details>
<summary>Evidence: DB-backed closeout dispatch UAT blocker evidence</summary>

```text
{
  "scenario": "evaluateCompleteMilestoneDispatch blocks milestone closeout until completed slice UAT records PASS",
  "missingUatAction": {
    "action": "stop",
    "reason": "Cannot complete milestone M007: missing UAT PASS verdict for S02. Manual UAT sign-off (PASS) is required before milestone closure.\nFix options:\n1. Run UAT for the most recently completed slice to record a verdict: `/gsd dispatch uat`\n2. If S02 is not the most recently completed slice, type a chat request to re-run UAT for S02; run-uat will record the verdict through `gsd_uat_result_save`.\n3. Review the UAT criteria and progress: `/gsd status`\n4. After UAT records PASS, run `/gsd auto` to complete the milestone.",
    "level": "warning"
  },
  "failingUatAction": {
    "action": "stop",
    "reason": "Cannot complete milestone M007: UAT verdict for S02 is \"fail\". Manual UAT sign-off (PASS) is required before milestone closure.\nFix options:\n1. Review the failing UAT findings: `/gsd status` (the S02 ASSESSMENT records what failed)\n2. Fix the issue, then re-run UAT for the most recently completed slice to record a fresh verdict: `/gsd dispatch uat`\n3. If S02 is not the most recently completed slice, type a chat request to re-run UAT for S02; run-uat will record the verdict through `gsd_uat_result_save`.\n4. If the fix needs new implementation work, add remediation slices: `/gsd dispatch reassess`\n5. After UAT records PASS, run `/gsd auto` to complete the milestone.",
    "level": "warning"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/resources/extensions/gsd/guidance.ts:108` - `/gsd dispatch uat` does not target the `sliceId` named in this blocker; the direct dispatch path picks the most recently completed slice, so a multi-slice milestone blocked on an earlier slice will re-run the wrong UAT and stay blocked. The guidance needs either a targetable command or wording that matches the actual dispatch behavior.
- ⚠️ `src/resources/extensions/gsd/guidance.ts:136` - This says work continues in the project root after worktree creation fails, but `_enterMilestoneCore` returns `ok: false` and `auto-start` immediately stops bootstrap for `creation-failed`. That makes the recovery notice misleading in the failure path this helper is wired into.

🔧 Fix: Clarify UAT and worktree guidance
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pwd && git status --short --branch && git rev-parse HEAD && git rev-parse --abbrev-ref HEAD && git branch --contains HEAD --format='%(refname:short)'`
- `git diff 12f59f76493d538a1b939a02c81b6bc5c2a5d7fb..2f88c85b728007952f67078889529675821f63ba -- src/resources/extensions/gsd/guidance.ts src/resources/extensions/gsd/auto-start.ts src/resources/extensions/gsd/milestone-closeout.ts src/resources/extensions/gsd/worktree-lifecycle.ts src/resources/extensions/gsd/tests/guidance.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/guidance.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/milestone-closeout.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts`
- <code>Generated `/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KTY901TENTXY6D1K5DY14D36/blocker-guidance-notices.txt` from the guidance module to show the exact end-user notices.</code>
- <code>Generated `/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KTY901TENTXY6D1K5DY14D36/closeout-dispatch-uat-blocker.json` by running `evaluateCompleteMilestoneDispatch` against a minimal DB-backed milestone with a completed slice and missing/failing UAT verdicts.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to user-facing guidance strings, their emit sites, and documentation; closeout and isolation gates behave the same, with clearer recovery wording only.
> 
> **Overview**
> Replaces terse auto-mode stop reasons with **centralized recovery guidance** in `guidance.ts`, wired into milestone closeout, auto-start milestone entry, and worktree lifecycle notifications.
> 
> **UAT closeout blockers** now return numbered fix paths (`/gsd dispatch uat`, slice-specific rerun via chat, `/gsd status`, `/gsd dispatch reassess`, `/gsd auto`) instead of a single “manual PASS required” line. **Worktree isolation** warnings distinguish session fallback (creation failed but continuing in project root) from hard bootstrap failure (cannot enter milestone), and consistently point at `/gsd worktree merge|remove`, `/gsd doctor fix`, and retry.
> 
> User-facing docs (English, Chinese, GitBook, Mintlify, dev UAT process, `GSD-WORKFLOW`) are aligned with the **UAT PASS → validate → complete** closeout contract and the expanded troubleshooting steps for degraded worktree isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2694867bf598698e59a995a7262cd0e158069c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->