### PR TITLE
fix(issue): [Bug]: Deadlock when trying to resume a parallel workflow

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1271,11 +1271,18 @@ export async function bootstrapAutoSession(
       }
     }
 
-    const blockingStrandedRecoveryAction = state.activeMilestone
+    const requestedMilestoneLock = process.env.GSD_MILESTONE_LOCK?.trim() || null;
+    const lockedStrandedRecoveryAction = requestedMilestoneLock
       ? strandedRecoveryActions.find(
-        (action) => action.milestoneId !== state.activeMilestone?.id,
-      ) ?? strandedRecoveryAction
-      : strandedRecoveryAction;
+        (action) => action.milestoneId === requestedMilestoneLock,
+      ) ?? null
+      : null;
+    const blockingStrandedRecoveryAction = lockedStrandedRecoveryAction
+      ?? (state.activeMilestone
+        ? strandedRecoveryActions.find(
+          (action) => action.milestoneId !== state.activeMilestone?.id,
+        ) ?? strandedRecoveryAction
+        : strandedRecoveryAction);
 
     if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -455,6 +455,93 @@ test("bootstrap blocks active stranded recovery when another open milestone also
   }
 });
 
+test("bootstrap honors explicit milestone lock when multiple milestones have stranded work", async () => {
+  const base = makeRepoWithMultipleStrandedMilestones();
+  const previousCwd = process.cwd();
+  const previousLock = process.env.GSD_MILESTONE_LOCK;
+  const s = new AutoSession();
+  const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    process.env.GSD_MILESTONE_LOCK = "M002";
+
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: () => ({ ok: true, mode: "none", path: base }),
+          adoptStrandedMilestone: (
+            milestoneId: string,
+            sessionBase: string,
+            _ctx: unknown,
+            opts: { mode: "worktree" | "branch" },
+          ) => {
+            adoptCalls.push({ milestoneId, mode: opts.mode });
+            s.basePath = sessionBase;
+            s.originalBasePath = sessionBase;
+            s.strandedRecoveryIsolationMode = opts.mode;
+            return { ok: true, mode: opts.mode, path: sessionBase };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    const messages = notifications.map((entry) => entry.message).join("\n");
+    assert.equal(ready, true);
+    assert.deepEqual(adoptCalls, [{ milestoneId: "M002", mode: "branch" }]);
+    assert.equal(s.currentMilestoneId, "M002");
+    assert.match(messages, /Resuming saved milestone work for M002/);
+    assert.doesNotMatch(messages, /Stranded work for M001 blocks auto-mode before M002/);
+  } finally {
+    if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+    else process.env.GSD_MILESTONE_LOCK = previousLock;
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("bootstrap honors explicit solo milestone lock when recovering stranded target worktree", async () => {
   const base = makeRepoWithActiveMismatchAndStrandedTarget();
   const previousCwd = process.cwd();


### PR DESCRIPTION
## Summary
- Fixed explicit locked stranded-milestone recovery to avoid parallel resume deadlocks and added a regression test; verified diff and TypeScript syntax locally.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #742
- [#742 [Bug]: Deadlock when trying to resume a parallel workflow](https://github.com/open-gsd/gsd-pi/issues/742)

## User
- @sbaechler

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/742-bug-deadlock-when-trying-to-resume-a-par-1781520411`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto bootstrap stranded-work gating used by parallel workers; behavior is narrow (env lock + multi-stranded case) and covered by a new test, but incorrect lock handling could still block or adopt the wrong milestone.
> 
> **Overview**
> Fixes parallel workflow resume deadlocks when **multiple milestones** have stranded work.
> 
> Auto bootstrap now reads **`GSD_MILESTONE_LOCK`** when choosing which stranded recovery action blocks startup. If the lock matches a stranded milestone, that milestone is treated as the recovery target instead of blocking on unrelated stranded work (e.g. no longer erroring with “M002 blocks auto-mode before M001” when the worker is explicitly locked to **M002**).
> 
> Adds a regression test: active **M001** plus stranded **M002**, lock **M002** → bootstrap resumes **M002** via `adoptStrandedMilestone` and does not emit the cross-milestone blocker message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3606ac3753b4eadada1979300749067cf2b266a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->