### PR TITLE
fix(issue): ENOENT: process.cwd() crash in teardownAutoWorktree when cwd was deleted during milestone merge

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -972,6 +972,14 @@ function _resolveIntegrationBranchForReuse(
   }
 }
 
+function safeCwd(fallback: string): string {
+  try {
+    return process.cwd();
+  } catch {
+    return fallback;
+  }
+}
+
 /**
  * When reusing an existing milestone branch, fast-forward it onto the
  * integration branch when that's safe (branch is a strict ancestor of
@@ -1155,7 +1163,7 @@ export function teardownAutoWorktree(
 
   const branch = autoWorktreeBranch(milestoneId);
   const { preserveBranch = false, preserveWorktree = false } = opts;
-  const previousCwd = process.cwd();
+  const previousCwd = safeCwd(originalBasePath);
 
   // Wrap the entire teardown body in a single try/finally so activeWorkspace
   // is ALWAYS cleared — even if process.chdir throws (e.g. originalBasePath
@@ -2229,6 +2237,11 @@ export function mergeMilestoneToMain(
       process.chdir(originalBasePath_);
     } catch (err) {
       logWarning("worktree", `chdir to project root after merge failed: ${err instanceof Error ? err.message : String(err)}`);
+      debugLog("mergeMilestoneToMain", {
+        phase: "post-merge-chdir-failed",
+        target: originalBasePath_,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   };
 

--- a/src/resources/extensions/gsd/tests/teardown-chdir-failure-clears-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/teardown-chdir-failure-clears-registry.test.ts
@@ -159,4 +159,21 @@ describe("teardown chdir failure clears registry", () => {
     assert.strictEqual(getAutoWorktreeOriginalBase(), null, "registry null after successful teardown");
     assert.strictEqual(getActiveAutoWorktreeContext(), null, "context null after successful teardown");
   });
+
+  test("teardown survives when current working directory was deleted", () => {
+    repoDir = createTempRepo();
+    seedMilestone(repoDir, "M003");
+
+    const worktreePath = createAutoWorktree(repoDir, "M003");
+    process.chdir(worktreePath);
+    rmSync(worktreePath, { recursive: true, force: true });
+
+    assert.doesNotThrow(
+      () => teardownAutoWorktree(repoDir, "M003"),
+      "teardownAutoWorktree should not call process.cwd() unguarded from a deleted cwd",
+    );
+
+    assert.strictEqual(getAutoWorktreeOriginalBase(), null, "registry null after deleted-cwd teardown");
+    assert.strictEqual(getActiveAutoWorktreeContext(), null, "context null after deleted-cwd teardown");
+  });
 });

--- a/src/resources/extensions/gsd/tests/worktree-teardown-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-teardown-safety.test.ts
@@ -25,6 +25,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
 
 import { createWorktree, removeWorktree, worktreePath, isInsideWorktreesDir } from "../worktree-manager.ts";
 import { createTestContext } from "./test-helpers.ts";
@@ -84,6 +85,27 @@ describe("worktree-teardown-safety", () => {
       existsSync(join(dataDir, "important.db")),
       "project data files survive teardown",
     );
+  });
+
+  it("removeWorktree survives when current working directory was deleted", () => {
+    const tempDir = createTempRepo();
+    dirs.push(tempDir);
+
+    const wt = createWorktree(tempDir, "deleted-cwd");
+    assertTrue(existsSync(wt.path), "worktree created successfully");
+
+    const safeCwd = process.cwd();
+    try {
+      process.chdir(wt.path);
+      rmSync(wt.path, { recursive: true, force: true });
+
+      assert.doesNotThrow(
+        () => removeWorktree(tempDir, "deleted-cwd"),
+        "removeWorktree should not call process.cwd() unguarded from a deleted cwd",
+      );
+    } finally {
+      process.chdir(safeCwd);
+    }
   });
 
   it("path validation rejects paths outside .gsd/worktrees/", () => {

--- a/src/resources/extensions/gsd/tests/worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree.test.ts
@@ -9,6 +9,7 @@ import {
   detectWorktreeName,
   getCurrentBranch,
   getMainBranch,
+  nudgeGitBranchCache,
   getSliceBranchName,
   parseSliceBranch,
   resolveProjectRoot,
@@ -94,6 +95,23 @@ describe('worktree', async () => {
   assert.ok(!SLICE_BRANCH_RE.test("main"), "regex rejects main");
   assert.ok(!SLICE_BRANCH_RE.test("gsd/"), "regex rejects bare gsd/");
   assert.ok(!SLICE_BRANCH_RE.test("worktree/foo"), "regex rejects worktree/foo");
+
+  console.log("\n=== nudgeGitBranchCache deleted cwd ===");
+  {
+    const safeCwd = process.cwd();
+    const deletedCwd = mkdtempSync(join(tmpdir(), "gsd-deleted-cwd-"));
+    try {
+      process.chdir(deletedCwd);
+      rmSync(deletedCwd, { recursive: true, force: true });
+
+      assert.doesNotThrow(
+        () => nudgeGitBranchCache(safeCwd),
+        "nudgeGitBranchCache should not call process.cwd() unguarded from a deleted cwd",
+      );
+    } finally {
+      process.chdir(safeCwd);
+    }
+  }
 
   console.log("\n=== detectWorktreeName ===");
   assert.deepStrictEqual(detectWorktreeName("/projects/myapp"), null, "no worktree in plain path");

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -656,7 +656,12 @@ export function removeWorktree(
   const resolvedPathSafe = isInsideWorktreesDir(basePath, resolvedWtPath);
 
   // If we're inside the worktree, move out first — git can't remove an in-use directory
-  const cwd = process.cwd();
+  let cwd: string;
+  try {
+    cwd = process.cwd();
+  } catch {
+    cwd = basePath;
+  }
   const resolvedCwd = existsSync(cwd) ? realpathSync(cwd) : cwd;
   if (resolvedCwd === resolvedWtPath || resolvedCwd.startsWith(resolvedWtPath + sep)) {
     process.chdir(basePath);

--- a/src/resources/extensions/gsd/worktree.ts
+++ b/src/resources/extensions/gsd/worktree.ts
@@ -224,7 +224,13 @@ export function resolveGitHeadPath(dir: string): string | null {
  */
 export function nudgeGitBranchCache(previousCwd: string): void {
   const now = new Date();
-  for (const dir of [previousCwd, process.cwd()]) {
+  let currentCwd: string | null = null;
+  try {
+    currentCwd = process.cwd();
+  } catch {
+    currentCwd = null;
+  }
+  for (const dir of [previousCwd, currentCwd].filter((dir): dir is string => Boolean(dir))) {
     try {
       const headPath = resolveGitHeadPath(dir);
       if (headPath) utimesSync(headPath, now, now);


### PR DESCRIPTION
## Summary
- Guarded teardown cwd reads against deleted working directories and verified the runnable deleted-cwd worktree regression test plus diff checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #733
- [#733 ENOENT: process.cwd() crash in teardownAutoWorktree when cwd was deleted during milestone merge](https://github.com/open-gsd/gsd-pi/issues/733)

## User
- @mattiaverio

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/733-enoent-process-cwd-crash-in-teardownauto-1781476373`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error handling around cwd reads during worktree lifecycle cleanup; behavior unchanged when cwd is valid, with added regression tests.
> 
> **Overview**
> Fixes crashes when the process still has its cwd inside a milestone worktree that was already removed during merge/teardown.
> 
> **`safeCwd`** (and matching try/catch at call sites) replaces bare **`process.cwd()`** in **`teardownAutoWorktree`**, **`removeWorktree`**, and **`nudgeGitBranchCache`** so ENOENT from a deleted cwd no longer aborts cleanup; teardown still clears **`activeWorkspace`** via the existing outer **`finally`**. **`mergeMilestoneToMain`** adds **`debugLog`** when post-merge **`chdir`** to the project root fails.
> 
> Regression tests cover deleted-cwd paths for teardown, worktree removal, and branch-cache nudging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 560a7643b64a6d2ea1a8bc1bf35b7bfd378423bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->