### PR TITLE
fix(dependabot): use root npm entry only for pnpm monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,9 @@
 version: 2
 updates:
+  # pnpm monorepo: single root entry only. Subdirectory npm entries fail when
+  # pnpm-workspace.yaml and pnpm-lock.yaml live at repo root (see /web, /vscode-extension).
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 0
-    labels:
-      - "dependencies"
-      - "security"
-
-  - package-ecosystem: "npm"
-    directory: "/web"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 0
-    labels:
-      - "dependencies"
-      - "security"
-
-  - package-ecosystem: "npm"
-    directory: "/vscode-extension"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- Remove Dependabot npm entries for `/web` and `/vscode-extension` that caused updates to fail with "Updating workspaces from inside a workspace subdirectory is not supported."
- Keep a single root `/` npm entry for the pnpm monorepo (lockfile and workspace config at repo root).
- Document why subdirectory npm entries are omitted in `.github/dependabot.yml`.

## Test plan
- [ ] Confirm Dependabot config validates (no duplicate or conflicting npm roots beyond `/`).
- [ ] After merge, verify the next Dependabot npm run succeeds for the root entry (no subdirectory workspace error).

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->