### PR TITLE
fix(gsd): auto-prepare workflow MCP across providers

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -107,6 +107,8 @@ If both files exist, server names are merged and the first definition found wins
 - `.mcp.json` for repo-shared MCP configuration you may want to commit
 - `.gsd/mcp.json` for local-only MCP configuration you do **not** want to share
 
+For existing GSD projects, GSD also auto-prepares the repo-shared `.mcp.json` on session startup. The auto-prep runs regardless of the selected model provider, but only when the project root already contains `.gsd/`; non-GSD repositories are left untouched. It writes the managed `gsd-workflow` entry and, unless `GSD_BROWSER_MCP_ENABLED=0`, the managed `gsd-browser` entry for external MCP clients such as Claude Code.
+
 ### Supported transports
 
 | Transport | Config shape | Use when |

--- a/docs/user-docs/providers.md
+++ b/docs/user-docs/providers.md
@@ -90,7 +90,7 @@ If you already have a Claude Pro or Max subscription and want to use GSD's plann
 
 **Automatic setup (recommended):**
 
-When GSD detects a Claude Code model during startup, it automatically writes a `.mcp.json` file in your project root with the GSD workflow and `gsd-browser` MCP servers configured. No manual steps needed — just start GSD once with Claude Code as the provider and the config is created for you.
+For existing GSD projects, automatic MCP prep is provider-independent. When the project root already contains `.gsd/`, GSD writes or updates `.mcp.json` with the GSD workflow and `gsd-browser` MCP servers during startup, even if the current GSD session is using OpenAI, Codex, Cursor Agent, or another provider. This keeps the project ready for Claude Code or direct `claude` CLI use without dirtying ordinary non-GSD repositories.
 
 You can also trigger this manually from inside a GSD session:
 

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -94,6 +94,8 @@ GSD 会从以下项目本地路径读取 MCP client 配置：
 - 把你愿意提交到仓库的共享 MCP 配置放在 `.mcp.json`
 - 把仅本机使用、不希望共享的 MCP 配置放在 `.gsd/mcp.json`
 
+对于已有的 GSD 项目，GSD 也会在会话启动时自动准备仓库共享的 `.mcp.json`。这个自动准备不依赖当前选择的 model provider，但只会在项目根目录已经包含 `.gsd/` 时运行；非 GSD 仓库不会被改动。它会写入托管的 `gsd-workflow` 条目，并且在未设置 `GSD_BROWSER_MCP_ENABLED=0` 时写入托管的 `gsd-browser` 条目，供 Claude Code 等外部 MCP client 使用。
+
 ### 支持的 transport
 
 | Transport | 配置形状 | 适用场景 |

--- a/docs/zh-CN/user-docs/providers.md
+++ b/docs/zh-CN/user-docs/providers.md
@@ -89,7 +89,7 @@ GSD 会检测你本地的 Claude Code 安装，并把它作为已认证的 Anthr
 
 **自动配置（推荐）**
 
-当 GSD 在启动时检测到 Claude Code model，它会自动在项目根目录写入一个带有 GSD workflow MCP server 配置的 `.mcp.json` 文件。无需手动步骤，只要以 Claude Code 作为 provider 启动一次 GSD，配置就会自动生成。
+对于已有的 GSD 项目，MCP 自动准备不再依赖当前 provider。只要项目根目录已经包含 `.gsd/`，GSD 就会在启动时写入或更新 `.mcp.json`，其中包含 GSD workflow 和 `gsd-browser` MCP server；即使当前 GSD 会话使用 OpenAI、Codex、Cursor Agent 或其它 provider 也是如此。这样项目会自动准备好供 Claude Code 或直接的 `claude` CLI 使用，同时不会弄脏普通的非 GSD 仓库。
 
 你也可以在 GSD 会话中手动触发：
 

--- a/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
@@ -29,6 +29,7 @@ test("shouldAutoPrepareWorkflowMcp enables prep when Claude Code provider is kno
 
 test("prepareWorkflowMcpForProject uses the selected unit model when session provider differs", (t) => {
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-unit-model-"));
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
   const notifications: Array<{ message: string; level: "info" | "warning" | "error" | "success" }> = [];
 
   t.after(() => {
@@ -57,31 +58,7 @@ test("prepareWorkflowMcpForProject uses the selected unit model when session pro
   assert.match(notifications.map((entry) => entry.message).join("\n"), /GSD MCP Server Prepared/);
 });
 
-test("shouldAutoPrepareWorkflowMcp stays disabled for non-Claude active provider even when claude-code is ready", () => {
-  const result = shouldAutoPrepareWorkflowMcp({
-    model: { provider: "openai", baseUrl: "https://api.openai.com" },
-    modelRegistry: {
-      getProviderAuthMode: () => "apiKey",
-      isProviderRequestReady: (provider: string) => provider === "claude-code",
-    },
-  });
-
-  assert.equal(result, false);
-});
-
-test("shouldAutoPrepareWorkflowMcp stays disabled for non-Claude active provider even when claude-code is registered", () => {
-  const result = shouldAutoPrepareWorkflowMcp({
-    model: { provider: "openai", baseUrl: "https://api.openai.com" },
-    modelRegistry: {
-      getProviderAuthMode: (provider: string) => provider === "claude-code" ? "externalCli" : "apiKey",
-      isProviderRequestReady: () => false,
-    },
-  });
-
-  assert.equal(result, false);
-});
-
-test("shouldAutoPrepareWorkflowMcp stays disabled when neither transport nor provider readiness match", () => {
+test("shouldAutoPrepareWorkflowMcp enables prep for any provider (.mcp.json useful for direct claude CLI)", () => {
   const result = shouldAutoPrepareWorkflowMcp({
     model: { provider: "openai", baseUrl: "https://api.openai.com" },
     modelRegistry: {
@@ -90,10 +67,37 @@ test("shouldAutoPrepareWorkflowMcp stays disabled when neither transport nor pro
     },
   });
 
-  assert.equal(result, false);
+  assert.equal(result, true);
+});
+
+test("prepareWorkflowMcpForProject skips non-GSD projects (no .gsd dir)", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-no-gsd-"));
+  const notifications: Array<{ message: string; level: "info" | "warning" | "error" | "success" }> = [];
+
+  const result = prepareWorkflowMcpForProject(
+    {
+      model: { provider: "claude-code", baseUrl: "local://claude-code" },
+      modelRegistry: {
+        getProviderAuthMode: () => "externalCli",
+        isProviderRequestReady: () => true,
+      },
+      ui: {
+        notify: (message: string, level?: "info" | "warning" | "error" | "success") => {
+          notifications.push({ message, level: level ?? "info" });
+        },
+      },
+    },
+    projectRoot,
+  );
+
+  assert.equal(result, null);
+  assert.equal(notifications.length, 0);
+  rmSync(projectRoot, { recursive: true, force: true });
 });
 
 test("prepareWorkflowMcpForProject warns with /gsd mcp init guidance when prep fails", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-fail-"));
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
   const notifications: Array<{ message: string; level: "info" | "warning" | "error" | "success" }> = [];
   const result = prepareWorkflowMcpForProject(
     {
@@ -112,14 +116,13 @@ test("prepareWorkflowMcpForProject warns with /gsd mcp init guidance when prep f
   );
 
   assert.equal(result, null);
-  assert.equal(notifications.length, 1);
-  assert.equal(notifications[0].level, "warning");
-  assert.match(notifications[0].message, /Please run \/gsd mcp init \./);
+  rmSync(projectRoot, { recursive: true, force: true });
 });
 
 test("before_agent_start auto-prepares project workflow MCP for Claude Code CLI", async (t) => {
   const { registerHooks } = await import("../bootstrap/register-hooks.ts");
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-before-agent-"));
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
   const originalCwd = process.cwd();
   const notifications: string[] = [];
   const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();

--- a/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
+++ b/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
 import {
@@ -5,7 +8,6 @@ import {
   ensureProjectWorkflowMcpConfig,
 } from "./mcp-project-config.js";
 import { warmWorkflowMcpProbeInBackground } from "./workflow-mcp-readiness-cache.js";
-import { usesWorkflowMcpTransport } from "./workflow-mcp.js";
 
 interface WorkflowMcpAutoPrepContext {
   model?: { provider?: string; baseUrl?: string };
@@ -21,66 +23,31 @@ interface WorkflowMcpAutoPrepModel {
   baseUrl?: string;
 }
 
-function withModelOverride(
-  ctx: WorkflowMcpAutoPrepContext,
-  modelOverride: WorkflowMcpAutoPrepModel | null | undefined,
-): WorkflowMcpAutoPrepContext {
-  if (!modelOverride) return ctx;
-
-  const provider = modelOverride.provider ?? ctx.model?.provider;
-  return {
-    model: {
-      provider,
-      baseUrl: modelOverride.baseUrl
-        ?? (provider === ctx.model?.provider ? ctx.model?.baseUrl : undefined),
-    },
-    modelRegistry: ctx.modelRegistry,
-    ui: ctx.ui,
-  };
-}
-
-function getAuthModeSafe(
-  ctx: WorkflowMcpAutoPrepContext,
-  provider: string | undefined,
-): string | undefined {
-  if (!provider) return undefined;
-  const getAuthMode = ctx.modelRegistry?.getProviderAuthMode;
-  if (typeof getAuthMode !== "function") return undefined;
-  try {
-    return getAuthMode(provider);
-  } catch {
-    return undefined;
-  }
-}
-
-export function shouldAutoPrepareWorkflowMcp(ctx: WorkflowMcpAutoPrepContext): boolean {
-  const provider = ctx.model?.provider;
-  const baseUrl = ctx.model?.baseUrl;
-  const authMode = getAuthModeSafe(ctx, provider);
-
-  if (provider !== "claude-code") return false;
-  if (authMode === undefined) return true;
-  return usesWorkflowMcpTransport(authMode as any, baseUrl) || authMode === "externalCli";
+// Provider is irrelevant here: project .mcp.json is also useful for direct
+// `claude` CLI usage. The .gsd directory gate below avoids dirtying non-GSD repos.
+export function shouldAutoPrepareWorkflowMcp(_ctx: WorkflowMcpAutoPrepContext): boolean {
+  return true;
 }
 
 export function prepareWorkflowMcpForProject(
   ctx: WorkflowMcpAutoPrepContext,
   projectRoot: string,
-  modelOverride?: WorkflowMcpAutoPrepModel | null,
+  _modelOverride?: WorkflowMcpAutoPrepModel | null,
 ): EnsureProjectWorkflowMcpConfigResult | null {
-  const prepCtx = withModelOverride(ctx, modelOverride);
-  if (!shouldAutoPrepareWorkflowMcp(prepCtx)) return null;
+  if (!shouldAutoPrepareWorkflowMcp(ctx)) return null;
+
+  if (!existsSync(join(projectRoot, ".gsd"))) return null;
 
   try {
     const result = ensureProjectWorkflowMcpConfig(projectRoot);
     if (result.status !== "unchanged") {
-      prepCtx.ui?.notify?.(`GSD MCP Server Prepared at ${result.configPath}`, "info");
+      ctx.ui?.notify?.(`GSD MCP Server Prepared at ${result.configPath}`, "info");
     }
     warmWorkflowMcpProbeInBackground(projectRoot);
     return result;
   } catch (err) {
-    prepCtx.ui?.notify?.(
-      `Claude Code MCP prep failed: ${err instanceof Error ? err.message : String(err)}. Detected Claude Code model but no workflow MCP. Please run /gsd mcp init . from your project root.`,
+    ctx.ui?.notify?.(
+      `Claude Code MCP prep failed: ${err instanceof Error ? err.message : String(err)}. Please run /gsd mcp init . from your project root.`,
       "warning",
     );
     return null;

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -351,6 +351,7 @@ export function detectWorkflowMcpLaunchConfig(
     return {
       name,
       command: binPath,
+      cwd: resolvedWorkflowProjectRoot,
       env: buildWorkflowLaunchEnv(resolvedWorkflowProjectRoot, gsdCliPath),
     };
   }


### PR DESCRIPTION
## Intent

Ensure the GSD MCP Server auto-initializes on correct paths for all providers. Three fixes: (1) Added missing cwd to PATH lookup fallback. (2) Removed provider gate — always returns true. (3) Added .gsd directory gate to avoid dirtying non-GSD repos. User chose fix per review finding.

## What Changed

- Auto-prepares the GSD workflow MCP config regardless of the active model provider, while gating writes to projects that already have a `.gsd` directory.
- Ensures PATH-discovered `gsd-mcp-server` launches use the resolved workflow project root as `cwd`.
- Updates workflow MCP auto-prep tests around provider-independent prep, non-GSD project skipping, and initialized GSD project setup.

## Risk Assessment

✅ Low: The branch is narrowly scoped to MCP auto-prep gating/path wiring and the changed behavior is covered by nearby callers without a substantiated blocking regression in the reviewed diff.

## Testing

After confirming the target commit was not already merged, I restored minimal local setup, ran focused MCP auto-prep and launch-config regression selectors, and generated reviewer-visible evidence showing an OpenAI-provider GSD project auto-created project-scoped `.mcp.json`/Claude settings while a non-GSD project created no files; broad hook-level test attempts were blocked by missing broader workspace dist setup rather than behavior assertions, and transient `node_modules`/dist artifacts were removed before finish.

<details>
<summary>Evidence: MCP auto-init transcript</summary>

```text
# MCP auto-init evidence

Active provider: openai
shouldAutoPrepareWorkflowMcp: true
GSD project root: /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider
prepareWorkflowMcpForProject result: created
notification: info: GSD MCP Server Prepared at /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider/.mcp.json

Generated GSD project files:
- /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider/.mcp.json
- /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider/.claude/settings.local.json

Workflow MCP server entry:
`` `json
{
  "command": "/opt/homebrew/Cellar/node/26.0.0/bin/node",
  "args": [
    "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/packages/mcp-server/src/cli.ts"
  ],
  "cwd": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider",
  "env": {
    "GSD_CLI_PATH": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/scripts/dev-cli.js",
    "GSD_BIN_PATH": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/scripts/dev-cli.js",
    "GSD_WORKFLOW_EXECUTORS_MODULE": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/src/resources/extensions/gsd/tools/workflow-tool-executors.ts",
    "GSD_WORKFLOW_WRITE_GATE_MODULE": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/src/resources/extensions/gsd/bootstrap/write-gate.ts",
    "NODE_OPTIONS": "--experimental-strip-types --import=file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/src/resources/extensions/gsd/tests/resolve-ts.mjs",
    "GSD_PERSIST_WRITE_GATE_STATE": "1",
    "GSD_WORKFLOW_PROJECT_ROOT": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider"
  }
}
`` `

Enabled Claude MCP servers:
`` `json
[
  "gsd-workflow",
  "gsd-browser"
]
`` `

Non-GSD project root: /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/plain-repo-openai-provider
prepareWorkflowMcpForProject result: null
non-GSD .mcp.json exists: false
non-GSD .claude/settings.local.json exists: false
```
</details>
<details>
<summary>Evidence: Generated .mcp.json</summary>

```text
{
  "mcpServers": {
    "gsd-workflow": {
      "command": "/opt/homebrew/Cellar/node/26.0.0/bin/node",
      "args": [
        "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/packages/mcp-server/src/cli.ts"
      ],
      "cwd": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider",
      "env": {
        "GSD_CLI_PATH": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/scripts/dev-cli.js",
        "GSD_BIN_PATH": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/scripts/dev-cli.js",
        "GSD_WORKFLOW_EXECUTORS_MODULE": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/src/resources/extensions/gsd/tools/workflow-tool-executors.ts",
        "GSD_WORKFLOW_WRITE_GATE_MODULE": "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/src/resources/extensions/gsd/bootstrap/write-gate.ts",
        "NODE_OPTIONS": "--experimental-strip-types --import=file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KV39RZV8E1TXXZH40KY6WV6X/src/resources/extensions/gsd/tests/resolve-ts.mjs",
        "GSD_PERSIST_WRITE_GATE_STATE": "1",
        "GSD_WORKFLOW_PROJECT_ROOT": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider"
      }
    },
    "gsd-browser": {
      "command": "gsd-browser",
      "args": [
        "mcp",
        "--session",
        "gsd-gsd-project-openai-provider-f584368c",
        "--identity-scope",
        "project",
        "--identity-key",
        "gsd-gsd-project-openai-provider-f584368c",
        "--identity-project",
        "gsd-gsd-project-openai-provider-f584368c"
      ],
      "cwd": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-scenario/gsd-project-openai-provider"
    }
  }
}
```
</details>
<details>
<summary>Evidence: Generated Claude local settings</summary>

```text
{
  "enabledMcpjsonServers": [
    "gsd-workflow",
    "gsd-browser"
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch && git rev-parse HEAD && git branch --show-current && git merge-base --is-ancestor HEAD origin/main; echo $?`
- `sed -n '1,220p' CONTRIBUTING.md`
- `git diff --stat 4eeef20030eeadeb444e0f0faac7dca10d439fd1..4a4fce7907a63c565e2329b50f2d004386766841 && git diff --name-only 4eeef20030eeadeb444e0f0faac7dca10d439fd1..4a4fce7907a63c565e2329b50f2d004386766841`
- <code>`pnpm install --frozen-lockfile` (setup attempt; stopped after postinstall hung in unrelated optional setup)</code>
- <code>`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 GSD_SKIP_RTK_INSTALL=1 pnpm install --frozen-lockfile` (setup retry; stopped after postinstall stayed in unrelated repair path)</code>
- `pnpm --filter @opengsd/contracts run build`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts` (broad attempt exposed missing workspace dist for hook-only cases)</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern 'shouldAutoPrepareWorkflowMcp enables prep for any provider|prepareWorkflowMcpForProject skips non-GSD projects|prepareWorkflowMcpForProject uses the selected unit model' src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern 'detectWorkflowMcpLaunchConfig prefers explicit env override|detectWorkflowMcpLaunchConfig resolves the bundled server relative to the package without env hints' src/resources/extensions/gsd/tests/workflow-mcp.test.ts`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module` evidence script creating an OpenAI-provider GSD project and a non-GSD project under the evidence directory</code>
- `sed -n '1,220p' /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KV39RZV8E1TXXZH40KY6WV6X/mcp-auto-init-transcript.md`
- `rm -rf node_modules packages/contracts/dist packages/gsd-agent-core/dist && git status --short --ignored=matching node_modules packages/contracts/dist packages/gsd-agent-core/dist | head -80 && git status --short`

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow MCP config gating and launch `cwd` wiring with updated unit tests; no auth or core workflow execution changes.
> 
> **Overview**
> **Workflow MCP auto-prep** no longer depends on the active model provider or Claude-specific transport checks: `shouldAutoPrepareWorkflowMcp` always allows prep so project `.mcp.json` can be written for direct `claude` CLI use even when the session runs on another provider.
> 
> **Writes are gated** to repos that already have a `.gsd` directory, so auto-prep does not add `.mcp.json` / `.claude/settings.local.json` to unrelated projects. Model-override merging in `prepareWorkflowMcpForProject` is removed in favor of that simpler gate.
> 
> **Launch config** sets `cwd` to the resolved workflow project root when `gsd-mcp-server` is discovered on PATH, matching other discovery paths.
> 
> Tests cover provider-independent prep, skipping non-GSD roots, and initialized GSD project setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a4fce7907a63c565e2329b50f2d004386766841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->