### PR TITLE
fix(gsd): use shared terminal milestone check in doctor git cleanup

### DIFF
--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -5,10 +5,9 @@ import { dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { loadFile } from "./files.js";
-import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
-import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { resolveMilestoneFile } from "./paths.js";
-import { deriveState, isMilestoneComplete } from "./state.js";
+import { isCompletedMilestoneTerminal } from "./milestone-closeout.js";
+import { deriveState } from "./state.js";
 import { allWorktreesDirs, createWorktree, listWorktrees, resolveGitDir } from "./worktree-manager.js";
 import { abortAndReset } from "./git-self-heal.js";
 import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegrationBranch } from "./git-service.js";
@@ -144,22 +143,6 @@ function getSnapshotDiffCheckFailure(basePath: string): string | null {
   }
 
   return failures.length > 0 ? failures.join("\n") : null;
-}
-
-async function isCompletedMilestoneTerminal(basePath: string, milestoneId: string): Promise<boolean> {
-  const summaryPath = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
-  if (!summaryPath) return false;
-
-  if (isDbAvailable()) {
-    const milestone = getMilestone(milestoneId);
-    return !!milestone && milestone.status === "complete";
-  }
-
-  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-  const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
-  if (!roadmapContent) return false;
-  const roadmap = parseLegacyRoadmap(roadmapContent);
-  return isMilestoneComplete(roadmap);
 }
 
 export async function checkGitHealth(

--- a/src/resources/extensions/gsd/tests/doctor-git-checks-terminal.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-git-checks-terminal.test.ts
@@ -1,0 +1,73 @@
+// Project/App: gsd-pi
+// File Purpose: Doctor git checks treat validation-pass closeout as terminal without SUMMARY.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runGSDDoctor } from "../doctor.ts";
+import { openDatabase, insertMilestone, insertSlice, insertAssessment, closeDatabase } from "../gsd-db.js";
+import { createWorktree, worktreePath } from "../worktree-manager.ts";
+
+function runGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function makeRepo(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-terminal-"));
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+  writeFileSync(join(base, "package.json"), "{\"scripts\":{}}\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "chore: init"], base);
+  return base;
+}
+
+test.after(() => {
+  closeDatabase();
+});
+
+test("doctor flags orphaned worktree for DB-complete milestone without SUMMARY", async (t) => {
+  const base = makeRepo();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M008", title: "Done", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M008", title: "Slice", status: "complete" });
+  insertAssessment({
+    path: "milestones/M008/M008-VALIDATION.md",
+    milestoneId: "M008",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: worktree\n---\n",
+  );
+  mkdirSync(join(base, ".gsd", "milestones", "M008"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M008", "M008-ROADMAP.md"),
+    "# M008 Roadmap\n\n- [x] **S01: Slice** `risk:low` `depends:[]`\n",
+  );
+
+  createWorktree(base, "M008", { branch: "milestone/M008" });
+  const wtPath = worktreePath(base, "M008");
+  assert.ok(existsSync(wtPath), "worktree should exist for the test");
+
+  const report = await runGSDDoctor(base, { isolationMode: "worktree" });
+
+  assert.ok(
+    report.issues.some((issue) => issue.code === "orphaned_auto_worktree" && issue.unitId === "M008"),
+    "doctor should treat DB-complete milestone without SUMMARY as terminal for cleanup",
+  );
+});


### PR DESCRIPTION
## Summary
- Doctor orphan worktree/branch cleanup now uses shared `isCompletedMilestoneTerminal` from milestone-closeout.

## Depends on
- #707 (fix/milestone-closeout-terminal-repair) — stacked PR

## Test plan
- [x] `doctor-git-checks-terminal.test.ts` — orphaned worktree without SUMMARY

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->