### PR TITLE
fix(gsd): anchor cwd before auto resume

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -859,6 +859,20 @@ export function _warnIfWorktreeMissingForTest(
   return false;
 }
 
+export function anchorProcessCwdForAutoResume(basePath: string): boolean {
+  try {
+    process.chdir(basePath);
+    return true;
+  } catch (err) {
+    logWarning(
+      "session",
+      `resume cwd anchor failed: ${err instanceof Error ? err.message : String(err)}`,
+      { file: "auto.ts", basePath },
+    );
+    return false;
+  }
+}
+
 export function isAutoPaused(): boolean {
   return s.paused;
 }
@@ -2642,6 +2656,7 @@ export async function startAuto(
     }
     // ADR-016 phase 2 / B3 (#5621): paused-resume worktree-path adoption.
     buildLifecycle().resumeFromPausedSession(base, resumeWorktreePath);
+    anchorProcessCwdForAutoResume(s.basePath || base);
     // Rebuild scope now that s.basePath reflects the actual worktree (or project root).
     rebuildScope(s.basePath, s.currentMilestoneId);
     // Ensure the workflow-logger audit log is pinned to the project root

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -7,7 +7,13 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { cleanupAfterLoopExit, pauseAuto, rerootCommandSession, stopAuto } from "../auto.ts";
+import {
+  anchorProcessCwdForAutoResume,
+  cleanupAfterLoopExit,
+  pauseAuto,
+  rerootCommandSession,
+  stopAuto,
+} from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 import { getAutoWorker, registerAutoWorker } from "../db/auto-workers.ts";
@@ -103,6 +109,25 @@ test("cleanupAfterLoopExit preserves paused worktree session and visible failure
     assert.equal(autoSession.paused, true);
   } finally {
     autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("anchorProcessCwdForAutoResume recovers when current cwd was deleted", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-resume-cwd-anchor-"));
+  const deletedCwd = join(base, ".gsd-worktrees", "M002");
+  const previousCwd = process.cwd();
+
+  mkdirSync(deletedCwd, { recursive: true });
+
+  try {
+    process.chdir(deletedCwd);
+    rmSync(deletedCwd, { recursive: true, force: true });
+
+    assert.equal(anchorProcessCwdForAutoResume(base), true);
+    assert.equal(realpathSync(process.cwd()), realpathSync(base));
+  } finally {
     process.chdir(previousCwd);
     rmSync(base, { recursive: true, force: true });
   }


### PR DESCRIPTION
## TL;DR

**What:** Anchors the process cwd to the resolved auto resume base path before paused-session resume work continues.
**Why:** Resuming after a milestone/worktree directory was removed could leave the process cwd deleted and crash with `uv_cwd` before workflow tools recovered.
**How:** After paused-session worktree adoption, `startAuto` now best-effort `chdir`s to `s.basePath || base` and logs if that fails.

## What

Adds `anchorProcessCwdForAutoResume` in the GSD auto extension and invokes it immediately after paused-session worktree adoption. The helper is intentionally small: it moves the process cwd to the already-resolved auto base path and returns whether the anchor succeeded.

Adds a regression test to `auto-paused-ui-cleanup.test.ts` that creates a cwd, deletes it, and verifies the resume cwd anchor recovers to the project base path.

## Why

A paused auto session can resume after its previous worktree/current directory has been deleted. In that state, any later `process.cwd()` call can throw `ENOENT ... uv_cwd`, aborting auto-start before resume-time rebuild, doctor, hooks, or MCP workflow tools can finish restoring.

## How

The resume path already resolves `s.basePath` through `WorktreeLifecycle.resumeFromPausedSession(base, resumeWorktreePath)`, falling back to project root if a stale worktree is missing. This change anchors the ambient process cwd to that resolved path before rebuilding scope and continuing resume work.

## Verification

- RED: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts` failed on `anchorProcessCwdForAutoResume recovers when current cwd was deleted` with `uv_cwd`.
- GREEN: same focused test file passes, 19/19 tests.
- Sabotage: temporarily replaced `process.chdir(basePath)` with `process.cwd()`; the new regression test failed with `false !== true`; restored the fix and reran green.
- `pnpm run typecheck:extensions` passed after building local workspace package dependencies (`build:rpc-client`, `build:mcp-server`).

### Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

### Breaking changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow resume-path change with best-effort chdir and regression test; no auth or data-model changes.
> 
> **Overview**
> Fixes **paused auto resume** when the process still has its cwd on a milestone/worktree directory that was removed while the session was paused. Session `basePath` could already fall back to project root via `resumeFromPausedSession`, but the ambient cwd stayed invalid and later `process.cwd()` / Node `uv_cwd` could abort startup before doctor, hooks, or MCP recovery ran.
> 
> Adds **`anchorProcessCwdForAutoResume`**, which best-effort `chdir`s to `s.basePath || base` immediately after worktree adoption in `startAuto`, with a session warning on failure. A regression test in `auto-paused-ui-cleanup.test.ts` deletes the current cwd and asserts recovery to the project base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ccc21617551f64d44201979a2225b3361e2c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->