### PR TITLE
fix(gsd): gate provider-keyed web search tools on configured credentials

### DIFF
--- a/extensions/google-search/index.ts
+++ b/extensions/google-search/index.ts
@@ -174,7 +174,20 @@ function cacheKey(query: string): string {
 
 // ── Extension ────────────────────────────────────────────────────────────────
 
-export default function (pi: ExtensionAPI) {
+// Track which ExtensionAPI instances have already registered the tool, so a
+// real single-instance process registers once across repeated session_start
+// fires, while tests that construct a fresh pi per case each register cleanly.
+const googleSearchRegisteredFor = new WeakSet<object>();
+
+/**
+ * Register the google_search tool. Gated on credential availability by the
+ * session_start hook: the tool is never advertised to the model when it cannot
+ * authenticate (GEMINI_API_KEY or Google OAuth), so the agent does not reach
+ * for a tool that can only return an auth error. Idempotent per pi instance.
+ */
+function registerGoogleSearchTool(pi: ExtensionAPI): void {
+	if (googleSearchRegisteredFor.has(pi)) return;
+	googleSearchRegisteredFor.add(pi);
 	pi.registerTool({
 		name: "google_search",
 		label: "Google Search",
@@ -411,7 +424,9 @@ export default function (pi: ExtensionAPI) {
 			return new Text(text, 0, 0);
 		},
 	});
+}
 
+export default function (pi: ExtensionAPI) {
 	// ── Session cleanup ─────────────────────────────────────────────────────
 
 	pi.on("session_shutdown", async () => {
@@ -419,18 +434,33 @@ export default function (pi: ExtensionAPI) {
 		client = null;
 	});
 
-	// ── Startup notification ─────────────────────────────────────────────────
+	// ── Credential-gated registration ────────────────────────────────────────
+	// Only register google_search when it can actually authenticate. Without
+	// credentials the tool can only return an auth error, so presenting it to
+	// the model is pure confusion — the agent reaches for a tool that cannot
+	// work. Re-evaluated each session so a key or Google login added before a
+	// later session is picked up without a restart.
 
 	pi.on("session_start", async (_event, ctx) => {
-		if (process.env.GEMINI_API_KEY) return;
-
-		const hasOAuth = await ctx.modelRegistry.authStorage.hasAuth("google-gemini-cli");
-		if (!hasOAuth) {
-			ctx.ui.notify(
-				"Google Search: No authentication set. Log in via Google or set GEMINI_API_KEY to use google_search.",
-				"warning",
-			);
+		const hasGeminiKey = !!process.env.GEMINI_API_KEY;
+		let hasOAuth = false;
+		if (!hasGeminiKey) {
+			try {
+				hasOAuth = await ctx.modelRegistry.authStorage.hasAuth("google-gemini-cli");
+			} catch {
+				hasOAuth = false;
+			}
 		}
+
+		if (hasGeminiKey || hasOAuth) {
+			registerGoogleSearchTool(pi);
+			return;
+		}
+
+		ctx.ui.notify(
+			"Google Search: No authentication set. Log in via Google or set GEMINI_API_KEY to use google_search.",
+			"warning",
+		);
 	});
 }
 

--- a/src/resources/extensions/search-the-web/index.ts
+++ b/src/resources/extensions/search-the-web/index.ts
@@ -3,38 +3,74 @@
  *
  * Native Anthropic hooks stay eager. Heavy tool registration is deferred in
  * interactive mode so startup is not blocked on the full search tool stack.
+ *
+ * Provider gating: the Brave/Tavily/Ollama-backed tools (search-the-web,
+ * search_and_read) are only registered when a provider API key is actually
+ * configured (resolveSearchProvider() !== null). Without a key these tools can
+ * only return an auth error, so presenting them to the model is pure confusion
+ * — the agent reaches for a tool that cannot work. fetch_page is always
+ * registered because it works key-free via Jina Reader.
  */
 
 import { importExtensionModule, type ExtensionAPI } from "@gsd/pi-coding-agent";
 import { registerSearchProviderCommand } from "./command-search-provider.js";
 import { registerNativeSearchHooks } from "./native-search.js";
+import { resolveSearchProvider } from "./provider.js";
 
-let toolsPromise: Promise<void> | null = null;
+// fetch_page registration — always available (key-free via Jina Reader).
+let fetchToolPromise: Promise<void> | null = null;
+// search-the-web + search_and_read registration — gated on provider key.
+let searchToolsPromise: Promise<void> | null = null;
 let resetSearchLoopGuardStateRef: (() => void) | null = null;
 
-async function registerSearchTools(pi: ExtensionAPI): Promise<void> {
-  if (!toolsPromise) {
-    toolsPromise = (async () => {
-      const [
-        { registerSearchTool, resetSearchLoopGuardState },
-        { registerFetchPageTool },
-        { registerLLMContextTool },
-      ] = await Promise.all([
-        importExtensionModule<typeof import("./tool-search.js")>(import.meta.url, "./tool-search.js"),
-        importExtensionModule<typeof import("./tool-fetch-page.js")>(import.meta.url, "./tool-fetch-page.js"),
-        importExtensionModule<typeof import("./tool-llm-context.js")>(import.meta.url, "./tool-llm-context.js"),
-      ]);
-      resetSearchLoopGuardStateRef = resetSearchLoopGuardState;
-      registerSearchTool(pi);
+async function registerFetchTool(pi: ExtensionAPI): Promise<void> {
+  if (!fetchToolPromise) {
+    fetchToolPromise = (async () => {
+      const { registerFetchPageTool } = await importExtensionModule<typeof import("./tool-fetch-page.js")>(
+        import.meta.url,
+        "./tool-fetch-page.js",
+      );
       registerFetchPageTool(pi);
-      registerLLMContextTool(pi);
     })().catch((error) => {
-      toolsPromise = null;
+      fetchToolPromise = null;
       throw error;
     });
   }
 
-  return toolsPromise;
+  return fetchToolPromise;
+}
+
+/**
+ * Register the provider-backed search tools, but only when a search provider
+ * key is configured. Memoized so it registers at most once per process; the
+ * guard is re-evaluated on each session_start so a key added before a later
+ * session is picked up without a restart.
+ */
+async function registerProviderSearchTools(pi: ExtensionAPI): Promise<void> {
+  if (resolveSearchProvider() === null) return;
+  if (!searchToolsPromise) {
+    searchToolsPromise = (async () => {
+      const [
+        { registerSearchTool, resetSearchLoopGuardState },
+        { registerLLMContextTool },
+      ] = await Promise.all([
+        importExtensionModule<typeof import("./tool-search.js")>(import.meta.url, "./tool-search.js"),
+        importExtensionModule<typeof import("./tool-llm-context.js")>(import.meta.url, "./tool-llm-context.js"),
+      ]);
+      resetSearchLoopGuardStateRef = resetSearchLoopGuardState;
+      registerSearchTool(pi);
+      registerLLMContextTool(pi);
+    })().catch((error) => {
+      searchToolsPromise = null;
+      throw error;
+    });
+  }
+
+  return searchToolsPromise;
+}
+
+async function registerSearchTools(pi: ExtensionAPI): Promise<void> {
+  await Promise.all([registerFetchTool(pi), registerProviderSearchTools(pi)]);
 }
 
 export default function (pi: ExtensionAPI) {

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -7,6 +7,7 @@
 
 import { isAnthropicApi } from "@gsd/pi-ai";
 import { resolveSearchProviderFromPreferences } from "../gsd/preferences.js";
+import { resolveSearchProvider } from "./provider.js";
 
 /** Tool names for the Brave-backed custom search tools */
 export const BRAVE_TOOL_NAMES = ["search-the-web", "search_and_read"];
@@ -194,11 +195,22 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
         active.filter((t: string) => !CUSTOM_SEARCH_TOOL_NAMES.includes(t))
       );
     } else if (!isAnthropicProvider && wasAnthropic) {
-      // Switching away from Anthropic — re-enable custom search tools (they
-      // were disabled while native search was active). If keys are missing,
-      // user sees the error rather than tools silently vanishing.
+      // Switching away from Anthropic — re-enable custom search tools that were
+      // disabled while native search was active. Only re-add the Brave/Tavily/
+      // Ollama-backed tools when a provider key is actually configured: without
+      // a key they can only return an auth error, and re-adding their names
+      // would advertise a tool the model cannot use (and, when unregistered,
+      // leak a schema-less phantom name into the tool surface). google_search
+      // is owned by its own extension (which now gates its registration on
+      // Gemini creds); re-adding its name here is harmless either way — it
+      // activates if registered, or is dropped as a no-op if not.
       const active = pi.getActiveTools();
-      const toAdd = CUSTOM_SEARCH_TOOL_NAMES.filter((t) => !active.includes(t));
+      const providerConfigured = resolveSearchProvider() !== null;
+      const toAdd = CUSTOM_SEARCH_TOOL_NAMES.filter((t) => {
+        if (active.includes(t)) return false;
+        if (BRAVE_TOOL_NAMES.includes(t)) return providerConfigured;
+        return true;
+      });
       if (toAdd.length > 0) {
         pi.setActiveTools([...active, ...toAdd]);
       }

--- a/src/tests/google-search-auth.repro.test.ts
+++ b/src/tests/google-search-auth.repro.test.ts
@@ -82,7 +82,7 @@ test("fix: google-search uses OAuth if GEMINI_API_KEY is missing", async (t) => 
   assert.ok(result.content[0].text.includes("Mocked AI Answer"));
 });
 
-test("google-search warns if NO authentication is present", async (t) => {
+test("google-search does NOT register the tool and warns when NO authentication is present", async (t) => {
   const originalKey = process.env.GEMINI_API_KEY;
   delete process.env.GEMINI_API_KEY;
 
@@ -97,13 +97,13 @@ test("google-search warns if NO authentication is present", async (t) => {
   };
 
   await pi.fire("session_start", {}, mockCtx);
+
+  // Registration is credential-gated: with no GEMINI_API_KEY and no OAuth, the
+  // tool must NOT be registered (so the model is never offered a tool that can
+  // only return an auth error), and the user is warned instead.
   assert.equal(notifications.length, 1);
   assert.ok(notifications[0].msg.includes("No authentication set"));
-
-  const registeredTool = (pi as any).registeredTool;
-  const result = await registeredTool.execute("call-2", { query: "test" }, new AbortController().signal, () => {}, mockCtx);
-  assert.equal(result.isError, true);
-  assert.ok(result.content[0].text.includes("No authentication found"));
+  assert.equal((pi as any).registeredTool, null, "google_search must not be registered without credentials");
 });
 
 test("google-search uses GEMINI_API_KEY if present (precedence)", async (t) => {

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -461,9 +461,9 @@ test("model_select disables all custom search tools when Anthropic even with BRA
   assert.ok(active.includes("fetch_page"), "fetch_page should remain active");
 });
 
-test("model_select re-enables Brave tools when switching away from Anthropic", async (t) => {
+test("model_select re-enables Brave tools when switching away from Anthropic (provider key present)", async (t) => {
   const originalKey = process.env.BRAVE_API_KEY;
-  delete process.env.BRAVE_API_KEY;
+  process.env.BRAVE_API_KEY = "test-key";
 
   t.after(() => {
     if (originalKey) process.env.BRAVE_API_KEY = originalKey;
@@ -483,7 +483,7 @@ test("model_select re-enables Brave tools when switching away from Anthropic", a
   let active = pi.getActiveTools();
   assert.ok(!active.includes("search-the-web"), "Should disable after Anthropic select");
 
-  // Second: switch to non-Anthropic — re-enables
+  // Second: switch to non-Anthropic — re-enables (a Brave key is configured)
   await pi.fire("model_select", {
     type: "model_select",
     model: { provider: "openai", name: "gpt-4o" },
@@ -495,6 +495,49 @@ test("model_select re-enables Brave tools when switching away from Anthropic", a
   assert.ok(active.includes("search-the-web"), "search-the-web should be re-enabled");
   assert.ok(active.includes("search_and_read"), "search_and_read should be re-enabled");
   assert.ok(active.includes("google_search"), "google_search should be re-enabled");
+});
+
+test("model_select does NOT re-enable Brave tools when no provider key is configured", async (t) => {
+  // Reversal of the prior "re-enable even if keys missing" behavior: an
+  // unconfigured Brave/Tavily/Ollama tool can only return an auth error, so it
+  // must not be re-advertised to the model. google_search has its own creds and
+  // is still re-enabled.
+  const originalBrave = process.env.BRAVE_API_KEY;
+  const originalTavily = process.env.TAVILY_API_KEY;
+  const originalOllama = process.env.OLLAMA_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+  delete process.env.TAVILY_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
+
+  t.after(() => {
+    if (originalBrave) process.env.BRAVE_API_KEY = originalBrave; else delete process.env.BRAVE_API_KEY;
+    if (originalTavily) process.env.TAVILY_API_KEY = originalTavily; else delete process.env.TAVILY_API_KEY;
+    if (originalOllama) process.env.OLLAMA_API_KEY = originalOllama; else delete process.env.OLLAMA_API_KEY;
+  });
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // First: select Anthropic — disables custom search tools
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  // Second: switch to non-Anthropic — Brave tools stay hidden (no key)
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "openai", name: "gpt-4o" },
+    previousModel: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    source: "set",
+  });
+
+  const active = pi.getActiveTools();
+  assert.ok(!active.includes("search-the-web"), "search-the-web must stay hidden without a provider key");
+  assert.ok(!active.includes("search_and_read"), "search_and_read must stay hidden without a provider key");
+  assert.ok(active.includes("google_search"), "google_search should still be re-enabled (own creds)");
+  assert.ok(active.includes("fetch_page"), "fetch_page should remain active");
 });
 
 test("model_select shows 'Native Anthropic web search active' for Anthropic provider", async () => {
@@ -656,8 +699,10 @@ test("before_provider_request removes all custom search tools from payload even 
 // ─── BUG-1 regression: duplicate Brave tools on repeated provider toggle ────
 
 test("model_select re-enable does not duplicate Brave tools across toggle cycles", async (t) => {
+  // A provider key is configured so the Brave tools are actually re-enabled on
+  // switch-away; this exercises the dedup guard (no accumulation across cycles).
   const originalKey = process.env.BRAVE_API_KEY;
-  delete process.env.BRAVE_API_KEY;
+  process.env.BRAVE_API_KEY = "test-key";
 
   t.after(() => {
     if (originalKey) process.env.BRAVE_API_KEY = originalKey;

--- a/src/tests/search-tool-registration-gating.test.ts
+++ b/src/tests/search-tool-registration-gating.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Registration gating for the web-search extension.
+ *
+ * The Brave/Tavily/Ollama-backed tools (search-the-web, search_and_read) must
+ * only be registered when a provider API key is configured. Without a key they
+ * can only return an auth error, so presenting them to the model causes the
+ * agent to reach for a tool that cannot work. fetch_page is always registered
+ * because it works key-free via Jina Reader.
+ *
+ * These tests share one imported module instance (per-file process isolation),
+ * so they rely on module-level memoization: the no-provider case runs first and
+ * must leave the search-tools promise unset so the with-provider case can still
+ * register them.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import searchExtension from "../resources/extensions/search-the-web/index.ts";
+
+interface MockPI {
+  registered: Set<string>;
+  fireSessionStart(hasUI: boolean): Promise<void>;
+}
+
+function createMockPI(): MockPI {
+  const registered = new Set<string>();
+  const handlers: Array<{ event: string; handler: (...args: any[]) => any }> = [];
+  let active: string[] = [];
+
+  const ctx = {
+    hasUI: false,
+    ui: { notify() {} },
+  };
+
+  const pi: any = {
+    registered,
+    on(event: string, handler: (...args: any[]) => any) {
+      handlers.push({ event, handler });
+    },
+    registerCommand() {},
+    registerTool(tool: any) {
+      if (typeof tool?.name === "string") {
+        registered.add(tool.name);
+        active.push(tool.name);
+      }
+    },
+    getActiveTools() {
+      return [...active];
+    },
+    setActiveTools(tools: string[]) {
+      active = tools;
+    },
+    writeTempFile: async () => "/tmp/search-out.txt",
+    async fireSessionStart(hasUI: boolean) {
+      for (const h of handlers) {
+        if (h.event === "session_start") {
+          await h.handler({ type: "session_start" }, { ...ctx, hasUI });
+        }
+      }
+    },
+  };
+
+  return pi as MockPI;
+}
+
+// Isolate provider resolution from the developer's real ~/.gsd config.
+const ORIGINAL = {
+  GSD_HOME: process.env.GSD_HOME,
+  BRAVE_API_KEY: process.env.BRAVE_API_KEY,
+  TAVILY_API_KEY: process.env.TAVILY_API_KEY,
+  OLLAMA_API_KEY: process.env.OLLAMA_API_KEY,
+};
+
+let tmpHome: string;
+
+function clearSearchKeys() {
+  delete process.env.BRAVE_API_KEY;
+  delete process.env.TAVILY_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
+}
+
+test.before(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "gsd-search-gating-"));
+  process.env.GSD_HOME = tmpHome;
+});
+
+test.after(() => {
+  for (const [key, value] of Object.entries(ORIGINAL)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test("no provider key: search-the-web and search_and_read are NOT registered, fetch_page is", async () => {
+  clearSearchKeys();
+
+  const pi = createMockPI();
+  searchExtension(pi as any);
+  await pi.fireSessionStart(false);
+
+  assert.ok(pi.registered.has("fetch_page"), "fetch_page should always register (key-free via Jina)");
+  assert.ok(
+    !pi.registered.has("search-the-web"),
+    "search-the-web must NOT register without a provider key",
+  );
+  assert.ok(
+    !pi.registered.has("search_and_read"),
+    "search_and_read must NOT register without a provider key",
+  );
+});
+
+test("provider key present: search-the-web and search_and_read register", async (t) => {
+  clearSearchKeys();
+  process.env.BRAVE_API_KEY = "test-brave-key";
+  t.after(() => clearSearchKeys());
+
+  const pi = createMockPI();
+  searchExtension(pi as any);
+  await pi.fireSessionStart(false);
+
+  assert.ok(
+    pi.registered.has("search-the-web"),
+    "search-the-web should register when a provider key is configured",
+  );
+  assert.ok(
+    pi.registered.has("search_and_read"),
+    "search_and_read should register when a provider key is configured",
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #784

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Only register the provider-keyed web-search tools when they can actually authenticate — `search-the-web` / `search_and_read` when a Tavily/Brave/Ollama key is set, and `google_search` when Gemini credentials are present — so the agent is never offered a search tool that can only return an auth error.
**Why:** With no key configured these tools were still advertised to the model, so the agent reached for them and got `No search API key set [auth_error]` mid-task (observed on `claude-opus-4-8` with no key).
**How:** Gate **registration** (not active-state) on credential availability in each extension's `session_start`; keep `fetch_page` always registered because it works key-free via Jina Reader; make the native-search re-enable path provider-aware so an unusable tool is never re-advertised.

This is a **tool-surface / agent-correctness** change. There is no change to how any tool behaves once a key *is* present.

## What this PR does (at a glance)

- Stops advertising `search-the-web` / `search_and_read` when no Tavily/Brave/Ollama key is configured
- Stops advertising `google_search` when no Gemini credential (`GEMINI_API_KEY` or Google OAuth) is present
- Keeps `fetch_page` always available (key-free via Jina Reader)
- Makes the native-search "re-enable on switch away from Anthropic" path provider-aware, so it never re-adds an unusable Brave tool (or a schema-less phantom name)
- Re-evaluates the gate each `session_start`, so a key/login added before a later session is picked up without a restart

## Why (the root problem)

`resolveSearchProvider()` already returns `null` when no key is set — but registration never consulted it, so the tools stayed in the model-facing surface and only failed at execute time with `auth_error`. The native-search hook only hides the custom tools when *native Anthropic web search* takes over, so on any non-native provider with no key the broken tools remained visible and the agent kept choosing them.

Gating **registration** (rather than just de-activating) is required because GSD auto-mode rebuilds the model surface from `getAllTools()` — *all registered tools*, regardless of active state — so a registered-but-inactive tool leaks straight back into the surface. The only reliable way to make a tool "unknown" to the model is to not register it. (Verified: `setActiveToolsByName` in `gsd-agent-core` filters every name through `_toolRegistry.get(name)`, so an unregistered name is silently dropped — which is also why a stray re-enabled phantom name is harmless, but we still avoid it for a clean active set.)

## What changed — every change and why

### A. Provider gating — `search-the-web` / `search_and_read` (Tavily/Brave/Ollama)

| File | What changed | Why |
| --- | --- | --- |
| `src/resources/extensions/search-the-web/index.ts` | Split registration into two memoized paths: `fetch_page` registers unconditionally; `search-the-web` + `search_and_read` register only when `resolveSearchProvider() !== null`. The provider gate is re-checked on each `session_start` (its own memo), so a key added before a later session is picked up. | Without a provider key these two tools can only return an auth error. Gating registration (not active-state) is required because GSD auto-mode rebuilds the surface from `getAllTools()`. `fetch_page` stays because it works key-free via Jina Reader. |
| `src/resources/extensions/search-the-web/native-search.ts` | Made the `model_select` "re-enable custom search tools when switching away from Anthropic" branch provider-aware: the Brave/Tavily/Ollama tools are re-added only when `resolveSearchProvider() !== null`; `google_search` (its own creds) is still re-added. | Reverses the prior "re-enable even if keys missing" behavior so an unusable tool is never re-advertised, and keeps the active set free of schema-less phantom names. |

### B. Credential gating — `google_search` (Gemini), standalone `@gsd-extensions/google-search`

| File | What changed | Why |
| --- | --- | --- |
| `extensions/google-search/index.ts` | Moved the `pi.registerTool(...)` body into `registerGoogleSearchTool(pi)` and gate it in `session_start` on credentials — `GEMINI_API_KEY` env or `google-gemini-cli` OAuth via `ctx.modelRegistry.authStorage.hasAuth`. Used a per-`pi` `WeakSet` memo so a single real process registers once across repeated `session_start` fires, while tests that construct a fresh `pi` per case each register cleanly. | Consistency with the search-the-web gating; an unconfigured `google_search` could only return an auth error. The bundled `src/resources/extensions/google-search/` is already a deprecation no-op stub, so this affects only the not-yet-published standalone package — making it correct on arrival. |

### C. Tests

| File | What changed | Why |
| --- | --- | --- |
| `src/tests/search-tool-registration-gating.test.ts` (new) | No provider key → `search-the-web` / `search_and_read` are NOT registered, `fetch_page` is; with a provider key → both register. Hermetic (isolated `GSD_HOME`, cleared keys). | Pins the core registration contract. |
| `src/tests/native-search.test.ts` (updated) | Split the re-enable test into provider-present (Brave tools re-enable on switch-away) and no-provider (Brave tools stay hidden; `google_search` still re-enabled) cases; the dedup-across-toggle-cycles test now sets a key so it still exercises dedup. | Encodes the new provider-aware re-enable behavior. |
| `src/tests/google-search-auth.repro.test.ts` (updated) | The no-credentials case now asserts the tool is NOT registered + a warning is shown (previously: registered, then an execute-time auth error). OAuth and `GEMINI_API_KEY` paths still register and execute. | Reflects the new gated contract; the old test encoded the "register always, error at execute" behavior this PR removes. |

## Change type

- [x] `fix` — provider/credential-gate web-search tool registration so unusable tools aren't advertised
- [x] `test` — registration-gating coverage + updated native-search and google-search contracts

## Scope

- [x] `gsd extension` — web-search extension (`search-the-web`) and standalone google-search extension

## Breaking changes

- [x] No breaking changes

The only behavior change is to the **model-facing tool surface**: tools that could not authenticate were previously advertised (and errored on use) and are now simply not offered. No public API, CLI, or config change. Behavior with a key present is unchanged. `fetch_page` is unaffected.

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — described below

Verified locally (compiled unit harness):

| Test file | Verifies |
| --- | --- |
| `src/tests/search-tool-registration-gating.test.ts` (new) | no key → search tools not registered, `fetch_page` is; key → registered |
| `src/tests/native-search.test.ts` | provider-aware re-enable (key vs no-key), dedup across toggles, native injection unchanged |
| `src/tests/google-search-auth.repro.test.ts` | no-creds → not registered + warn; OAuth / `GEMINI_API_KEY` → registered + executes |
| `src/tests/google-search-oauth-shape.test.ts` | OAuth Cloud Code Assist wire format unchanged (creds present) |
| `src/resources/extensions/gsd/tests/google-search-stub.test.ts` | bundled deprecation stub remains a no-op |

- Targeted suites above: **60 / 60 pass**.
- `pnpm run verify:merge`: all **code-quality gates pass** — `build:core`, `build:web-host`, `typecheck:extensions`, `validate-pack`, `verify:workspace-coverage`, `verify:extension-coverage`.
- Full `pnpm run test:unit`: 10911 pass / 23 fail — **no new failures vs a clean-HEAD baseline** (clean `main` = 24; **zero failures in any changed area**). The 23 are pre-existing/environmental (a non-default local GSD home, ambient provider auth in the env, the `rtk` managed-bin path, and a borderline prompt-size gate).
- `test:packages` + `test:integration`: **baseline-confirmed** in the same checkout — 81 failing on this branch vs 79 on clean `main`, the sole delta being a flaky CLI-spawn smoke test that passes 3/3 in isolation. **Zero failures in any changed area.** (These suites are env-sensitive — git-worktree / `.gsd`-state / built-CLI integration tests fail identically on clean `main` in this local setup.)
- Runtime smoke: the built CLI loads the full extension stack cleanly; the gating itself is verified by driving the **compiled** extension through the real `session_start` flow with registration awaited (no key → `search-the-web` / `search_and_read` not registered, `fetch_page` is; key → registered).
- Re-verified end-to-end in a dedicated worktree (`pnpm install` → `build:pi` → `build:core`).

Reviewer note: the local environment (non-default GSD home + a linked git worktree) makes a fully-green `verify:merge` impossible locally — the env-sensitive worktree/`.gsd`/CLI integration suites fail identically on clean `main`. CI is the authoritative green gate; every failure observed locally is pre-existing and environmental, none in a changed area.

## AI disclosure

- [x] This PR includes AI-assisted code. Tooling: GSD-pi agent. All changes were tested to the same standard as human-written code (behavior-executing tests, full affected-suite run, clean-baseline comparison). The AI is not credited as an author or co-author.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784511433&installation_id=134682257&pr_number=785&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F785&signature=bf2d34fb7aee41574275abb5088673c774156f089e97bb6d8c01be7c13b5d098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->