### PR TITLE
fix(issue): [Bug]: Cant do anything: Error: spawn ENAMETOOLONG

### DIFF
--- a/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
@@ -38,6 +38,17 @@ describe("resolveGsdBrowserMcpLaunchConfig identity flags", () => {
     assert.equal(args[args.indexOf("--identity-key") + 1], "custom-key");
   });
 
+  it("splits GSD_BROWSER_MCP_COMMAND command lines before spawning", () => {
+    const commandLine = '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\Test User\\AppData\\Roaming\\npm\\node_modules\\@opengsd\\gsd-browser\\bin\\gsd-browser"';
+    const { command, args } = resolveGsdBrowserMcpLaunchConfig("C:\\Users\\Test User\\project", {
+      GSD_BROWSER_MCP_COMMAND: commandLine,
+    });
+
+    assert.equal(command, "C:\\Program Files\\nodejs\\node.exe");
+    assert.equal(args[0], "C:\\Users\\Test User\\AppData\\Roaming\\npm\\node_modules\\@opengsd\\gsd-browser\\bin\\gsd-browser");
+    assert.equal(args[1], "mcp");
+  });
+
   it("uses a path-safe identity-project identifier", () => {
     const { args } = resolveGsdBrowserMcpLaunchConfig("/tmp/example/project", {});
     const projectId = args[args.indexOf("--identity-project") + 1];

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -55,6 +55,24 @@ function parseGsdBrowserVersion(output: string): string | null {
   return output.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
 }
 
+function splitCommandLine(commandLine: string): string[] {
+  const parts = commandLine.match(/(?:"[^"]*"|'[^']*'|[^\s"']+)/g) ?? [];
+  return parts.map((part) => {
+    const quote = part[0];
+    if ((quote === '"' || quote === "'") && part.endsWith(quote)) {
+      return part.slice(1, -1);
+    }
+    return part;
+  });
+}
+
+function buildPathGsdBrowserVersionInvocation(platform: NodeJS.Platform): { command: string; args: string[] } {
+  if (platform === "win32") {
+    return { command: "cmd", args: ["/d", "/s", "/c", "gsd-browser", "--version"] };
+  }
+  return { command: "gsd-browser", args: ["--version"] };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -86,7 +104,8 @@ function resolvePathGsdBrowserVersion(env: NodeJS.ProcessEnv): string | null {
   if (cachedPathProbeVersion !== undefined) return cachedPathProbeVersion;
 
   try {
-    cachedPathProbeVersion = parseGsdBrowserVersion(execFileSync("gsd-browser", ["--version"], {
+    const invocation = buildPathGsdBrowserVersionInvocation(process.platform);
+    cachedPathProbeVersion = parseGsdBrowserVersion(execFileSync(invocation.command, invocation.args, {
       encoding: "utf-8",
       env,
       stdio: ["ignore", "pipe", "ignore"],
@@ -216,7 +235,8 @@ export function resolveGsdBrowserMcpLaunchConfig(
   const serverName = env.GSD_BROWSER_MCP_NAME?.trim() || GSD_BROWSER_MCP_SERVER_NAME;
   const explicitArgs = parseJsonEnv<unknown>(env, "GSD_BROWSER_MCP_ARGS");
   const explicitEnv = parseJsonEnv<Record<string, string>>(env, "GSD_BROWSER_MCP_ENV");
-  const explicitCommand = env.GSD_BROWSER_MCP_COMMAND?.trim();
+  const explicitCommandLine = env.GSD_BROWSER_MCP_COMMAND?.trim();
+  const [explicitCommand, ...explicitCommandArgs] = explicitCommandLine ? splitCommandLine(explicitCommandLine) : [];
   const explicitCliPath = resolveExplicitGsdBrowserCliPath(env);
   const preferPathCli = !explicitCommand && !explicitCliPath && shouldPreferPathGsdBrowser(env);
   const bundledCliPath = !explicitCommand && !explicitCliPath && !preferPathCli
@@ -241,6 +261,7 @@ export function resolveGsdBrowserMcpLaunchConfig(
   const args = Array.isArray(explicitArgs) && explicitArgs.length > 0
     ? explicitArgs.map(String)
     : [
+        ...explicitCommandArgs,
         ...(bundledCliPath ? [bundledCliPath] : []),
         "mcp",
         "--session",


### PR DESCRIPTION
## Summary
- Fixed gsd-browser MCP spawn command normalization and verified the focused launch regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #687
- [#687 [Bug]: Cant do anything: Error: spawn ENAMETOOLONG](https://github.com/open-gsd/gsd-pi/issues/687)

## User
- @aloxuhik

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/687-bug-cant-do-anything-error-spawn-enameto-1781303071`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized launch-config and version-probe changes in gsd-browser-cli with a focused test; no auth or data-path changes.
> 
> **Overview**
> Fixes **spawn ENAMETOOLONG** when gsd-browser MCP is started from a full Windows command line in `GSD_BROWSER_MCP_COMMAND` (quoted `node.exe` plus script path with spaces).
> 
> `resolveGsdBrowserMcpLaunchConfig` now uses a new **`splitCommandLine`** helper to turn that env value into a **`command`** and leading **`args`**, then appends the usual `mcp` session/identity flags. A regression test covers a typical `Program Files` / `Test User` path layout.
> 
> PATH version detection on **win32** runs **`gsd-browser --version`** through **`cmd /d /s /c`** instead of calling `gsd-browser` directly, matching how Windows resolves CLI shims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70d595d458d602bbec54622a5cc713cd6069921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->