### PR TITLE
fix(tui): fix inline image rendering in tool cards (overflow, stacking, alignment)

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -1,14 +1,29 @@
 // Project/App: gsd-pi
 // File Purpose: Tests for interactive terminal tool execution rendering.
-import { describe, test } from "node:test";
+import { afterEach, beforeEach, describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import stripAnsi from "strip-ansi";
+import { isImageLine, resetCapabilitiesCache, setCapabilities, setCellDimensions } from "@gsd/pi-tui";
 import { ToolExecutionComponent, ToolPhaseSummaryComponent, type ToolExecutionPhase } from "../tool-execution.js";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { READ_TUI_EXPANDED_MAX_LINES } from "@gsd/pi-coding-agent/core/tools/read.js";
 
 initTheme("dark", false);
+
+/**
+ * Build a minimal valid PNG header (signature + IHDR) with the given dimensions.
+ * getImageDimensions/getPngDimensions only read the 24-byte header, so this is
+ * enough to drive image rendering without a real encoded image.
+ */
+function tinyPngBase64(widthPx: number, heightPx: number): string {
+	const buf = Buffer.alloc(24);
+	// PNG signature
+	buf.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+	buf.writeUInt32BE(widthPx, 16);
+	buf.writeUInt32BE(heightPx, 20);
+	return buf.toString("base64");
+}
 
 function renderTool(
 	toolName: string,
@@ -588,5 +603,100 @@ describe("ToolExecutionComponent", () => {
 		// Multi-line JSON dump for the complex payload
 		assert.match(rendered, /"payload"/);
 		assert.match(rendered, /"nested"/);
+	});
+});
+
+// Regression coverage for inline image (Kitty/Ghostty protocol) rendering inside
+// a tool card. The original bug ran collapseBlankLines() + trimOuterBlankLines()
+// over the card body, which crushed the (rows-1) blank padding lines an image
+// emits to reserve its height — framing a 24-row image as ~1 row so the terminal
+// painted the full image over the chat and footer below it.
+describe("ToolExecutionComponent inline image (Kitty) rendering", () => {
+	// Force the Kitty image protocol and a representative cell size for the whole
+	// block; restore the module-global capabilities/cell-size after each case so
+	// these tests never leak terminal state into the rest of the suite.
+	beforeEach(() => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 8, heightPx: 20 });
+	});
+	afterEach(() => {
+		resetCapabilitiesCache();
+		setCellDimensions({ widthPx: 9, heightPx: 18 });
+	});
+
+	// Render a `read` tool result that carries one inline PNG and return the RAW
+	// card lines (not stripAnsi — image lines carry graphics escapes we assert on).
+	function renderImageToolRaw(widthPx: number, heightPx: number, termWidth = 120): string[] {
+		const component = new ToolExecutionComponent(
+			"read",
+			{ file_path: "/tmp/tall.png" },
+			{ showImages: true },
+			undefined as any,
+			{ requestRender() {} } as any,
+		);
+		component.setExpanded(true);
+		component.updateResult({
+			content: [
+				{ type: "text", text: "Read image file [image/png]" },
+				{ type: "image", data: tinyPngBase64(widthPx, heightPx), mimeType: "image/png" } as any,
+			],
+			isError: false,
+		});
+		return component.render(termWidth);
+	}
+
+	test("reserves the image's full row height inside the card (no overflow)", () => {
+		const lines = renderImageToolRaw(800, 2400); // very tall image (1:3)
+
+		const seqIdx = lines.findIndex((l) => isImageLine(l));
+		assert.ok(seqIdx >= 0, "card must contain the inline image sequence");
+
+		// The card must keep many blank padding rows after the sequence so content
+		// below the image is not overpainted. The original regression collapsed
+		// them to ~1, framing a tall image as a single row. We don't pin the exact
+		// row count (it depends on cell-size/maxHeight math); a tall image must
+		// reserve far more than the broken ~1 row.
+		const bottomBorderIdx = lines.length - 1;
+		const blankRowsAfterSeq = lines
+			.slice(seqIdx + 1, bottomBorderIdx)
+			.filter((l) => l.trim().length === 0).length;
+		assert.ok(
+			blankRowsAfterSeq >= 10,
+			`a tall image must reserve its height as blank padding rows; only ${blankRowsAfterSeq} were kept ` +
+				`(regression: padding rows were collapsed/trimmed → image overflows the card)`,
+		);
+	});
+
+	test("passes the image sequence through verbatim, left-aligned under the card text", () => {
+		const lines = renderImageToolRaw(800, 2400);
+		const seqLine = lines.find((l) => isImageLine(l));
+		assert.ok(seqLine, "image sequence line should be present");
+
+		// The raw Kitty sequence must be intact (no padRight/truncate corruption)…
+		const afterIndent = seqLine.replace(/^ +/, "");
+		assert.ok(afterIndent.startsWith("\x1b_G"), "Kitty sequence must survive verbatim after the indent");
+
+		// …and the image is offset to sit under the card text (indent + 3 spaces),
+		// not hugging column 0.
+		const leadingSpaces = seqLine.match(/^ */)?.[0].length ?? 0;
+		assert.ok(leadingSpaces >= 4, `image row should be indented under the card text, got ${leadingSpaces} spaces`);
+	});
+
+	test("non-image tool output still collapses blank rows (fix is image-scoped)", () => {
+		// A generic (expanded) tool's text output flows through collapseBlankLines.
+		// The image-preservation branch must NOT disable that for ordinary text —
+		// a run of consecutive blank lines should still collapse.
+		const rendered = renderTool(
+			"mcp__demo__blanks",
+			{ ok: true },
+			{ content: [{ type: "text", text: "first\n\n\n\n\nsecond" }], isError: false },
+		);
+		assert.match(rendered, /first/);
+		assert.match(rendered, /second/);
+		assert.doesNotMatch(
+			rendered,
+			/first[\s\S]*?\n\s*\n\s*\n\s*\nsecond/,
+			"plain text should still have consecutive blank rows collapsed",
+		);
 	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/transcript-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/transcript-design.test.ts
@@ -3,11 +3,18 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { padRight, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { isImageLine, padRight, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
-import { renderConnectedCard } from "../transcript-design.js";
+import { renderConnectedCard, renderTranscriptCard } from "../transcript-design.js";
 
 initTheme("dark", false);
+
+// A Kitty image "block" as the Image component emits it: the sequence on line 0
+// then (rows-1) blank padding lines that reserve the image's on-screen height.
+const KITTY_SEQ = "\x1b_Ga=T,f=100,q=2,C=1,c=10,r=8,i=42,p=1;AAAA\x1b\\";
+function imageBlock(rows: number): string[] {
+	return [KITTY_SEQ, ...Array.from({ length: rows - 1 }, () => "")];
+}
 
 describe("renderConnectedCard", () => {
 	test("keeps long ANSI body rows on the existing width contract", () => {
@@ -22,5 +29,42 @@ describe("renderConnectedCard", () => {
 		assert.ok(body, "expected a body row");
 		assert.equal(body, " ".repeat(indent) + expectedInner);
 		assert.equal(visibleWidth(body), width);
+	});
+
+	test("preserves image padding rows so a tall image does not overflow", () => {
+		const rows = 8;
+		const body = ["[Image: 800x2400]", "", ...imageBlock(rows)];
+
+		const rendered = renderConnectedCard(80, "READ", body, { closeBottom: true });
+
+		// The image sequence must survive intact (no padRight/truncate corruption)…
+		const seqRow = rendered.find((l) => isImageLine(l));
+		assert.ok(seqRow, "image sequence row should be present");
+		assert.ok(seqRow.includes(KITTY_SEQ), "image sequence must survive verbatim");
+		// …but be left-offset to align under the card text (indent + 3 spaces),
+		// not hugging column 0.
+		assert.ok(seqRow.startsWith(" ".repeat(4) + "   "), "image row should be indented under the card text");
+
+		// The (rows-1) reserved blank padding rows must NOT be trimmed/collapsed.
+		const seqIdx = rendered.findIndex((l) => isImageLine(l));
+		const bottomIdx = rendered.length - 1; // closing border
+		const blanksAfter = rendered.slice(seqIdx + 1, bottomIdx).filter((l) => l.trim().length === 0).length;
+		assert.ok(
+			blanksAfter >= rows - 1,
+			`expected >= ${rows - 1} reserved blank rows after the image, got ${blanksAfter}`,
+		);
+	});
+});
+
+describe("renderTranscriptCard image handling", () => {
+	test("does not trim image padding rows", () => {
+		const rows = 6;
+		const body = ["read /tmp/x.png", "", "[Image: ...]", "", ...imageBlock(rows)];
+		const card = renderTranscriptCard(body, 100, { title: "READ", right: "success", tone: "success" });
+
+		const seqIdx = card.findIndex((l) => isImageLine(l));
+		assert.ok(seqIdx >= 0, "image sequence should be present in the card");
+		const blanksAfter = card.slice(seqIdx + 1, card.length - 1).filter((l) => l.trim().length === 0).length;
+		assert.ok(blanksAfter >= rows - 1, `expected >= ${rows - 1} reserved rows, got ${blanksAfter}`);
 	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -2,10 +2,12 @@
 // File Purpose: Interactive terminal tool execution renderer for commands, tool calls, diffs, images, and summaries.
 import { normalizeToolArguments } from "@gsd/pi-ai";
 import {
+	allocateImageId,
 	Box,
 	Container,
 	getCapabilities,
 	Image,
+	isImageLine,
 	type ImageDimensions,
 	imageFallback,
 	Spacer,
@@ -360,6 +362,14 @@ export class ToolExecutionComponent extends Container {
 	// Cached resolved image dimensions to avoid re-triggering async parsing
 	// when updateDisplay() recreates Image components (#3455).
 	private resolvedImageDimensions: Map<number, ImageDimensions> = new Map();
+	// Stable Kitty image ids, keyed by image index. updateDisplay() destroys and
+	// recreates Image components on every streaming tick; without a stable id each
+	// recreation would call allocateImageId() and get a fresh random id, so the
+	// Kitty placement key (imageId, p) would change every render and the terminal
+	// would STACK a new placement instead of replacing the old one — painting
+	// overlapping copies over the chat and footer. Reusing one id per image index
+	// keeps the placement identity stable so re-emits replace in place.
+	private stableImageIds: Map<number, number> = new Map();
 	// Incremental syntax highlighting cache for write tool call args
 	private writeHighlightCache?: WriteHighlightCache;
 	// When true, this component intentionally renders no lines
@@ -451,6 +461,7 @@ export class ToolExecutionComponent extends Container {
 	dispose(): void {
 		this.stopRunningRailTimer();
 		this.convertedImages.clear();
+		this.stableImageIds.clear();
 		this.imageComponents = [];
 		this.imageSpacers = [];
 		this.editDiffPreview = undefined;
@@ -784,7 +795,15 @@ export class ToolExecutionComponent extends Container {
 				hidden: !this.isPartial && !!this.result,
 			});
 		}
-		const lines = collapseBlankLines(super.render(contentWidth));
+		// collapseBlankLines merges consecutive blank rows. An inline image reserves
+		// its height as (rows-1) trailing blank padding lines after the sequence;
+		// collapsing those would shrink a tall image to a single row and the terminal
+		// would paint the full image over everything below it. Preserve the exact
+		// line structure whenever the content includes an image.
+		const renderedBody = super.render(contentWidth);
+		const lines = hasImages || renderedBody.some((l) => isImageLine(l))
+			? renderedBody
+			: collapseBlankLines(renderedBody);
 		return renderTranscriptCard(lines, frameWidth, {
 			title: frameLabel,
 			right: frameStatus,
@@ -1008,11 +1027,19 @@ export class ToolExecutionComponent extends Container {
 					// Pass cached dimensions to avoid re-triggering async parsing
 					// when updateDisplay() recreates Image components (#3455).
 					const cachedDims = this.resolvedImageDimensions.get(i);
+					// Reuse a stable Kitty image id per image index so the recreated
+					// component keeps the same placement identity across redraws
+					// (otherwise every updateDisplay() stacks a new placement).
+					let stableImageId = this.stableImageIds.get(i);
+					if (caps.images === "kitty" && stableImageId === undefined) {
+						stableImageId = allocateImageId();
+						this.stableImageIds.set(i, stableImageId);
+					}
 					const imageComponent = new Image(
 						imageData,
 						imageMimeType,
 						{ fallbackColor: (s: string) => theme.fg("toolOutput", s) },
-						{ maxWidthCells: 60 },
+						{ maxWidthCells: 60, imageId: stableImageId },
 						cachedDims,
 					);
 					if (!cachedDims) {

--- a/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: Shared recommended transcript rendering primitives for assistant, tool, command, footer, and auto-mode TUI surfaces.
 
-import { alignRight, padRight, style, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { alignRight, isImageLine, padRight, style, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { theme, type ThemeBg, type ThemeColor } from "@gsd/pi-coding-agent/theme/theme.js";
 import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
 
@@ -134,12 +134,26 @@ export function renderConnectedCard(
 		}
 	}
 	const paintBody = (line: string) => {
+		// Image (Kitty/iTerm2) sequence lines carry raw terminal graphics escapes and
+		// rely on exact column/row positioning. Prepend the SAME left offset normal
+		// body lines get (card indent + 3 spaces) so the image aligns under the card
+		// text rather than hugging column 0, but do NOT padRight/truncate — trailing
+		// padding or clipping after the sequence would corrupt the placement. The
+		// leading spaces simply advance the cursor before the image draws.
+		if (isImageLine(line)) {
+			return prefix + "   " + line;
+		}
 		const innerWidth = Math.max(1, width - indent);
 		const inner = padRight("   " + line, innerWidth);
 		const painted = opts.bodyBg ? theme.bg(opts.bodyBg, inner) : inner;
 		return prefix + painted;
 	};
-	const bodySource = trimOuterBlankLines(bodyLines);
+	// When the body contains an inline image, its reserved blank padding rows (the
+	// rows the TUI counts so content below the image lands in the right place) must
+	// NOT be trimmed/collapsed — trimming them collapses a tall image to one line
+	// and the terminal then paints the full image over the chat and footer below.
+	const hasImage = bodyLines.some((l) => isImageLine(l));
+	const bodySource = hasImage ? bodyLines : trimOuterBlankLines(bodyLines);
 	const out = [padLine(topLine, width)];
 	for (const line of bodySource) {
 		out.push(paintBody(line));
@@ -415,7 +429,9 @@ export function renderTranscriptCard(
 	const outerWidth = Math.max(20, width);
 	const indent = opts.indent ?? TRANSCRIPT_CARD_INDENT;
 	const tone = toneColor(opts.tone);
-	const body = trimOuterBlankLines(lines);
+	// Preserve image padding rows (see renderConnectedCard) — trimming them would
+	// collapse a tall inline image and make it overflow the card.
+	const body = lines.some((l) => isImageLine(l)) ? lines : trimOuterBlankLines(lines);
 	let titleRight = opts.right ? theme.fg(tone, opts.right) : undefined;
 	if (opts.footerLeft || opts.footerRight) {
 		const hint = [opts.footerLeft, opts.footerRight].filter(Boolean).join(" · ");

--- a/packages/pi-tui/src/index.ts
+++ b/packages/pi-tui/src/index.ts
@@ -110,6 +110,7 @@ export {
 	type ImageProtocol,
 	type ImageRenderOptions,
 	imageFallback,
+	isImageLine,
 	renderImage,
 	resetCapabilitiesCache,
 	setCapabilities,

--- a/packages/pi-tui/src/terminal-image.ts
+++ b/packages/pi-tui/src/terminal-image.ts
@@ -39,6 +39,47 @@ export function setCellDimensions(dims: CellDimensions): void {
 	cellDimensions = dims;
 }
 
+/**
+ * Parse a terminal cell-size reply into integer pixel dimensions, or null if the
+ * data is not a recognized cell-size reply. Two formats are supported:
+ *
+ *  - xterm `CSI 16 t` reply:        `CSI 6 ; height ; width t`
+ *  - iTerm2 `OSC 1337 ; ReportCellSize` reply (iTerm2 does NOT answer CSI 16t):
+ *      `OSC 1337 ; ReportCellSize=[height] ; [width] ST`           or
+ *      `OSC 1337 ; ReportCellSize=[height] ; [width] ; [scale] ST`
+ *    where height/width are floating-point point sizes and the optional scale is
+ *    physical-pixels-per-point (retina). We size cells in points (the logical
+ *    units the image protocol uses), so the scale factor is intentionally ignored.
+ *
+ * Non-positive sizes are rejected (returns null) so a bogus reply never poisons
+ * the cell-size used for image math.
+ *
+ * The patterns are anchored to the whole payload: the reply must be the entire
+ * input, not embedded in it. Cell-size replies arrive as their own read chunk
+ * (the terminal answering pi's startup query), and anchoring means a reply that
+ * happened to be batched with a keystroke is NOT consumed — so the caller never
+ * swallows real input. This matches the original CSI-16t handler's behavior.
+ */
+export function parseCellSizeResponse(data: string): CellDimensions | null {
+	// xterm CSI 16t reply: ESC [ 6 ; height ; width t
+	const xterm = data.match(/^\x1b\[6;(\d+);(\d+)t$/);
+	if (xterm) {
+		const heightPx = Math.round(Number(xterm[1]));
+		const widthPx = Math.round(Number(xterm[2]));
+		return widthPx > 0 && heightPx > 0 ? { widthPx, heightPx } : null;
+	}
+
+	// iTerm2 OSC 1337 ; ReportCellSize=height;width[;scale] ST (ST = BEL or ESC \)
+	const iterm = data.match(/^\x1b\]1337;ReportCellSize=([\d.]+);([\d.]+)(?:;[\d.]+)?(?:\x07|\x1b\\)$/);
+	if (iterm) {
+		const heightPx = Math.round(Number(iterm[1]));
+		const widthPx = Math.round(Number(iterm[2]));
+		return widthPx > 0 && heightPx > 0 ? { widthPx, heightPx } : null;
+	}
+
+	return null;
+}
+
 export function detectCapabilities(): TerminalCapabilities {
 	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
 	const term = process.env.TERM?.toLowerCase() || "";
@@ -129,6 +170,17 @@ export function encodeKitty(
 		columns?: number;
 		rows?: number;
 		imageId?: number;
+		/**
+		 * Kitty placement id (`p` key). A placement is uniquely identified by the
+		 * pair (image id, placement id). Sending the same (i, p) again REPLACES the
+		 * existing placement instead of stacking a new one on top — this is how the
+		 * protocol says to move/resize an image without flicker. The TUI re-emits an
+		 * image's sequence on many redraws (scroll, spinner ticks, viewport realign);
+		 * without a stable placement id every redraw would add another copy, painting
+		 * stacked/overflowing images over the chat and footer. Requires a non-zero
+		 * imageId (the protocol ignores `p` when the image has id=0). Default: 1.
+		 */
+		placementId?: number;
 		/** Whether Kitty should apply its default cursor movement after placement. Default: true. */
 		moveCursor?: boolean;
 	} = {},
@@ -140,7 +192,13 @@ export function encodeKitty(
 	if (options.moveCursor === false) params.push("C=1");
 	if (options.columns) params.push(`c=${options.columns}`);
 	if (options.rows) params.push(`r=${options.rows}`);
-	if (options.imageId) params.push(`i=${options.imageId}`);
+	if (options.imageId) {
+		params.push(`i=${options.imageId}`);
+		// Pin a stable placement id so re-emitting this image replaces its single
+		// placement rather than appending a new one. Only meaningful when the image
+		// has a non-zero id (kitty ignores `p` for id=0 images).
+		params.push(`p=${options.placementId ?? 1}`);
+	}
 
 	if (base64Data.length <= CHUNK_SIZE) {
 		return `\x1b_G${params.join(",")};${base64Data}\x1b\\`;
@@ -415,9 +473,18 @@ export function renderImage(
 	}
 
 	if (caps.images === "iterm2") {
+		// Pin the height to the cell box the TUI reserved (size.rows) instead of
+		// "auto". With height="auto" iTerm2 renders at the image's natural aspect
+		// height, which for tall images (documents, screenshots) overflows the
+		// reserved rows and paints over the chat, status, and footer — meanwhile
+		// the TUI's cursor accounting only knows about size.rows, so everything
+		// below drifts. Bounding both width and height to the box makes iTerm2
+		// letterbox the image within size.rows; preserveAspectRatio stays on so
+		// the image is never distorted (the box is already aspect-fitted by
+		// calculateImageCellSize, so letterboxing is near-exact).
 		const sequence = encodeITerm2(base64Data, {
 			width: size.columns,
-			height: "auto",
+			height: size.rows,
 			preserveAspectRatio: options.preserveAspectRatio ?? true,
 		});
 		return { sequence, rows: size.rows };

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -9,7 +9,13 @@ import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.js";
 import { isMouseEvent, type MouseEvent, parseMouseEvent } from "./mouse.js";
 import type { Terminal } from "./terminal.js";
-import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
+import {
+	deleteKittyImage,
+	getCapabilities,
+	isImageLine,
+	parseCellSizeResponse,
+	setCellDimensions,
+} from "./terminal-image.js";
 import {
 	extractSegments,
 	normalizeTerminalOutput,
@@ -554,13 +560,23 @@ export class TUI extends Container {
 	}
 
 	private queryCellSize(): void {
+		const caps = getCapabilities();
 		// Only query if terminal supports images (cell size is only used for image rendering)
-		if (!getCapabilities().images) {
+		if (!caps.images) {
 			return;
 		}
-		// Query terminal for cell size in pixels: CSI 16 t
-		// Response format: CSI 6 ; height ; width t
+		// xterm cell-size query: CSI 16 t → reply CSI 6 ; height ; width t.
 		this.terminal.write("\x1b[16t");
+		// iTerm2 does NOT answer CSI 16t — its only cell-size mechanism is the
+		// proprietary OSC 1337 ; ReportCellSize query → reply
+		// OSC 1337 ; ReportCellSize=height;width[;scale] ST. Without this, pi falls
+		// back to a default cell size on iTerm2 and sizes inline images with the
+		// wrong cell aspect (leaving trailing slack / mis-fit). Both replies are
+		// handled by parseCellSizeResponse; sending both queries is harmless on
+		// terminals that ignore one of them.
+		if (caps.images === "iterm2") {
+			this.terminal.write("\x1b]1337;ReportCellSize\x07");
+		}
 	}
 
 	stop(): void {
@@ -768,19 +784,15 @@ export class TUI extends Container {
 	}
 
 	private consumeCellSizeResponse(data: string): boolean {
-		// Response format: ESC [ 6 ; height ; width t
-		const match = data.match(/^\x1b\[6;(\d+);(\d+)t$/);
-		if (!match) {
+		// Handles both the xterm CSI 16t reply and the iTerm2 OSC 1337;ReportCellSize
+		// reply (see parseCellSizeResponse). Returns false for unrelated input so it
+		// flows on to the other input handlers.
+		const dims = parseCellSizeResponse(data);
+		if (!dims) {
 			return false;
 		}
 
-		const heightPx = parseInt(match[1], 10);
-		const widthPx = parseInt(match[2], 10);
-		if (heightPx <= 0 || widthPx <= 0) {
-			return true;
-		}
-
-		setCellDimensions({ widthPx, heightPx });
+		setCellDimensions(dims);
 		// Invalidate all components so images re-render with correct dimensions.
 		this.invalidate();
 		this.requestRender();
@@ -1024,6 +1036,18 @@ export class TUI extends Container {
 		return ids;
 	}
 
+	/**
+	 * Record the lines committed in the frame we just rendered. We snapshot the
+	 * Kitty image ids here (not just at the start of the next render) because a
+	 * forced full render resets previousLines to [] before doRender runs — the
+	 * persistent previousKittyImageIds set is what lets the full-repaint paths
+	 * delete the prior frame's GPU placements even after that reset.
+	 */
+	private commitRenderedLines(newLines: string[]): void {
+		this.previousLines = newLines;
+		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+	}
+
 	private deleteKittyImages(ids: Iterable<number>): string {
 		let buffer = "";
 		for (const id of ids) {
@@ -1183,6 +1207,17 @@ export class TUI extends Container {
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
 			let buffer = this.useSynchronizedOutput ? "\x1b[?2026h" : "";
+			// Delete every Kitty placement from the previous frame before repainting.
+			// \x1b[2J clears graphics on Ghostty but NOT on upstream Kitty, and the
+			// no-clear branch never erases graphics at all — so an unconditional
+			// delete of the prior frame's image ids is the only terminal-agnostic way
+			// to stop placements from lingering/stacking across a full repaint. We use
+			// previousKittyImageIds (not previousLines) because a forced full render
+			// resets previousLines to [] before we get here, but the GPU placements
+			// from the prior frame are still on screen and must be cleared. Any image
+			// still in newLines is re-emitted below and replaces its (now-deleted)
+			// prior placement via its stable id.
+			buffer += this.deleteKittyImages(this.previousKittyImageIds);
 			const startRow = Math.max(1, height - Math.max(1, newLines.length) + 1);
 			if (clear) {
 				buffer += `\x1b[2J\x1b[${startRow};1H`;
@@ -1208,7 +1243,7 @@ export class TUI extends Container {
 			}
 			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousLines = newLines;
+			this.commitRenderedLines(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
 		};
@@ -1224,6 +1259,10 @@ export class TUI extends Container {
 		const repaintBottomAnchoredShortBlock = (): void => {
 			const startRow = Math.max(1, height - Math.max(1, newLines.length) + 1);
 			let buffer = this.useSynchronizedOutput ? "\x1b[?2026h" : "";
+			// Same rationale as fullRender: this path repaints whole lines with
+			// \x1b[2K, which does not remove Kitty graphics. Delete the prior frame's
+			// placements so re-emitted images replace rather than stack.
+			buffer += this.deleteKittyImages(this.previousKittyImageIds);
 			buffer += `\x1b[${startRow};1H`;
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
@@ -1241,7 +1280,7 @@ export class TUI extends Container {
 			this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
 			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousLines = newLines;
+			this.commitRenderedLines(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
 		};
@@ -1277,6 +1316,9 @@ export class TUI extends Container {
 			const newViewportTop = getViewportTop(newLines.length);
 			const currentScreenRow = Math.max(0, hardwareCursorRow - prevViewportTop);
 			let buffer = this.useSynchronizedOutput ? "\x1b[?2026h" : "";
+			// This viewport repaint also clears lines with \x1b[2K only; delete prior
+			// Kitty placements so images displaced by the realign don't linger/stack.
+			buffer += this.deleteKittyImages(this.previousKittyImageIds);
 			if (currentScreenRow > 0) {
 				buffer += `\x1b[${currentScreenRow}A`;
 			}
@@ -1298,7 +1340,7 @@ export class TUI extends Container {
 			this.maxLinesRendered = newLines.length;
 			this.previousViewportTop = newViewportTop;
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousLines = newLines;
+			this.commitRenderedLines(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
 			this._shrinkDebounceActive = false;
@@ -1392,7 +1434,7 @@ export class TUI extends Container {
 				this.hardwareCursorRow = targetRow;
 			}
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousLines = newLines;
+			this.commitRenderedLines(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
 			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
@@ -1424,6 +1466,15 @@ export class TUI extends Container {
 		}
 
 		let buffer = this.useSynchronizedOutput ? "\x1b[?2026h" : "";
+		// Free any Kitty image placements that lived on the changed lines before we
+		// repaint them. Kitty/Ghostty placements are GPU-side graphics that text
+		// erasure (\x1b[2K) does NOT remove; without an explicit delete the old
+		// placement lingers while the redraw adds a new one, stacking copies over
+		// the chat and footer. Stable placement ids (see encodeKitty) make the
+		// common in-place redraw replace rather than stack, but a line whose image
+		// is being replaced by different content (or a different image id) still
+		// needs the prior id explicitly deleted.
+		buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
 		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
 		if (moveTargetRow > prevViewportBottom) {
@@ -1533,7 +1584,7 @@ export class TUI extends Container {
 		// Position hardware cursor for IME
 		this.positionHardwareCursor(cursorPos, newLines.length);
 
-		this.previousLines = newLines;
+		this.commitRenderedLines(newLines);
 		this.previousWidth = width;
 		this.previousHeight = height;
 	}

--- a/packages/pi-tui/test/terminal-image.test.ts
+++ b/packages/pi-tui/test/terminal-image.test.ts
@@ -12,6 +12,7 @@ import {
 	encodeKitty,
 	hyperlink,
 	isImageLine,
+	parseCellSizeResponse,
 	renderImage,
 	resetCapabilitiesCache,
 	setCapabilities,
@@ -310,6 +311,50 @@ describe("Kitty image cursor movement", () => {
 		assert.strictEqual(deleteAllKittyImages(), "\x1b_Ga=d,d=A,q=2\x1b\\");
 	});
 
+	it("pins a stable placement id when an image id is given (anti-stacking)", () => {
+		// Without a placement id, kitty/Ghostty append a NEW placement for every
+		// re-emission of the same image (spec: "p=0 for multiple put commands with
+		// the same image id results in multiple placements"), which stacks copies
+		// over the chat and footer. A stable p= makes re-emission replace in place.
+		const seq = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 42, moveCursor: false });
+		assert.ok(seq.includes("i=42"), "image id present");
+		assert.ok(/(?:^|,)p=1(?:,|;)/.test(seq), `expected a stable p= in ${JSON.stringify(seq)}`);
+	});
+
+	it("re-emits the same (image id, placement id) across renders so it replaces", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			const seqOf = (lines: string[]) => lines.find((l) => l.includes("\x1b_G")) ?? "";
+			const idOf = (s: string) => s.match(/\x1b_G[^;]*?i=(\d+)/)?.[1];
+			const pOf = (s: string) => s.match(/\x1b_G[^;]*?p=(\d+)/)?.[1];
+
+			const first = seqOf(image.render(12));
+			image.invalidate();
+			const second = seqOf(image.render(12));
+
+			assert.ok(idOf(first), "first render has an image id");
+			assert.strictEqual(idOf(first), idOf(second), "image id is stable across renders");
+			assert.ok(pOf(first), "placement id present");
+			assert.strictEqual(pOf(first), pOf(second), "placement id is stable across renders");
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
+	it("omits the placement id when there is no image id (spec: p ignored for id=0)", () => {
+		const seq = encodeKitty("AAAA", { columns: 2, rows: 2 });
+		assert.ok(!seq.includes("p="), `expected no p= without an image id in ${JSON.stringify(seq)}`);
+	});
+
 	it("preserves renderImage's default terminal-side cursor movement", () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
 		setCellDimensions({ widthPx: 10, heightPx: 10 });
@@ -395,6 +440,113 @@ describe("Kitty image cursor movement", () => {
 			resetCapabilitiesCache();
 			setCellDimensions({ widthPx: 9, heightPx: 18 });
 		}
+	});
+});
+
+describe("iTerm2 image sizing", () => {
+	it("bounds height to the reserved rows instead of auto", () => {
+		setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 10, heightPx: 20 });
+		try {
+			// Tall image: 100x1000px. In a 10-wide box the aspect fit yields few
+			// columns and a bounded number of rows — height must equal those rows,
+			// never "auto" (which would overflow the reserved lines).
+			const result = renderImage("AAAA", { widthPx: 100, heightPx: 1000 }, { maxWidthCells: 10, maxHeightCells: 8 });
+			assert.ok(result);
+			assert.ok(!result.sequence.includes("height=auto"), "must not use height=auto");
+			assert.ok(result.sequence.includes(`height=${result.rows}`), `expected height=${result.rows} in ${result.sequence}`);
+			assert.ok(result.rows <= 8, "rows must respect maxHeightCells");
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
+	it("keeps width and height in cell units matching the reserved box", () => {
+		setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: true });
+		// Square cells so a square image maps to a square cell box.
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			// Square 20x20px image in a 2-cell-wide box => 2x2 cells.
+			const result = renderImage("AAAA", { widthPx: 20, heightPx: 20 }, { maxWidthCells: 2 });
+			assert.ok(result);
+			assert.strictEqual(result.rows, 2);
+			assert.ok(result.sequence.includes("width=2"));
+			assert.ok(result.sequence.includes("height=2"));
+			assert.ok(result.sequence.startsWith("\x1b]1337;File="));
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
+	it("Image component reserves exactly `rows` lines for an iTerm2 image", () => {
+		setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 10, heightPx: 20 });
+		try {
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 10 },
+				{ widthPx: 10, heightPx: 100 },
+			);
+			const lines = image.render(12);
+			// Last line carries the image sequence; the rest are blank padding so
+			// the TUI accounts for the full height. Total lines === reserved rows.
+			const seqLine = lines[lines.length - 1];
+			assert.ok(seqLine.includes("\x1b]1337;File="));
+			assert.ok(!seqLine.includes("height=auto"));
+			for (let i = 0; i < lines.length - 1; i++) {
+				assert.strictEqual(lines[i], "");
+			}
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+});
+
+describe("parseCellSizeResponse", () => {
+	// pi queries the terminal for its cell pixel size to size inline images. Two
+	// reply formats exist: the xterm CSI 16t reply, and iTerm2's proprietary
+	// OSC 1337;ReportCellSize reply. iTerm2 does NOT answer CSI 16t at all (its
+	// only cell-size mechanism is ReportCellSize), so without parsing the OSC
+	// reply pi falls back to a default cell size on iTerm2 and inline images are
+	// sized with the wrong cell aspect.
+	it("parses the xterm CSI 16t reply (CSI 6 ; height ; width t)", () => {
+		assert.deepStrictEqual(parseCellSizeResponse("\x1b[6;34;15t"), { widthPx: 15, heightPx: 34 });
+	});
+
+	it("parses the iTerm2 ReportCellSize reply (height ; width)", () => {
+		// OSC 1337 ; ReportCellSize=[height];[width] ST  (ST = BEL here)
+		assert.deepStrictEqual(parseCellSizeResponse("\x1b]1337;ReportCellSize=17.50;8.00\x07"), {
+			widthPx: 8,
+			heightPx: 18, // 17.50 rounds to 18
+		});
+	});
+
+	it("parses the iTerm2 ReportCellSize reply with a retina scale factor", () => {
+		// OSC 1337 ; ReportCellSize=[height];[width];[scale] ST — scale gives
+		// physical-pixels-per-point; the points size is what we want for cell math.
+		assert.deepStrictEqual(parseCellSizeResponse("\x1b]1337;ReportCellSize=17.50;8.00;2.0\x07"), {
+			widthPx: 8,
+			heightPx: 18,
+		});
+	});
+
+	it("parses the iTerm2 ReportCellSize reply terminated by ST (ESC \\\\)", () => {
+		assert.deepStrictEqual(parseCellSizeResponse("\x1b]1337;ReportCellSize=20;10\x1b\\"), {
+			widthPx: 10,
+			heightPx: 20,
+		});
+	});
+
+	it("returns null for unrelated input and rejects non-positive sizes", () => {
+		assert.strictEqual(parseCellSizeResponse("\x1b[I"), null);
+		assert.strictEqual(parseCellSizeResponse("hello"), null);
+		assert.strictEqual(parseCellSizeResponse("\x1b[6;0;0t"), null);
+		assert.strictEqual(parseCellSizeResponse("\x1b]1337;ReportCellSize=0;0\x07"), null);
 	});
 });
 

--- a/packages/pi-tui/test/tui-cell-size-input.test.ts
+++ b/packages/pi-tui/test/tui-cell-size-input.test.ts
@@ -78,4 +78,29 @@ describe("TUI cell size responses", () => {
 			tui.stop();
 		});
 	});
+
+	it("consumes the iTerm2 OSC 1337 ReportCellSize reply (iTerm2 ignores CSI 16t)", () => {
+		// iTerm2 does not answer CSI 16t; its only cell-size mechanism is the
+		// proprietary OSC 1337;ReportCellSize reply. pi must consume it and adopt
+		// the reported (point) cell size so inline images size with the right
+		// cell aspect. height=17.50, width=8.00, scale=2.0 → rounded 8x18.
+		withImageTerminal(() => {
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+
+			const terminal = new VirtualTerminal(80, 24);
+			const tui = new TUI(terminal);
+			const recorder = new InputRecorder();
+
+			tui.setFocus(recorder);
+			tui.start();
+
+			terminal.sendInput("\x1b]1337;ReportCellSize=17.50;8.00;2.0\x07");
+			assert.deepStrictEqual(recorder.inputs, []);
+			assert.deepStrictEqual(getCellDimensions(), { widthPx: 8, heightPx: 18 });
+
+			terminal.sendInput("q");
+			assert.deepStrictEqual(recorder.inputs, ["q"]);
+			tui.stop();
+		});
+	});
 });


### PR DESCRIPTION

## Linked issue

Closes #751

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fix inline image rendering inside tool cards so a tall image (screenshot, document) stays inside its card instead of overflowing and painting over the chat, status bar, and footer — and stop graphics-capable terminals (Ghostty/Kitty/WezTerm) from stacking overlapping copies of it.
**Why:** The tool-card framing collapsed and trimmed the blank padding rows an image uses to reserve its on-screen height, so the card under-reserved height and the terminal painted the full image over everything below it. Two secondary defects (no Kitty placement id, and a fresh image id on every redraw) made the image stack copies; the iTerm2 path requested `height="auto"` and overflowed too; and on iTerm2 pi never learned the real cell size (iTerm2 ignores `CSI 16t`), so once the overflow was bounded the image was sized with the wrong cell aspect and left a trailing gap.
**How:** Preserve image rows verbatim through the card framing (skip collapse/trim, keep the reserved padding, indent the sequence under the card text without padding it), pin a stable Kitty placement id and reuse a stable image id across redraws, delete prior placements before full repaints, bound the iTerm2 sequence height to the reserved rows, and query iTerm2's real cell size via `OSC 1337 ; ReportCellSize`.

This is a **TUI rendering** fix. The headline is the overflow (card framing); the placement-id / stable-image-id and iTerm2 height/cell-size work is complementary (anti-stacking and correct sizing on the iTerm2 protocol path).

## What this PR does (at a glance)

- Stops a tall inline image overflowing its tool card and overpainting the chat, status bar, and footer
- Stops Ghostty/Kitty/WezTerm stacking overlapping copies of the image on redraw
- Left-aligns the image under the card text instead of hugging column 0
- Bounds the iTerm2 image height to the reserved rows (was `height="auto"`)
- Queries iTerm2's real cell size via `OSC 1337 ; ReportCellSize` (iTerm2 ignores the xterm `CSI 16t` query), so images are sized with the correct cell aspect and no longer leave a trailing gap on iTerm2
- Adds regression tests at the unit and end-to-end level, each proven to fail on `main`

Scope: 9 files, +522 / −29. No production dependency changes. Verified end-to-end in real **Ghostty** and **iTerm2** windows.

---

## Why (the root problem)

Found via a live diagnostic in a real Ghostty session: `caps=kitty cell=8x20 c=21 r=24 reservedLines=24`. The image geometry was **correct** — pi-tui computed 24 rows and reserved 24 lines. The defect was downstream in the tool-card framing.

An inline image is emitted as its escape sequence on line 0 followed by `(rows-1)` blank padding lines — those blanks are how the TUI reserves the image's on-screen height so content below it lands in the right place. The card render path destroyed them:

1. `ToolExecutionComponent.render()` ran `collapseBlankLines()` over the body, merging the `(rows-1)` padding rows down to a single blank.
2. `renderTranscriptCard()` / `renderConnectedCard()` ran `trimOuterBlankLines()` (stripping trailing blanks) and prefixed every body line with `"   " + padRight(...)`, which also shifts the raw Kitty sequence.

Net effect: a 24-row image was framed as ~1 row, so the terminal painted all 24 rows of pixels over the chat and footer below the card.

Two secondary defects made graphics terminals stack copies:

- pi-tui emitted the Kitty image with **no placement id (`p=`)**. Per the Kitty protocol, re-emitting the same `(image id, placement id)` replaces a placement; without `p=`, each re-emit appends a new one.
- `ToolExecutionComponent.updateDisplay()` destroys and recreates its `Image` components on every streaming tick, and the recreated `Image` had no image id — so it called `allocateImageId()` and got a fresh random id each time, changing the placement key every redraw and defeating the stable `p=`.

And the iTerm2 path requested `height="auto"`, letting iTerm2 draw at the image's natural aspect height and overflow the reserved rows on that protocol. Once that was bounded, a third iTerm2-specific issue surfaced: iTerm2 does **not** answer the xterm `CSI 16t` cell-size query (confirmed against the iTerm2 spec and a live session — its only mechanism is the proprietary `OSC 1337 ; ReportCellSize`). pi only sent `CSI 16t`, so on iTerm2 it fell back to a default cell size and sized the image with the wrong cell aspect, leaving a trailing blank gap under it.

---

## What changed — every change and why

### A. Overflow fix: preserve image rows through the card framing (the headline)

| File | What changed | Why |
| --- | --- | --- |
| `gsd-agent-modes/.../components/tool-execution.ts` | `render()` skips `collapseBlankLines()` when the body contains an image line; the body is passed through with its reserved padding intact. | `collapseBlankLines` crushed the `(rows-1)` padding rows to one, framing a tall image as a single row. |
| `gsd-agent-modes/.../components/transcript-design.ts` | `renderTranscriptCard()` and `renderConnectedCard()` skip `trimOuterBlankLines()` when the body has an image, and `paintBody()` passes image-sequence lines through verbatim — offset by the same `indent + 3` spaces as normal text so the image sits under the card text, but **never** `padRight`/`truncate`d (which would corrupt the placement). | Trimming stripped the reserved rows; the `"   " + padRight` prefix shifted/clipped the Kitty sequence. The image now reserves its full height and aligns under the card text. |
| `pi-tui/src/index.ts` | Export `isImageLine`. | The card layer needs to detect image rows to special-case them. |

### B. Anti-stacking: stable Kitty placement identity (Ghostty/Kitty/WezTerm)

| File | What changed | Why |
| --- | --- | --- |
| `pi-tui/src/terminal-image.ts` | `encodeKitty()` accepts a `placementId` and emits a stable `p=1` alongside the image id (only when an image id is present; the protocol ignores `p` for id=0). | Re-emitting the same `(image id, p)` REPLACES the placement; without `p=`, every redraw appends a new placement and copies stack. |
| `gsd-agent-modes/.../components/tool-execution.ts` | Cache a stable Kitty image id per image index (`stableImageIds` map) and pass it as `options.imageId` on recreation; cleared in `dispose()`. | `updateDisplay()` recreates the `Image` on every streaming tick; without a stable id each recreation got a fresh random id, changing the placement key and defeating the stable `p=`. |
| `pi-tui/src/tui.ts` | Delete prior Kitty placements before the full-repaint paths (`fullRender`, bottom-anchored repaint, tall→tall realign) and the partial-diff path, tracked via a persistent `previousKittyImageIds` set (committed by a new `commitRenderedLines()` at every render-completion site) that survives the forced-render `previousLines` reset. | `\x1b[2J` clears graphics on Ghostty but not upstream Kitty, and `\x1b[2K` never clears graphics — so an explicit delete is the only terminal-agnostic cleanup that stops placements lingering across a repaint. |

### C. iTerm2 height bound + correct cell size

| File | What changed | Why |
| --- | --- | --- |
| `pi-tui/src/terminal-image.ts` | The iTerm2 path pins the sequence height to `size.rows` (was `height="auto"`), with `preserveAspectRatio` on. | `height="auto"` let iTerm2 draw at the image's natural aspect height and overflow the reserved rows; pinning to the reserved rows matches the Kitty path and letterboxes within the box. |
| `pi-tui/src/terminal-image.ts` | New exported `parseCellSizeResponse()` parses both the xterm `CSI 6;h;w t` reply and iTerm2's proprietary `OSC 1337;ReportCellSize=h;w[;scale]` reply (anchored to the whole payload so a batched reply never swallows a keystroke; the retina `scale` is ignored since image math uses points). | iTerm2 does **not** answer `CSI 16t` (confirmed against the iTerm2 spec and a live session). Its only cell-size mechanism is `ReportCellSize`. Without parsing it, pi fell back to a default cell size on iTerm2 and sized images with the wrong cell aspect — leaving a trailing gap under the image. |
| `pi-tui/src/tui.ts` | `queryCellSize()` also sends `OSC 1337;ReportCellSize` when the protocol is iTerm2; `consumeCellSizeResponse()` routes through the shared `parseCellSizeResponse()`. | Makes pi learn iTerm2's true cell pixel size so reserved rows match the rows iTerm2 actually draws. Sending both queries is harmless on terminals that ignore one. |

---

## Change type

- [x] `fix` — inline image overflow, stacking, iTerm2 height + cell-size sizing
- [x] `test` — new behavior-executing regression tests

## Scope

- [x] `pi-tui` — `terminal-image.ts` (Kitty placement id, `parseCellSizeResponse`, `isImageLine` export), `tui.ts` (redraw cleanup + iTerm2 `ReportCellSize` query)
- [x] `gsd-agent-modes` — interactive tool cards (`tool-execution.ts`, `transcript-design.ts`)

## Breaking changes

- [x] No

New public surface only: `isImageLine` and `parseCellSizeResponse` are now exported from `@gsd/pi-tui`. No existing API, CLI, or config behavior changes.

## Test plan

- [x] CI passes (see reviewer note below on pre-existing local failures)
- [x] New/updated tests included
- [x] Manual testing — verified end-to-end in real **Ghostty** and **iTerm2** windows: a tall image stays inside its card, aligned under the card text, with the chat/footer intact, no stacking after spinner ticks + a forced full render, and (iTerm2) no trailing gap below the image.

Behavior-executing tests only — no source-grep (confirmed by `scripts/check-source-grep-tests.sh`). 17 new tests across 4 files; each regression test was confirmed to **FAIL against `main`** (exact `origin/main` source, fix reverted) and **PASS** after the fix, so the overflow/stacking/sizing cannot silently return.

| Test file | New tests | Verifies |
| --- | --- | --- |
| `gsd-agent-modes/.../__tests__/tool-execution.test.ts` | 3 | End-to-end through the real `ToolExecutionComponent`: a tall image reserves its full row height inside the card (no overflow); the Kitty sequence is passed through verbatim and left-aligned under the card text; ordinary text still collapses blank rows (fix is image-scoped). |
| `gsd-agent-modes/.../__tests__/transcript-design.test.ts` | 2 | `renderConnectedCard` / `renderTranscriptCard` preserve image padding rows and emit the sequence verbatim under the card indent. |
| `pi-tui/test/terminal-image.test.ts` | 11 | `encodeKitty` pins a stable `p=` when an image id is present and omits it for id=0; the same `(image id, p)` is re-emitted across renders so it replaces; iTerm2 sizing bounds height to the reserved rows (never `auto`) and keeps width/height in cell units; `parseCellSizeResponse` parses both the xterm `CSI 16t` reply and the iTerm2 `OSC 1337;ReportCellSize` reply (incl. retina scale + `ST` terminator) and rejects junk/non-positive sizes. |
| `pi-tui/test/tui-cell-size-input.test.ts` | 1 | End-to-end through a real `TUI` + virtual terminal: pi consumes the iTerm2 `ReportCellSize` reply and adopts the reported cell size, without leaking it to the focused input. |

On `main` the headline overflow test fails with `"a tall image must reserve its height as blank padding rows; only 0 were kept"`, and the iTerm2 `ReportCellSize` test fails because the unparsed reply leaks through to user input. After the fix both pass.

Suite totals on the affected files (all green): `terminal-image` 57/57, `tui-cell-size-input` 3/3, `tool-execution` 38/38, `transcript-design` 3/3. `verify:fast` passes (strict test matrix, source-grep check, pi-boundary, secret-scan).

**Reviewer note — pre-existing local unit failures (not from this PR).** A full local `test:unit` shows a handful of failing unit tests that are unrelated to this change and **pre-existing on `main`**: I reverted every file in this PR to `origin/main` and re-ran the suite, yielding the same failures with none in the changed files. They are environment/fixture-sensitive (the exact count varies by run and base — e.g. 16 on one base, 9 on a later one): onboarding temp-dir tests, auto-mode cost-spike / retry-bypass telemetry, a `dist-redirect` loader-hook issue, GSD prompt/compaction fixtures, and a `GSD_BIN_PATH` check that on my machine reads a path from a *different* local worktree (pure env inheritance). None touch `pi-tui` or the `gsd-agent-modes` components changed here. CI on a clean runner is the authoritative gate.

## AI disclosure

- [x] This PR includes AI-assisted code. Tooling: GSD-pi agent. All changes are tested to the same standard as human-written code (behavior-executing unit + end-to-end tests, each proven to fail on `main`, plus manual verification in real Ghostty and iTerm2 windows). The AI is not credited as an author or co-author.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784135626&installation_id=134682257&pr_number=752&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F752&signature=29b3295316e16ce6ff118bd5e74cfc683b42ce4795922d27553b49165097b876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->