### PR TITLE
fix(gsd): route queue order writes through transaction runner

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -24,7 +24,8 @@ gsd-db.ts  ← barrel: re-exports the single-writer layer (callers import from h
        ├── db/writers/*.ts  ← the Single Writer Layer (one write subsystem per file)
        ├── db/queries.ts    ← the Query Module (read-only SELECT wrappers)
        │
-       ├── transaction()  (db/engine.ts via db-transaction.ts — depth counter, no nested BEGIN)
+       ├── transaction()/immediateTransaction()
+       │   (db/engine.ts via db-transaction.ts — depth counter, no nested BEGIN)
        │
        ▼
 db-adapter.ts  ← normalized prepared-statement cache
@@ -747,7 +748,7 @@ remain outside manifest restore.
 
 1. **Single-writer rule**: all write SQL lives in the single-writer *layer* — `db/engine.ts` (schema/migrations + transaction primitives) and `db/writers/**` (one write subsystem per file). `gsd-db.ts` is a barrel re-exporting that layer (and still holds some wrappers mid-migration), so callers keep importing from it unchanged. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks a directory predicate (not a single filename).
 
-2. **Transaction wrapping**: every multi-table write uses `transaction()`. Rollback on any error. Re-entrant: nested calls increment depth counter; no nested BEGIN.
+2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`.
 
 3. **Cascade semantics**: hierarchy status cascades are named **Domain Write Operations** in `db/writers/cascades.ts`, each owning its own `transaction()` so the milestone/slice/task subtree transitions atomically (callers keep only projection/file-cleanup/event logic):
    - `gsd_slice_complete` (`completeSliceCascade`) cascades `pending` tasks → `skipped`

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -41,7 +41,7 @@ See also:
               gsd-db.ts  (barrel over the single-writer layer:
                           db/engine.ts + db/writers/**)
                        │
-                 transaction()
+                 transaction()/immediateTransaction()
                        │
                        ▼
                SQLite writes
@@ -356,7 +356,7 @@ unit completes
 | Single-writer: all write SQL in the single-writer layer (`db/engine.ts` + `db/writers/**`); `gsd-db.ts` is the barrel re-exporting it; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (directory predicate) |
 | Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
 | Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
-| No nested transactions | `db-transaction.ts` depth counter |
+| No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter | `db-transaction.test.ts` |
 | Workspace isolation: one DB per project root, shared across worktrees via WAL | `db-connection-cache.ts` identityKey |
 | Coordination: one active dispatch per unit_id at a time | `idx_unit_dispatches_active_per_unit` unique partial index |
 | Memory FTS fallback: LIKE scan if FTS5 unavailable | `tryCreateMemoriesFtsSchema` onUnavailable callback |

--- a/src/resources/extensions/gsd/db-transaction.ts
+++ b/src/resources/extensions/gsd/db-transaction.ts
@@ -4,6 +4,7 @@
 export interface DbTransactionControls {
   begin(): void;
   beginRead(): void;
+  /** Starts a write transaction that obtains SQLite's reserved lock up front. */
   beginImmediate?(): void;
   commit(): void;
   rollback(): void;
@@ -20,6 +21,10 @@ export class DbTransactionRunner {
     return this.runTransaction(controls, () => controls.begin(), fn);
   }
 
+  /**
+   * Run a BEGIN IMMEDIATE transaction through the same depth counter as regular
+   * transactions so callers can compose it inside existing transaction scopes.
+   */
   immediateTransaction<T>(controls: DbTransactionControls, fn: () => T): T {
     if (!controls.beginImmediate) {
       throw new Error("db transaction controls do not support immediate transactions");

--- a/src/resources/extensions/gsd/db-transaction.ts
+++ b/src/resources/extensions/gsd/db-transaction.ts
@@ -4,6 +4,7 @@
 export interface DbTransactionControls {
   begin(): void;
   beginRead(): void;
+  beginImmediate?(): void;
   commit(): void;
   rollback(): void;
 }
@@ -16,22 +17,15 @@ export class DbTransactionRunner {
   }
 
   transaction<T>(controls: DbTransactionControls, fn: () => T): T {
-    if (this.depth > 0) {
-      return this.runNested(fn);
+    return this.runTransaction(controls, () => controls.begin(), fn);
+  }
+
+  immediateTransaction<T>(controls: DbTransactionControls, fn: () => T): T {
+    if (!controls.beginImmediate) {
+      throw new Error("db transaction controls do not support immediate transactions");
     }
 
-    controls.begin();
-    this.depth++;
-    try {
-      const result = fn();
-      controls.commit();
-      return result;
-    } catch (err) {
-      controls.rollback();
-      throw err;
-    } finally {
-      this.depth--;
-    }
+    return this.runTransaction(controls, () => controls.beginImmediate!(), fn);
   }
 
   readTransaction<T>(
@@ -39,22 +33,27 @@ export class DbTransactionRunner {
     fn: () => T,
     logRollbackError: (error: Error) => void,
   ): T {
+    return this.runTransaction(controls, () => controls.beginRead(), fn, logRollbackError);
+  }
+
+  private runTransaction<T>(
+    controls: DbTransactionControls,
+    begin: () => void,
+    fn: () => T,
+    logRollbackError?: (error: Error) => void,
+  ): T {
     if (this.depth > 0) {
       return this.runNested(fn);
     }
 
-    controls.beginRead();
+    begin();
     this.depth++;
     try {
       const result = fn();
       controls.commit();
       return result;
     } catch (err) {
-      try {
-        controls.rollback();
-      } catch (rollbackErr) {
-        logRollbackError(rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)));
-      }
+      this.rollback(controls, logRollbackError);
       throw err;
     } finally {
       this.depth--;
@@ -67,6 +66,19 @@ export class DbTransactionRunner {
       return fn();
     } finally {
       this.depth--;
+    }
+  }
+
+  private rollback(controls: DbTransactionControls, logRollbackError?: (error: Error) => void): void {
+    if (!logRollbackError) {
+      controls.rollback();
+      return;
+    }
+
+    try {
+      controls.rollback();
+    } catch (rollbackErr) {
+      logRollbackError(rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)));
     }
   }
 }

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -735,6 +735,7 @@ function createTransactionControls(db: DbAdapter) {
   return {
     begin: () => db.exec("BEGIN"),
     beginRead: () => db.exec("BEGIN DEFERRED"),
+    beginImmediate: () => db.exec("BEGIN IMMEDIATE"),
     commit: () => db.exec("COMMIT"),
     rollback: () => db.exec("ROLLBACK"),
   };
@@ -753,6 +754,11 @@ export function isInTransaction(): boolean {
 export function transaction<T>(fn: () => T): T {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   return _transactionRunner.transaction(createTransactionControls(currentDb), fn);
+}
+
+export function immediateTransaction<T>(fn: () => T): T {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  return _transactionRunner.immediateTransaction(createTransactionControls(currentDb), fn);
 }
 
 /**

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -756,6 +756,11 @@ export function transaction<T>(fn: () => T): T {
   return _transactionRunner.transaction(createTransactionControls(currentDb), fn);
 }
 
+/**
+ * Run a BEGIN IMMEDIATE write transaction for operations that need SQLite's
+ * reserved writer lock before issuing updates. Re-entrant like transaction():
+ * nested calls run inside the outer transaction without a nested BEGIN.
+ */
 export function immediateTransaction<T>(fn: () => T): T {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   return _transactionRunner.immediateTransaction(createTransactionControls(currentDb), fn);

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -46,7 +46,7 @@ import { rowToSlice, rowToTask, type SliceRow, type TaskRow } from "./db-task-sl
 // primitives now live in the engine; re-export the full public surface so
 // existing `from "./gsd-db.js"` imports keep working.
 export * from "./db/engine.js";
-import { transaction, getDb, getDbOrNull } from "./db/engine.js";
+import { immediateTransaction, transaction, getDb, getDbOrNull } from "./db/engine.js";
 
 // ─── Single Writer Layer re-exports ──────────────────────────────────────
 // Write subsystems live in db/writers/*; re-exported here so callers keep
@@ -707,19 +707,14 @@ export function insertVerificationEvidence(e: {
 
 
 export function setMilestoneQueueOrder(order: string[]): void {
-  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  getDbOrNull()!.exec("BEGIN IMMEDIATE");
-  try {
-    getDbOrNull()!.prepare("UPDATE milestones SET sequence = 0").run();
-    const stmt = getDbOrNull()!.prepare("UPDATE milestones SET sequence = :sequence WHERE id = :id");
+  const db = getDb();
+  immediateTransaction(() => {
+    db.prepare("UPDATE milestones SET sequence = 0").run();
+    const stmt = db.prepare("UPDATE milestones SET sequence = :sequence WHERE id = :id");
     order.forEach((id, index) => {
       stmt.run({ ":id": id, ":sequence": index + 1 });
     });
-    getDbOrNull()!.exec("COMMIT");
-  } catch (err) {
-    getDbOrNull()!.exec("ROLLBACK");
-    throw err;
-  }
+  });
 }
 
 function getMilestoneStatusForUpdate(milestoneId: string): string | null {
@@ -1442,4 +1437,3 @@ export function upsertQualityGate(g: {
     ":evaluated_at": g.evaluatedAt,
   });
 }
-

--- a/src/resources/extensions/gsd/tests/db-transaction.test.ts
+++ b/src/resources/extensions/gsd/tests/db-transaction.test.ts
@@ -17,6 +17,10 @@ class FakeTransactionControls implements DbTransactionControls {
     this.record("BEGIN DEFERRED");
   }
 
+  beginImmediate(): void {
+    this.record("BEGIN IMMEDIATE");
+  }
+
   commit(): void {
     this.record("COMMIT");
   }
@@ -106,5 +110,60 @@ describe("db-transaction", () => {
     assert.deepEqual(controls.calls, ["BEGIN DEFERRED", "ROLLBACK"]);
     assert.equal(rollbackErrors.length, 1);
     assert.match(rollbackErrors[0].message, /failed ROLLBACK/);
+  });
+
+  test("commits successful immediate transactions", () => {
+    const runner = createDbTransactionRunner();
+    const controls = new FakeTransactionControls();
+
+    const result = runner.immediateTransaction(controls, () => {
+      assert.equal(runner.isInTransaction(), true);
+      return "ok";
+    });
+
+    assert.equal(result, "ok");
+    assert.equal(runner.isInTransaction(), false);
+    assert.deepEqual(controls.calls, ["BEGIN IMMEDIATE", "COMMIT"]);
+  });
+
+  test("rolls back failed immediate transactions and clears depth", () => {
+    const runner = createDbTransactionRunner();
+    const controls = new FakeTransactionControls();
+
+    assert.throws(
+      () => runner.immediateTransaction(controls, () => {
+        throw new Error("boom");
+      }),
+      /boom/,
+    );
+
+    assert.equal(runner.isInTransaction(), false);
+    assert.deepEqual(controls.calls, ["BEGIN IMMEDIATE", "ROLLBACK"]);
+  });
+
+  test("nested immediate transactions inside write transactions do not issue nested BEGIN", () => {
+    const runner = createDbTransactionRunner();
+    const controls = new FakeTransactionControls();
+
+    runner.transaction(controls, () => {
+      runner.immediateTransaction(controls, () => {
+        assert.equal(runner.isInTransaction(), true);
+      });
+    });
+
+    assert.deepEqual(controls.calls, ["BEGIN", "COMMIT"]);
+  });
+
+  test("nested write transactions inside immediate transactions do not issue nested BEGIN", () => {
+    const runner = createDbTransactionRunner();
+    const controls = new FakeTransactionControls();
+
+    runner.immediateTransaction(controls, () => {
+      runner.transaction(controls, () => {
+        assert.equal(runner.isInTransaction(), true);
+      });
+    });
+
+    assert.deepEqual(controls.calls, ["BEGIN IMMEDIATE", "COMMIT"]);
   });
 });

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -21,6 +21,7 @@ import {
   insertSlice,
   insertTask,
   setMilestoneQueueOrder,
+  transaction,
   updateTaskStatus,
 } from '../gsd-db.ts';
 
@@ -467,6 +468,31 @@ describe('derive-state-helpers', () => {
 
       assert.equal(state.activeMilestone?.id, 'M002', 'queue-order: DB sequence chooses M002');
       assert.equal(state.registry[0]?.id, 'M002', 'queue-order: registry[0] follows DB sequence');
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('setMilestoneQueueOrder can be composed inside a transaction', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-CONTEXT.md', '# M001\n\nContext.');
+      writeFile(base, 'milestones/M002/M002-CONTEXT.md', '# M002\n\nContext.');
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'First', status: 'active' });
+      insertMilestone({ id: 'M002', title: 'Second', status: 'active' });
+
+      transaction(() => {
+        setMilestoneQueueOrder(['M002', 'M001']);
+      });
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.activeMilestone?.id, 'M002', 'queue-order: nested transaction chooses M002');
+      assert.deepEqual(state.registry.map(entry => entry.id), ['M002', 'M001']);
     } finally {
       closeDatabase();
       cleanup(base);


### PR DESCRIPTION
## Intent

Validate and publish the transaction-runner queue ordering change as its own focused PR. The goal is to ensure GSD queue-order writes participate in the shared database transaction runner instead of issuing transaction control directly, preserving nested transaction safety and keeping state derivation aligned with DB-backed queue order. This branch intentionally touches the transaction helper, DB engine surface, gsd-db queue order wiring, and focused transaction/state-derivation tests.

## What Changed
- Added `immediateTransaction()` to the GSD database transaction runner and engine so `BEGIN IMMEDIATE` writes share the same nested transaction depth handling as regular writes.
- Routed milestone queue-order updates through the shared transaction runner instead of issuing direct `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` calls.
- Updated database docs and added focused transaction/state-derivation coverage for nested queue-order writes.

## Risk Assessment

✅ Low: The change is a small, focused routing of queue-order writes through the existing transaction runner with targeted coverage for immediate and nested transaction behavior; no material merge-blocking issues were found.

## Testing

Initial focused test execution showed a setup-only missing built package; after `build:pi`, the focused transaction and derived-state tests passed, and the evidence JSON demonstrates nested queue-order writes persist DB sequence `M002,M001` and derive active milestone `M002`.

<details>
<summary>Evidence: Queue order transaction evidence</summary>

<code>{&#10;&#34;scenario&#34;: &#34;setMilestoneQueueOrder called inside an outer transaction&#34;,&#10;&#34;dbRows&#34;: [&#10;{ &#34;id&#34;: &#34;M002&#34;, &#34;title&#34;: &#34;Second&#34;, &#34;status&#34;: &#34;active&#34;, &#34;sequence&#34;: 1 },&#10;{ &#34;id&#34;: &#34;M001&#34;, &#34;title&#34;: &#34;First&#34;, &#34;status&#34;: &#34;active&#34;, &#34;sequence&#34;: 2 }&#10;],&#10;&#34;derivedActiveMilestone&#34;: &#34;M002&#34;,&#10;&#34;derivedRegistryOrder&#34;: [&#34;M002&#34;, &#34;M001&#34;],&#10;&#34;passed&#34;: true&#10;}</code>

```text
{
  "scenario": "setMilestoneQueueOrder called inside an outer transaction",
  "dbRows": [
    {
      "id": "M002",
      "title": "Second",
      "status": "active",
      "sequence": 1
    },
    {
      "id": "M001",
      "title": "First",
      "status": "active",
      "sequence": 2
    }
  ],
  "derivedActiveMilestone": "M002",
  "derivedRegistryOrder": [
    "M002",
    "M001"
  ],
  "passed": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pwd && git status --short --branch && git rev-parse --show-toplevel && git branch --show-current && git log --oneline --decorate -5`
- `git diff --stat a6376d758223f351dec7fe74a73b8f0605c1c8d6..78f84b0529d96204d5ac09775583872f629f3e22 && git diff --name-only a6376d758223f351dec7fe74a73b8f0605c1c8d6..78f84b0529d96204d5ac09775583872f629f3e22`
- `test -d node_modules && echo node_modules-present || echo node_modules-missing; node --version; pnpm --version`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-transaction.test.ts src/resources/extensions/gsd/tests/derive-state-helpers.test.ts`
- `pnpm run build:agent-core`
- `pnpm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-transaction.test.ts src/resources/extensions/gsd/tests/derive-state-helpers.test.ts`
- `mkdir -p /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVEM3PPW2YCZTT2Z8K0NR14D && node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module - <<'EOF' > /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVEM3PPW2YCZTT2Z8K0NR14D/queue-order-transaction-evidence.json ... EOF`
- `sed -n '1,220p' /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVEM3PPW2YCZTT2Z8K0NR14D/queue-order-transaction-evidence.json`
- `rm -rf node_modules web/node_modules extensions/google-search/node_modules packages/cloud-mcp-gateway/node_modules packages/daemon/node_modules packages/gsd-agent-core/node_modules packages/gsd-agent-modes/node_modules packages/mcp-server/node_modules packages/native/node_modules packages/pi-agent-core/node_modules packages/pi-ai/node_modules packages/pi-coding-agent/node_modules packages/pi-tui/node_modules packages/rpc-client/node_modules packages/contracts/node_modules packages/native/dist packages/pi-agent-core/dist packages/contracts/dist packages/pi-ai/dist packages/gsd-agent-core/dist packages/gsd-agent-modes/dist packages/pi-coding-agent/dist packages/pi-tui/dist pkg/dist`
- `git restore -- pkg/dist/core/export-html/template.css pkg/dist/core/export-html/template.html pkg/dist/core/export-html/template.js pkg/dist/core/export-html/vendor/highlight.min.js pkg/dist/core/export-html/vendor/marked.min.js`
- `git status --short --ignored`
- `git diff --stat`
- `test -f /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVEM3PPW2YCZTT2Z8K0NR14D/queue-order-transaction-evidence.json && echo evidence-present`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused refactor of one write path plus transaction plumbing; behavior is covered by unit and state-derivation tests with no auth or broad API surface changes.
> 
> **Overview**
> Adds **`immediateTransaction()`** so `BEGIN IMMEDIATE` writes use the same re-entrant depth counter as **`transaction()`** and **`readTransaction()`**, with shared **`runTransaction`** / rollback handling in **`DbTransactionRunner`**.
> 
> **`setMilestoneQueueOrder`** no longer issues raw `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`; it runs inside **`immediateTransaction()`**, so queue reordering can nest safely inside an outer **`transaction()`** without a second `BEGIN`.
> 
> Docs note **`transaction()`** / **`immediateTransaction()`** for multi-table writes. Tests cover immediate commit/rollback, mixed nesting, and **`deriveStateFromDb`** when queue order is set inside an outer transaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce3d035eed0ce3f6b25939c262da46e1395a3a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->