### PR TITLE
fix(issue): [Bug]: Switching to fallback models does not work correctly

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -18,7 +18,7 @@ import { getSessionModelOverride } from "./session-model-override.js";
 import { logWarning } from "./workflow-logger.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { applyModelPolicyFilter } from "./uok/model-policy.js";
-import { isModelBlocked } from "./blocked-models.js";
+import { isModelBlocked, isModelTemporarilyUnavailable } from "./blocked-models.js";
 import { getRequiredWorkflowToolsForAutoUnit, isWorkflowMcpSurfaceTool } from "./workflow-mcp.js";
 
 /**
@@ -270,6 +270,15 @@ function buildModelPolicyBlockReasons(
     modelId: modelsToTry.join(", ") || "(none)",
     reason: `configured model(s) did not resolve against policy-eligible registry [${eligibleSummary}]`,
   }];
+}
+
+function isModelUnavailable(
+  basePath: string,
+  provider: string | undefined,
+  id: string | undefined,
+): boolean {
+  return isModelBlocked(basePath, provider, id) ||
+    isModelTemporarilyUnavailable(basePath, provider, id);
 }
 
 function restoreToolBaseline(pi: ExtensionAPI): void {
@@ -817,9 +826,9 @@ export async function selectAndApplyModel(
       // (issue #4513).  The block is persisted in .gsd/runtime/blocked-models.json
       // so it survives /gsd auto restarts — without this, the same dead model
       // gets reselected after every restart.
-      if (isModelBlocked(basePath, model.provider, model.id)) {
+      if (isModelUnavailable(basePath, model.provider, model.id)) {
         ctx.ui.notify(
-          `Skipping blocked model ${model.provider}/${model.id} (provider rejected it for this account).`,
+          `Skipping unavailable model ${model.provider}/${model.id}.`,
           "warning",
         );
         continue;
@@ -896,7 +905,7 @@ export async function selectAndApplyModel(
       for (const model of buildPolicyEligibleFallbackOrder(ctx, routingEligibleModels, autoModeStartModel)) {
         const key = `${model.provider.toLowerCase()}/${model.id.toLowerCase()}`;
         if (!policyAllowedModelKeys.has(key)) continue;
-        if (isModelBlocked(basePath, model.provider, model.id)) continue;
+        if (isModelUnavailable(basePath, model.provider, model.id)) continue;
         const ok = await pi.setModel(model, { persist: false });
         if (!ok) continue;
         appliedModel = model;
@@ -926,10 +935,10 @@ export async function selectAndApplyModel(
       autoModeStartModel,
       effectiveSessionModelOverride,
     );
-    const startBlocked = isModelBlocked(basePath, autoModeStartModel.provider, autoModeStartModel.id);
+    const startBlocked = isModelUnavailable(basePath, autoModeStartModel.provider, autoModeStartModel.id);
     if (startBlocked) {
       ctx.ui.notify(
-        `Auto-mode start model ${autoModeStartModel.provider}/${autoModeStartModel.id} is blocked for this account. Using current session model instead.`,
+        `Auto-mode start model ${autoModeStartModel.provider}/${autoModeStartModel.id} is unavailable. Using current session model instead.`,
         "warning",
       );
     } else {
@@ -940,7 +949,7 @@ export async function selectAndApplyModel(
         const ok = await pi.setModel(startModel, { persist: false });
         if (!ok) {
           const byId = availableModels.find(
-            m => m.id === autoModeStartModel.id && !isModelBlocked(basePath, m.provider, m.id),
+            m => m.id === autoModeStartModel.id && !isModelUnavailable(basePath, m.provider, m.id),
           );
           if (byId) {
             const fallbackOk = await pi.setModel(byId, { persist: false });

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -924,6 +924,14 @@ export function setCurrentDispatchedModelId(model: { provider: string; id: strin
   s.currentDispatchedModelId = model ? `${model.provider}/${model.id}` : null;
 }
 
+/**
+ * Update the active unit model after runtime recovery switches models mid-unit.
+ * The next session restore path reads this field before dispatching again.
+ */
+export function setCurrentUnitModelForRecovery(model: any | null): void {
+  s.currentUnitModel = model;
+}
+
 // Tool tracking — delegates to auto-tool-tracking.ts
 export function markToolStart(toolCallId: string, toolName?: string): void {
   _markToolStart(toolCallId, s.active, toolName);

--- a/src/resources/extensions/gsd/blocked-models.ts
+++ b/src/resources/extensions/gsd/blocked-models.ts
@@ -23,12 +23,25 @@ interface BlockedModelsFile {
   blocked: BlockedModelEntry[];
 }
 
+interface TemporaryBlockedModelEntry {
+  provider: string;
+  id: string;
+  reason: string;
+  blockedUntil: number;
+}
+
+const temporaryBlockedModels = new Map<string, TemporaryBlockedModelEntry>();
+
 function blockedModelsPath(basePath: string): string {
   return join(gsdRoot(basePath), "runtime", "blocked-models.json");
 }
 
 function modelKey(provider: string, id: string): string {
   return `${provider.toLowerCase()}/${id.toLowerCase()}`;
+}
+
+function temporaryModelKey(basePath: string, provider: string, id: string): string {
+  return `${basePath}:${modelKey(provider, id)}`;
 }
 
 function readFileSafe(path: string): BlockedModelsFile {
@@ -64,6 +77,42 @@ export function isModelBlocked(
   return loadBlockedModels(basePath).some(
     (e) => modelKey(e.provider, e.id) === target,
   );
+}
+
+export function blockModelUntil(
+  basePath: string,
+  provider: string,
+  id: string,
+  blockedUntil: number,
+  reason: string,
+): void {
+  const key = temporaryModelKey(basePath, provider, id);
+  if (blockedUntil <= Date.now()) {
+    temporaryBlockedModels.delete(key);
+    return;
+  }
+  temporaryBlockedModels.set(key, { provider, id, reason, blockedUntil });
+}
+
+export function isModelTemporarilyUnavailable(
+  basePath: string,
+  provider: string | undefined,
+  id: string | undefined,
+  now = Date.now(),
+): boolean {
+  if (!provider || !id) return false;
+  const key = temporaryModelKey(basePath, provider, id);
+  const entry = temporaryBlockedModels.get(key);
+  if (!entry) return false;
+  if (entry.blockedUntil <= now) {
+    temporaryBlockedModels.delete(key);
+    return false;
+  }
+  return true;
+}
+
+export function clearTemporaryModelBlocksForTest(): void {
+  temporaryBlockedModels.clear();
 }
 
 export function blockModel(

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -19,6 +19,7 @@ import {
   isAutoCompletionStopInProgress,
   pauseAuto,
   setCurrentDispatchedModelId,
+  setCurrentUnitModelForRecovery,
 } from "../auto.js";
 import { getNextFallbackModel, resolveModelWithFallbacksForUnit } from "../preferences.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
@@ -41,7 +42,7 @@ import {
   isTransient,
   type ErrorClass,
 } from "../error-classifier.js";
-import { blockModel, isModelBlocked } from "../blocked-models.js";
+import { blockModel, blockModelUntil, isModelBlocked, isModelTemporarilyUnavailable } from "../blocked-models.js";
 import { getProjectGSDPreferencesPath } from "../preferences.js";
 import { resolveProviderErrorGuidance } from "../provider-error-guidance.js";
 import { formatGuidance } from "../guidance.js";
@@ -143,9 +144,14 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
       const nextModelId = getNextFallbackModel(cursorModelId, modelConfig);
       if (!nextModelId) break;
       const candidate = resolveModelId(nextModelId, availableModels, rejectedProvider);
-      if (candidate && !isModelBlocked(basePath, candidate.provider, candidate.id)) {
+      if (
+        candidate &&
+        !isModelBlocked(basePath, candidate.provider, candidate.id) &&
+        !isModelTemporarilyUnavailable(basePath, candidate.provider, candidate.id)
+      ) {
         const ok = await pi.setModel(candidate, { persist: false });
         if (ok) {
+          setCurrentUnitModelForRecovery(candidate);
           setCurrentDispatchedModelId({ provider: candidate.provider, id: candidate.id });
           switchedNotify(`${candidate.provider}/${candidate.id}`);
           pi.sendMessage(
@@ -163,7 +169,8 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
   if (
     sessionModel &&
     !(sessionModel.provider === rejectedProvider && sessionModel.id === rejectedId) &&
-    !isModelBlocked(basePath, sessionModel.provider, sessionModel.id)
+    !isModelBlocked(basePath, sessionModel.provider, sessionModel.id) &&
+    !isModelTemporarilyUnavailable(basePath, sessionModel.provider, sessionModel.id)
   ) {
     const startModel = availableModels.find(
       (m) => m.provider === sessionModel.provider && m.id === sessionModel.id,
@@ -171,6 +178,7 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
     if (startModel) {
       const ok = await pi.setModel(startModel, { persist: false });
       if (ok) {
+        setCurrentUnitModelForRecovery(startModel);
         setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
         switchedNotify(`${startModel.provider}/${startModel.id}`);
         pi.sendMessage(
@@ -676,6 +684,16 @@ export async function handleAgentEnd(
       if (currentProvider === "openai-codex" || currentProvider === "google-gemini-cli") {
         cls.retryAfterMs = Math.min(cls.retryAfterMs, 30_000);
       }
+      const dash = getAutoDashboardData();
+      if (dash.basePath && ctx.model?.provider && ctx.model?.id) {
+        blockModelUntil(
+          dash.basePath,
+          ctx.model.provider,
+          ctx.model.id,
+          Date.now() + cls.retryAfterMs,
+          rawErrorMsg || displayMsg || "rate limit",
+        );
+      }
     }
 
     // ── 2. Decide & Act ──────────────────────────────────────────────────
@@ -721,9 +739,14 @@ export async function handleAgentEnd(
             retryState.networkRetryCount = 0;
             retryState.currentRetryModelId = undefined;
             const modelToSet = resolveModelId(nextModelId, availableModels, ctx.model?.provider);
-            if (modelToSet) {
+            const modelUnavailable = dash.basePath && modelToSet
+              ? isModelBlocked(dash.basePath, modelToSet.provider, modelToSet.id) ||
+                isModelTemporarilyUnavailable(dash.basePath, modelToSet.provider, modelToSet.id)
+              : false;
+            if (modelToSet && !modelUnavailable) {
               const ok = await pi.setModel(modelToSet, { persist: false });
               if (ok) {
+                setCurrentUnitModelForRecovery(modelToSet);
                 setCurrentDispatchedModelId({ provider: modelToSet.provider, id: modelToSet.id });
                 ctx.ui.notify(`Model error${errorDetail}. Switched to fallback: ${nextModelId} and resuming.`, "warning");
                 pi.sendMessage({ customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false }, { triggerTurn: true });
@@ -737,11 +760,17 @@ export async function handleAgentEnd(
       // Try restoring session model
       const sessionModel = getAutoModeStartModel();
       if (sessionModel) {
-        if (ctx.model?.id !== sessionModel.id || ctx.model?.provider !== sessionModel.provider) {
+        const dash = getAutoDashboardData();
+        const sessionModelUnavailable = dash.basePath
+          ? isModelBlocked(dash.basePath, sessionModel.provider, sessionModel.id) ||
+            isModelTemporarilyUnavailable(dash.basePath, sessionModel.provider, sessionModel.id)
+          : false;
+        if (!sessionModelUnavailable && (ctx.model?.id !== sessionModel.id || ctx.model?.provider !== sessionModel.provider)) {
           const startModel = ctx.modelRegistry.getAvailable().find((m) => m.provider === sessionModel.provider && m.id === sessionModel.id);
           if (startModel) {
             const ok = await pi.setModel(startModel, { persist: false });
             if (ok) {
+              setCurrentUnitModelForRecovery(startModel);
               setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
               retryState.networkRetryCount = 0;
               retryState.currentRetryModelId = undefined;

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import { ModelPolicyDispatchBlockedError, resolvePreferredModelConfig, resolveModelId, selectAndApplyModel, floorThinkingLevelForUnit } from "../auto-model-selection.js";
+import { blockModelUntil, clearTemporaryModelBlocksForTest } from "../blocked-models.ts";
 
 function makeTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -215,6 +216,74 @@ test("selectAndApplyModel honors explicit phase models without downgrading (#361
     assert.equal(result.appliedModel?.provider, "anthropic");
     assert.equal(result.appliedModel?.id, "claude-opus-4-6");
   } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
+test("selectAndApplyModel skips a rate-limited primary until its reset time", async () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = makeTempDir("gsd-rate-limit-fallback-project-");
+  const tempGsdHome = makeTempDir("gsd-rate-limit-fallback-home-");
+  const setModelCalls: string[] = [];
+
+  try {
+    clearTemporaryModelBlocksForTest();
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "models:",
+        "  execution:",
+        "    model: gpt-5.5",
+        "    provider: openai-codex",
+        "    fallbacks:",
+        "      - anthropic/claude-sonnet-4-6",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const availableModels = [
+      { id: "gpt-5.5", provider: "openai-codex", api: "responses" },
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const ctx = {
+      modelRegistry: { getAvailable: () => availableModels },
+      sessionManager: { getSessionId: () => "test-session" },
+      ui: { notify: () => {} },
+      model: { provider: "openai-codex", id: "gpt-5.5", api: "responses" },
+    } as any;
+    const pi = {
+      setModel: async (model: { provider: string; id: string }) => {
+        setModelCalls.push(`${model.provider}/${model.id}`);
+        return true;
+      },
+      emitBeforeModelSelect: async () => undefined,
+      getActiveTools: () => [],
+      emitAdjustToolSet: async () => undefined,
+      setActiveTools: () => {},
+    } as any;
+
+    blockModelUntil(tempProject, "openai-codex", "gpt-5.5", Date.now() + 60_000, "session limit");
+    await selectAndApplyModel(ctx, pi, "execute-task", "M001/S01/T01", tempProject, undefined, false, { provider: "openai-codex", id: "gpt-5.5" }, undefined, true);
+
+    blockModelUntil(tempProject, "openai-codex", "gpt-5.5", Date.now() - 1, "expired");
+    await selectAndApplyModel(ctx, pi, "execute-task", "M001/S01/T02", tempProject, undefined, false, { provider: "openai-codex", id: "gpt-5.5" }, undefined, true);
+
+    assert.deepEqual(setModelCalls, [
+      "anthropic/claude-sonnet-4-6",
+      "openai-codex/gpt-5.5",
+    ]);
+  } finally {
+    clearTemporaryModelBlocksForTest();
     process.chdir(originalCwd);
     if (originalGsdHome === undefined) delete process.env.GSD_HOME;
     else process.env.GSD_HOME = originalGsdHome;

--- a/src/resources/extensions/gsd/tests/blocked-models.test.ts
+++ b/src/resources/extensions/gsd/tests/blocked-models.test.ts
@@ -8,7 +8,10 @@ import { join } from "node:path";
 
 import {
   blockModel,
+  blockModelUntil,
+  clearTemporaryModelBlocksForTest,
   isModelBlocked,
+  isModelTemporarilyUnavailable,
   loadBlockedModels,
 } from "../blocked-models.ts";
 
@@ -93,6 +96,22 @@ test("blocked-models: file created under .gsd/runtime/", () => {
     blockModel(base, "openai-codex", "gpt-5", "reason");
     assert.ok(existsSync(join(base, ".gsd", "runtime", "blocked-models.json")));
   } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocked-models: temporary rate-limit blocks expire without persisting", () => {
+  const base = mkBase();
+  try {
+    clearTemporaryModelBlocksForTest();
+    blockModelUntil(base, "openai-codex", "gpt-5.5", Date.now() + 60_000, "session limit");
+    assert.equal(isModelTemporarilyUnavailable(base, "openai-codex", "gpt-5.5"), true);
+    assert.equal(loadBlockedModels(base).length, 0, "rate-limit windows must not persist as account blocks");
+
+    blockModelUntil(base, "openai-codex", "gpt-5.5", Date.now() - 1, "expired");
+    assert.equal(isModelTemporarilyUnavailable(base, "openai-codex", "gpt-5.5"), false);
+  } finally {
+    clearTemporaryModelBlocksForTest();
     rmSync(base, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Fixed fallback model continuation and reset-window primary retry handling, with focused tests and syntax/diff verification.

## Bugs Addressed
- [x] **Fallback model is selected but not used immediately**
- [x] **Primary model is not retried after limit reset**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #716
- [#716 [Bug]: Switching to fallback models does not work correctly](https://github.com/open-gsd/gsd-pi/issues/716)

## User
- @sharkpd

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/716-bug-switching-to-fallback-models-does-no-1781359042`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auto-mode model selection and agent-end recovery paths; behavior changes when rate limits and fallbacks interact, though scoped to GSD extension logic with new tests.
> 
> **Overview**
> Fixes auto-mode model fallback so a switched model is actually used on the next turn, and so rate-limited primaries are skipped until their reset window passes.
> 
> **Temporary unavailability** is added alongside the persistent account blocklist: `blockModelUntil` / `isModelTemporarilyUnavailable` keep in-memory, time-bounded blocks (not written to `blocked-models.json`). On rate-limit errors, the current model is blocked for `retryAfterMs` (capped for CLI-style providers). Dispatch and recovery both treat a model as unavailable when it is persistently blocked *or* temporarily blocked via `isModelUnavailable`.
> 
> **`selectAndApplyModel`** skips unavailable models in the primary/fallback chain and policy-eligible fallbacks, with user-facing “unavailable” messaging instead of only “blocked.”
> 
> **Mid-unit recovery** (`agent-end-recovery`) skips temporarily blocked candidates when walking fallbacks or restoring the session model, and calls new **`setCurrentUnitModelForRecovery`** so the session state matches the model `setModel` applied—so the next restore/dispatch does not re-select the rejected primary.
> 
> Tests cover temporary block expiry and rate-limited primary → fallback → primary retry after expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0957ffe60b80a8a3b3d406d884a62223a6972731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->