### PR TITLE
fix(issue): roadmap-divergence reconciliation drift persists after repair: parseTableSlices false-positive on demo text containing | characters

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -154,6 +154,23 @@ function parseTableSlices(section: string): RoadmapSliceEntry[] {
   return slices;
 }
 
+function looksLikeTable(section: string): boolean {
+  const lines = section.split("\n");
+  const firstContentLineIndex = lines.findIndex(line => line.trim() !== "");
+  if (firstContentLineIndex < 0 || !/^\s*\|/.test(lines[firstContentLineIndex]!)) {
+    return false;
+  }
+
+  const firstPipeLineIndex = lines.findIndex(line => /^\s*\|/.test(line));
+  if (firstPipeLineIndex < 0) return false;
+
+  const separatorLine = lines.slice(firstPipeLineIndex + 1).find(line => /^\s*\|/.test(line));
+  if (!separatorLine) return false;
+
+  const cells = separatorLine.split("|").map(c => c.trim()).filter(Boolean);
+  return /^\s*\|[\s:-]+\|/.test(separatorLine) && cells.length >= 2 && cells.every(c => /^[\s:-]+$/.test(c));
+}
+
 export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
   const slicesSection = extractSlicesSection(content);
   if (!slicesSection) {
@@ -165,9 +182,11 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
 
   // Try table format first — if the section contains pipe-delimited rows with
   // slice IDs, parse them as a table (#1736).
-  const tableSlices = parseTableSlices(slicesSection);
-  if (tableSlices.length > 0) {
-    return tableSlices;
+  if (looksLikeTable(slicesSection)) {
+    const tableSlices = parseTableSlices(slicesSection);
+    if (tableSlices.length > 0) {
+      return tableSlices;
+    }
   }
 
   // Standard checkbox format

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -156,19 +156,25 @@ function parseTableSlices(section: string): RoadmapSliceEntry[] {
 
 function looksLikeTable(section: string): boolean {
   const lines = section.split("\n");
-  const firstContentLineIndex = lines.findIndex(line => line.trim() !== "");
-  if (firstContentLineIndex < 0 || !/^\s*\|/.test(lines[firstContentLineIndex]!)) {
+
+  // Checkbox format takes precedence — embedded demo tables must not switch mode (#721).
+  if (lines.some(line => /^\s*-\s+\[[ xX]\]/.test(line))) {
     return false;
   }
 
-  const firstPipeLineIndex = lines.findIndex(line => /^\s*\|/.test(line));
-  if (firstPipeLineIndex < 0) return false;
+  const pipeLines = lines.filter(line => /^\s*\|/.test(line));
+  if (pipeLines.length < 2) return false;
 
-  const separatorLine = lines.slice(firstPipeLineIndex + 1).find(line => /^\s*\|/.test(line));
-  if (!separatorLine) return false;
+  const hasSeparatorRow = pipeLines.some((line, index) => {
+    if (index === 0) return false;
+    const cells = line.split("|").map(c => c.trim()).filter(Boolean);
+    return /^\s*\|[\s:-]+\|/.test(line) && cells.length >= 2 && cells.every(c => /^[\s:-]+$/.test(c));
+  });
 
-  const cells = separatorLine.split("|").map(c => c.trim()).filter(Boolean);
-  return /^\s*\|[\s:-]+\|/.test(separatorLine) && cells.length >= 2 && cells.every(c => /^[\s:-]+$/.test(c));
+  if (hasSeparatorRow) return true;
+
+  // Tables without a separator row still expose slice IDs in data rows.
+  return pipeLines.some(line => /\bS\d+\b/.test(line));
 }
 
 export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -200,6 +200,31 @@ test("parseRoadmapSlices: checkbox slices with pipe characters do not switch to 
   assert.deepEqual(slices[2]?.depends, ["S01", "S02"]);
 });
 
+test("parseRoadmapSlices: demo markdown table does not switch checkbox roadmap to table mode (#721)", () => {
+  const checkboxWithDemoTable = [
+    "# M004: Demo Table Repro",
+    "",
+    "## Slices",
+    "",
+    "- [x] **S01: First** `risk:low` `depends:[]`",
+    "  > After this: cli can render examples:",
+    "| Example | Meaning |",
+    "| --- | --- |",
+    "| S01 | Not a roadmap row |",
+    "- [ ] **S02: Second** `risk:medium` `depends:[S01]`",
+    "  > After this: cat file | sort returns stable output.",
+    "",
+  ].join("\n");
+
+  const slices = parseRoadmapSlices(checkboxWithDemoTable);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.title, "First");
+  assert.equal(slices[0]?.done, true);
+  assert.equal(slices[1]?.id, "S02");
+  assert.deepEqual(slices[1]?.depends, ["S01"]);
+});
+
 // --- Prose slice header completion marker tests (#1803) ---
 
 test("parseRoadmapSlices: prose headers with ✓ marker detected as done", () => {

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -225,6 +225,49 @@ test("parseRoadmapSlices: demo markdown table does not switch checkbox roadmap t
   assert.deepEqual(slices[1]?.depends, ["S01"]);
 });
 
+test("parseRoadmapSlices: table preceded by intro prose still parsed as table (#722)", () => {
+  const tableWithIntro = [
+    "# M005: Intro Before Table",
+    "",
+    "## Slices",
+    "",
+    "This milestone is broken into the following slices:",
+    "",
+    "| Slice | Title | Risk | Status |",
+    "| --- | --- | --- | --- |",
+    "| S01 | Foundation | Low | [x] Done |",
+    "| S02 | Core | High | [ ] Pending |",
+    "",
+  ].join("\n");
+
+  const slices = parseRoadmapSlices(tableWithIntro);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true);
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false);
+});
+
+test("parseRoadmapSlices: table without markdown separator row still parsed as table (#722)", () => {
+  const tableWithoutSeparator = [
+    "# M006: No Separator",
+    "",
+    "## Slices",
+    "",
+    "| Slice | Title | Risk | Status |",
+    "| S01 | Foundation | Low | [x] Done |",
+    "| S02 | Core | High | [ ] Pending |",
+    "",
+  ].join("\n");
+
+  const slices = parseRoadmapSlices(tableWithoutSeparator);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true);
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false);
+});
+
 // --- Prose slice header completion marker tests (#1803) ---
 
 test("parseRoadmapSlices: prose headers with ✓ marker detected as done", () => {


### PR DESCRIPTION
## Summary
- Added a table-shape guard and regression test so demo markdown tables no longer override checkbox roadmap slice parsing; focused parser tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #721
- [#721 roadmap-divergence reconciliation drift persists after repair: parseTableSlices false-positive on demo text containing | characters](https://github.com/open-gsd/gsd-pi/issues/721)

## User
- @Azd325

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/721-roadmap-divergence-reconciliation-drift--1781391611`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to roadmap markdown parsing with a regression test; no auth, data, or runtime behavior outside slice extraction.
> 
> **Overview**
> Fixes **roadmap slice parsing** when a checkbox-style `## Slices` section includes an embedded markdown demo table (pipes and `S01`-like cells). Previously `parseTableSlices` could win and misread slices, causing reconciliation drift.
> 
> **`parseRoadmapSlices`** now calls **`looksLikeTable`** before table parsing: if any line matches the checkbox slice pattern (`- [ ] **Sxx:`), table mode is skipped and the standard checkbox parser runs. Real table roadmaps (separator row or pipe rows with slice IDs, no checkboxes) still use **`parseTableSlices`**.
> 
> Adds a regression test for a demo table nested under a slice’s “After this” block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0a66d696fa2f839e777692df08e7d6daa381a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->