### PR TITLE
fix(update): reconcile stale PATH gsd-browser binary after install

### DIFF
--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -601,13 +601,20 @@ export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Pro
     execSync(installCmd, {
       stdio: ["ignore", "pipe", "ignore"],
     });
-    const reconcile = browserUpdate
-      ? reconcileGsdBrowserPathAfterInstall({
+    let reconcile: ReturnType<typeof reconcileGsdBrowserPathAfterInstall> | null = null;
+    if (browserUpdate) {
+      try {
+        reconcile = reconcileGsdBrowserPathAfterInstall({
           latestVersion: latest,
           compareSemver: compareSemverLocal,
           resolvePathVersion: resolveGsdBrowserPathVersionForCommand,
-        })
-      : null;
+        });
+      } catch {
+        // Reconciliation is best-effort: the install above already succeeded,
+        // so a reconcile failure must not flip the result to "Update failed".
+        reconcile = null;
+      }
+    }
     const newPathVersion = browserUpdate ? resolveGsdBrowserPathVersionForCommand() : null;
     const pathNote = browserUpdate && !(newPathVersion && compareSemverLocal(newPathVersion, latest) >= 0)
       ? (reconcile?.message

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -29,6 +29,7 @@ import { getAutoWorktreePath } from "./auto-worktree.js";
 import { currentDirectoryRoot, projectRoot } from "./commands/context.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { buildClaudeRuntimeFloorAdvisory } from "../../shared/claude-runtime-floor.js";
+import { reconcileGsdBrowserPathAfterInstall } from "../../shared/gsd-browser-path-sync.js";
 import { isPnpmInstall } from "../../shared/package-manager-detection.js";
 import {
   buildDoctorHealIssuePayload,
@@ -600,12 +601,23 @@ export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Pro
     execSync(installCmd, {
       stdio: ["ignore", "pipe", "ignore"],
     });
+    const reconcile = browserUpdate
+      ? reconcileGsdBrowserPathAfterInstall({
+          latestVersion: latest,
+          compareSemver: compareSemverLocal,
+          resolvePathVersion: resolveGsdBrowserPathVersionForCommand,
+        })
+      : null;
     const newPathVersion = browserUpdate ? resolveGsdBrowserPathVersionForCommand() : null;
-    const pathReady = !browserUpdate || (!!newPathVersion && compareSemverLocal(newPathVersion, latest) >= 0);
+    const pathNote = browserUpdate && !(newPathVersion && compareSemverLocal(newPathVersion, latest) >= 0)
+      ? (reconcile?.message
+        ?? "Ensure the npm global bin directory is on your PATH so MCP automation uses the updated binary.")
+      : "";
     ctx.ui.notify(
       browserUpdate
         ? `Updated gsd-browser to v${latest}. Restart your GSD session to use the new browser automation version.` +
-          (pathReady ? "" : "\nNote: Ensure the npm global bin directory is on your PATH so MCP automation uses the updated binary.")
+          (reconcile?.action === "synced" && reconcile.message ? `\n${reconcile.message}` : "") +
+          (pathNote ? `\nNote: ${pathNote}` : "")
         : `Updated to v${latest}. Restart your GSD session to use the new version.`,
       "info",
     );

--- a/src/resources/shared/gsd-browser-path-sync.ts
+++ b/src/resources/shared/gsd-browser-path-sync.ts
@@ -108,11 +108,18 @@ function resolveRealPath(pathValue: string): string {
 }
 
 function resolveSymlinkTarget(pathCli: string): string {
-  const stat = lstatSync(pathCli)
-  if (!stat.isSymbolicLink()) return pathCli
+  try {
+    const stat = lstatSync(pathCli)
+    if (!stat.isSymbolicLink()) return pathCli
 
-  const target = readlinkSync(pathCli)
-  return isAbsolute(target) ? target : resolvePath(dirname(pathCli), target)
+    const target = readlinkSync(pathCli)
+    return isAbsolute(target) ? target : resolvePath(dirname(pathCli), target)
+  } catch {
+    // PATH entry vanished or is inaccessible between resolution and sync.
+    // Fall back to the original path; subsequent sync will surface a useful
+    // error rather than escaping as an unhandled throw.
+    return pathCli
+  }
 }
 
 function resolveHomeDir(env: NodeJS.ProcessEnv): string {
@@ -231,20 +238,27 @@ export function reconcileGsdBrowserPathAfterInstall(
     }
   }
 
+  let syncSucceeded = false
   try {
     syncBinary(installedCli, syncTarget, platform)
-    const refreshedVersion = options.resolvePathVersion(env)
-    if (refreshedVersion && options.compareSemver(refreshedVersion, options.latestVersion) >= 0) {
-      return {
-        action: 'synced',
-        pathCli,
-        installedCli,
-        syncTarget,
-        message: `Synced PATH-resolved gsd-browser at ${syncTarget} to the updated global install.`,
-      }
-    }
+    syncSucceeded = true
   } catch {
     // Fall through to shadowed guidance.
+  }
+
+  if (syncSucceeded) {
+    const refreshedVersion = options.resolvePathVersion(env)
+    const verified = refreshedVersion !== null
+      && options.compareSemver(refreshedVersion, options.latestVersion) >= 0
+    return {
+      action: 'synced',
+      pathCli,
+      installedCli,
+      syncTarget,
+      message: verified
+        ? `Synced PATH-resolved gsd-browser at ${syncTarget} to the updated global install.`
+        : `Synced PATH-resolved gsd-browser at ${syncTarget} to the updated global install. Could not verify the new version on PATH; restart your shell or rerun if it still reports the old version.`,
+    }
   }
 
   return {

--- a/src/resources/shared/gsd-browser-path-sync.ts
+++ b/src/resources/shared/gsd-browser-path-sync.ts
@@ -1,0 +1,259 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, copyFileSync, existsSync, lstatSync, readlinkSync, realpathSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, isAbsolute, join, delimiter as pathDelimiter, resolve as resolvePath } from 'node:path'
+import { isPnpmInstall, pathStartsWith } from './package-manager-detection.js'
+
+export interface GsdBrowserPathReconcileResult {
+  action: 'none' | 'synced' | 'shadowed'
+  pathCli?: string
+  installedCli?: string
+  syncTarget?: string
+  message?: string
+}
+
+function isBunGlobalInstall(argv1: string | undefined, env: NodeJS.ProcessEnv): boolean {
+  if ('bun' in process.versions) return true
+  if (!argv1) return false
+
+  const bunBinDirs: string[] = []
+  if (env.BUN_INSTALL) bunBinDirs.push(join(env.BUN_INSTALL, 'bin'))
+  bunBinDirs.push(join(homedir(), '.bun', 'bin'))
+
+  return bunBinDirs.some((dir) => pathStartsWith(argv1, dir))
+}
+
+function gsdBrowserBinaryName(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'gsd-browser.cmd' : 'gsd-browser'
+}
+
+function tryResolveFromBinDir(binDir: string, platform: NodeJS.Platform): string | null {
+  const primary = join(binDir, gsdBrowserBinaryName(platform))
+  if (existsSync(primary)) return primary
+
+  if (platform === 'win32') {
+    const fallback = join(binDir, 'gsd-browser')
+    if (existsSync(fallback)) return fallback
+  }
+
+  return null
+}
+
+function tryResolveFromPackageRoot(
+  rootDir: string,
+  platform: NodeJS.Platform,
+): string | null {
+  const candidate = join(rootDir, '@opengsd', 'gsd-browser', 'bin', gsdBrowserBinaryName(platform))
+  if (existsSync(candidate)) return candidate
+
+  if (platform === 'win32') {
+    const fallback = join(rootDir, '@opengsd', 'gsd-browser', 'bin', 'gsd-browser')
+    if (existsSync(fallback)) return fallback
+  }
+
+  return null
+}
+
+function tryExecLookup(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  resolve: (dir: string, platform: NodeJS.Platform) => string | null,
+): string | null {
+  try {
+    const dir = execFileSync(command, args, {
+      encoding: 'utf-8',
+      env,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim()
+    return resolve(dir, platform)
+  } catch {
+    return null
+  }
+}
+
+function resolvePathBinary(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | null {
+  if (platform === 'win32') {
+    try {
+      const out = execFileSync('where', ['gsd-browser'], {
+        encoding: 'utf-8',
+        env,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000,
+      }).trim()
+      const first = out.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
+      return first && existsSync(first) ? first : null
+    } catch {
+      return null
+    }
+  }
+
+  for (const entry of (env.PATH ?? '').split(pathDelimiter)) {
+    if (!entry) continue
+    const candidate = join(entry, 'gsd-browser')
+    if (existsSync(candidate)) return candidate
+  }
+
+  return null
+}
+
+function resolveRealPath(pathValue: string): string {
+  try {
+    return realpathSync(pathValue)
+  } catch {
+    return resolvePath(pathValue)
+  }
+}
+
+function resolveSymlinkTarget(pathCli: string): string {
+  const stat = lstatSync(pathCli)
+  if (!stat.isSymbolicLink()) return pathCli
+
+  const target = readlinkSync(pathCli)
+  return isAbsolute(target) ? target : resolvePath(dirname(pathCli), target)
+}
+
+function resolveHomeDir(env: NodeJS.ProcessEnv): string {
+  const fromEnv = env.HOME?.trim() || env.USERPROFILE?.trim()
+  return resolvePath(fromEnv || homedir())
+}
+
+function canAutoSyncTarget(targetPath: string, env: NodeJS.ProcessEnv): boolean {
+  const home = resolveHomeDir(env)
+  const resolved = resolvePath(targetPath)
+  return pathStartsWith(resolved, home)
+}
+
+function syncBinary(installedCli: string, targetPath: string, platform: NodeJS.Platform): void {
+  const source = resolveRealPath(installedCli)
+  copyFileSync(source, targetPath)
+  if (platform !== 'win32') {
+    chmodSync(targetPath, 0o755)
+  }
+}
+
+/**
+ * Resolve the gsd-browser binary installed by the active global package manager.
+ */
+export function resolveGlobalGsdBrowserCliPath(
+  options: { env?: NodeJS.ProcessEnv; argv1?: string; platform?: NodeJS.Platform } = {},
+): string | null {
+  const env = options.env ?? process.env
+  const argv1 = options.argv1 ?? process.argv[1]
+  const platform = options.platform ?? process.platform
+
+  if (isBunGlobalInstall(argv1, env)) {
+    return (
+      tryExecLookup('bun', ['pm', 'bin', '-g'], env, platform, tryResolveFromBinDir)
+      ?? (env.BUN_INSTALL ? tryResolveFromBinDir(join(env.BUN_INSTALL, 'bin'), platform) : null)
+      ?? tryResolveFromBinDir(join(homedir(), '.bun', 'bin'), platform)
+    )
+  }
+
+  if (isPnpmInstall(argv1, env)) {
+    return (
+      tryExecLookup('pnpm', ['bin', '-g'], env, platform, tryResolveFromBinDir)
+      ?? tryExecLookup('pnpm', ['root', '-g'], env, platform, tryResolveFromPackageRoot)
+    )
+  }
+
+  return (
+    tryExecLookup('npm', ['bin', '-g'], env, platform, tryResolveFromBinDir)
+    ?? tryExecLookup('npm', ['root', '-g'], env, platform, tryResolveFromPackageRoot)
+  )
+}
+
+/**
+ * Resolve the gsd-browser binary that wins on PATH (`command -v` / `where`).
+ */
+export function resolveGsdBrowserOnPath(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  return resolvePathBinary(env, platform)
+}
+
+/**
+ * After a global gsd-browser install, ensure the PATH-resolved binary matches
+ * the freshly installed global binary when an older copy is shadowing it.
+ */
+export function reconcileGsdBrowserPathAfterInstall(
+  options: {
+    latestVersion: string
+    compareSemver: (a: string, b: string) => number
+    resolvePathVersion: (env: NodeJS.ProcessEnv) => string | null
+    env?: NodeJS.ProcessEnv
+    argv1?: string
+    platform?: NodeJS.Platform
+  },
+): GsdBrowserPathReconcileResult {
+  const env = options.env ?? process.env
+  const argv1 = options.argv1 ?? process.argv[1]
+  const platform = options.platform ?? process.platform
+
+  const installedCli = resolveGlobalGsdBrowserCliPath({ env, argv1, platform })
+  if (!installedCli) {
+    return { action: 'none' }
+  }
+
+  const pathCli = resolveGsdBrowserOnPath(env, platform)
+  const installedReal = resolveRealPath(installedCli)
+  if (pathCli && resolveRealPath(pathCli) === installedReal) {
+    return { action: 'none', pathCli, installedCli }
+  }
+
+  const pathVersion = options.resolvePathVersion(env)
+  if (pathVersion && options.compareSemver(pathVersion, options.latestVersion) >= 0) {
+    return { action: 'none', pathCli: pathCli ?? undefined, installedCli }
+  }
+
+  if (!pathCli) {
+    return {
+      action: 'shadowed',
+      installedCli,
+      message:
+        'Installed gsd-browser globally, but no gsd-browser was found on PATH. Add your package manager global bin directory to PATH.',
+    }
+  }
+
+  const syncTarget = resolveSymlinkTarget(pathCli)
+  if (!canAutoSyncTarget(syncTarget, env)) {
+    return {
+      action: 'shadowed',
+      pathCli,
+      installedCli,
+      syncTarget,
+      message:
+        `PATH resolves gsd-browser to ${pathCli}, but the updated global install is at ${installedCli}. ` +
+        'Move your package manager global bin directory ahead of the stale location on PATH, or update the stale binary manually.',
+    }
+  }
+
+  try {
+    syncBinary(installedCli, syncTarget, platform)
+    const refreshedVersion = options.resolvePathVersion(env)
+    if (refreshedVersion && options.compareSemver(refreshedVersion, options.latestVersion) >= 0) {
+      return {
+        action: 'synced',
+        pathCli,
+        installedCli,
+        syncTarget,
+        message: `Synced PATH-resolved gsd-browser at ${syncTarget} to the updated global install.`,
+      }
+    }
+  } catch {
+    // Fall through to shadowed guidance.
+  }
+
+  return {
+    action: 'shadowed',
+    pathCli,
+    installedCli,
+    syncTarget,
+    message:
+      `PATH resolves gsd-browser to ${pathCli}, but the updated global install is at ${installedCli}. ` +
+      'Move your package manager global bin directory ahead of the stale location on PATH, or update the stale binary manually.',
+  }
+}

--- a/src/resources/shared/package-manager-detection.ts
+++ b/src/resources/shared/package-manager-detection.ts
@@ -12,7 +12,7 @@ function hasPnpmPath(value: string | undefined): boolean {
   )
 }
 
-function pathStartsWith(pathValue: string | undefined, dir: string): boolean {
+export function pathStartsWith(pathValue: string | undefined, dir: string): boolean {
   if (!pathValue) return false
   const resolvedPath = resolvePath(pathValue)
   const resolvedDir = resolvePath(dir)

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -6,13 +6,15 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
+import { execFileSync } from "node:child_process";
 
 import { runUpdate } from "../update-cmd.ts";
 import { handleUpdate } from "../resources/extensions/gsd/commands-handlers.ts";
-import { GSD_BROWSER_PACKAGE_NAME, GSD_BROWSER_REGISTRY_URL, resolveInstalledPackageVersion } from "../update-check.js";
+import { compareSemver, GSD_BROWSER_PACKAGE_NAME, GSD_BROWSER_REGISTRY_URL, resolveInstalledPackageVersion } from "../update-check.js";
+import { reconcileGsdBrowserPathAfterInstall } from "../resources/shared/gsd-browser-path-sync.ts";
 
 function writeFakeClaude(binDir: string, output: string): void {
   mkdirSync(binDir, { recursive: true });
@@ -22,6 +24,41 @@ function writeFakeClaude(binDir: string, output: string): void {
     : `#!/bin/sh\necho "${output}"\n`;
   writeFileSync(script, content);
   if (process.platform !== "win32") chmodSync(script, 0o755);
+}
+
+function writeFakeGsdBrowser(dir: string, version: string): string {
+  mkdirSync(dir, { recursive: true });
+  const script = join(dir, process.platform === "win32" ? "gsd-browser.cmd" : "gsd-browser");
+  const content = process.platform === "win32"
+    ? `@echo off\r\necho gsd-browser ${version}\r\n`
+    : `#!/bin/sh\necho "gsd-browser ${version}"\n`;
+  writeFileSync(script, content);
+  if (process.platform !== "win32") chmodSync(script, 0o755);
+  return script;
+}
+
+function resolveGsdBrowserPathVersionFromEnv(env: NodeJS.ProcessEnv): string | null {
+  try {
+    const out = execFileSync("gsd-browser", ["--version"], {
+      encoding: "utf-8",
+      env,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    });
+    return out.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeFakeNpmGlobalBin(dir: string, globalBinDir: string): void {
+  mkdirSync(dir, { recursive: true });
+  const npm = join(dir, process.platform === "win32" ? "npm.cmd" : "npm");
+  const content = process.platform === "win32"
+    ? `@echo off\r\nif "%1"=="bin" if "%2"=="-g" (\r\n  echo ${globalBinDir}\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n`
+    : `#!/bin/sh\nif [ "$1" = "bin" ] && [ "$2" = "-g" ]; then\n  echo "${globalBinDir}"\n  exit 0\nfi\nexit 1\n`;
+  writeFileSync(npm, content);
+  if (process.platform !== "win32") chmodSync(npm, 0o755);
 }
 
 test("update-cmd prints latest version before comparison (#3445)", async (t) => {
@@ -735,4 +772,84 @@ test("isPnpmInstall detects pnpm user agent, exec path, and PNPM_HOME", async ()
     isPnpmInstall("/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js", {} as any),
     false,
   );
+});
+
+test("reconcileGsdBrowserPathAfterInstall syncs stale managed PATH binary", (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX symlink PATH shadowing scenario");
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-browser-path-sync-"));
+  const homeDir = join(tmp, "home");
+  const managedBinDir = join(homeDir, ".gsd-browser", "bin");
+  const pathBinDir = join(tmp, "path-bin");
+  const globalBinDir = join(tmp, "global-bin");
+  const fakeNpmDir = join(tmp, "fake-npm");
+
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const managedCli = writeFakeGsdBrowser(managedBinDir, "1.0.0");
+  writeFakeGsdBrowser(globalBinDir, "2.0.0");
+  mkdirSync(pathBinDir, { recursive: true });
+  symlinkSync(managedCli, join(pathBinDir, "gsd-browser"));
+  writeFakeNpmGlobalBin(fakeNpmDir, globalBinDir);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    PATH: `${pathBinDir}${delimiter}${fakeNpmDir}`,
+    npm_config_user_agent: undefined,
+    npm_execpath: undefined,
+    PNPM_HOME: undefined,
+  };
+
+  const result = reconcileGsdBrowserPathAfterInstall({
+    latestVersion: "2.0.0",
+    compareSemver,
+    resolvePathVersion: resolveGsdBrowserPathVersionFromEnv,
+    env,
+    argv1: "/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js",
+  });
+
+  assert.equal(result.action, "synced");
+  assert.equal(resolveGsdBrowserPathVersionFromEnv(env), "2.0.0");
+  assert.match(result.message ?? "", /Synced PATH-resolved gsd-browser/);
+});
+
+test("reconcileGsdBrowserPathAfterInstall reports shadowing for non-home targets", (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX symlink PATH shadowing scenario");
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-browser-path-shadow-"));
+  const staleBinDir = join(tmp, "usr", "local", "bin");
+  const globalBinDir = join(tmp, "global-bin");
+  const fakeNpmDir = join(tmp, "fake-npm");
+
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeFakeGsdBrowser(staleBinDir, "1.0.0");
+  writeFakeGsdBrowser(globalBinDir, "2.0.0");
+  writeFakeNpmGlobalBin(fakeNpmDir, globalBinDir);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: join(tmp, "home"),
+    PATH: `${staleBinDir}${delimiter}${fakeNpmDir}`,
+    npm_config_user_agent: undefined,
+    npm_execpath: undefined,
+    PNPM_HOME: undefined,
+  };
+
+  const result = reconcileGsdBrowserPathAfterInstall({
+    latestVersion: "2.0.0",
+    compareSemver,
+    resolvePathVersion: resolveGsdBrowserPathVersionFromEnv,
+    env,
+    argv1: "/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js",
+  });
+
+  assert.equal(result.action, "shadowed");
+  assert.equal(resolveGsdBrowserPathVersionFromEnv(env), "1.0.0");
+  assert.match(result.message ?? "", /Move your package manager global bin directory ahead/);
 });

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -853,3 +853,113 @@ test("reconcileGsdBrowserPathAfterInstall reports shadowing for non-home targets
   assert.equal(resolveGsdBrowserPathVersionFromEnv(env), "1.0.0");
   assert.match(result.message ?? "", /Move your package manager global bin directory ahead/);
 });
+
+test("reconcileGsdBrowserPathAfterInstall reports synced when copy succeeds even if PATH version probe is inconclusive", (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX symlink PATH shadowing scenario");
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-browser-path-sync-unverified-"));
+  const homeDir = join(tmp, "home");
+  const managedBinDir = join(homeDir, ".gsd-browser", "bin");
+  const pathBinDir = join(tmp, "path-bin");
+  const globalBinDir = join(tmp, "global-bin");
+  const fakeNpmDir = join(tmp, "fake-npm");
+
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const managedCli = writeFakeGsdBrowser(managedBinDir, "1.0.0");
+  writeFakeGsdBrowser(globalBinDir, "2.0.0");
+  mkdirSync(pathBinDir, { recursive: true });
+  symlinkSync(managedCli, join(pathBinDir, "gsd-browser"));
+  writeFakeNpmGlobalBin(fakeNpmDir, globalBinDir);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    PATH: `${pathBinDir}${delimiter}${fakeNpmDir}`,
+    npm_config_user_agent: undefined,
+    npm_execpath: undefined,
+    PNPM_HOME: undefined,
+  };
+
+  // Pretend the post-sync version probe cannot read the new version (timeout,
+  // shell cache, etc.) by returning null on the second call. The first call —
+  // before sync — sees the old binary; the second — after sync — returns null.
+  let probeCalls = 0;
+  const flakyResolvePathVersion = (probeEnv: NodeJS.ProcessEnv): string | null => {
+    probeCalls += 1;
+    return probeCalls === 1 ? resolveGsdBrowserPathVersionFromEnv(probeEnv) : null;
+  };
+
+  const result = reconcileGsdBrowserPathAfterInstall({
+    latestVersion: "2.0.0",
+    compareSemver,
+    resolvePathVersion: flakyResolvePathVersion,
+    env,
+    argv1: "/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js",
+  });
+
+  // The copy actually succeeded — the post-sync probe being inconclusive
+  // must not flip the result to "shadowed".
+  assert.equal(result.action, "synced");
+  assert.equal(resolveGsdBrowserPathVersionFromEnv(env), "2.0.0");
+  assert.match(result.message ?? "", /Synced PATH-resolved gsd-browser/);
+});
+
+test("reconcileGsdBrowserPathAfterInstall does not throw when PATH entry vanishes between resolve and sync", (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX symlink PATH shadowing scenario");
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-browser-path-vanish-"));
+  const homeDir = join(tmp, "home");
+  const pathBinDir = join(tmp, "path-bin");
+  const globalBinDir = join(tmp, "global-bin");
+  const fakeNpmDir = join(tmp, "fake-npm");
+
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeFakeGsdBrowser(globalBinDir, "2.0.0");
+  mkdirSync(pathBinDir, { recursive: true });
+  // Write a stale binary on PATH so resolvePathBinary finds it, then delete it
+  // before reconciliation reads it via lstatSync. resolvePathBinary uses
+  // existsSync which can race with deletion in real systems; simulate that
+  // here by leaving an entry that disappears between the two reads.
+  writeFakeGsdBrowser(pathBinDir, "1.0.0");
+  writeFakeNpmGlobalBin(fakeNpmDir, globalBinDir);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    PATH: `${pathBinDir}${delimiter}${fakeNpmDir}`,
+    npm_config_user_agent: undefined,
+    npm_execpath: undefined,
+    PNPM_HOME: undefined,
+  };
+
+  // Patch resolvePathVersion to remove the PATH binary the moment it is first
+  // queried — that mimics the entry vanishing between resolution and the
+  // lstatSync call inside reconcileGsdBrowserPathAfterInstall.
+  let firstCall = true;
+  const racyResolvePathVersion = (probeEnv: NodeJS.ProcessEnv): string | null => {
+    if (firstCall) {
+      firstCall = false;
+      const version = resolveGsdBrowserPathVersionFromEnv(probeEnv);
+      rmSync(join(pathBinDir, "gsd-browser"), { force: true });
+      return version;
+    }
+    return resolveGsdBrowserPathVersionFromEnv(probeEnv);
+  };
+
+  // The reconciliation must not throw even if the PATH entry disappears.
+  assert.doesNotThrow(() => {
+    reconcileGsdBrowserPathAfterInstall({
+      latestVersion: "2.0.0",
+      compareSemver,
+      resolvePathVersion: racyResolvePathVersion,
+      env,
+      argv1: "/usr/local/lib/node_modules/@opengsd/gsd-pi/dist/loader.js",
+    });
+  });
+});

--- a/src/update-cmd.ts
+++ b/src/update-cmd.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 import { agentDir as defaultAgentDir } from './app-paths.js'
 import { initResources } from './resource-loader.js'
 import { buildClaudeRuntimeFloorAdvisory } from './resources/shared/claude-runtime-floor.js'
+import { reconcileGsdBrowserPathAfterInstall } from './resources/shared/gsd-browser-path-sync.js'
 import {
   compareSemver,
   fetchLatestVersionFromRegistry,
@@ -76,13 +77,21 @@ async function runBrowserUpdate(): Promise<void> {
       stdio: 'inherit',
     })
     process.stdout.write(`\n${green}${bold}Updated gsd-browser to v${latest}${reset}\n`)
-    // Verify the new version is reachable via PATH (MCP prefers PATH binary when newer)
+
+    const reconcile = reconcileGsdBrowserPathAfterInstall({
+      latestVersion: latest,
+      compareSemver,
+      resolvePathVersion: resolveGsdBrowserPathVersion,
+    })
+    if (reconcile.action === 'synced' && reconcile.message) {
+      process.stdout.write(`${green}${reconcile.message}${reset}\n`)
+    }
+
     const newPathVersion = resolveGsdBrowserPathVersion()
     if (!newPathVersion || compareSemver(newPathVersion, latest) < 0) {
-      process.stdout.write(
-        `${yellow}Note:${reset} ${dim}Ensure the npm global bin directory is on your PATH` +
-        ` so MCP automation uses the updated binary.${reset}\n`,
-      )
+      const guidance = reconcile.message
+        ?? `${dim}Ensure the npm global bin directory is on your PATH so MCP automation uses the updated binary.${reset}`
+      process.stdout.write(`${yellow}Note:${reset} ${guidance}\n`)
     }
   } catch {
     process.stderr.write(`\n${yellow}gsd-browser update failed. Try manually: ${installCmd}${reset}\n`)

--- a/src/update-cmd.ts
+++ b/src/update-cmd.ts
@@ -78,18 +78,25 @@ async function runBrowserUpdate(): Promise<void> {
     })
     process.stdout.write(`\n${green}${bold}Updated gsd-browser to v${latest}${reset}\n`)
 
-    const reconcile = reconcileGsdBrowserPathAfterInstall({
-      latestVersion: latest,
-      compareSemver,
-      resolvePathVersion: resolveGsdBrowserPathVersion,
-    })
-    if (reconcile.action === 'synced' && reconcile.message) {
+    let reconcile: ReturnType<typeof reconcileGsdBrowserPathAfterInstall> | null = null
+    try {
+      reconcile = reconcileGsdBrowserPathAfterInstall({
+        latestVersion: latest,
+        compareSemver,
+        resolvePathVersion: resolveGsdBrowserPathVersion,
+      })
+    } catch {
+      // Reconciliation is best-effort: the install above already succeeded,
+      // so a reconcile failure must not flip the result to "Update failed".
+      reconcile = null
+    }
+    if (reconcile?.action === 'synced' && reconcile.message) {
       process.stdout.write(`${green}${reconcile.message}${reset}\n`)
     }
 
     const newPathVersion = resolveGsdBrowserPathVersion()
     if (!newPathVersion || compareSemver(newPathVersion, latest) < 0) {
-      const guidance = reconcile.message
+      const guidance = reconcile?.message
         ?? `${dim}Ensure the npm global bin directory is on your PATH so MCP automation uses the updated binary.${reset}`
       process.stdout.write(`${yellow}Note:${reset} ${guidance}\n`)
     }


### PR DESCRIPTION
## Summary

Recovers orphaned work that reconciles the managed `gsd-browser` binary on `PATH` after `gsd update` / browser-only updates.

- Adds `reconcileGsdBrowserPathAfterInstall` to copy the freshly installed managed binary over a stale or shadowed `PATH` target when appropriate
- Surfaces shadowing when a non-home `PATH` entry would win over the managed install
- Wires reconciliation into `update-cmd` and `/gsd update browser` so version checks and installs stay consistent with what users actually run

## Problem

After a global or managed update, an older `gsd-browser` earlier on `PATH` could still be executed. Update diagnostics could report the bundled or managed version while the shell invoked a different binary.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/update-cmd-diagnostics.test.ts` (23/23 pass)
- [ ] Run `gsd update` / browser update on a machine with a stale `~/.local/bin/gsd-browser` and confirm PATH binary matches the new install


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->