### PR TITLE
fix(pi-agent-core): terminate tool batch on external results to stop duplicate assistant bubbles

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -685,6 +685,15 @@ async function prepareToolCall(
 						? (externalResult.content as AgentToolResult<any>["content"])
 						: [{ type: "text", text: "" }],
 				details: externalResult.details ?? {},
+				// The provider (claude-code-cli) already executed this tool inside its
+				// own agentic session and emitted ONE final assistant message carrying
+				// both the tool blocks and the post-tool text. There is no follow-up
+				// LLM work for the agent-loop to do, so terminate the batch. Without
+				// this, shouldTerminateToolBatch() returns false → hasMoreToolCalls
+				// stays true → the loop makes a redundant streamAssistantResponse call,
+				// emitting a second message_start that the TUI renders as a duplicate
+				// assistant bubble / stacked `╭─ GSD ─` header (issue #654).
+				terminate: true,
 			},
 			isError: externalResult.isError ?? false,
 		};

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -733,6 +733,80 @@ describe("agentLoop with AgentMessage", () => {
 		expect(toolResults.map((event) => event.result.content[0]?.text).join("\n")).not.toContain("not found");
 	});
 
+	it("does not request another assistant turn after externalResult tool calls (issue #654)", async () => {
+		// Regression for the duplicate-bubble / duplicate `╭─ GSD ─` header bug.
+		// The claude-code-cli adapter pre-executes its tools and emits ONE final
+		// AssistantMessage containing both the tool-call blocks (with externalResult
+		// attached) AND the post-tool text. The agent-loop must recognize that this
+		// batch is already finished and NOT loop back for a second streamAssistantResponse
+		// call — a second call emits a second message_start, which the interactive
+		// renderer draws as a second assistant bubble (a stacked second `╭─ GSD ─` header).
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (streamCallCount === 1) {
+					// One logical claude-code turn: tool call (already executed by the
+					// SDK, so externalResult is attached) followed by the model's final text.
+					const message = createAssistantMessage(
+						[
+							{
+								type: "toolCall",
+								id: "tool-bash",
+								name: "Bash",
+								arguments: { command: "lsof -i :3000" },
+								externalResult: {
+									content: [{ type: "text", text: "nothing on :3000" }],
+									details: { source: "claude-code" },
+									isError: false,
+								},
+							} as any,
+							{ type: "text", text: "Nothing is running on port 3000." },
+						],
+						"toolUse",
+					);
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					// If the loop reaches here, it has looped back for a redundant turn —
+					// this is the duplicate-bubble bug. Emit a distinct duplicate so the
+					// assertion can show what leaked through.
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "Nothing is running on port 3000." }]),
+					});
+				}
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("Is anything running on port 3000?")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messageStarts = events.filter(
+			(event): event is Extract<AgentEvent, { type: "message_start" }> => event.type === "message_start",
+		);
+		const assistantStarts = messageStarts.filter((event) => event.message.role === "assistant");
+
+		// The externalResult batch is terminal: exactly one assistant turn, one bubble.
+		expect(streamCallCount).toBe(1);
+		expect(assistantStarts.length).toBe(1);
+	});
+
 	it("returns ToolSearch guidance when the shim is not in the active tool registry", async () => {
 		const context: AgentContext = {
 			systemPrompt: "",


### PR DESCRIPTION
## Linked issue

Closes #654

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Mark the tool batch as terminal when its results came from the provider's own pre-executed tools (`externalResult`), so the agent-loop does not request another assistant turn.
**Why:** Without that signal the loop made a redundant `streamAssistantResponse` call after a claude-code tool-interleaved turn, emitting a second `message_start` that the TUI draws as a duplicate assistant bubble (a stacked second `╭─ GSD ─` header).
**How:** Set `terminate: true` on the `externalResult` immediate result in `prepareToolCall`; `shouldTerminateToolBatch()` then returns true and the inner loop exits without a second turn.

## What this PR does (at a glance)

- Stops one logical claude-code turn from rendering as two assistant bubbles when it interleaves tool calls (most visible on `claude-opus-4-8`)
- Touches only the `externalResult` path in `packages/pi-agent-core/src/agent-loop.ts` (1 production line + comment)
- Adds a regression test that fails on the prior behavior (the loop issued a second `streamAssistantResponse` call → two assistant `message_start` events)

Scope: 2 files, +83 / −0. No dependency changes.

## Why (the root problem)

The `claude-code-cli` provider runs its tools inside its own agentic session (`sdk.query()`) and emits **one** final `AssistantMessage` whose `content[]` carries both the tool-call blocks (with `externalResult` attached by the adapter) and the post-tool text. By the time the agent-loop sees this message, all tool work is already done.

The agent-loop still walks that message through `executeToolCalls` → `prepareToolCall`. The `externalResult` branch correctly returns an `immediate` result (it does **not** re-execute the tool), but it omitted the `terminate` flag:

- `shouldTerminateToolBatch()` returns `finalizedCalls.every(f => f.result.terminate === true)` → `false`
- `hasMoreToolCalls = !executedToolBatch.terminate` → `true`
- the inner loop runs another iteration → a second `streamAssistantResponse()` → a second `message_start`

The interactive renderer draws each assistant `message_start` as a new bubble, so the single logical reply appears twice — the stacked `╭─ GSD ─` headers reported in #654. `claude-opus-4-8` makes this routine because its adaptive thinking produces tool-interleaved turns.

## How (the fix)

Set `terminate: true` on the `externalResult` immediate result. The batch is then recognized as terminal and the loop does not request another assistant turn.

The signal is correct and narrowly scoped: `externalResult` is set **only** by the `claude-code-cli` adapter (`attachExternalResultsToToolBlocks`), which has already completed all tool work — there is no follow-up LLM work for the loop to do. Direct Anthropic/OpenAI paths never set `externalResult`, so their behavior is unchanged.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [x] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described below
- [ ] No tests needed — explained above

Regression test (`packages/pi-agent-core/test/agent-loop.test.ts`): drives `agentLoop` with one claude-code-style turn whose tool call carries `externalResult` plus post-tool text, and asserts exactly one assistant `message_start` and a single `streamAssistantResponse` invocation. It fails on `main` (two of each) and passes with this change. Full `agent-loop.test.ts` suite (26 tests) passes; `verify:merge` run locally.

## AI disclosure

- [x] This PR includes AI-assisted code <!-- Diagnosed and implemented with AI assistance; regression test proven to fail on main and pass with the fix; verified locally via verify:merge. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784515698&installation_id=134682257&pr_number=786&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F786&signature=572514c23e167580005c7a1f6a336a3b2d36e8179ad3423054d12caa4a4220b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->