### PR TITLE
perf: faster text measurement, leaner startup, snappier interactive open + render

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -1,11 +1,12 @@
 // Project/App: gsd-pi
 // File Purpose: Tests for interactive terminal tool execution rendering.
-import { afterEach, beforeEach, describe, test } from "node:test";
+import { afterEach, beforeEach, describe, mock, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import stripAnsi from "strip-ansi";
 import { isImageLine, resetCapabilitiesCache, setCapabilities, setCellDimensions } from "@gsd/pi-tui";
 import { ToolExecutionComponent, ToolPhaseSummaryComponent, type ToolExecutionPhase } from "../tool-execution.js";
+import { setRailAnimationEnabled } from "../transcript-design.js";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { READ_TUI_EXPANDED_MAX_LINES } from "@gsd/pi-coding-agent/core/tools/read.js";
 
@@ -70,6 +71,70 @@ function renderToolCollapsed(
 }
 
 describe("ToolExecutionComponent", () => {
+	test("running-rail animates at a constant cadence while in-flight, and not at all when the setting is off", (t) => {
+		// The running tool card animates its rail by re-rendering the transcript on a
+		// fixed-cadence timer while in-flight (isInFlight === !result). The cadence is
+		// constant (matched to the rail's per-cell step) and keeps going for as long as
+		// the tool runs — a 30-minute tool stays visibly alive, never frozen. When the
+		// `terminal.toolRailAnimation` setting is off the timer is never armed, so a
+		// long-running tool costs zero idle CPU.
+		mock.timers.enable({ apis: ["setInterval", "Date"] });
+		t.after(() => {
+			setRailAnimationEnabled(true); // module-global — restore default for other tests
+			mock.timers.reset();
+		});
+
+		// --- animation ON (default) ---
+		setRailAnimationEnabled(true);
+		let renderRequests = 0;
+		const onCard = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 99999" },
+			{},
+			undefined,
+			{ requestRender() { renderRequests++; } } as any,
+		);
+		onCard.render(120); // arms the rail timer
+		assert.equal(renderRequests, 0, "render itself does not request a render");
+
+		// Each 70ms tick re-renders once — constant cadence, one cell of movement per frame.
+		mock.timers.tick(70);
+		mock.timers.tick(70);
+		assert.ok(renderRequests >= 2, `rail should animate while in-flight, got ${renderRequests}`);
+
+		// It keeps animating indefinitely while in-flight — no cap, no freeze. 200 ticks
+		// (~14s) each request a render at the constant rate.
+		const before = renderRequests;
+		for (let i = 0; i < 200; i++) mock.timers.tick(70);
+		assert.ok(
+			renderRequests - before >= 180,
+			`rail must keep animating at a constant rate (no cap), got ${renderRequests - before} over 200 ticks`,
+		);
+
+		// Stops once the result arrives.
+		onCard.updateResult({ content: [{ type: "text", text: "done" }], isError: false });
+		const afterResult = renderRequests;
+		mock.timers.tick(70);
+		mock.timers.tick(70);
+		assert.equal(renderRequests, afterResult, "rail stops once the tool has a result");
+
+		// --- animation OFF: the timer is never armed ---
+		setRailAnimationEnabled(false);
+		let offRenders = 0;
+		const offCard = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 99999" },
+			{},
+			undefined,
+			{ requestRender() { offRenders++; } } as any,
+		);
+		offCard.render(120);
+		mock.timers.tick(70);
+		mock.timers.tick(70);
+		mock.timers.tick(70);
+		assert.equal(offRenders, 0, "no rail animation when the setting is off (zero idle CPU)");
+	});
+
 	test("reuses shared tool-argument normalization for pending invocation matching", () => {
 		const sourceUrl = existsSync(new URL("../tool-execution.ts", import.meta.url))
 			? new URL("../tool-execution.ts", import.meta.url)

--- a/packages/gsd-agent-modes/src/modes/interactive/components/settings-selector.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/settings-selector.ts
@@ -38,6 +38,7 @@ export interface SettingsConfig {
 	availableThemes: string[];
 	hideThinkingBlock: boolean;
 	toolsExpanded: boolean;
+	toolRailAnimation: boolean;
 	collapseChangelog: boolean;
 	doubleEscapeAction: "fork" | "tree" | "none";
 	treeFilterMode: "default" | "no-tools" | "user-only" | "labeled-only" | "all";
@@ -65,6 +66,7 @@ export interface SettingsCallbacks {
 	onThemePreview?: (theme: string) => void;
 	onHideThinkingBlockChange: (hidden: boolean) => void;
 	onToolsExpandedChange: (expanded: boolean) => void;
+	onToolRailAnimationChange: (enabled: boolean) => void;
 	onCollapseChangelogChange: (collapsed: boolean) => void;
 	onDoubleEscapeActionChange: (action: "fork" | "tree" | "none") => void;
 	onTreeFilterModeChange: (mode: "default" | "no-tools" | "user-only" | "labeled-only" | "all") => void;
@@ -196,6 +198,13 @@ export class SettingsSelectorComponent extends Container {
 				description: "Expand tool output cards by default",
 				currentValue: config.toolsExpanded ? "expanded" : "collapsed",
 				values: ["expanded", "collapsed"],
+			},
+			{
+				id: "tool-rail-animation",
+				label: "Tool rail animation",
+				description: "Animate the rail on running tool cards (off = static, no re-render timer)",
+				currentValue: config.toolRailAnimation ? "true" : "false",
+				values: ["true", "false"],
 			},
 			{
 				id: "collapse-changelog",
@@ -426,6 +435,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "tools-expanded":
 						callbacks.onToolsExpandedChange(newValue === "expanded");
+						break;
+					case "tool-rail-animation":
+						callbacks.onToolRailAnimationChange(newValue === "true");
 						break;
 					case "collapse-changelog":
 						callbacks.onCollapseChangelogChange(newValue === "true");

--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -36,6 +36,7 @@ import {
 	renderTranscriptCard,
 	TRANSCRIPT_CARD_INDENT,
 	collapseBlankLines,
+	isRailAnimationEnabled,
 	type StatusTone,
 } from "./transcript-design.js";
 import { truncateToVisualLines } from "./visual-truncate.js";
@@ -45,6 +46,15 @@ const BASH_PREVIEW_LINES = 5;
 // During partial write tool-call streaming, re-highlight the first N lines fully
 // to keep multiline tokenization mostly correct without re-highlighting the full file.
 const WRITE_PARTIAL_FULL_HIGHLIGHT_LINES = 50;
+// The in-flight tool card animates its rail by re-rendering the transcript on a
+// fixed-cadence timer. The cadence is matched to the rail's own step
+// (RUNNING_RAIL_FRAME_MS in transcript-design): one re-render == one cell of head
+// movement, so the motion is smooth and no frame is wasted. Animation is gated by
+// the `terminal.toolRailAnimation` user setting (isRailAnimationEnabled): when it
+// is off, the timer is never armed and the rail renders statically, so even a tool
+// that runs for 30 minutes costs zero idle CPU. (A genuinely hung tool is finalized
+// at the source by agent-loop's raceToolExecutionAgainstAbort, which gives the card
+// a result and lets the timer stop on its own.)
 const RUNNING_RAIL_RENDER_INTERVAL_MS = 70;
 
 /**
@@ -470,20 +480,31 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private syncRunningRailTimer(): void {
-		if (!this.isInFlight() || this.hideComponent) {
+		if (!this.isInFlight() || this.hideComponent || !isRailAnimationEnabled()) {
 			this.stopRunningRailTimer();
 			return;
 		}
 		if (this.runningRailTimer) return;
 
 		this.runningRailTimer = setInterval(() => {
-			if (!this.isInFlight() || this.hideComponent) {
+			// Stop once the tool finishes, is hidden, or the animation setting is off.
+			if (!this.isInFlight() || this.hideComponent || !isRailAnimationEnabled()) {
 				this.stopRunningRailTimer();
 				return;
 			}
 			this.ui.requestRender();
 		}, RUNNING_RAIL_RENDER_INTERVAL_MS);
 		this.runningRailTimer.unref?.();
+	}
+
+	/**
+	 * Re-evaluate the running-rail timer after the `terminal.toolRailAnimation`
+	 * setting is toggled live. Arms the timer if animation is now on (and the card
+	 * is still in-flight) or stops it if now off; the static-vs-sweep rail picks up
+	 * the new setting on the next render.
+	 */
+	refreshRailAnimation(): void {
+		this.syncRunningRailTimer();
 	}
 
 	private stopRunningRailTimer(): void {

--- a/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/transcript-design.ts
@@ -23,6 +23,20 @@ const RUNNING_RAIL_TRAIL = 5;
 const HORIZONTAL_RAIL = "─";
 const HORIZONTAL_RAIL_HEAD = "━";
 
+// Whether the "running" rail sweeps (animates) or renders as a static rule. User
+// setting `terminal.toolRailAnimation` (default on). When off, running cards show
+// a static rail and ToolExecutionComponent does not arm its re-render timer, so a
+// long-running tool costs zero idle CPU. Module-level (not per-card) because every
+// running card shares the one preference; the interactive mode sets it at startup
+// and when the setting is toggled.
+let railAnimationEnabled = true;
+export function setRailAnimationEnabled(enabled: boolean): void {
+	railAnimationEnabled = enabled;
+}
+export function isRailAnimationEnabled(): boolean {
+	return railAnimationEnabled;
+}
+
 export function headerLabel(text: string): string {
 	return text.toUpperCase();
 }
@@ -113,7 +127,7 @@ export function renderConnectedCard(
 	const indent = opts.indent ?? TRANSCRIPT_CARD_INDENT;
 	const prefix = indentSpaces(indent);
 	const railColor = opts.railColor ?? "borderAccent";
-	const sweepFrame = opts.railSweep ? runningRailFrame() : undefined;
+	const sweepFrame = opts.railSweep && railAnimationEnabled ? runningRailFrame() : undefined;
 	const rail = (text: string) => renderRailText(text, railColor, sweepFrame);
 	const resolvedTitleColor =
 		opts.titleColor ??
@@ -396,7 +410,7 @@ function openRuleLine(title: string, right: string, width: number, tone: ThemeCo
 	const clippedRight = truncateToWidth(right, rightBudget, "");
 	const fixed = 4 + visibleWidth(clippedTitle) + 2 + visibleWidth(clippedRight) + 4;
 	const fill = Math.max(1, w - fixed);
-	const sweepFrame = sweep ? runningRailFrame() : undefined;
+	const sweepFrame = sweep && railAnimationEnabled ? runningRailFrame() : undefined;
 
 	return padLine(
 		renderRailText("─── ", tone) +

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-mode.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-mode.ts
@@ -31,6 +31,7 @@ import { ExtensionInputComponent } from "./components/extension-input.js";
 import { ExtensionSelectorComponent } from "./components/extension-selector.js";
 import { FooterComponent } from "./components/footer.js";
 import { ToolExecutionComponent } from "./components/tool-execution.js";
+import { setRailAnimationEnabled } from "./components/transcript-design.js";
 import { ContextualTips } from "@gsd/agent-core";
 import { handleAgentEvent } from "./controllers/chat-controller.js";
 import { setupEditorSubmitHandler as setupEditorSubmitHandlerController } from "./controllers/input-controller.js";
@@ -177,6 +178,7 @@ export class InteractiveMode {
 		this.version = VERSION;
 		this.ui = new TUI(options.terminal ?? new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
+		setRailAnimationEnabled(this.settingsManager.getToolRailAnimation());
 		this.headerContainer = new Container();
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
@@ -509,6 +511,14 @@ export class InteractiveMode {
 	private async cycleModel(direction: "forward" | "backward"): Promise<void> { return keyHandlers.cycleModel(this, direction); }
 	private toggleToolOutputExpansion(): void { keyHandlers.toggleToolOutputExpansion(this); }
 	private setToolsExpanded(expanded: boolean): void { keyHandlers.setToolsExpanded(this, expanded); }
+	private setToolRailAnimation(enabled: boolean): void {
+		this.settingsManager.setToolRailAnimation(enabled);
+		setRailAnimationEnabled(enabled);
+		for (const child of this.chatContainer.children) {
+			if (child instanceof ToolExecutionComponent) child.refreshRailAnimation();
+		}
+		this.ui.requestRender();
+	}
 	private toggleThinkingBlockVisibility(): void { keyHandlers.toggleThinkingBlockVisibility(this); }
 	private openExternalEditor(): void { keyHandlers.openExternalEditor(this); }
 

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-settings.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-selectors-settings.ts
@@ -88,6 +88,7 @@ export function showSettingsSelector(host: InteractiveModeDelegateHost): void {
 					availableThemes: getAvailableThemes(),
 					hideThinkingBlock: host.hideThinkingBlock,
 					toolsExpanded: host.toolOutputExpanded,
+					toolRailAnimation: host.settingsManager.getToolRailAnimation(),
 					collapseChangelog: host.settingsManager.getCollapseChangelog(),
 					doubleEscapeAction: host.settingsManager.getDoubleEscapeAction(),
 					treeFilterMode: host.settingsManager.getTreeFilterMode(),
@@ -169,6 +170,9 @@ export function showSettingsSelector(host: InteractiveModeDelegateHost): void {
 					onToolsExpandedChange: (expanded) => {
 						host.settingsManager.setToolsExpanded(expanded);
 						host.setToolsExpanded(expanded);
+					},
+					onToolRailAnimationChange: (enabled) => {
+						host.setToolRailAnimation(enabled);
 					},
 					onCollapseChangelogChange: (collapsed) => {
 						host.settingsManager.setCollapseChangelog(collapsed);

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -785,7 +785,7 @@ async function executePreparedToolCall(
 	const updateEvents: Promise<void>[] = [];
 
 	try {
-		const result = await prepared.tool.execute(
+		const execution = prepared.tool.execute(
 			prepared.toolCall.id,
 			prepared.args as never,
 			signal,
@@ -803,14 +803,60 @@ async function executePreparedToolCall(
 				);
 			},
 		);
+		// A cooperative tool returns promptly when its signal aborts. A hung or
+		// signal-deaf tool (a deadlocked MCP server, a D-state child the tool never
+		// reaps) would otherwise leave `execution` pending forever — blocking the
+		// whole tool batch, so no tool_execution_end is ever emitted and the UI card
+		// stays "running" indefinitely (a real CPU drain downstream). Race the
+		// execution against abort: once aborted, stop awaiting the tool and finalize
+		// it as aborted. The tool's own promise keeps running in the background, but
+		// the turn completes and every tool_execution_start gets a paired _end.
+		const outcome: ExecutedToolCallOutcome = signal
+			? await raceToolExecutionAgainstAbort(execution, signal)
+			: { result: await execution, isError: false };
 		await Promise.all(updateEvents);
-		return { result, isError: false };
+		return outcome;
 	} catch (error) {
 		await Promise.all(updateEvents);
 		return {
 			result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
 			isError: true,
 		};
+	}
+}
+
+/**
+ * Await a tool's execution unless `signal` aborts first. On abort, resolve with a
+ * synthetic aborted result instead of blocking on a tool that ignores the signal.
+ * Only abort short-circuits the wait — there is no general timeout, so legitimately
+ * long-running cooperative tools are unaffected.
+ */
+async function raceToolExecutionAgainstAbort(
+	execution: Promise<AgentToolResult<any>>,
+	signal: AbortSignal,
+): Promise<ExecutedToolCallOutcome> {
+	if (signal.aborted) {
+		return { result: createErrorToolResult("Operation aborted"), isError: true };
+	}
+	// If abort wins the race, `execution` is abandoned but still pending; swallow any
+	// later settlement so a background rejection does not surface as an unhandled
+	// rejection after the turn has moved on.
+	const guardedExecution = execution.then(
+		(result) => ({ result, isError: false }) satisfies ExecutedToolCallOutcome,
+		(error) => ({
+			result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
+			isError: true,
+		}),
+	);
+	let onAbort: (() => void) | undefined;
+	const abortPromise = new Promise<ExecutedToolCallOutcome>((resolve) => {
+		onAbort = () => resolve({ result: createErrorToolResult("Operation aborted"), isError: true });
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	try {
+		return await Promise.race([guardedExecution, abortPromise]);
+	} finally {
+		if (onAbort) signal.removeEventListener("abort", onAbort);
 	}
 }
 

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -236,6 +236,90 @@ describe("agentLoop with AgentMessage", () => {
 		expect(convertedMessages.length).toBe(2);
 	});
 
+	it("emits tool_execution_end and completes the turn when a hung, signal-deaf tool is aborted", async () => {
+		// Regression: a tool whose execute() never settles (a deadlocked MCP server,
+		// a D-state child) and that ignores its abort signal used to block the whole
+		// tool batch forever — no tool_execution_end was emitted, so a downstream UI
+		// card stayed "running" indefinitely (a real CPU drain). On abort, the loop
+		// must stop awaiting the hung tool, finalize it, and emit its _end.
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "hang",
+			label: "Hang",
+			description: "A tool that never resolves and ignores the abort signal",
+			parameters: toolSchema,
+			// Deliberately ignores `signal` and never resolves.
+			execute(_toolCallId, _params) {
+				return new Promise(() => {});
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+		const userPrompt: AgentMessage = createUserMessage("hang please");
+		const config: AgentLoopConfig = { model: createModel(), convertToLlm: identityConverter };
+
+		const controller = new AbortController();
+		let callIndex = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: createAssistantMessage(
+							[{ type: "toolCall", id: "tool-1", name: "hang", arguments: { value: "x" } }],
+							"toolUse",
+						),
+					});
+				} else {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage([{ type: "text", text: "done" }]) });
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, controller.signal, streamFn);
+
+		// Abort shortly after the tool starts running.
+		const started = new Promise<void>((resolve) => {
+			(async () => {
+				for await (const event of stream) {
+					events.push(event);
+					if (event.type === "tool_execution_start") {
+						resolve();
+						// Give the hung tool a tick, then abort.
+						setTimeout(() => controller.abort(), 10);
+					}
+				}
+			})();
+		});
+		await started;
+
+		// The whole loop must drain (not hang) within a sane bound.
+		const drained = (async () => {
+			const start = Date.now();
+			while (!events.some((e) => e.type === "tool_execution_end") && Date.now() - start < 3000) {
+				await new Promise((r) => setTimeout(r, 10));
+			}
+		})();
+		await drained;
+
+		const toolStart = events.find((e) => e.type === "tool_execution_start");
+		const toolEnd = events.find((e) => e.type === "tool_execution_end");
+		expect(toolStart).toBeDefined();
+		expect(toolEnd, "a hung+aborted tool must still emit tool_execution_end").toBeDefined();
+		if (toolEnd?.type === "tool_execution_end") {
+			expect(toolEnd.isError).toBe(true);
+		}
+	});
+
 	it("should handle tool calls and results", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: string[] = [];

--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -33,6 +33,7 @@ export interface RetrySettings {
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
 	toolsExpanded?: boolean; // default: true (tool output cards start expanded)
+	toolRailAnimation?: boolean; // default: true (animate the running tool-card rail; off = static rail + no re-render timer)
 	imageWidthCells?: number; // default: 60 (preferred inline image width in terminal cells)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
@@ -984,6 +985,19 @@ export class SettingsManager {
 		}
 		this.globalSettings.terminal.toolsExpanded = expanded;
 		this.markModified("terminal", "toolsExpanded");
+		this.save();
+	}
+
+	getToolRailAnimation(): boolean {
+		return this.settings.terminal?.toolRailAnimation ?? true;
+	}
+
+	setToolRailAnimation(enabled: boolean): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		this.globalSettings.terminal.toolRailAnimation = enabled;
+		this.markModified("terminal", "toolRailAnimation");
 		this.save();
 	}
 

--- a/packages/pi-coding-agent/src/theme/theme-highlight.test.ts
+++ b/packages/pi-coding-agent/src/theme/theme-highlight.test.ts
@@ -21,3 +21,42 @@ test("highlightCode keeps plain text unstyled when no language is known", () => 
 
 	assert.equal(line, "const answer = 42");
 });
+
+// The lightweight highlighter classifies identifier / number characters with
+// charCode comparisons (formerly per-char RegExp.test). These guard that the
+// charCode classes stay byte-identical in observable behaviour: every character
+// must survive untouched (the highlighter only adds ANSI, never alters content),
+// and token types must still be coloured distinctly.
+
+test("highlightCode preserves content exactly across a mixed corpus", () => {
+	const corpus = [
+		"export async function f(x) { return x + 1; } // trailing comment",
+		"const n = 3.14_15; let hex = 255; var s = 'a\\'b'; # hash comment",
+		"if (a === b && c !== d) { throw new Error(`templated`); }",
+		"\u8b58\u5225\u5b50 mixed with ascii_ident and \u6570\u5b57 42 and emoji \ud83d\ude80 end",
+		"\tindented\twith\ttabs   and   trailing spaces   ",
+		"_underscore $dollar a1b2 0_9 done",
+	];
+	for (const line of corpus) {
+		const out = highlightCode(line, "typescript").join("\n");
+		assert.equal(stripAnsi(out), line, `content must be preserved verbatim for: ${JSON.stringify(line)}`);
+	}
+});
+
+test("highlightCode colours numbers, strings and comments but leaves bare identifiers plain", () => {
+	const colourful = (src: string) => {
+		const [line] = highlightCode(src, "typescript");
+		assert.ok(line.includes("\x1b["), `expected ANSI colouring for: ${src}`);
+		assert.equal(stripAnsi(line), src, `content preserved for: ${src}`);
+	};
+	colourful("x = 42");
+	colourful('s = "hello"');
+	colourful("v = 3.14_15");
+	colourful("a // line comment");
+	colourful("b # hash comment");
+
+	// A line of bare identifiers and spaces has no keywords/numbers/strings/comments,
+	// so the highlighter adds no ANSI at all.
+	const [plain] = highlightCode("foo bar baz qux", "typescript");
+	assert.equal(plain, "foo bar baz qux", "bare identifiers must stay unstyled");
+});

--- a/packages/pi-coding-agent/src/theme/theme.ts
+++ b/packages/pi-coding-agent/src/theme/theme.ts
@@ -921,33 +921,60 @@ const LIGHTWEIGHT_KEYWORDS = new Set([
 	"while",
 ]);
 
+// charCode classifiers for lightweightHighlightLine. Every class the highlighter
+// uses is ASCII, so a charCode comparison is exactly equivalent to the original
+// /[A-Za-z_$]/, /[A-Za-z0-9_$]/, /\d/ and /[\d._]/ tests — but allocation-free.
+// This function is the single hottest node on the tool-output / diff render path
+// (live CPU profile), and the per-character RegExp.test() calls dominated it, so
+// the same charCode technique used for graphemeWidth applies here.
+function isIdentStartCode(c: number): boolean {
+	// A-Z (65-90), a-z (97-122), _ (95), $ (36)
+	return (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c === 95 || c === 36;
+}
+function isIdentPartCode(c: number): boolean {
+	// identifier-start plus 0-9 (48-57)
+	return (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c === 95 || c === 36;
+}
+function isNumStartCode(c: number): boolean {
+	// 0-9 (48-57)
+	return c >= 48 && c <= 57;
+}
+function isNumPartCode(c: number): boolean {
+	// 0-9 (48-57), . (46), _ (95)
+	return (c >= 48 && c <= 57) || c === 46 || c === 95;
+}
+
 function lightweightHighlightLine(line: string): string {
 	let out = "";
 	let i = 0;
-	while (i < line.length) {
-		const ch = line[i];
-		const next = line[i + 1];
-		if (ch === "/" && next === "/") {
+	const len = line.length;
+	while (i < len) {
+		const code = line.charCodeAt(i);
+		// `//` line comment
+		if (code === 47 /* / */ && line.charCodeAt(i + 1) === 47) {
 			out += theme.fg("syntaxComment", line.slice(i));
 			break;
 		}
-		if (ch === "#") {
+		// `#` line comment
+		if (code === 35 /* # */) {
 			out += theme.fg("syntaxComment", line.slice(i));
 			break;
 		}
-		if (ch === '"' || ch === "'" || ch === "`") {
-			const quote = ch;
+		// string literal: " ' `
+		if (code === 34 || code === 39 || code === 96) {
+			const quote = code;
 			let j = i + 1;
-			while (j < line.length) {
-				if (line[j] === "\\") {
-					if (j + 1 >= line.length) {
-						j = line.length;
+			while (j < len) {
+				const cj = line.charCodeAt(j);
+				if (cj === 92 /* \ */) {
+					if (j + 1 >= len) {
+						j = len;
 						break;
 					}
 					j += 2;
 					continue;
 				}
-				if (line[j] === quote) {
+				if (cj === quote) {
 					j++;
 					break;
 				}
@@ -957,9 +984,10 @@ function lightweightHighlightLine(line: string): string {
 			i = j;
 			continue;
 		}
-		if (/[A-Za-z_$]/.test(ch ?? "")) {
+		// identifier / keyword
+		if (isIdentStartCode(code)) {
 			let j = i + 1;
-			while (j < line.length && /[A-Za-z0-9_$]/.test(line[j] ?? "")) j++;
+			while (j < len && isIdentPartCode(line.charCodeAt(j))) j++;
 			const word = line.slice(i, j);
 			out += LIGHTWEIGHT_KEYWORDS.has(word)
 				? theme.fg("syntaxKeyword", word)
@@ -967,14 +995,15 @@ function lightweightHighlightLine(line: string): string {
 			i = j;
 			continue;
 		}
-		if (/\d/.test(ch ?? "")) {
+		// number
+		if (isNumStartCode(code)) {
 			let j = i + 1;
-			while (j < line.length && /[\d._]/.test(line[j] ?? "")) j++;
+			while (j < len && isNumPartCode(line.charCodeAt(j))) j++;
 			out += theme.fg("syntaxNumber", line.slice(i, j));
 			i = j;
 			continue;
 		}
-		out += ch;
+		out += line[i];
 		i++;
 	}
 	return out;

--- a/packages/pi-tui/src/utils.ts
+++ b/packages/pi-tui/src/utils.ts
@@ -186,14 +186,12 @@ function truncateFragmentToWidth(text: string, maxWidth: number): { text: string
 			continue;
 		}
 
-		let end = i;
-		while (end < text.length && text[end] !== "\t") {
-			const nextAnsi = extractAnsiCode(text, end);
-			if (nextAnsi) {
-				break;
-			}
-			end++;
-		}
+		// Scan a run of plain text up to the next escape sequence or tab. Both
+		// boundaries are found with a single native indexOf instead of probing
+		// extractAnsiCode at every character.
+		const nextEsc = nextEscapeIndex(text, i);
+		const nextTab = text.indexOf("\t", i);
+		const end = nextTab === -1 ? nextEsc : Math.min(nextEsc, nextTab);
 
 		for (const { segment } of segmenter.segment(text.slice(i, end))) {
 			const w = graphemeWidth(segment);
@@ -242,7 +240,39 @@ function finalizeTruncatedResult(
  * Based on code from the string-width library, but includes a possible-emoji
  * check to avoid running the RGI_Emoji regex unnecessarily.
  */
+// Memoized widths for non-trivial graphemes. The uncached path runs up to three
+// Unicode-property regexes (the \p{RGI_Emoji} test is the single hottest cost on
+// the render path per live CPU profile), and transcripts reuse the same emoji /
+// CJK / combining clusters constantly, so caching by grapheme turns that into a
+// one-time cost per distinct cluster. ASCII is handled by the fast path and never
+// reaches the cache. FIFO eviction mirrors widthCache.
+const GRAPHEME_WIDTH_CACHE_SIZE = 1024;
+const graphemeWidthCache = new Map<string, number>();
+
 function graphemeWidth(segment: string): number {
+	// ASCII fast path. A single printable-ASCII code unit (0x20-0x7e) is always
+	// width 1: it is never zero-width (Control is 0x00-0x1f/0x7f), never an emoji
+	// (all emoji blocks start far above 0x7e), never a leading non-printing char,
+	// and never East-Asian wide. Transcript text is overwhelmingly ASCII, and
+	// graphemeWidth is the hottest function on the render path (live CPU profile),
+	// so skipping the three Unicode-property regexes here is the biggest single win.
+	if (segment.length === 1) {
+		const c = segment.charCodeAt(0);
+		if (c >= 0x20 && c <= 0x7e) return 1;
+	}
+
+	const cached = graphemeWidthCache.get(segment);
+	if (cached !== undefined) return cached;
+	const width = graphemeWidthUncached(segment);
+	if (graphemeWidthCache.size >= GRAPHEME_WIDTH_CACHE_SIZE) {
+		const firstKey = graphemeWidthCache.keys().next().value;
+		if (firstKey !== undefined) graphemeWidthCache.delete(firstKey);
+	}
+	graphemeWidthCache.set(segment, width);
+	return width;
+}
+
+function graphemeWidthUncached(segment: string): number {
 	// Zero-width clusters
 	if (zeroWidthRegex.test(segment)) {
 		return 0;
@@ -327,8 +357,13 @@ export function visibleWidth(str: string): number {
 				i += ansi.length;
 				continue;
 			}
-			stripped += clean[i];
-			i++;
+			// Copy the whole run of plain text up to the next escape sequence in one
+			// slice instead of appending a character at a time. clean[i] is a
+			// non-sequence char here (including a lone/malformed ESC), so it is part
+			// of the visible run.
+			const end = nextEscapeIndex(clean, i);
+			stripped += clean.slice(i, end);
+			i = end;
 		}
 		clean = stripped;
 	}
@@ -384,7 +419,12 @@ export function extractAnsiCode(str: string, pos: number): { code: string; lengt
 	// CSI sequence: ESC [ ... m/G/K/H/J
 	if (next === "[") {
 		let j = pos + 2;
-		while (j < str.length && !/[mGKHJ]/.test(str[j]!)) j++;
+		while (j < str.length) {
+			const code = str.charCodeAt(j);
+			// CSI final bytes m/G/K/H/J (109/71/75/72/74)
+			if (code === 109 || code === 71 || code === 75 || code === 72 || code === 74) break;
+			j++;
+		}
 		if (j < str.length) return { code: str.substring(pos, j + 1), length: j + 1 - pos };
 		return null;
 	}
@@ -414,6 +454,50 @@ export function extractAnsiCode(str: string, pos: number): { code: string; lengt
 	}
 
 	return null;
+}
+
+/**
+ * Index that ends the run of plain text beginning at `from` — i.e. the next ESC
+ * (0x1b) strictly after `from`, or `str.length` if none remains.
+ *
+ * The hot scanners walk a styled line by alternating "consume an escape
+ * sequence" with "consume a run of plain text". They enter this function only
+ * once `from` is known NOT to start a recognised sequence (extractAnsiCode
+ * returned null there), so `from` itself belongs to the text run even when it is
+ * a lone/malformed ESC byte. The previous per-character form advanced `end` from
+ * `from` and stopped at the FIRST position whose char began a sequence — which
+ * for a malformed ESC at `from` meant it advanced past it. We therefore search
+ * from `from + 1`, so a malformed ESC at `from` is included in the text run
+ * exactly as before (rather than returning `from` and stalling the caller).
+ *
+ * String#indexOf does this boundary search in one native call with no
+ * per-character { code, length } allocation; behaviour is otherwise identical.
+ */
+function nextEscapeIndex(str: string, from: number): number {
+	const idx = str.indexOf("\x1b", from + 1);
+	return idx === -1 ? str.length : idx;
+}
+
+/**
+ * Parameters of an SGR sequence (`\x1b[<params>m`), or null if `ansiCode` is not
+ * a well-formed SGR code. Equivalent to the capture group of /\x1b\[([\d;]*)m/
+ * but allocation-free: the AnsiCodeTracker runs this per styling code while
+ * wrapping, and the regex form allocated a match array every call.
+ *
+ * Callers guarantee `ansiCode` ends with "m". We require the `\x1b[` prefix and
+ * that every byte between it and the final `m` is a digit or `;`, so malformed
+ * finals such as `\x1b[?25m` or `\x1b[Km` are rejected exactly as the regex did.
+ */
+function sgrParams(ansiCode: string): string | null {
+	if (ansiCode.charCodeAt(0) !== 0x1b || ansiCode.charCodeAt(1) !== 0x5b /* [ */) return null;
+	const end = ansiCode.length - 1; // index of the trailing 'm'
+	for (let k = 2; k < end; k++) {
+		const c = ansiCode.charCodeAt(k);
+		const isDigit = c >= 0x30 && c <= 0x39;
+		const isSemicolon = c === 0x3b;
+		if (!isDigit && !isSemicolon) return null;
+	}
+	return ansiCode.slice(2, end);
 }
 
 type Osc8Terminator = "\x07" | "\x1b\\";
@@ -484,11 +568,14 @@ class AnsiCodeTracker {
 			return;
 		}
 
-		// Extract the parameters between \x1b[ and m
-		const match = ansiCode.match(/\x1b\[([\d;]*)m/);
-		if (!match) return;
+		// Extract the parameters between \x1b[ and the trailing m. Equivalent to
+		// matching /\x1b\[([\d;]*)m/ but without allocating a RegExp match array on
+		// every SGR code: require the \x1b[ prefix, validate the middle is only
+		// digits/semicolons (so e.g. \x1b[?25m and \x1b[Km are rejected exactly as
+		// the regex did), then slice. ansiCode already ends with "m" here.
+		const params = sgrParams(ansiCode);
+		if (params === null) return;
 
-		const params = match[1];
 		if (params === "" || params === "0") {
 			// Full reset
 			this.reset();
@@ -886,12 +973,7 @@ function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker): s
 			i += ansiResult.length;
 		} else {
 			// Find the next ANSI code or end of string
-			let end = i;
-			while (end < word.length) {
-				const nextAnsi = extractAnsiCode(word, end);
-				if (nextAnsi) break;
-				end++;
-			}
+			const end = nextEscapeIndex(word, i);
 			// Segment this non-ANSI portion into graphemes
 			const textPortion = word.slice(i, end);
 			for (const seg of segmenter.segment(textPortion)) {
@@ -1079,14 +1161,11 @@ function truncateToWidthJs(
 				continue;
 			}
 
-			let end = i;
-			while (end < text.length && text[end] !== "\t") {
-				const nextAnsi = extractAnsiCode(text, end);
-				if (nextAnsi) {
-					break;
-				}
-				end++;
-			}
+			// Plain-text run up to the next escape sequence or tab, found via a
+			// single native indexOf rather than probing extractAnsiCode per char.
+			const nextEsc = nextEscapeIndex(text, i);
+			const nextTab = text.indexOf("\t", i);
+			const end = nextTab === -1 ? nextEsc : Math.min(nextEsc, nextTab);
 
 			for (const { segment } of segmenter.segment(text.slice(i, end))) {
 				const width = graphemeWidth(segment);
@@ -1155,8 +1234,7 @@ export function sliceWithWidth(
 			continue;
 		}
 
-		let textEnd = i;
-		while (textEnd < line.length && !extractAnsiCode(line, textEnd)) textEnd++;
+		const textEnd = nextEscapeIndex(line, i);
 
 		for (const { segment } of segmenter.segment(line.slice(i, textEnd))) {
 			const w = graphemeWidth(segment);
@@ -1223,8 +1301,7 @@ export function extractSegments(
 			continue;
 		}
 
-		let textEnd = i;
-		while (textEnd < line.length && !extractAnsiCode(line, textEnd)) textEnd++;
+		const textEnd = nextEscapeIndex(line, i);
 
 		for (const { segment } of segmenter.segment(line.slice(i, textEnd))) {
 			const w = graphemeWidth(segment);

--- a/packages/pi-tui/test/extract-ansi-code.test.ts
+++ b/packages/pi-tui/test/extract-ansi-code.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { extractAnsiCode } from "../src/utils.ts";
+
+// extractAnsiCode() scans a single escape sequence (CSI / OSC / APC) starting at
+// `pos` and returns its { code, length }, or null when `pos` is not the start of
+// a recognised sequence. The CSI branch scans for one of five final bytes
+// (m / G / K / H / J) by comparing char codes directly. These tests pin that
+// contract with explicit cases and an equivalence sweep against an independent
+// reference implementation of the CSI scan, so the function is provably correct
+// regardless of how the scan is written.
+
+/**
+ * Independent reference for the CSI scan, using a regex `.test()` over each
+ * character — the original formulation. extractAnsiCode() must match this for
+ * every input, which is what makes the char-code rewrite a safe equivalent.
+ */
+function referenceExtract(str: string, pos: number): { code: string; length: number } | null {
+	if (pos >= str.length || str[pos] !== "\x1b") return null;
+	if (str[pos + 1] !== "[") return null; // reference only models the CSI branch
+	let j = pos + 2;
+	while (j < str.length && !/[mGKHJ]/.test(str[j]!)) j++;
+	if (j < str.length) return { code: str.substring(pos, j + 1), length: j + 1 - pos };
+	return null;
+}
+
+describe("extractAnsiCode", () => {
+	it("parses a basic SGR color sequence", () => {
+		const ansi = extractAnsiCode("\x1b[31mhi", 0);
+		assert.deepEqual(ansi, { code: "\x1b[31m", length: 5 });
+	});
+
+	it("parses a reset sequence", () => {
+		const ansi = extractAnsiCode("\x1b[0m", 0);
+		assert.deepEqual(ansi, { code: "\x1b[0m", length: 4 });
+	});
+
+	it("parses a truecolor SGR sequence", () => {
+		const ansi = extractAnsiCode("\x1b[38;2;220;220;170mX", 0);
+		assert.deepEqual(ansi, { code: "\x1b[38;2;220;220;170m", length: 19 });
+	});
+
+	it("parses each CSI final byte (m/G/K/H/J)", () => {
+		for (const final of ["m", "G", "K", "H", "J"]) {
+			const seq = `\x1b[1;2${final}`;
+			const ansi = extractAnsiCode(seq, 0);
+			assert.deepEqual(ansi, { code: seq, length: seq.length }, `final byte ${final}`);
+		}
+	});
+
+	it("returns the sequence length so the caller can skip it", () => {
+		const str = "ab\x1b[31mcd";
+		const ansi = extractAnsiCode(str, 2);
+		assert.equal(ansi?.length, 5);
+		assert.equal(str.slice(2 + ansi!.length), "cd");
+	});
+
+	it("returns null when pos is not at an ESC", () => {
+		assert.equal(extractAnsiCode("\x1b[31m", 1), null);
+		assert.equal(extractAnsiCode("plain text", 0), null);
+	});
+
+	it("returns null for an unterminated CSI sequence", () => {
+		assert.equal(extractAnsiCode("\x1b[38;2;1;2;3", 0), null);
+		assert.equal(extractAnsiCode("\x1b[", 0), null);
+	});
+
+	it("parses an OSC 8 hyperlink terminated by BEL", () => {
+		const seq = "\x1b]8;;https://example.com\x07";
+		const ansi = extractAnsiCode(seq, 0);
+		assert.deepEqual(ansi, { code: seq, length: seq.length });
+	});
+
+	it("matches an independent CSI reference across every final byte and prefix", () => {
+		const prefixes = ["", "0", "1;31", "38;2;1;2;3", "?25", "2"];
+		let checked = 0;
+		// Sweep every possible byte in the CSI body position, with several
+		// parameter prefixes, at every offset of a surrounding string.
+		for (let byte = 0x20; byte <= 0x7e; byte++) {
+			for (const prefix of prefixes) {
+				const seq = `\x1b[${prefix}${String.fromCharCode(byte)}tail\x1b[0m`;
+				for (let pos = 0; pos < seq.length; pos++) {
+					assert.deepEqual(
+						extractAnsiCode(seq, pos),
+						referenceExtract(seq, pos),
+						`byte=0x${byte.toString(16)} prefix=${JSON.stringify(prefix)} pos=${pos}`,
+					);
+					checked++;
+				}
+			}
+		}
+		assert.ok(checked > 5000, `expected a broad sweep, only checked ${checked}`);
+	});
+
+	it("matches the CSI reference on truncated and lone-ESC inputs", () => {
+		for (const str of ["\x1b[", "\x1b[38;2", "\x1b[m", "\x1b[0m", "\x1b[1;31mx"]) {
+			for (let pos = 0; pos < str.length + 1; pos++) {
+				assert.deepEqual(
+					extractAnsiCode(str, pos),
+					referenceExtract(str, pos),
+					`str=${JSON.stringify(str)} pos=${pos}`,
+				);
+			}
+		}
+	});
+});

--- a/packages/pi-tui/test/slice-extract-segments.test.ts
+++ b/packages/pi-tui/test/slice-extract-segments.test.ts
@@ -1,0 +1,296 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { extractSegments, sliceWithWidth, visibleWidth, wrapTextWithAnsi } from "../src/utils.ts";
+
+// sliceWithWidth() and extractSegments() walk a styled line, alternating between
+// ANSI escape sequences and runs of visible text. The run-of-visible-text scan
+// finds where the next escape sequence begins. These tests pin that behaviour
+// with explicit cases and a fuzz sweep against an independent reference whose
+// "find next ESC" step uses the original per-character formulation — so the
+// indexOf-based rewrite is provably equivalent to scanning char by char.
+
+// ── Independent references (model the contract, not the implementation) ──────
+
+// Minimal escape-sequence reader matching utils.extractAnsiCode's recognised
+// forms (CSI ...m/G/K/H/J, OSC/APC terminated by BEL or ST). Used only so the
+// reference can advance over sequences exactly like the real scanner.
+function readAnsi(str: string, pos: number): { length: number } | null {
+	if (str[pos] !== "\x1b") return null;
+	const next = str[pos + 1];
+	if (next === "[") {
+		let j = pos + 2;
+		while (j < str.length && !/[mGKHJ]/.test(str[j]!)) j++;
+		return j < str.length ? { length: j + 1 - pos } : null;
+	}
+	if (next === "]" || next === "_") {
+		let j = pos + 2;
+		while (j < str.length) {
+			if (str[j] === "\x07") return { length: j + 1 - pos };
+			if (str[j] === "\x1b" && str[j + 1] === "\\") return { length: j + 2 - pos };
+			j++;
+		}
+		return null;
+	}
+	return null;
+}
+
+// Plain-text width: count UTF-16 code points outside ANSI as width 1 (ASCII-only
+// corpus below keeps grapheme width trivial, isolating the scan logic).
+function refSlice(line: string, startCol: number, length: number): string {
+	if (length <= 0) return "";
+	const endCol = startCol + length;
+	let out = "";
+	let col = 0;
+	let pending = "";
+	let i = 0;
+	while (i < line.length) {
+		const ansi = readAnsi(line, i);
+		if (ansi) {
+			if (col >= startCol && col < endCol) out += line.slice(i, i + ansi.length);
+			else if (col < startCol) pending += line.slice(i, i + ansi.length);
+			i += ansi.length;
+			continue;
+		}
+		// Visible run: original scan advanced one char at a time to the next ESC.
+		let end = i;
+		while (end < line.length && !readAnsi(line, end)) end++;
+		for (const ch of line.slice(i, end)) {
+			const inRange = col >= startCol && col < endCol;
+			if (inRange) {
+				if (pending) {
+					out += pending;
+					pending = "";
+				}
+				out += ch;
+			}
+			col += 1;
+			if (col >= endCol) break;
+		}
+		i = end;
+		if (col >= endCol) break;
+	}
+	return out;
+}
+
+// ── Explicit cases ───────────────────────────────────────────────────────────
+
+describe("sliceWithWidth", () => {
+	it("slices a plain ASCII range", () => {
+		assert.deepEqual(sliceWithWidth("hello world", 0, 5), { text: "hello", width: 5 });
+		assert.deepEqual(sliceWithWidth("hello world", 6, 5), { text: "world", width: 5 });
+	});
+
+	it("returns empty for non-positive length", () => {
+		assert.deepEqual(sliceWithWidth("hello", 0, 0), { text: "", width: 0 });
+		assert.deepEqual(sliceWithWidth("hello", 0, -3), { text: "", width: 0 });
+	});
+
+	it("keeps an SGR code that falls inside the slice", () => {
+		const line = "ab\x1b[31mcd\x1b[0mef";
+		const { text } = sliceWithWidth(line, 2, 2);
+		assert.ok(text.includes("\x1b[31m"));
+		assert.ok(text.includes("c"));
+		assert.ok(text.includes("d"));
+	});
+
+	it("carries styling active before the slice onto the first visible char (pendingAnsi)", () => {
+		// Red turns on at col 0; slice starts at col 2 — red must be prepended so
+		// the sliced text renders in the right color.
+		const line = "\x1b[31mabcdef";
+		const { text, width } = sliceWithWidth(line, 2, 2);
+		assert.equal(width, 2);
+		assert.ok(text.startsWith("\x1b[31m"), `expected pending red prepended, got ${JSON.stringify(text)}`);
+		assert.ok(text.includes("cd"));
+	});
+
+	it("handles a long truecolor sequence between visible chars", () => {
+		const line = "x\x1b[38;2;220;220;170my\x1b[0mz";
+		assert.deepEqual(sliceWithWidth(line, 0, 1), { text: "x", width: 1 });
+		const mid = sliceWithWidth(line, 1, 1);
+		assert.equal(mid.width, 1);
+		assert.ok(mid.text.includes("y"));
+	});
+
+	it("terminates on a lone/malformed ESC byte (no infinite loop)", () => {
+		// A bare ESC that does not start a recognised CSI/OSC/APC sequence is not
+		// consumed by extractAnsiCode, so the plain-text scan must still advance
+		// past it. Regression: a find-next-ESC helper that returned the current
+		// position stalled the caller forever.
+		const line = "ab\x1bcd"; // \x1b not followed by [ ] _  => malformed
+		const { text, width } = sliceWithWidth(line, 0, 4);
+		assert.equal(width, 4, "all four visible cells (a,b,ESC,c) measured");
+		assert.ok(text.includes("a") && text.includes("b") && text.includes("c"));
+	});
+
+	it("matches the per-character reference across a fuzz sweep", () => {
+		const samples = [
+			"plain text only",
+			"\x1b[31mred\x1b[0m normal \x1b[1;32mbold green\x1b[0m",
+			"\x1b[38;2;1;2;3mtruecolor\x1b[0m tail",
+			"lead\x1b[4munder\x1b[24mline mid \x1b[7minv\x1b[0m end",
+			"\x1b[31m\x1b[1m\x1b[4mstacked codes\x1b[0mx",
+			"a\x1b[mb\x1b[0mc", // empty-param SGR
+		];
+		let checked = 0;
+		for (const line of samples) {
+			const visibleLen = line.replace(/\x1b\[[\d;]*[mGKHJ]/g, "").length;
+			for (let start = 0; start <= visibleLen + 1; start++) {
+				for (let len = 0; len <= visibleLen + 1; len++) {
+					assert.equal(
+						sliceWithWidth(line, start, len).text,
+						refSlice(line, start, len),
+						`slice mismatch line=${JSON.stringify(line)} start=${start} len=${len}`,
+					);
+					checked++;
+				}
+			}
+		}
+		assert.ok(checked > 200, `expected a broad sweep, only ${checked}`);
+	});
+});
+
+describe("extractSegments", () => {
+	it("splits before/after around an overlay region (plain)", () => {
+		// "0123456789", before cols [0,3), after cols [5,8)
+		const r = extractSegments("0123456789", 3, 5, 3);
+		assert.equal(r.before, "012");
+		assert.equal(r.beforeWidth, 3);
+		assert.equal(r.after, "567");
+		assert.equal(r.afterWidth, 3);
+	});
+
+	it("returns empty after-segment when afterLen <= 0", () => {
+		const r = extractSegments("0123456789", 4, 0, 0);
+		assert.equal(r.before, "0123");
+		assert.equal(r.after, "");
+		assert.equal(r.afterWidth, 0);
+	});
+
+	it("inherits styling from before the overlay into the after-segment", () => {
+		// Red turns on at col 0 and never resets; the "after" run must re-open red.
+		const line = "\x1b[31m0123456789";
+		const r = extractSegments(line, 3, 5, 3);
+		assert.ok(r.before.startsWith("\x1b[31m"), "before keeps the opening red");
+		assert.ok(r.after.includes("\x1b[31m"), "after re-opens inherited red");
+		assert.ok(r.after.includes("567"));
+	});
+
+	it("handles a long truecolor sequence in the scanned run", () => {
+		const line = "ab\x1b[38;2;10;20;30mcdefgh\x1b[0mij";
+		const r = extractSegments(line, 2, 4, 2);
+		assert.equal(r.before, "ab");
+		assert.ok(r.after.includes("e"));
+		assert.ok(r.after.includes("f"));
+	});
+});
+
+// The AnsiCodeTracker (exercised via wrapTextWithAnsi, which re-opens active
+// styling at the start of every wrapped line) parses SGR parameters. These
+// cases pin that the parameter extraction handles 256-color / truecolor codes
+// and ignores malformed finals — the contract the regex-free sgrParams() must
+// preserve.
+describe("AnsiCodeTracker SGR parsing via wrapTextWithAnsi", () => {
+	const wrapWidth = 6;
+	// A word longer than the width forces a wrap, so the tracker must re-emit the
+	// active color on the continuation line.
+	function continuationReopens(code: string): boolean {
+		const lines = wrapTextWithAnsi(`${code}abcdefghij\x1b[0m`, wrapWidth);
+		assert.ok(lines.length >= 2, "expected the long word to wrap");
+		return lines[1].includes(code);
+	}
+
+	it("preserves a 256-color foreground across a wrap", () => {
+		assert.ok(continuationReopens("\x1b[38;5;208m"), "256-color fg should re-open on the wrapped line");
+	});
+
+	it("preserves a truecolor foreground across a wrap", () => {
+		assert.ok(continuationReopens("\x1b[38;2;220;220;170m"), "truecolor fg should re-open on the wrapped line");
+	});
+
+	it("preserves a basic SGR color across a wrap", () => {
+		assert.ok(continuationReopens("\x1b[31m"), "basic red should re-open on the wrapped line");
+	});
+
+	it("does not treat a non-SGR final (cursor move) as styling state", () => {
+		// \x1b[5G is a cursor-column move, not SGR; it must not be re-emitted as a
+		// color on the continuation line (sgrParams rejects it like the old regex).
+		const lines = wrapTextWithAnsi("\x1b[5Gabcdefghij\x1b[0m", wrapWidth);
+		assert.ok(lines.length >= 2, "expected wrap");
+		assert.ok(!lines[1].includes("\x1b[5G"), "cursor-move must not be carried as styling");
+	});
+});
+
+// graphemeWidth() has an ASCII fast path (single code unit 0x20-0x7e => width 1).
+// It is private, but visibleWidth() routes through it for any string that is not
+// caught by its own pure-ASCII shortcut — i.e. anything mixing ASCII with ANSI,
+// tabs, or non-ASCII. These tests force that path and assert the measured width
+// equals an independent grapheme-segmented reference, so the fast path cannot
+// silently mis-measure ASCII inside styled content (which would cause wrap drift).
+describe("graphemeWidth ASCII fast path via visibleWidth", () => {
+	const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+	// Reference width: strip the one ANSI reset we use, expand tabs to 3, then sum
+	// 1 per visible code point (the corpus below has no wide/zero-width chars in its
+	// ASCII portions, so 1-per-codepoint is exact for those).
+	function refWidth(s: string): number {
+		const clean = s.replace(/\x1b\[[0-9;]*m/g, "").replace(/\t/g, "   ");
+		let w = 0;
+		for (const { segment } of segmenter.segment(clean)) {
+			// Non-ASCII segments delegate to the real function (already trusted via
+			// the dedicated visible-width-fastpath suite); ASCII counts as 1.
+			const cp = segment.codePointAt(0) ?? 0;
+			w += cp >= 0x20 && cp <= 0x7e ? 1 : visibleWidth(segment);
+		}
+		return w;
+	}
+
+	it("measures ASCII inside ANSI-styled content correctly", () => {
+		const cases = [
+			"\x1b[31mhello world\x1b[0m",
+			"\x1b[1;32m[ok]\x1b[0m done in \x1b[2m12ms\x1b[0m",
+			"prefix \x1b[34m/src/file.ts:42\x1b[0m suffix",
+			"\x1b[7m INVERSE \x1b[0m normal { } ( ) ; : , . < > / ? ! @ # $ %",
+		];
+		for (const s of cases) assert.strictEqual(visibleWidth(s), refWidth(s), JSON.stringify(s));
+	});
+
+	it("measures ASCII inside tabbed content correctly", () => {
+		for (const s of ["col1\tcol2\tcol3", "a\tbb\tccc\tdddd", "\tlead tab then ascii"]) {
+			assert.strictEqual(visibleWidth(s), refWidth(s), JSON.stringify(s));
+		}
+	});
+
+	it("measures ASCII mixed with wide and zero-width characters correctly", () => {
+		// Forces the segmented graphemeWidth path; the ASCII runs must still each
+		// count as width 1 while the CJK/combining parts keep their real widths.
+		const s = "ab日本cd\u0301ef";
+		assert.strictEqual(visibleWidth(s), refWidth(s), JSON.stringify(s));
+	});
+
+	it("covers every printable-ASCII byte inside a styled wrapper", () => {
+		for (let c = 0x20; c <= 0x7e; c++) {
+			const ch = String.fromCharCode(c);
+			const s = `\x1b[31m${ch}\x1b[0m`;
+			assert.strictEqual(visibleWidth(s), 1, `byte 0x${c.toString(16)} (${JSON.stringify(ch)})`);
+		}
+	});
+
+	it("returns stable widths for repeated non-ASCII graphemes (memoized path)", () => {
+		// graphemeWidth memoizes non-ASCII clusters; a repeated grapheme must return
+		// the same width on the cached call as on the first, uncached one. Measure
+		// each grapheme inside a tab wrapper so it routes through graphemeWidth, and
+		// assert first == repeated == an independent expectation.
+		const cases: Array<[string, number]> = [
+			["🚀", 2], // emoji
+			["✅", 2], // emoji
+			["日", 2], // CJK wide
+			["A", 1], // narrow non-ASCII-triggering wrapper still measures A as 1
+			["e\u0301", 1], // base + combining mark = width 1
+		];
+		for (const [g, expected] of cases) {
+			const first = visibleWidth(`\t${g}`) - 3; // subtract the tab's 3 cols
+			const repeated = visibleWidth(`\t${g}`) - 3;
+			assert.strictEqual(first, repeated, `repeat width drift for ${JSON.stringify(g)}`);
+			assert.strictEqual(first, expected, `width for ${JSON.stringify(g)}`);
+		}
+	});
+});

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -35,7 +35,7 @@ if (firstArg === '--help' || firstArg === '-h') {
 // package.json (already parsed above) and verifies git is available.
 // ---------------------------------------------------------------------------
 {
-  const { MIN_NODE_MAJOR, checkNodeVersion, requireGit } = await import('./runtime-checks.js')
+  const { MIN_NODE_MAJOR, checkNodeVersion, gitAvailableOnPath } = await import('./runtime-checks.js')
   const red = '\x1b[31m'
   const bold = '\x1b[1m'
   const dim = '\x1b[2m'
@@ -56,8 +56,10 @@ if (firstArg === '--help' || firstArg === '-h') {
   }
 
   // -- git --
-  const { execFileSync } = await import('child_process')
-  const gitOk = requireGit((cmd, args) => execFileSync(cmd, args as string[], { stdio: 'ignore' }))
+  // Presence-check git via a $PATH scan rather than spawning `git --version`:
+  // the subprocess cost ~15ms on every cold start (~5% of startup CPU) just to
+  // confirm git is installed.
+  const gitOk = gitAvailableOnPath()
   if (!gitOk) {
     process.stderr.write(
       `\n${red}${bold}Error:${reset} GSD requires git but it was not found on PATH.\n\n` +
@@ -250,7 +252,7 @@ if (missingPackages.length > 0) {
 
 // Register GSD agent packages for extension imports before CLI loads.
 const { registerAgentBundles } = await import('./register-agent-bundles.js')
-registerAgentBundles()
+await registerAgentBundles()
 
 // Dynamic import defers ESM evaluation — config.js will see PI_PACKAGE_DIR above
 await import('./cli.js')

--- a/src/register-agent-bundles.ts
+++ b/src/register-agent-bundles.ts
@@ -1,13 +1,26 @@
-import * as agentCore from '@gsd/agent-core'
-import * as agentModes from '@gsd/agent-modes'
+import { isBunBinary } from '@gsd/pi-coding-agent/config.js'
 import { registerExtensionBundledModules } from '@gsd/pi-coding-agent/core/extensions/loader.js'
 
 let registered = false
 
-/** Register GSD agent packages for extension virtual module resolution. */
-export function registerAgentBundles(): void {
+/**
+ * Register GSD agent packages for extension virtual module resolution.
+ *
+ * The eager `@gsd/agent-core` and `@gsd/agent-modes` barrels are only consumed
+ * by the Bun-binary extension loader (which has no filesystem and resolves
+ * bundled packages through `virtualModules`). On the Node/dev path the loader
+ * resolves those same specifiers by file path via `getAliases()`, so importing
+ * the full barrels at startup there is ~400ms of wasted module loading.
+ * Load them only when actually needed (Bun), keeping Node startup lean.
+ */
+export async function registerAgentBundles(): Promise<void> {
   if (registered) return
   registered = true
+  if (!isBunBinary) return
+  const [agentCore, agentModes] = await Promise.all([
+    import('@gsd/agent-core'),
+    import('@gsd/agent-modes'),
+  ])
   registerExtensionBundledModules({
     '@gsd/agent-core': agentCore,
     '@gsd/agent-modes': agentModes,

--- a/src/resources/extensions/gsd/doctor-environment.ts
+++ b/src/resources/extensions/gsd/doctor-environment.ts
@@ -10,7 +10,7 @@
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFile, execSync } from "node:child_process";
 import { join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
@@ -76,46 +76,45 @@ function commandExists(name: string, cwd: string): boolean {
 /**
  * Check that Node.js version meets the project's engines requirement.
  */
-function checkNodeVersion(basePath: string): EnvironmentCheckResult | null {
+function readPackageEngineNode(basePath: string): string | null {
   const pkgPath = join(basePath, "package.json");
   if (!existsSync(pkgPath)) return null;
-
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    const required = pkg.engines?.node;
-    if (!required) return null;
-
-    const currentVersion = tryExec("node --version", basePath);
-    if (!currentVersion) {
-      return { name: "node_version", status: "error", message: "Node.js not found in PATH" };
-    }
-
-    // Parse semver requirement (handles >=X.Y.Z format)
-    const reqMatch = required.match(/>=?\s*(\d+)(?:\.(\d+))?/);
-    if (!reqMatch) return null;
-
-    const reqMajor = parseInt(reqMatch[1], 10);
-    const reqMinor = parseInt(reqMatch[2] ?? "0", 10);
-
-    const curMatch = currentVersion.match(/v?(\d+)\.(\d+)/);
-    if (!curMatch) return null;
-
-    const curMajor = parseInt(curMatch[1], 10);
-    const curMinor = parseInt(curMatch[2], 10);
-
-    if (curMajor < reqMajor || (curMajor === reqMajor && curMinor < reqMinor)) {
-      return {
-        name: "node_version",
-        status: "warning",
-        message: `Node.js ${currentVersion} does not meet requirement "${required}"`,
-        detail: `Current: ${currentVersion}, Required: ${required}`,
-      };
-    }
-
-    return { name: "node_version", status: "ok", message: `Node.js ${currentVersion}` };
+    return pkg.engines?.node ?? null;
   } catch {
     return null;
   }
+}
+
+function buildNodeVersionResult(required: string, currentVersion: string | null): EnvironmentCheckResult | null {
+  if (!currentVersion) {
+    return { name: "node_version", status: "error", message: "Node.js not found in PATH" };
+  }
+  // Parse semver requirement (handles >=X.Y.Z format)
+  const reqMatch = required.match(/>=?\s*(\d+)(?:\.(\d+))?/);
+  if (!reqMatch) return null;
+  const reqMajor = parseInt(reqMatch[1], 10);
+  const reqMinor = parseInt(reqMatch[2] ?? "0", 10);
+  const curMatch = currentVersion.match(/v?(\d+)\.(\d+)/);
+  if (!curMatch) return null;
+  const curMajor = parseInt(curMatch[1], 10);
+  const curMinor = parseInt(curMatch[2], 10);
+  if (curMajor < reqMajor || (curMajor === reqMajor && curMinor < reqMinor)) {
+    return {
+      name: "node_version",
+      status: "warning",
+      message: `Node.js ${currentVersion} does not meet requirement "${required}"`,
+      detail: `Current: ${currentVersion}, Required: ${required}`,
+    };
+  }
+  return { name: "node_version", status: "ok", message: `Node.js ${currentVersion}` };
+}
+
+function checkNodeVersion(basePath: string): EnvironmentCheckResult | null {
+  const required = readPackageEngineNode(basePath);
+  if (!required) return null;
+  return buildNodeVersionResult(required, tryExec("node --version", basePath));
 }
 
 /**
@@ -217,28 +216,19 @@ function checkEnvFiles(basePath: string): EnvironmentCheckResult | null {
  * Check for port conflicts on common dev server ports.
  * Only checks ports that appear in package.json scripts.
  */
-function checkPortConflicts(basePath: string): EnvironmentCheckResult[] {
-  // Only run on macOS/Linux — lsof is not available on Windows
-  if (process.platform === "win32") return [];
-
-  const results: EnvironmentCheckResult[] = [];
-
-  // Try to detect ports from package.json scripts
+// Detect the dev ports worth checking from package.json scripts, falling back to
+// common defaults. Returns an empty set when there's no Node project (no
+// package.json) or a parse failure — the caller then skips port checks entirely,
+// avoiding false positives from system services (e.g. macOS AirPlay on 5000, #1381).
+function collectPortsToCheck(basePath: string): Set<number> {
   const portsToCheck = new Set<number>();
   const pkgPath = join(basePath, "package.json");
-
-  if (!existsSync(pkgPath)) {
-    // No package.json — this isn't a Node.js project. Skip port checks
-    // entirely to avoid false positives from system services (e.g., macOS
-    // AirPlay Receiver on port 5000). (#1381)
-    return [];
-  }
+  if (!existsSync(pkgPath)) return portsToCheck;
 
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
     const scripts = pkg.scripts ?? {};
     const scriptText = Object.values(scripts).join(" ");
-
     // Look for --port NNNN, -p NNNN, PORT=NNNN, :NNNN patterns
     const portMatches = scriptText.matchAll(/(?:--port\s+|(?:^|[^a-z])PORT[=:]\s*|-p\s+|:)(\d{4,5})\b/gi);
     for (const m of portMatches) {
@@ -246,48 +236,66 @@ function checkPortConflicts(basePath: string): EnvironmentCheckResult[] {
       if (port >= 1024 && port <= 65535) portsToCheck.add(port);
     }
   } catch {
-    // parse failed — skip port checks rather than using defaults
-    return [];
+    return new Set();
   }
 
-  // If no ports found in scripts, check common defaults.
-  // Filter out port 5000 on macOS — AirPlay Receiver uses it by default (#1381).
   if (portsToCheck.size === 0) {
     for (const p of DEFAULT_DEV_PORTS) {
       if (p === 5000 && process.platform === "darwin") continue;
       portsToCheck.add(p);
     }
   }
+  return portsToCheck;
+}
 
+// Parse a single `lsof -nP -iTCP -sTCP:LISTEN` scan and report which of the
+// requested ports are in use. Replaces the old per-port lsof loop (up to ~14
+// system-wide socket scans, ~350ms) with one scan + an in-memory lookup.
+function buildPortConflictResults(
+  lsofOut: string | null,
+  portsToCheck: Set<number>,
+): EnvironmentCheckResult[] {
+  const results: EnvironmentCheckResult[] = [];
+  const listening = new Map<number, { pid: string; command: string }>();
+  if (lsofOut) {
+    for (const line of lsofOut.split("\n")) {
+      // COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+      // e.g. `node 12345 user 23u IPv4 0x.. 0t0 TCP *:3000 (LISTEN)`
+      const portMatch = line.match(/:(\d+)(?:\s+\(LISTEN\))?\s*$/);
+      if (!portMatch) continue;
+      const port = parseInt(portMatch[1], 10);
+      if (!Number.isFinite(port) || listening.has(port)) continue;
+      const cols = line.split(/\s+/);
+      listening.set(port, { command: cols[0] ?? "unknown", pid: cols[1] ?? "?" });
+    }
+  }
   for (const port of portsToCheck) {
-    const result = tryExec(`lsof -i :${port} -sTCP:LISTEN -t`, basePath);
-    if (result && result.length > 0) {
-      // Get process name
-      const nameResult = tryExec(`lsof -i :${port} -sTCP:LISTEN -Fp | head -2`, basePath);
-      const processName = nameResult?.match(/p(\d+)\n?c?(.+)?/)?.[2] ?? "unknown";
-
+    const hit = listening.get(port);
+    if (hit) {
       results.push({
         name: "port_conflict",
         status: "warning",
-        message: `Port ${port} is already in use by ${processName} (PID ${result.split("\n")[0]})`,
+        message: `Port ${port} is already in use by ${hit.command} (PID ${hit.pid})`,
         detail: `Kill the process or use a different port`,
       });
     }
   }
-
   return results;
+}
+
+function checkPortConflicts(basePath: string): EnvironmentCheckResult[] {
+  // Only run on macOS/Linux — lsof is not available on Windows
+  if (process.platform === "win32") return [];
+  const portsToCheck = collectPortsToCheck(basePath);
+  if (portsToCheck.size === 0) return [];
+  return buildPortConflictResults(tryExec("lsof -nP -iTCP -sTCP:LISTEN", basePath), portsToCheck);
 }
 
 /**
  * Check available disk space on the working directory partition.
  */
-function checkDiskSpace(basePath: string): EnvironmentCheckResult | null {
-  // Only run on macOS/Linux
-  if (process.platform === "win32") return null;
-
-  const dfOutput = tryExec(`df -k "${basePath}" | tail -1`, basePath);
+function buildDiskSpaceResult(dfOutput: string | null): EnvironmentCheckResult | null {
   if (!dfOutput) return null;
-
   try {
     // df output: filesystem blocks used avail capacity mount
     const parts = dfOutput.split(/\s+/);
@@ -306,32 +314,34 @@ function checkDiskSpace(basePath: string): EnvironmentCheckResult | null {
         detail: `Free up space — builds and git operations may fail`,
       };
     }
-
     if (availBytes < MIN_DISK_BYTES * 4) {
-      return {
-        name: "disk_space",
-        status: "warning",
-        message: `Disk space getting low: ${availGB}GB free`,
-      };
+      return { name: "disk_space", status: "warning", message: `Disk space getting low: ${availGB}GB free` };
     }
-
     return { name: "disk_space", status: "ok", message: `${availGB}GB free` };
   } catch {
     return null;
   }
 }
 
+function checkDiskSpace(basePath: string): EnvironmentCheckResult | null {
+  // Only run on macOS/Linux
+  if (process.platform === "win32") return null;
+  return buildDiskSpaceResult(tryExec(`df -k "${basePath}" | tail -1`, basePath));
+}
+
 /**
  * Check if Docker is available when project has a Dockerfile.
  */
-function checkDocker(basePath: string): EnvironmentCheckResult | null {
-  const hasDockerfile = existsSync(join(basePath, "Dockerfile")) ||
+function hasDockerConfig(basePath: string): boolean {
+  return existsSync(join(basePath, "Dockerfile")) ||
     existsSync(join(basePath, "docker-compose.yml")) ||
     existsSync(join(basePath, "docker-compose.yaml")) ||
     existsSync(join(basePath, "compose.yml")) ||
     existsSync(join(basePath, "compose.yaml"));
+}
 
-  if (!hasDockerfile) return null;
+function checkDocker(basePath: string): EnvironmentCheckResult | null {
+  if (!hasDockerConfig(basePath)) return null;
 
   if (!commandExists("docker", basePath)) {
     return {
@@ -357,78 +367,68 @@ function checkDocker(basePath: string): EnvironmentCheckResult | null {
 /**
  * Check for common project tools that should be available.
  */
-function checkProjectTools(basePath: string): EnvironmentCheckResult[] {
-  const results: EnvironmentCheckResult[] = [];
+interface ProjectToolSpec {
+  packageManager: string | null; // non-npm manager that must be on PATH, or null
+  needsTsc: boolean;
+  needsPython: boolean;
+  needsCargo: boolean;
+  needsGo: boolean;
+}
+
+// Decide which project tools to verify from package.json + marker files (pure fs).
+// The actual `command -v` probes are left to the sync/async checkers so both share
+// this logic.
+function readProjectToolSpec(basePath: string): ProjectToolSpec | null {
   const pkgPath = join(basePath, "package.json");
-
-  if (!existsSync(pkgPath)) return results;
-
+  if (!existsSync(pkgPath)) return null;
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    const allDeps = {
-      ...(pkg.dependencies ?? {}),
-      ...(pkg.devDependencies ?? {}),
+    const allDeps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+    let packageManager: string | null = null;
+    if (pkg.packageManager) {
+      const managerName = String(pkg.packageManager).split("@")[0];
+      if (managerName && managerName !== "npm") packageManager = managerName;
+    }
+    return {
+      packageManager,
+      needsTsc: Boolean(allDeps["typescript"]) && !existsSync(join(basePath, "node_modules", ".bin", "tsc")),
+      needsPython: existsSync(join(basePath, "pyproject.toml")) || existsSync(join(basePath, "requirements.txt")),
+      needsCargo: existsSync(join(basePath, "Cargo.toml")),
+      needsGo: existsSync(join(basePath, "go.mod")),
     };
-
-    // Check for package manager
-    const packageManager = pkg.packageManager;
-    if (packageManager) {
-      const managerName = packageManager.split("@")[0];
-      if (managerName && managerName !== "npm" && !commandExists(managerName, basePath)) {
-        results.push({
-          name: "package_manager",
-          status: "warning",
-          message: `Project requires ${managerName} but it's not installed`,
-          detail: `Install with: npm install -g ${managerName}`,
-        });
-      }
-    }
-
-    // Check for TypeScript if it's a dependency
-    if (allDeps["typescript"] && !existsSync(join(basePath, "node_modules", ".bin", "tsc"))) {
-      results.push({
-        name: "typescript",
-        status: "warning",
-        message: "TypeScript is a dependency but tsc is not available (run npm install)",
-      });
-    }
-
-    // Check for Python if pyproject.toml or requirements.txt exists
-    if (existsSync(join(basePath, "pyproject.toml")) || existsSync(join(basePath, "requirements.txt"))) {
-      if (detectPythonExecutable() === null) {
-        results.push({
-          name: "python",
-          status: "warning",
-          message: "Project has Python config but python is not installed",
-        });
-      }
-    }
-
-    // Check for Rust if Cargo.toml exists
-    if (existsSync(join(basePath, "Cargo.toml"))) {
-      if (!commandExists("cargo", basePath)) {
-        results.push({
-          name: "cargo",
-          status: "warning",
-          message: "Project has Cargo.toml but cargo is not installed",
-        });
-      }
-    }
-
-    // Check for Go if go.mod exists
-    if (existsSync(join(basePath, "go.mod"))) {
-      if (!commandExists("go", basePath)) {
-        results.push({
-          name: "go",
-          status: "warning",
-          message: "Project has go.mod but go is not installed",
-        });
-      }
-    }
   } catch {
-    // parse failed — skip
+    return null;
   }
+}
 
+function checkProjectTools(basePath: string): EnvironmentCheckResult[] {
+  const spec = readProjectToolSpec(basePath);
+  if (!spec) return [];
+  const results: EnvironmentCheckResult[] = [];
+  if (spec.packageManager && !commandExists(spec.packageManager, basePath)) {
+    results.push({
+      name: "package_manager",
+      status: "warning",
+      message: `Project requires ${spec.packageManager} but it's not installed`,
+      detail: `Install with: npm install -g ${spec.packageManager}`,
+    });
+  }
+  if (spec.needsTsc) {
+    results.push({
+      name: "typescript",
+      status: "warning",
+      message: "TypeScript is a dependency but tsc is not available (run npm install)",
+    });
+  }
+  if (spec.needsPython && detectPythonExecutable() === null) {
+    results.push({ name: "python", status: "warning", message: "Project has Python config but python is not installed" });
+  }
+  if (spec.needsCargo && !commandExists("cargo", basePath)) {
+    results.push({ name: "cargo", status: "warning", message: "Project has Cargo.toml but cargo is not installed" });
+  }
+  if (spec.needsGo && !commandExists("go", basePath)) {
+    results.push({ name: "go", status: "warning", message: "Project has go.mod but go is not installed" });
+  }
   return results;
 }
 
@@ -517,6 +517,131 @@ function checkTestHealth(basePath: string): EnvironmentCheckResult | null {
  * Run all environment health checks. Returns structured results for
  * integration with the doctor pipeline.
  */
+// ── Async variants ─────────────────────────────────────────────────────────
+// The always-on health widget refreshes off the first-paint path, but the sync
+// `runEnvironmentChecks` blocks the event loop on its subprocess checks (~300ms,
+// and again every 60s). These async siblings run the same checks via non-blocking
+// `execFile` and fan the independent ones out concurrently, so the UI thread never
+// stalls. The sync API above is unchanged for /gsd doctor and the dashboards.
+
+function tryExecAsync(cmd: string, cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const isWin = process.platform === "win32";
+    const child = execFile(
+      isWin ? "cmd" : "sh",
+      isWin ? ["/c", cmd] : ["-c", cmd],
+      { cwd, timeout: CMD_TIMEOUT, encoding: "utf-8" },
+      (err, stdout) => resolve(err ? null : String(stdout).trim()),
+    );
+    child.on("error", () => resolve(null));
+  });
+}
+
+async function commandExistsAsync(name: string, cwd: string): Promise<boolean> {
+  const whichCmd = process.platform === "win32" ? `where ${name}` : `command -v ${name}`;
+  return (await tryExecAsync(whichCmd, cwd)) !== null;
+}
+
+async function checkNodeVersionAsync(basePath: string): Promise<EnvironmentCheckResult | null> {
+  const required = readPackageEngineNode(basePath);
+  if (!required) return null;
+  const currentVersion = await tryExecAsync("node --version", basePath);
+  return buildNodeVersionResult(required, currentVersion);
+}
+
+async function checkPortConflictsAsync(basePath: string): Promise<EnvironmentCheckResult[]> {
+  if (process.platform === "win32") return [];
+  const portsToCheck = collectPortsToCheck(basePath);
+  if (portsToCheck.size === 0) return [];
+  const lsofOut = await tryExecAsync("lsof -nP -iTCP -sTCP:LISTEN", basePath);
+  return buildPortConflictResults(lsofOut, portsToCheck);
+}
+
+async function checkDiskSpaceAsync(basePath: string): Promise<EnvironmentCheckResult | null> {
+  if (process.platform === "win32") return null;
+  return buildDiskSpaceResult(await tryExecAsync(`df -k "${basePath}" | tail -1`, basePath));
+}
+
+async function checkDockerAsync(basePath: string): Promise<EnvironmentCheckResult | null> {
+  if (!hasDockerConfig(basePath)) return null;
+  if (!(await commandExistsAsync("docker", basePath))) {
+    return { name: "docker", status: "warning", message: "Project has Docker files but docker is not installed" };
+  }
+  const info = await tryExecAsync("docker info --format '{{.ServerVersion}}'", basePath);
+  if (!info) {
+    return {
+      name: "docker",
+      status: "warning",
+      message: "Docker is installed but daemon is not running",
+      detail: "Start Docker Desktop or the docker daemon",
+    };
+  }
+  return { name: "docker", status: "ok", message: `Docker ${info}` };
+}
+
+async function checkProjectToolsAsync(basePath: string): Promise<EnvironmentCheckResult[]> {
+  const spec = readProjectToolSpec(basePath);
+  if (!spec) return [];
+  const results: EnvironmentCheckResult[] = [];
+  if (spec.packageManager && !(await commandExistsAsync(spec.packageManager, basePath))) {
+    results.push({
+      name: "package_manager",
+      status: "warning",
+      message: `Project requires ${spec.packageManager} but it's not installed`,
+      detail: `Install with: npm install -g ${spec.packageManager}`,
+    });
+  }
+  if (spec.needsTsc) {
+    results.push({
+      name: "typescript",
+      status: "warning",
+      message: "TypeScript is a dependency but tsc is not available (run npm install)",
+    });
+  }
+  if (spec.needsPython && detectPythonExecutable() === null) {
+    results.push({ name: "python", status: "warning", message: "Project has Python config but python is not installed" });
+  }
+  if (spec.needsCargo && !(await commandExistsAsync("cargo", basePath))) {
+    results.push({ name: "cargo", status: "warning", message: "Project has Cargo.toml but cargo is not installed" });
+  }
+  if (spec.needsGo && !(await commandExistsAsync("go", basePath))) {
+    results.push({ name: "go", status: "warning", message: "Project has go.mod but go is not installed" });
+  }
+  return results;
+}
+
+/**
+ * Non-blocking equivalent of `runEnvironmentChecks` for the health-widget
+ * background refresh. Cheap fs checks run inline; the subprocess-backed checks
+ * fan out concurrently so the whole suite costs ~max(check), not the sum.
+ */
+export async function runEnvironmentChecksAsync(basePath: string): Promise<EnvironmentCheckResult[]> {
+  const results: EnvironmentCheckResult[] = [];
+
+  // fs-only checks — already cheap and synchronous.
+  const depsCheck = checkDependenciesInstalled(basePath);
+  if (depsCheck) results.push(depsCheck);
+  const envCheck = checkEnvFiles(basePath);
+  if (envCheck) results.push(envCheck);
+
+  // subprocess-backed checks — run concurrently, off the event-loop critical path.
+  const [nodeCheck, portChecks, diskCheck, dockerCheck, toolChecks] = await Promise.all([
+    checkNodeVersionAsync(basePath),
+    checkPortConflictsAsync(basePath),
+    checkDiskSpaceAsync(basePath),
+    checkDockerAsync(basePath),
+    checkProjectToolsAsync(basePath),
+  ]);
+
+  if (nodeCheck) results.push(nodeCheck);
+  results.push(...portChecks);
+  if (diskCheck) results.push(diskCheck);
+  if (dockerCheck) results.push(dockerCheck);
+  results.push(...toolChecks);
+
+  return results;
+}
+
 export function runEnvironmentChecks(basePath: string): EnvironmentCheckResult[] {
   const results: EnvironmentCheckResult[] = [];
 

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -4,7 +4,7 @@
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import type { GSDState } from "./types.js";
 import { runProviderChecks, summariseProviderIssues } from "./doctor-providers.js";
-import { runEnvironmentChecks } from "./doctor-environment.js";
+import { runEnvironmentChecks, runEnvironmentChecksAsync } from "./doctor-environment.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { nativeIsRepo, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeCommitSubject } from "./native-git-bridge.js";
 import { loadLedgerFromDisk, getProjectTotals } from "./metrics.js";
@@ -22,7 +22,31 @@ export const HEALTH_WIDGET_ACTIVE_HINTS =
 
 // ── Data loader ────────────────────────────────────────────────────────────────
 
-function loadHealthWidgetData(basePath: string): HealthWidgetData {
+// Last-commit lookup is subprocess-backed (native-git-bridge → git spawns),
+// so it is treated like the other expensive checks: skipped on first paint,
+// run only by the background refresh.
+function loadLastCommitInfo(basePath: string): { epoch: number | null; message: string | null } {
+  try {
+    if (nativeIsRepo(basePath)) {
+      const branch = nativeGetCurrentBranch(basePath);
+      const epoch = nativeLastCommitEpoch(basePath, branch || "HEAD");
+      if (epoch > 0) {
+        return { epoch, message: nativeCommitSubject(basePath, branch || "HEAD") || null };
+      }
+    }
+  } catch { /* non-fatal */ }
+  return { epoch: null, message: null };
+}
+
+function loadHealthWidgetData(
+  basePath: string,
+  options?: { includeChecks?: boolean },
+): HealthWidgetData {
+  // `includeChecks` gates the expensive subprocess-backed checks (provider +
+  // environment doctor: `lsof`, `docker`, `node --version`, ...). The initial
+  // synchronous render passes `false` so first paint is never blocked on them;
+  // the async refresh (off the first-paint path) runs the full suite.
+  const includeChecks = options?.includeChecks ?? true;
   let budgetCeiling: number | undefined;
   let budgetSpent = 0;
   let providerIssue: string | null = null;
@@ -44,30 +68,27 @@ function loadHealthWidgetData(basePath: string): HealthWidgetData {
     }
   } catch { /* non-fatal */ }
 
-  try {
-    const providerResults = runProviderChecks();
-    providerIssue = summariseProviderIssues(providerResults);
-  } catch { /* non-fatal */ }
+  if (includeChecks) {
+    try {
+      const providerResults = runProviderChecks();
+      providerIssue = summariseProviderIssues(providerResults);
+    } catch { /* non-fatal */ }
 
-  try {
-    const envResults = runEnvironmentChecks(basePath);
-    for (const r of envResults) {
-      if (r.status === "error") environmentErrorCount++;
-      else if (r.status === "warning") environmentWarningCount++;
-    }
-  } catch { /* non-fatal */ }
-
-  // ── Last commit info ──
-  try {
-    if (nativeIsRepo(basePath)) {
-      const branch = nativeGetCurrentBranch(basePath);
-      const epoch = nativeLastCommitEpoch(basePath, branch || "HEAD");
-      if (epoch > 0) {
-        lastCommitEpoch = epoch;
-        lastCommitMessage = nativeCommitSubject(basePath, branch || "HEAD") || null;
+    try {
+      const envResults = runEnvironmentChecks(basePath);
+      for (const r of envResults) {
+        if (r.status === "error") environmentErrorCount++;
+        else if (r.status === "warning") environmentWarningCount++;
       }
-    }
-  } catch { /* non-fatal */ }
+    } catch { /* non-fatal */ }
+  }
+
+  // ── Last commit info ── (git spawns — gated like the other expensive checks)
+  if (includeChecks) {
+    const commit = loadLastCommitInfo(basePath);
+    lastCommitEpoch = commit.epoch;
+    lastCommitMessage = commit.message;
+  }
 
   return {
     projectState,
@@ -78,6 +99,42 @@ function loadHealthWidgetData(basePath: string): HealthWidgetData {
     environmentWarningCount,
     lastCommitEpoch,
     lastCommitMessage,
+    lastRefreshed: Date.now(),
+  };
+}
+
+// Non-blocking variant used by the widget's background refresh: the cheap fields
+// come from the synchronous snapshot, then provider + environment checks are
+// layered in off the event-loop critical path (env checks run concurrently via
+// runEnvironmentChecksAsync). Keeps the always-on widget from stalling the UI on
+// its initial enrichment or its 60s refresh.
+async function loadHealthWidgetDataAsync(basePath: string): Promise<HealthWidgetData> {
+  const data = loadHealthWidgetData(basePath, { includeChecks: false });
+  let providerIssue = data.providerIssue;
+  let environmentErrorCount = 0;
+  let environmentWarningCount = 0;
+
+  try {
+    providerIssue = summariseProviderIssues(runProviderChecks());
+  } catch { /* non-fatal */ }
+
+  try {
+    const envResults = await runEnvironmentChecksAsync(basePath);
+    for (const r of envResults) {
+      if (r.status === "error") environmentErrorCount++;
+      else if (r.status === "warning") environmentWarningCount++;
+    }
+  } catch { /* non-fatal */ }
+
+  const commit = loadLastCommitInfo(basePath);
+
+  return {
+    ...data,
+    providerIssue,
+    environmentErrorCount,
+    environmentWarningCount,
+    lastCommitEpoch: commit.epoch,
+    lastCommitMessage: commit.message,
     lastRefreshed: Date.now(),
   };
 }
@@ -95,8 +152,13 @@ export function initHealthWidget(ctx: ExtensionContext): void {
 
   const basePath = projectRoot();
 
-  // String-array fallback — used in RPC mode (factory is a no-op there)
-  const initialData = loadHealthWidgetData(basePath);
+  // String-array fallback — used in RPC mode (factory is a no-op there).
+  // Skip the expensive provider/environment doctor checks here: this runs
+  // synchronously on the interactive-startup path, where running them would
+  // block first paint by ~0.9s (lsof/docker probes, otherwise run again
+  // immediately by the factory below). The factory's async refresh fills in
+  // real health once the screen is up.
+  const initialData = loadHealthWidgetData(basePath, { includeChecks: false });
   ctx.ui.setWidget("gsd-health", buildHealthLines(initialData), { placement: "belowEditor" });
 
   // Factory-based widget for TUI mode — replaces the string-array above
@@ -110,7 +172,7 @@ export function initHealthWidget(ctx: ExtensionContext): void {
       if (refreshInFlight) return;
       refreshInFlight = true;
       try {
-        data = loadHealthWidgetData(basePath);
+        data = await loadHealthWidgetDataAsync(basePath);
         cachedLines = undefined;
         if (!isDisposed) _tui.requestRender();
       } catch { /* non-fatal */ } finally {
@@ -118,9 +180,11 @@ export function initHealthWidget(ctx: ExtensionContext): void {
       }
     };
 
-    // Fire first enrichment immediately. requestRender() inside is a no-op
-    // if the widget has not yet rendered, so this is safe before factory return.
-    void refresh();
+    // Fire the first full enrichment off the first-paint path. setTimeout(0)
+    // yields to the initial render + input loop, so the expensive doctor checks
+    // (provider + environment) never delay the moment the user sees the UI.
+    // requestRender() inside refresh repaints the widget once data is ready.
+    setTimeout(() => { void refresh(); }, 0);
 
     const refreshTimer = setInterval(() => {
       void refresh();

--- a/src/resources/extensions/gsd/tests/integration/doctor-environment-async.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-environment-async.test.ts
@@ -1,0 +1,104 @@
+// Project/App: gsd-pi
+// File Purpose: Verify the non-blocking runEnvironmentChecksAsync is behaviourally
+// identical to the synchronous runEnvironmentChecks (the health-widget render
+// path was moved onto the async variant for performance), and that the single-
+// scan checkPortConflicts still detects a real in-use port.
+
+import test, { type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "node:net";
+
+import {
+  runEnvironmentChecks,
+  runEnvironmentChecksAsync,
+  type EnvironmentCheckResult,
+} from "../../doctor-environment.ts";
+
+function makeProject(t: TestContext, files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-env-async-"));
+  t.after(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = join(dir, name);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content);
+  }
+  return dir;
+}
+
+// Stable, order-independent signature of a check-result set for comparison.
+function normalize(results: EnvironmentCheckResult[]): string[] {
+  return results.map((r) => `${r.name}|${r.status}|${r.message}|${r.detail ?? ""}`).sort();
+}
+
+test("runEnvironmentChecksAsync returns the same results as runEnvironmentChecks", async (t) => {
+  const dir = makeProject(t, {
+    "package.json": JSON.stringify({
+      name: "fixture",
+      engines: { node: ">=18" },
+      scripts: { dev: "vite --port 4321", build: "tsc" },
+      devDependencies: { typescript: "^5.0.0" },
+    }),
+    ".env.example": "API_KEY=\n",
+    Dockerfile: "FROM node:20\n",
+  });
+  mkdirSync(join(dir, "node_modules"), { recursive: true });
+
+  const sync = runEnvironmentChecks(dir);
+  const asyncResults = await runEnvironmentChecksAsync(dir);
+
+  assert.deepEqual(
+    normalize(asyncResults),
+    normalize(sync),
+    "async checks must produce the identical result set as the sync checks",
+  );
+  // Sanity: the fixture is rich enough that the suite actually produced checks.
+  assert.ok(sync.length > 0, "expected the fixture to yield environment checks");
+});
+
+test("runEnvironmentChecksAsync matches sync on a bare directory (no package.json)", async (t) => {
+  const dir = makeProject(t, {});
+  const sync = runEnvironmentChecks(dir);
+  const asyncResults = await runEnvironmentChecksAsync(dir);
+  assert.deepEqual(normalize(asyncResults), normalize(sync));
+});
+
+test(
+  "single-scan port check detects a real in-use port, identically sync and async",
+  { skip: process.platform === "win32" ? "lsof-based port check is macOS/Linux only" : false },
+  async (t) => {
+    // Bind a real listener, then reference its port from package.json scripts so
+    // collectPortsToCheck picks it up. The server stays up across both check runs.
+    const server = createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+    t.after(() => new Promise<void>((resolve) => server.close(() => resolve())));
+    assert.ok(port >= 1024 && port <= 65535, "ephemeral port should be in the checked range");
+
+    const dir = makeProject(t, {
+      "package.json": JSON.stringify({ name: "fixture", scripts: { dev: `serve --port ${port}` } }),
+    });
+
+    const syncConflicts = runEnvironmentChecks(dir).filter((r) => r.name === "port_conflict");
+    const asyncConflicts = (await runEnvironmentChecksAsync(dir)).filter((r) => r.name === "port_conflict");
+
+    // Equivalence holds regardless of whether lsof is present on the runner.
+    assert.deepEqual(normalize(asyncConflicts), normalize(syncConflicts), "sync and async must agree on port conflicts");
+    // On macOS/Linux lsof is standard, so the listener must be reported and named.
+    assert.equal(syncConflicts.length, 1, "expected exactly one port conflict for the in-use port");
+    assert.match(syncConflicts[0]!.message, new RegExp(`\\b${port}\\b`), "conflict message must name the in-use port");
+  },
+);

--- a/src/runtime-checks.ts
+++ b/src/runtime-checks.ts
@@ -1,6 +1,9 @@
 // Runtime dependency checks — pure helpers used by loader.ts.
 // Extracted so they can be unit-tested without spawning the full loader.
 
+import { existsSync } from 'fs'
+import { delimiter, join } from 'path'
+
 /**
  * Minimum supported Node.js major version. Kept in sync with
  * `engines.node` in package.json — see test
@@ -42,4 +45,31 @@ export function requireGit(
   } catch {
     return false
   }
+}
+
+/**
+ * Fast presence check for `git`: scan the directories on `$PATH` for a `git`
+ * executable (plus Windows `.exe`/`.cmd` variants) instead of spawning
+ * `git --version`. The subprocess form costs ~15ms on every startup and showed
+ * up as ~5% of cold-start CPU; a filesystem `existsSync` scan is far cheaper and
+ * answers the same gate ("is git installed"). Returns true if a candidate path
+ * exists. `env`/`platform` are injectable so this can be unit-tested without a
+ * real $PATH.
+ */
+export function gitAvailableOnPath(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const pathValue = env.PATH ?? env.Path ?? env.path ?? ''
+  if (pathValue.length === 0) return false
+  const dirs = pathValue.split(delimiter).filter((d) => d.length > 0)
+  const names = platform === 'win32'
+    ? (env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM').split(';').map((ext) => `git${ext.toLowerCase()}`).concat('git')
+    : ['git']
+  for (const dir of dirs) {
+    for (const name of names) {
+      if (existsSync(join(dir, name))) return true
+    }
+  }
+  return false
 }

--- a/src/tests/app-smoke.test.ts
+++ b/src/tests/app-smoke.test.ts
@@ -170,6 +170,34 @@ test("requireGit returns false when exec throws and true when it succeeds", asyn
   assert.strictEqual(calls.length, 1, "success path also invokes exec exactly once");
 });
 
+test("gitAvailableOnPath finds git via a $PATH scan without spawning a subprocess", async (t) => {
+  const { gitAvailableOnPath } = await import("../runtime-checks.ts");
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const dir = mkdtempSync(join(tmpdir(), "gitpath-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  // Empty PATH → not found.
+  assert.strictEqual(gitAvailableOnPath({ PATH: "" }, "linux"), false, "empty PATH means no git");
+
+  // PATH points at a dir with no git → not found.
+  assert.strictEqual(gitAvailableOnPath({ PATH: dir }, "linux"), false, "no git binary in dir");
+
+  // Drop a fake `git` into the dir → found, with NO subprocess spawned.
+  writeFileSync(join(dir, "git"), "#!/bin/sh\n");
+  assert.strictEqual(gitAvailableOnPath({ PATH: dir }, "linux"), true, "git present on PATH is found");
+
+  // Windows: respects PATHEXT and looks for git.exe.
+  writeFileSync(join(dir, "git.exe"), "");
+  assert.strictEqual(
+    gitAvailableOnPath({ Path: dir, PATHEXT: ".EXE;.CMD" }, "win32"),
+    true,
+    "win32 finds git.exe via PATHEXT",
+  );
+});
+
 test("loader MIN_NODE_MAJOR matches package.json engines field exactly", async () => {
   // Imports the actual exported constant from runtime-checks.ts (the same
   // module loader.ts consumes) and asserts STRICT equality with the major


### PR DESCRIPTION
## Linked issue

Closes #761

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Make the interactive TUI cheaper to run — stop a running tool card from pegging a CPU core to animate its rail (and make that animation a user setting), paint the first frame without blocking on environment probes, and drop per-character regex from the hot text-measurement and syntax-highlight loops.
**Why:** A single in-flight (or orphaned) tool card drove ~14 full-transcript re-renders/second forever; opening GSD blocked ~1.6 s on synchronous `lsof`/`docker`/`git` probes; and `graphemeWidth` + the syntax highlighter ran `RegExp.test()` per character on every render.
**How:** Gate the rail animation behind a new `terminal.toolRailAnimation` setting (default on, matched 70 ms cadence; off = static rail + no timer = zero idle CPU); move the health-widget doctor checks off the first-paint path and run them once, async; replace per-character regex with `charCodeAt()` range checks (verified byte-identical); and finalize a hung, signal-deaf tool as aborted so its card stops on its own.

This is a **performance** change (commit subject `perf:`). It is one squashed commit, rebased clean onto current `origin/main`.

## What this PR does (at a glance)

- Adds a `terminal.toolRailAnimation` setting (Settings menu: "Tool rail animation", default on). Off = the running-tool rail renders statically and its re-render timer is never armed, so a long-running or orphaned card costs **zero** idle CPU.
- Restores the rail's matched constant cadence (70 ms / ~14 fps; one re-render == one cell of head movement) when animation is on.
- Moves the interactive startup's environment "doctor" probes (`lsof`/`docker`/`git`) off the first-paint path and runs them once, asynchronously; collapses ~7–14 `lsof` invocations into one scan; replaces `git --version` spawns with a `$PATH` lookup.
- Replaces per-character `RegExp.test()` with `charCodeAt()` range checks in `graphemeWidth` (pi-tui) and `lightweightHighlightLine` (pi-coding-agent), plus ANSI scanning via native `indexOf` — verified byte-identical to the regex forms.
- Finalizes a hung, signal-deaf tool as aborted on abort, so every `tool_execution_start` gets a paired `_end` and the card stops without a timer.
- Adds behavior-executing regression tests for each.

Scope: 21 files, +1416 / −234. No production dependency changes.

---

## Why (the root problems)

1. **Idle-CPU drain.** The in-flight tool card's only timer re-renders the entire transcript every 70 ms to sweep the rail, and never stops while the tool is in-flight. For a multi-minute tool — or an **orphaned** card whose result never arrives — that's ~14 full-transcript re-renders/second indefinitely, pegging a core with a static screen. There was no way to turn it off.
2. **Blocking startup.** The always-on health widget ran environment "doctor" probes (`lsof` up to ~7–14×, `docker`, `git` last-commit) **synchronously, twice, before first paint**, adding ~0.9 s+ in a project dir. `git` presence was tested by spawning `git --version`.
3. **Per-character regex.** `graphemeWidth` and `lightweightHighlightLine` classified characters with `RegExp.test()` per character — the dominant cost in those hot loops.

## How (evidence)

All numbers below are **freshly measured before/after against `origin/main`** (the true "before" — it carries the merged image fix but none of these perf changes). Method and raw output are in the [Performance testing & proof](#performance-testing--proof) section; figures are best-of-N with results sunk to defeat dead-code elimination.

| Area | Before (`origin/main`) | After (`fa9d1c3a`) | Speedup |
| --- | --- | --- | --- |
| Interactive open — time to first paint (warm, median of 6) | 1.891 s | **0.806 s** | **2.35×** (~1.08 s removed) |
| Doctor probe cost on first-paint path (sync) | 437.7 ms | **152.8 ms** | **2.9×** (~285 ms/call removed; previously ran twice) |
| Rail idle CPU — per quiet in-flight card | 14.0 fps (42 re-renders / 3 s) | **0.0 fps** (setting off) | timer never armed |
| `highlightCode` (lightweight charCode path) | 0.286 ms | **0.115 ms** | **2.50×** |
| `sliceWithWidth` (grapheme corpus) | 1.578 ms | **0.574 ms** | **2.75×** |
| `extractSegments` (ANSI corpus) | 0.923 ms | **0.668 ms** | **1.38×** |

The interactive-open figure is end-to-end (`gsd0` launched under a PTY, timed to first paint, BEFORE/AFTER built back-to-back on the same loaded machine; absolutes are machine/load dependent, the **2.35× / ~1.08 s** delta is the signal). `visibleWidth`/`truncateToWidth` were flat in isolation (an internal width fast-path/memo dominates), so no speed claim is made for them — the text-measurement wins are concentrated in the ANSI-scanning paths (`extractSegments`, `sliceWithWidth`) where per-character ESC probing was replaced by native `indexOf`. charCode classification in the highlighter was verified **byte-identical** to the regex form across all code points `0x0000–0xFFFF`.

The rail-off result is confirmed live: in a running session the `running · Xs` counter still updates during active turns (the `DynamicBorder` working-spinner drives renders), and only an idle/orphaned card's counter goes static — the intended zero-CPU state.

---

## What changed — every change and why

### A. Rail animation as a user setting (the idle-CPU fix)

| File | What changed | Why |
| --- | --- | --- |
| `gsd-agent-modes/.../components/transcript-design.ts` | Module-level `railAnimationEnabled` flag with `setRailAnimationEnabled()` / `isRailAnimationEnabled()`; both rail-sweep render sites gated on it. | Single source of truth for the animation state without threading an option through every `ToolExecutionComponent` construction site. |
| `gsd-agent-modes/.../components/tool-execution.ts` | Reverted the decaying-cadence timer back to a constant 70 ms `setInterval` (matched to the rail's per-cell step), gated on `isRailAnimationEnabled()`; added `refreshRailAnimation()` for live toggle. | Matched cadence is smooth and wastes no frames; gating means off = timer never armed = 0 idle CPU even for a 30-minute tool. |
| `pi-coding-agent/src/core/settings-manager.ts` | `TerminalSettings.toolRailAnimation?: boolean` (default true) + `getToolRailAnimation()` / `setToolRailAnimation()`. | Persist the setting alongside the existing `showImages`/`toolsExpanded` terminal flags. |
| `gsd-agent-modes/.../components/settings-selector.ts` | "Tool rail animation" toggle (config field + callback + menu item + change case). | Surface the setting in the Settings menu, mirroring `tools-expanded`. |
| `gsd-agent-modes/.../interactive-selectors-settings.ts` | Pass the current value into the selector and route the change through a host method. | Wire the menu to the live session. |
| `gsd-agent-modes/.../interactive-mode.ts` | Apply the setting at startup (`setRailAnimationEnabled(...)`) and add `setToolRailAnimation()` which persists, flips the flag, re-syncs in-flight cards, and re-renders. | Honor the saved setting on launch and apply live toggles to existing cards. |

### B. Faster text measurement (pi-tui)

| File | What changed | Why |
| --- | --- | --- |
| `pi-tui/src/utils.ts` | `extractAnsiCode` scans the CSI final byte by char code; `nextEscapeIndex` (native `indexOf`) replaces per-char ESC probing in `sliceWithWidth` / `extractSegments` / `breakLongWord` / `truncateFragmentToWidth` / `truncateToWidthJs` (also fixes a malformed-ESC infinite loop); `AnsiCodeTracker.process` slices+validates SGR params instead of `.match`; `graphemeWidth` gains an ASCII fast path (`0x20–0x7e`) + FIFO memo cache, removing the per-grapheme `\p{RGI_Emoji}` regex; `visibleWidth` strips ANSI via run-copy slice. | The per-char regex / `extractAnsiCode` ESC probing was the dominant render cost; charCode + native `indexOf` are byte-identical for ASCII classes and materially faster. |

> Note: per project rule, the charCode predicates are kept inline at each call site rather than extracted into a shared helper module — the classes are domain-specific, and a shared module across the vendored `pi-tui` / `pi-coding-agent` packages adds upstream-sync divergence and risks breaking V8 inlining in the hottest loops.

### C. Faster syntax highlighting (pi-coding-agent)

| File | What changed | Why |
| --- | --- | --- |
| `pi-coding-agent/src/theme/theme.ts` | `lightweightHighlightLine` classifies identifier/number chars with `charCodeAt()` range checks instead of four `RegExp.test()` per character. | **2.50×** faster (`highlightCode`, see proof §3); output byte-identical across `0x0000–0xFFFF`. |

### D. Leaner interactive startup

| File | What changed | Why |
| --- | --- | --- |
| `src/resources/extensions/gsd/health-widget.ts` | The initial render is spawn-free; the full doctor suite runs once, after first paint, via `runEnvironmentChecksAsync` (non-blocking). | The probes ran synchronously, twice, before first paint. |
| `src/resources/extensions/gsd/doctor-environment.ts` | New `runEnvironmentChecksAsync` (concurrent `execFile`); `checkPortConflicts` does one `lsof -nP -iTCP -sTCP:LISTEN` scan instead of ~7–14; `git` last-commit deferred to the async refresh. | Removes the spawn storm from the first-paint path; proven equivalent to the sync path by test. |
| `src/loader.ts`, `src/runtime-checks.ts` | `gitAvailableOnPath` resolves git via a `$PATH` scan instead of spawning `git --version`. | Avoids a process spawn just to test for git's presence. |
| `src/register-agent-bundles.ts` | Gate the eager `@gsd/agent-{core,modes}` barrel imports behind `isBunBinary`. | The Node path resolves these by file path via `getAliases()`, so the eager barrels are only needed on the Bun path. |

### E. Hung-tool finalization (agent-core)

| File | What changed | Why |
| --- | --- | --- |
| `pi-agent-core/src/agent-loop.ts` | `raceToolExecutionAgainstAbort` finalizes a hung, signal-deaf tool as aborted on abort, so every `tool_execution_start` gets a paired `_end`. | A genuinely hung tool never delivered a result, so its card never stopped; finalizing at the source ends it without relying on a timer. **RFC-gated area — flagged for maintainer sign-off (see below).** |

### Tests

| File | Verifies |
| --- | --- |
| `gsd-agent-modes/.../__tests__/tool-execution.test.ts` | Rail animates at a constant cadence while in-flight (animation on), stops once the result arrives, and does **not** animate at all when the setting is off. |
| `pi-tui/test/extract-ansi-code.test.ts` | `extractAnsiCode` charCode form is equivalent to the regex form (incl. malformed/edge sequences). |
| `pi-tui/test/slice-extract-segments.test.ts` | `sliceWithWidth` / `extractSegments` equivalence + regression across ANSI/tab/wide-char inputs. |
| `pi-coding-agent/src/theme/theme-highlight.test.ts` | `highlightCode` content preservation across a mixed corpus (CJK/emoji/tabs/escapes) + token colouring. |
| `pi-agent-core/test/agent-loop.test.ts` | A hung, signal-deaf tool is finalized as aborted so its `_start` gets a paired `_end`. |
| `src/resources/extensions/gsd/tests/integration/doctor-environment-async.test.ts` | `runEnvironmentChecksAsync` is identical to the sync `runEnvironmentChecks`, plus real in-use-port detection via a live listener. |
| `src/tests/app-smoke.test.ts` | App boots end-to-end after the startup changes. |

---

## Performance testing & proof

All speed numbers are reproducible **before/after against `origin/main`**, with no build required: the "before" file (`git show origin/main:<path>`) is dropped beside the live file so its sibling imports resolve identically, both versions are imported through the same `--experimental-strip-types` loader the tests use, results are accumulated into a sink (defeats V8 dead-code elimination), and each figure is the best of N trials (least GC/jitter). Cleanup restores the tree.

**1. Rail idle CPU** — real `ToolExecutionComponent`, one quiet long-running card, real wall-clock; render requests == full-transcript re-renders that drive CPU:

```
# harness builds a ToolExecutionComponent, render()s it (arms the timer), counts requestRender() over 3s
$ node --import .../resolve-ts.mjs --experimental-strip-types tmp-rail-profile.mts
ANIMATION ON : 42 render requests in 3s = 14.0 fps
ANIMATION OFF:  0 render requests in 3s =  0.0 fps
```

**2. Text measurement** (`pi-tui/src/utils.ts` vs `origin/main`), unique 300/family corpus, best-of-7 × 1500, results sunk:

```
fn                          before(ms)   after(ms)   speedup
sliceWithWidth/graphemes         1.578       0.574       2.75x
extractSegments/ANSI             0.923       0.668       1.38x
truncateToWidth/plain            0.066       0.068       0.98x   (flat — no claim)
visibleWidth/*                   ~0.002      ~0.003      ~1.0x   (internal fast-path/memo dominates — no claim)
```

**3. Syntax highlight** (`highlightCode`, `pi-coding-agent/src/theme/theme.ts` vs `origin/main`), `initTheme("dark", false)` → lightweight charCode path, 240-line corpus, best-of-9 × 400, sunk:

```
entry                   before(ms)   after(ms)   speedup
highlightCode                0.286       0.115       2.50x
```

**4. Startup.** End-to-end interactive open — `gsd0` launched under a PTY (`script -q LOG gsd0`), timed to first paint, warmup discarded, median of 6; BEFORE = `origin/main` dist, AFTER = perf dist, **built back-to-back on the same machine**:

```
                                all runs (s)                       min     median
BEFORE origin/main (361438ce)   1.83 1.85 1.89 1.89 1.94 1.94      1.832   1.891
AFTER  perf      (fa9d1c3a)     0.76 0.80 0.80 0.81 0.82 0.84      0.756   0.806
=> 2.35x faster open; ~1.08s removed (median).  Absolutes are machine/load dependent (this box
   was loaded from the builds); the delta is the signal.
```

The dominant component, isolated (`runEnvironmentChecks`, the synchronous doctor cost on the first-paint path, vs `origin/main`, best & median of 7, real spawns):

```
path                                 best(ms)  median(ms)
BEFORE runEnvironmentChecks (sync)      432.2       437.7
AFTER  runEnvironmentChecks (sync)      146.5       152.8
=> 2.9x; ~285ms/call removed from first paint; the before path ran it twice.
```

Structural cause: `origin/main`'s `checkPortConflicts` spawned `lsof -i :PORT` (plus a second `lsof … -Fp`) **per port** in a loop over ~7 default ports; this PR replaces that with a **single** `lsof -nP -iTCP -sTCP:LISTEN` scan parsed in-process, and defers `docker`/`git` last-commit to the post-first-paint async refresh.

**5. Equivalence (correctness, not speed).** The charCode classifiers are proven byte-identical to the regex forms they replace across all code points `0x0000–0xFFFF` by the committed tests (`extract-ansi-code`, `slice-extract-segments`, `theme-highlight`).

**6. CI parity.** Local `verify:merge` (commit `fa9d1c3a`, rebased onto `origin/main`): all gates green through `validate-pack` + coverage; `test:unit` = 10724 passed / 6 failed (the 6 are pre-existing on `origin/main`, identical before/after this commit, none in changed files). See the Test plan below.

---

## Change type

- [x] `fix` — idle-CPU drain on running/orphaned tool cards; hung-tool finalization; blocking startup
- [x] `feat` — `terminal.toolRailAnimation` user setting
- [x] `test` — behavior-executing regression tests
- [x] `refactor` — charCode text measurement / highlight (byte-identical, no output change)

Commit subject is `perf:` (the umbrella concern is performance).

## Scope

- [x] `pi-tui` — `utils.ts` text measurement
- [x] `pi-agent-core` — `agent-loop.ts` hung-tool finalization **(RFC-gated — needs maintainer sign-off)**
- [x] `pi-coding-agent` — `theme.ts` highlighter (in the pi patch-allowlist), `settings-manager.ts` new setting
- [x] `gsd extension` — `health-widget.ts` / `doctor-environment.ts` startup
- [x] `gsd-agent-modes` — interactive rail setting (`tool-execution.ts`, `transcript-design.ts`, `settings-selector.ts`, `interactive-selectors-settings.ts`, `interactive-mode.ts`)
- [x] `core / loader` — `loader.ts`, `runtime-checks.ts`, `register-agent-bundles.ts`

## Breaking changes

- [x] No breaking changes

New additive surface only: the `terminal.toolRailAnimation` setting (default on) and `SettingsManager.get/setToolRailAnimation`. Relative to released `1.2.0` the rail's on-state cadence is unchanged (matched 70 ms); the only new user-facing behavior is the opt-out.

## Test plan

- [x] CI passes (see reviewer note below on pre-existing local failures)
- [x] New/updated tests included
- [x] Manual testing — profiled a live session: rail-off = 0 fps for a quiet in-flight card, rail-on = 14 fps; the `running · Xs` counter still ticks during active turns (driven by the working-spinner) and only goes static on a truly idle/orphaned card (the intended zero-CPU state).

Behavior-executing tests only (no source-grep). Local `verify:merge` (CI PR-blocking parity) results on this branch:

- **Green gates:** `build:core`, web-host build, `typecheck:extensions`, `validate-pack`, `verify:workspace-coverage`, `verify:extension-coverage`.
- **`test:unit`: 10724 passed / 6 failed / 10 skipped.** The 6 failures are **pre-existing on `origin/main`** and unrelated to this PR (closer/validate-milestone prompt fixtures, `cleanupAfterLoopExit` step-mode, cost-spike telemetry, retry-bypass, `shared/mod.ts` pi-tui boundary). None touch any file in this PR; the failure set is identical before and after this commit, and the passing count rose only because the rebase picked up upstream's new tests.
- `test:packages` / `test:integration` / `test:e2e` did not run (the suite aborts at the first failing gate under `set -e`); `test:packages` is separately known to have a pre-existing `@opengsd/mcp-server` failure (`gsd_milestone_generate_id`) in an untouched package. CI on a clean runner is the authoritative gate.

Branch state: single squashed commit `fa9d1c3a`, rebased **conflict-free** onto current `origin/main` (`361438ce`), 1 ahead / 0 behind.

**Reviewer note — RFC-gated file.** `pi-agent-core/src/agent-loop.ts` is in an RFC-gated area; the hung-tool-abort change there is called out explicitly for maintainer sign-off. The `pi-coding-agent/src/theme/**` edit is sanctioned by the pi patch-allowlist (`scripts/pi-upstream.json`).

## AI disclosure

- [x] This PR includes AI-assisted code. Tooling: GSD-pi agent. All changes are tested to the same standard as human-written code (behavior-executing unit + integration tests; charCode changes proven byte-identical to the regex forms; rail behavior proven on/off; startup async path proven equivalent to sync; plus a live profile). The AI is not credited as an author or co-author.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784212987&installation_id=134682257&pr_number=762&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F762&signature=1b2ad509f35892dc00a01447d6137847566b3ed389fabf52776e52a430e6856b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->