### PR TITLE
test: stabilize managed browser skill sync coverage

### DIFF
--- a/scripts/compile-tests.mjs
+++ b/scripts/compile-tests.mjs
@@ -123,7 +123,16 @@ async function removeStaleMirroredFiles(distDir, srcDir, options = {}) {
     const distPath = join(distDir, entry.name);
     const srcPath = join(srcDir, entry.name);
     if (entry.isDirectory()) {
+      if (!existsSync(srcPath)) {
+        await rm(distPath, { recursive: true, force: true });
+        staleCleaned++;
+        continue;
+      }
       staleCleaned += await removeStaleMirroredFiles(distPath, srcPath, options);
+      if ((await isEmptyDir(distPath)) && (await isEmptyDir(srcPath))) {
+        await rm(distPath, { recursive: true, force: true });
+        staleCleaned++;
+      }
       continue;
     }
     if (!entry.isFile()) continue;
@@ -141,6 +150,14 @@ async function removeStaleMirroredFiles(distDir, srcDir, options = {}) {
   }
 
   return staleCleaned;
+}
+
+async function isEmptyDir(dir) {
+  try {
+    return (await readdir(dir)).length === 0;
+  } catch {
+    return false;
+  }
 }
 
 function isCompiledTestArtifact(filePath) {
@@ -378,12 +395,18 @@ async function main() {
     logLevel: 'warning',
   });
 
+  let staleCleaned = 0;
+
   // Copy non-compiled assets from src/ to dist-test/src/ maintaining structure.
   // Tests use import.meta.url to resolve sibling .md, .yaml, .json, .ts etc.
   // Also copy original .ts files — jiti-based imports load .ts source directly.
   const srcDir = join(ROOT, 'src');
   const distSrcDir = join(DIST_TEST_DIR, 'src');
   await copyAssets(srcDir, distSrcDir);
+  staleCleaned += await removeStaleMirroredFiles(
+    join(distSrcDir, 'resources'),
+    join(srcDir, 'resources'),
+  );
   console.log('Copied non-TS assets and .ts source files to dist-test/src/');
 
   // Copy packages/*/src/ assets as well
@@ -436,6 +459,10 @@ async function main() {
   const rootDistDir = join(ROOT, 'dist');
   const distTestDistDir = join(DIST_TEST_DIR, 'dist');
   await copyAssets(rootDistDir, distTestDistDir);
+  staleCleaned += await removeStaleMirroredFiles(
+    join(distTestDistDir, 'resources'),
+    join(rootDistDir, 'resources'),
+  );
 
   // Post-process: rewrite .ts import specifiers to .js in all compiled JS files.
   // esbuild with bundle:false preserves original specifiers; Node can't load .ts.
@@ -476,7 +503,6 @@ async function main() {
       join(ROOT, 'packages', entry.name, 'src'),
     ]);
   }
-  let staleCleaned = 0;
   for (const [distDir, srcDir] of testDirsToClean) {
     staleCleaned += await removeStaleMirroredFiles(distDir, srcDir, { testOnly: true });
   }

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -34,6 +34,7 @@ const resourceFingerprintFileName = '.managed-resources-content-hash'
 const gsdBrowserSkillName = 'gsd-browser'
 const requireFromResourceLoader = createRequire(import.meta.url)
 const gsdBrowserSkillReferenceDirs = ['docs', 'scripts', 'gsd-browser-skill']
+let gsdBrowserPackageSkillPathForTests: string | null | undefined
 
 interface ManagedResourceManifest {
   gsdVersion: string
@@ -192,11 +193,18 @@ function getCurrentResourceFingerprint(): string {
 }
 
 function resolveGsdBrowserPackageSkillPath(): string | null {
+  if (gsdBrowserPackageSkillPathForTests !== undefined) {
+    return gsdBrowserPackageSkillPathForTests
+  }
   try {
     return requireFromResourceLoader.resolve('@opengsd/gsd-browser/SKILL.md')
   } catch {
     return null
   }
+}
+
+export function setGsdBrowserPackageSkillPathForTests(skillPath: string | null | undefined): void {
+  gsdBrowserPackageSkillPathForTests = skillPath
 }
 
 export function collectGsdBrowserPackageSkillReferences(content: string): string[] {

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join, parse } from "node:path";
+import { dirname, join, parse } from "node:path";
 import { tmpdir } from "node:os";
 import { parse as parseYaml } from "yaml";
 
@@ -59,8 +59,12 @@ function currentPackageVersion(): string {
     : packageJson.version;
 }
 
+function packagedGsdBrowserSkillPath(): string {
+  return requireFromTest.resolve("@opengsd/gsd-browser/SKILL.md");
+}
+
 function packagedGsdBrowserSkill(): string {
-  return readFileSync(requireFromTest.resolve("@opengsd/gsd-browser/SKILL.md"), "utf-8");
+  return readFileSync(packagedGsdBrowserSkillPath(), "utf-8");
 }
 
 test("getExtensionKey normalizes top-level .ts and .js entry names to the same key", async () => {
@@ -272,35 +276,23 @@ test("initResources syncs the gsd-browser skill from the installed gsd-browser p
   const supportRefs = collectGsdBrowserPackageSkillReferences(packageSkill);
   assert.ok(supportRefs.includes("docs/mcp.md"), "test package skill should reference MCP docs");
 
-  // sync installs only the SKILL.md backtick-referenced files the package
-  // actually ships beside its SKILL.md (no placeholder fallback). Verify
-  // each shipped reference lands at the target with the correct mode, and
-  // that references the package omits are NOT installed as stubs.
-  const sourceSkillPath = requireFromTest.resolve("@opengsd/gsd-browser/SKILL.md");
-  const sourceDir = join(sourceSkillPath, "..");
-  let shippedRefCount = 0;
+  const packageSkillDir = dirname(packagedGsdBrowserSkillPath());
+
   for (const relPath of supportRefs) {
-    const sourcePath = join(sourceDir, relPath);
     const targetPath = join(fakeAgentDir, "skills", "gsd-browser", relPath);
-    if (existsSync(sourcePath)) {
-      shippedRefCount += 1;
-      assert.equal(existsSync(targetPath), true, `${relPath} ships with the package and must be installed`);
-      if (relPath.startsWith("scripts/") && relPath.endsWith(".sh")) {
-        assert.notEqual(statSync(targetPath).mode & 0o111, 0, `${relPath} should be executable`);
-      }
-    } else {
-      assert.equal(
-        existsSync(targetPath),
-        false,
-        `${relPath} is referenced by SKILL.md but not shipped by the package; sync must not fabricate a stub`,
-      );
+    const packagePath = join(packageSkillDir, relPath);
+    const packageShipsRef = existsSync(packagePath);
+
+    assert.equal(
+      existsSync(targetPath),
+      packageShipsRef,
+      `${relPath} install state should match whether @opengsd/gsd-browser ships it`,
+    );
+
+    if (packageShipsRef && relPath.startsWith("scripts/") && relPath.endsWith(".sh")) {
+      assert.notEqual(statSync(targetPath).mode & 0o111, 0, `${relPath} should be executable`);
     }
   }
-  // The shippedRefCount may legitimately be zero today: @opengsd/gsd-browser@0.1.27
-  // only ships SKILL.md itself and not the backtick-referenced support files.
-  // The non-stub assertion above is still meaningful; record the count for
-  // diagnostic output if the suite fails.
-  void shippedRefCount;
 });
 
 test("initResources refreshes a stale managed gsd-browser package skill", async (t) => {
@@ -314,16 +306,28 @@ test("initResources refreshes a stale managed gsd-browser package skill", async 
   });
 
   const {
+    collectGsdBrowserPackageSkillReferences,
     computeResourceFingerprint,
     hasStaleGsdBrowserPackageSkill,
     initResources,
   } = await import("../resource-loader.ts");
   initResources(fakeAgentDir);
+  const packageSkill = packagedGsdBrowserSkill();
+  const packageSkillDir = dirname(packagedGsdBrowserSkillPath());
+  const missingSupportRef = collectGsdBrowserPackageSkillReferences(packageSkill)
+    .find((relPath) => !existsSync(join(packageSkillDir, relPath)));
+
+  if (missingSupportRef) {
+    const placeholderPath = join(fakeAgentDir, "skills", "gsd-browser", missingSupportRef);
+    mkdirSync(dirname(placeholderPath), { recursive: true });
+    writeFileSync(placeholderPath, "stale placeholder\n");
+  }
 
   writeFileSync(
     join(fakeAgentDir, "skills", "gsd-browser", "SKILL.md"),
     "---\nname: gsd-browser\ndescription: stale\n---\n",
   );
+  rmSync(join(fakeAgentDir, "skills", "gsd-browser", "docs", "mcp.md"), { force: true });
   writeFileSync(
     join(fakeAgentDir, "managed-resources.json"),
     JSON.stringify({
@@ -343,9 +347,16 @@ test("initResources refreshes a stale managed gsd-browser package skill", async 
 
   assert.equal(
     readFileSync(join(fakeAgentDir, "skills", "gsd-browser", "SKILL.md"), "utf-8"),
-    packagedGsdBrowserSkill(),
+    packageSkill,
     "current managed-resource manifests must not skip stale package-owned gsd-browser skills",
   );
+  if (missingSupportRef) {
+    assert.equal(
+      existsSync(join(fakeAgentDir, "skills", "gsd-browser", missingSupportRef)),
+      false,
+      "current managed-resource manifests must prune stale placeholder support files not shipped by @opengsd/gsd-browser",
+    );
+  }
 });
 
 test("syncGsdBrowserPackageSkill preserves existing managed skill when the package is unresolvable", async (t) => {
@@ -353,22 +364,13 @@ test("syncGsdBrowserPackageSkill preserves existing managed skill when the packa
   const fakeAgentDir = join(tmp, ".gsd", "agent");
   const restoreHomeEnv = overrideHomeEnv(tmp);
 
-  // Make @opengsd/gsd-browser unresolvable by temporarily renaming its
-  // node_modules entry. Restore on teardown regardless of test outcome.
-  const browserPkgDir = join(process.cwd(), "node_modules", "@opengsd", "gsd-browser");
-  const browserPkgBackup = `${browserPkgDir}.test-backup`;
-  const { renameSync } = await import("node:fs");
-
-  let renamed = false;
   t.after(() => {
-    if (renamed) {
-      try { renameSync(browserPkgBackup, browserPkgDir); } catch { /* best effort */ }
-    }
     restoreHomeEnv();
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  const { initResources } = await import("../resource-loader.ts");
+  const { initResources, setGsdBrowserPackageSkillPathForTests } = await import("../resource-loader.ts");
+  t.after(() => setGsdBrowserPackageSkillPathForTests(undefined));
 
   // Seed a known-good managed install from the real package while it is
   // still resolvable.
@@ -381,9 +383,8 @@ test("syncGsdBrowserPackageSkill preserves existing managed skill when the packa
   );
   const installedContent = readFileSync(targetSkillPath, "utf-8");
 
-  // Now make the package unresolvable.
-  renameSync(browserPkgDir, browserPkgBackup);
-  renamed = true;
+  // Now make the package unresolvable without mutating shared node_modules.
+  setGsdBrowserPackageSkillPathForTests(null);
 
   // Force a sync attempt by deleting the manifest so initResources cannot
   // short-circuit on the fingerprint.
@@ -407,24 +408,20 @@ test("hasStaleGsdBrowserPackageSkill does not report stale when the package is u
   const fakeAgentDir = join(tmp, ".gsd", "agent");
   const restoreHomeEnv = overrideHomeEnv(tmp);
 
-  const browserPkgDir = join(process.cwd(), "node_modules", "@opengsd", "gsd-browser");
-  const browserPkgBackup = `${browserPkgDir}.test-backup`;
-  const { renameSync } = await import("node:fs");
-
-  let renamed = false;
   t.after(() => {
-    if (renamed) {
-      try { renameSync(browserPkgBackup, browserPkgDir); } catch { /* best effort */ }
-    }
     restoreHomeEnv();
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  const { hasStaleGsdBrowserPackageSkill, initResources } = await import("../resource-loader.ts");
+  const {
+    hasStaleGsdBrowserPackageSkill,
+    initResources,
+    setGsdBrowserPackageSkillPathForTests,
+  } = await import("../resource-loader.ts");
+  t.after(() => setGsdBrowserPackageSkillPathForTests(undefined));
   initResources(fakeAgentDir);
 
-  renameSync(browserPkgDir, browserPkgBackup);
-  renamed = true;
+  setGsdBrowserPackageSkillPathForTests(null);
 
   assert.equal(
     hasStaleGsdBrowserPackageSkill(join(fakeAgentDir, "skills")),

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -448,6 +448,7 @@ test("/gsd update browser handler fetches latest gsd-browser version", async () 
   const originalFetch = globalThis.fetch;
   const originalGsdHome = process.env.GSD_HOME;
   const originalPath = process.env.PATH;
+  const originalBrowserPathVersion = process.env.GSD_BROWSER_PATH_VERSION;
   const fetchUrls: string[] = [];
   const notifications: Array<{ message: string; level: string }> = [];
   const browserVersion = resolveInstalledPackageVersion(GSD_BROWSER_PACKAGE_NAME) ?? "0.1.27";
@@ -461,6 +462,7 @@ test("/gsd update browser handler fetches latest gsd-browser version", async () 
     writeFakeClaude(binDir, "2.1.100 (Claude Code)");
     process.env.GSD_HOME = tmp;
     process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`;
+    process.env.GSD_BROWSER_PATH_VERSION = browserVersion;
     globalThis.fetch = async (input) => {
       fetchUrls.push(String(input));
       return Response.json({ version: browserVersion });
@@ -485,6 +487,11 @@ test("/gsd update browser handler fetches latest gsd-browser version", async () 
       delete process.env.PATH;
     } else {
       process.env.PATH = originalPath;
+    }
+    if (originalBrowserPathVersion === undefined) {
+      delete process.env.GSD_BROWSER_PATH_VERSION;
+    } else {
+      process.env.GSD_BROWSER_PATH_VERSION = originalBrowserPathVersion;
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid mutating node_modules when testing missing @opengsd/gsd-browser package resolution
- prune stale mirrored resource assets/directories from dist-test during test compilation
- isolate /gsd update browser tests from local PATH gsd-browser versions

## Verification
- PATH="/Users/jeremymcspadden/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm run verify:pr
- 10703 passed, 0 failed, 10 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test compilation cleanup and test-only hooks/env isolation; production resource-loader resolution is unchanged unless the test setter is used.
> 
> **Overview**
> Improves **test reliability** around managed `gsd-browser` skill sync and `dist-test` mirrors without changing production sync behavior for normal installs.
> 
> **`compile-tests.mjs`** extends stale mirror cleanup: drop `dist-test` dirs/files when the source tree no longer has them, remove empty mirrored directories, and run that pass on **`resources`** under both `dist-test/src` and `dist-test/dist` right after asset copy so old resource artifacts do not linger across compiles.
> 
> **`resource-loader.ts`** adds **`setGsdBrowserPackageSkillPathForTests`** so tests can simulate an unresolvable `@opengsd/gsd-browser` package without renaming shared `node_modules`. **`resource-loader.test.ts`** uses that hook, tightens support-file assertions to match what the package actually ships, and covers pruning stale placeholders on refresh.
> 
> **`update-cmd-diagnostics.test.ts`** pins **`GSD_BROWSER_PATH_VERSION`** during the `/gsd update browser` handler test so results do not depend on whatever `gsd-browser` is on the developer PATH.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd932406c9f8ae16b9fb218029ca23b8682181d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->