### PR TITLE
fix(issue): [Bug]: GitHub Copilot login doss not work in v1.1.1

### DIFF
--- a/packages/pi-ai/src/utils/oauth/github-copilot.ts
+++ b/packages/pi-ai/src/utils/oauth/github-copilot.ts
@@ -77,6 +77,11 @@ function getBaseUrlFromToken(token: string): string | null {
 	return `https://${apiHost}`;
 }
 
+function getCopilotAccessToken(credentials: OAuthCredentials): string | undefined {
+	const legacyApiKey = (credentials as { apiKey?: unknown }).apiKey;
+	return credentials.access || (typeof legacyApiKey === "string" && legacyApiKey ? legacyApiKey : undefined);
+}
+
 export function getGitHubCopilotBaseUrl(token?: string, enterpriseDomain?: string): string {
 	// If we have a token, extract the base URL from proxy-ep
 	if (token) {
@@ -333,13 +338,13 @@ export const githubCopilotOAuthProvider: OAuthProviderInterface = {
 	},
 
 	getApiKey(credentials: OAuthCredentials): string {
-		return credentials.access;
+		return getCopilotAccessToken(credentials) as string;
 	},
 
 	modifyModels(models: Model<Api>[], credentials: OAuthCredentials): Model<Api>[] {
 		const creds = credentials as CopilotCredentials;
 		const domain = creds.enterpriseUrl ? (normalizeDomain(creds.enterpriseUrl) ?? undefined) : undefined;
-		const baseUrl = getGitHubCopilotBaseUrl(creds.access, domain);
+		const baseUrl = getGitHubCopilotBaseUrl(getCopilotAccessToken(creds), domain);
 		return models.map((m) => (m.provider === "github-copilot" ? { ...m, baseUrl } : m));
 	},
 };

--- a/packages/pi-coding-agent/test/auth-storage.test.ts
+++ b/packages/pi-coding-agent/test/auth-storage.test.ts
@@ -501,6 +501,19 @@ describe("AuthStorage", () => {
 			expect(apiKey).toBe("oauth-access-token");
 		});
 
+		test("resolves legacy GitHub Copilot OAuth apiKey credentials", async () => {
+			authStorage = AuthStorage.inMemory({
+				"github-copilot": {
+					type: "oauth",
+					apiKey: "ghu-copilot-token",
+					expires: Date.now() + 60_000,
+				} as never,
+			});
+
+			const apiKey = await authStorage.getApiKey("github-copilot");
+			expect(apiKey).toBe("ghu-copilot-token");
+		});
+
 		test("falls back to stored API key when OAuth refresh fails", async () => {
 			const providerId = `test-oauth-api-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 			registerOAuthProvider({


### PR DESCRIPTION
## Summary
- Fixed legacy GitHub Copilot OAuth apiKey credential resolution and added focused regression coverage; verification was limited to diff checks because dependency install/test execution was blocked.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #491
- [#491 [Bug]: GitHub Copilot login doss not work in v1.1.1](https://github.com/open-gsd/gsd-pi/issues/491)

## User
- @mgerdov-igt

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/491-bug-github-copilot-login-doss-not-work-i-1781304273`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth credential resolution change with a focused regression test; no broader security or data-path changes.
> 
> **Overview**
> Fixes GitHub Copilot auth when stored OAuth entries still use the legacy **`apiKey`** field instead of **`access`**, which broke login/API use in v1.1.1.
> 
> A new **`getCopilotAccessToken`** helper in the Copilot OAuth provider prefers **`access`** and falls back to a non-empty string **`apiKey`**. **`getApiKey`** and **`modifyModels`** (Copilot base URL from the token) now use that helper instead of reading **`access`** only.
> 
> Adds an **`AuthStorage`** regression test that **`getApiKey("github-copilot")`** returns the legacy **`apiKey`** value for OAuth-shaped credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19032ff502390b5dfe1e02069d6dd8608bec17fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->