### PR TITLE
chore: ignore local .opencode/ agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ docs/coherence-audit/
 # Local agent/editor state
 .claude/
 .agents/
+.opencode/
 .idea/
 .vscode/
 *.code-workspace


### PR DESCRIPTION
## What Changed

- Added `.opencode/` to `.gitignore` so local OpenCode agent session state stays untracked and out of `git status`.

## Risk Assessment

✅ Low: The only change is a one-line addition of `.opencode/` to the existing local-agent-state block in .gitignore, which is cosmetic and well-bounded.

## Testing

This is a trivial, non-UI `.gitignore` change, so the appropriate end-user evidence is a git CLI transcript rather than a visual artifact. I created a representative `.opencode/sessions/local-state.json` file and demonstrated that git now ignores it (`git check-ignore` points to the new `.gitignore:48` rule and `git status` reports a clean tree), while the base commit had no such rule — confirming the developer-facing behavior of keeping local OpenCode agent state out of version control. The transient `.opencode/` directory was removed afterward, leaving the worktree clean.

<details>
<summary>Evidence: git check-ignore + status transcript</summary>

```text
$ git check-ignore -v .opencode/ .opencode/sessions/local-state.json
.gitignore:48:.opencode/ .opencode/
.gitignore:48:.opencode/ .opencode/sessions/local-state.json

$ git status --porcelain
(empty — no .opencode entries, tree clean)

# Counterfactual at base commit 822c9439:
$ git show 822c9439:.gitignore | grep opencode
(no .opencode rule at base commit)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff` base..target — confirmed the only change is `+.opencode/` in `.gitignore`</code>
- <code>Created `.opencode/sessions/local-state.json`, then `git check-ignore -v` confirmed it matches the new rule at `.gitignore:48`</code>
- <code>`git status --porcelain` — confirmed no `.opencode` entries appear (stays clean)</code>
- <code>`git show &lt;base&gt;:.gitignore` — confirmed base commit had no `.opencode` rule (counterfactual)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` entry with no runtime, security, or data-path behavior changes.
> 
> **Overview**
> Adds **`.opencode/`** to the local agent/editor ignore block in `.gitignore`, alongside `.claude/` and `.agents/`, so OpenCode session and workspace state under that directory is not tracked or shown in `git status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57940d8f24157a94412ca0c5ff0b52e1941af0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->