### PR TITLE
fix(issue): refresh bundled gsd-browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "@mariozechner/jiti": "^2.6.2",
     "@mistralai/mistralai": "2.2.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@opengsd/gsd-browser": "0.1.27",
+    "@opengsd/gsd-browser": "0.2.2",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "@sinclair/typebox": "^0.34.41",
     "@smithy/node-http-handler": "^4.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^1.27.1
         version: 1.29.0(zod@4.4.3)
       '@opengsd/gsd-browser':
-        specifier: 0.1.27
-        version: 0.1.27
+        specifier: 0.2.2
+        version: 0.2.2
       '@silvia-odwyer/photon-node':
         specifier: ^0.3.4
         version: 0.3.4
@@ -393,16 +393,16 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
-        version: 0.91.1(zod@3.25.76)
+        version: 0.91.1(zod@4.4.3)
       '@anthropic-ai/vertex-sdk':
         specifier: 0.14.4
-        version: 0.14.4(zod@3.25.76)
+        version: 0.14.4(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
       '@google/genai':
         specifier: 1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai':
         specifier: 2.2.1
         version: 2.2.1
@@ -417,7 +417,7 @@ importers:
         version: 7.0.6
       openai:
         specifier: 6.26.0
-        version: 6.26.0(ws@8.21.0)(zod@3.25.76)
+        version: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json:
         specifier: 0.1.7
         version: 0.1.7
@@ -1960,8 +1960,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@opengsd/gsd-browser@0.1.27':
-    resolution: {integrity: sha512-bUSdFD5VgX1gOk1l5PaZrMBPRc+eh6zQsMLS6nwX4PHDpQgLojIFqD+NTZzifEOynSlHPBy8LbD8T8Bj1iQnDg==}
+  '@opengsd/gsd-browser@0.2.2':
+    resolution: {integrity: sha512-ld4TOZKcXJF3v0KVlUqrOfHC+rYG8l00Dw0GkEuHtQTIYq7+blYO2acnGHN+P2Owod0xlq/2k1UQDaYgrRSKgw==}
     engines: {node: '>=16'}
     cpu: [arm64, x64]
     os: [darwin, linux, win32]
@@ -6401,25 +6401,11 @@ snapshots:
 
   '@anthropic-ai/sdk@0.52.0': {}
 
-  '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
-
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-
-  '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.76)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      google-auth-library: 9.15.1
-    transitivePeerDependencies:
-      - supports-color
-      - zod
 
   '@anthropic-ai/vertex-sdk@0.14.4(zod@4.4.3)':
     dependencies:
@@ -7299,19 +7285,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.6.1
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
@@ -7628,29 +7601,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
@@ -7741,7 +7691,7 @@ snapshots:
   '@opengsd/engine-win32-x64-msvc@1.2.0':
     optional: true
 
-  '@opengsd/gsd-browser@0.1.27': {}
+  '@opengsd/gsd-browser@0.2.2': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -11539,11 +11489,6 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
-
-  openai@6.26.0(ws@8.21.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 3.25.76
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -246,6 +246,36 @@ test('checkForGsdBrowserUpdates checks and caches the browser package independen
   assert.equal(readUpdateCache(cachePath, GSD_BROWSER_PACKAGE_NAME)?.latestVersion, '0.1.99')
 })
 
+test('checkForGsdBrowserUpdates treats a newer PATH browser as the current version', async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-browser-update-'))
+  const cachePath = join(tmp, '.update-check-gsd-browser')
+  const registry = await startMockRegistry({ version: '0.2.2' })
+  const originalPathVersion = process.env.GSD_BROWSER_PATH_VERSION
+  t.after(async () => {
+    if (originalPathVersion === undefined) {
+      delete process.env.GSD_BROWSER_PATH_VERSION
+    } else {
+      process.env.GSD_BROWSER_PATH_VERSION = originalPathVersion
+    }
+    await registry.close()
+    rmSync(tmp, { recursive: true, force: true })
+  });
+
+  process.env.GSD_BROWSER_PATH_VERSION = '0.2.2'
+  let called = false
+
+  await checkForGsdBrowserUpdates({
+    cachePath,
+    registryUrl: registry.url,
+    checkIntervalMs: 0,
+    fetchTimeoutMs: 5000,
+    onUpdate: () => { called = true },
+  })
+
+  assert.equal(called, false, 'startup banner must not fire when PATH already has latest gsd-browser')
+  assert.equal(readUpdateCache(cachePath, GSD_BROWSER_PACKAGE_NAME)?.latestVersion, '0.2.2')
+})
+
 test('checkForUpdates uses cache and skips fetch when checked recently', async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), 'gsd-update-'))
   const cachePath = join(tmp, '.update-check')


### PR DESCRIPTION
## Linked issue

Closes #738

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Refresh the bundled `@opengsd/gsd-browser` dependency to `0.2.2` and add a startup notifier regression.
**Why:** `gsd-pi@1.2.0` bundles `gsd-browser@0.1.27`, which can keep reporting a stale browser update even after users install the newer top-level browser.
**How:** Update the root dependency and lockfile, then assert `checkForGsdBrowserUpdates()` treats a newer PATH `gsd-browser` as the effective current version.

## What

- Bumps the bundled `@opengsd/gsd-browser` package from `0.1.27` to `0.2.2`.
- Refreshes the pnpm lockfile for the new browser package version.
- Adds a regression test covering the startup browser update check when PATH already resolves the latest browser binary.

## Why

Users who run `gsd update browser` should not be stuck with a recurring, misleading `gsd-browser update available` banner. The existing runtime/update code already compares against the effective PATH version; this PR makes the bundled version current and pins the startup-notifier behavior with a test.

## How

The dependency bump aligns the package GSD installs and loads with the current npm `latest` for `@opengsd/gsd-browser`. The new test exercises `checkForGsdBrowserUpdates()` without an explicit `currentVersion`, so it covers the default bundled-vs-PATH version selection used during CLI startup.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/update-check.test.ts src/tests/update-cmd-diagnostics.test.ts src/resources/extensions/gsd/tests/mcp-project-config.test.ts`
- [x] `pnpm run test:changed:src`
- [x] `pnpm run verify:fast`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run validate-pack`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and test-only change; no auth or runtime logic edits beyond aligning the bundled browser version.
> 
> **Overview**
> **Bumps the bundled `@opengsd/gsd-browser` dependency from `0.1.27` to `0.2.2`** and refreshes `pnpm-lock.yaml` so installs ship the current browser package instead of an older bundled copy that could disagree with what users install via `gsd update browser`.
> 
> Adds a regression test for **`checkForGsdBrowserUpdates()`** when no explicit `currentVersion` is passed: with `GSD_BROWSER_PATH_VERSION` set to the registry’s latest (`0.2.2`), the startup update callback must **not** run and the browser-specific cache should record `0.2.2`. That pins the PATH-vs-bundled version behavior used at CLI startup so users who already have the latest `gsd-browser` on PATH are not nagged by a misleading banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9878886e5edcf2198e53451688ec5efdde440755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->