### PR TITLE
fix(issue): [Bug]: Deadlock when trying to resume a parallel workflow

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1274,15 +1274,26 @@ export async function bootstrapAutoSession(
     const requestedMilestoneLock = process.env.GSD_MILESTONE_LOCK?.trim() || null;
     const lockedActiveMilestone =
       requestedMilestoneLock && state.activeMilestone?.id === requestedMilestoneLock;
-    const blockingStrandedRecoveryAction = lockedActiveMilestone
-      ? strandedRecoveryActions.find(
+    let blockingStrandedRecoveryAction: OrphanAuditAction | null;
+    if (lockedActiveMilestone) {
+      // Parallel worker or explicit `/gsd auto Mxxx`: sibling milestones'
+      // stranded work must not block this milestone's resumption, and the
+      // downstream `strandedRecoveryAction` (used for currentMilestoneId,
+      // setActiveMilestoneId, and adoptStrandedMilestone) must be scoped to
+      // the locked milestone only. Falling back to the first sibling action
+      // would mis-target adoption (#742).
+      const lockMatch = strandedRecoveryActions.find(
         (action) => action.milestoneId === requestedMilestoneLock,
-      ) ?? null
-      : state.activeMilestone
-        ? strandedRecoveryActions.find(
-          (action) => action.milestoneId !== state.activeMilestone?.id,
-        ) ?? strandedRecoveryAction
-        : strandedRecoveryAction;
+      ) ?? null;
+      blockingStrandedRecoveryAction = lockMatch;
+      strandedRecoveryAction = lockMatch;
+    } else if (state.activeMilestone) {
+      blockingStrandedRecoveryAction = strandedRecoveryActions.find(
+        (action) => action.milestoneId !== state.activeMilestone?.id,
+      ) ?? strandedRecoveryAction;
+    } else {
+      blockingStrandedRecoveryAction = strandedRecoveryAction;
+    }
 
     if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1271,11 +1271,18 @@ export async function bootstrapAutoSession(
       }
     }
 
-    const blockingStrandedRecoveryAction = state.activeMilestone
+    const requestedMilestoneLock = process.env.GSD_MILESTONE_LOCK?.trim() || null;
+    const lockedActiveMilestone =
+      requestedMilestoneLock && state.activeMilestone?.id === requestedMilestoneLock;
+    const blockingStrandedRecoveryAction = lockedActiveMilestone
       ? strandedRecoveryActions.find(
-        (action) => action.milestoneId !== state.activeMilestone?.id,
-      ) ?? strandedRecoveryAction
-      : strandedRecoveryAction;
+        (action) => action.milestoneId === requestedMilestoneLock,
+      ) ?? null
+      : state.activeMilestone
+        ? strandedRecoveryActions.find(
+          (action) => action.milestoneId !== state.activeMilestone?.id,
+        ) ?? strandedRecoveryAction
+        : strandedRecoveryAction;
 
     if (blockingStrandedRecoveryAction) {
       if (!state.activeMilestone) {

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1315,6 +1315,8 @@ export async function bootstrapAutoSession(
         formatStrandedWorkRecoveryMessage(strandedRecoveryAction),
         "info",
       );
+    } else if (lockedActiveMilestone) {
+      strandedRecoveryAction = null;
     }
 
     if (

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -118,6 +118,45 @@ function makeRepoWithMultipleStrandedMilestones(): string {
   return base;
 }
 
+function makeRepoWithOnlySiblingStrandedAndLockedActive(): string {
+  // Locked milestone (M002) is the active row but has NO stranded
+  // milestone branch. A sibling milestone (M001) has a stranded branch.
+  // A parallel worker locked to M002 must skip the sibling's stranded
+  // action entirely — neither block on it nor adopt it.
+  const base = mkdtempSync(join(tmpdir(), "gsd-locked-no-stranded-bootstrap-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M002"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: \"none\"\n---\n",
+  );
+  runGit(base, ["init"]);
+  runGit(base, ["config", "user.email", "test@test.com"]);
+  runGit(base, ["config", "user.name", "Test"]);
+  writeFileSync(join(base, "README.md"), "# test\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "init"]);
+  runGit(base, ["branch", "-M", "main"]);
+
+  // Sibling M001 has stranded work on milestone/M001.
+  runGit(base, ["checkout", "-b", "milestone/M001"]);
+  writeFileSync(join(base, "m001.txt"), "sibling stranded work\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M001 in progress"]);
+  runGit(base, ["checkout", "main"]);
+
+  // M002 has no stranded branch at all.
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  // Both milestones are open so the stranded audit produces a blocking
+  // action for the sibling (M001). M002 is the lock target and active
+  // row; getActiveMilestoneId honors the lock regardless of M001 order.
+  insertMilestone({ id: "M001", title: "Sibling milestone", status: "pending" });
+  insertMilestone({ id: "M002", title: "Locked milestone", status: "active" });
+  closeDatabase();
+
+  return base;
+}
+
 function makeRepoWithActiveMismatchAndStrandedTarget(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-targeted-stranded-bootstrap-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
@@ -534,6 +573,105 @@ test("parallel worker recovers its locked stranded milestone despite stranded si
     assert.match(messages, /Resuming saved milestone work for M002/);
     assert.doesNotMatch(messages, /blocks auto-mode before M002/);
     assert.doesNotMatch(messages, /\/gsd auto M001/);
+  } finally {
+    if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+    else process.env.GSD_MILESTONE_LOCK = previousLock;
+    if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
+    else process.env.GSD_PARALLEL_WORKER = previousWorker;
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("locked worker with no own stranded action does not adopt sibling stranded action", async () => {
+  const base = makeRepoWithOnlySiblingStrandedAndLockedActive();
+  const previousCwd = process.cwd();
+  const previousLock = process.env.GSD_MILESTONE_LOCK;
+  const previousWorker = process.env.GSD_PARALLEL_WORKER;
+  const s = new AutoSession();
+  const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];
+  const enterCalls: string[] = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    process.env.GSD_PARALLEL_WORKER = "1";
+    process.env.GSD_MILESTONE_LOCK = "M002";
+
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: (mid: string) => {
+            enterCalls.push(mid);
+            return { ok: true, mode: "none", path: base };
+          },
+          adoptStrandedMilestone: (
+            milestoneId: string,
+            sessionBase: string,
+            _ctx: unknown,
+            opts: { mode: "worktree" | "branch" },
+          ) => {
+            adoptCalls.push({ milestoneId, mode: opts.mode });
+            s.basePath = sessionBase;
+            s.originalBasePath = sessionBase;
+            s.strandedRecoveryIsolationMode = opts.mode;
+            return { ok: true, mode: opts.mode, path: sessionBase };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    const messages = notifications.map((entry) => entry.message).join("\n");
+    assert.equal(ready, true);
+    // Must not adopt M001 (the sibling stranded action) — the locked
+    // worker has no stranded action of its own, so adoption should not
+    // run at all. enterMilestone for M002 is also gated off by
+    // isolation=none with no stranded recoveryMode (#742 regression).
+    assert.deepEqual(adoptCalls, []);
+    assert.equal(s.currentMilestoneId, "M002");
+    assert.doesNotMatch(messages, /Resuming saved milestone work for M001/);
+    assert.doesNotMatch(messages, /blocks auto-mode before M002/);
   } finally {
     if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
     else process.env.GSD_MILESTONE_LOCK = previousLock;

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -455,6 +455,98 @@ test("bootstrap blocks active stranded recovery when another open milestone also
   }
 });
 
+test("parallel worker recovers its locked stranded milestone despite stranded siblings", async () => {
+  const base = makeRepoWithMultipleStrandedMilestones();
+  const previousCwd = process.cwd();
+  const previousLock = process.env.GSD_MILESTONE_LOCK;
+  const previousWorker = process.env.GSD_PARALLEL_WORKER;
+  const s = new AutoSession();
+  const adoptCalls: Array<{ milestoneId: string; mode: string }> = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    process.env.GSD_PARALLEL_WORKER = "1";
+    process.env.GSD_MILESTONE_LOCK = "M002";
+
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+          enterMilestone: () => ({ ok: true, mode: "none", path: base }),
+          adoptStrandedMilestone: (
+            milestoneId: string,
+            sessionBase: string,
+            _ctx: unknown,
+            opts: { mode: "worktree" | "branch" },
+          ) => {
+            adoptCalls.push({ milestoneId, mode: opts.mode });
+            s.basePath = sessionBase;
+            s.originalBasePath = sessionBase;
+            s.strandedRecoveryIsolationMode = opts.mode;
+            return { ok: true, mode: opts.mode, path: sessionBase };
+          },
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    const messages = notifications.map((entry) => entry.message).join("\n");
+    assert.equal(ready, true);
+    assert.deepEqual(adoptCalls, [{ milestoneId: "M002", mode: "branch" }]);
+    assert.equal(s.currentMilestoneId, "M002");
+    assert.match(messages, /Resuming saved milestone work for M002/);
+    assert.doesNotMatch(messages, /blocks auto-mode before M002/);
+    assert.doesNotMatch(messages, /\/gsd auto M001/);
+  } finally {
+    if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+    else process.env.GSD_MILESTONE_LOCK = previousLock;
+    if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
+    else process.env.GSD_PARALLEL_WORKER = previousWorker;
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("bootstrap honors explicit solo milestone lock when recovering stranded target worktree", async () => {
   const base = makeRepoWithActiveMismatchAndStrandedTarget();
   const previousCwd = process.cwd();

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -126,6 +126,12 @@ function makeRepoWithOnlySiblingStrandedAndLockedActive(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-locked-no-stranded-bootstrap-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
   mkdirSync(join(base, ".gsd", "milestones", "M002"), { recursive: true });
+  // M002 has CONTEXT so bootstrap's pre-planning gate doesn't route to
+  // showSmartEntry and the test reaches the post-lock session-init path.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M002", "M002-CONTEXT.md"),
+    "# M002 context\n",
+  );
   writeFileSync(
     join(base, ".gsd", "PREFERENCES.md"),
     "---\ngit:\n  isolation: \"none\"\n---\n",


### PR DESCRIPTION
## Summary
- Fixed locked parallel stranded-work recovery arbitration and added regression coverage; lightweight diff verification passed, but dependency-based tests were blocked by missing packages and network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #742
- [#742 [Bug]: Deadlock when trying to resume a parallel workflow](https://github.com/open-gsd/gsd-pi/issues/742)

## User
- @sbaechler

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/742-bug-deadlock-when-trying-to-resume-a-par-1781520072`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-bootstrap stranded-work arbitration for parallel workers and explicit milestone locks; wrong scoping could still block or mis-adopt milestones, but behavior is narrow and covered by new tests.
> 
> **Overview**
> Fixes parallel auto-mode **deadlock on resume** when another milestone still has stranded git work: workers with **`GSD_MILESTONE_LOCK`** matching the active milestone no longer treat **sibling** stranded actions as blockers or fall back to the first orphan audit action.
> 
> In **`bootstrapAutoSession`**, locked workers only consider stranded recovery for the locked milestone ID, clear **`strandedRecoveryAction`** when that milestone has no stranded work (so a sibling is not adopted), and keep solo-session behavior unchanged when the lock does not match the active milestone.
> 
> Adds bootstrap regression tests for a locked worker recovering its own stranded branch alongside siblings, and for a locked active milestone with **no** stranded branch (must not adopt the sibling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cef01177e719a1a1a5a8ba072f788e62713a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->