### PR TITLE
fix(gsd): surface idle milestone residue recovery on /gsd home

### DIFF
--- a/src/resources/extensions/gsd/closeout-wizard.ts
+++ b/src/resources/extensions/gsd/closeout-wizard.ts
@@ -1,6 +1,9 @@
 // Project/App: gsd-pi
 // File Purpose: Shared closeout detection and merge actions for /gsd home and smart entry.
 
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import type { NextAction } from "../shared/next-action-ui.js";
@@ -14,12 +17,20 @@ import {
   type UnmergedMilestoneBlocker,
 } from "./unmerged-milestone-guard.js";
 import { appendRequirementsBacklogToSummary } from "./requirements-backlog.js";
+import { nativeBranchList, nativeIsRepo } from "./native-git-bridge.js";
+import { allWorktreesDirs } from "./worktree-manager.js";
 
 export type CloseoutActionId = "finish_quick" | "finish_milestone";
+
+export interface IdleMilestoneResidueHint {
+  message: string;
+  milestoneIds: string[];
+}
 
 export interface CloseoutContext {
   strandedQuick: StrandedQuickBranch | null;
   unmergedMilestones: UnmergedMilestoneBlocker[];
+  idleResidueHint?: IdleMilestoneResidueHint | null;
 }
 
 const MILESTONE_MERGE_CLOSEOUT_COMMANDS = [
@@ -29,11 +40,76 @@ const MILESTONE_MERGE_CLOSEOUT_COMMANDS = [
   "/gsd start for new work",
 ];
 
+const MILESTONE_ID_DIR_RE = /^M\d+$/;
+
+function listMilestoneWorktreeIds(basePath: string): string[] {
+  const ids = new Set<string>();
+  for (const wtDir of allWorktreesDirs(basePath)) {
+    if (!existsSync(wtDir)) continue;
+    for (const entry of readdirSync(wtDir)) {
+      if (!MILESTONE_ID_DIR_RE.test(entry)) continue;
+      try {
+        if (statSync(join(wtDir, entry)).isDirectory()) ids.add(entry);
+      } catch {
+        // skip unreadable entries
+      }
+    }
+  }
+  return [...ids].sort();
+}
+
+function listMilestoneBranchIds(basePath: string): string[] {
+  try {
+    return nativeBranchList(basePath, "milestone/*")
+      .map((branch) => branch.replace(/^milestone\//, ""))
+      .filter((id) => MILESTONE_ID_DIR_RE.test(id))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** Surface stranded milestone git residue when closeout guards did not classify it. */
+export function detectIdleMilestoneResidueHint(basePath: string): IdleMilestoneResidueHint | null {
+  if (!nativeIsRepo(basePath)) return null;
+
+  const gsdDir = join(basePath, ".gsd");
+  const dbPath = join(gsdDir, "gsd.db");
+  if (!existsSync(gsdDir) || !existsSync(dbPath)) {
+    return {
+      milestoneIds: [],
+      message:
+        "This git repo has no local GSD workflow database (.gsd/gsd.db). " +
+        "Workflow state may live in an external worktree, or run /gsd new-project to initialize here.",
+    };
+  }
+
+  const worktreeIds = listMilestoneWorktreeIds(basePath);
+  const branchIds = listMilestoneBranchIds(basePath);
+  const milestoneIds = [...new Set([...worktreeIds, ...branchIds])].sort();
+  if (milestoneIds.length === 0) return null;
+
+  const listed = milestoneIds.join(", ");
+  const recovery =
+    milestoneIds.length === 1
+      ? `/gsd dispatch complete-milestone ${milestoneIds[0]}`
+      : "/gsd doctor --fix";
+  return {
+    milestoneIds,
+    message:
+      `Stranded milestone git residue detected (${listed}: worktree dir and/or milestone/* branch). ` +
+      `Run ${recovery} or /gsd status to recover closeout before starting new work.`,
+  };
+}
+
 export async function loadCloseoutContext(basePath: string): Promise<CloseoutContext> {
   const unmergedMilestones = await findUnmergedCompletedMilestones(basePath);
+  const idleResidueHint =
+    unmergedMilestones.length === 0 ? detectIdleMilestoneResidueHint(basePath) : null;
   return {
     strandedQuick: detectStrandedQuickBranch(basePath),
     unmergedMilestones,
+    idleResidueHint,
   };
 }
 
@@ -94,6 +170,10 @@ export function buildIdleMenuSummary(state: GSDState, closeout: CloseoutContext)
         ? `All milestones complete after ${last.id}: ${last.title}.`
         : "All milestones complete.",
     ]);
+  }
+
+  if (closeout.idleResidueHint) {
+    return [closeout.idleResidueHint.message];
   }
 
   return [state.nextAction || "No active milestone."];

--- a/src/resources/extensions/gsd/closeout-wizard.ts
+++ b/src/resources/extensions/gsd/closeout-wizard.ts
@@ -10,8 +10,12 @@ import type { NextAction } from "../shared/next-action-ui.js";
 import type { GSDState } from "./types.js";
 import { setAutoOutcomeWidget } from "./auto-dashboard.js";
 import { invalidateAllCaches } from "./cache.js";
+import { isDbAvailable } from "./db/engine.js";
+import { getMilestone } from "./db/queries.js";
+import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import { mergeCompletedMilestone } from "./parallel-merge.js";
 import { cleanupQuickBranch, detectStrandedQuickBranch, type StrandedQuickBranch } from "./quick.js";
+import { isClosedStatus } from "./status-guards.js";
 import {
   findUnmergedCompletedMilestones,
   type UnmergedMilestoneBlocker,
@@ -40,14 +44,12 @@ const MILESTONE_MERGE_CLOSEOUT_COMMANDS = [
   "/gsd start for new work",
 ];
 
-const MILESTONE_ID_DIR_RE = /^M\d+$/;
-
 function listMilestoneWorktreeIds(basePath: string): string[] {
   const ids = new Set<string>();
   for (const wtDir of allWorktreesDirs(basePath)) {
     if (!existsSync(wtDir)) continue;
     for (const entry of readdirSync(wtDir)) {
-      if (!MILESTONE_ID_DIR_RE.test(entry)) continue;
+      if (!MILESTONE_ID_RE.test(entry)) continue;
       try {
         if (statSync(join(wtDir, entry)).isDirectory()) ids.add(entry);
       } catch {
@@ -62,11 +64,26 @@ function listMilestoneBranchIds(basePath: string): string[] {
   try {
     return nativeBranchList(basePath, "milestone/*")
       .map((branch) => branch.replace(/^milestone\//, ""))
-      .filter((id) => MILESTONE_ID_DIR_RE.test(id))
+      .filter((id) => MILESTONE_ID_RE.test(id))
       .sort();
   } catch {
     return [];
   }
+}
+
+/**
+ * A milestone ID is "stranded residue" only when its worktree/branch artifacts
+ * exist for a milestone the DB does not consider currently in flight — i.e. the
+ * row is closed (complete/done/skipped/closed) or absent. Active, pending,
+ * blocked, parked, queued, and deferred rows describe normal in-flight or
+ * intentionally-preserved state, never residue. Returning `false` skips the ID;
+ * returning `true` keeps it in the hint.
+ */
+function isStrandedMilestoneId(milestoneId: string): boolean {
+  if (!isDbAvailable()) return true;
+  const row = getMilestone(milestoneId);
+  if (!row) return true;
+  return isClosedStatus(row.status);
 }
 
 /** Surface stranded milestone git residue when closeout guards did not classify it. */
@@ -86,7 +103,8 @@ export function detectIdleMilestoneResidueHint(basePath: string): IdleMilestoneR
 
   const worktreeIds = listMilestoneWorktreeIds(basePath);
   const branchIds = listMilestoneBranchIds(basePath);
-  const milestoneIds = [...new Set([...worktreeIds, ...branchIds])].sort();
+  const candidateIds = [...new Set([...worktreeIds, ...branchIds])].sort();
+  const milestoneIds = candidateIds.filter(isStrandedMilestoneId);
   if (milestoneIds.length === 0) return null;
 
   const listed = milestoneIds.join(", ");
@@ -163,6 +181,14 @@ export function buildIdleMenuSummary(state: GSDState, closeout: CloseoutContext)
     ];
   }
 
+  // Surface idle residue before the completion summary so smart entry shows
+  // the same recovery text /gsd home would: a closed/unknown milestone with
+  // lingering worktree/branch artifacts must not be hidden behind the
+  // "all milestones complete" message.
+  if (closeout.idleResidueHint) {
+    return [closeout.idleResidueHint.message];
+  }
+
   if (state.phase === "complete") {
     const last = state.lastCompletedMilestone;
     return appendRequirementsBacklogToSummary(state, [
@@ -170,10 +196,6 @@ export function buildIdleMenuSummary(state: GSDState, closeout: CloseoutContext)
         ? `All milestones complete after ${last.id}: ${last.title}.`
         : "All milestones complete.",
     ]);
-  }
-
-  if (closeout.idleResidueHint) {
-    return [closeout.idleResidueHint.message];
   }
 
   return [state.nextAction || "No active milestone."];

--- a/src/resources/extensions/gsd/gsd-command-home.ts
+++ b/src/resources/extensions/gsd/gsd-command-home.ts
@@ -66,7 +66,7 @@ function disabled(description: string, reason: string): string {
 
 export function buildGsdHomeModel(
   state: GSDState,
-  closeout?: Pick<CloseoutContext, "strandedQuick" | "unmergedMilestones">,
+  closeout?: Pick<CloseoutContext, "strandedQuick" | "unmergedMilestones" | "idleResidueHint">,
 ): GsdHomeModel {
   const blocked = isBlocked(state);
   const complete = state.phase === "complete";
@@ -74,10 +74,14 @@ export function buildGsdHomeModel(
   const workLabel = activeWorkLabel(state);
   const strandedQuick = closeout?.strandedQuick ?? null;
   const unmergedMilestone = closeout?.unmergedMilestones?.[0];
+  const idleResidueHint = closeout?.idleResidueHint ?? null;
+  const hasIdleResidue = Boolean(idleResidueHint);
   const nextReason = complete
     ? "all milestones are complete"
     : blocked
       ? "the active milestone is blocked"
+      : hasIdleResidue
+        ? "milestone git residue needs recovery"
       : !hasActiveWork
         ? "there is no active milestone"
         : "";
@@ -91,6 +95,8 @@ export function buildGsdHomeModel(
       ? "finish_milestone"
       : blocked
         ? "fix_recover"
+        : hasIdleResidue
+          ? "fix_recover"
         : canAdvance
           ? "continue_step"
           : complete && unmappedActive > 0
@@ -107,6 +113,8 @@ export function buildGsdHomeModel(
     ? [`Quick task Q${strandedQuick.taskNum} finished on ${strandedQuick.quickBranch} but is not merged to ${strandedQuick.originalBranch}.`]
     : unmergedMilestone
       ? [`${unmergedMilestone.milestoneId} is complete but not merged into ${unmergedMilestone.integrationBranch}.`]
+      : idleResidueHint
+        ? [idleResidueHint.message]
       : completionSummary;
 
   return {
@@ -181,10 +189,12 @@ export function buildGsdHomeModel(
         label: "Fix or recover",
         description: blocked
           ? "Review the blocker and recovery commands for the active milestone."
+          : hasIdleResidue
+            ? "Review stranded milestone worktrees/branches and run the suggested recovery command."
           : disabled("This becomes active when closeout, validation, or state recovery is needed.", "no blocker is active"),
-        enabled: blocked,
+        enabled: blocked || hasIdleResidue,
         recommended: recommended === "fix_recover",
-        disabledReason: blocked ? undefined : "no blocker is active",
+        disabledReason: blocked || hasIdleResidue ? undefined : "no blocker is active",
       },
       {
         id: "start_configure",

--- a/src/resources/extensions/gsd/tests/gsd-command-home.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-command-home.test.ts
@@ -4,10 +4,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { buildGsdHomeModel, showGsdHome } from "../gsd-command-home.ts";
+import { detectIdleMilestoneResidueHint } from "../closeout-wizard.ts";
 import type { GSDState } from "../types.ts";
 
 function baseState(overrides: Partial<GSDState> = {}): GSDState {
@@ -116,6 +118,42 @@ test("/gsd home recommends start or configure after all milestones complete", ()
   assert.equal(action(model, "continue_step").enabled, false);
   assert.equal(action(model, "run_auto").enabled, false);
   assert.match(model.summary.join("\n"), /All milestones complete/);
+});
+
+test("/gsd home recommends fix or recover when milestone git residue is stranded", () => {
+  const model = buildGsdHomeModel(baseState({
+    activeMilestone: null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "complete",
+    nextAction: "All milestones complete.",
+  }), {
+    strandedQuick: null,
+    unmergedMilestones: [],
+    idleResidueHint: {
+      milestoneIds: ["M008"],
+      message:
+        "Stranded milestone git residue detected (M008: worktree dir and/or milestone/* branch). " +
+        "Run /gsd dispatch complete-milestone M008 or /gsd status to recover closeout before starting new work.",
+    },
+  });
+
+  assert.equal(action(model, "fix_recover").recommended, true);
+  assert.equal(action(model, "fix_recover").enabled, true);
+  assert.match(model.summary[0], /Stranded milestone git residue/);
+  assert.equal(action(model, "continue_step").enabled, false);
+});
+
+test("detectIdleMilestoneResidueHint reports missing workflow database in a git repo", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-home-residue-"));
+  try {
+    execFileSync("git", ["init", "-b", "main"], { cwd: base, stdio: "ignore" });
+    const hint = detectIdleMilestoneResidueHint(base);
+    assert.ok(hint);
+    assert.match(hint!.message, /\.gsd\/gsd\.db/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("showGsdHome renders the five-slot home text without an interactive TUI", async () => {

--- a/src/resources/extensions/gsd/tests/gsd-command-home.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-command-home.test.ts
@@ -9,7 +9,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { buildGsdHomeModel, showGsdHome } from "../gsd-command-home.ts";
-import { detectIdleMilestoneResidueHint } from "../closeout-wizard.ts";
+import { buildIdleMenuSummary, detectIdleMilestoneResidueHint } from "../closeout-wizard.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
 import type { GSDState } from "../types.ts";
 
 function baseState(overrides: Partial<GSDState> = {}): GSDState {
@@ -154,6 +155,87 @@ test("detectIdleMilestoneResidueHint reports missing workflow database in a git 
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("detectIdleMilestoneResidueHint matches unique-format milestone ids (M###-abc123)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-home-residue-unique-"));
+  try {
+    execFileSync("git", ["init", "-b", "main"], { cwd: base, stdio: "ignore" });
+    mkdirSync(join(base, ".gsd-worktrees", "M042-abc123"), { recursive: true });
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    try {
+      // Closed milestone with lingering worktree dir — classic residue.
+      insertMilestone({ id: "M042-abc123", title: "Closed Unique", status: "complete" });
+      const hint = detectIdleMilestoneResidueHint(base);
+      assert.ok(hint, "unique-format closed milestone with worktree should be detected");
+      assert.deepEqual(hint!.milestoneIds, ["M042-abc123"]);
+      assert.match(hint!.message, /M042-abc123/);
+    } finally {
+      closeDatabase();
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("detectIdleMilestoneResidueHint ignores in-flight milestones with worktree artifacts", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-home-residue-active-"));
+  try {
+    execFileSync("git", ["init", "-b", "main"], { cwd: base, stdio: "ignore" });
+    mkdirSync(join(base, ".gsd-worktrees", "M001"), { recursive: true });
+    mkdirSync(join(base, ".gsd-worktrees", "M002-abc123"), { recursive: true });
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    try {
+      // Active and pending milestones must not be flagged as stranded residue.
+      insertMilestone({ id: "M001", title: "Active milestone", status: "active" });
+      insertMilestone({ id: "M002-abc123", title: "Pending milestone", status: "pending" });
+      const hint = detectIdleMilestoneResidueHint(base);
+      assert.equal(hint, null, "active/pending milestone worktrees must not be classified as residue");
+    } finally {
+      closeDatabase();
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("buildIdleMenuSummary surfaces idle residue hint even when phase is complete", () => {
+  const summary = buildIdleMenuSummary(
+    {
+      activeMilestone: null,
+      activeSlice: null,
+      activeTask: null,
+      phase: "complete",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "All milestones complete.",
+      lastCompletedMilestone: { id: "M001", title: "Menu Cleanup" },
+      registry: [{ id: "M001", title: "Menu Cleanup", status: "complete" }],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: {
+        milestones: { done: 1, total: 1 },
+        slices: { done: 0, total: 0 },
+        tasks: { done: 0, total: 0 },
+      },
+    },
+    {
+      strandedQuick: null,
+      unmergedMilestones: [],
+      idleResidueHint: {
+        milestoneIds: ["M008"],
+        message:
+          "Stranded milestone git residue detected (M008: worktree dir and/or milestone/* branch). " +
+          "Run /gsd dispatch complete-milestone M008 or /gsd status to recover closeout before starting new work.",
+      },
+    },
+  );
+
+  assert.match(summary[0] ?? "", /Stranded milestone git residue/);
+  assert.doesNotMatch(summary.join("\n"), /All milestones complete/);
 });
 
 test("showGsdHome renders the five-slot home text without an interactive TUI", async () => {


### PR DESCRIPTION
## Summary
- Detect stranded `.gsd/worktrees/M*` dirs, `milestone/*` branches, and missing `.gsd/gsd.db`.
- Show actionable recovery guidance on `/gsd` home instead of generic "no active milestone" idle text.

## Test plan
- [x] `gsd-command-home.test.ts` — idle residue hint detection

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->