### PR TITLE
fix(auto): force-stop remote auto-mode sessions

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1009,6 +1009,41 @@ export function stopAutoRemote(projectRoot: string): {
 }
 
 /**
+ * Force-stop a remote auto-mode session before stealing its lock.
+ * The normal stop path stays SIGTERM-only so cooperative sessions can clean up;
+ * this path is only for the explicit "Force start" action.
+ */
+export function forceStopAutoRemote(projectRoot: string): {
+  found: boolean;
+  pid?: number;
+  error?: string;
+} {
+  const lock = readCrashLock(projectRoot);
+  if (!lock) return { found: false };
+
+  if (lock.pid === process.pid) {
+    clearLock(projectRoot);
+    return { found: false };
+  }
+
+  if (!isLockProcessAlive(lock)) {
+    clearLock(projectRoot);
+    return { found: false };
+  }
+
+  try {
+    process.kill(lock.pid, "SIGTERM");
+    if (isLockProcessAlive(lock)) {
+      process.kill(lock.pid, "SIGKILL");
+    }
+    clearLock(projectRoot);
+    return { found: true, pid: lock.pid };
+  } catch (err) {
+    return { found: false, error: (err as Error).message };
+  }
+}
+
+/**
  * Check if a remote auto-mode session is running (from a different process).
  * Reads the crash lock, checks PID liveness, and returns session details.
  * Used by the guard in commands.ts to prevent bare /gsd, /gsd next, and
@@ -2408,7 +2443,7 @@ export async function startAuto(
     const pid = freshStartAssessment.lock?.pid;
     ctx.ui.notify(
       pid
-        ? `Another auto-mode session (PID ${pid}) appears to be running.\nStop it with \`kill ${pid}\` before starting a new session.`
+        ? `Another auto-mode session (PID ${pid}) appears to be running.\nRun \`/gsd stop\` for graceful shutdown, or choose "Force start" from \`/gsd auto\` to terminate it.`
         : "Another auto-mode session appears to be running.",
       "error",
     );

--- a/src/resources/extensions/gsd/commands/context.ts
+++ b/src/resources/extensions/gsd/commands/context.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
-import { checkRemoteAutoSession, isAutoActive, isAutoPaused, stopAutoRemote } from "../auto.js";
+import { checkRemoteAutoSession, forceStopAutoRemote, isAutoActive, isAutoPaused, stopAutoRemote } from "../auto.js";
 import { validateDirectory } from "../validate-directory.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { showNextAction } from "../../shared/tui.js";
@@ -155,5 +155,19 @@ export async function guardRemoteSession(
     return false;
   }
 
-  return choice === "force";
+  if (choice === "force") {
+    const result = forceStopAutoRemote(projectRoot());
+    if (result.error) {
+      ctx.ui.notify(`Failed to force-stop remote auto-mode: ${result.error}`, "error");
+      return false;
+    }
+    if (result.found) {
+      ctx.ui.notify(`Force-stopped auto-mode session (PID ${result.pid}). Starting a new session.`, "warning");
+    } else {
+      ctx.ui.notify("Remote session is no longer running. Starting a new session.", "info");
+    }
+    return true;
+  }
+
+  return false;
 }

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -223,6 +223,7 @@ export function writeLock(
  * stale session-file pointer.
  */
 export function clearLock(basePath: string): void {
+  const legacyLock = readLegacyLock(basePath);
   clearLegacyLockFile(basePath);
 
   if (!isDbAvailable()) return;
@@ -235,8 +236,15 @@ export function clearLock(basePath: string): void {
       deleteRuntimeKv("worker", staleWorker.worker_id, SESSION_FILE_KV_KEY);
       return;
     }
-    const lock = readLegacyLock(basePath);
-    if (lock?.pid) markWorkerStoppingByPid(projectRoot, lock.pid);
+    if (legacyLock?.pid) {
+      markWorkerStoppingByPid(projectRoot, legacyLock.pid);
+      const workerByLegacyPid = getAllAutoWorkers().find(
+        (w) =>
+          w.pid === legacyLock.pid
+          && normalizeRealPath(w.project_root_realpath) === projectRoot,
+      );
+      if (workerByLegacyPid) forceReleaseLeasesForWorker(workerByLegacyPid.worker_id);
+    }
     const worker = findActiveWorkerForCurrentProcess(projectRoot);
     if (worker) deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
 

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -387,7 +387,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     // #3218: Provide actionable workaround when lock recovery fails
     const lockDirPath = lockTarget + ".lock";
     const reason = existingPid
-      ? `Another auto-mode session (PID ${existingPid}) appears to be running.\nStop it with \`kill ${existingPid}\` before starting a new session.`
+      ? `Another auto-mode session (PID ${existingPid}) appears to be running.\nRun \`/gsd stop\` for graceful shutdown, or choose "Force start" from \`/gsd auto\` to terminate it.`
       : `Another auto-mode session lock is stuck on this project.\nRun: rm -rf "${lockDirPath}" && rm -f "${lp}"`;
 
     return { acquired: false, reason, existingPid };

--- a/src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts
@@ -1,12 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { checkRemoteAutoSession } from "../auto.ts";
+import { checkRemoteAutoSession, forceStopAutoRemote } from "../auto.ts";
 import { openDatabase, closeDatabase, _getAdapter } from "../gsd-db.ts";
-import { registerAutoWorker } from "../db/auto-workers.ts";
+import { getAutoWorker, registerAutoWorker } from "../db/auto-workers.ts";
+import { claimMilestoneLease, getMilestoneLease } from "../db/milestone-leases.ts";
 import { normalizeRealPath } from "../paths.ts";
 import { readCrashLock } from "../crash-recovery.ts";
 
@@ -35,6 +36,29 @@ function setWorkerPid(workerId: string, pid: number): void {
   ).run({ ":pid": pid, ":worker_id": workerId });
 }
 
+function insertMilestone(id: string): void {
+  const db = _getAdapter()!;
+  db.prepare(
+    `INSERT INTO milestones (id, title, status, created_at)
+     VALUES (:id, :title, 'active', :created_at)`,
+  ).run({
+    ":id": id,
+    ":title": id,
+    ":created_at": new Date().toISOString(),
+  });
+}
+
+function writeLegacyLock(base: string, pid: number): void {
+  const now = new Date().toISOString();
+  writeFileSync(join(base, ".gsd", "auto.lock"), JSON.stringify({
+    pid,
+    startedAt: now,
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    unitStartedAt: now,
+  }));
+}
+
 function findDeadPidCandidate(): number {
   const candidates = [99_999, 199_999, 299_999, 399_999];
   for (const pid of candidates) {
@@ -61,4 +85,42 @@ test("checkRemoteAutoSession clears stale lock state when lock PID is dead", (t)
   const remote = checkRemoteAutoSession(base);
   assert.deepEqual(remote, { running: false });
   assert.equal(readCrashLock(base), null, "stale lock should be cleared by remote session check");
+});
+
+test("forceStopAutoRemote escalates a live remote PID and releases worker state", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+  const pid = 424_242;
+  setWorkerPid(workerId, pid);
+  insertMilestone("M001");
+  writeLegacyLock(base, pid);
+  const lease = claimMilestoneLease(workerId, "M001");
+  assert.equal(lease.ok, true, "precondition: worker holds a milestone lease");
+
+  const signals: Array<NodeJS.Signals | 0> = [];
+  const originalKill = process.kill;
+  process.kill = ((target: number, signal?: NodeJS.Signals | number) => {
+    assert.equal(target, pid);
+    signals.push((signal ?? 0) as NodeJS.Signals | 0);
+    return true;
+  }) as typeof process.kill;
+  t.after(() => {
+    process.kill = originalKill;
+  });
+
+  const result = forceStopAutoRemote(base);
+
+  assert.deepEqual(result, { found: true, pid });
+  assert.ok(signals.includes("SIGTERM"), "force stop should request graceful termination first");
+  assert.ok(signals.includes("SIGKILL"), "force stop should escalate when the PID is still alive");
+  assert.equal(getAutoWorker(workerId)?.status, "stopping");
+  assert.equal(
+    getMilestoneLease("M001")?.status,
+    "released",
+    "force stop should release held milestone leases",
+  );
+  assert.equal(readCrashLock(base), null, "force stop should remove the visible remote lock");
 });


### PR DESCRIPTION
## TL;DR

**What:** Make the explicit remote auto-mode force-start path terminate the remote PID and clear its worker lock state.
**Why:** A user could send a graceful stop signal, then immediately get blocked by the same still-running PID with guidance to run a plain shell `kill`.
**How:** Keep `/gsd stop` graceful, add force-stop escalation for the Force start action, preserve legacy lock PID metadata during cleanup, and add regression coverage for live-PID force stop.

## What

This updates the remote auto-mode stop/start control path:

- Adds `forceStopAutoRemote()` for the explicit Force start action.
- Keeps normal `/gsd stop` as SIGTERM-only graceful shutdown.
- Makes Force start send SIGTERM first, then SIGKILL if the PID still appears alive.
- Clears the visible lock and marks the matching worker row as stopping.
- Updates the stale PID guidance to point users at `/gsd stop` or Force start instead of bare `kill <pid>`.
- Adds focused regression coverage for force-stopping a live remote PID.

## Why

The previous flow could report that a stop signal was sent but still block the next auto-mode start because the remote process had not exited yet. That left the UI telling users to run `kill <pid>` manually, even though GSD already exposes a Force start recovery path.

## How

The change keeps the safety boundary explicit: graceful stop remains cooperative, while forceful termination is only used when the user chooses Force start. `clearLock()` now reads legacy lock metadata before removing the file so DB-backed worker cleanup can still target the PID that owned the lock.

## Validation

- [x] `pnpm exec tsx --test src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run verify:fast`

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process termination and lock/worker/lease cleanup paths; mistakes could kill the wrong session or leave stale coordination state, though scope is limited to explicit Force start and best-effort clearLock.
> 
> **Overview**
> **Force start** now actually terminates a live remote auto-mode process instead of only sending a graceful stop and still blocking the next session.
> 
> Adds **`forceStopAutoRemote()`**: SIGTERM first, then **SIGKILL** if the PID still looks alive, followed by **`clearLock()`**. **`/gsd stop`** and **`stopAutoRemote()`** stay **SIGTERM-only**. The remote-session guard in **`guardRemoteSession`** wires **Force start** to this path with clearer UI notifications.
> 
> **`clearLock()`** reads legacy **`auto.lock`** metadata **before** deleting the file so DB cleanup can **`markWorkerStoppingByPid`** and **`forceReleaseLeasesForWorker`** for the lock owner’s worker row.
> 
> User-facing lock errors now point to **`/gsd stop`** or **Force start** from **`/gsd auto`**, not bare **`kill <pid>`**. Regression test covers escalation, worker **stopping**, lease release, and lock removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221d70a3803aab1c6479aea7a45638e03b711de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->