### PR TITLE
fix(gsd): broaden milestone terminal detection and repair missing SUMMARY

### DIFF
--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -5,10 +5,9 @@ import { dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { loadFile } from "./files.js";
-import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
-import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { resolveMilestoneFile } from "./paths.js";
-import { deriveState, isMilestoneComplete } from "./state.js";
+import { deriveState } from "./state.js";
+import { isCompletedMilestoneTerminal } from "./milestone-closeout.js";
 import { allWorktreesDirs, createWorktree, listWorktrees, resolveGitDir } from "./worktree-manager.js";
 import { abortAndReset } from "./git-self-heal.js";
 import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegrationBranch } from "./git-service.js";
@@ -144,22 +143,6 @@ function getSnapshotDiffCheckFailure(basePath: string): string | null {
   }
 
   return failures.length > 0 ? failures.join("\n") : null;
-}
-
-async function isCompletedMilestoneTerminal(basePath: string, milestoneId: string): Promise<boolean> {
-  const summaryPath = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
-  if (!summaryPath) return false;
-
-  if (isDbAvailable()) {
-    const milestone = getMilestone(milestoneId);
-    return !!milestone && milestone.status === "complete";
-  }
-
-  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-  const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
-  if (!roadmapContent) return false;
-  const roadmap = parseLegacyRoadmap(roadmapContent);
-  return isMilestoneComplete(roadmap);
 }
 
 export async function checkGitHealth(

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -110,7 +110,8 @@ export async function repairMissingMilestoneSummaryProjection(
   if ("error" in result) {
     return { ok: false, error: result.error };
   }
-  if (result.stale || !summaryPath || !existsSync(summaryPath)) {
+  const writtenSummaryPath = result.summaryPath;
+  if (result.stale || !writtenSummaryPath || !existsSync(writtenSummaryPath)) {
     return { ok: false, error: "milestone SUMMARY projection write failed" };
   }
   return { ok: true };

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -53,7 +53,7 @@ export async function isCompletedMilestoneTerminal(
     const milestone = getMilestone(milestoneId);
     if (!milestone) return false;
 
-    if (milestone.status === "complete") {
+    if (isClosedStatus(milestone.status)) {
       return true;
     }
 
@@ -109,6 +109,9 @@ export async function repairMissingMilestoneSummaryProjection(
 
   if ("error" in result) {
     return { ok: false, error: result.error };
+  }
+  if (result.stale || !summaryPath || !existsSync(summaryPath)) {
+    return { ok: false, error: "milestone SUMMARY projection write failed" };
   }
   return { ok: true };
 }

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -16,9 +16,7 @@ import {
   getMilestoneSlices,
   isDbAvailable,
 } from "./gsd-db.js";
-import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
 import { isClosedStatus } from "./status-guards.js";
-import { isMilestoneComplete } from "./state.js";
 import { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
 import { handleCompleteMilestone } from "./tools/complete-milestone.js";
 import { runSafely } from "./auto-utils.js";
@@ -42,39 +40,32 @@ const COMPLETE_MILESTONE_DB_SETTLE_POLL_MS = 100;
 
 /**
  * True when a milestone is terminal for git cleanup (orphaned worktrees, stale branches).
- * DB-authoritative when available: complete status, or validation-pass with all slices closed.
- * Legacy fallback requires SUMMARY + roadmap completion when the DB is unavailable.
+ * DB-authoritative (ADR-017): closed status, or validation-pass with all slices closed.
+ * When the DB is unavailable we cannot make this decision and conservatively
+ * return false so callers leave the worktree/branch alone instead of cleaning
+ * up based on parsed projections.
  */
 export async function isCompletedMilestoneTerminal(
-  basePath: string,
+  _basePath: string,
   milestoneId: string,
 ): Promise<boolean> {
-  if (isDbAvailable()) {
-    const milestone = getMilestone(milestoneId);
-    if (!milestone) return false;
+  if (!isDbAvailable()) return false;
 
-    if (isClosedStatus(milestone.status)) {
-      return true;
-    }
+  const milestone = getMilestone(milestoneId);
+  if (!milestone) return false;
 
-    const validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
-    if (validation?.status !== "pass") {
-      return false;
-    }
-
-    const slices = getMilestoneSlices(milestoneId);
-    if (slices.length === 0) return false;
-    return slices.every((slice) => isClosedStatus(slice.status));
+  if (isClosedStatus(milestone.status)) {
+    return true;
   }
 
-  const summaryPath = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
-  if (!summaryPath) return false;
+  const validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
+  if (validation?.status !== "pass") {
+    return false;
+  }
 
-  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-  const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
-  if (!roadmapContent) return false;
-  const roadmap = parseLegacyRoadmap(roadmapContent);
-  return isMilestoneComplete(roadmap);
+  const slices = getMilestoneSlices(milestoneId);
+  if (slices.length === 0) return false;
+  return slices.every((slice) => isClosedStatus(slice.status));
 }
 
 /** Write a missing milestone SUMMARY projection when canonical DB closeout already settled. */

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -5,10 +5,22 @@
 // - postUnit: git commit, artifact verify, DB settle, then GitHub finalize
 // - recovery: DB repair from artifacts, then GitHub finalize
 
+import { existsSync } from "node:fs";
+
 import { loadFile } from "./files.js";
 import { resolveMilestoneFile } from "./paths.js";
-import { getMilestone, getClosedSliceIds, isDbAvailable } from "./gsd-db.js";
+import {
+  getMilestone,
+  getClosedSliceIds,
+  getLatestAssessmentByScope,
+  getMilestoneSlices,
+  isDbAvailable,
+} from "./gsd-db.js";
+import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
 import { isClosedStatus } from "./status-guards.js";
+import { isMilestoneComplete } from "./state.js";
+import { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
+import { handleCompleteMilestone } from "./tools/complete-milestone.js";
 import { runSafely } from "./auto-utils.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 import { uatSignoffBlockerGuidance } from "./guidance.js";
@@ -27,6 +39,79 @@ import {
 
 const COMPLETE_MILESTONE_DB_SETTLE_MS = 1500;
 const COMPLETE_MILESTONE_DB_SETTLE_POLL_MS = 100;
+
+/**
+ * True when a milestone is terminal for git cleanup (orphaned worktrees, stale branches).
+ * DB-authoritative when available: complete status, or validation-pass with all slices closed.
+ * Legacy fallback requires SUMMARY + roadmap completion when the DB is unavailable.
+ */
+export async function isCompletedMilestoneTerminal(
+  basePath: string,
+  milestoneId: string,
+): Promise<boolean> {
+  if (isDbAvailable()) {
+    const milestone = getMilestone(milestoneId);
+    if (!milestone) return false;
+
+    if (milestone.status === "complete") {
+      return true;
+    }
+
+    const validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
+    if (validation?.status !== "pass") {
+      return false;
+    }
+
+    const slices = getMilestoneSlices(milestoneId);
+    if (slices.length === 0) return false;
+    return slices.every((slice) => isClosedStatus(slice.status));
+  }
+
+  const summaryPath = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
+  if (!summaryPath) return false;
+
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
+  if (!roadmapContent) return false;
+  const roadmap = parseLegacyRoadmap(roadmapContent);
+  return isMilestoneComplete(roadmap);
+}
+
+/** Write a missing milestone SUMMARY projection when canonical DB closeout already settled. */
+export async function repairMissingMilestoneSummaryProjection(
+  basePath: string,
+  milestoneId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const milestone = getMilestone(milestoneId);
+  if (!milestone) {
+    return { ok: false, error: `milestone not found: ${milestoneId}` };
+  }
+
+  const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, milestoneId);
+  const summaryPath = resolveExpectedArtifactPath("complete-milestone", milestoneId, artifactBasePath);
+  if (summaryPath && existsSync(summaryPath)) {
+    return { ok: true };
+  }
+
+  const result = await handleCompleteMilestone(
+    {
+      milestoneId,
+      title: milestone.title,
+      oneLiner: "Canonical closeout completed; summary projection repaired automatically.",
+      narrative:
+        "The workflow database recorded this milestone as complete, but the milestone SUMMARY artifact was missing on disk. " +
+        "Dispatch policy repaired the projection so closeout proof and cleanup can proceed.",
+      verificationPassed: true,
+      triggerReason: "closeout-projection-repair",
+    },
+    basePath,
+  );
+
+  if ("error" in result) {
+    return { ok: false, error: result.error };
+  }
+  return { ok: true };
+}
 
 /**
  * True when the milestone is closed in the DB and the completion summary artifact exists.
@@ -78,7 +163,22 @@ export async function evaluateCompleteMilestoneDispatch(
   if (isDbAvailable()) {
     const milestone = getMilestone(mid);
     if (milestone && isClosedStatus(milestone.status)) {
-      return { action: "skip" };
+      const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, mid);
+      const summaryPath = resolveExpectedArtifactPath("complete-milestone", mid, artifactBasePath);
+      const summaryMissing = !summaryPath || !existsSync(summaryPath);
+      if (summaryMissing) {
+        const repair = await repairMissingMilestoneSummaryProjection(basePath, mid);
+        if (!repair.ok) {
+          logWarning(
+            "dispatch",
+            `Milestone ${mid} is closed in DB but SUMMARY repair failed: ${repair.error}. Dispatching complete-milestone to retry.`,
+          );
+        } else {
+          return { action: "skip" };
+        }
+      } else {
+        return { action: "skip" };
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
@@ -176,6 +176,26 @@ test("evaluateCompleteMilestoneDispatch repairs missing SUMMARY when DB is close
   );
 });
 
+test("repairMissingMilestoneSummaryProjection succeeds when milestone dir does not exist yet", async () => {
+  // Regression: resolveExpectedArtifactPath returns null before the milestone
+  // directory exists. The post-write success check must use the handler's
+  // returned summaryPath (the absolute path it just created), not the
+  // pre-write resolver result, otherwise repair always reports failure and
+  // dispatch falls back to re-dispatching complete-milestone.
+  const base = mkdtempSync(join(tmpdir(), "gsd-repair-summary-new-dir-"));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M042", title: "Done", status: "complete" });
+
+  const repair = await repairMissingMilestoneSummaryProjection(base, "M042");
+  assert.equal(repair.ok, true, "repair should report success when handler creates the SUMMARY");
+  assert.ok(
+    existsSync(join(base, ".gsd", "milestones", "M042", "M042-SUMMARY.md")),
+    "repair should write the SUMMARY artifact to the canonical projection path",
+  );
+});
+
 test("repairMissingMilestoneSummaryProjection is idempotent when SUMMARY exists", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-repair-summary-idempotent-"));
   tmpDirs.push(base);

--- a/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
@@ -3,22 +3,24 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { openDatabase, insertAssessment, insertMilestone, insertSlice, closeDatabase } from "../gsd-db.js";
 import {
   isMilestoneCloseoutSettled,
   evaluateCompleteMilestoneDispatch,
+  isCompletedMilestoneTerminal,
+  repairMissingMilestoneSummaryProjection,
 } from "../milestone-closeout.js";
 import type { DispatchContext } from "../auto-dispatch.js";
 
 /** Build a minimal DispatchContext for the dispatch-policy branches under test. */
-function makeDispatchCtx(base: string, phase: string): DispatchContext {
+function makeDispatchCtx(base: string, phase: string, mid = "M001"): DispatchContext {
   return {
     basePath: base,
-    mid: "M001",
-    midTitle: "M001: Test",
+    mid,
+    midTitle: `${mid}: Test`,
     state: { phase } as DispatchContext["state"],
     prefs: undefined,
   } as DispatchContext;
@@ -118,4 +120,73 @@ test("evaluateCompleteMilestoneDispatch skips when milestone is already closed",
   );
   assert.ok(action, "an already-closed milestone in completing-milestone should yield an action");
   assert.equal(action!.action, "skip", "already-closed milestone should resolve to skip (idempotent)");
+});
+
+test("isCompletedMilestoneTerminal accepts DB complete without SUMMARY artifact", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-terminal-db-complete-"));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M008", title: "Done", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M008", title: "Slice", status: "complete" });
+
+  assert.equal(await isCompletedMilestoneTerminal(base, "M008"), true);
+});
+
+test("isCompletedMilestoneTerminal accepts validation-pass with all slices closed", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-terminal-validation-pass-"));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M008", title: "Active", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M008", title: "Slice", status: "complete" });
+  insertAssessment({
+    path: "milestones/M008/M008-VALIDATION.md",
+    milestoneId: "M008",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  assert.equal(await isCompletedMilestoneTerminal(base, "M008"), true);
+});
+
+test("evaluateCompleteMilestoneDispatch repairs missing SUMMARY when DB is closed", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dispatch-repair-summary-"));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd", "milestones", "M008"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M008", title: "Live Text Search", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M008", title: "Slice", status: "complete" });
+  insertAssessment({
+    path: "milestones/M008/M008-VALIDATION.md",
+    milestoneId: "M008",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  const action = await evaluateCompleteMilestoneDispatch(
+    makeDispatchCtx(base, "completing-milestone", "M008"),
+  );
+  assert.equal(action?.action, "skip");
+  assert.ok(
+    existsSync(join(base, ".gsd", "milestones", "M008", "M008-SUMMARY.md")),
+    "repair should write the missing milestone SUMMARY projection",
+  );
+});
+
+test("repairMissingMilestoneSummaryProjection is idempotent when SUMMARY exists", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-repair-summary-idempotent-"));
+  tmpDirs.push(base);
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Done", status: "complete" });
+  const summaryPath = join(milestoneDir, "M001-SUMMARY.md");
+  writeFileSync(summaryPath, "# Existing summary\n");
+
+  const repair = await repairMissingMilestoneSummaryProjection(base, "M001");
+  assert.equal(repair.ok, true);
+  assert.equal(readFileSync(summaryPath, "utf-8"), "# Existing summary\n");
 });

--- a/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
@@ -52,7 +52,6 @@ const ALLOWED_IMPORTERS = new Set([
   "gsd/auto-recovery.ts",
   // diagnostics-only surfaces: report on projections, make no dispatch decisions
   "gsd/doctor.ts",
-  "gsd/doctor-git-checks.ts",
   // display/telemetry-only surfaces
   "gsd/workspace-index.ts",
   "gsd/visualizer-data.ts",


### PR DESCRIPTION
## Summary
- Export `isCompletedMilestoneTerminal` so milestones are terminal when DB is complete or validation passes with all slices closed (SUMMARY not required).
- Repair missing `M*-SUMMARY.md` projections when DB closeout already settled instead of silently skipping `complete-milestone` dispatch.

## Context
Prevents M008-shaped failures where validation finished but closeout never ran, leaving no summary artifact and stale git residue.

## Test plan
- [x] `milestone-closeout.test.ts` — terminal detection + SUMMARY repair dispatch

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->