### PR TITLE
fix(gsd): reject disabled hard-blocker escalation

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -80,6 +80,20 @@ function createTempProject(): { basePath: string; planPath: string } {
   return { basePath, planPath };
 }
 
+function writeProjectPreferences(basePath: string, yaml: string): void {
+  fs.writeFileSync(path.join(basePath, '.gsd', 'PREFERENCES.md'), `---\n${yaml}---\n`);
+}
+
+async function withWorkingDirectory<T>(cwd: string, action: () => Promise<T>): Promise<T> {
+  const previousCwd = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await action();
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
+
 function makeValidParams() {
   return {
     taskId: 'T01',
@@ -102,6 +116,13 @@ function makeValidParams() {
       },
     ],
   };
+}
+
+function makeEscalationOptions() {
+  return [
+    { id: 'continue', label: 'Continue', tradeoffs: 'Keeps execution moving with the default path.' },
+    { id: 'pause', label: 'Pause', tradeoffs: 'Stops execution until the blocker is reviewed.' },
+  ];
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -354,6 +375,105 @@ console.log('\n=== complete-task: handler happy path ===');
     assertEq(sliceAfter!.depends, ['S00'], 'complete-task should preserve existing slice dependencies');
     assertEq(sliceAfter!.demo, 'basic functionality works', 'complete-task should preserve existing slice demo');
   }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-task: hard-blocker escalation with mid-execution escalation disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: disabled hard-blocker escalation rolls back completion ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath } = createTempProject();
+  writeProjectPreferences(basePath, 'phases:\n  mid_execution_escalation: false\n');
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+
+  const params = {
+    ...makeValidParams(),
+    blockerDiscovered: true,
+    escalation: {
+      question: 'Should execution pause for the hard blocker?',
+      options: makeEscalationOptions(),
+      recommendation: 'pause',
+      recommendationRationale: 'The blocker should not be silently advanced.',
+      continueWithDefault: false,
+    },
+  };
+
+  const result = await withWorkingDirectory(basePath, () => handleCompleteTask(params, basePath));
+
+  assertTrue('error' in result, 'hard-blocker escalation should fail when escalation handling is disabled');
+  if ('error' in result) {
+    assertMatch(result.error, /hard-blocker escalation/, 'error should mention hard-blocker escalation');
+    assertMatch(result.error, /mid_execution_escalation is disabled/, 'error should mention disabled preference');
+  }
+
+  const task = getTask('M001', 'S01', 'T01');
+  assertTrue(task !== null, 'task row should remain after rollback');
+  assertEq(task!.status, 'pending', 'task status should be rolled back to pending');
+  assertEq(task!.blocker_discovered, true, 'blocker flag should remain recorded for visibility');
+  assertEq(task!.escalation_pending, 0, 'disabled preference should not create a pending escalation flag');
+  assertEq(task!.escalation_awaiting_review, 0, 'disabled preference should not create an awaiting-review flag');
+
+  const adapter = _getAdapter()!;
+  const evRows = adapter.prepare(
+    "SELECT * FROM verification_evidence WHERE task_id = 'T01' AND slice_id = 'S01' AND milestone_id = 'M001'"
+  ).all();
+  assertEq(evRows.length, 0, 'verification evidence should be deleted when completion rolls back');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-task: soft escalation with mid-execution escalation disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: disabled soft escalation still completes ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath } = createTempProject();
+  writeProjectPreferences(basePath, 'phases:\n  mid_execution_escalation: false\n');
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+
+  const params = {
+    ...makeValidParams(),
+    escalation: {
+      question: 'Should execution continue with the default?',
+      options: makeEscalationOptions(),
+      recommendation: 'continue',
+      recommendationRationale: 'The default path is safe enough to continue.',
+      continueWithDefault: true,
+    },
+  };
+
+  const result = await withWorkingDirectory(basePath, () => handleCompleteTask(params, basePath));
+
+  assertTrue(!('error' in result), 'soft escalation should still complete when escalation handling is disabled');
+  if (!('error' in result)) {
+    assertTrue(!result.escalation, 'disabled preference should not return escalation metadata');
+  }
+
+  const task = getTask('M001', 'S01', 'T01');
+  assertTrue(task !== null, 'task row should exist');
+  assertEq(task!.status, 'complete', 'soft escalation should leave task complete');
+
+  const adapter = _getAdapter()!;
+  const evRows = adapter.prepare(
+    "SELECT * FROM verification_evidence WHERE task_id = 'T01' AND slice_id = 'S01' AND milestone_id = 'M001'"
+  ).all();
+  assertEq(evRows.length, 1, 'verification evidence should remain for soft escalation completion');
 
   cleanupDir(basePath);
   cleanup(dbPath);

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -453,6 +453,25 @@ export async function handleCompleteTask(
       }
     }
   } else if (params.escalation && !escalationWriteEnabled) {
+    if (params.escalation.continueWithDefault === false) {
+      const msg = `complete-task received a hard-blocker escalation (continueWithDefault=false) but phases.mid_execution_escalation is disabled for ${params.milestoneId}/${params.sliceId}/${params.taskId}; reverting to pending instead of silently advancing.`;
+      logWarning("tool", msg);
+      try {
+        deleteVerificationEvidence(params.milestoneId, params.sliceId, params.taskId);
+        updateTaskStatus(params.milestoneId, params.sliceId, params.taskId, 'pending');
+        invalidateStateCache();
+        logWarning(
+          "tool",
+          `complete-task rolled back DB completion for ${params.milestoneId}/${params.sliceId}/${params.taskId} because hard-blocker escalation handling is disabled; SUMMARY.md left on disk for retry.`,
+        );
+      } catch (rollbackErr) {
+        logWarning(
+          "tool",
+          `complete-task rollback failed after disabled hard-blocker escalation for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(rollbackErr as Error).message}`,
+        );
+      }
+      return { error: msg };
+    }
     logWarning(
       "tool",
       `complete-task received escalation payload but phases.mid_execution_escalation is not enabled; ignoring (${params.milestoneId}/${params.sliceId}/${params.taskId})`,


### PR DESCRIPTION
## TL;DR

**What:** Hard-blocker escalations no longer silently complete tasks when `phases.mid_execution_escalation` is disabled.
**Why:** A `continueWithDefault=false` blocker should not be swallowed and treated as a clean task finish.
**How:** The disabled-preference branch now mirrors the existing escalation write-failure compensation by reverting the task to `pending`, deleting verification evidence, invalidating state, and returning an explicit error.

## What

- Updates `gsd_complete_task` handling for disabled mid-execution escalation.
- Keeps soft `continueWithDefault=true` escalation payloads on the existing complete-and-ignore path when the feature is off.
- Adds regression coverage for hard rollback and soft completion behavior in `complete-task.test.ts`.

## Why

When a task reports a hard blocker with `continueWithDefault=false`, marking the task `complete` while dropping the escalation lets auto-mode advance as if nothing needs review.

Closes #719

## How

The handler now checks disabled escalation payloads before the existing ignore warning. Hard blockers delete verification evidence, restore task status to `pending`, invalidate state cache, and fail the tool call loudly. Soft escalations retain the previous behavior.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/complete-task.test.ts`
- [x] `pnpm run test:changed:src`
- [x] `pnpm run verify:pr`
- [x] `pnpm run verify:merge`

## Impact analysis

- Blast radius: moderate. The change affects task completion when an escalation payload is present and the mid-execution escalation preference is disabled.
- Affected workflows: `gsd_complete_task`, auto-mode redispatch/stuck-surfacing, verification evidence for rolled-back hard-blocker completions.
- Risks or compatibility notes: Soft escalations keep the prior complete behavior; no schema, migration, or public API shape changes.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task completion and rollback behavior when escalations are present with mid-execution escalation disabled, which affects auto-mode dispatch and verification evidence consistency.
> 
> **Overview**
> When **`gsd_complete_task`** runs with an escalation payload but **`phases.mid_execution_escalation`** is off, a **hard blocker** (`continueWithDefault=false`) no longer finishes the task as if nothing needed review.
> 
> The handler now treats that case like escalation write failure: it **deletes verification evidence**, sets the task back to **`pending`**, invalidates state cache, and **returns an error** so auto-mode does not advance past an unresolved blocker. **Soft** escalations (`continueWithDefault=true`) still complete and ignore the payload, unchanged.
> 
> Regression tests cover rollback for hard blockers and successful completion for soft ones when the preference is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f551ebd11781644213a9bbaa181ad07bd6950337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->