### PR TITLE
Add fallback file search when fd not installed

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-autocomplete.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-autocomplete.ts
@@ -7,6 +7,7 @@ import type { Api, Model } from "@gsd/pi-ai";
 import { BUILTIN_SLASH_COMMANDS } from "@gsd/pi-coding-agent/core/slash-commands.js";
 import type { PromptTemplate } from "@gsd/pi-coding-agent/core/prompt-templates.js";
 import type { RegisteredCommand } from "@gsd/pi-coding-agent/core/extensions/index.js";
+import { getToolPath } from "@gsd/pi-coding-agent/utils/tools-manager.js";
 import { providerDisplayName } from "./components/model-selector.js";
 import type { InteractiveModeDelegateHost } from "./interactive-mode-delegate-host.js";
 
@@ -85,9 +86,12 @@ export function setupAutocomplete(host: InteractiveModeDelegateHost): void {
 		}
 	}
 
+	const fdPath = getToolPath("fd");
+
 	host.autocompleteProvider = new CombinedAutocompleteProvider(
 		[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
 		process.cwd(),
+		fdPath,
 	);
 	host.autocompleteProvider.setRespectGitignore(host.settingsManager.getRespectGitignoreInPicker());
 	host.defaultEditor.setAutocompleteProvider(host.autocompleteProvider);

--- a/packages/pi-tui/src/autocomplete.ts
+++ b/packages/pi-tui/src/autocomplete.ts
@@ -294,10 +294,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const atPrefix = this.extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
 			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-			const suggestions = await this.getFuzzyFileSuggestions(rawPrefix, {
+
+			// Try fd-based fuzzy search first (fast, respects .gitignore)
+			let suggestions = await this.getFuzzyFileSuggestions(rawPrefix, {
 				isQuotedPrefix,
 				signal: options.signal,
 			});
+
+			// Fallback to readdirSync-based search when fd is not available
+			if (suggestions.length === 0 && !this.fdPath) {
+				suggestions = this.getFileSuggestions(atPrefix);
+			}
+
 			if (suggestions.length === 0) return null;
 
 			return {

--- a/packages/pi-tui/test/autocomplete.test.ts
+++ b/packages/pi-tui/test/autocomplete.test.ts
@@ -114,6 +114,37 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 
+	describe("non-fd @ file suggestions", () => {
+		let rootDir = "";
+		let baseDir = "";
+
+		beforeEach(() => {
+			rootDir = mkdtempSync(join(tmpdir(), "pi-autocomplete-no-fd-"));
+			baseDir = join(rootDir, "cwd");
+			mkdirSync(baseDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			rmSync(rootDir, { recursive: true, force: true });
+		});
+
+		test("falls back to directory suggestions when fd is unavailable", async () => {
+			setupFolder(baseDir, {
+				dirs: ["src"],
+				files: {
+					"README.md": "readme",
+				},
+			});
+
+			const provider = new CombinedAutocompleteProvider([], baseDir, null);
+			const line = "@RE";
+			const result = await getSuggestions(provider, [line], 0, line.length);
+
+			assert.deepStrictEqual(result?.items.map((item) => item.value), ["@README.md"]);
+			assert.equal(result?.prefix, "@RE");
+		});
+	});
+
 	describe("fd @ file suggestions", { skip: !isFdInstalled }, () => {
 		let rootDir = "";
 		let baseDir = "";


### PR DESCRIPTION
## Linked issue

Closes #- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Add a `readdirSync`-based fallback for file autocomplete when `fd` is not installed.
**Why:** File suggestions were completely broken for users without `fd` — autocomplete silently returned nothing.
**How:** Pass `fdPath` from the autocomplete setup down to `CombinedAutocompleteProvider`, and fall back to `getFileSuggestions` when the fuzzy `fd`-based search returns empty and `fdPath` is unavailable.

## What

Two files changed:

- **`packages/gsd-agent-modes/src/modes/interactive/interactive-autocomplete.ts`** — retrieves `fd` path via `getToolPath("fd")` and forwards it to `CombinedAutocompleteProvider`.
- **`packages/pi-tui/src/autocomplete.ts`** — `CombinedAutocompleteProvider` now accepts an optional `fdPath`. After `getFuzzyFileSuggestions` returns no results **and** `fdPath` is falsy, it calls `getFileSuggestions` (a `readdirSync`-based search) as a fallback.

## Why

The autocomplete depends on `fd` for fast, `.gitignore`-aware fuzzy file matching. When `fd` is not installed on the user's system, the fuzzy search returns zero suggestions and the user sees no autocomplete results at all. This is a silent degradation — no error, just a broken experience. Millions of users may not have `fd` installed; this PR makes autocomplete resilient to that.

## How

The implementation is a two-step change:

1. **Expose `fd` availability.** `getToolPath` returns a path if `fd` is on `PATH`, `undefined` otherwise. This boolean signal is threaded through the constructor.
2. **Conditional fallback.** The autocomplete's `getSuggestions` method already tries fuzzy search first. The new code checks: *did fuzzy search fail AND is fd missing?* If so, it calls the simpler `getFileSuggestions` which walks the filesystem with Node's `fs.readdirSync`. No new dependencies, no new I/O unless the fallback is triggered.

Alternatives considered:
- Installing `fd` as a bundled dependency — rejected because it adds platform-specific binary weight.
- Always running both searches in parallel — rejected because `getFileSuggestions` is heavier; we only want the cost when necessary.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `pi-tui` — Terminal UI
- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] Manual testing — steps described above
- [ ] CI passes

**Manual test:**

| Scenario | Expected |
|----------|----------|
| `fd` installed | Autocomplete uses fuzzy `fd`-based search (no behavior change) |
| `fd` **not** installed | Autocomplete falls back to `readdirSync`-based search; file suggestions still appear |