### PR TITLE
fix(issue): Orchestrator bails on dispatch when all milestones parked — pre-planning rules never fire

### DIFF
--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -243,8 +243,15 @@ export async function decideOrchestratorDispatch(
         ? "true"
         : "false");
 
+  // Only replay a milestone-scoped verification retry when a milestone is
+  // active. Pre-PR (#712 fix), `!active` returned null before reaching this
+  // block, so the retry was preserved for a future tick. The new
+  // pre-planning + deep-pending fall-through must keep that contract:
+  // otherwise a stale execute-task / complete-slice / complete-milestone
+  // retry whose target milestone has since been parked would preempt
+  // project-level deep rules like `discuss-project`.
   const pendingRetry = session?.pendingVerificationRetryDispatch;
-  if (session && pendingRetry) {
+  if (session && pendingRetry && active) {
     session.pendingVerificationRetryDispatch = null;
     const alreadyClosedReason = getAlreadyClosedDispatchReason(
       pendingRetry.unitType,

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -22,7 +22,7 @@ type BlockedAdvanceResult = Extract<AutoAdvanceResult, { kind: "blocked" }>;
 import { debugCount, debugLog, debugTime } from "../debug-logger.js";
 import { reconcileBeforeDispatch } from "../state-reconciliation.js";
 import { isLegalEdge, IllegalPhaseTransitionError } from "../state-transition-matrix.js";
-import { resolveDispatch } from "../auto-dispatch.js";
+import { hasPendingDeepStage, resolveDispatch } from "../auto-dispatch.js";
 import { classifyFailure } from "../recovery-classification.js";
 import { verifyExpectedArtifact, refreshRecoveryDbForArtifact } from "../auto-recovery.js";
 import { invalidateAllCaches } from "../cache.js";
@@ -193,14 +193,25 @@ export async function decideOrchestratorDispatch(
 ): Promise<DispatchDecision> {
   const state = input.stateSnapshot;
   const active = state.activeMilestone;
-  if (!active) return null;
-
   const activeSession = input.session ?? session;
   const activeDispatchBasePath = activeSession?.basePath || dispatchBasePath;
-  if (activeSession && shouldAdoptActiveMilestone(state, activeSession, activeDispatchBasePath)) {
+  const prefs = loadEffectiveGSDPreferences(activeDispatchBasePath)?.preferences;
+  if (!active) {
+    if (state.phase !== "pre-planning") return null;
+    if (!hasPendingDeepStage(prefs, activeDispatchBasePath)) {
+      return {
+        kind: "blocked",
+        reason: state.nextAction || "No active milestone. Run /gsd unpark <id> or create a new milestone.",
+        action: "stop",
+      };
+    }
+  }
+
+  if (active && activeSession && shouldAdoptActiveMilestone(state, activeSession, activeDispatchBasePath)) {
     activeSession.currentMilestoneId = active.id;
   }
-  const prefs = loadEffectiveGSDPreferences(activeDispatchBasePath)?.preferences;
+  const dispatchMid = active?.id ?? activeSession?.currentMilestoneId ?? "";
+  const dispatchMidTitle = active?.title ?? "";
 
   // Derive session-derived dispatch inputs the same way phases.ts:runDispatch does
   // (#5789). Prefer caller-supplied values when present so test harnesses and
@@ -255,8 +266,8 @@ export async function decideOrchestratorDispatch(
 
   const action = await resolveDispatch({
     basePath: activeDispatchBasePath,
-    mid: active.id,
-    midTitle: active.title,
+    mid: dispatchMid,
+    midTitle: dispatchMidTitle,
     state,
     prefs,
     session: activeSession,
@@ -300,8 +311,8 @@ export async function decideOrchestratorDispatch(
       prompt: action.prompt,
       pauseAfterUatDispatch: action.pauseAfterDispatch ?? false,
       state,
-      mid: active.id,
-      midTitle: active.title,
+      mid: dispatchMid,
+      midTitle: dispatchMidTitle,
     };
     session.pendingOrchestrationDispatch = pending;
   }

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1264,6 +1264,62 @@ test("decideOrchestratorDispatch evaluates deep pre-planning rules without an ac
   assert.equal(result.unitId, "PROJECT");
 });
 
+test("decideOrchestratorDispatch does not replay milestone-scoped verification retry when no milestone is active", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-no-active-retry-"));
+  t.after(() => {
+    resetRegistry();
+    rmSync(base, { recursive: true, force: true });
+  });
+  resetRegistry();
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "planning_depth: deep",
+      "workflow_prefs_captured: true",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  const stateSnapshot: GSDState = {
+    ...makeState(),
+    activeMilestone: null,
+    phase: "pre-planning",
+    nextAction: "All remaining milestones are parked (M027). Run /gsd unpark M027 or create a new milestone.",
+    registry: [{ id: "M027", title: "Parked", status: "parked" }],
+  };
+  const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as never;
+  const pi = { getActiveTools: () => [] } as never;
+  const stalePendingRetry = {
+    unitType: "execute-task",
+    unitId: "M027.S1.T1",
+    prompt: "stale retry prompt",
+    pauseAfterUatDispatch: false,
+    state: stateSnapshot,
+    mid: "M027",
+    midTitle: "Parked",
+  };
+  const session = {
+    basePath: base,
+    originalBasePath: base,
+    currentMilestoneId: "M027",
+    pendingVerificationRetryDispatch: stalePendingRetry,
+  } as never;
+
+  const result = await decideOrchestratorDispatch(ctx, pi, base, session, { stateSnapshot });
+
+  assert.ok(result && "unitType" in result, `expected project-level dispatch, got ${JSON.stringify(result)}`);
+  assert.equal(result.unitType, "discuss-project");
+  assert.equal(result.unitId, "PROJECT");
+  // The stale retry must be preserved for a future tick, not consumed by this
+  // no-active-milestone path (mirrors pre-#712-fix behavior where !active
+  // returned null before touching the retry).
+  const sess = session as unknown as { pendingVerificationRetryDispatch: unknown };
+  assert.equal(sess.pendingVerificationRetryDispatch, stalePendingRetry);
+});
+
 test("decideOrchestratorDispatch adopts next active milestone after the session milestone is closed", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-milestone-adopt-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1223,6 +1223,47 @@ test("decideOrchestratorDispatch forwards constructor session when advance input
   }
 });
 
+test("decideOrchestratorDispatch evaluates deep pre-planning rules without an active milestone", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-no-active-"));
+  t.after(() => {
+    resetRegistry();
+    rmSync(base, { recursive: true, force: true });
+  });
+  resetRegistry();
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "planning_depth: deep",
+      "workflow_prefs_captured: true",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  const stateSnapshot: GSDState = {
+    ...makeState(),
+    activeMilestone: null,
+    phase: "pre-planning",
+    nextAction: "All remaining milestones are parked (M027). Run /gsd unpark M027 or create a new milestone.",
+    registry: [{ id: "M027", title: "Parked", status: "parked" }],
+  };
+  const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as never;
+  const pi = { getActiveTools: () => [] } as never;
+  const session = {
+    basePath: base,
+    originalBasePath: base,
+    currentMilestoneId: "M027",
+  } as never;
+
+  const result = await decideOrchestratorDispatch(ctx, pi, base, session, { stateSnapshot });
+
+  assert.ok(result && "unitType" in result, `expected project-level dispatch, got ${JSON.stringify(result)}`);
+  assert.equal(result.unitType, "discuss-project");
+  assert.equal(result.unitId, "PROJECT");
+});
+
 test("decideOrchestratorDispatch adopts next active milestone after the session milestone is closed", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-milestone-adopt-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- Fixed orchestrator no-active pre-planning dispatch handling and added a regression test; static diff check passed but focused tests were blocked by missing dependencies and network setup failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #712
- [#712 Orchestrator bails on dispatch when all milestones parked — pre-planning rules never fire](https://github.com/open-gsd/gsd-pi/issues/712)

## User
- @vtsamourtzis

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/712-orchestrator-bails-on-dispatch-when-all--1781350043`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auto-orchestration dispatch gating; behavior change is narrow (no active milestone + pre-planning/deep) and covered by a new test.
> 
> **Overview**
> **Fixes orchestrator dispatch when there is no active milestone** (e.g. all milestones parked). `decideOrchestratorDispatch` no longer returns `null` immediately on missing `activeMilestone`; it only bails out in that case when the phase is not `pre-planning`, or when deep planning has no pending project setup stages.
> 
> When **deep** pre-planning still has pending stages, dispatch continues into `resolveDispatch` using milestone id/title from the active milestone or session (`dispatchMid` / `dispatchMidTitle`), so project-level units like `discuss-project` can run even with no active milestone.
> 
> If there is no active milestone and deep setup is not pending, the decision is **`blocked`** with `state.nextAction` (or a default unpark hint) instead of falling through to a generic “no remaining units” stop.
> 
> A regression test covers **pre-planning + deep prefs + all parked** and expects `discuss-project` / `PROJECT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d217609dac636f0c6c01309f4d12de14208e9320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->