### PR TITLE
fix(issue): [Bug]: gsd-pi upgrade does not work after v1.0.2

### DIFF
--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 import { existsSync, readFileSync, mkdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { join, resolve as resolvePath, sep } from "node:path";
+import { join, resolve as resolvePath, sep, win32 as pathWin32 } from "node:path";
 import { homedir } from "node:os";
 import { deriveState } from "./state.js";
 import { gsdRoot } from "./paths.js";
@@ -65,7 +65,24 @@ function isBunInstall(argv1: string | undefined = process.argv[1]): boolean {
 function resolveInstallCommand(pkg: string): string {
   if (isBunInstall()) return `bun add -g ${pkg}`;
   if (isPnpmInstall()) return `pnpm add -g ${pkg}`;
+  const npmPrefix = resolveWindowsNpmGlobalPrefix();
+  if (npmPrefix) return `npm --prefix ${quoteWindowsArg(npmPrefix)} install -g ${pkg}`;
   return `npm install -g ${pkg}`;
+}
+
+function resolveWindowsNpmGlobalPrefix(
+  argv1: string | undefined = process.argv[1],
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (platform !== "win32" || !argv1) return null;
+  const normalized = pathWin32.normalize(argv1);
+  const marker = `${pathWin32.sep}node_modules${pathWin32.sep}`;
+  const index = normalized.toLowerCase().lastIndexOf(marker);
+  return index > 0 ? normalized.slice(0, index) : null;
+}
+
+function quoteWindowsArg(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
 }
 
 function notifyClaudeRuntimeFloorAdvisory(ctx: ExtensionCommandContext): void {

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -78,7 +78,14 @@ function resolveWindowsNpmGlobalPrefix(
   const normalized = pathWin32.normalize(argv1);
   const marker = `${pathWin32.sep}node_modules${pathWin32.sep}`;
   const index = normalized.toLowerCase().lastIndexOf(marker);
-  return index > 0 ? normalized.slice(0, index) : null;
+  if (index <= 0) return null;
+  const prefix = normalized.slice(0, index);
+  // Verify this is a real npm global prefix: such a directory always contains
+  // npm's own bin shim (`npm.cmd`) as a sibling of `node_modules/`. Local
+  // project `node_modules/`, npx caches, and other non-global layouts do not,
+  // so without this check `--prefix` would target the wrong directory.
+  if (!existsSync(pathWin32.join(prefix, "npm.cmd"))) return null;
+  return prefix;
 }
 
 function quoteWindowsArg(value: string): string {

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -207,6 +207,26 @@ test("resolveInstallCommand returns npm command when not running under Bun (#414
   }
 });
 
+test("resolveInstallCommand pins Windows npm updates to the running global prefix (#490)", async () => {
+  const { resolveInstallCommand } = await import("../update-check.js");
+  const orig = (process.versions as Record<string, string | undefined>).bun;
+  try {
+    delete (process.versions as Record<string, string | undefined>).bun;
+    assert.equal(
+      resolveInstallCommand("@opengsd/gsd-pi@latest", {
+        argv1: "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@opengsd\\gsd-pi\\dist\\loader.js",
+        env: {} as any,
+        platform: "win32",
+      }),
+      'npm --prefix "C:\\Users\\me\\AppData\\Roaming\\npm" install -g @opengsd/gsd-pi@latest',
+    );
+  } finally {
+    if (orig !== undefined) {
+      (process.versions as Record<string, string | undefined>).bun = orig;
+    }
+  }
+});
+
 test("resolveInstallCommand returns pnpm command when installed via pnpm", async () => {
   const { resolveInstallCommand } = await import("../update-check.js");
   const orig = (process.versions as Record<string, string | undefined>).bun;

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -217,8 +217,44 @@ test("resolveInstallCommand pins Windows npm updates to the running global prefi
         argv1: "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@opengsd\\gsd-pi\\dist\\loader.js",
         env: {} as any,
         platform: "win32",
+        // Simulate the npm.cmd sibling that lives at the global prefix root.
+        existsFn: (p) => p === "C:\\Users\\me\\AppData\\Roaming\\npm\\npm.cmd",
       }),
       'npm --prefix "C:\\Users\\me\\AppData\\Roaming\\npm" install -g @opengsd/gsd-pi@latest',
+    );
+  } finally {
+    if (orig !== undefined) {
+      (process.versions as Record<string, string | undefined>).bun = orig;
+    }
+  }
+});
+
+test("resolveInstallCommand falls back to plain npm for Windows non-global layouts (npx cache, local node_modules)", async () => {
+  const { resolveInstallCommand } = await import("../update-check.js");
+  const orig = (process.versions as Record<string, string | undefined>).bun;
+  try {
+    delete (process.versions as Record<string, string | undefined>).bun;
+
+    // npx cache: directory above node_modules has no npm.cmd sibling.
+    assert.equal(
+      resolveInstallCommand("@opengsd/gsd-pi@latest", {
+        argv1: "C:\\Users\\me\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\@opengsd\\gsd-pi\\dist\\loader.js",
+        env: {} as any,
+        platform: "win32",
+        existsFn: () => false,
+      }),
+      "npm install -g @opengsd/gsd-pi@latest",
+    );
+
+    // Local project node_modules: same story — no npm.cmd at the project root.
+    assert.equal(
+      resolveInstallCommand("@opengsd/gsd-pi@latest", {
+        argv1: "C:\\Users\\me\\projects\\app\\node_modules\\@opengsd\\gsd-pi\\dist\\loader.js",
+        env: {} as any,
+        platform: "win32",
+        existsFn: () => false,
+      }),
+      "npm install -g @opengsd/gsd-pi@latest",
     );
   } finally {
     if (orig !== undefined) {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { execSync, execFileSync } from 'node:child_process'
-import { dirname, join, resolve as resolvePath, sep } from 'node:path'
+import { dirname, join, resolve as resolvePath, sep, win32 as pathWin32 } from 'node:path'
 import { homedir } from 'node:os'
 import { createRequire } from 'node:module'
 import chalk from 'chalk'
@@ -152,11 +152,28 @@ export function isBunInstall(argv1: string | undefined = process.argv[1]): boole
 
 export function resolveInstallCommand(
   pkg: string,
-  options: { argv1?: string; env?: NodeJS.ProcessEnv } = {},
+  options: { argv1?: string; env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {},
 ): string {
   if (isBunInstall(options.argv1)) return `bun add -g ${pkg}`
   if (isPnpmInstall(options.argv1, options.env)) return `pnpm add -g ${pkg}`
+  const npmPrefix = resolveWindowsNpmGlobalPrefix(options.argv1, options.platform)
+  if (npmPrefix) return `npm --prefix ${quoteWindowsArg(npmPrefix)} install -g ${pkg}`
   return `npm install -g ${pkg}`
+}
+
+function resolveWindowsNpmGlobalPrefix(
+  argv1: string | undefined = process.argv[1],
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (platform !== 'win32' || !argv1) return null
+  const normalized = pathWin32.normalize(argv1)
+  const marker = `${pathWin32.sep}node_modules${pathWin32.sep}`
+  const index = normalized.toLowerCase().lastIndexOf(marker)
+  return index > 0 ? normalized.slice(0, index) : null
+}
+
+function quoteWindowsArg(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`
 }
 
 function printUpdateBanner(current: string, latest: string, packageName: string = GSD_PI_PACKAGE_NAME): void {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -152,11 +152,16 @@ export function isBunInstall(argv1: string | undefined = process.argv[1]): boole
 
 export function resolveInstallCommand(
   pkg: string,
-  options: { argv1?: string; env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {},
+  options: {
+    argv1?: string
+    env?: NodeJS.ProcessEnv
+    platform?: NodeJS.Platform
+    existsFn?: (path: string) => boolean
+  } = {},
 ): string {
   if (isBunInstall(options.argv1)) return `bun add -g ${pkg}`
   if (isPnpmInstall(options.argv1, options.env)) return `pnpm add -g ${pkg}`
-  const npmPrefix = resolveWindowsNpmGlobalPrefix(options.argv1, options.platform)
+  const npmPrefix = resolveWindowsNpmGlobalPrefix(options.argv1, options.platform, options.existsFn)
   if (npmPrefix) return `npm --prefix ${quoteWindowsArg(npmPrefix)} install -g ${pkg}`
   return `npm install -g ${pkg}`
 }
@@ -164,12 +169,20 @@ export function resolveInstallCommand(
 function resolveWindowsNpmGlobalPrefix(
   argv1: string | undefined = process.argv[1],
   platform: NodeJS.Platform = process.platform,
+  existsFn: (path: string) => boolean = existsSync,
 ): string | null {
   if (platform !== 'win32' || !argv1) return null
   const normalized = pathWin32.normalize(argv1)
   const marker = `${pathWin32.sep}node_modules${pathWin32.sep}`
   const index = normalized.toLowerCase().lastIndexOf(marker)
-  return index > 0 ? normalized.slice(0, index) : null
+  if (index <= 0) return null
+  const prefix = normalized.slice(0, index)
+  // Verify this is a real npm global prefix: such a directory always contains
+  // npm's own bin shim (`npm.cmd`) as a sibling of `node_modules/`. Local
+  // project `node_modules/`, npx caches, and other non-global layouts do not,
+  // so without this check `--prefix` would target the wrong directory.
+  if (!existsFn(pathWin32.join(prefix, 'npm.cmd'))) return null
+  return prefix
 }
 
 function quoteWindowsArg(value: string): string {


### PR DESCRIPTION
## Summary
- Pinned Windows npm self-updates to the running global prefix and added regression coverage; whitespace check passed while tests were blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #490
- [#490 [Bug]: gsd-pi upgrade does not work after v1.0.2](https://github.com/open-gsd/gsd-pi/issues/490)

## User
- @ma99us

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/490-bug-gsd-pi-upgrade-does-not-work-after-v-1781303674`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to how upgrade/install command strings are built on win32 npm installs; no auth or data-path changes, with test coverage for the new branch.
> 
> **Overview**
> Fixes **gsd-pi self-upgrade on Windows** when the CLI was installed via npm under the user global tree (e.g. `AppData\Roaming\npm`). Plain `npm install -g` could target the wrong location; upgrade commands now derive the prefix from the running script path (`argv[1]`) and emit `npm --prefix "<prefix>" install -g …`.
> 
> The same `resolveInstallCommand` behavior is applied in **`update-check.ts`** (CLI update banners, `gsd upgrade`, interactive prompt) and the duplicated helper in **`commands-handlers.ts`** for `/gsd update`. Bun and pnpm detection is unchanged. A regression test asserts the Windows npm command shape for a typical Roaming npm layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db5ba3a4fd2084e24edbd58fa3b49cfc7b28dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->