### PR TITLE
fix(gsd): surface actionable SQLite db-open warnings

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -103,7 +103,7 @@ function dbOpenPhaseHint(status: WorkflowDatabaseStatus): string {
 
 export function formatWorkflowDatabaseOpenFailure(
   result: WorkflowDatabaseOpenFailure,
-  status: WorkflowDatabaseStatus = getWorkflowDatabaseStatus(),
+  status?: WorkflowDatabaseStatus,
   nodeVersion: string = process.versions.node,
 ): string {
   if (result.reason === "missing-gsd-dir") {
@@ -114,11 +114,12 @@ export function formatWorkflowDatabaseOpenFailure(
     return `ensureDbOpen failed — no GSD database found at ${result.location.projectDb}`;
   }
 
-  const detail = result.error?.message ?? status.lastError?.message ?? "";
+  const resolvedStatus = status ?? getWorkflowDatabaseStatus();
+  const detail = result.error?.message ?? resolvedStatus.lastError?.message ?? "";
   const detailSuffix = detail ? ` (${detail})` : "";
   return (
     `ensureDbOpen failed for ${result.location.projectDb}: ` +
-    `${dbOpenPhaseHint(status)}${detailSuffix}. ${sqliteProviderHint(status, nodeVersion)}`
+    `${dbOpenPhaseHint(resolvedStatus)}${detailSuffix}. ${sqliteProviderHint(resolvedStatus, nodeVersion)}`
   );
 }
 

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -8,7 +8,12 @@ import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { createBashTool, createEditTool, createReadTool, createWriteTool } from "@gsd/pi-coding-agent";
 
 import { logWarning } from "../workflow-logger.js";
-import { openWorkflowDatabase } from "../db-workspace.js";
+import {
+  getWorkflowDatabaseStatus,
+  openWorkflowDatabase,
+  type WorkflowDatabaseOpenResult,
+  type WorkflowDatabaseStatus,
+} from "../db-workspace.js";
 import { getAutoWorktreePath } from "../auto-worktree.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { worktreesDirs } from "../worktree-placement.js";
@@ -69,15 +74,59 @@ export function resolveWorkflowToolBasePath(
 
 export { resolveProjectRootDbPath } from "../db-workspace.js";
 
+type WorkflowDatabaseOpenFailure = Extract<WorkflowDatabaseOpenResult, { ok: false }>;
+
+function sqliteProviderHint(status: WorkflowDatabaseStatus, nodeVersion: string): string {
+  if (status.provider) return `Provider: ${status.provider}.`;
+
+  const major = Number.parseInt(nodeVersion.split(".")[0] ?? "", 10);
+  if (Number.isFinite(major) && major < 22) {
+    return (
+      `No SQLite provider available. Upgrade Node to >= 22.0.0 (current: v${nodeVersion}), ` +
+      "use the packaged GSD runtime, or install/restore better-sqlite3 in this runtime."
+    );
+  }
+
+  return (
+    "No SQLite provider available. Use a Node build with node:sqlite enabled, " +
+    "run the packaged GSD runtime, or install/restore better-sqlite3 in this runtime."
+  );
+}
+
+function dbOpenPhaseHint(status: WorkflowDatabaseStatus): string {
+  if (status.lastPhase === "open") return "The database file could not be opened";
+  if (status.lastPhase === "initSchema") return "The database schema could not be initialized";
+  if (status.lastPhase === "vacuum-recovery") return "Corruption recovery (VACUUM) failed";
+  if (status.attempted) return "The database could not be opened";
+  return "The database provider could not be loaded";
+}
+
+export function formatWorkflowDatabaseOpenFailure(
+  result: WorkflowDatabaseOpenFailure,
+  status: WorkflowDatabaseStatus = getWorkflowDatabaseStatus(),
+  nodeVersion: string = process.versions.node,
+): string {
+  if (result.reason === "missing-gsd-dir") {
+    return `ensureDbOpen failed — no .gsd directory found at ${result.location.projectGsd}`;
+  }
+
+  if (result.reason === "missing-database") {
+    return `ensureDbOpen failed — no GSD database found at ${result.location.projectDb}`;
+  }
+
+  const detail = result.error?.message ?? status.lastError?.message ?? "";
+  const detailSuffix = detail ? ` (${detail})` : "";
+  return (
+    `ensureDbOpen failed for ${result.location.projectDb}: ` +
+    `${dbOpenPhaseHint(status)}${detailSuffix}. ${sqliteProviderHint(status, nodeVersion)}`
+  );
+}
+
 export async function ensureDbOpen(basePath: string = safeWorkspaceCwd()): Promise<boolean> {
   const result = openWorkflowDatabase(basePath);
   if (result.ok) return true;
 
-  if (result.reason === "missing-gsd-dir") {
-    logWarning("bootstrap", "ensureDbOpen failed — no .gsd directory found");
-  } else {
-    logWarning("bootstrap", `ensureDbOpen failed: ${result.error?.message ?? "open failed"}`);
-  }
+  logWarning("bootstrap", formatWorkflowDatabaseOpenFailure(result));
   return false;
 }
 

--- a/src/resources/extensions/gsd/tests/dist-redirect.mjs
+++ b/src/resources/extensions/gsd/tests/dist-redirect.mjs
@@ -7,6 +7,10 @@ const require = createRequire(import.meta.url);
 const ROOT = new URL("../../../../../", import.meta.url);
 
 export function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('node:')) {
+    return { url: specifier, format: 'builtin', shortCircuit: true };
+  }
+
   // 1. Redirect all workspace package bare imports to source.
   //    CI portability runs don't build any packages/ dist artifacts, so every
   //    @gsd/* specifier (including transitive ones pulled in by pi-coding-agent
@@ -100,6 +104,10 @@ export function resolve(specifier, context, nextResolve) {
 }
 
 export function load(url, context, nextLoad) {
+  if (url.startsWith('node:') || context.format === 'builtin') {
+    return { format: 'builtin', source: '', shortCircuit: true };
+  }
+
   // jiti/CJS may still enter through stale packages/*/dist/index.js — redirect to src.
   if (url.includes('/packages/pi-ai/dist/index.js')) {
     url = url.replace('/dist/index.js', '/src/index.ts');

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -11,7 +11,10 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { closeDatabase, isDbAvailable, getDecisionById, SCHEMA_VERSION, _getAdapter } from '../gsd-db.ts';
+import { formatWorkflowDatabaseOpenFailure } from '../bootstrap/dynamic-tools.ts';
 
 const _require = createRequire(import.meta.url);
 
@@ -288,6 +291,102 @@ function createLegacyV15Db(dbPath: string): void {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('ensure-db-open', () => {
+  test('formatWorkflowDatabaseOpenFailure: open failure without provider gives actionable SQLite guidance', () => {
+    const message = formatWorkflowDatabaseOpenFailure(
+      {
+        ok: false,
+        reason: 'open-failed',
+        location: {
+          projectRoot: '/tmp/example',
+          projectGsd: '/tmp/example/.gsd',
+          projectDb: '/tmp/example/.gsd/gsd.db',
+        },
+      },
+      {
+        available: false,
+        provider: null,
+        attempted: true,
+        lastError: null,
+        lastPhase: null,
+      },
+      '22.15.0',
+    );
+
+    assert.match(message, /\/tmp\/example\/\.gsd\/gsd\.db/);
+    assert.match(message, /No SQLite provider available/);
+    assert.match(message, /node:sqlite/);
+    assert.match(message, /better-sqlite3/);
+  });
+
+  test('formatWorkflowDatabaseOpenFailure: old Node includes upgrade guidance', () => {
+    const message = formatWorkflowDatabaseOpenFailure(
+      {
+        ok: false,
+        reason: 'open-failed',
+        location: {
+          projectRoot: '/tmp/example',
+          projectGsd: '/tmp/example/.gsd',
+          projectDb: '/tmp/example/.gsd/gsd.db',
+        },
+      },
+      {
+        available: false,
+        provider: null,
+        attempted: true,
+        lastError: null,
+        lastPhase: null,
+      },
+      '20.11.1',
+    );
+
+    assert.match(message, />= 22\.0\.0/);
+    assert.match(message, /current: v20\.11\.1/);
+  });
+
+  test('ensureDbOpen: source-mode runtime without node:sqlite records actionable guidance', () => {
+    const loaderPath = fileURLToPath(new URL('./resolve-ts.mjs', import.meta.url));
+    const script = `
+      const fs = require('node:fs');
+      const os = require('node:os');
+      const path = require('node:path');
+      const { pathToFileURL } = require('node:url');
+      (async () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-missing-sqlite-'));
+        try {
+          fs.mkdirSync(path.join(base, '.gsd'), { recursive: true });
+          const dynamicTools = await import(pathToFileURL(path.resolve('src/resources/extensions/gsd/bootstrap/dynamic-tools.ts')).href);
+          const logger = await import(pathToFileURL(path.resolve('src/resources/extensions/gsd/workflow-logger.ts')).href);
+          await dynamicTools.ensureDbOpen(base);
+          const messages = logger.peekLogs().map((entry) => entry.message);
+          console.log(JSON.stringify(messages));
+        } finally {
+          fs.rmSync(base, { recursive: true, force: true });
+        }
+      })().catch((error) => {
+        console.error(error.stack || error.message || String(error));
+        process.exit(1);
+      });
+    `;
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--no-experimental-sqlite',
+        '--import',
+        loaderPath,
+        '--experimental-strip-types',
+        '-e',
+        script,
+      ],
+      { cwd: process.cwd(), encoding: 'utf-8' },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const messages = JSON.parse(result.stdout.trim()) as string[];
+    assert.ok(messages.some((message) => /No SQLite provider available/.test(message)), result.stdout);
+    assert.ok(messages.some((message) => /node:sqlite/.test(message)), result.stdout);
+    assert.ok(messages.some((message) => /better-sqlite3/.test(message)), result.stdout);
+  });
+
   test('ensureDbOpen: creates empty DB without importing Markdown', async () => {
     const tmpDir = makeTmpDir();
     const gsdDir = path.join(tmpDir, '.gsd');

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -12,7 +12,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { closeDatabase, isDbAvailable, getDecisionById, SCHEMA_VERSION, _getAdapter } from '../gsd-db.ts';
 import { formatWorkflowDatabaseOpenFailure } from '../bootstrap/dynamic-tools.ts';
 
@@ -345,17 +345,31 @@ describe('ensure-db-open', () => {
 
   test('ensureDbOpen: source-mode runtime without node:sqlite records actionable guidance', () => {
     const loaderPath = fileURLToPath(new URL('./resolve-ts.mjs', import.meta.url));
+    const runningFromDistTest = fileURLToPath(import.meta.url).includes(`${path.sep}dist-test${path.sep}`);
+    const dynamicToolsImportUrl = pathToFileURL(
+      path.resolve(
+        runningFromDistTest
+          ? 'dist-test/src/resources/extensions/gsd/bootstrap/dynamic-tools.js'
+          : 'src/resources/extensions/gsd/bootstrap/dynamic-tools.ts',
+      ),
+    ).href;
+    const loggerImportUrl = pathToFileURL(
+      path.resolve(
+        runningFromDistTest
+          ? 'dist-test/src/resources/extensions/gsd/workflow-logger.ts'
+          : 'src/resources/extensions/gsd/workflow-logger.ts',
+      ),
+    ).href;
     const script = `
       const fs = require('node:fs');
       const os = require('node:os');
       const path = require('node:path');
-      const { pathToFileURL } = require('node:url');
       (async () => {
         const base = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-missing-sqlite-'));
         try {
           fs.mkdirSync(path.join(base, '.gsd'), { recursive: true });
-          const dynamicTools = await import(pathToFileURL(path.resolve('src/resources/extensions/gsd/bootstrap/dynamic-tools.ts')).href);
-          const logger = await import(pathToFileURL(path.resolve('src/resources/extensions/gsd/workflow-logger.ts')).href);
+          const dynamicTools = await import(${JSON.stringify(dynamicToolsImportUrl)});
+          const logger = await import(${JSON.stringify(loggerImportUrl)});
           await dynamicTools.ensureDbOpen(base);
           const messages = logger.peekLogs().map((entry) => entry.message);
           console.log(JSON.stringify(messages));

--- a/src/tests/resolve-ts-loader.test.ts
+++ b/src/tests/resolve-ts-loader.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test"
 import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
 
 import { load as loadWithTestLoader, resolve as resolveWithTestLoader } from "../resources/extensions/gsd/tests/dist-redirect.mjs"
 
@@ -47,4 +49,25 @@ test("resolve-ts loader transpiles pi-coding-agent source files that strip-only 
   assert.equal(loaded.shortCircuit, true)
   assert.match(loaded.source, /class Agent/, "transpiled source should include the Agent class")
   assert.doesNotMatch(loaded.source, /private readonly listeners/, "TypeScript field modifiers should be removed")
+})
+
+test("resolve-ts loader allows source-mode DB provider to require node:sqlite", () => {
+  const loaderPath = fileURLToPath(
+    new URL("../resources/extensions/gsd/tests/resolve-ts.mjs", import.meta.url),
+  )
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      loaderPath,
+      "--experimental-strip-types",
+      "-e",
+      "const sqlite = require('node:sqlite'); console.log(typeof sqlite.DatabaseSync)",
+    ],
+    { encoding: "utf-8" },
+  )
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout.trim(), "function")
 })


### PR DESCRIPTION
## TL;DR

**What:** Improves `ensureDbOpen` failure warnings so missing SQLite providers and DB open phases produce actionable guidance.
**Why:** Source-mode runtimes without `node:sqlite` or `better-sqlite3` previously logged opaque DB-open failures.
**How:** Adds a formatter for workflow DB open failures, teaches the source-mode test loader to preserve `node:` builtins, and covers the behavior with focused regression tests.

## What

This updates the GSD bundled extension bootstrap path to format database-open failures with the failing database path, open phase, provider status, and runtime-specific SQLite remediation. It also updates the source-mode test loader so `node:` builtin imports, including `node:sqlite`, resolve as builtins during tests.

Affected files:

- `src/resources/extensions/gsd/bootstrap/dynamic-tools.ts`
- `src/resources/extensions/gsd/tests/dist-redirect.mjs`
- `src/resources/extensions/gsd/tests/ensure-db-open.test.ts`
- `src/tests/resolve-ts-loader.test.ts`

## Why

When the workflow database cannot open in a runtime without an available SQLite provider, users need to know whether to upgrade/use a compatible Node runtime, use the packaged GSD runtime, or restore/install `better-sqlite3`. The old warning did not provide enough context to diagnose that environment problem.

## How

`formatWorkflowDatabaseOpenFailure` maps the DB open failure reason and latest workflow database status into a concrete warning. It distinguishes missing `.gsd`, missing `gsd.db`, open failures, schema initialization failures, VACUUM recovery failures, and missing SQLite providers.

The source-mode loader now treats `node:` imports as builtins, and the DB warning regression test chooses the matching source or compiled module path so it works in both direct source-mode runs and CI compiled `dist-test` runs.

## Testing

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/ensure-db-open.test.ts src/tests/resolve-ts-loader.test.ts`
- `pnpm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test "dist-test/src/resources/extensions/gsd/tests/ensure-db-open.test.js"`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test "dist-test/src/tests/resolve-ts-loader.test.js"`
- GitHub Actions CI: passed

## Change type checklist

- [ ] `feat` - New feature or capability
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Breaking changes

None.