### PR TITLE
fix(mcp-server): avoid cwd lookup for project-qualified MCP orphans

### DIFF
--- a/packages/mcp-server/src/pid-registry.test.ts
+++ b/packages/mcp-server/src/pid-registry.test.ts
@@ -450,6 +450,46 @@ describe('registerMcpInstance', () => {
 });
 
 describe('sweepProjectOrphanMcpServers', () => {
+  test('does not inspect cwd when an orphan command already contains the project path', () => {
+    const projectDir = '/workspace/project';
+    const alive = new Set([1101]);
+    const signals: Array<{ pid: number; signal: NodeJS.Signals | 0 | undefined }> = [];
+
+    const result = sweepProjectOrphanMcpServers(projectDir, {
+      isOrphaned: isPpidOneOrphan,
+      listProcesses() {
+        return [
+          { pid: 1101, ppid: 1, command: `node ${projectDir}/packages/mcp-server/dist/cli.js` },
+        ];
+      },
+      getProcessCwd() {
+        throw new Error('cwd lookup should not run for project-qualified MCP commands');
+      },
+      kill(pid, signal) {
+        signals.push({ pid, signal });
+        if (!alive.has(pid)) {
+          const err = new Error('dead') as NodeJS.ErrnoException;
+          err.code = 'ESRCH';
+          throw err;
+        }
+        if (signal === 'SIGTERM') alive.delete(pid);
+      },
+      waitForExit() {},
+    });
+
+    assert.deepEqual(signals, [
+      { pid: 1101, signal: 0 },
+      { pid: 1101, signal: 'SIGTERM' },
+      { pid: 1101, signal: 0 },
+    ]);
+    assert.deepEqual(result, {
+      matched: [1101],
+      terminated: [1101],
+      forceKilled: [],
+      skipped: [],
+    });
+  });
+
   test('terminates only orphaned MCP servers for the same project and force-kills TERM-resistant processes', () => {
     const projectDir = '/workspace/project';
     const otherDir = '/workspace/other';

--- a/packages/mcp-server/src/pid-registry.ts
+++ b/packages/mcp-server/src/pid-registry.ts
@@ -387,7 +387,9 @@ export function sweepProjectOrphanMcpServers(
   for (const proc of listProcesses()) {
     if (!isSafePid(proc.pid) || proc.pid === process.pid) continue;
     if (!isOrphaned(proc)) continue;
-    if (!isSameProjectMcpProcess(proc.command, getProcessCwd(proc.pid), projectDir)) continue;
+    if (!isMcpServerCommand(proc.command)) continue;
+    const cwd = commandContainsProjectPath(proc.command, projectDir) ? null : getProcessCwd(proc.pid);
+    if (!isSameProjectMcpProcess(proc.command, cwd, projectDir)) continue;
     result.matched.push(proc.pid);
 
     if (!isPidAlive(proc.pid, sendSignal)) {


### PR DESCRIPTION
## TL;DR

**What:** Skip expensive cwd inspection during orphan MCP sweeps when the process command already contains the exact project MCP server path.
**Why:** Stale gsd-workflow MCP processes could pile up and make workflow tool discovery/readiness take much longer than expected.
**How:** Filter to MCP server commands first, use the project path embedded in the command as sufficient project identity, and keep cwd fallback for global launcher shapes.

## What

This updates `packages/mcp-server/src/pid-registry.ts` so `sweepProjectOrphanMcpServers()` avoids `getProcessCwd(pid)` for orphaned MCP processes whose command already includes the current project path.

It also adds a regression test in `packages/mcp-server/src/pid-registry.test.ts` that fails if cwd lookup runs for a project-qualified MCP command.

## Why

Workflow MCP readiness regressed when many orphaned MCP server processes accumulated. Direct MCP probes could still look healthy, but the startup cleanup path could spend too long inspecting process cwd before new workflow tools registered.

## How

The sweep now:

- ignores non-MCP commands before any cwd inspection
- treats an exact project path in the MCP command as enough to skip cwd lookup
- preserves the existing cwd-based fallback for global `gsd-mcp-server` commands that do not include the project path

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/pid-registry.test.ts`
- `pnpm --filter @opengsd/mcp-server test`
- `git diff --check`
- GitHub CI passed for #774: fast-gates, build, ci-gate, node22-smoke, security, risk, and triage checks.

Local note: `pnpm run verify:merge` passed build, extension typecheck, validate-pack, coverage checks, packaging/install checks, then hit a local prompt-golden fixture failure in the compiled unit suite (`execute-task should be at least 40% smaller than Phase 2 start baseline (8202/13576)`). That failure did not reproduce in GitHub CI, where unit tests passed.

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow performance and filtering change in orphan cleanup; matching and signal behavior for global-install orphans is unchanged via cwd fallback.
> 
> **Overview**
> **`sweepProjectOrphanMcpServers()`** is faster when many stale orphan MCP processes are present: startup cleanup no longer pays for per-process **cwd** inspection when it is not needed.
> 
> The sweep now drops non-MCP commands before any cwd work, and when an orphaned process command already embeds the current project path (e.g. `…/project/packages/mcp-server/dist/cli.js`), it treats that as sufficient project identity and **skips `getProcessCwd(pid)`**. Global **`gsd-mcp-server`**-style launchers that omit the project path still use the existing cwd-based matching.
> 
> A regression test asserts cwd lookup is not invoked for project-qualified orphan commands while termination behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a384e9ea87e491e17115bc4ff7a6423bbb4ece4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->