### PR TITLE
fix(gsd): ignore completed workflow template state

### DIFF
--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -80,13 +80,13 @@ function datePrefix(): string {
 
 // ─── State Types ─────────────────────────────────────────────────────────────
 
-interface WorkflowPhaseState {
+export interface WorkflowPhaseState {
   name: string;
   index: number;
   status: "pending" | "active" | "completed";
 }
 
-interface WorkflowState {
+export interface WorkflowState {
   template: string;
   templateName: string;
   description: string;
@@ -97,6 +97,13 @@ interface WorkflowState {
   updatedAt: string;
   completedAt?: string;
   artifactDir: string;
+}
+
+export function isWorkflowStateComplete(state: WorkflowState): boolean {
+  if (state.completedAt) return true;
+  return Array.isArray(state.phases) &&
+    state.phases.length > 0 &&
+    state.phases.every((phase) => phase.status === "completed");
 }
 
 /**
@@ -133,7 +140,7 @@ function writeWorkflowState(
  * Scan all workflow artifact directories for in-progress STATE.json files.
  * Returns workflows that were started but not completed.
  */
-function findInProgressWorkflows(basePath: string): WorkflowState[] {
+export function findInProgressWorkflows(basePath: string): WorkflowState[] {
   const workflowsRoot = join(gsdRoot(basePath), "workflows");
   if (!existsSync(workflowsRoot)) return [];
 
@@ -152,7 +159,7 @@ function findInProgressWorkflows(basePath: string): WorkflowState[] {
         try {
           const raw = readFileSync(statePath, "utf-8");
           const state = JSON.parse(raw) as WorkflowState;
-          if (!state.completedAt) {
+          if (!isWorkflowStateComplete(state)) {
             results.push(state);
           }
         } catch { /* corrupted state file — skip */ }

--- a/src/resources/extensions/gsd/prompts/workflow-start.md
+++ b/src/resources/extensions/gsd/prompts/workflow-start.md
@@ -25,4 +25,5 @@ Follow the workflow defined below. Execute each phase in order, completing one b
 3. **Atomic commits.** Commit working code after each meaningful change. Use conventional commit format: `<type>(<scope>): <description>`.
 4. **Verify before shipping.** Run the project's test suite and build before marking the workflow complete.
 5. **Decision gates, not ceremony.** After each phase, summarize what changed. For low/medium complexity, ask for confirmation only when the next phase depends on a real user choice or external approval. For high complexity, confirm before proceeding to each new phase.
-6. **Stay focused.** This is a {{complexity}}-complexity workflow. Match your ceremony level to the task — don't over-engineer or under-deliver.
+6. **Persist workflow state.** If the artifact directory contains `STATE.json`, update it after each phase: mark the finished phase `completed`, mark the next phase `active`, set `currentPhase` to the active phase index, and refresh `updatedAt`. When every phase is completed, set `completedAt` to the completion timestamp.
+7. **Stay focused.** This is a {{complexity}}-complexity workflow. Match your ceremony level to the task — don't over-engineer or under-deliver.

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -240,6 +240,8 @@ test("workflow-start prompt defaults to autonomy instead of per-phase confirmati
   const prompt = readPrompt("workflow-start");
   assert.match(prompt, /Keep moving by default/i);
   assert.match(prompt, /Decision gates, not ceremony/i);
+  assert.match(prompt, /Persist workflow state/i);
+  assert.match(prompt, /completedAt/i);
   assert.doesNotMatch(prompt, /confirm with the user before proceeding/i);
   assert.doesNotMatch(prompt, /Gate between phases/i);
 });

--- a/src/resources/extensions/gsd/tests/workflow-templates.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-templates.test.ts
@@ -7,6 +7,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   loadRegistry,
   resolveByName,
@@ -16,6 +19,11 @@ import {
   getTemplateInfo,
   loadWorkflowTemplate,
 } from '../workflow-templates.ts';
+import {
+  findInProgressWorkflows,
+  isWorkflowStateComplete,
+  type WorkflowState,
+} from '../commands-workflow-templates.ts';
 
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -194,5 +202,89 @@ console.log('\n── Load Workflow Template ──');
   const missingContent = loadWorkflowTemplate('nonexistent');
   assert.ok(missingContent === null, 'Should return null for unknown template');
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Workflow Resume State ──');
+
+{
+  const started: WorkflowState = {
+    template: 'bugfix',
+    templateName: 'Bug Fix',
+    description: 'fix resume drift',
+    branch: 'gsd/bugfix/fix-resume-drift',
+    phases: [
+      { name: 'triage', index: 0, status: 'completed' },
+      { name: 'fix', index: 1, status: 'active' },
+      { name: 'verify', index: 2, status: 'pending' },
+    ],
+    currentPhase: 1,
+    startedAt: '2026-06-15T00:00:00.000Z',
+    updatedAt: '2026-06-15T00:01:00.000Z',
+    artifactDir: 'workflows/bugfixes/260615-1-fix-resume-drift',
+  };
+
+  assert.equal(isWorkflowStateComplete(started), false, 'active phase should be resumable');
+  assert.equal(
+    isWorkflowStateComplete({
+      ...started,
+      phases: started.phases.map((phase) => ({ ...phase, status: 'completed' })),
+      currentPhase: 2,
+      updatedAt: '2026-06-15T00:02:00.000Z',
+    }),
+    true,
+    'all completed phases should be treated as complete even when completedAt is absent',
+  );
+  assert.equal(
+    isWorkflowStateComplete({ ...started, completedAt: '2026-06-15T00:03:00.000Z' }),
+    true,
+    'completedAt should mark the workflow complete',
+  );
+}
+
+test('findInProgressWorkflows ignores completed phase-only STATE files', (t) => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-workflow-resume-'));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const workflowsRoot = join(base, '.gsd', 'workflows', 'bugfixes');
+  mkdirSync(join(workflowsRoot, '260615-1-complete'), { recursive: true });
+  mkdirSync(join(workflowsRoot, '260615-2-active'), { recursive: true });
+
+  const common = {
+    template: 'bugfix',
+    templateName: 'Bug Fix',
+    description: 'fix resume drift',
+    branch: 'gsd/bugfix/fix-resume-drift',
+    startedAt: '2026-06-15T00:00:00.000Z',
+    artifactDir: 'workflows/bugfixes/260615-1-complete',
+  };
+
+  writeFileSync(join(workflowsRoot, '260615-1-complete', 'STATE.json'), JSON.stringify({
+    ...common,
+    phases: [
+      { name: 'triage', index: 0, status: 'completed' },
+      { name: 'fix', index: 1, status: 'completed' },
+      { name: 'verify', index: 2, status: 'completed' },
+    ],
+    currentPhase: 2,
+    updatedAt: '2026-06-15T00:02:00.000Z',
+  }), 'utf-8');
+
+  writeFileSync(join(workflowsRoot, '260615-2-active', 'STATE.json'), JSON.stringify({
+    ...common,
+    artifactDir: 'workflows/bugfixes/260615-2-active',
+    phases: [
+      { name: 'triage', index: 0, status: 'completed' },
+      { name: 'fix', index: 1, status: 'active' },
+      { name: 'verify', index: 2, status: 'pending' },
+    ],
+    currentPhase: 1,
+    updatedAt: '2026-06-15T00:03:00.000Z',
+  }), 'utf-8');
+
+  const inProgress = findInProgressWorkflows(base);
+  assert.equal(inProgress.length, 1);
+  assert.equal(inProgress[0]?.artifactDir, 'workflows/bugfixes/260615-2-active');
+});
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Linked issue

Closes #720

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Prevent `/gsd start resume` from resuming workflow-template runs whose `STATE.json` already has every phase marked completed.
**Why:** Completed markdown-phase workflows could be redispatched when `completedAt` was missing.
**How:** Treat all-completed phase state as complete, and teach the workflow prompt to persist phase progress plus `completedAt`.

## What

- Adds workflow-template state completion detection for both explicit `completedAt` and all-phases-completed state.
- Filters completed state files out of `/gsd start resume` discovery.
- Updates `workflow-start.md` so future markdown-phase runs keep `STATE.json` phase status, `currentPhase`, `updatedAt`, and `completedAt` current.
- Adds focused regression coverage for the reader guard and prompt contract.

## Why

Markdown-phase workflow templates can produce `STATE.json` files where all phases are complete but `completedAt` is absent. The resume reader only checked `completedAt`, so those completed runs stayed permanently resumable and could restart from phase 0.

## How

The reader now classifies a workflow as complete when `completedAt` exists or when the phase list is non-empty and every phase has `status: "completed"`. This keeps existing incomplete/resumable state behavior unchanged while making the reader resilient to older or partially persisted state files. The prompt update addresses the writer side for new runs.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-templates.test.ts src/resources/extensions/gsd/tests/prompt-contracts.test.ts`
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run verify:fast`
- [ ] CI passes

## AI disclosure

- [x] This PR includes AI-assisted code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized GSD extension resume/state logic with focused tests; behavior change only affects which runs appear resumable.
> 
> **Overview**
> Fixes **`/gsd start resume`** treating finished markdown-phase runs as still in progress when **`STATE.json`** had every phase **`completed`** but no **`completedAt`**.
> 
> **Reader:** Adds **`isWorkflowStateComplete`** (complete if **`completedAt`** is set or all phases are **`completed`**) and uses it in **`findInProgressWorkflows`** instead of only checking **`completedAt`**. Exports **`WorkflowState`** / **`WorkflowPhaseState`** and the helper for tests.
> 
> **Writer:** **`workflow-start.md`** now requires updating **`STATE.json`** after each phase (phase statuses, **`currentPhase`**, **`updatedAt`**, **`completedAt`** when done).
> 
> Regression tests cover completion detection, resume scanning, and the prompt contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb57e57fd299accd787e4a3602f9b47a87201842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->