### PR TITLE
fix(agent-core): forward resolved model in before_provider_request event

### DIFF
--- a/packages/gsd-agent-core/src/sdk.ts
+++ b/packages/gsd-agent-core/src/sdk.ts
@@ -372,12 +372,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				headers,
 			});
 		},
-		onPayload: async (payload, _model) => {
+		onPayload: async (payload, model) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner?.hasHandlers("before_provider_request")) {
 				return payload;
 			}
-			return runner.emitBeforeProviderRequest(payload);
+			// Thread the resolved model into the event so extensions can gate on
+			// provider/api (e.g. native web_search injection). Without this the
+			// before_provider_request event carries no model and provider-shape
+			// detection silently fails.
+			return runner.emitBeforeProviderRequest(payload, model);
 		},
 		onResponse: async (response, _model) => {
 			const runner = extensionRunnerRef.current;

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -938,7 +938,10 @@ export class ExtensionRunner {
 		return currentMessages;
 	}
 
-	async emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
+	async emitBeforeProviderRequest(
+		payload: unknown,
+		model?: { provider: string; id: string; api?: string },
+	): Promise<unknown> {
 		const ctx = this.createContext();
 		let currentPayload = payload;
 
@@ -951,6 +954,7 @@ export class ExtensionRunner {
 					const event: BeforeProviderRequestEvent = {
 						type: "before_provider_request",
 						payload: currentPayload,
+						model,
 					};
 					const handlerResult = await handler(event, ctx);
 					if (handlerResult !== undefined) {

--- a/packages/pi-coding-agent/test/extensions-runner.test.ts
+++ b/packages/pi-coding-agent/test/extensions-runner.test.ts
@@ -847,4 +847,33 @@ describe("ExtensionRunner", () => {
 			expect(runner.hasHandlers("agent_end")).toBe(false);
 		});
 	});
+
+	// Regression: the before_provider_request event must carry the resolved model.
+	// Extensions (e.g. native Anthropic web_search injection) gate on
+	// event.model.provider/api; previously the runner dropped the model, so the
+	// event arrived with model=undefined and provider-shape detection silently
+	// failed. See gsd-agent-core sdk.ts onPayload bridge.
+	it("emitBeforeProviderRequest forwards the resolved model into the event", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.on("before_provider_request", (event) => {
+					globalThis.__bprEventModel = event.model
+						? { provider: event.model.provider, api: event.model.api, id: event.model.id }
+						: null;
+					return event.payload;
+				});
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "bpr-model.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+		const model = { provider: "anthropic", id: "claude-opus-4-8", api: "anthropic-messages" };
+		await runner.emitBeforeProviderRequest({ model: "claude-opus-4-8", tools: [] }, model);
+
+		const captured = (globalThis as unknown as { __bprEventModel?: unknown }).__bprEventModel;
+		expect(captured).toEqual(model);
+		delete (globalThis as unknown as { __bprEventModel?: unknown }).__bprEventModel;
+	});
 });


### PR DESCRIPTION
## Linked issue

Closes #791

- [x] I have linked an issue above.

## TL;DR

**What:** Pass the resolved model into the `before_provider_request` extension event so it carries `event.model`.
**Why:** Native Anthropic web search never injected — the `onPayload` bridge dropped the model, so native-search's primary `event.model` detection always failed and the agent fell back to `fetch_page`.
**How:** Thread `model` through `gsd-agent-core` `onPayload` → `runner.emitBeforeProviderRequest(payload, model)` and attach it to the event (the event type already declares `model?`).

This is a **plumbing / agent-correctness** fix. No tool behavior changes — it only restores `event.model` on an extension event that already declared the field.

## What this PR does (at a glance)

- Threads the resolved model from the `onPayload` bridge into the `before_provider_request` extension event, so `event.model` is populated.
- Re-enables native Anthropic `web_search` injection, which had been silently dead on every Anthropic-provider session (the agent fell back to `fetch_page` and reported having no web search).
- Adds a runner-level contract test asserting the event carries the model — the guard that was missing and let this regress unnoticed.
- No change to any extension that ignores `event.model`; no new public types.

## What changed — every change and why

| File | What changed | Why |
| --- | --- | --- |
| `packages/gsd-agent-core/src/sdk.ts` | The `onPayload` bridge in `createAgentSession` forwards the resolved model: `runner.emitBeforeProviderRequest(payload, model)` (was `(payload)`, model received as `_model` and discarded). | This is where the model was dropped. It is already available from the `pi-ai` `onPayload(params, model)` callback. |
| `packages/pi-coding-agent/src/core/extensions/runner.ts` | `emitBeforeProviderRequest` accepts an optional `model?: { provider; id; api? }` and attaches `model` to the `BeforeProviderRequestEvent`. | The event type has always declared `model?`; the runner just never populated it. |
| `packages/pi-coding-agent/test/extensions-runner.test.ts` | New regression test: registers a `before_provider_request` handler and asserts the runner forwards the resolved model into the event. | The missing contract test. The existing `native-search.test.ts` mocks `event.model` directly, so it stayed green while the runtime was broken — this guards the *producer* side. Verified red without the fix, green with it. |

## Why (the root problem)

On an Anthropic provider (`claude-opus-4-8` / `anthropic-messages`), native web search (`web_search_20250305`) was never injected. The search-the-web `native-search` hook reads `event.model` as its primary, "most reliable" provider-detection path; the event arrived with `model === undefined`, `model_select` never fired to arm the fallback flag, and the payload-name heuristic is correctly refused by the `#648` guard — so it hit the fail-safe and never injected. The agent had no `web_search` tool, fell back to `fetch_page`, and reported having no web search.

This was a latent wiring gap: `BeforeProviderRequestEvent` declared `model?` from the initial import, but the bridge never populated it.

**This re-applies a fix that already shipped upstream.** In `gsd-2` (https://github.com/gsd-build/gsd-2), PR **#444 / #446** (`654a9f5f1`, "fix: prevent web_search tool injection for non-Anthropic providers serving Claude models") added exactly this model threading. #444 was a cross-cutting fix: the vendored-Pi *plumbing* that supplies `event.model` **and** the GSD `native-search.ts` *consumer* that reads it. The ADR-010 "clean seam" restructure (re-vendor upstream `earendil-works/pi` + extract the SDK into `@gsd/agent-core`; see `docs/dev/pi-upstream.md`) bisected it: the consumer half was migrated intact (it still cites `#444`), but the plumbing half reverted to pre-#444 upstream and the relocated `gsd-agent-core/src/sdk.ts` bridge came back in the one-arg shape. With no test on the "event carries the model" contract and a fail-safe (`#648`) that hides the breakage, native web search went dark unnoticed. This change brings `gsd-pi` back in line with gsd-2 #444 and adds that missing contract test.

## How

The model is available in the `pi-ai` provider `onPayload(params, model)` callback and is passed up to `gsd-agent-core`'s `onPayload(payload, _model)`. We simply forward it:

```ts
// gsd-agent-core/src/sdk.ts
onPayload: async (payload, model) => {
  const runner = extensionRunnerRef.current;
  if (!runner?.hasHandlers("before_provider_request")) return payload;
  return runner.emitBeforeProviderRequest(payload, model);
},
```

```ts
// pi-coding-agent/.../runner.ts
async emitBeforeProviderRequest(
  payload: unknown,
  model?: { provider: string; id: string; api?: string },
): Promise<unknown> {
  ...
  const event: BeforeProviderRequestEvent = {
    type: "before_provider_request",
    payload: currentPayload,
    model,
  };
  ...
}
```

No new types, no behavior change for extensions that ignore `event.model`. Native-search's existing, documented `event.model` path now works as designed — no change needed in the search extension.

### Verification (runtime, before vs after)

Instrumented the Anthropic provider to log final `params.tools` after `onPayload`, and native-search's own decision:

| | `event.model` | `isAnthropic` | request tools | `web_search` present |
|---|---|---|---|---|
| before | `undefined` | `false` | 141 → 141 | ❌ |
| after  | `{anthropic, anthropic-messages}` | `true` | 141 → **142** | ✅ |

After the fix the agent calls `web_search` instead of `fetch_page`. (Instrumentation was temporary and is not part of this PR.)

### Notes for reviewers

- **`model_select` doesn't fire to extensions in interactive mode** (`modelSelectFired=false` in all observed requests), so native-search's fallback flag is never armed. This fix makes that moot for native search (the `event.model` path is the intended primary), but the non-delivery is worth a separate look since other extensions may rely on it.
- **This is a re-regression of a fix that already shipped (gsd-2 #444), and it may not be the only one.** The fix was lost because it was a *cross-cutting gsd-2-local delta* — vendored-Pi plumbing plus a GSD-side consumer — and the ADR-010 re-vendor reset the plumbing half while keeping the consumer. The same pattern could have bisected other gsd-2 deltas spanning the `pi-coding-agent` → `@gsd/agent-core`/`@gsd/agent-modes` seam, leaving them silently degraded. A sweep of gsd-2's allowlisted/local deltas against the current vendored tree may be worth doing; the tell is code that still cites a gsd-2 PR number while the wiring it added is gone (and a unit test that mocks the missing input stays green).

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `pi-agent-core` — Agent orchestration <!-- gsd-agent-core SDK bridge -->
- [x] `pi-coding-agent` — Coding agent <!-- extension runner event -->

## Breaking changes

- [x] No breaking changes — additive optional parameter and an optional event field already present on the type.

## Test plan

- [x] New/updated tests included — `extensions-runner.test.ts` "emitBeforeProviderRequest forwards the resolved model into the event" (verified **red** with the fix reverted, **green** with it).
- [x] No regression — `native-search.test.ts` (the consumer suite) stays green (46/46); `tsc` clean on the changed files.
- [x] Manual testing — runtime-verified on `claude-opus-4-8` / `anthropic-messages` (before/after table above); `web_search` injected (`tools 141 → 142`) and used by the agent.
- [x] `pnpm run verify:merge` — ran against `e253f25`. Exits 1 **only** due to pre-existing, environment-driven unit failures (local `GSD_HOME` override, home-dependent provider-auth/path tests); the failure set is byte-identical to the `main` baseline (**10910 passed / 24 failed / 10 skipped** on both → **0 PR-attributable regressions**). PR-surface evidence is green: `extensions-runner` 29/29 incl. the new contract test, `gsd-agent-core` typecheck 0 errors, `pi-coding-agent` build exit 0.

## AI disclosure

- [x] This PR includes AI-assisted code. Root-caused and implemented with an AI coding agent (GSD). Verified by runtime request-tool capture on a live Anthropic session and a red/green regression test in `pi-coding-agent`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784576205&installation_id=134682257&pr_number=792&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F792&signature=35586a84c011275a9415052a99f23db5aa37e61402480221eb2b5020ef8f03cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
