### PR TITLE
fix(issue): models.json custom headers not applied to outgoing requests

### DIFF
--- a/packages/gsd-agent-core/src/sdk.ts
+++ b/packages/gsd-agent-core/src/sdk.ts
@@ -358,16 +358,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 			const providerRetrySettings = settingsManager.getProviderRetrySettings();
 			const attributionHeaders = getAttributionHeaders(model, settingsManager, options?.sessionId);
-			return streamSimple(model, context, {
+			const headers =
+				attributionHeaders || auth.headers || options?.headers
+					? { ...attributionHeaders, ...auth.headers, ...options?.headers }
+					: undefined;
+			const requestModel = auth.headers ? { ...model, headers: { ...model.headers, ...auth.headers } } : model;
+			return streamSimple(requestModel, context, {
 				...options,
 				apiKey: auth.apiKey,
 				timeoutMs: options?.timeoutMs ?? providerRetrySettings.timeoutMs,
 				maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,
 				maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
-				headers:
-					attributionHeaders || auth.headers || options?.headers
-						? { ...attributionHeaders, ...auth.headers, ...options?.headers }
-						: undefined,
+				headers,
 			});
 		},
 		onPayload: async (payload, _model) => {

--- a/packages/pi-coding-agent/test/sdk-openrouter-attribution.test.ts
+++ b/packages/pi-coding-agent/test/sdk-openrouter-attribution.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -85,8 +85,10 @@ describe("createAgentSession OpenRouter attribution headers", () => {
 		options: {
 			telemetryEnabled?: boolean;
 			providerHeaders?: Record<string, string>;
+			modelsJsonProviders?: Record<string, unknown>;
 			requestHeaders?: Record<string, string>;
 			sessionId?: string;
+			captureModelHeaders?: boolean;
 		} = {},
 	): Promise<Record<string, string> | undefined> {
 		const settingsManager = SettingsManager.create(cwd, agentDir);
@@ -96,13 +98,18 @@ describe("createAgentSession OpenRouter attribution headers", () => {
 
 		const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
 		authStorage.setRuntimeApiKey(model.provider, "test-api-key");
+		if (options.modelsJsonProviders) {
+			writeFileSync(join(agentDir, "models.json"), JSON.stringify({ providers: options.modelsJsonProviders }));
+		}
 		const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
-		const registeredProviders = ["capture-provider"];
+		const registeredProviders = [model.provider];
 		let capturedOptions: SimpleStreamOptions | undefined;
+		let capturedModelHeaders: Record<string, string> | undefined;
 
-		modelRegistry.registerProvider("capture-provider", {
+		modelRegistry.registerProvider(model.provider, {
 			api: "openai-completions",
-			streamSimple: (_model, _context, providerOptions) => {
+			streamSimple: (providerModel, _context, providerOptions) => {
+				capturedModelHeaders = providerModel.headers;
 				capturedOptions = providerOptions;
 				return createDoneStream();
 			},
@@ -137,7 +144,7 @@ describe("createAgentSession OpenRouter attribution headers", () => {
 					...(options.requestHeaders ? { headers: options.requestHeaders } : {}),
 				},
 			);
-			return capturedOptions?.headers;
+			return options.captureModelHeaders ? capturedModelHeaders : capturedOptions?.headers;
 		} finally {
 			session.dispose();
 			for (const provider of registeredProviders.reverse()) {
@@ -208,5 +215,39 @@ describe("createAgentSession OpenRouter attribution headers", () => {
 
 		expect(headers?.["x-opencode-session"]).toBe("configured-session");
 		expect(headers?.["x-opencode-client"]).toBe("configured-client");
+	});
+
+	it("applies model-level headers from models.json to outgoing requests", async () => {
+		const model = createModel("kimi", "https://api.moonshot.ai/v1");
+		const headers = await captureHeaders(model, {
+			captureModelHeaders: true,
+			modelsJsonProviders: {
+				kimi: {
+					baseUrl: "https://api.moonshot.ai/v1",
+					apiKey: "KIMI_API_KEY",
+					api: "openai-completions",
+					models: [
+						{
+							id: model.id,
+							name: model.name,
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 4096,
+							headers: {
+								"User-Agent": "KimiCLI/1.30.0",
+								"X-Msh-Platform": "kimi_cli",
+								"X-Msh-Version": "1.30.0",
+							},
+						},
+					],
+				},
+			},
+		});
+
+		expect(headers?.["User-Agent"]).toBe("KimiCLI/1.30.0");
+		expect(headers?.["X-Msh-Platform"]).toBe("kimi_cli");
+		expect(headers?.["X-Msh-Version"]).toBe("1.30.0");
 	});
 });


### PR DESCRIPTION
## Summary
- Fixed models.json custom headers propagation to provider requests and added regression coverage; whitespace verification passed but Vitest was unavailable in the worktree.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #748
- [#748 models.json custom headers not applied to outgoing requests](https://github.com/open-gsd/gsd-pi/issues/748)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/748-models-json-custom-headers-not-applied-t-1781537488`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to the provider streaming path with test coverage; no auth or data-model changes beyond header propagation.
> 
> **Overview**
> Fixes **models.json** per-model `headers` not reaching the HTTP layer when the agent streams to a provider.
> 
> In `createAgentSession`'s `streamFn`, resolved auth/model headers are still merged into `streamSimple` options, but the call now also passes a **`requestModel`** that merges `auth.headers` onto the `Model` when present—so providers that read headers from the model object (not only from options) get Kimi-style `User-Agent` / `X-Msh-*` values from config.
> 
> Adds a regression test that loads provider config from a temp `models.json` and asserts those headers appear on the model passed into the registered `streamSimple` stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d10ddf6927b23389d6cea83a53a145d5338e4d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->