### PR TITLE
fix(issue): One-shot mutating commands (`new-milestone` / `gsd_ln`) bypass the Phase B lease layer — unsafe to co-run with an active `gsd auto` worker

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -246,9 +246,9 @@ export function insertMilestone(m: {
   status?: string;
   depends_on?: string[];
   planning?: Partial<MilestonePlanningRecord>;
-}): void {
+}): boolean {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  getDbOrNull()!.prepare(
+  const result = getDbOrNull()!.prepare(
     `INSERT OR IGNORE INTO milestones (
       id, title, status, depends_on, created_at,
       vision, success_criteria, key_risks, proof_strategy,
@@ -279,7 +279,8 @@ export function insertMilestone(m: {
     ":definition_of_done": JSON.stringify(m.planning?.definitionOfDone ?? []),
     ":requirement_coverage": m.planning?.requirementCoverage ?? "",
     ":boundary_map_markdown": m.planning?.boundaryMapMarkdown ?? "",
-  });
+  }) as { changes?: number };
+  return (result.changes ?? 0) > 0;
 }
 
 export function upsertMilestonePlanning(milestoneId: string, planning: Partial<MilestonePlanningRecord> & { title?: string; status?: string; depends_on?: string[] }): void {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -15,6 +15,8 @@ import {
   upsertRequirement,
   getAllMilestones,
 } from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import { claimMilestoneLease, getMilestoneLease } from "../db/milestone-leases.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { markApprovalGateVerified, markDepthVerified, clearDiscussionFlowState, loadWriteGateSnapshot, setPendingGate } from "../bootstrap/write-gate.ts";
@@ -92,6 +94,28 @@ function seedMilestone(milestoneId: string, title: string, status = "active"): v
   db.prepare(
     "INSERT OR REPLACE INTO milestones (id, title, status, created_at) VALUES (?, ?, ?, ?)",
   ).run(milestoneId, title, status, new Date().toISOString());
+}
+
+function validMilestonePlan(milestoneId = "M001"): Parameters<typeof executePlanMilestone>[0] {
+  return {
+    milestoneId,
+    title: "Workflow MCP planning",
+    vision: "Plan milestone over shared executors.",
+    slices: [
+      {
+        sliceId: "S01",
+        title: "Bridge planning",
+        risk: "medium",
+        depends: [],
+        demo: "Milestone plan persists through MCP.",
+        goal: "Persist roadmap state.",
+        successCriteria: "ROADMAP.md renders from DB.",
+        proofLevel: "integration",
+        integrationClosure: "Prompts and MCP call the same handler.",
+        observabilityImpact: "Executor tests cover output paths.",
+      },
+    ],
+  };
 }
 
 function seedSlice(milestoneId: string, sliceId: string, status: string): void {
@@ -461,25 +485,7 @@ test("executePlanMilestone writes roadmap state and rendered roadmap path", asyn
   try {
     openTestDb(base);
 
-    const result = await inProjectDir(base, () => executePlanMilestone({
-      milestoneId: "M001",
-      title: "Workflow MCP planning",
-      vision: "Plan milestone over shared executors.",
-      slices: [
-        {
-          sliceId: "S01",
-          title: "Bridge planning",
-          risk: "medium",
-          depends: [],
-          demo: "Milestone plan persists through MCP.",
-          goal: "Persist roadmap state.",
-          successCriteria: "ROADMAP.md renders from DB.",
-          proofLevel: "integration",
-          integrationClosure: "Prompts and MCP call the same handler.",
-          observabilityImpact: "Executor tests cover output paths.",
-        },
-      ],
-    }, base));
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan(), base));
 
     assert.equal(result.details.operation, "plan_milestone");
     assert.equal(result.details.milestoneId, "M001");
@@ -492,29 +498,49 @@ test("executePlanMilestone writes roadmap state and rendered roadmap path", asyn
   }
 });
 
+test("executePlanMilestone refuses a same-milestone lease conflict", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Existing holder");
+    const holder = registerAutoWorker({ projectRootRealpath: join(base, "other-project") });
+    const lease = claimMilestoneLease(holder, "M001");
+    assert.equal(lease.ok, true);
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M001"), base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details.operation, "plan_milestone");
+    assert.equal(result.details.error, "milestone_lease_conflict");
+    assert.match(result.content[0].text, /Milestone M001 is currently leased/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone releases its one-shot milestone lease after planning", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M001"), base));
+
+    assert.equal(result.isError, undefined);
+    const lease = getMilestoneLease("M001");
+    assert.ok(lease, "planning should participate in milestone lease coordination");
+    assert.equal(lease.status, "released");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executePlanSlice writes task planning state and rendered plan artifacts", async () => {
   const base = makeTmpBase();
   try {
     openTestDb(base);
-    await inProjectDir(base, () => executePlanMilestone({
-      milestoneId: "M001",
-      title: "Workflow MCP planning",
-      vision: "Plan milestone over shared executors.",
-      slices: [
-        {
-          sliceId: "S01",
-          title: "Bridge planning",
-          risk: "medium",
-          depends: [],
-          demo: "Milestone plan persists through MCP.",
-          goal: "Persist roadmap state.",
-          successCriteria: "ROADMAP.md renders from DB.",
-          proofLevel: "integration",
-          integrationClosure: "Prompts and MCP call the same handler.",
-          observabilityImpact: "Executor tests cover output paths.",
-        },
-      ],
-    }, base));
+    await inProjectDir(base, () => executePlanMilestone(validMilestonePlan(), base));
 
     const result = await inProjectDir(base, () => executePlanSlice({
       milestoneId: "M001",

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -536,6 +536,67 @@ test("executePlanMilestone releases its one-shot milestone lease after planning"
   }
 });
 
+test("executePlanMilestone does not leave a placeholder behind when planning validation fails", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    // handlePlanMilestone rejects empty slice arrays during validation. The
+    // executor inserts a queued placeholder row on first-time planning and
+    // must roll it back when the handler then returns an error.
+    const invalid = { ...validMilestonePlan("M042"), slices: [] };
+    const result = await inProjectDir(base, () => executePlanMilestone(invalid, base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details.operation, "plan_milestone");
+    const milestones = getAllMilestones();
+    assert.equal(milestones.find(m => m.id === "M042"), undefined,
+      "failed planning must not leave a placeholder milestone row behind");
+    assert.equal(getMilestoneLease("M042"), null,
+      "failed planning must not leave a lease row behind");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone does not delete a peer worker's milestone row on lease conflict", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    // Simulate a peer worker (different project_root) that has already
+    // created the milestone row and taken its lease. The one-shot executor
+    // must observe the active lease and refuse — without removing the peer's
+    // milestone row or lease. The pre-rollback bug was that
+    // INSERT OR IGNORE's silent no-op was treated as proof of authorship and
+    // the cleanup path then deleted the peer's row.
+    const peer = registerAutoWorker({ projectRootRealpath: join(base, "peer-project") });
+    seedMilestone("M050", "Peer-owned milestone");
+    const peerLease = claimMilestoneLease(peer, "M050");
+    assert.equal(peerLease.ok, true);
+    const peerLeaseToken = peerLease.ok ? peerLease.token : -1;
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M050"), base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details.error, "milestone_lease_conflict");
+    const peerMilestone = getAllMilestones().find(m => m.id === "M050");
+    assert.ok(peerMilestone, "peer milestone row must survive the one-shot conflict path");
+    assert.equal(peerMilestone?.title, "Peer-owned milestone",
+      "peer milestone row must not be clobbered or recreated");
+    const surviving = getMilestoneLease("M050");
+    assert.ok(surviving, "peer lease row must survive");
+    assert.equal(surviving.status, "held", "peer must still hold the lease");
+    assert.equal(surviving.worker_id, peer);
+    assert.equal(surviving.fencing_token, peerLeaseToken,
+      "peer's fencing token must not be incremented by the rejected one-shot");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executePlanSlice writes task planning state and rendered plan artifacts", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -19,6 +19,7 @@ import { registerAutoWorker } from "../db/auto-workers.ts";
 import { claimMilestoneLease, getMilestoneLease } from "../db/milestone-leases.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
 import { autoSession } from "../auto-runtime-state.ts";
+import { normalizeRealPath } from "../paths.ts";
 import { markApprovalGateVerified, markDepthVerified, clearDiscussionFlowState, loadWriteGateSnapshot, setPendingGate } from "../bootstrap/write-gate.ts";
 import {
   executeCompleteMilestone,
@@ -523,6 +524,7 @@ test("executePlanMilestone releases its one-shot milestone lease after planning"
   const base = makeTmpBase();
   try {
     openTestDb(base);
+    seedMilestone("M001", "Existing milestone");
 
     const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M001"), base));
 
@@ -536,14 +538,32 @@ test("executePlanMilestone releases its one-shot milestone lease after planning"
   }
 });
 
-test("executePlanMilestone does not leave a placeholder behind when planning validation fails", async () => {
+test("executePlanMilestone creates a fresh milestone without a one-shot lease", async () => {
   const base = makeTmpBase();
   try {
     openTestDb(base);
 
-    // handlePlanMilestone rejects empty slice arrays during validation. The
-    // executor inserts a queued placeholder row on first-time planning and
-    // must roll it back when the handler then returns an error.
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M042"), base));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.operation, "plan_milestone");
+    assert.equal(result.details.milestoneId, "M042");
+    assert.equal(getMilestoneLease("M042"), null,
+      "fresh milestone creation must pass through without creating a lease row");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone does not create a placeholder when fresh planning validation fails", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    // handlePlanMilestone rejects empty slice arrays during validation. Fresh
+    // milestone creation must pass through without pre-inserting a leaseable
+    // placeholder row.
     const invalid = { ...validMilestonePlan("M042"), slices: [] };
     const result = await inProjectDir(base, () => executePlanMilestone(invalid, base));
 
@@ -551,9 +571,9 @@ test("executePlanMilestone does not leave a placeholder behind when planning val
     assert.equal(result.details.operation, "plan_milestone");
     const milestones = getAllMilestones();
     assert.equal(milestones.find(m => m.id === "M042"), undefined,
-      "failed planning must not leave a placeholder milestone row behind");
+      "failed fresh planning must not leave a milestone row behind");
     assert.equal(getMilestoneLease("M042"), null,
-      "failed planning must not leave a lease row behind");
+      "failed fresh planning must not create a lease row");
   } finally {
     closeDatabase();
     cleanup(base);
@@ -592,6 +612,134 @@ test("executePlanMilestone does not delete a peer worker's milestone row on leas
     assert.equal(surviving.fencing_token, peerLeaseToken,
       "peer's fencing token must not be incremented by the rejected one-shot");
   } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone refuses when a foreign active worker holds the lease even while in-process auto is active", async () => {
+  const base = makeTmpBase();
+  autoSession.reset();
+  try {
+    openTestDb(base);
+    seedMilestone("M060", "Foreign-held milestone");
+
+    // In-process auto must still reject a lease held by another worker.
+    const foreign = registerAutoWorker({ projectRootRealpath: join(base, "foreign-project") });
+    const foreignLease = claimMilestoneLease(foreign, "M060");
+    assert.equal(foreignLease.ok, true);
+    const foreignToken = foreignLease.ok ? foreignLease.token : -1;
+
+    const ownAutoWorker = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+    autoSession.active = true;
+    autoSession.workerId = ownAutoWorker;
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M060"), base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details.error, "milestone_lease_conflict",
+      "in-process auto must NOT skip lease checks when the lease is held by a different active worker");
+    const surviving = getMilestoneLease("M060");
+    assert.ok(surviving);
+    assert.equal(surviving.status, "held");
+    assert.equal(surviving.worker_id, foreign);
+    assert.equal(surviving.fencing_token, foreignToken,
+      "foreign worker's fencing token must not be incremented by the rejected call");
+  } finally {
+    autoSession.reset();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone proceeds without re-claiming when in-process auto holds the lease itself", async () => {
+  const base = makeTmpBase();
+  autoSession.reset();
+  try {
+    openTestDb(base);
+    seedMilestone("M070", "Auto-held milestone");
+
+    // In-process auto should not re-claim its own lease and bump its token.
+    const ownAutoWorker = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+    const heldLease = claimMilestoneLease(ownAutoWorker, "M070");
+    assert.equal(heldLease.ok, true);
+    const heldToken = heldLease.ok ? heldLease.token : -1;
+    autoSession.active = true;
+    autoSession.workerId = ownAutoWorker;
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M070"), base));
+
+    assert.equal(result.isError, undefined, `auto's own plan-milestone call should succeed: ${result.content?.[0]?.text}`);
+    const surviving = getMilestoneLease("M070");
+    assert.ok(surviving);
+    assert.equal(surviving.status, "held", "auto's lease must still be held after the planning call");
+    assert.equal(surviving.worker_id, ownAutoWorker);
+    assert.equal(surviving.fencing_token, heldToken,
+      "auto's fencing token must not be incremented by an in-process plan call");
+  } finally {
+    autoSession.reset();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone refuses a same-process holder when active auto does not own it", async () => {
+  const base = makeTmpBase();
+  autoSession.reset();
+  try {
+    openTestDb(base);
+    seedMilestone("M080", "Same-process holder");
+    const staleWorker = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+    const heldLease = claimMilestoneLease(staleWorker, "M080");
+    assert.equal(heldLease.ok, true);
+    const heldToken = heldLease.ok ? heldLease.token : -1;
+
+    autoSession.active = true;
+    autoSession.workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M080"), base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details?.error, "milestone_lease_conflict");
+    const surviving = getMilestoneLease("M080");
+    assert.ok(surviving, "same-process holder lease must remain after conflict");
+    assert.equal(surviving.worker_id, staleWorker);
+    assert.equal(surviving.fencing_token, heldToken);
+    assert.equal(surviving.status, "held");
+  } finally {
+    autoSession.reset();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executePlanMilestone takes over a stale same-process lease via reentry instead of waiting for TTL", async () => {
+  const base = makeTmpBase();
+  autoSession.reset();
+  try {
+    openTestDb(base);
+    seedMilestone("M080", "Stale-locked milestone");
+
+    // One-shot planning should reach claimMilestoneLease so its same-process
+    // reentry clause can recover stale worker rows.
+    const staleWorker = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+    const staleLease = claimMilestoneLease(staleWorker, "M080");
+    assert.equal(staleLease.ok, true);
+    const staleToken = staleLease.ok ? staleLease.token : -1;
+
+    const result = await inProjectDir(base, () => executePlanMilestone(validMilestonePlan("M080"), base));
+
+    assert.equal(result.isError, undefined,
+      `same-process reentry takeover must succeed, not return milestone_lease_conflict: ${result.content?.[0]?.text}`);
+    const after = getMilestoneLease("M080");
+    assert.ok(after, "lease row must remain after takeover + release");
+    assert.equal(after.status, "released", "the executor releases its own claim before returning");
+    assert.notEqual(after.worker_id, staleWorker,
+      "lease must be owned by the new worker after takeover");
+    assert.ok(after.fencing_token > staleToken,
+      `fencing token must monotonically advance on takeover (was ${staleToken}, now ${after.fencing_token})`);
+  } finally {
+    autoSession.reset();
     closeDatabase();
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -11,6 +11,7 @@ import {
   getSliceStatusSummary,
   getSliceTaskCounts,
   insertMilestone,
+  deleteMilestone,
   insertAssessment,
   insertGateRun,
   readTransaction,
@@ -56,7 +57,13 @@ import {
   type UatResultSaveParams,
 } from "../uat-run.js";
 import { registerAutoWorker, markWorkerStopping, getAutoWorker } from "../db/auto-workers.js";
-import { claimMilestoneLease, releaseMilestoneLease, getMilestoneLease } from "../db/milestone-leases.js";
+import {
+  claimMilestoneLease,
+  releaseMilestoneLease,
+  getMilestoneLease,
+  refreshMilestoneLease,
+  milestoneLeaseTtlSeconds,
+} from "../db/milestone-leases.js";
 export type {
   UatCheckResultInput,
   UatEvidenceRef,
@@ -1246,10 +1253,6 @@ export async function executePlanMilestone(
     isError: true,
       };
   }
-  if (!getMilestone(params.milestoneId)) {
-    insertMilestone({ id: params.milestoneId, title: params.milestoneId, status: "queued" });
-  }
-
   const heldLease = getMilestoneLease(params.milestoneId);
   if (heldLease?.status === "held" && Date.parse(heldLease.expires_at) > Date.now()) {
     const holder = getAutoWorker(heldLease.worker_id);
@@ -1270,7 +1273,15 @@ export async function executePlanMilestone(
 
   const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(basePath) });
   let acquiredToken: number | null = null;
+  let insertedPlaceholder = false;
+  let planningSucceeded = false;
+  let leaseRefreshTimer: ReturnType<typeof setInterval> | undefined;
   try {
+    if (!getMilestone(params.milestoneId)) {
+      insertMilestone({ id: params.milestoneId, title: params.milestoneId, status: "queued" });
+      insertedPlaceholder = true;
+    }
+
     const lease = claimMilestoneLease(workerId, params.milestoneId);
     if (!lease.ok) {
       return {
@@ -1287,6 +1298,13 @@ export async function executePlanMilestone(
     }
     acquiredToken = lease.token;
 
+    const leaseRefreshMs = (milestoneLeaseTtlSeconds() / 2) * 1000;
+    leaseRefreshTimer = setInterval(() => {
+      if (acquiredToken !== null) {
+        refreshMilestoneLease(workerId, params.milestoneId, acquiredToken);
+      }
+    }, leaseRefreshMs);
+
     const result = await handlePlanMilestone(params, basePath);
     if ("error" in result) {
       return {
@@ -1295,6 +1313,7 @@ export async function executePlanMilestone(
       isError: true,
       };
     }
+    planningSucceeded = true;
     return {
       content: [{ type: "text", text: `Planned milestone ${result.milestoneId}` }],
       details: {
@@ -1313,10 +1332,19 @@ export async function executePlanMilestone(
       };
   }
   finally {
+    if (leaseRefreshTimer !== undefined) {
+      clearInterval(leaseRefreshTimer);
+    }
     if (acquiredToken !== null) {
       releaseMilestoneLease(workerId, params.milestoneId, acquiredToken);
     }
     markWorkerStopping(workerId);
+    if (insertedPlaceholder && !planningSucceeded) {
+      const milestone = getMilestone(params.milestoneId);
+      if (milestone?.status === "queued" && milestone.title === params.milestoneId) {
+        deleteMilestone(params.milestoneId);
+      }
+    }
   }
 }
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -19,7 +19,7 @@ import {
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
-import { clearPathCache, relSliceFile, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { clearPathCache, normalizeRealPath, relSliceFile, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";
@@ -55,6 +55,8 @@ import {
   saveUatAttemptArtifact,
   type UatResultSaveParams,
 } from "../uat-run.js";
+import { registerAutoWorker, markWorkerStopping } from "../db/auto-workers.js";
+import { claimMilestoneLease, releaseMilestoneLease } from "../db/milestone-leases.js";
 export type {
   UatCheckResultInput,
   UatEvidenceRef,
@@ -1244,6 +1246,22 @@ export async function executePlanMilestone(
     isError: true,
       };
   }
+  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(basePath) });
+  const lease = claimMilestoneLease(workerId, params.milestoneId);
+  if (!lease.ok) {
+    markWorkerStopping(workerId);
+    return {
+      content: [{ type: "text", text: `Milestone ${params.milestoneId} is currently leased by ${lease.byWorker}. Retry after ${lease.expiresAt}.` }],
+      details: {
+        operation: "plan_milestone",
+        error: "milestone_lease_conflict",
+        milestoneId: params.milestoneId,
+        byWorker: lease.byWorker,
+        expiresAt: lease.expiresAt,
+      },
+      isError: true,
+    };
+  }
   try {
     const result = await handlePlanMilestone(params, basePath);
     if ("error" in result) {
@@ -1269,6 +1287,10 @@ export async function executePlanMilestone(
       details: { operation: "plan_milestone", error: msg },
     isError: true,
       };
+  }
+  finally {
+    releaseMilestoneLease(workerId, params.milestoneId, lease.token);
+    markWorkerStopping(workerId);
   }
 }
 

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -11,7 +11,6 @@ import {
   getSliceStatusSummary,
   getSliceTaskCounts,
   insertMilestone,
-  deleteMilestone,
   insertAssessment,
   insertGateRun,
   readTransaction,
@@ -23,6 +22,7 @@ import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
 import { clearPathCache, normalizeRealPath, relSliceFile, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { unlinkSync } from "node:fs";
+import { hostname } from "node:os";
 import { join } from "node:path";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
 import { handleCompleteMilestone } from "./complete-milestone.js";
@@ -49,7 +49,7 @@ import { logError, logWarning } from "../workflow-logger.js";
 import { invalidateStateCache } from "../state.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
-import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
+import { autoSession, getAutoRuntimeSnapshot, isAutoActive } from "../auto-runtime-state.js";
 import { renderPlanFromDb } from "../markdown-renderer.js";
 import {
   prepareUatRun,
@@ -110,6 +110,24 @@ function blockIfWrongAutoUnit(requiredUnitType: string, operation: string): Tool
   return {
     content: [{ type: "text", text: error }],
     details: { operation, error },
+    isError: true,
+  };
+}
+
+function milestoneLeaseConflictResult(
+  milestoneId: string,
+  byWorker: string,
+  expiresAt: string,
+): ToolExecutionResult {
+  return {
+    content: [{ type: "text", text: `Milestone ${milestoneId} is currently leased by ${byWorker}. Retry after ${expiresAt}.` }],
+    details: {
+      operation: "plan_milestone",
+      error: "milestone_lease_conflict",
+      milestoneId,
+      byWorker,
+      expiresAt,
+    },
     isError: true,
   };
 }
@@ -1253,58 +1271,47 @@ export async function executePlanMilestone(
     isError: true,
       };
   }
-  const heldLease = getMilestoneLease(params.milestoneId);
-  if (heldLease?.status === "held" && Date.parse(heldLease.expires_at) > Date.now()) {
-    const holder = getAutoWorker(heldLease.worker_id);
-    if (holder?.status === "active") {
-      return {
-        content: [{ type: "text", text: `Milestone ${params.milestoneId} is currently leased by ${heldLease.worker_id}. Retry after ${heldLease.expires_at}.` }],
-        details: {
-          operation: "plan_milestone",
-          error: "milestone_lease_conflict",
-          milestoneId: params.milestoneId,
-          byWorker: heldLease.worker_id,
-          expiresAt: heldLease.expires_at,
-        },
-        isError: true,
-      };
-    }
-  }
-
-  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(basePath) });
+  let workerId: string | null = null;
   let acquiredToken: number | null = null;
-  let insertedPlaceholder = false;
-  let planningSucceeded = false;
   let leaseRefreshTimer: ReturnType<typeof setInterval> | undefined;
   try {
-    insertedPlaceholder = insertMilestone({
-      id: params.milestoneId,
-      title: params.milestoneId,
-      status: "queued",
-    });
-
-    const lease = claimMilestoneLease(workerId, params.milestoneId);
-    if (!lease.ok) {
-      return {
-        content: [{ type: "text", text: `Milestone ${params.milestoneId} is currently leased by ${lease.byWorker}. Retry after ${lease.expiresAt}.` }],
-        details: {
-          operation: "plan_milestone",
-          error: "milestone_lease_conflict",
-          milestoneId: params.milestoneId,
-          byWorker: lease.byWorker,
-          expiresAt: lease.expiresAt,
-        },
-        isError: true,
-      };
-    }
-    acquiredToken = lease.token;
-
-    const leaseRefreshMs = (milestoneLeaseTtlSeconds() / 2) * 1000;
-    leaseRefreshTimer = setInterval(() => {
-      if (acquiredToken !== null) {
-        refreshMilestoneLease(workerId, params.milestoneId, acquiredToken);
+    // Re-read at the gate so a peer-created milestone is not treated as fresh.
+    const milestoneExists = getMilestone(params.milestoneId) !== null;
+    if (milestoneExists) {
+      const heldLease = getMilestoneLease(params.milestoneId);
+      if (heldLease?.status === "held" && Date.parse(heldLease.expires_at) > Date.now()) {
+        const holder = getAutoWorker(heldLease.worker_id);
+        // Let the one-shot claim path recover stale same-process worker rows.
+        const projectRoot = normalizeRealPath(basePath);
+        const isOurAutoLease = isAutoActive() && heldLease.worker_id === autoSession.workerId;
+        const holderIsOneShotReentrantPeer = !isAutoActive()
+          && !!holder
+          && holder.host === hostname()
+          && holder.pid === process.pid
+          && holder.project_root_realpath === projectRoot;
+        if (holder?.status === "active" && !isOurAutoLease && !holderIsOneShotReentrantPeer) {
+          return milestoneLeaseConflictResult(params.milestoneId, heldLease.worker_id, heldLease.expires_at);
+        }
       }
-    }, leaseRefreshMs);
+    }
+
+    // Fresh creation cannot claim a lease because the FK row does not exist.
+    // In-process auto already owns its lease; re-claiming would bump its token.
+    if (!isAutoActive() && milestoneExists) {
+      workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(basePath) });
+      const lease = claimMilestoneLease(workerId, params.milestoneId);
+      if (!lease.ok) {
+        return milestoneLeaseConflictResult(params.milestoneId, lease.byWorker, lease.expiresAt);
+      }
+      acquiredToken = lease.token;
+
+      const leaseRefreshMs = (milestoneLeaseTtlSeconds() / 2) * 1000;
+      leaseRefreshTimer = setInterval(() => {
+        if (acquiredToken !== null && workerId !== null) {
+          refreshMilestoneLease(workerId, params.milestoneId, acquiredToken);
+        }
+      }, leaseRefreshMs);
+    }
 
     const result = await handlePlanMilestone(params, basePath);
     if ("error" in result) {
@@ -1314,7 +1321,6 @@ export async function executePlanMilestone(
       isError: true,
       };
     }
-    planningSucceeded = true;
     return {
       content: [{ type: "text", text: `Planned milestone ${result.milestoneId}` }],
       details: {
@@ -1336,15 +1342,11 @@ export async function executePlanMilestone(
     if (leaseRefreshTimer !== undefined) {
       clearInterval(leaseRefreshTimer);
     }
-    if (acquiredToken !== null) {
+    if (workerId !== null && acquiredToken !== null) {
       releaseMilestoneLease(workerId, params.milestoneId, acquiredToken);
     }
-    markWorkerStopping(workerId);
-    if (insertedPlaceholder && !planningSucceeded) {
-      const milestone = getMilestone(params.milestoneId);
-      if (milestone?.status === "queued" && milestone.title === params.milestoneId) {
-        deleteMilestone(params.milestoneId);
-      }
+    if (workerId !== null) {
+      markWorkerStopping(workerId);
     }
   }
 }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1277,10 +1277,11 @@ export async function executePlanMilestone(
   let planningSucceeded = false;
   let leaseRefreshTimer: ReturnType<typeof setInterval> | undefined;
   try {
-    if (!getMilestone(params.milestoneId)) {
-      insertMilestone({ id: params.milestoneId, title: params.milestoneId, status: "queued" });
-      insertedPlaceholder = true;
-    }
+    insertedPlaceholder = insertMilestone({
+      id: params.milestoneId,
+      title: params.milestoneId,
+      status: "queued",
+    });
 
     const lease = claimMilestoneLease(workerId, params.milestoneId);
     if (!lease.ok) {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -55,8 +55,8 @@ import {
   saveUatAttemptArtifact,
   type UatResultSaveParams,
 } from "../uat-run.js";
-import { registerAutoWorker, markWorkerStopping } from "../db/auto-workers.js";
-import { claimMilestoneLease, releaseMilestoneLease } from "../db/milestone-leases.js";
+import { registerAutoWorker, markWorkerStopping, getAutoWorker } from "../db/auto-workers.js";
+import { claimMilestoneLease, releaseMilestoneLease, getMilestoneLease } from "../db/milestone-leases.js";
 export type {
   UatCheckResultInput,
   UatEvidenceRef,
@@ -1246,23 +1246,47 @@ export async function executePlanMilestone(
     isError: true,
       };
   }
-  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(basePath) });
-  const lease = claimMilestoneLease(workerId, params.milestoneId);
-  if (!lease.ok) {
-    markWorkerStopping(workerId);
-    return {
-      content: [{ type: "text", text: `Milestone ${params.milestoneId} is currently leased by ${lease.byWorker}. Retry after ${lease.expiresAt}.` }],
-      details: {
-        operation: "plan_milestone",
-        error: "milestone_lease_conflict",
-        milestoneId: params.milestoneId,
-        byWorker: lease.byWorker,
-        expiresAt: lease.expiresAt,
-      },
-      isError: true,
-    };
+  if (!getMilestone(params.milestoneId)) {
+    insertMilestone({ id: params.milestoneId, title: params.milestoneId, status: "queued" });
   }
+
+  const heldLease = getMilestoneLease(params.milestoneId);
+  if (heldLease?.status === "held" && Date.parse(heldLease.expires_at) > Date.now()) {
+    const holder = getAutoWorker(heldLease.worker_id);
+    if (holder?.status === "active") {
+      return {
+        content: [{ type: "text", text: `Milestone ${params.milestoneId} is currently leased by ${heldLease.worker_id}. Retry after ${heldLease.expires_at}.` }],
+        details: {
+          operation: "plan_milestone",
+          error: "milestone_lease_conflict",
+          milestoneId: params.milestoneId,
+          byWorker: heldLease.worker_id,
+          expiresAt: heldLease.expires_at,
+        },
+        isError: true,
+      };
+    }
+  }
+
+  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(basePath) });
+  let acquiredToken: number | null = null;
   try {
+    const lease = claimMilestoneLease(workerId, params.milestoneId);
+    if (!lease.ok) {
+      return {
+        content: [{ type: "text", text: `Milestone ${params.milestoneId} is currently leased by ${lease.byWorker}. Retry after ${lease.expiresAt}.` }],
+        details: {
+          operation: "plan_milestone",
+          error: "milestone_lease_conflict",
+          milestoneId: params.milestoneId,
+          byWorker: lease.byWorker,
+          expiresAt: lease.expiresAt,
+        },
+        isError: true,
+      };
+    }
+    acquiredToken = lease.token;
+
     const result = await handlePlanMilestone(params, basePath);
     if ("error" in result) {
       return {
@@ -1289,7 +1313,9 @@ export async function executePlanMilestone(
       };
   }
   finally {
-    releaseMilestoneLease(workerId, params.milestoneId, lease.token);
+    if (acquiredToken !== null) {
+      releaseMilestoneLease(workerId, params.milestoneId, acquiredToken);
+    }
     markWorkerStopping(workerId);
   }
 }


### PR DESCRIPTION
## Summary
- Aligns plan-milestone one-shot lease handling with the refined issue #699 design.
- Fresh milestone creation now passes through without a placeholder milestone or lease row.
- Existing milestone re-planning claims, refreshes, releases, and cleans up a DB-backed milestone lease.

## Verification
- `pnpm run build:core`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/milestone-leases.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`

## Related Issue
- Closes #699
- [#699 One-shot mutating commands (`new-milestone` / `gsd_ln`) bypass the Phase B lease layer — unsafe to co-run with an active `gsd auto` worker](https://github.com/open-gsd/gsd-pi/issues/699)

## User
- @rndjams

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/699-one-shot-mutating-commands-new-milestone-1781302493`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent-write coordination for milestone planning and fixes a prior bug where lease conflicts could harm peer-owned DB rows; scope is focused on plan_milestone but affects multi-worker safety.
> 
> **Overview**
> **One-shot `plan_milestone` now participates in the Phase B milestone lease layer** so CLI/MCP planning cannot race an active `gsd auto` worker (or another peer) on an existing milestone.
> 
> For **existing** milestones, `executePlanMilestone` checks for an active held lease (with exceptions for in-process auto’s own lease and same-host/pid reentry), registers a one-shot worker, **claims** the lease with periodic **refresh**, then **releases** and marks the worker stopping in a `finally` block. Conflicts return `milestone_lease_conflict` without mutating the peer’s milestone row or fencing token.
> 
> **New milestones** skip lease claim entirely (no placeholder row or lease row before planning). Failed validation on a fresh plan likewise leaves no milestone or lease behind.
> 
> `insertMilestone` now **returns a boolean** from `INSERT OR IGNORE` `changes`, supporting callers that must distinguish a real insert from a silent no-op (avoiding mistaken cleanup of another worker’s row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2404b207f902908f941f437d03633ce186ec89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->