### PR TITLE
fix(gsd): hand off completed web tasks to browser UAT

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -50,6 +50,7 @@ import { getSlice } from "./gsd-db.js";
 import { getLedger } from "./metrics.js";
 import { getUnitCostSpikeAction, resolveUnitCostSpikeMultiplier } from "./auto-budget.js";
 import { formatPostUnitStatusCard } from "./auto-status-message.js";
+import { detectWebApp } from "./web-app-uat.js";
 
 export interface VerificationContext {
   s: AutoSession;
@@ -787,17 +788,27 @@ export async function runPostUnitVerification(
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       return "continue";
-    } else if (verdict.reason === "no-host-checks") {
+    } else if (verdict.reason === "no-host-checks" && taskAlreadyComplete && detectWebApp(s.basePath)) {
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       ctx.ui.notify(
-        "Verification gate FAILED — no runnable host-owned verification checks were discovered. Pausing for human review.",
+        "No task-level host verification command was found for a completed browser-facing task; continuing so slice UAT can verify the UI with browser tools.",
+        "warning",
+      );
+      return "continue";
+    } else if (verdict.reason === "no-host-checks") {
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
+      s.pendingVerificationRetry = null;
+      const pauseMessage = `Verification failed: ${verdict.failureContext}`;
+      ctx.ui.notify(
+        `Verification gate FAILED — ${verdict.failureContext}`,
         "error",
       );
       process.stderr.write(`verification-gate: ${verdict.failureContext}\n`);
       await pauseAuto(ctx, pi, {
-        message: "Verification failed: no runnable host-owned verification checks were discovered.",
+        message: pauseMessage,
         category: "unknown",
       });
       return "pause";

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -788,7 +788,12 @@ export async function runPostUnitVerification(
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       return "continue";
-    } else if (verdict.reason === "no-host-checks" && taskAlreadyComplete && detectWebApp(s.basePath)) {
+    } else if (
+      verdict.reason === "no-host-checks" &&
+      taskAlreadyComplete &&
+      detectWebApp(s.basePath) &&
+      !result.runtimeErrors?.some((e) => e.blocking)
+    ) {
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -145,7 +145,7 @@ function createBasicTask(): void {
   });
 }
 
-function createTaskWithoutVerify(): void {
+function createTaskWithoutVerify(status = "pending"): void {
   insertMilestone({ id: "M001" });
   insertSlice({
     id: "S01",
@@ -159,7 +159,7 @@ function createTaskWithoutVerify(): void {
     sliceId: "S01",
     milestoneId: "M001",
     title: "Task without host verification",
-    status: "pending",
+    status,
     planning: {
       description: "Task intentionally missing runnable verification",
       estimate: "1h",
@@ -558,12 +558,73 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(pauseAutoMock.mock.callCount(), 1);
     assert.equal(s.pendingVerificationRetry, null);
 
+    const notifyMessages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) =>
+      String(c.arguments[0])
+    );
+    assert.ok(
+      notifyMessages.some(
+        (m: string) =>
+          m.includes(".gsd/PREFERENCES.md") &&
+          m.includes("task-plan Verify command") &&
+          m.includes("/gsd next")
+      ),
+      "no-host-checks notification should guide the user to add verification and resume",
+    );
+
+    const pauseCalls = pauseAutoMock.mock.calls as Array<{ arguments: unknown[] }>;
+    const pauseCallArgs = pauseCalls[0]?.arguments[2] as
+      | { message?: string }
+      | undefined;
+    assert.ok(
+      pauseCallArgs?.message?.includes(".gsd/PREFERENCES.md"),
+      "pause reason should include the project verification configuration path",
+    );
+    assert.ok(
+      pauseCallArgs?.message?.includes("/gsd next"),
+      "pause reason should tell the user how to resume",
+    );
+
     const evidencePath = join(tempDir, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-VERIFY.json");
     const evidence = JSON.parse(readFileSync(evidencePath, "utf-8"));
     assert.equal(evidence.passed, false);
     assert.equal(evidence.discoverySource, "none");
     assert.ok(!("retryAttempt" in evidence), "no-host-checks evidence must not include retryAttempt");
     assert.ok(!("maxRetries" in evidence), "no-host-checks evidence must not include maxRetries");
+  });
+
+  test("completed browser-facing execute-task with no host-owned verification continues toward browser UAT", async () => {
+    createTaskWithoutVerify("complete");
+    writeFileSync(join(tempDir, "index.html"), "<!doctype html><button>Import</button>", "utf-8");
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "continue");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.equal(s.pendingVerificationRetry, null);
+
+    const notifyMessages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) =>
+      String(c.arguments[0])
+    );
+    assert.ok(
+      notifyMessages.some(
+        (m: string) =>
+          m.includes("browser-facing task") &&
+          m.includes("slice UAT") &&
+          m.includes("browser tools")
+      ),
+      "completed web tasks without task-level commands should explain browser UAT handoff",
+    );
+
+    const evidencePath = join(tempDir, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-VERIFY.json");
+    const evidence = JSON.parse(readFileSync(evidencePath, "utf-8"));
+    assert.equal(evidence.passed, false);
+    assert.equal(evidence.discoverySource, "none");
+    assert.ok(!("retryAttempt" in evidence), "browser-UAT handoff evidence must not request a task retry");
   });
 
   test("auto-discovered package.json verification failure retries instead of continuing", async () => {

--- a/src/resources/extensions/gsd/tests/verification-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-verdict.test.ts
@@ -24,6 +24,8 @@ test("execute-task fails closed when no host-owned checks are discovered", () =>
   assert.equal(verdict.reason, "no-host-checks");
   assert.equal(verdict.retryable, false);
   assert.match(verdict.failureContext, /No runnable host-owned verification command/);
+  assert.match(verdict.failureContext, /\.gsd\/PREFERENCES\.md/);
+  assert.match(verdict.failureContext, /\/gsd next/);
 });
 
 test("execute-task passes when non-runnable task-plan prose is the verification source", () => {

--- a/src/resources/extensions/gsd/verification-verdict.ts
+++ b/src/resources/extensions/gsd/verification-verdict.ts
@@ -15,6 +15,9 @@ export interface VerificationVerdict {
   failureContext: string;
 }
 
+export const NO_HOST_CHECKS_FAILURE_CONTEXT =
+  "No runnable host-owned verification command was discovered. Add project verification_commands in .gsd/PREFERENCES.md or a runnable task-plan Verify command, then resume with /gsd next.";
+
 export function decideVerificationVerdict(
   unitType: string,
   result: VerificationGateResult,
@@ -33,8 +36,7 @@ export function decideVerificationVerdict(
       passed: false,
       reason: "no-host-checks",
       retryable: false,
-      failureContext:
-        "No runnable host-owned verification command was discovered. Add project verification_commands or a runnable task-plan Verify command before completing this execute-task.",
+      failureContext: NO_HOST_CHECKS_FAILURE_CONTEXT,
     };
   }
 


### PR DESCRIPTION
## TL;DR

**What:** Completed browser-facing execute-task units without task-level host commands now continue toward slice UAT instead of hard-pausing.
**Why:** Web-app verification should be performed by the browser-capable UAT path rather than forcing users to manually author shell checks before GSD can continue.
**How:** The no-host-checks verdict still fails closed for pending tasks, but completed web tasks are allowed to proceed with an explanatory warning so run-uat can use browser tools.

## What

This updates post-execute-task verification in `auto-verification.ts` and the no-host-checks verdict message in `verification-verdict.ts`. It also expands regression coverage for both paths:

- Pending execute-task units with no host-owned verification still pause with actionable guidance.
- Completed browser-facing execute-task units with no task-level command continue toward slice UAT/browser verification.

## Why

The previous step-mode behavior stranded browser-facing tasks at the execute-task verification gate. That gate only discovers host-owned shell commands, while browser UI verification is owned by slice UAT/run-uat. For web apps, this made the user manually add verification commands even when the correct next verifier was already the browser-capable UAT layer.

## How

The fix uses the existing web-app detector in the no-host-checks branch. If the task is already complete and the project is browser-facing, GSD clears retry state, emits a warning explaining the browser UAT handoff, and continues. Otherwise, the gate remains fail-closed and now tells the user exactly how to add host-owned verification and resume.

## Validation

- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-verdict.test.ts src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`
- `git diff --check`

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode control flow for execute-task verification (when to pause vs continue), which can affect step-mode progression for web apps; scope is narrow and covered by new tests.
> 
> **Overview**
> **Post-execute-task verification** no longer hard-pauses every `no-host-checks` case. **Pending** tasks still fail closed; **completed** tasks on **browser-facing** projects (`detectWebApp`) with no blocking runtime errors **continue** toward slice UAT with a warning instead of forcing shell verification first.
> 
> The **no-host-checks** user messaging is centralized in `NO_HOST_CHECKS_FAILURE_CONTEXT`, pointing at `.gsd/PREFERENCES.md`, task-plan Verify, and **`/gsd next`**; pause/notify paths now surface that text via `verdict.failureContext`.
> 
> Regression tests cover actionable pause copy for pending tasks and the completed-web **continue** path (including evidence without retry metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51bbe5d227d4eeaf50b3c762276ff9e898263486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->