### PR TITLE
fix(gsd): fail closed on incomplete migration backups

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -50,6 +50,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 - Sibling worktrees share the same `.gsd/gsd.db` via SQLite WAL
 - Only one connection is "active" at a time; others cached for fast re-activation
 - On process exit: checkpoint WAL → vacuum → close
+- Before file-backed schema migrations, `db-migration-backup.ts` checkpoints WAL and copies `.gsd/gsd.db` to `.gsd/gsd.db.backup-vN`; same-version backups are reused, and checkpoint/copy failures stop before migration DDL.
 
 **Provider fallback chain:**
 1. `node:sqlite` (Node ≥ 22 built-in) — preferred
@@ -766,3 +767,5 @@ remain outside manifest restore.
 5. **FTS fallback**: if FTS5 unavailable, `memory_query` falls back to LIKE scan on `memories.content`.
 
 6. **Workspace isolation**: same `.gsd/gsd.db` for all worktrees of one project; separate `.gsd/gsd.db` per project root. Coordination tables assume single-host shared WAL. Multi-host needs external coordinator.
+
+7. **Pre-migration backup**: file-backed migrations checkpoint WAL before copying the base DB to `.backup-vN`. If the same-version backup already exists, backup is skipped and migrations continue; if checkpointing or copying fails, the error propagates before any migration DDL runs.

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -50,7 +50,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 - Sibling worktrees share the same `.gsd/gsd.db` via SQLite WAL
 - Only one connection is "active" at a time; others cached for fast re-activation
 - On process exit: checkpoint WAL → vacuum → close
-- Before file-backed schema migrations, `db-migration-backup.ts` checkpoints WAL and copies `.gsd/gsd.db` to `.gsd/gsd.db.backup-vN`; same-version backups are reused, and checkpoint/copy failures stop before migration DDL.
+- Before file-backed schema migrations, `db-migration-backup.ts` checkpoints WAL and copies `.gsd/gsd.db` to `.gsd/gsd.db.backup-vN`; same-version backups are reused, and checkpoint/copy failures warn then fail closed before migration DDL.
 
 **Provider fallback chain:**
 1. `node:sqlite` (Node ≥ 22 built-in) — preferred
@@ -768,4 +768,4 @@ remain outside manifest restore.
 
 6. **Workspace isolation**: same `.gsd/gsd.db` for all worktrees of one project; separate `.gsd/gsd.db` per project root. Coordination tables assume single-host shared WAL. Multi-host needs external coordinator.
 
-7. **Pre-migration backup**: file-backed migrations checkpoint WAL before copying the base DB to `.backup-vN`. If the same-version backup already exists, backup is skipped and migrations continue; if checkpointing or copying fails, the error propagates before any migration DDL runs.
+7. **Pre-migration backup**: file-backed migrations checkpoint WAL before copying the base DB to `.gsd/gsd.db.backup-vN`. If the same-version backup already exists, backup is skipped and migrations continue; if checkpointing or copying fails, GSD warns and the error propagates before any migration DDL runs.

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -360,6 +360,6 @@ unit completes
 | Workspace isolation: one DB per project root, shared across worktrees via WAL | `db-connection-cache.ts` identityKey |
 | Coordination: one active dispatch per unit_id at a time | `idx_unit_dispatches_active_per_unit` unique partial index |
 | Memory FTS fallback: LIKE scan if FTS5 unavailable | `tryCreateMemoriesFtsSchema` onUnavailable callback |
-| Pre-migration backup: file-backed migrations checkpoint WAL before copying `.backup-vN`; existing same-version backups are reused/skipped, and checkpoint/copy failures stop before migration DDL | `db-migration-backup.ts` |
+| Pre-migration backup: file-backed migrations checkpoint WAL before copying `.gsd/gsd.db.backup-vN`; existing same-version backups are reused/skipped, and checkpoint/copy failures warn then stop before migration DDL | `db-migration-backup.ts` |
 | Prompt template vars: all `{{vars}}` must be provided before substitution | `prompt-loader.ts` pre-substitution validation |
 | Prompt cache stability: static sections always before dynamic | `prompt-ordering.ts` reorderForCaching |

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -360,6 +360,6 @@ unit completes
 | Workspace isolation: one DB per project root, shared across worktrees via WAL | `db-connection-cache.ts` identityKey |
 | Coordination: one active dispatch per unit_id at a time | `idx_unit_dispatches_active_per_unit` unique partial index |
 | Memory FTS fallback: LIKE scan if FTS5 unavailable | `tryCreateMemoriesFtsSchema` onUnavailable callback |
-| Pre-migration backup: .db.bak-vN before any migration run | `db-migration-backup.ts` |
+| Pre-migration backup: file-backed migrations checkpoint WAL before copying `.backup-vN`; existing same-version backups are reused/skipped, and checkpoint/copy failures stop before migration DDL | `db-migration-backup.ts` |
 | Prompt template vars: all `{{vars}}` must be provided before substitution | `prompt-loader.ts` pre-substitution validation |
 | Prompt cache stability: static sections always before dynamic | `prompt-ordering.ts` reorderForCaching |

--- a/src/resources/extensions/gsd/db-migration-backup.ts
+++ b/src/resources/extensions/gsd/db-migration-backup.ts
@@ -21,14 +21,11 @@ export function backupDatabaseBeforeMigration(
     const backupPath = `${dbPath}.backup-v${currentVersion}`;
     if (deps.existsSync(backupPath)) return;
 
-    try {
-      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    } catch {
-      // Checkpoint is best effort; copying the base file is still better than no backup.
-    }
+    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
     deps.copyFileSync(dbPath, backupPath);
   } catch (backupErr) {
     const message = backupErr instanceof Error ? backupErr.message : String(backupErr);
     deps.logWarning("db", `Pre-migration backup failed: ${message}`);
+    throw backupErr;
   }
 }

--- a/src/resources/extensions/gsd/db-migration-backup.ts
+++ b/src/resources/extensions/gsd/db-migration-backup.ts
@@ -9,6 +9,7 @@ export interface MigrationBackupDeps {
   logWarning(scope: string, message: string): void;
 }
 
+/** Marks pre-migration backup failures so DB-open recovery cannot mask them. */
 export class MigrationBackupError extends Error {
   constructor(message: string, cause?: unknown) {
     super(message, { cause });
@@ -16,10 +17,18 @@ export class MigrationBackupError extends Error {
   }
 }
 
+/** Returns true for errors raised while checkpointing or copying a migration backup. */
 export function isMigrationBackupError(err: unknown): err is MigrationBackupError {
   return err instanceof MigrationBackupError;
 }
 
+/**
+ * Creates a same-version backup before file-backed schema migrations.
+ *
+ * Existing same-version backups are reused. New backups fail closed: WAL
+ * checkpoint failures, incomplete checkpoints, and copy failures are logged
+ * and then rethrown before migration DDL runs.
+ */
 export function backupDatabaseBeforeMigration(
   db: DbAdapter,
   dbPath: string | null,

--- a/src/resources/extensions/gsd/db-migration-backup.ts
+++ b/src/resources/extensions/gsd/db-migration-backup.ts
@@ -9,6 +9,17 @@ export interface MigrationBackupDeps {
   logWarning(scope: string, message: string): void;
 }
 
+export class MigrationBackupError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
+    this.name = "MigrationBackupError";
+  }
+}
+
+export function isMigrationBackupError(err: unknown): err is MigrationBackupError {
+  return err instanceof MigrationBackupError;
+}
+
 export function backupDatabaseBeforeMigration(
   db: DbAdapter,
   dbPath: string | null,
@@ -21,11 +32,43 @@ export function backupDatabaseBeforeMigration(
     const backupPath = `${dbPath}.backup-v${currentVersion}`;
     if (deps.existsSync(backupPath)) return;
 
-    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    checkpointWal(db);
     deps.copyFileSync(dbPath, backupPath);
   } catch (backupErr) {
-    const message = backupErr instanceof Error ? backupErr.message : String(backupErr);
-    deps.logWarning("db", `Pre-migration backup failed: ${message}`);
-    throw backupErr;
+    const error = toMigrationBackupError(backupErr);
+    deps.logWarning("db", `Pre-migration backup failed: ${error.message}`);
+    throw error;
   }
+}
+
+function checkpointWal(db: DbAdapter): void {
+  const row = db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get();
+  if (!isCheckpointComplete(row)) {
+    const busy = formatCheckpointValue(row, "busy");
+    const log = formatCheckpointValue(row, "log");
+    const checkpointed = formatCheckpointValue(row, "checkpointed");
+    throw new MigrationBackupError(
+      `WAL checkpoint incomplete: busy=${busy} log=${log} checkpointed=${checkpointed}`,
+    );
+  }
+}
+
+function isCheckpointComplete(row: Record<string, unknown> | undefined): boolean {
+  if (!row) return false;
+  const busy = Number(row["busy"]);
+  const log = Number(row["log"]);
+  const checkpointed = Number(row["checkpointed"]);
+  if (!Number.isFinite(busy) || !Number.isFinite(log) || !Number.isFinite(checkpointed)) return false;
+  return busy === 0 && log === checkpointed;
+}
+
+function formatCheckpointValue(row: Record<string, unknown> | undefined, key: string): string {
+  const value = row?.[key];
+  return value === undefined ? "unknown" : String(value);
+}
+
+function toMigrationBackupError(err: unknown): MigrationBackupError {
+  if (isMigrationBackupError(err)) return err;
+  const message = err instanceof Error ? err.message : String(err);
+  return new MigrationBackupError(message, err);
 }

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -603,7 +603,8 @@ export function openDatabase(path: string): boolean {
     initSchema(adapter, fileBacked, path);
   } catch (err) {
     // Corrupt freelist: DDL fails with "malformed" but VACUUM can rebuild.
-    // Attempt VACUUM recovery before giving up (see #2519).
+    // Pre-migration backup failures are already pre-DDL and must propagate
+    // instead of being masked by VACUUM recovery (see #2519).
     if (shouldAttemptVacuumRecovery(fileBacked, err)) {
       try {
         adapter.exec("VACUUM");

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -18,7 +18,7 @@ import { createDbAdapter, type DbAdapter } from "../db-adapter.js";
 import { createBaseSchemaObjects } from "../db-base-schema.js";
 import { createCoordinationTablesV24 } from "../db-coordination-schema.js";
 import { createDbConnectionCache, type DbConnectionCacheEntry } from "../db-connection-cache.js";
-import { backupDatabaseBeforeMigration } from "../db-migration-backup.js";
+import { backupDatabaseBeforeMigration, isMigrationBackupError } from "../db-migration-backup.js";
 import {
   applyMigrationV2Artifacts,
   applyMigrationV3Memories,
@@ -604,7 +604,7 @@ export function openDatabase(path: string): boolean {
   } catch (err) {
     // Corrupt freelist: DDL fails with "malformed" but VACUUM can rebuild.
     // Attempt VACUUM recovery before giving up (see #2519).
-    if (fileBacked && err instanceof Error && err.message?.includes("malformed")) {
+    if (shouldAttemptVacuumRecovery(fileBacked, err)) {
       try {
         adapter.exec("VACUUM");
         initSchema(adapter, fileBacked, path);
@@ -635,6 +635,12 @@ export function openDatabase(path: string): boolean {
 
   return true;
 }
+
+function shouldAttemptVacuumRecovery(fileBacked: boolean, err: unknown): boolean {
+  return fileBacked && err instanceof Error && err.message.includes("malformed") && !isMigrationBackupError(err);
+}
+
+export const _shouldAttemptVacuumRecoveryForTest = shouldAttemptVacuumRecovery;
 
 export function closeDatabase(): void {
   if (currentDb) {

--- a/src/resources/extensions/gsd/tests/db-migration-backup.test.ts
+++ b/src/resources/extensions/gsd/tests/db-migration-backup.test.ts
@@ -3,16 +3,22 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { backupDatabaseBeforeMigration } from "../db-migration-backup.ts";
+import { MigrationBackupError, backupDatabaseBeforeMigration } from "../db-migration-backup.ts";
 import type { DbAdapter, DbStatement } from "../db-adapter.ts";
 
 class FakeStatement implements DbStatement {
+  private readonly row: Record<string, unknown> | undefined;
+
+  constructor(row: Record<string, unknown> | undefined = undefined) {
+    this.row = row;
+  }
+
   run(): unknown {
     return undefined;
   }
 
   get(): Record<string, unknown> | undefined {
-    return undefined;
+    return this.row;
   }
 
   all(): Record<string, unknown>[] {
@@ -22,15 +28,19 @@ class FakeStatement implements DbStatement {
 
 class FakeAdapter implements DbAdapter {
   readonly execCalls: string[] = [];
+  readonly prepareCalls: string[] = [];
   failCheckpoint = false;
+  checkpointRow: Record<string, unknown> = { busy: 0, log: 0, checkpointed: 0 };
 
   exec(sql: string): void {
     this.execCalls.push(sql);
     if (this.failCheckpoint) throw new Error("checkpoint failed");
   }
 
-  prepare(): DbStatement {
-    return new FakeStatement();
+  prepare(sql: string): DbStatement {
+    this.prepareCalls.push(sql);
+    if (this.failCheckpoint) throw new Error("checkpoint failed");
+    return new FakeStatement(this.checkpointRow);
   }
 
   close(): void {}
@@ -73,7 +83,7 @@ describe("db-migration-backup", () => {
       logWarning: () => assert.fail("should not warn"),
     });
 
-    assert.deepEqual(db.execCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
+    assert.deepEqual(db.prepareCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
     assert.deepEqual(copies, [["/tmp/gsd.db", "/tmp/gsd.db.backup-v12"]]);
   });
 
@@ -93,10 +103,32 @@ describe("db-migration-backup", () => {
       /checkpoint failed/,
     );
 
-    assert.deepEqual(db.execCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
+    assert.deepEqual(db.prepareCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
     assert.deepEqual(copies, []);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /Pre-migration backup failed: checkpoint failed/);
+  });
+
+  test("throws and skips copying when checkpoint result is incomplete", () => {
+    const db = new FakeAdapter();
+    db.checkpointRow = { busy: 1, log: 4, checkpointed: 3 };
+    const copies: Array<[string, string]> = [];
+    const warnings: string[] = [];
+
+    assert.throws(
+      () =>
+        backupDatabaseBeforeMigration(db, "/tmp/gsd.db", 12, {
+          existsSync: (path) => path === "/tmp/gsd.db",
+          copyFileSync: (src, dest) => copies.push([src, dest]),
+          logWarning: (_scope, message) => warnings.push(message),
+        }),
+      MigrationBackupError,
+    );
+
+    assert.deepEqual(db.prepareCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
+    assert.deepEqual(copies, []);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Pre-migration backup failed: WAL checkpoint incomplete/);
   });
 
   test("throws and warns when copy fails", () => {
@@ -115,7 +147,7 @@ describe("db-migration-backup", () => {
       /read only/,
     );
 
-    assert.deepEqual(db.execCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
+    assert.deepEqual(db.prepareCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /Pre-migration backup failed: read only/);
   });

--- a/src/resources/extensions/gsd/tests/db-migration-backup.test.ts
+++ b/src/resources/extensions/gsd/tests/db-migration-backup.test.ts
@@ -77,28 +77,45 @@ describe("db-migration-backup", () => {
     assert.deepEqual(copies, [["/tmp/gsd.db", "/tmp/gsd.db.backup-v12"]]);
   });
 
-  test("continues copying when checkpoint fails and warns when copy fails", () => {
+  test("throws and skips copying when checkpoint fails", () => {
     const db = new FakeAdapter();
     db.failCheckpoint = true;
     const copies: Array<[string, string]> = [];
     const warnings: string[] = [];
 
-    backupDatabaseBeforeMigration(db, "/tmp/gsd.db", 12, {
-      existsSync: (path) => path === "/tmp/gsd.db",
-      copyFileSync: (src, dest) => copies.push([src, dest]),
-      logWarning: (_scope, message) => warnings.push(message),
-    });
+    assert.throws(
+      () =>
+        backupDatabaseBeforeMigration(db, "/tmp/gsd.db", 12, {
+          existsSync: (path) => path === "/tmp/gsd.db",
+          copyFileSync: (src, dest) => copies.push([src, dest]),
+          logWarning: (_scope, message) => warnings.push(message),
+        }),
+      /checkpoint failed/,
+    );
 
-    assert.deepEqual(copies, [["/tmp/gsd.db", "/tmp/gsd.db.backup-v12"]]);
+    assert.deepEqual(db.execCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
+    assert.deepEqual(copies, []);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Pre-migration backup failed: checkpoint failed/);
+  });
 
-    backupDatabaseBeforeMigration(db, "/tmp/fail.db", 13, {
-      existsSync: (path) => path === "/tmp/fail.db",
-      copyFileSync: () => {
-        throw new Error("read only");
-      },
-      logWarning: (_scope, message) => warnings.push(message),
-    });
+  test("throws and warns when copy fails", () => {
+    const db = new FakeAdapter();
+    const warnings: string[] = [];
 
+    assert.throws(
+      () =>
+        backupDatabaseBeforeMigration(db, "/tmp/fail.db", 13, {
+          existsSync: (path) => path === "/tmp/fail.db",
+          copyFileSync: () => {
+            throw new Error("read only");
+          },
+          logWarning: (_scope, message) => warnings.push(message),
+        }),
+      /read only/,
+    );
+
+    assert.deepEqual(db.execCalls, ["PRAGMA wal_checkpoint(TRUNCATE)"]);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /Pre-migration backup failed: read only/);
   });

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -41,7 +41,9 @@ import {
   refreshOpenDatabaseFromDisk,
   tryCreateMemoriesFts,
   _isLikelyWslDrvFsPathForTest,
+  _shouldAttemptVacuumRecoveryForTest,
 } from '../gsd-db.ts';
+import { MigrationBackupError } from '../db-migration-backup.ts';
 import { _resetLogs, peekLogs, setStderrLoggingEnabled } from '../workflow-logger.ts';
 
 const _require = createRequire(import.meta.url);
@@ -537,6 +539,23 @@ describe('gsd-db', () => {
     assert.equal(index?.['name'], 'idx_memories_scope', 'scope index should be created after bootstrap columns are present');
 
     cleanup(dbPath);
+  });
+
+  test('gsd-db: migration backup errors bypass malformed-DB VACUUM recovery', () => {
+    assert.equal(
+      _shouldAttemptVacuumRecoveryForTest(
+        true,
+        new MigrationBackupError('database disk image is malformed during backup'),
+      ),
+      false,
+    );
+    assert.equal(
+      _shouldAttemptVacuumRecoveryForTest(
+        true,
+        new Error('database disk image is malformed'),
+      ),
+      true,
+    );
   });
 
   test('gsd-db: pre-v18 DB with memory_sources missing scope opens without crash (issue #4607)', () => {


### PR DESCRIPTION
## Intent

Validate and publish the migration-backup fail-closed change as its own focused PR. The goal is to ensure GSD SQLite migration backups do not silently proceed when the WAL checkpoint or backup copy fails: checkpoint failures should throw before copying, copy failures should throw after warning, and docs/tests should describe that fail-closed behavior. This branch intentionally touches the migration backup helper, focused tests, and DB map documentation for the backup path.

## What Changed

- Hardened GSD migration backup creation so WAL checkpoint failures, incomplete checkpoint results, and backup copy failures stop migration instead of allowing a potentially incomplete backup.
- Marked migration backup failures distinctly so database open/recovery logic does not treat them as recoverable malformed-schema initialization errors.
- Expanded focused DB backup/openDatabase tests and DB map documentation to cover the fail-closed migration backup path.

## Risk Assessment

✅ Low: The change is narrowly scoped to pre-migration backup fail-closed behavior and malformed-DB recovery gating, with no material regressions found in the reviewed diff.

## Testing

Checked branch/merge state, ran the focused backup and DB-engine tests, verified the docs mention checkpoint/copy fail-closed behavior, generated helper-level behavior evidence, and generated actual file-backed `openDatabase()` evidence for copy-failure fail-closed behavior; an initial chmod-based evidence setup was discarded because SQLite failed before reaching the backup helper, and the working tree finished clean.

<details>
<summary>Evidence: Migration backup fail-closed behavior evidence</summary>

```text
# Migration Backup Fail-Closed Evidence

| Scenario | Threw | Error | Checkpoint calls | Copies | Warning |
| --- | --- | --- | --- | --- | --- |
| successful backup checkpoints WAL before copying | false |  | PRAGMA wal_checkpoint(TRUNCATE) | /tmp/example/.gsd/gsd.db -> /tmp/example/.gsd/gsd.db.backup-v42 |  |
| checkpoint exception fails closed before copy | true | checkpoint failed | PRAGMA wal_checkpoint(TRUNCATE) |  | Pre-migration backup failed: checkpoint failed |
| incomplete checkpoint fails closed before copy | true | WAL checkpoint incomplete: busy=1 log=4 checkpointed=3 | PRAGMA wal_checkpoint(TRUNCATE) |  | Pre-migration backup failed: WAL checkpoint incomplete: busy=1 log=4 checkpointed=3 |
| copy failure fails closed after warning | true | read only filesystem | PRAGMA wal_checkpoint(TRUNCATE) |  | Pre-migration backup failed: read only filesystem |
```
</details>
<details>
<summary>Evidence: Migration backup fail-closed behavior data</summary>

```text
{
  "generatedAt": "2026-06-19T00:58:35.606Z",
  "dbPath": "/tmp/example/.gsd/gsd.db",
  "backupVersion": 42,
  "scenarios": [
    {
      "name": "successful backup checkpoints WAL before copying",
      "threw": false,
      "errorName": null,
      "errorMessage": null,
      "prepareCalls": [
        "PRAGMA wal_checkpoint(TRUNCATE)"
      ],
      "copies": [
        {
          "src": "/tmp/example/.gsd/gsd.db",
          "dest": "/tmp/example/.gsd/gsd.db.backup-v42"
        }
      ],
      "warnings": []
    },
    {
      "name": "checkpoint exception fails closed before copy",
      "threw": true,
      "errorName": "MigrationBackupError",
      "errorMessage": "checkpoint failed",
      "prepareCalls": [
        "PRAGMA wal_checkpoint(TRUNCATE)"
      ],
      "copies": [],
      "warnings": [
        "Pre-migration backup failed: checkpoint failed"
      ]
    },
    {
      "name": "incomplete checkpoint fails closed before copy",
      "threw": true,
      "errorName": "MigrationBackupError",
      "errorMessage": "WAL checkpoint incomplete: busy=1 log=4 checkpointed=3",
      "prepareCalls": [
        "PRAGMA wal_checkpoint(TRUNCATE)"
      ],
      "copies": [],
      "warnings": [
        "Pre-migration backup failed: WAL checkpoint incomplete: busy=1 log=4 checkpointed=3"
      ]
    },
    {
      "name": "copy failure fails closed after warning",
      "threw": true,
      "errorName": "MigrationBackupError",
      "errorMessage": "read only filesystem",
      "prepareCalls": [
        "PRAGMA wal_checkpoint(TRUNCATE)"
      ],
      "copies": [],
      "warnings": [
        "Pre-migration backup failed: read only filesystem"
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Actual openDatabase copy-failure evidence</summary>

```text
{
  "dbPath": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVENM048RTQCVB63R75RYT0G/actual-openDatabase-copy-failure/gsd.db",
  "backupPath": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVENM048RTQCVB63R75RYT0G/actual-openDatabase-copy-failure/gsd.db.backup-v28",
  "observations": [
    {
      "step": "fresh openDatabase",
      "schemaVersion": 29
    },
    {
      "step": "force migration needed with broken backup symlink",
      "schemaVersion": 28,
      "backupPathExists": false,
      "backupPathIsSymlink": true
    },
    {
      "step": "openDatabase migration with copy failure",
      "thrown": {
        "name": "MigrationBackupError",
        "message": "ENOENT: no such file or directory, copyfile '/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVENM048RTQCVB63R75RYT0G/actual-openDatabase-copy-failure/gsd.db' -> '/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVENM048RTQCVB63R75RYT0G/actual-openDatabase-copy-failure/gsd.db.backup-v28'"
      },
      "schemaVersion": 28,
      "backupCreated": false
    }
  ],
  "conclusion": "A file-backed openDatabase migration aborts when the pre-migration backup copy cannot be created; schema_version stays at 28 and no usable .backup-v28 file is present."
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/resources/extensions/gsd/db-migration-backup.ts:24` - `PRAGMA wal_checkpoint(TRUNCATE)` can report an incomplete checkpoint as a result row, for example when another reader keeps the WAL busy, without necessarily throwing. Because this uses `exec()` and discards the result, the code can still copy the base DB after an incomplete checkpoint, producing an incomplete backup while claiming fail-closed behavior. Use a statement/get path and throw unless the checkpoint status is successful before copying.
- 🚨 `src/resources/extensions/gsd/db-migration-backup.ts:29` - Throwing the raw checkpoint error lets `openDatabase()` treat backup failures whose SQLite message includes `malformed` as recoverable init-schema corruption: it runs `VACUUM` and retries `initSchema`, so the backup failure may not stop the migration path. Mark backup failures distinctly and bypass the malformed-DB VACUUM recovery for them so checkpoint/copy failures remain terminal.

🔧 Fix: Fail closed on incomplete migration backups
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch`
- `git merge-base --is-ancestor HEAD origin/main; echo ancestor_origin_main=$?`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-migration-backup.test.ts src/resources/extensions/gsd/tests/gsd-db.test.ts`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module &lt;&lt;&#39;EOF&#39; ... EOF` (helper-level evidence for success, checkpoint exception, incomplete checkpoint, and copy failure)</code>
- `rg -n "checkpoint WAL|checkpoint/copy failures|backup-vN|before any migration DDL|copy failures stop" docs/db-map.md docs/prompt-db-combined-map.md`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module &lt;&lt;&#39;EOF&#39; ... EOF` (actual `openDatabase()` copy-failure evidence using a forced v28 DB and broken backup-path symlink)</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to pre-migration backup and open-time recovery gating; migrations stop instead of proceeding with a bad backup, with no broader workflow or auth changes.
> 
> **Overview**
> Pre-migration SQLite backups now **fail closed** instead of best-effort continuing when checkpoint or copy fails.
> 
> **`backupDatabaseBeforeMigration`** runs `PRAGMA wal_checkpoint(TRUNCATE)` via `prepare().get()`, requires a complete checkpoint (`busy === 0` and `log === checkpointed`), then copies `.gsd/gsd.db` to `.gsd/gsd.db.backup-vN`. Checkpoint errors, incomplete checkpoints, and copy failures are logged, wrapped in **`MigrationBackupError`**, and rethrown so **migration DDL never runs** without a valid backup (existing same-version backups are still skipped).
> 
> **`openDatabase`** no longer treats those backup failures as recoverable **malformed** init errors: **`shouldAttemptVacuumRecovery`** excludes `MigrationBackupError`, so VACUUM retry cannot mask a failed pre-migration backup.
> 
> Docs and tests describe and lock in this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea0688888a665d50fe3ef2a2b8d45039ad8b6bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->