### PR TITLE
fix(ci): pin install-action to valid cargo-audit commit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@59bdb325aeb39aca0cb80c297ec5b4c295d6a35f # cargo-audit branch
+        uses: taiki-e/install-action@1cacf5c5198b25f60b90968ce45860e926d584b0 # cargo-audit
 
       - name: cargo audit
         working-directory: native


### PR DESCRIPTION
## Summary
- Replace deleted `taiki-e/install-action` commit pin with the current `cargo-audit` tag SHA
- Unblocks Dependabot github-actions update jobs that failed with `no such commit 59bdb325...`

## Test plan
- [ ] Merge and wait for next Dependabot github-actions scheduled run to succeed
- [ ] Confirm `cargo-audit` job in Security audit workflow still installs `cargo-audit`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->