### PR TITLE
refactor(gsd): deepen workflow architecture seams

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -31,10 +31,7 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { pauseAuto } from "./auto.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
-import {
-  getWorkflowTransportSupportError,
-  getRequiredWorkflowToolsForAutoUnit,
-} from "./workflow-mcp.js";
+import { getUnitWorkflowDispatchReadinessError } from "./tool-contract.js";
 
 export async function dispatchDirectPhase(
   ctx: ExtensionCommandContext,
@@ -256,18 +253,15 @@ export async function dispatchDirectPhase(
       return;
   }
 
-  const compatibilityError = getWorkflowTransportSupportError(
-    ctx.model?.provider,
-    getRequiredWorkflowToolsForAutoUnit(unitType),
-    {
-      projectRoot,
-      surface: "direct phase dispatch",
-      unitType,
-      authMode: ctx.model?.provider ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider) : undefined,
-      baseUrl: ctx.model?.baseUrl,
-      activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
-    },
-  );
+  const compatibilityError = getUnitWorkflowDispatchReadinessError({
+    provider: ctx.model?.provider,
+    projectRoot,
+    surface: "direct phase dispatch",
+    unitType,
+    authMode: ctx.model?.provider ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider) : undefined,
+    baseUrl: ctx.model?.baseUrl,
+    activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
+  });
   if (compatibilityError) {
     ctx.ui.notify(compatibilityError, "error");
     return;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -91,11 +91,8 @@ import { isAutoActive } from "./auto.js";
 import { hostWriteGateAdapter } from "./bootstrap/write-gate.js";
 import { ensureWorkflowPreferencesCaptured } from "./planning-depth.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
-import {
-  getWorkflowTransportSupportError,
-  getRequiredWorkflowToolsForAutoUnit,
-  resolveWorkflowMcpProjectRoot,
-} from "./workflow-mcp.js";
+import { resolveWorkflowMcpProjectRoot } from "./workflow-mcp.js";
+import { getUnitWorkflowDispatchReadinessError } from "./tool-contract.js";
 import { prepareBrowserDaemonForUat } from "./browser-daemon-auto-prep.js";
 import {
   PROJECT_RESEARCH_INFLIGHT_MARKER,
@@ -745,11 +742,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Transport preflight: verify required MCP tools are actually connected
       // before consuming a retry attempt. Fixes tool-starved sessions burning
       // all MAX_UAT_ATTEMPTS before stopping (#477).
-      const transportError = getWorkflowTransportSupportError(
-        sessionProvider,
-        getRequiredWorkflowToolsForAutoUnit("run-uat"),
-        { projectRoot: basePath, surface: "auto-mode", unitType: "run-uat", authMode: sessionAuthMode, baseUrl: sessionBaseUrl, activeTools },
-      );
+      const transportError = getUnitWorkflowDispatchReadinessError({
+        provider: sessionProvider,
+        projectRoot: basePath,
+        surface: "auto-mode",
+        unitType: "run-uat",
+        authMode: sessionAuthMode,
+        baseUrl: sessionBaseUrl,
+        activeTools,
+      });
       if (transportError) {
         return { action: "stop" as const, reason: transportError, level: "warning" as const };
       }

--- a/src/resources/extensions/gsd/auto-unit-closeout.ts
+++ b/src/resources/extensions/gsd/auto-unit-closeout.ts
@@ -33,6 +33,24 @@ export interface UnitActivitySnapshot {
   assistantMessages: number;
 }
 
+export interface AutoUnitCloseoutRequest {
+  ctx: ExtensionContext;
+  basePath: string;
+  unitType: string;
+  unitId: string;
+  startedAt: number;
+  opts?: CloseoutOptions;
+}
+
+export interface AutoUnitCloseoutResult {
+  activityFile?: string;
+  gitTransactionRecorded: boolean;
+}
+
+type GitTransactionCloseoutOptions =
+  Required<Pick<CloseoutOptions, "traceId" | "turnId" | "gitAction" | "gitStatus">>
+  & Pick<CloseoutOptions, "gitPush" | "gitError">;
+
 export const GHOST_COMPLETION_MAX_ELAPSED_MS = 500;
 
 export function snapshotUnitActivity(
@@ -76,8 +94,91 @@ export function isSuspiciousGhostCompletion(
 }
 
 /**
- * Snapshot metrics, save activity log, and fire-and-forget memory extraction
- * for a completed unit. Returns the activity log file path (if any).
+ * Snapshot metrics, save activity log, extract memories, and record the git
+ * transaction for a completed auto-mode unit.
+ */
+export async function closeoutAutoUnit(
+  request: AutoUnitCloseoutRequest,
+): Promise<AutoUnitCloseoutResult> {
+  const modelId = request.ctx.model?.id ?? "unknown";
+  snapshotUnitMetrics(
+    request.ctx,
+    request.unitType,
+    request.unitId,
+    request.startedAt,
+    modelId,
+    request.opts,
+  );
+  const activityFile = saveActivityLog(request.ctx, request.basePath, request.unitType, request.unitId);
+
+  if (activityFile) {
+    try {
+      const { buildMemoryLLMCall, extractMemoriesFromUnit } = await import("./memory-extractor.js");
+      const llmCallFn = buildMemoryLLMCall(request.ctx);
+      if (llmCallFn) {
+        // Awaited: a fire-and-forget here lets memory-extractor writes land in
+        // .gsd/ after closeoutUnit returns but before the milestone merge
+        // runs, which made the working tree appear dirty to `git merge
+        // --squash` (root cause class of #4704). Completion latency is now
+        // bounded by the extractor's LLM call, which is the acceptable price
+        // for not racing the merge boundary.
+        try {
+          await extractMemoriesFromUnit(activityFile, request.unitType, request.unitId, llmCallFn);
+        } catch (err) {
+          logWarning(
+            "engine",
+            `memory extraction failed for ${request.unitType}/${request.unitId}: ${(err as Error).message}`,
+          );
+        }
+      }
+    } catch (err) { /* non-fatal */
+      logWarning("engine", `operation failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const gitTransaction = resolveGitTransactionOptions(request.opts);
+
+  if (gitTransaction) {
+    writeTurnGitTransaction({
+      basePath: request.basePath,
+      traceId: gitTransaction.traceId,
+      turnId: gitTransaction.turnId,
+      unitType: request.unitType,
+      unitId: request.unitId,
+      stage: "record",
+      action: gitTransaction.gitAction,
+      push: gitTransaction.gitPush === true,
+      status: gitTransaction.gitStatus,
+      error: gitTransaction.gitError,
+      metadata: {
+        activityFile,
+      },
+    });
+  }
+
+  return {
+    ...(activityFile ? { activityFile } : {}),
+    gitTransactionRecorded: Boolean(gitTransaction),
+  };
+}
+
+function resolveGitTransactionOptions(
+  opts: CloseoutOptions | undefined,
+): GitTransactionCloseoutOptions | null {
+  if (!opts?.traceId || !opts.turnId || !opts.gitAction || !opts.gitStatus) return null;
+  return {
+    traceId: opts.traceId,
+    turnId: opts.turnId,
+    gitAction: opts.gitAction,
+    gitStatus: opts.gitStatus,
+    gitPush: opts.gitPush,
+    gitError: opts.gitError,
+  };
+}
+
+/**
+ * Compatibility wrapper for existing auto-loop callers. New code should prefer
+ * closeoutAutoUnit so the closeout request and result stay explicit.
  */
 export async function closeoutUnit(
   ctx: ExtensionContext,
@@ -87,52 +188,6 @@ export async function closeoutUnit(
   startedAt: number,
   opts?: CloseoutOptions,
 ): Promise<string | undefined> {
-  const modelId = ctx.model?.id ?? "unknown";
-  snapshotUnitMetrics(ctx, unitType, unitId, startedAt, modelId, opts);
-  const activityFile = saveActivityLog(ctx, basePath, unitType, unitId);
-
-  if (activityFile) {
-    try {
-      const { buildMemoryLLMCall, extractMemoriesFromUnit } = await import('./memory-extractor.js');
-      const llmCallFn = buildMemoryLLMCall(ctx);
-      if (llmCallFn) {
-        // Awaited: a fire-and-forget here lets memory-extractor writes land in
-        // .gsd/ after closeoutUnit returns but before the milestone merge
-        // runs, which made the working tree appear dirty to `git merge
-        // --squash` (root cause class of #4704). Completion latency is now
-        // bounded by the extractor's LLM call, which is the acceptable price
-        // for not racing the merge boundary.
-        try {
-          await extractMemoriesFromUnit(activityFile, unitType, unitId, llmCallFn);
-        } catch (err) {
-          logWarning(
-            "engine",
-            `memory extraction failed for ${unitType}/${unitId}: ${(err as Error).message}`,
-          );
-        }
-      }
-    } catch (err) { /* non-fatal */
-      logWarning("engine", `operation failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
-  if (opts?.traceId && opts.turnId && opts.gitAction && opts.gitStatus) {
-    writeTurnGitTransaction({
-      basePath,
-      traceId: opts.traceId,
-      turnId: opts.turnId,
-      unitType,
-      unitId,
-      stage: "record",
-      action: opts.gitAction,
-      push: opts.gitPush === true,
-      status: opts.gitStatus,
-      error: opts.gitError,
-      metadata: {
-        activityFile,
-      },
-    });
-  }
-
-  return activityFile ?? undefined;
+  const result = await closeoutAutoUnit({ ctx, basePath, unitType, unitId, startedAt, opts });
+  return result.activityFile;
 }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -82,11 +82,8 @@ import { parseUnitId } from "../unit-id.js";
 import { createCheckpoint, cleanupCheckpoint, rollbackToCheckpoint } from "../safety/git-checkpoint.js";
 import { resolveSafetyHarnessConfig } from "../safety/safety-harness.js";
 import { getContextPauseAction } from "../auto-budget.js";
-import {
-  getWorkflowTransportSupportError,
-  getRequiredWorkflowToolsForAutoUnit,
-  supportsStructuredQuestions,
-} from "../workflow-mcp.js";
+import { supportsStructuredQuestions } from "../workflow-mcp.js";
+import { getUnitWorkflowDispatchReadinessError } from "../tool-contract.js";
 import { prepareWorkflowMcpForProject } from "../workflow-mcp-auto-prep.js";
 import {
   applyThinkingLevelForModel,
@@ -2324,22 +2321,19 @@ export async function runUnitPhase(
     ? `${(s.currentUnitModel as any).provider ?? ""}/${(s.currentUnitModel as any).id ?? ""}`
     : null;
 
-  const compatibilityError = getWorkflowTransportSupportError(
-    s.currentUnitModel?.provider ?? ctx.model?.provider,
-    getRequiredWorkflowToolsForAutoUnit(unitType),
-    {
-      projectRoot: s.basePath,
-      surface: "auto-mode",
-      unitType,
-      authMode: s.currentUnitModel?.provider
-        ? ctx.modelRegistry.getProviderAuthMode(s.currentUnitModel.provider)
-        : ctx.model?.provider
-          ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider)
-          : undefined,
-      baseUrl: (s.currentUnitModel as any)?.baseUrl ?? ctx.model?.baseUrl,
-      activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
-    },
-  );
+  const compatibilityError = getUnitWorkflowDispatchReadinessError({
+    provider: s.currentUnitModel?.provider ?? ctx.model?.provider,
+    projectRoot: s.basePath,
+    surface: "auto-mode",
+    unitType,
+    authMode: s.currentUnitModel?.provider
+      ? ctx.modelRegistry.getProviderAuthMode(s.currentUnitModel.provider)
+      : ctx.model?.provider
+        ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider)
+        : undefined,
+    baseUrl: (s.currentUnitModel as any)?.baseUrl ?? ctx.model?.baseUrl,
+    activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
+  });
   const workflowMcpPrepModel = s.currentUnitModel;
   if (compatibilityError) {
     s.currentUnitRouting = prevUnitRouting;

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -7,7 +7,7 @@ import { isAfter, latestExplicitReopenAt } from "./milestone-reopen-events.js";
 import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
 import { deriveState } from "./state.js";
 import { readEvents } from "./workflow-events.js";
-import { renderAllProjections } from "./workflow-projections.js";
+import { flushWorkflowProjections } from "./projection-flush.js";
 
 export async function checkEngineHealth(
   basePath: string,
@@ -270,7 +270,7 @@ export async function checkEngineHealth(
           const roadmapPath = resolveMilestoneFile(basePath, milestone.id, "ROADMAP");
           if (!roadmapPath || !existsSync(roadmapPath)) {
             try {
-              await renderAllProjections(basePath, milestone.id);
+              await flushWorkflowProjections(basePath, { milestoneId: milestone.id });
               fixesApplied.push(`re-rendered missing projections for ${milestone.id}`);
             } catch {
               // Non-fatal — projection re-render failed
@@ -280,7 +280,7 @@ export async function checkEngineHealth(
           const projectionMtime = statSync(roadmapPath).mtimeMs;
           if (lastEventTs > projectionMtime) {
             try {
-              await renderAllProjections(basePath, milestone.id);
+              await flushWorkflowProjections(basePath, { milestoneId: milestone.id });
               fixesApplied.push(`re-rendered stale projections for ${milestone.id}`);
             } catch {
               // Non-fatal — projection re-render failed

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -78,11 +78,8 @@ import {
 } from "./requirements-backlog.js";
 import { selectAndApplyModel } from "./auto-model-selection.js";
 import { DISCUSS_TOOLS_ALLOWLIST } from "./constants.js";
-import {
-  getWorkflowTransportSupportError,
-  getRequiredWorkflowToolsForGuidedUnit,
-  supportsStructuredQuestions,
-} from "./workflow-mcp.js";
+import { supportsStructuredQuestions } from "./workflow-mcp.js";
+import { getUnitWorkflowDispatchReadinessError } from "./tool-contract.js";
 import {
   runPreparation,
   formatCodebaseBrief,
@@ -555,7 +552,7 @@ interface DispatchWorkflowOptions {
   deps?: {
     loadPreferences?: typeof loadEffectiveGSDPreferences;
     selectModel?: typeof selectAndApplyModel;
-    getTransportSupportError?: typeof getWorkflowTransportSupportError;
+    getDispatchReadinessError?: typeof getUnitWorkflowDispatchReadinessError;
   };
 }
 
@@ -584,7 +581,8 @@ async function dispatchWorkflow(
   const projectRoot = resolveGuidedDispatchProjectRoot(resolvedOptions.basePath);
   const loadPreferences = resolvedOptions.deps?.loadPreferences ?? loadEffectiveGSDPreferences;
   const selectModel = resolvedOptions.deps?.selectModel ?? selectAndApplyModel;
-  const getTransportSupportError = resolvedOptions.deps?.getTransportSupportError ?? getWorkflowTransportSupportError;
+  const getDispatchReadinessError = resolvedOptions.deps?.getDispatchReadinessError
+    ?? getUnitWorkflowDispatchReadinessError;
 
   // Route through the dynamic routing pipeline (complexity classification,
   // tier downgrade, fallback chains) — same path as auto-mode dispatches (#2958).
@@ -603,25 +601,22 @@ async function dispatchWorkflow(
       });
     }
 
-    const compatibilityError = getTransportSupportError(
-      result.appliedModel?.provider ?? ctx.model?.provider,
-      getRequiredWorkflowToolsForGuidedUnit(unitType),
-      {
-        projectRoot,
-        surface: "guided flow",
-        unitType,
-        authMode: result.appliedModel?.provider
-          ? ctx.modelRegistry.getProviderAuthMode(result.appliedModel.provider)
-          : ctx.model?.provider
-            ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider)
-            : undefined,
-        baseUrl: result.appliedModel?.baseUrl ?? ctx.model?.baseUrl,
-        // Guided flow starts the MCP workflow server as part of dispatch, so the
-        // parent session's activeTools doesn't include MCP tools yet. The MCP
-        // launch config check (detectWorkflowMcpLaunchConfig) is the right gate
-        // here — not whether MCP tools are pre-registered in the parent session.
-      },
-    );
+    const compatibilityError = getDispatchReadinessError({
+      provider: result.appliedModel?.provider ?? ctx.model?.provider,
+      projectRoot,
+      surface: "guided flow",
+      unitType,
+      authMode: result.appliedModel?.provider
+        ? ctx.modelRegistry.getProviderAuthMode(result.appliedModel.provider)
+        : ctx.model?.provider
+          ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider)
+          : undefined,
+      baseUrl: result.appliedModel?.baseUrl ?? ctx.model?.baseUrl,
+      // Guided flow starts the MCP workflow server as part of dispatch, so the
+      // parent session's activeTools doesn't include MCP tools yet. The MCP
+      // launch config check (detectWorkflowMcpLaunchConfig) is the right gate
+      // here — not whether MCP tools are pre-registered in the parent session.
+    });
     if (compatibilityError) {
       ctx.ui.notify(compatibilityError, "error");
       return;

--- a/src/resources/extensions/gsd/milestone-planning-persistence.ts
+++ b/src/resources/extensions/gsd/milestone-planning-persistence.ts
@@ -15,7 +15,7 @@ import {
 } from "./gsd-db.js";
 import { invalidateStateCache } from "./state.js";
 import { renderRoadmapFromDb } from "./markdown-renderer.js";
-import { renderAllProjections } from "./workflow-projections.js";
+import { flushWorkflowProjections } from "./projection-flush.js";
 import { writeManifest } from "./workflow-manifest.js";
 import { appendEvent } from "./workflow-events.js";
 import { logWarning } from "./workflow-logger.js";
@@ -171,7 +171,7 @@ async function renderPlanArtifacts(
 
 async function runPostPlanHooks(basePath: string, params: PersistMilestonePlanParams): Promise<void> {
   try {
-    await renderAllProjections(basePath, params.milestoneId);
+    await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
     writeManifest(basePath);
     appendEvent(basePath, {
       cmd: "plan-milestone",

--- a/src/resources/extensions/gsd/projection-flush.ts
+++ b/src/resources/extensions/gsd/projection-flush.ts
@@ -1,0 +1,20 @@
+// Project/App: gsd-pi
+// File Purpose: Single workflow projection flush seam for mutation exits.
+
+import { renderAllProjections } from "./workflow-projections.js";
+
+export interface ProjectionFlushScope {
+  milestoneId: string;
+}
+
+export interface ProjectionFlushResult {
+  milestoneId: string;
+}
+
+export async function flushWorkflowProjections(
+  basePath: string,
+  scope: ProjectionFlushScope,
+): Promise<ProjectionFlushResult> {
+  await renderAllProjections(basePath, scope.milestoneId);
+  return { milestoneId: scope.milestoneId };
+}

--- a/src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts
@@ -77,12 +77,8 @@ test("guided dispatch passes the explicit project root through model and compati
             seen.modelRoot = projectRoot;
             return { routing: null, appliedModel: null };
           },
-          getTransportSupportError: (
-            _provider: string | undefined,
-            _requiredTools: string[],
-            options?: { projectRoot?: string },
-          ) => {
-            seen.compatibilityRoot = options?.projectRoot ?? "";
+          getDispatchReadinessError: (input: { projectRoot?: string }) => {
+            seen.compatibilityRoot = input.projectRoot ?? "";
             return null;
           },
         },

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -6,7 +6,11 @@ import assert from "node:assert/strict";
 
 import { classifyFailure } from "../recovery-classification.js";
 import { reconcileBeforeDispatch } from "../state-reconciliation.js";
-import { compileUnitContextContract, compileUnitToolContract } from "../tool-contract.js";
+import {
+  compileUnitContextContract,
+  compileUnitToolContract,
+  getUnitWorkflowDispatchReadinessError,
+} from "../tool-contract.js";
 import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
 import type { GSDState } from "../types.js";
 
@@ -85,6 +89,20 @@ test("Tool Contract compiles known Unit prompt and tool policy", () => {
     maxBytes: 50 * 1024,
     maxLines: 2000,
   });
+});
+
+test("Tool Contract derives dispatch readiness from Unit workflow tools", () => {
+  const error = getUnitWorkflowDispatchReadinessError({
+    provider: "claude-code",
+    unitType: "plan-slice",
+    projectRoot: "/tmp/project",
+    env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
+    surface: "auto-mode",
+    authMode: "externalCli",
+    baseUrl: "local://claude-code",
+  });
+
+  assert.equal(error, null);
 });
 
 test("Unit Context Contract exposes prompt context without workflow tool surface", () => {

--- a/src/resources/extensions/gsd/tool-contract.ts
+++ b/src/resources/extensions/gsd/tool-contract.ts
@@ -9,8 +9,14 @@ import {
   type ToolsPolicy,
   type UnitContextManifest,
 } from "./unit-context-manifest.js";
-import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
-import { getUnitToolSurfaceContract } from "./unit-tool-contracts.js";
+import {
+  getWorkflowTransportSupportError,
+  type WorkflowCapabilityOptions,
+} from "./workflow-mcp.js";
+import {
+  getRequiredWorkflowToolsForUnit,
+  getUnitToolSurfaceContract,
+} from "./unit-tool-contracts.js";
 import {
   WHOLE_FILE_OBSERVATION_MAX_BYTES,
   WHOLE_FILE_OBSERVATION_MAX_LINES,
@@ -68,6 +74,17 @@ export type UnitContextContractResult =
   | { ok: true; contract: UnitPromptContextContract }
   | { ok: false; reason: "unknown-unit-type"; detail: string };
 
+export interface UnitWorkflowDispatchReadinessInput {
+  provider?: string;
+  unitType: string;
+  projectRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  surface?: string;
+  authMode?: WorkflowCapabilityOptions["authMode"];
+  baseUrl?: string;
+  activeTools?: string[];
+}
+
 export function compileUnitContextContract(unitType: string): UnitContextContractResult {
   const manifest = resolveManifest(unitType);
   if (!manifest) {
@@ -78,6 +95,24 @@ export function compileUnitContextContract(unitType: string): UnitContextContrac
     };
   }
   return { ok: true, contract: buildPromptContextContract(unitType, manifest) };
+}
+
+export function getUnitWorkflowDispatchReadinessError(
+  input: UnitWorkflowDispatchReadinessInput,
+): string | null {
+  return getWorkflowTransportSupportError(
+    input.provider,
+    getRequiredWorkflowToolsForUnit(input.unitType),
+    {
+      projectRoot: input.projectRoot,
+      env: input.env,
+      surface: input.surface,
+      unitType: input.unitType,
+      authMode: input.authMode,
+      baseUrl: input.baseUrl,
+      activeTools: input.activeTools,
+    },
+  );
 }
 
 export function compileUnitToolContract(unitType: string): ToolContractResult {
@@ -91,7 +126,7 @@ export function compileUnitToolContract(unitType: string): ToolContractResult {
     };
   }
 
-  const requiredWorkflowTools = getRequiredWorkflowToolsForAutoUnit(unitType);
+  const requiredWorkflowTools = getRequiredWorkflowToolsForUnit(unitType);
   const forbiddenWorkflowTools = Object.entries(surfaceContract?.forbiddenGsdTools ?? {})
     .map(([name, reason]) => ({ name, reason }));
   const closeoutTools = requiredWorkflowTools.filter((tool) =>

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -26,7 +26,8 @@ import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { isClosedStatus } from "../status-guards.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
-import { renderAllProjections, stripIdPrefix } from "../workflow-projections.js";
+import { stripIdPrefix } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
@@ -240,7 +241,7 @@ export async function handleCompleteMilestone(
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
   try {
-    await renderAllProjections(artifactBasePath, params.milestoneId);
+    await flushWorkflowProjections(artifactBasePath, { milestoneId: params.milestoneId });
   } catch (projErr) {
     logWarning("tool", `complete-milestone projection warning: ${(projErr as Error).message}`);
   }

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -30,7 +30,7 @@ import { classifyUatContent, escalatesArtifactUatToBrowser } from "../uat-policy
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb, roadmapRenderMarksSliceDone } from "../markdown-renderer.js";
 import { isStaleWrite } from "../auto/turn-epoch.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
@@ -537,7 +537,7 @@ export async function handleCompleteSlice(
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
   try {
-    await renderAllProjections(artifactBasePath, params.milestoneId);
+    await flushWorkflowProjections(artifactBasePath, { milestoneId: params.milestoneId });
   } catch (projErr) {
     logWarning("tool", `complete-slice projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
   }

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -35,7 +35,8 @@ import { checkOwnership, taskUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { renderPlanCheckboxes } from "../markdown-renderer.js";
-import { renderAllProjections, renderSummaryContent } from "../workflow-projections.js";
+import { renderSummaryContent } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
@@ -467,7 +468,7 @@ export async function handleCompleteTask(
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
   try {
-    await renderAllProjections(artifactBasePath, params.milestoneId);
+    await flushWorkflowProjections(artifactBasePath, { milestoneId: params.milestoneId });
   } catch (projErr) {
     logWarning("tool", `complete-task projection warning: ${(projErr as Error).message}`);
   }

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -21,7 +21,7 @@ import {
 import type { GateEvaluationConfig, GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
 import { renderPlanFromDb } from "../markdown-renderer.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -468,7 +468,7 @@ export async function handlePlanSlice(
 
     // ── Post-mutation hook: projections, manifest, event log ─────────────
     try {
-      await renderAllProjections(basePath, params.milestoneId);
+      await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
       writeManifest(basePath);
       appendEvent(basePath, {
         cmd: "plan-slice",

--- a/src/resources/extensions/gsd/tools/plan-task.ts
+++ b/src/resources/extensions/gsd/tools/plan-task.ts
@@ -4,7 +4,7 @@ import { isNonEmptyString, validateStringArray } from "../validation.js";
 import { transaction, getSlice, getTask, insertTask, upsertTaskPlanning } from "../gsd-db.js";
 import { invalidateStateCache } from "../state.js";
 import { renderTaskPlanFromDb } from "../markdown-renderer.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -142,7 +142,7 @@ export async function handlePlanTask(
 
     // ── Post-mutation hook: projections, manifest, event log ─────────────
     try {
-      await renderAllProjections(basePath, params.milestoneId);
+      await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
       writeManifest(basePath);
       appendEvent(basePath, {
         cmd: "plan-task",

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -16,7 +16,7 @@ import {
 } from "../gsd-db.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb, renderAssessmentFromDb } from "../markdown-renderer.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -306,7 +306,7 @@ export async function handleReassessRoadmap(
 
     // ── Post-mutation hook: projections, manifest, event log ─────
     try {
-      await renderAllProjections(basePath, params.milestoneId);
+      await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
       writeManifest(basePath);
       appendEvent(basePath, {
         cmd: "reassess-roadmap",

--- a/src/resources/extensions/gsd/tools/reopen-milestone.ts
+++ b/src/resources/extensions/gsd/tools/reopen-milestone.ts
@@ -15,7 +15,7 @@ import {
   reopenMilestoneCascade,
 } from "../gsd-db.js";
 import { invalidateStateCache } from "../state.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -98,7 +98,7 @@ export async function handleReopenMilestone(
 
   // ── Post-mutation hook ───────────────────────────────────────────────────
   try {
-    await renderAllProjections(basePath, params.milestoneId);
+    await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
     writeManifest(basePath);
     appendEvent(basePath, {
       cmd: "reopen-milestone",

--- a/src/resources/extensions/gsd/tools/reopen-slice.ts
+++ b/src/resources/extensions/gsd/tools/reopen-slice.ts
@@ -16,7 +16,7 @@ import {
   reopenSliceCascade,
 } from "../gsd-db.js";
 import { invalidateStateCache } from "../state.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -97,7 +97,7 @@ export async function handleReopenSlice(
 
   // ── Post-mutation hook ───────────────────────────────────────────────────
   try {
-    await renderAllProjections(basePath, params.milestoneId);
+    await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
     writeManifest(basePath);
     appendEvent(basePath, {
       cmd: "reopen-slice",

--- a/src/resources/extensions/gsd/tools/reopen-task.ts
+++ b/src/resources/extensions/gsd/tools/reopen-task.ts
@@ -19,7 +19,7 @@ import {
 } from "../gsd-db.js";
 import { invalidateStateCache } from "../state.js";
 import { isClosedStatus } from "../status-guards.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -119,7 +119,7 @@ export async function handleReopenTask(
 
   // ── Post-mutation hook ───────────────────────────────────────────────────
   try {
-    await renderAllProjections(basePath, params.milestoneId);
+    await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
     writeManifest(basePath);
     appendEvent(basePath, {
       cmd: "reopen-task",

--- a/src/resources/extensions/gsd/tools/replan-slice.ts
+++ b/src/resources/extensions/gsd/tools/replan-slice.ts
@@ -13,7 +13,7 @@ import { invalidateStateCache } from "../state.js";
 import { isClosedStatus } from "../status-guards.js";
 import { isNonEmptyString } from "../validation.js";
 import { renderPlanFromDb, renderReplanFromDb } from "../markdown-renderer.js";
-import { renderAllProjections } from "../workflow-projections.js";
+import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -216,7 +216,7 @@ export async function handleReplanSlice(
 
     // ── Post-mutation hook: projections, manifest, event log ─────
     try {
-      await renderAllProjections(basePath, params.milestoneId);
+      await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
       writeManifest(basePath);
       appendEvent(basePath, {
         cmd: "replan-slice",

--- a/tests/live-workflow/scenario.ts
+++ b/tests/live-workflow/scenario.ts
@@ -1,0 +1,210 @@
+/**
+ * Live-workflow scenario runner.
+ *
+ * Each scenario seeds an isolated project, dispatches one real workflow Unit,
+ * and asserts durable outcomes. Scenario files stay small: they describe the
+ * seed and proof, while this module owns the shared live-run interface.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+
+import { artifactsFor, createTmpProject, type TmpProject } from "../e2e/_shared/index.ts";
+import {
+  credentialNames,
+  hasUsableCredentials,
+  liveEnv,
+  runStreaming,
+  runVerification,
+} from "./harness.ts";
+
+export interface LiveWorkflowScenario {
+  slug: string;
+  skipReason?: string | null;
+  seed(project: TmpProject): LiveWorkflowSeed;
+  dispatch?: {
+    command?: "next";
+    timeoutMs?: number;
+    maxRestarts?: number;
+  };
+  expect?: {
+    verification?: readonly string[];
+    commits?: "increased" | "unchanged" | "any";
+    toolEvents?: "required" | "optional";
+    toolNames?: readonly string[];
+  };
+}
+
+export interface LiveWorkflowSeed {
+  verifyArgv?: readonly string[];
+}
+
+export interface LiveWorkflowRunResult {
+  project: TmpProject;
+  artifactsDir: string;
+  transcript: string;
+  stdout: string;
+  stderr: string;
+  events: readonly Record<string, unknown>[];
+}
+
+type LiveWorkflowOutputFormat = "text" | "stream-json";
+
+function skip(reason: string): never {
+  console.log(`SKIPPED: ${reason}`);
+  process.exit(77);
+}
+
+function resolveOutputFormat(): LiveWorkflowOutputFormat {
+  return process.env.GSD_LIVE_WORKFLOW_OUTPUT?.trim() === "stream-json" ? "stream-json" : "text";
+}
+
+function resolveTimeoutMs(scenario: LiveWorkflowScenario): number {
+  return scenario.dispatch?.timeoutMs ?? Number(process.env.GSD_LIVE_WORKFLOW_TIMEOUT_MS ?? 300_000);
+}
+
+function parseJsonEvents(stdout: string): Record<string, unknown>[] {
+  const events: Record<string, unknown>[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === "object" && "type" in parsed) {
+        events.push(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // Text-mode output and progress preambles are intentionally ignored.
+    }
+  }
+  return events;
+}
+
+function collectToolNames(events: readonly Record<string, unknown>[]): string[] {
+  return events
+    .filter((event) => event.type === "tool_execution_start")
+    .map((event) => String(event.toolName ?? ""))
+    .filter(Boolean);
+}
+
+function assertToolEvents(events: readonly Record<string, unknown>[]): void {
+  assert.ok(
+    events.some((event) => event.type === "tool_execution_start"),
+    "expected stream-json output to include at least one tool_execution_start event",
+  );
+  assert.ok(
+    events.some((event) => event.type === "tool_execution_end"),
+    "expected stream-json output to include at least one tool_execution_end event",
+  );
+}
+
+function assertToolNames(events: readonly Record<string, unknown>[], expectedNames: readonly string[]): void {
+  const seen = collectToolNames(events);
+  for (const expected of expectedNames) {
+    assert.ok(seen.includes(expected), `expected live run to call ${expected}; saw: ${seen.join(", ") || "(none)"}`);
+  }
+}
+
+export async function runLiveWorkflowScenario(scenario: LiveWorkflowScenario): Promise<LiveWorkflowRunResult> {
+  if (process.env.GSD_LIVE_TESTS !== "1") skip("set GSD_LIVE_TESTS=1 to enable");
+  if (scenario.skipReason) skip(scenario.skipReason);
+  if (!hasUsableCredentials()) {
+    skip("no provider credentials in env (export a *_API_KEY or *_OAUTH_TOKEN)");
+  }
+  console.log(`Credentials: ${credentialNames().join(", ")}`);
+
+  const project = createTmpProject({ git: true });
+  const artifacts = artifactsFor(scenario.slug);
+
+  try {
+    const seed = scenario.seed(project);
+    const verifyArgv = scenario.expect?.verification ?? seed.verifyArgv;
+
+    if (verifyArgv) {
+      const before = runVerification(project, [...verifyArgv]);
+      assert.equal(before.ok, false, `fixture should fail before the agent runs, but it passed:\n${before.output}`);
+    }
+
+    const commitsBefore = Number(
+      execFileSync("git", ["rev-list", "--count", "HEAD"], { cwd: project.dir, encoding: "utf8" }).trim(),
+    );
+
+    const model = process.env.GSD_LIVE_WORKFLOW_MODEL?.trim();
+    const timeoutMs = resolveTimeoutMs(scenario);
+    const outputFormat = resolveOutputFormat();
+    const dispatchArgs = [
+      "headless",
+      "--output-format",
+      outputFormat,
+      ...(outputFormat === "text" ? ["--verbose"] : []),
+      "--timeout",
+      String(timeoutMs),
+      "--max-restarts",
+      String(scenario.dispatch?.maxRestarts ?? 0),
+      ...(model ? ["--model", model] : []),
+      scenario.dispatch?.command ?? "next",
+    ];
+
+    console.log(`Running: gsd ${dispatchArgs.join(" ")}${model ? "" : " (model auto-resolved from available credentials)"}`);
+    console.log("─── live transcript ─────────────────────────────────────────");
+    const result = await runStreaming(dispatchArgs, {
+      cwd: project.dir,
+      timeoutMs: timeoutMs + 30_000,
+      env: liveEnv(),
+    });
+    console.log("─── end transcript ──────────────────────────────────────────");
+
+    const transcript = [result.stdoutClean, result.stderrClean].filter((s) => s.trim()).join("\n");
+    const events = parseJsonEvents(result.stdout);
+    artifacts.write("transcript.txt", transcript);
+    artifacts.write("dispatch.stdout.log", result.stdout);
+    artifacts.write("dispatch.stderr.log", result.stderr);
+    if (events.length > 0) artifacts.write("dispatch.events.json", `${JSON.stringify(events, null, 2)}\n`);
+    console.log(`exit code: ${result.code} (0=success, 10=blocked, 1=error/timeout, 11=cancelled)`);
+    console.log(`transcript: ${artifacts.dir}/transcript.txt`);
+
+    assert.ok(!result.timedOut, "unit dispatch hit the harness timeout — raise GSD_LIVE_WORKFLOW_TIMEOUT_MS");
+    assert.equal(
+      result.code,
+      0,
+      `expected the dispatched unit to complete (exit 0), got ${result.code}. See ${artifacts.dir}/transcript.txt`,
+    );
+    assert.ok(transcript.trim().length > 0 || events.length > 0, "expected the unit dispatch to produce output");
+
+    if (verifyArgv) {
+      const after = runVerification(project, [...verifyArgv]);
+      assert.ok(after.ok, `verification still fails — the agent did not complete the task:\n${after.output}`);
+    }
+
+    const commitsAfter = Number(
+      execFileSync("git", ["rev-list", "--count", "HEAD"], { cwd: project.dir, encoding: "utf8" }).trim(),
+    );
+    if ((scenario.expect?.commits ?? "increased") === "increased") {
+      assert.ok(
+        commitsAfter > commitsBefore,
+        `expected the agent to add at least one commit (before=${commitsBefore}, after=${commitsAfter})`,
+      );
+    } else if (scenario.expect?.commits === "unchanged") {
+      assert.equal(commitsAfter, commitsBefore, "expected the scenario to leave git history unchanged");
+    }
+
+    if (scenario.expect?.toolEvents === "required") {
+      assertToolEvents(events);
+    }
+
+    if (scenario.expect?.toolNames?.length) {
+      assertToolNames(events, scenario.expect.toolNames);
+    }
+
+    return {
+      project,
+      artifactsDir: artifacts.dir,
+      transcript,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      events,
+    };
+  } catch (err) {
+    project.cleanup();
+    throw err;
+  }
+}

--- a/tests/live-workflow/test-tiny-milestone.ts
+++ b/tests/live-workflow/test-tiny-milestone.ts
@@ -17,106 +17,28 @@
  * Exit: 0 pass · 77 skip (no creds) · non-zero fail.
  */
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 
-import { artifactsFor, createTmpProject } from "../e2e/_shared/index.ts";
-import {
-  credentialNames,
-  hasUsableCredentials,
-  liveEnv,
-  runStreaming,
-  runVerification,
-  seedTinyMilestone,
-} from "./harness.ts";
+import { seedTinyMilestone } from "./harness.ts";
+import { runLiveWorkflowScenario } from "./scenario.ts";
 
-function skip(reason: string): never {
-  console.log(`SKIPPED: ${reason}`);
-  process.exit(77);
+function shouldRequireToolEvents(): boolean {
+  return process.env.GSD_LIVE_WORKFLOW_OUTPUT === "stream-json";
 }
 
-if (process.env.GSD_LIVE_TESTS !== "1") skip("set GSD_LIVE_TESTS=1 to enable");
-if (!hasUsableCredentials()) {
-  skip("no provider credentials in env (export a *_API_KEY or *_OAUTH_TOKEN)");
-}
-console.log(`Credentials: ${credentialNames().join(", ")}`);
-
-const model = process.env.GSD_LIVE_WORKFLOW_MODEL?.trim();
-const autoTimeoutMs = Number(process.env.GSD_LIVE_WORKFLOW_TIMEOUT_MS ?? 300_000);
-
-const project = createTmpProject({ git: true });
-const artifacts = artifactsFor("live-tiny-milestone");
+const result = await runLiveWorkflowScenario({
+  slug: "live-tiny-milestone",
+  seed: seedTinyMilestone,
+  expect: {
+    commits: "increased",
+    toolEvents: shouldRequireToolEvents() ? "required" : "optional",
+  },
+});
 
 try {
-  const { verifyArgv } = seedTinyMilestone(project);
-
-  // Sanity: the fixture must actually be broken before the agent runs,
-  // otherwise a no-op agent would "pass" the durable assertion.
-  const before = runVerification(project, verifyArgv);
-  assert.equal(before.ok, false, `fixture should fail before the agent runs, but it passed:\n${before.output}`);
-
-  const commitsBefore = Number(
-    execFileSync("git", ["rev-list", "--count", "HEAD"], { cwd: project.dir, encoding: "utf8" }).trim(),
-  );
-
-  // Dispatch a single unit (execute-task T01) via `next`. Default to text+verbose
-  // so the agent's work renders as a READABLE transcript (gsd's own formatProgress
-  // renderer); set GSD_LIVE_WORKFLOW_OUTPUT=stream-json for machine-parseable JSONL.
-  const outputFormat = process.env.GSD_LIVE_WORKFLOW_OUTPUT?.trim() || "text";
-  const dispatchArgs = [
-    "headless",
-    "--output-format",
-    outputFormat,
-    ...(outputFormat === "text" ? ["--verbose"] : []),
-    "--timeout",
-    String(autoTimeoutMs),
-    "--max-restarts",
-    "0",
-    ...(model ? ["--model", model] : []),
-    "next",
-  ];
-  console.log(`Running: gsd ${dispatchArgs.join(" ")}${model ? "" : " (model auto-resolved from available credentials)"}`);
-  console.log("─── live transcript ─────────────────────────────────────────");
-
-  // Stream the readable transcript to the terminal live, while still capturing it.
-  // This wall-clock budget (gsd timeout + a small grace) is the authoritative
-  // limit on the run.
-  const result = await runStreaming(dispatchArgs, {
-    cwd: project.dir,
-    timeoutMs: autoTimeoutMs + 30_000,
-    env: liveEnv(),
-  });
-  console.log("─── end transcript ──────────────────────────────────────────");
-
-  // Save a clean, ANSI-stripped transcript plus the raw streams for post-mortem.
-  const transcript = [result.stdoutClean, result.stderrClean].filter((s) => s.trim()).join("\n");
-  artifacts.write("transcript.txt", transcript);
-  artifacts.write("dispatch.stdout.log", result.stdout);
-  artifacts.write("dispatch.stderr.log", result.stderr);
-  console.log(`exit code: ${result.code} (0=success, 10=blocked, 1=error/timeout, 11=cancelled)`);
-  console.log(`transcript: ${artifacts.dir}/transcript.txt`);
-
-  assert.ok(!result.timedOut, "unit dispatch hit the harness timeout — raise GSD_LIVE_WORKFLOW_TIMEOUT_MS");
-  assert.equal(
-    result.code,
-    0,
-    `expected the dispatched unit to complete (exit 0), got ${result.code}. See ${artifacts.dir}/transcript.txt`,
-  );
-  assert.ok(transcript.trim().length > 0, "expected the unit dispatch to produce a transcript");
-
-  // Durable proof #1: the task's own verification now passes.
-  const after = runVerification(project, verifyArgv);
-  assert.ok(after.ok, `verification still fails — the agent did not complete the task:\n${after.output}`);
-
-  // Durable proof #2: the agent committed its work.
-  const commitsAfter = Number(
-    execFileSync("git", ["rev-list", "--count", "HEAD"], { cwd: project.dir, encoding: "utf8" }).trim(),
-  );
-  assert.ok(
-    commitsAfter > commitsBefore,
-    `expected the agent to add at least one commit (before=${commitsBefore}, after=${commitsAfter})`,
-  );
-
   console.log("PASS: live agent completed the dispatched task and verification passes.");
+  if (shouldRequireToolEvents()) {
+    assert.ok(result.events.length > 0, "expected stream-json live run to save parseable events");
+  }
 } finally {
-  project.cleanup();
+  result.project.cleanup();
 }


### PR DESCRIPTION
## TL;DR

**What:** Deepens several GSD workflow architecture seams without changing the public workflow behavior.
**Why:** These paths were duplicating contract, closeout, projection, and live-run orchestration logic across callers.
**How:** Adds focused module seams for live workflow scenarios, unit dispatch readiness, auto closeout results, and projection flushing, then routes existing callers through them.

## What

This change adds and wires four architecture surfaces:

- A reusable live workflow scenario runner under `tests/live-workflow/scenario.ts`.
- Unit-level workflow dispatch readiness in `tool-contract.ts`, used by auto-mode, guided flow, direct dispatch, and UAT retry preflight.
- An explicit `closeoutAutoUnit` request/result seam while preserving the existing `closeoutUnit` wrapper.
- A `projection-flush.ts` seam used by projection-producing workflow mutations and repair paths.

It also updates focused tests around guided dispatch root propagation and runtime invariant contracts.

## Why

The existing code had several places hand-wiring the same architectural rules:

- Dispatch callers each paired unit types with required workflow tools themselves.
- Auto closeout returned only an activity path even though it also records git transaction state.
- Workflow mutation tools called projection rendering directly, spreading projection policy across handlers.
- The live workflow proof had useful setup and transcript behavior embedded in one test file.

Centralizing those seams makes the workflow easier to extend and test while keeping the blast radius narrow.

## How

The implementation keeps behavior compatible and intentionally avoids broad rewrites:

- `getUnitWorkflowDispatchReadinessError` derives required workflow tools from the Unit registry and delegates to the existing transport compatibility check.
- Existing dispatch call sites pass their provider/auth/baseUrl/active tool context into that unit-level helper.
- `closeoutAutoUnit` accepts a structured request and returns whether git transaction evidence was recorded; `closeoutUnit` remains as a compatibility wrapper for current callers.
- `flushWorkflowProjections` wraps the existing `renderAllProjections` behavior behind a named mutation-exit seam.
- `test-tiny-milestone.ts` now uses the reusable scenario runner and can require stream-json tool events when requested.

## Validation

- `pnpm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts src/resources/extensions/gsd/tests/unit-closeout.test.ts src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts`
- `node --experimental-strip-types tests/live-workflow/run.ts`
- `git diff --check origin/main...HEAD`

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only routing through new seams; dispatch and projection behavior delegates to existing implementations, with compatibility wrappers preserved.
> 
> **Overview**
> Introduces four shared seams and routes existing callers through them without changing outward workflow behavior.
> 
> **Dispatch readiness** — `getUnitWorkflowDispatchReadinessError` in `tool-contract.ts` resolves required workflow tools from the unit registry and runs the existing transport check. Auto-mode, guided flow, direct phase dispatch, and run-UAT preflight now call this helper instead of pairing `getRequiredWorkflowToolsForAutoUnit` / guided variants with `getWorkflowTransportSupportError` locally.
> 
> **Auto closeout** — `closeoutAutoUnit` takes a structured request and returns `activityFile` plus `gitTransactionRecorded`; `closeoutUnit` remains a thin wrapper for legacy callers.
> 
> **Projection flush** — `flushWorkflowProjections` in `projection-flush.ts` wraps `renderAllProjections` for mutation exits (complete/plan/reopen tools, doctor repair, milestone planning persistence).
> 
> **Live tests** — `tests/live-workflow/scenario.ts` centralizes seed, headless dispatch, durable assertions, and optional stream-json tool events; `test-tiny-milestone.ts` delegates to it.
> 
> Tests updated for guided dispatch DI (`getDispatchReadinessError`) and runtime invariant dispatch-readiness coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c06750cc3d5842052b1cc1ee7b27a063b6d2b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->