### PR TITLE
test(gsd): add log-assertion coverage for high-value recovery/dispatch/orchestrator/worktree/db paths

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -12,7 +12,7 @@
  * without modifying orchestration code.
  */
 
-import type { GSDState } from "./types.js";
+import type { GSDState, TaskIO } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
@@ -178,6 +178,26 @@ type ResearchProjectPromptBuilder = typeof buildResearchProjectPrompt;
 
 let reassessmentChecker: ReassessmentChecker = checkNeedsReassessment;
 let researchProjectPromptBuilder: ResearchProjectPromptBuilder = buildResearchProjectPrompt;
+
+/**
+ * Optional override for the reactive graph derivation step inside the
+ * "executing → reactive-execute" rule. Production leaves this null so the rule
+ * uses the real loadSliceTaskIO + deriveTaskGraph; tests inject a throwing
+ * function to deterministically exercise the best-effort failure path
+ * (auto-dispatch.ts:1494). The catch is otherwise unreachable because every
+ * operation it wraps (loadSliceTaskIO, deriveTaskGraph, saveReactiveState) is
+ * internally defensive.
+ * @internal
+ */
+let _reactiveGraphDeriveFn: ((basePath: string, mid: string, sid: string) => Promise<TaskIO[]>) | null = null;
+
+export function setReactiveGraphDeriveFnForTest(
+  fn: ((basePath: string, mid: string, sid: string) => Promise<TaskIO[]>) | null,
+): () => void {
+  const previous = _reactiveGraphDeriveFn;
+  _reactiveGraphDeriveFn = fn;
+  return () => { _reactiveGraphDeriveFn = previous; };
+}
 
 function shouldBypassMilestoneDepthGateInAuto(prefs: GSDPreferences | undefined): boolean {
   return isAutoActive() && prefs?.planning_depth !== "deep";
@@ -1421,7 +1441,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
           graphMetrics,
         } = await import("./reactive-graph.js");
 
-        const taskIO = await loadSliceTaskIO(basePath, mid, sid);
+        const taskIO = _reactiveGraphDeriveFn
+          ? await _reactiveGraphDeriveFn(basePath, mid, sid)
+          : await loadSliceTaskIO(basePath, mid, sid);
         if (taskIO.length < 2) return null; // single task, no point
 
         const graph = deriveTaskGraph(taskIO);

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -83,6 +83,53 @@ export {
 } from "./milestone-summary-classifier.js";
 export { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 
+/**
+ * Optional override for the legacy roadmap parser used by verifyExpectedArtifact.
+ * Production leaves this null so the real parseLegacyRoadmap runs; tests inject
+ * a throwing function to deterministically exercise the parse-failure catches
+ * (auto-recovery.ts:515 plan-milestone and :622 complete-slice). Those catches
+ * are otherwise unreachable because parseLegacyRoadmap is internally defensive
+ * against every malformed input.
+ * @internal
+ */
+let _roadmapParserFn: ((content: string) => { slices: Array<{ id: string; done: boolean; depends?: string[] }> }) | null = null;
+
+/**
+ * Inject an override for the legacy roadmap parser, returning a function that
+ * restores the default (real parser) behavior. No production caller.
+ * @internal
+ */
+export function _setRoadmapParserFnForTests(
+  fn: ((content: string) => { slices: Array<{ id: string; done: boolean; depends?: string[] }> }) | null,
+): () => void {
+  const previous = _roadmapParserFn;
+  _roadmapParserFn = fn;
+  return () => { _roadmapParserFn = previous; };
+}
+
+function parseRoadmapForRecovery(content: string): ReturnType<NonNullable<typeof _roadmapParserFn>> {
+  if (_roadmapParserFn) return _roadmapParserFn(content);
+  return parseLegacyRoadmap(content) as unknown as ReturnType<NonNullable<typeof _roadmapParserFn>>;
+}
+
+/**
+ * Optional override for the detached GitHub milestone finalize invoked after DB
+ * closeout in refreshRecoveryDbForArtifact. Production leaves this null so the
+ * real finalizeMilestoneGitHubSync runs; tests inject a throwing function to
+ * deterministically exercise the best-effort catch (auto-recovery.ts:232),
+ * which otherwise needs a real GitHub remote + network failure.
+ * @internal
+ */
+let _githubFinalizeFn: ((basePath: string, mid: string) => void | Promise<void>) | null = null;
+
+export function _setGithubFinalizeFnForTests(
+  fn: ((basePath: string, mid: string) => void | Promise<void>) | null,
+): () => void {
+  const previous = _githubFinalizeFn;
+  _githubFinalizeFn = fn;
+  return () => { _githubFinalizeFn = previous; };
+}
+
 // ─── Artifact Resolution & Verification ───────────────────────────────────────
 
 export function diagnoseWorktreeIntegrityFailure(basePath: string): string | null {
@@ -197,11 +244,18 @@ export function refreshRecoveryDbForArtifact(
     }
 
     updateMilestoneStatus(mid, "complete", new Date().toISOString());
-    void import("../github-sync/sync.js")
-      .then(({ finalizeMilestoneGitHubSync }) => finalizeMilestoneGitHubSync(basePath, mid))
-      .catch((err) => {
-        logWarning("recovery", `GitHub milestone finalize failed after DB closeout: ${getErrorMessage(err)}`);
-      });
+    // Detached GitHub sync — best-effort. Test seam: when
+    // _githubFinalizeFn is injected, route through it so the catch
+    // (:232) is deterministically reachable (otherwise it needs a real
+    // GitHub remote + network failure). Production leaves it null. The
+    // seam is wrapped so a synchronous throw becomes a rejected promise,
+    // matching the real import-then-call deferred semantics.
+    const finalizePromise = _githubFinalizeFn
+      ? new Promise<void>((resolve) => { resolve(_githubFinalizeFn!(basePath, mid)); })
+      : import("../github-sync/sync.js").then(({ finalizeMilestoneGitHubSync }) => finalizeMilestoneGitHubSync(basePath, mid));
+    void finalizePromise.catch((err) => {
+      logWarning("recovery", `GitHub milestone finalize failed after DB closeout: ${getErrorMessage(err)}`);
+    });
     return { ok: true };
   }
 
@@ -446,7 +500,7 @@ export function verifyExpectedArtifact(
       return false;
     }
     try {
-      const roadmap = parseLegacyRoadmap(readFileSync(roadmapFile, "utf-8"));
+      const roadmap = parseRoadmapForRecovery(readFileSync(roadmapFile, "utf-8"));
       const milestoneResearchFile = resolveExpectedArtifactPath("research-milestone", mid, base);
       const hasMilestoneResearch = !!milestoneResearchFile && existsSync(milestoneResearchFile);
       for (const slice of roadmap.slices) {
@@ -506,7 +560,7 @@ export function verifyExpectedArtifact(
 
   if (unitType === "plan-milestone") {
     try {
-      const roadmap = parseLegacyRoadmap(readFileSync(absPath, "utf-8"));
+      const roadmap = parseRoadmapForRecovery(readFileSync(absPath, "utf-8"));
       if (roadmap.slices.length === 0) {
         logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap has zero slices at ${absPath}`);
         return false;
@@ -615,7 +669,7 @@ export function verifyExpectedArtifact(
         if (roadmapFile && existsSync(roadmapFile)) {
           try {
             const roadmapContent = readFileSync(roadmapFile, "utf-8");
-            const roadmap = parseLegacyRoadmap(roadmapContent);
+            const roadmap = parseRoadmapForRecovery(roadmapContent);
             const slice = roadmap.slices.find((s) => s.id === sid);
             if (slice && !slice.done) return false;
           } catch (e) {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -242,6 +242,17 @@ function stripGsdDisplayPrefix(value: string | undefined | null, id: string): st
 /** Active workspace registry — replaces the legacy `originalBase` singleton. */
 let activeWorkspace: GsdWorkspace | null = null;
 
+/**
+ * Optional override for the shelter restore copy step (milestone merge #2505).
+ * Production leaves this null so restoreShelter uses the real cpSync; tests
+ * inject a throwing function to deterministically exercise the best-effort
+ * failure path (auto-worktree.ts:1809) and the shelter-retention guarantee,
+ * which is otherwise unreachable because shelter and restore run synchronously
+ * in one mergeMilestoneToMain call (the filesystem cannot change between them).
+ * @internal
+ */
+let _restoreEntryFn: ((src: string, dest: string) => void) | null = null;
+
 function setActiveWorkspace(ws: GsdWorkspace | null): void {
   activeWorkspace = ws;
 }
@@ -1394,6 +1405,22 @@ export function _resetAutoWorktreeOriginalBaseForTests(): void {
   setActiveWorkspace(null);
 }
 
+/**
+ * Inject an override for the shelter restore copy step, returning a function
+ * that restores the default (real cpSync) behavior. Used by tests to
+ * deterministically exercise the best-effort restore-failure path
+ * (auto-worktree.ts:1809) and the #2505 shelter-retention guarantee — which is
+ * otherwise unreachable because shelter + restore run synchronously in one
+ * mergeMilestoneToMain call. No production caller.
+ * @internal
+ */
+export function _setRestoreEntryFnForTests(
+  fn: ((src: string, dest: string) => void) | null,
+): () => void {
+  _restoreEntryFn = fn;
+  return () => { _restoreEntryFn = null; };
+}
+
 export function getActiveAutoWorktreeContext(): {
   originalBase: string;
   worktreeName: string;
@@ -1803,7 +1830,15 @@ export function mergeMilestoneToMain(
       }
       try {
         mkdirSync(milestonesDir, { recursive: true });
-        cpSync(src, join(milestonesDir, dirName), { recursive: true, force: true });
+        // Test seam: when _restoreEntryFn is injected, route the copy through it
+        // so the best-effort failure path (and shelter-retention guarantee) can
+        // be exercised deterministically. Production leaves it null → real cpSync.
+        const dest = join(milestonesDir, dirName);
+        if (_restoreEntryFn) {
+          _restoreEntryFn(src, dest);
+        } else {
+          cpSync(src, dest, { recursive: true, force: true });
+        }
       } catch (err) { /* best-effort */
         restoreFailed = true;
         logError("worktree", `shelter restore failed (${dirName}): ${err instanceof Error ? err.message : String(err)}`);

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -80,6 +80,17 @@ function now(): number {
   return Date.now();
 }
 
+/**
+ * Optional override for the post-settlement markdown projection rebuild
+ * (mergePendingCompleteMilestone). Production leaves this null so the real
+ * rebuild runs; tests inject a throwing function to deterministically exercise
+ * the best-effort failure path (orchestrator.ts:637), which is otherwise only
+ * reachable by driving advance() through a full merge-pending milestone
+ * settlement and then contriving a projection-rebuild fault.
+ * @internal
+ */
+let _projectionRebuildFn: ((projectRoot: string) => Promise<void>) | null = null;
+
 function noRemainingUnitsOutcome(stateSnapshot: GSDState): AutoTerminalOutcome {
   if (stateSnapshot.phase === "complete") {
     return {
@@ -631,8 +642,15 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.s.milestoneSettlement = { ok: true, reason: "settled" };
     try {
       const projectRoot = this.s.originalBasePath || this.s.canonicalProjectRoot || this.runtimeBasePath;
-      const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.js");
-      await rebuildMarkdownProjectionsFromDb(projectRoot);
+      // Test seam: when _projectionRebuildFn is injected, route the rebuild
+      // through it so the best-effort failure path (:637) is deterministically
+      // reachable. Production leaves it null → real rebuildMarkdownProjectionsFromDb.
+      if (_projectionRebuildFn) {
+        await _projectionRebuildFn(projectRoot);
+      } else {
+        const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.js");
+        await rebuildMarkdownProjectionsFromDb(projectRoot);
+      }
     } catch (err) {
       logWarning(
         "engine",
@@ -1424,4 +1442,20 @@ export function resolveLiveOrchestratorBasePath(input: {
 
 export function createAutoOrchestrator(context: OrchestratorContext): AutoOrchestrationModule {
   return new AutoOrchestrator(context);
+}
+
+/**
+ * Inject an override for the post-settlement markdown projection rebuild,
+ * returning a function that restores the default (real rebuild) behavior. Used
+ * by tests to deterministically exercise the best-effort rebuild-failure path
+ * (orchestrator.ts:637) — otherwise only reachable by driving advance() through
+ * a full merge-pending milestone settlement and then contriving a projection
+ * fault. No production caller.
+ * @internal
+ */
+export function _setProjectionRebuildFnForTests(
+  fn: ((projectRoot: string) => Promise<void>) | null,
+): () => void {
+  _projectionRebuildFn = fn;
+  return () => { _projectionRebuildFn = null; };
 }

--- a/src/resources/extensions/gsd/db/writers/reconcile.ts
+++ b/src/resources/extensions/gsd/db/writers/reconcile.ts
@@ -11,6 +11,29 @@ import { logError, logWarning } from "../../workflow-logger.js";
 import { getDbOrNull, openDatabase } from "../engine.js";
 import { TERMINAL_STATUS_SQL } from "../sql-constants.js";
 
+/**
+ * Optional override for the project-root DB open inside reconcileWorktreeDb.
+ * Production leaves this null so the real engine.openDatabase runs; tests
+ * inject a function returning false to deterministically exercise the
+ * cannot-open-main-DB branch (reconcile.ts:82), which is otherwise unreachable
+ * without a contrived provider/OS fault (openDatabase rethrows on real failures
+ * rather than returning false across providers).
+ * @internal
+ */
+let _mainDbOpenerFn: ((mainDbPath: string) => boolean) | null = null;
+
+export function _setMainDbOpenerFnForTests(
+  fn: ((mainDbPath: string) => boolean) | null,
+): () => void {
+  const previous = _mainDbOpenerFn;
+  _mainDbOpenerFn = fn;
+  return () => { _mainDbOpenerFn = previous; };
+}
+
+function openMainDb(mainDbPath: string): boolean {
+  return _mainDbOpenerFn ? _mainDbOpenerFn(mainDbPath) : openDatabase(mainDbPath);
+}
+
 export function copyWorktreeDb(srcDbPath: string, destDbPath: string): boolean {
   try {
     if (!existsSync(srcDbPath)) return false;
@@ -77,7 +100,7 @@ export function reconcileWorktreeDb(
     return zero;
   }
   if (!getDbOrNull()!) {
-    const opened = openDatabase(mainDbPath);
+    const opened = openMainDb(mainDbPath);
     if (!opened) {
       logError("db", "worktree DB reconciliation failed: cannot open main DB");
       return zero;

--- a/src/resources/extensions/gsd/tests/blocker-placeholder-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/blocker-placeholder-logs.test.ts
@@ -1,0 +1,218 @@
+// gsd-pi — Blocker-placeholder recovery log coverage.
+//
+// writeBlockerPlaceholder (auto-recovery.ts:782) writes a placeholder artifact
+// so the pipeline can advance past a stuck unit, then marks the task/slice
+// complete in the DB and appends a workflow event so reconciliation can replay
+// the recovery. Each of those side-effects is individually best-effort and logs
+// a recovery warning on failure (auto-recovery.ts:837/840/843/844/853/854). No
+// test asserted any of them. We trigger each by breaking the specific sink
+// (drop the relevant DB table, or block the events-file append) and assert the
+// warning lands.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { writeBlockerPlaceholder } from "../auto-recovery.ts";
+import { writeReactiveExecuteBlocker } from "../auto-recovery.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+  _getAdapter,
+} from "../gsd-db.ts";
+import {
+  drainLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+
+function makeBase(prefix = "gsd-blocker-logs-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  // Slice projection dirs so the placeholder path resolves.
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function captureLogs<T>(fn: () => T): { result: T; logs: LogEntry[] } {
+  const previous = setStderrLoggingEnabled(false);
+  _resetLogs();
+  try {
+    const result = fn();
+    return { result, logs: drainLogs() };
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previous);
+  }
+}
+
+function recoveryWarnings(logs: readonly LogEntry[]): LogEntry[] {
+  return logs.filter((e) => e.component === "recovery" && e.severity === "warn");
+}
+
+test("writeBlockerPlaceholder logs a recovery warning when updateTaskStatus throws (auto-recovery.ts:837)", () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    // Drop tasks so updateTaskStatus throws inside the execute-task DB block.
+    _getAdapter()!.exec("DROP TABLE tasks");
+
+    const { logs } = captureLogs(() =>
+      writeBlockerPlaceholder("execute-task", "M001/S01/T01", base, "exhausted retries"),
+    );
+
+    const warn = recoveryWarnings(logs).find((w) => /updateTaskStatus failed during context exhaustion/u.test(w.message));
+    assert.ok(warn, "a recovery warning must be logged when updateTaskStatus throws");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeBlockerPlaceholder logs a recovery warning when updateSliceStatus throws (auto-recovery.ts:843)", () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    // Drop slices so updateSliceStatus throws inside the complete-slice DB block.
+    _getAdapter()!.exec("DROP TABLE slices");
+
+    const { logs } = captureLogs(() =>
+      writeBlockerPlaceholder("complete-slice", "M001/S01", base, "exhausted retries"),
+    );
+
+    const warn = recoveryWarnings(logs).find((w) => /updateSliceStatus failed during context exhaustion/u.test(w.message));
+    assert.ok(warn, "a recovery warning must be logged when updateSliceStatus throws");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeBlockerPlaceholder logs a recovery warning when the plan-milestone insertSlice throws (auto-recovery.ts:853)", () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    // Drop slices so the S00-blocker insertSlice throws inside the
+    // plan-milestone placeholder branch.
+    _getAdapter()!.exec("DROP TABLE slices");
+
+    const { logs } = captureLogs(() =>
+      writeBlockerPlaceholder("plan-milestone", "M001", base, "exhausted retries"),
+    );
+
+    const warn = recoveryWarnings(logs).find((w) =>
+      /insertSlice placeholder failed for plan-milestone recovery/u.test(w.message),
+    );
+    assert.ok(warn, "a recovery warning must be logged when the blocker slice insert throws");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeBlockerPlaceholder logs a recovery warning when the workflow-event append throws (auto-recovery.ts:840)", () => {
+  const base = makeBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    // Block the workflow-events append by turning its target into a directory
+    // (appendFileSync on a directory throws EISDIR). The placeholder write still
+    // succeeds because it targets a different path under milestones/.
+    mkdirSync(join(base, ".gsd", "event-log.jsonl"), { recursive: true });
+
+    const { logs } = captureLogs(() =>
+      writeBlockerPlaceholder("execute-task", "M001/S01/T01", base, "exhausted retries"),
+    );
+
+    const warn = recoveryWarnings(logs).find((w) => /appendEvent failed for task recovery/u.test(w.message));
+    assert.ok(warn, "a recovery warning must be logged when the recovery event append fails");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeBlockerPlaceholder logs a recovery warning when the complete-slice appendEvent throws (auto-recovery.ts:898)", () => {
+  const base = makeBase("gsd-blocker-logs-cs-");
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    // Slices table intact so updateSliceStatus (:897) succeeds; block the
+    // workflow-event append so the complete-slice appendEvent (:898) throws.
+    mkdirSync(join(base, ".gsd", "event-log.jsonl"), { recursive: true });
+
+    const { logs } = captureLogs(() =>
+      writeBlockerPlaceholder("complete-slice", "M001/S01", base, "exhausted retries"),
+    );
+
+    const warn = recoveryWarnings(logs).find((w) => /appendEvent failed for slice recovery/u.test(w.message));
+    assert.ok(warn, "a recovery warning must be logged when the complete-slice appendEvent throws");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeBlockerPlaceholder logs a recovery warning when the plan-milestone appendEvent throws (auto-recovery.ts:908)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-blocker-logs-pm-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    // Slices table intact so the S00-blocker insertSlice (:907) succeeds;
+    // block the workflow-event append so the plan-milestone appendEvent (:908) throws.
+    mkdirSync(join(base, ".gsd", "event-log.jsonl"), { recursive: true });
+
+    const { logs } = captureLogs(() =>
+      writeBlockerPlaceholder("plan-milestone", "M001", base, "exhausted retries"),
+    );
+
+    const warn = recoveryWarnings(logs).find((w) => /appendEvent failed for plan-milestone recovery/u.test(w.message));
+    assert.ok(warn, "a recovery warning must be logged when the plan-milestone appendEvent throws");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ── writeReactiveExecuteBlocker append-event warnings (:755 / :768) ────────
+// These fire after the reactive batch recovery transaction commits, when the
+// per-task workflow-event append throws. We seed a real slice with two tasks,
+// plant the event-log target as a directory (appendFileSync → EISDIR), and call
+// writeReactiveExecuteBlocker; both the complete-task and skip-task appends fail.
+
+test("writeReactiveExecuteBlocker logs recovery warnings when the post-recovery event appends throw (auto-recovery.ts:755/:768)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-blocker-logs-reactive-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "M", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "S", status: "active", risk: "low", depends: [], demo: "", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "T1", status: "active" });
+    insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "T2", status: "active" });
+    // T01 has a summary (→ complete recovery path → :755), T02 does not
+    // (→ skip recovery path → :768).
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"), "# T01\n", "utf-8");
+    // Block the workflow-event append (event-log.jsonl is the real ledger file).
+    mkdirSync(join(base, ".gsd", "event-log.jsonl"), { recursive: true });
+
+    const { logs } = captureLogs(() =>
+      writeReactiveExecuteBlocker("M001/S01/reactive+T01,T02", base, "batch exhausted"),
+    );
+
+    const warnings = recoveryWarnings(logs).map((w) => w.message);
+    assert.ok(
+      warnings.some((m) => /appendEvent failed for reactive complete recovery/u.test(m)),
+      "the complete-task append warning must be logged (:755)",
+    );
+    assert.ok(
+      warnings.some((m) => /appendEvent failed for reactive skip recovery/u.test(m)),
+      "the skip-task append warning must be logged (:768)",
+    );
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/db-engine-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/db-engine-logs.test.ts
@@ -1,0 +1,207 @@
+// gsd-pi — DB engine failure-branch log coverage.
+//
+// `checkpointDatabase` / `closeDatabase` / `vacuumDatabase` in db/engine.ts are
+// the highest-frequency runtime paths (called every turn and at closeout).
+// Each wraps its destructive PRAGMA in a try/catch that emits a `db` warning so
+// a failed checkpoint/vacuum/close never breaks orchestration but is still
+// observable. The existing gsd-db tests only assert the *happy* path (WAL gets
+// truncated); no test exercises any of these catch branches, so a regression
+// that drops or misroutes the warning would pass silently.
+//
+// This file pins the log output for the three checkpoint/vacuum/close failure
+// branches by stubbing the live adapter's `exec`/`close` to throw on demand.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync as fsChmodSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { checkpointDatabase, closeDatabase, openDatabase, vacuumDatabase, _getAdapter } from "../gsd-db.ts";
+import { backupDatabaseSnapshot, readTransaction } from "../db/engine.ts";
+import {
+  drainLogs,
+  peekLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+import type { DbAdapter } from "../db-adapter.ts";
+
+function makeBase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-db-engine-logs-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return dir;
+}
+
+/** Capture log entries emitted while running fn. Stderr is suppressed. */
+function captureLogs<T>(fn: () => T): { result: T; logs: LogEntry[] } {
+  const previous = setStderrLoggingEnabled(false);
+  _resetLogs();
+  try {
+    const result = fn();
+    return { result, logs: drainLogs() };
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previous);
+  }
+}
+
+/**
+ * Wrap the live adapter's `exec` so it throws for SQL matching `needle`,
+ * delegating everything else to the original. Returns a restore function.
+ */
+function breakExecOn(adapter: DbAdapter, needle: string): () => void {
+  const origExec = adapter.exec.bind(adapter);
+  adapter.exec = (sql: string): void => {
+    if (sql.includes(needle)) throw new Error(`forced failure for: ${needle}`);
+    return origExec(sql);
+  };
+  return () => {
+    adapter.exec = origExec;
+  };
+}
+
+test("checkpointDatabase logs a `db` warning when the WAL checkpoint throws", () => {
+  const base = makeBase();
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  try {
+    const adapter = _getAdapter();
+    assert.ok(adapter, "an adapter must be open");
+    const restore = breakExecOn(adapter!, "wal_checkpoint");
+
+    const { logs } = captureLogs(() => checkpointDatabase());
+    restore();
+
+    const dbWarn = logs.find((e) => e.component === "db" && e.severity === "warn");
+    assert.ok(dbWarn, "a db warning must be logged on checkpoint failure");
+    assert.match(dbWarn!.message, /WAL checkpoint failed/u);
+    assert.match(dbWarn!.message, /forced failure for: wal_checkpoint/u);
+    // checkpointDatabase must not rethrow — orchestration continues.
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("vacuumDatabase logs a `db` warning when VACUUM throws", () => {
+  const base = makeBase();
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  try {
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    const restore = breakExecOn(adapter!, "VACUUM");
+
+    const { logs } = captureLogs(() => vacuumDatabase());
+    restore();
+
+    const dbWarn = logs.find((e) => e.component === "db" && e.severity === "warn");
+    assert.ok(dbWarn, "a db warning must be logged on VACUUM failure");
+    assert.match(dbWarn!.message, /VACUUM failed/u);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("closeDatabase logs `db` warnings when WAL checkpoint and close throw on teardown", () => {
+  const base = makeBase();
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  // Break both the WAL checkpoint and the final close. The incremental_vacuum
+  // pragma is left intact so we can assert the checkpoint/close warnings land
+  // without the teardown itself exploding mid-way.
+  const restoreExec = breakExecOn(adapter!, "wal_checkpoint");
+  const origClose = adapter!.close.bind(adapter!);
+  adapter!.close = (): void => {
+    throw new Error("forced close failure");
+  };
+
+  const { logs } = captureLogs(() => closeDatabase());
+  restoreExec();
+  adapter!.close = origClose;
+
+  try {
+    const messages = logs.filter((e) => e.component === "db").map((e) => e.message);
+    assert.ok(
+      messages.some((m) => /WAL checkpoint failed/u.test(m)),
+      "WAL checkpoint failure must be logged during close",
+    );
+    assert.ok(
+      messages.some((m) => /database close failed/u.test(m)),
+      "close failure must be logged during close",
+    );
+    // closeDatabase must fully reset engine state even when teardown steps throw.
+    assert.equal(_getAdapter(), null, "engine must release the adapter after a broken close");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("checkpointDatabase and vacuumDatabase are no-ops (and log nothing) when no DB is open", () => {
+  _resetLogs();
+  const previous = setStderrLoggingEnabled(false);
+  try {
+    checkpointDatabase();
+    vacuumDatabase();
+    assert.equal(peekLogs().length, 0, "no-db paths must not emit any logs");
+  } finally {
+    setStderrLoggingEnabled(previous);
+    _resetLogs();
+  }
+});
+
+test("readTransaction logs a db error when ROLLBACK fails after a read error (split-brain signal)", () => {
+  const base = makeBase();
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  // Make ROLLBACK throw so the read-failure path invokes the rollback-error
+  // callback (engine.ts:768-775), which logs the split-brain error.
+  const restore = breakExecOn(adapter!, "ROLLBACK");
+
+  const { logs } = captureLogs(() => {
+    assert.throws(
+      () => readTransaction(() => {
+        throw new Error("read body failed");
+      }),
+      /read body failed/u,
+      "the original read error must still propagate",
+    );
+  });
+  restore();
+  closeDatabase();
+  try {
+    const err = logs.find((e) => e.component === "db" && e.severity === "error");
+    assert.ok(err, "a db error must be logged when ROLLBACK fails");
+    assert.equal(err!.message, "snapshotState ROLLBACK failed");
+    assert.match(err!.context?.error ?? "", /forced failure for: ROLLBACK/u);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("backupDatabaseSnapshot logs a db warning when the snapshot copy fails", () => {
+  const base = makeBase();
+  const dbPath = join(base, ".gsd", "gsd.db");
+  assert.equal(openDatabase(dbPath), true);
+  // Make the snapshot destination's parent dir read-only so the copy step
+  // inside backupDatabaseSnapshot (mkdirSync(backups) + copyFileSync) fails —
+  // exercising the outer catch (engine.ts:726-728). The DB handle stays open,
+  // so currentPath is set and the read-only parent only blocks the new copy.
+  fsChmodSync(join(base, ".gsd"), 0o555);
+
+  const { result, logs } = captureLogs(() => backupDatabaseSnapshot("test-label"));
+  closeDatabase();
+  try {
+    assert.equal(result, null, "a failed snapshot must return null");
+    const warn = logs.find((e) => e.component === "db" && e.severity === "warn");
+    assert.ok(warn, "a db warning must be logged on snapshot failure");
+    assert.match(warn!.message, /database snapshot failed/u);
+  } finally {
+    fsChmodSync(join(base, ".gsd"), 0o755);
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/dispatch-db-degradation-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-db-degradation-logs.test.ts
@@ -1,0 +1,98 @@
+// gsd-pi — Dispatch DB-degradation log coverage.
+//
+// `hasMilestonePassedDiscuss` (auto-dispatch.ts:397) queries the slices table to
+// decide whether a milestone has progressed past discuss. When the DB is
+// available but the query throws (corrupt schema, dropped table, locked DB),
+// the catch (auto-dispatch.ts:407) logs a `dispatch` warning and falls back to
+// the filesystem. That warning is the operator's only signal that dispatch
+// silently degraded to filesystem heuristics; no test asserted it. This file
+// triggers it by opening a DB, seeding a milestone, then dropping the slices
+// table so getMilestoneSlices() throws inside the rule's DB branch.
+//
+// Companion to dispatch-logs.test.ts (registry fallback :1834).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveDispatch, DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+  _getAdapter,
+} from "../gsd-db.ts";
+import {
+  drainLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+import { convertDispatchRules, initRegistry, getRegistry, resetRegistry } from "../rule-registry.ts";
+
+function makeExecutingState(): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Degraded" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+  } as GSDState;
+}
+
+test("hasMilestonePassedDiscuss logs a dispatch warning when the DB slices query throws", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dispatch-db-degrade-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+
+  // Snapshot + (re)initialize the registry so resolveDispatch uses the inline
+  // rule set, then restore the prior state afterwards.
+  let previousExists = false;
+  try { getRegistry(); previousExists = true; } catch { previousExists = false; }
+  initRegistry(convertDispatchRules(DISPATCH_RULES));
+
+  const previousStderr = setStderrLoggingEnabled(false);
+  let logs: LogEntry[] = [];
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Degraded", status: "active" });
+    // Break the slices table so getMilestoneSlices("M001") throws inside the
+    // DB branch of hasMilestonePassedDispatch → :407 warning.
+    _getAdapter()!.exec("DROP TABLE slices");
+
+    const ctx: DispatchContext = {
+      basePath: base,
+      mid: "M001",
+      midTitle: "Degraded",
+      state: makeExecutingState(),
+      prefs: undefined,
+    };
+
+    // resolveDispatch must not throw — the rule catches the DB error and falls
+    // back to the filesystem. We assert only that the degradation warning lands.
+    await resolveDispatch(ctx);
+    logs = drainLogs();
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previousStderr);
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+    // Restore registry state for subsequent tests.
+    initRegistry(convertDispatchRules(DISPATCH_RULES));
+    if (!previousExists) resetRegistry();
+    void t;
+  }
+
+  const warn = logs.find((e) => e.component === "dispatch" && e.severity === "warn");
+  assert.ok(warn, "a dispatch warning must be logged when the slices query fails");
+  assert.match(
+    warn!.message,
+    /discuss-progress DB check failed for M001, falling back to filesystem/u,
+    "warning must name the milestone and the filesystem fallback",
+  );
+});

--- a/src/resources/extensions/gsd/tests/dispatch-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-logs.test.ts
@@ -1,0 +1,103 @@
+// gsd-pi — Dispatch-path log coverage.
+//
+// `resolveDispatch` delegates to the rule registry when one is initialized
+// (auto-dispatch.ts:1818-1835). If `getRegistry()` throws — e.g. the registry
+// was never initialized or was reset — the catch logs a `dispatch` warning
+// ("registry dispatch failed, falling back to inline rules") and falls through
+// to the inline DISPATCH_RULES loop. That warning is the operator's only signal
+// that dispatch silently degraded from registry-driven to inline; no test
+// asserted it. This file pins it.
+//
+// Strategy: resetRegistry() so getRegistry() throws, then call resolveDispatch
+// with a minimal no-DB context. We assert the warning lands and that the
+// function still returns a DispatchAction rather than throwing (resilience).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveDispatch, DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import {
+  convertDispatchRules,
+  getRegistry,
+  initRegistry,
+  resetRegistry,
+} from "../rule-registry.ts";
+import {
+  drainLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+
+/**
+ * Build a minimal DispatchContext that passes resolveDispatch's early guards
+ * without a database:
+ *  - isDbAvailable() is false → the closed-milestone guard is skipped.
+ *  - activeMilestone is null → the activeMid/scope mismatch guards are skipped.
+ * So execution reaches the registry delegation block.
+ */
+function makeMinimalCtx(basePath: string): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    prefs: undefined,
+    state: {
+      activeMilestone: null,
+      activeSlice: null,
+      activeTask: null,
+      phase: "unhandled",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+    } as unknown as DispatchContext["state"],
+  };
+}
+
+test("resolveDispatch logs a dispatch warning and falls back to inline rules when the registry is uninitialized", async () => {
+  // Snapshot and clear the singleton so getRegistry() throws inside resolveDispatch.
+  let previousExists = false;
+  try {
+    getRegistry();
+    previousExists = true;
+  } catch {
+    previousExists = false;
+  }
+  resetRegistry();
+
+  const base = mkdtempSync(join(tmpdir(), "gsd-dispatch-logs-"));
+  const previousStderr = setStderrLoggingEnabled(false);
+  _resetLogs();
+  let logs: LogEntry[] = [];
+  try {
+    // resolveDispatch must NOT throw — it catches the registry failure, logs,
+    // and falls through to inline DISPATCH_RULES.
+    const action = await resolveDispatch(makeMinimalCtx(base));
+    assert.ok(action, "resolveDispatch must still return a DispatchAction after registry failure");
+    logs = drainLogs();
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previousStderr);
+    rmSync(base, { recursive: true, force: true });
+    // Restore a usable registry for any subsequent test in the process.
+    initRegistry(convertDispatchRules(DISPATCH_RULES));
+    if (!previousExists) resetRegistry();
+  }
+
+  const warn = logs.find((e) => e.component === "dispatch" && e.severity === "warn");
+  assert.ok(warn, "a dispatch warning must be logged when the registry is unavailable");
+  assert.match(
+    warn!.message,
+    /registry dispatch failed, falling back to inline rules/u,
+    "warning must identify the registry fallback reason",
+  );
+  assert.match(
+    warn!.message,
+    /not initialized/u,
+    "warning must carry the underlying getRegistry() error detail",
+  );
+});

--- a/src/resources/extensions/gsd/tests/dispatch-reactive-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-reactive-logs.test.ts
@@ -1,0 +1,98 @@
+// gsd-pi — Dispatch reactive graph derivation log coverage.
+//
+// The "executing → reactive-execute" rule wraps its graph derivation in a
+// best-effort catch (auto-dispatch.ts:1492-1496) that logs a `dispatch` ERROR
+// "reactive graph derivation failed" and falls through to sequential execution.
+// The catch is otherwise unreachable because every operation it wraps
+// (loadSliceTaskIO, deriveTaskGraph, saveReactiveState) is internally
+// defensive — so we inject a throwing derive function via the sanctioned
+// setReactiveGraphDeriveFnForTest seam (mirroring the :1809 / :637 pattern) to
+// deterministically exercise the failure path.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  resolveDispatch,
+  DISPATCH_RULES,
+  setReactiveGraphDeriveFnForTest,
+  type DispatchContext,
+} from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+import {
+  drainLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+import { convertDispatchRules, initRegistry, getRegistry, resetRegistry } from "../rule-registry.ts";
+
+function makeExecutingCtx(base: string): DispatchContext {
+  return {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Milestone",
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Milestone", status: "active" },
+      activeSlice: { id: "S01", title: "Slice" },
+      activeTask: { id: "T01", title: "Task" },
+      registry: [],
+      blockers: [],
+    } as unknown as GSDState,
+    // Explicit opt-in keeps the legacy min-ready threshold (2) and ensures the
+    // rule proceeds past the enabled/maxParallel guards into the derivation try.
+    prefs: { reactive_execution: { enabled: true, max_parallel: 2 } } as DispatchContext["prefs"],
+  };
+}
+
+test("reactive rule logs a dispatch error when graph derivation throws (auto-dispatch.ts:1494)", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-reactive-logs-"));
+  // Minimal slice projection so the rule's earlier filesystem guards resolve.
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), "# S01\n\n## Tasks\n\n- [ ] **T01: A**\n", "utf-8");
+
+  // Snapshot + initialize the registry so resolveDispatch uses the inline rules.
+  let previousExists = false;
+  try { getRegistry(); previousExists = true; } catch { previousExists = false; }
+  initRegistry(convertDispatchRules(DISPATCH_RULES));
+
+  // Inject a throwing derive fn so the rule's try block (auto-dispatch.ts:1414+)
+  // throws before any defensive operation, hitting the :1494 catch.
+  const restoreDerive = setReactiveGraphDeriveFnForTest(async () => {
+    throw new Error("forced graph derivation failure");
+  });
+
+  const previousStderr = setStderrLoggingEnabled(false);
+  _resetLogs();
+  let logs: LogEntry[] = [];
+  try {
+    // resolveDispatch must NOT throw — the rule catches the derivation failure
+    // and falls through to sequential execution.
+    await resolveDispatch(makeExecutingCtx(base));
+    logs = drainLogs();
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previousStderr);
+    restoreDerive();
+    initRegistry(convertDispatchRules(DISPATCH_RULES));
+    if (!previousExists) resetRegistry();
+    rmSync(base, { recursive: true, force: true });
+    void t;
+  }
+
+  const err = logs.find(
+    (e) => e.component === "dispatch" && e.severity === "error" && /reactive graph derivation failed/u.test(e.message),
+  );
+  assert.ok(
+    err,
+    "a dispatch ERROR must be logged when reactive graph derivation fails (got: " +
+      logs.filter((e) => e.component === "dispatch").map((e) => e.message).join(" | ") + ")",
+  );
+  assert.equal(err!.message, "reactive graph derivation failed");
+  assert.match(err!.context?.error ?? "", /forced graph derivation failure/u);
+});

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -23,6 +23,7 @@ import {
   createAutoWorktree,
   mergeMilestoneToMain,
   getAutoWorktreeOriginalBase,
+  _setRestoreEntryFnForTests,
 } from "../../auto-worktree.ts";
 import { getSliceBranchName } from "../../worktree.ts";
 import { nativeMergeSquash } from "../../native-git-bridge.ts";
@@ -1011,5 +1012,79 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
     assert.ok(existsSync(join(queuedDir, "CONTEXT.md")), "queued milestone restored from shelter");
     assert.ok(!existsSync(join(repo, ".gsd", ".milestone-shelter")), "shelter removed on successful restore");
     assert.ok(result.commitMessage.length > 0, "merge completed");
+  });
+
+  // #2505 log coverage: when the per-entry shelter restore throws (here via the
+  // _setRestoreEntryFnForTests seam — the only deterministic way to reach this
+  // path, since shelter + restore run synchronously in one merge call), the
+  // merge must log a `worktree` ERROR naming the entry (auto-worktree.ts:1809),
+  // emit a retention warning (:1816), and PRESERVE the shelter dir so the
+  // queued milestone files (whose on-disk sources were deleted during the
+  // shelter step) remain recoverable. The existing #2505 test only covered the
+  // success path; this pins the failure-path log + the data-loss guard.
+  test("#2505 logs: shelter restore failure logs a worktree error and retains the shelter", () => {
+    const repo = freshRepo();
+    const wtPath = createAutoWorktree(repo, "M210");
+
+    addSliceToMilestone(repo, wtPath, "M210", "S01", "Feature", [
+      { file: "feature.ts", content: "export const f = 1;\n", message: "add feature" },
+    ]);
+
+    // Seed a queued (non-target) milestone that will be sheltered then restored.
+    const queuedDir = join(repo, ".gsd", "milestones", "M211");
+    mkdirSync(queuedDir, { recursive: true });
+    writeFileSync(join(queuedDir, "CONTEXT.md"), "# queued\n");
+
+    const roadmap = makeRoadmap("M210", "Milestone w/ failing restore", [
+      { id: "S01", title: "Feature" },
+    ]);
+
+    // Inject a restore entry fn that always throws, forcing the best-effort
+    // failure path. restoreDefault() is invoked in finally so no other test in
+    // the process observes the injected behavior.
+    const restoreDefault = _setRestoreEntryFnForTests(() => {
+      throw new Error("forced restore failure");
+    });
+
+    const previousStderr = setStderrLoggingEnabled(false);
+    let logs: ReturnType<typeof drainLogs> = [];
+    try {
+      mergeMilestoneToMain(repo, "M210", roadmap);
+      logs = drainLogs();
+    } finally {
+      setStderrLoggingEnabled(previousStderr);
+      restoreDefault();
+    }
+
+    const worktreeLogs = logs.filter((e) => e.component === "worktree");
+
+    const restoreError = worktreeLogs.find(
+      (e) => e.severity === "error" && /shelter restore failed/u.test(e.message),
+    );
+    assert.ok(
+      restoreError,
+      "a worktree ERROR must be logged when the shelter restore fails (got: " +
+        worktreeLogs.map((e) => e.message).join(" | ") + ")",
+    );
+    assert.match(
+      restoreError!.message,
+      /shelter restore failed \(M211\)/u,
+      "the error must name the unrestored milestone entry",
+    );
+    assert.match(
+      restoreError!.message,
+      /forced restore failure/u,
+      "the error must carry the underlying restore failure detail",
+    );
+
+    // #2505 data-loss guard: the shelter must survive so files stay recoverable.
+    assert.ok(
+      worktreeLogs.some((e) => /shelter retained/u.test(e.message)),
+      "a retention warning must be logged when a restore entry fails",
+    );
+    assert.ok(
+      existsSync(join(repo, ".gsd", ".milestone-shelter")),
+      "the shelter dir must be retained when a restore entry fails",
+    );
   });
 });

--- a/src/resources/extensions/gsd/tests/orchestrator-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/orchestrator-logs.test.ts
@@ -1,0 +1,335 @@
+// gsd-pi — Orchestrator advance() log coverage.
+//
+// The orchestrator's private methods (findPriorSliceCompletionBlocker,
+// emitUokGate, mergePendingCompleteMilestone) each emit `engine` warnings on
+// their failure paths (orchestrator.ts:660 / :538 / :637). They are only
+// reachable by driving advance() through a real AutoOrchestrator constructed
+// via createAutoOrchestrator. This file builds a minimal fixture (git repo +
+// seeded DB + session lock + registry dispatch rule, modelled on
+// auto-orchestrator.test.ts's makeFixture) and drives advance() into each
+// branch, asserting the log output.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  createAutoOrchestrator,
+  _setProjectionRebuildFnForTests,
+  type OrchestratorContext,
+} from "../auto/orchestrator.ts";
+import type { AutoSessionContext } from "../auto/contracts.ts";
+import { RuleRegistry, setRegistry, resetRegistry } from "../rule-registry.ts";
+import type { UnifiedRule } from "../rule-types.ts";
+import {
+  closeDatabase,
+  insertAssessment,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+  _getAdapter,
+} from "../gsd-db.ts";
+import { resolveExpectedArtifactPath } from "../auto-artifact-paths.ts";
+import { AutoSession } from "../auto/session.ts";
+import { acquireSessionLock, releaseSessionLock } from "../session-lock.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import { invalidateStateCache } from "../state.ts";
+import {
+  drainLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+
+const SESSION_CONTEXT: AutoSessionContext = { basePath: "/tmp/project", trigger: "manual" };
+
+function gitInit(base: string): void {
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, ".gitkeep"), "");
+  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: base, stdio: "ignore" });
+}
+
+interface FixtureOptions {
+  /** Override the session's originalBasePath (used by findPriorSliceCompletionBlocker's guard). */
+  originalBasePath?: string;
+  /** The dispatch decision the registry rule returns. */
+  dispatch?: UnifiedRule["where"];
+  /** Drop the gate_runs table after seeding so emitUokGate's insertGateRun throws (:538 path). */
+  dropGateRuns?: boolean;
+}
+
+interface Fixture {
+  base: string;
+  session: AutoSession;
+  orchestrator: ReturnType<typeof createAutoOrchestrator>;
+  cleanup(): void;
+}
+
+function makeFixture(opts: FixtureOptions = {}): Fixture {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orch-logs-"));
+  gitInit(base);
+
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const sliceDir = join(milestoneDir, "slices", "S01");
+  mkdirSync(join(sliceDir, "tasks"), { recursive: true });
+
+  invalidateAllCaches();
+  invalidateStateCache();
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active", risk: "low", depends: [], demo: "", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task", status: "active" });
+  if (opts.dropGateRuns) {
+    // Break the gate_runs sink so UokGateRunner.run → insertGateRun throws,
+    // exercising emitUokGate's catch (orchestrator.ts:538).
+    _getAdapter()!.exec("DROP TABLE gate_runs");
+  }
+
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    ["# M001: Milestone", "", "**Vision:** Fixture", "", "## Slices", "", "- [ ] **S01: Slice** `risk:low` `depends:[]`", ""].join("\n"),
+  );
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    ["# S01: Slice", "", "**Goal:** g", "**Demo:** d", "", "## Tasks", "", "- [ ] **T01: Task** `est:1h`", ""].join("\n"),
+  );
+
+  acquireSessionLock(base);
+
+  const session = new AutoSession();
+  session.basePath = base;
+  // originalBasePath feeds resolveWorktreeProjectRoot inside
+  // findPriorSliceCompletionBlocker → getMainBranch(guardBasePath). Pointing it
+  // at a non-git directory makes branch discovery throw → :660 warning.
+  session.originalBasePath = opts.originalBasePath ?? base;
+  session.currentMilestoneId = "M001";
+  session.resourceVersionOnStart = null;
+
+  const ctx: OrchestratorContext = {
+    ctx: { model: {}, modelRegistry: { getAll: () => [] }, ui: { notify() {} } } as never,
+    pi: { getActiveTools: () => [] } as never,
+    dispatchBasePath: base,
+    runtimeBasePath: base,
+    session,
+  };
+
+  const rule: UnifiedRule = {
+    name: "fixture-dispatch",
+    when: "dispatch",
+    evaluation: "first-match",
+    where: opts.dispatch ?? (async () => ({
+      action: "dispatch",
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "fixture-prompt",
+    })),
+    then: (r) => r,
+  };
+  setRegistry(new RuleRegistry([rule]));
+
+  const orchestrator = createAutoOrchestrator(ctx);
+
+  return {
+    base,
+    session,
+    orchestrator,
+    cleanup() {
+      resetRegistry();
+      try { releaseSessionLock(base); } catch { /* */ }
+      try { closeDatabase(); } catch { /* */ }
+      try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+    },
+  };
+}
+
+/** Capture log entries emitted during fn, with stderr suppressed. */
+async function captureLogs<T>(fn: () => Promise<T>): Promise<{ result: T; logs: LogEntry[] }> {
+  const previous = setStderrLoggingEnabled(false);
+  _resetLogs();
+  try {
+    const result = await fn();
+    return { result, logs: drainLogs() };
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previous);
+  }
+}
+
+// orchestrator.ts:660 — findPriorSliceCompletionBlocker catches a getMainBranch
+// failure and logs `branch discovery failed, falling back to main`. Triggered
+// by pointing session.originalBasePath at a non-git directory.
+test("advance() logs an engine warning when branch discovery fails (orchestrator.ts:660)", async (t) => {
+  // A second temp dir that is deliberately NOT a git repo.
+  const nonGit = mkdtempSync(join(tmpdir(), "gsd-orch-logs-nongit-"));
+  const f = makeFixture({ originalBasePath: nonGit });
+  t.after(() => {
+    f.cleanup();
+    rmSync(nonGit, { recursive: true, force: true });
+  });
+
+  const { logs } = await captureLogs(() => f.orchestrator.advance());
+
+  const branchWarn = logs.find(
+    (e) => e.component === "engine" && e.severity === "warn" && /branch discovery failed/u.test(e.message),
+  );
+  assert.ok(
+    branchWarn,
+    "an engine warning must be logged when getMainBranch fails (got: " +
+      logs.filter((e) => e.component === "engine").map((e) => e.message).join(" | ") + ")",
+  );
+  assert.match(branchWarn!.message, /branch discovery failed, falling back to main/u);
+});
+
+// orchestrator.ts:538 — emitUokGate catches a UokGateRunner.run failure and logs
+// `uok gate emit failed`. Gates are enabled by default (uok.gates.enabled ?? true),
+// and runner.run persists via insertGateRun; dropping the gate_runs table makes
+// that persistence throw, surfacing through the catch.
+test("advance() logs an engine warning when the uok gate emit fails (orchestrator.ts:538)", async (t) => {
+  const f = makeFixture({ dropGateRuns: true });
+  t.after(() => f.cleanup());
+
+  const { logs } = await captureLogs(() => f.orchestrator.advance());
+
+  const uokFail = logs.find(
+    (e) => e.component === "engine" && e.severity === "warn" && /uok gate emit failed/u.test(e.message),
+  );
+  assert.ok(
+    uokFail,
+    "an engine warning must be logged when UokGateRunner.run fails (got: " +
+      logs.filter((e) => e.component === "engine").map((e) => e.message).join(" | ") + ")",
+  );
+  assert.match(uokFail!.message, /uok gate emit failed/u);
+  assert.equal(uokFail!.context?.file, "orchestrator.ts");
+  assert.ok(uokFail!.context?.gateId, "the failing gate id must be captured in context");
+});
+
+// orchestrator.ts:637 — mergePendingCompleteMilestone catches a
+// rebuildMarkdownProjectionsFromDb failure after the system-owned milestone
+// merge and logs `markdown projection rebuild after settlement merge failed`.
+// Reached only when advance() hits a merge-pending settlement (auto-worktree,
+// complete milestone, proven closeout, no remaining units). We build that state
+// (real git worktree + closed milestone + SUMMARY artifact, modelled on
+// milestone-settlement.test.ts), inject a throwing rebuild via the test seam,
+// and assert the engine warning.
+test("advance() logs an engine warning when the post-settlement projection rebuild fails (orchestrator.ts:637)", async (t) => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-orch-logs-settle-"));
+  // Real git repo at the project root.
+  execFileSync("git", ["init", "-b", "main"], { cwd: projectRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: projectRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: projectRoot, stdio: "ignore" });
+  writeFileSync(join(projectRoot, "README.md"), "# fixture\n");
+  execFileSync("git", ["add", "."], { cwd: projectRoot, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "chore: init"], { cwd: projectRoot, stdio: "ignore" });
+
+  // Auto-worktree for M001 — required so evaluateAllCompleteSettlement returns
+  // merge-pending (isActiveUnmergedWorktree must be true).
+  const worktree = join(projectRoot, ".gsd", "worktrees", "M001");
+  mkdirSync(dirname(worktree), { recursive: true });
+  execFileSync("git", ["worktree", "add", "-b", "milestone/M001", worktree, "HEAD"], { cwd: projectRoot, stdio: "ignore" });
+
+  // Seed a closed milestone + proven closeout SUMMARY so proveMilestoneCloseout
+  // passes and the settlement resolves to merge-pending.
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+  invalidateAllCaches();
+  invalidateStateCache();
+  openDatabase(join(projectRoot, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice One", status: "complete" });
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task One",
+    status: "complete",
+    verificationResult: "passed",
+  });
+  insertAssessment({
+    path: ".gsd/milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass\n",
+  });
+  // Create the milestone projection dir in the worktree BEFORE resolving the
+  // summary artifact path (resolveExpectedArtifactPath needs the dir to exist).
+  const milestoneProjDir = join(worktree, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneProjDir, { recursive: true });
+  const summaryPath = resolveExpectedArtifactPath("complete-milestone", "M001", worktree);
+  assert.ok(summaryPath, "complete-milestone summary path must resolve");
+  mkdirSync(dirname(summaryPath), { recursive: true });
+  writeFileSync(summaryPath, "# Milestone One\n\nComplete.\n");
+
+  acquireSessionLock(projectRoot);
+
+  const session = new AutoSession();
+  session.basePath = worktree;
+  session.originalBasePath = projectRoot;
+  session.currentMilestoneId = "M001";
+  session.resourceVersionOnStart = null;
+
+  const ctx: OrchestratorContext = {
+    ctx: { model: {}, modelRegistry: { getAll: () => [] }, ui: { notify() {} } } as never,
+    pi: { getActiveTools: () => [] } as never,
+    dispatchBasePath: worktree,
+    runtimeBasePath: worktree,
+    session,
+  };
+
+  // Registry rule returns skip (no remaining units) so advance() reaches the
+  // no-remaining-units settlement branch and calls mergePendingCompleteMilestone.
+  const rule: UnifiedRule = {
+    name: "settle-no-units",
+    when: "dispatch",
+    evaluation: "first-match",
+    where: async () => ({ action: "skip", matchedRule: "settle-no-units" }),
+    then: (r) => r,
+  };
+  setRegistry(new RuleRegistry([rule]));
+
+  const orchestrator = createAutoOrchestrator(ctx);
+
+  // Inject a throwing projection rebuild so :637 fires after exitMilestone
+  // completes the system-owned merge. restoreDefault() in finally keeps the
+  // seam production-neutral for every other test in the process.
+  const restoreDefault = _setProjectionRebuildFnForTests(async () => {
+    throw new Error("forced projection rebuild failure");
+  });
+
+  t.after(() => {
+    restoreDefault();
+    resetRegistry();
+    try { releaseSessionLock(projectRoot); } catch { /* */ }
+    try { closeDatabase(); } catch { /* */ }
+    try { execFileSync("git", ["worktree", "remove", "--force", worktree], { cwd: projectRoot, stdio: "ignore" }); } catch { /* */ }
+    try { rmSync(projectRoot, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  const previous = setStderrLoggingEnabled(false);
+  _resetLogs();
+  let logs: LogEntry[] = [];
+  try {
+    await orchestrator.advance();
+    logs = drainLogs();
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previous);
+  }
+
+  const rebuildWarn = logs.find(
+    (e) => e.component === "engine" && e.severity === "warn" &&
+      /markdown projection rebuild after settlement merge failed/u.test(e.message),
+  );
+  assert.ok(
+    rebuildWarn,
+    "an engine warning must be logged when the post-settlement projection rebuild fails (got: " +
+      logs.filter((e) => e.component === "engine").map((e) => e.message).join(" | ") + ")",
+  );
+  assert.match(rebuildWarn!.message, /forced projection rebuild failure/u);
+});

--- a/src/resources/extensions/gsd/tests/reconcile-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/reconcile-logs.test.ts
@@ -1,0 +1,244 @@
+// gsd-pi — Worktree DB reconciliation log coverage.
+//
+// `reconcileWorktreeDb` / `copyWorktreeDb` in db/writers/reconcile.ts ATTACH-
+// and-merge a worktree's gsd.db back into the project-root DB. Each failure
+// branch logs a `db` error/warning so a failed merge never silently drops
+// worktree state — these logs are the only record that worktree-only decisions
+// were lost. The existing worktree-db tests assert only the merge RESULT counts;
+// none asserts any of the failure-path logs. This file pins them:
+//   - copyWorktreeDb failed              (reconcile.ts:22)
+//   - realpathSync failed                 (reconcile.ts:71)
+//   - unsafe characters in path           (reconcile.ts:76)
+//   - cannot open main DB                 (reconcile.ts:82)
+//   - reconcile transaction failed        (reconcile.ts:494)
+//   - rollback / detach failures          (reconcile.ts:486, :491)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import {
+  closeDatabase,
+  copyWorktreeDb,
+  openDatabase,
+  reconcileWorktreeDb,
+  insertDecision,
+} from "../gsd-db.ts";
+import { _setMainDbOpenerFnForTests } from "../db/writers/reconcile.ts";
+import {
+  drainLogs,
+  peekLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+
+function tempDir(prefix = "gsd-reconcile-logs-"): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Capture log entries emitted while running fn (stderr suppressed). */
+function captureLogs<T>(fn: () => T): { result: T; logs: LogEntry[] } {
+  const previous = setStderrLoggingEnabled(false);
+  _resetLogs();
+  try {
+    const result = fn();
+    return { result, logs: drainLogs() };
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previous);
+  }
+}
+
+function dbLogs(logs: readonly LogEntry[]): LogEntry[] {
+  return logs.filter((e) => e.component === "db");
+}
+
+/** Make a minimal valid gsd.db at `dbPath` so a worktree file exists/opens. */
+function seedDb(dbPath: string): void {
+  openDatabase(dbPath);
+  insertDecision({
+    id: "D001",
+    when_context: "2025-01-01",
+    scope: "M001/S01",
+    decision: "x",
+    choice: "x",
+    rationale: "x",
+    revisable: "yes",
+    made_by: "agent",
+    superseded_by: null,
+  });
+  closeDatabase();
+}
+
+test("copyWorktreeDb logs a db error when the source DB cannot be read", () => {
+  const srcDir = tempDir();
+  const destDir = tempDir();
+  const srcDb = path.join(srcDir, "gsd.db");
+  const destDb = path.join(destDir, "gsd.db");
+  try {
+    seedDb(srcDb);
+    // Make the source unreadable so copyFileSync throws EACCES.
+    fs.chmodSync(srcDb, 0o000);
+
+    const { result, logs } = captureLogs(() => copyWorktreeDb(srcDb, destDb));
+
+    assert.equal(result, false, "copy must report failure");
+    const err = dbLogs(logs).find((e) => e.severity === "error");
+    assert.ok(err, "a db error must be logged");
+    assert.match(err!.message, /failed to copy DB to worktree/u);
+    assert.ok(err!.context?.error, "the underlying error must be captured in context");
+  } finally {
+    // Restore perms so cleanup can delete the file.
+    try { fs.chmodSync(srcDb, 0o644); } catch { /* already gone */ }
+    fs.rmSync(srcDir, { recursive: true, force: true });
+    fs.rmSync(destDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileWorktreeDb logs a db error for an unsafe path (rejected before ATTACH)", () => {
+  const mainDir = tempDir();
+  const wtDir = tempDir("gsd-reconcile-logs-unsafe-'");
+  try {
+    const mainDb = path.join(mainDir, "gsd.db");
+    seedDb(mainDb);
+    // Worktree file must EXIST so the existsSync guard (reconcile.ts:66)
+    // passes and execution reaches the path-sanitizer (:75). The parent temp
+    // dir name carries a single-quote so the resolved path is rejected.
+    const wtDb = path.join(wtDir, "gsd.db");
+    fs.copyFileSync(mainDb, wtDb);
+
+    openDatabase(mainDb);
+    const { result, logs } = captureLogs(() => reconcileWorktreeDb(mainDb, wtDb));
+    closeDatabase();
+
+    assert.equal(result.decisions, 0, "unsafe path must yield a zero reconcile");
+    const err = dbLogs(logs).find((e) => e.severity === "error");
+    assert.ok(err, "a db error must be logged for the rejected path");
+    assert.match(err!.message, /worktree DB reconciliation failed: path contains unsafe characters/u);
+  } finally {
+    closeDatabase();
+    fs.rmSync(mainDir, { recursive: true, force: true });
+    fs.rmSync(wtDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileWorktreeDb logs a db warning when realpathSync on the main path fails", () => {
+  const wtDir = tempDir();
+  const mainDir = tempDir();
+  try {
+    // A real worktree DB so the existsSync guard (reconcile.ts:66) passes.
+    // The main path does not yet exist, so realpathSync(mainDbPath) throws
+    // ENOENT — exercising the same-file-guard catch (reconcile.ts:71). The
+    // function then proceeds to openDatabase(), which creates the file, so the
+    // reconcile completes; we assert only the realpath warning landed.
+    const wtDb = path.join(wtDir, "gsd.db");
+    seedDb(wtDb);
+    closeDatabase();
+    const mainDb = path.join(mainDir, "gsd.db");
+
+    const { logs } = captureLogs(() => reconcileWorktreeDb(mainDb, wtDb));
+    closeDatabase();
+
+    const warn = dbLogs(logs).find((e) => e.severity === "warn");
+    assert.ok(warn, "a db warning must be logged when realpathSync fails");
+    assert.match(warn!.message, /realpathSync failed/u);
+  } finally {
+    closeDatabase();
+    fs.rmSync(wtDir, { recursive: true, force: true });
+    fs.rmSync(mainDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileWorktreeDb logs a db error and zero-result when the worktree DB is corrupt", () => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  try {
+    const mainDb = path.join(mainDir, "gsd.db");
+    seedDb(mainDb);
+
+    // A worktree DB whose bytes are not SQLite — ATTACH DATABASE will throw,
+    // hitting the outer reconcile-failed catch (reconcile.ts:494).
+    const wtDb = path.join(wtDir, "gsd.db");
+    fs.writeFileSync(wtDb, "this is not a sqlite database", "utf-8");
+
+    openDatabase(mainDb);
+    const { result, logs } = captureLogs(() => reconcileWorktreeDb(mainDb, wtDb));
+    closeDatabase();
+
+    assert.equal(result.decisions, 0, "a corrupt worktree DB must yield a zero reconcile");
+    const err = dbLogs(logs).find((e) => e.severity === "error");
+    assert.ok(err, "a db error must be logged for the failed reconcile transaction");
+    assert.match(err!.message, /worktree DB reconciliation failed/u);
+    assert.ok(err!.context?.error, "the underlying ATTACH/merge error must be captured");
+  } finally {
+    closeDatabase();
+    fs.rmSync(mainDir, { recursive: true, force: true });
+    fs.rmSync(wtDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileWorktreeDb produces no db errors on the happy path", () => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  try {
+    const mainDb = path.join(mainDir, "gsd.db");
+    const wtDb = path.join(wtDir, "gsd.db");
+    seedDb(mainDb);
+    closeDatabase();
+    copyWorktreeDb(mainDb, wtDb);
+
+    openDatabase(mainDb);
+    const { result, logs } = captureLogs(() => reconcileWorktreeDb(mainDb, wtDb));
+    closeDatabase();
+
+    assert.ok(result.decisions >= 0, "happy-path reconcile must return a result");
+    assert.equal(
+      dbLogs(logs).filter((e) => e.severity === "error").length,
+      0,
+      "no db error should be logged on a successful reconcile",
+    );
+  } finally {
+    closeDatabase();
+    fs.rmSync(mainDir, { recursive: true, force: true });
+    fs.rmSync(wtDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileWorktreeDb logs a db error when the main DB cannot be opened (reconcile.ts:82)", () => {
+  const mainDir = tempDir();
+  const wtDir = tempDir();
+  try {
+    // A real worktree DB so the existsSync guard passes; a real main DB so the
+    // realpath same-file guard passes. No DB is open, so reconcileWorktreeDb
+    // reaches the openDatabase(main) branch.
+    const mainDb = path.join(mainDir, "gsd.db");
+    seedDb(mainDb);
+    closeDatabase();
+    const wtDb = path.join(wtDir, "gsd.db");
+    fs.copyFileSync(mainDb, wtDb);
+
+    // Inject an opener that always reports failure so the cannot-open-main-DB
+    // branch (reconcile.ts:82) fires deterministically. openDatabase() rethrows
+    // on real failures across providers rather than returning false, so this is
+    // the only reliable way to exercise the `!opened` branch.
+    const restore = _setMainDbOpenerFnForTests(() => false);
+
+    const { result, logs } = captureLogs(() => reconcileWorktreeDb(mainDb, wtDb));
+    restore();
+
+    assert.equal(result.decisions, 0, "an unopenable main DB must yield a zero reconcile");
+    const err = dbLogs(logs).find((e) => e.severity === "error");
+    assert.ok(err, "a db error must be logged when the main DB cannot be opened");
+    assert.match(err!.message, /worktree DB reconciliation failed: cannot open main DB/u);
+  } finally {
+    closeDatabase();
+    fs.rmSync(mainDir, { recursive: true, force: true });
+    fs.rmSync(wtDir, { recursive: true, force: true });
+  }
+});
+
+// keep peekLogs import live for any future inline assertions in this file
+void peekLogs;

--- a/src/resources/extensions/gsd/tests/recovery-finalize-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/recovery-finalize-logs.test.ts
@@ -1,0 +1,119 @@
+// gsd-pi — Recovery GitHub-finalize detached-promise log coverage.
+//
+// refreshRecoveryDbForArtifact fires a detached GitHub milestone finalize after
+// a complete-milestone DB closeout (auto-recovery.ts finalize block). Its catch
+// logs `GitHub milestone finalize failed after DB closeout` (:232, formerly
+// :203). The catch is otherwise reachable only with a real GitHub remote +
+// network failure, so we drive the real complete-milestone recovery path
+// (seeded closed milestone + proven closeout) and inject a throwing finalize
+// via the sanctioned _setGithubFinalizeFnForTests seam.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { refreshRecoveryDbForArtifact, _setGithubFinalizeFnForTests } from "../auto-recovery.ts";
+import { resolveExpectedArtifactPath } from "../auto-artifact-paths.ts";
+import {
+  closeDatabase,
+  insertAssessment,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  drainLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+test("refreshRecoveryDbForArtifact logs a recovery warning when the detached GitHub finalize throws (auto-recovery.ts:232)", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-recovery-finalize-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  try {
+    // Real git repo with an implementation change on a milestone branch so
+    // hasImplementationArtifacts(base, "M001") returns "present" — required for
+    // proveMilestoneCloseout to pass and the recovery to reach the finalize block.
+    git(base, ["init", "-b", "main"]);
+    git(base, ["config", "user.email", "test@test.com"]);
+    git(base, ["config", "user.name", "Test"]);
+    writeFileSync(join(base, "README.md"), "# init\n");
+    git(base, ["add", "."]);
+    git(base, ["commit", "-m", "init"]);
+    git(base, ["checkout", "-b", "milestone/M001"]);
+    writeFileSync(join(base, "src.ts"), "export const x = 1;\n");
+    git(base, ["add", "."]);
+    git(base, ["commit", "-m", "impl"]);
+
+    invalidateAllCaches();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice One", status: "complete" });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+      verificationResult: "passed",
+    });
+    insertAssessment({
+      path: ".gsd/milestones/M001/M001-VALIDATION.md",
+      milestoneId: "M001",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass\n",
+    });
+
+    // Proven closeout SUMMARY artifact so proveMilestoneCloseout passes and the
+    // recovery reaches the finalize block.
+    const summaryPath = resolveExpectedArtifactPath("complete-milestone", "M001", base);
+    assert.ok(summaryPath, "complete-milestone summary path must resolve");
+    mkdirSync(dirname(summaryPath), { recursive: true });
+    writeFileSync(summaryPath, "# Milestone One\n\nComplete.\n", "utf-8");
+
+    // Inject a throwing finalize so the detached-promise catch fires. The
+    // detached promise resolves on a microtask, so we await one before draining.
+    const restoreFinalize = _setGithubFinalizeFnForTests(() => {
+      throw new Error("forced github finalize failure");
+    });
+
+    const previous = setStderrLoggingEnabled(false);
+    _resetLogs();
+    let logs: LogEntry[] = [];
+    try {
+      const result = refreshRecoveryDbForArtifact("complete-milestone", "M001", base);
+      assert.equal(result.ok, true, "DB closeout must succeed before the detached finalize");
+      // Drain detached-promise queue so the catch's logWarning lands.
+      await new Promise((resolve) => setImmediate(resolve));
+      logs = drainLogs();
+    } finally {
+      _resetLogs();
+      setStderrLoggingEnabled(previous);
+      restoreFinalize();
+    }
+
+    const warn = logs.find(
+      (e) => e.component === "recovery" && /GitHub milestone finalize failed after DB closeout/u.test(e.message),
+    );
+    assert.ok(
+      warn,
+      "a recovery warning must be logged when the detached GitHub finalize throws (got: " +
+        logs.filter((e) => e.component === "recovery").map((e) => e.message).join(" | ") + ")",
+    );
+    assert.match(warn!.message, /forced github finalize failure/u);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/recovery-verify-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/recovery-verify-logs.test.ts
@@ -1,0 +1,428 @@
+// gsd-pi — Recovery artifact-verification log coverage.
+//
+// `verifyExpectedArtifact` is the gate that prevents an LLM from advancing the
+// pipeline with a stub or incomplete artifact. Each verify-fail branch emits a
+// `recovery` warning (or error) describing the exact reason — these logs are
+// the operator's signal during stuck-loop diagnosis, so regressions that change
+// or drop them must surface. The existing artifact-verification tests assert
+// only the boolean return value; this file pins the log output for each
+// important gate:
+//   - plan-milestone roadmap has zero slices      (auto-recovery.ts:511)
+//   - run-uat assessment missing a verdict        (auto-recovery.ts:502)
+//   - validate-milestone validation not terminal  (auto-recovery.ts:494)
+//   - generic verify-fail: artifact file missing  (auto-recovery.ts:487)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { verifyExpectedArtifact, _setRoadmapParserFnForTests } from "../auto-recovery.ts";
+import { closeDatabase, openDatabase, _getAdapter } from "../gsd-db.ts";
+import {
+  drainLogs,
+  peekLogs,
+  setStderrLoggingEnabled,
+  _resetLogs,
+  type LogEntry,
+} from "../workflow-logger.ts";
+
+function createFixtureBase(prefix = "gsd-recovery-logs-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function milestoneDir(base: string, mid: string): string {
+  const dir = join(base, ".gsd", "milestones", mid);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function sliceDir(base: string, mid: string, sid: string): string {
+  const dir = join(base, ".gsd", "milestones", mid, "slices", sid);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Run `verifyExpectedArtifact` with stderr suppressed and capture both the
+ * return value and the log entries emitted by the call. The log buffer is
+ * reset before the call (so no bleed from prior tests) and drained inside the
+ * capture scope (before the finally clears it) so callers can assert on logs
+ * after the helper returns.
+ *
+ * NOTE: the workflow-logger `_buffer` is a process-wide singleton shared with
+ * the code under test, so we must drain inside this scope — reading it after
+ * the finally would see an already-cleared buffer.
+ */
+function verifyAndCaptureLogs(
+  unitType: string,
+  unitId: string,
+  base: string,
+): { result: boolean; logs: LogEntry[] } {
+  const previous = setStderrLoggingEnabled(false);
+  _resetLogs();
+  try {
+    const result = verifyExpectedArtifact(unitType, unitId, base);
+    return { result, logs: drainLogs() };
+  } finally {
+    _resetLogs();
+    setStderrLoggingEnabled(previous);
+  }
+}
+
+function findRecovery(logs: readonly LogEntry[]): LogEntry | undefined {
+  return logs.find((e) => e.component === "recovery");
+}
+
+test("plan-milestone verify-fail logs a recovery warning naming the zero-slice roadmap", () => {
+  const base = createFixtureBase();
+  try {
+    const dir = milestoneDir(base, "M001");
+    writeFileSync(join(dir, "M001-ROADMAP.md"), "# M001: Stub\n\n## Slices\n\n_TBD_\n", "utf-8");
+
+    const { result, logs } = verifyAndCaptureLogs("plan-milestone", "M001", base);
+
+    assert.equal(result, false, "zero-slice roadmap must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.equal(recovery!.severity, "warn");
+    assert.match(recovery!.message, /verify-fail plan-milestone M001: roadmap has zero slices/u);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("run-uat verify-fail logs a recovery warning when the assessment has no verdict", () => {
+  const base = createFixtureBase();
+  try {
+    const dir = sliceDir(base, "M001", "S01");
+    // No `verdict:` frontmatter → hasVerdict() returns false → warning fires.
+    writeFileSync(join(dir, "S01-ASSESSMENT.md"), "# UAT\n\nNo verdict yet.\n", "utf-8");
+
+    const { result, logs } = verifyAndCaptureLogs("run-uat", "M001/S01", base);
+
+    assert.equal(result, false, "verdict-less assessment must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery entry must be logged");
+    assert.equal(recovery!.severity, "warn");
+    assert.match(recovery!.message, /verify-fail run-uat M001\/S01: assessment missing verdict/u);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("validate-milestone verify-fail logs a recovery warning when the validation is not terminal", () => {
+  const base = createFixtureBase();
+  try {
+    const dir = milestoneDir(base, "M001");
+    // No `verdict:` → isValidationTerminal() returns false → warning fires.
+    writeFileSync(join(dir, "M001-VALIDATION.md"), "# Validation\n\nStill in progress.\n", "utf-8");
+
+    const { result, logs } = verifyAndCaptureLogs("validate-milestone", "M001", base);
+
+    assert.equal(result, false, "non-terminal validation must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.equal(recovery!.severity, "warn");
+    assert.match(recovery!.message, /verify-fail validate-milestone M001: validation not terminal/u);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("verify-fail logs a recovery warning when an expected artifact file is absent", () => {
+  const base = createFixtureBase();
+  try {
+    // complete-slice resolves a SUMMARY path under the milestone dir, but we
+    // never write the file → existsSync is false → the generic verify-fail path
+    // logs and returns false.
+    sliceDir(base, "M001", "S01");
+
+    const { result, logs } = verifyAndCaptureLogs("complete-slice", "M001/S01", base);
+
+    assert.equal(result, false, "missing artifact must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.equal(recovery!.severity, "warn");
+    assert.match(recovery!.message, /verify-fail complete-slice M001\/S01: existsSync false/u);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("a passing verification produces no recovery warnings", () => {
+  const base = createFixtureBase();
+  try {
+    const dir = milestoneDir(base, "M001");
+    writeFileSync(
+      join(dir, "M001-ROADMAP.md"),
+      ["# M001: Real roadmap", "", "## Slices", "", "- [ ] **S01: First slice** `risk:low` `depends:[]`", ""].join("\n"),
+      "utf-8",
+    );
+
+    const { result, logs } = verifyAndCaptureLogs("plan-milestone", "M001", base);
+
+    assert.equal(result, true, "a real roadmap must pass verification");
+    assert.equal(
+      findRecovery(logs),
+      undefined,
+      "no recovery warning should be logged on success",
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ─── plan-slice verification gates (legacy path, no DB) ────────────────────
+// These run the filesystem fallback when isDbAvailable() is false. Each verify-
+// fail branch logs a recovery warning naming the exact missing artifact, so a
+// regression that drops the reason would hide why a slice refused to advance.
+
+test("plan-slice verify-fail logs a recovery warning when the plan has no task entries", () => {
+  const base = createFixtureBase("gsd-recovery-logs-plan-");
+  try {
+    const dir = sliceDir(base, "M001", "S01");
+    // A PLAN with neither a `- [ ] **T0x:**` checkbox nor a `## T0x --` heading.
+    writeFileSync(join(dir, "S01-PLAN.md"), "# S01: Stub\n\n## Tasks\n\n_TBD_\n", "utf-8");
+
+    const { result, logs } = verifyAndCaptureLogs("plan-slice", "M001/S01", base);
+
+    assert.equal(result, false, "a task-less plan must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(
+      recovery!.message,
+      /verify-fail plan-slice M001\/S01: plan has no task checkbox\/heading/u,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("plan-slice verify-fail logs a recovery warning when the tasks dir is missing", () => {
+  const base = createFixtureBase("gsd-recovery-logs-tasksdir-");
+  try {
+    const dir = sliceDir(base, "M001", "S01");
+    // Valid checkbox task, but we deliberately do NOT create the tasks/ dir.
+    writeFileSync(
+      join(dir, "S01-PLAN.md"),
+      "# S01: Has task\n\n## Tasks\n\n- [ ] **T01: A** `est:15m`\n",
+      "utf-8",
+    );
+
+    const { result, logs } = verifyAndCaptureLogs("plan-slice", "M001/S01", base);
+
+    assert.equal(result, false, "a plan without its tasks dir must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(
+      recovery!.message,
+      /verify-fail plan-slice M001\/S01: tasks dir missing/u,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("plan-slice verify-fail logs a recovery warning when an individual task plan file is missing", () => {
+  const base = createFixtureBase("gsd-recovery-logs-taskplan-");
+  try {
+    const dir = sliceDir(base, "M001", "S01");
+    writeFileSync(
+      join(dir, "S01-PLAN.md"),
+      "# S01: Has task\n\n## Tasks\n\n- [ ] **T01: A** `est:15m`\n",
+      "utf-8",
+    );
+    // Create the tasks dir but NOT the T01-PLAN.md file inside it.
+    mkdirSync(join(dir, "tasks"), { recursive: true });
+
+    const { result, logs } = verifyAndCaptureLogs("plan-slice", "M001/S01", base);
+
+    assert.equal(result, false, "a missing task plan file must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(
+      recovery!.message,
+      /verify-fail plan-slice M001\/S01: task plan missing .*T01-PLAN\.md/u,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ─── parallel-research sentinel verification gates ─────────────────────────
+// The "{mid}/parallel-research" sentinel fans research across multiple slices.
+// verifyExpectedArtifact checks every research-ready slice has a RESEARCH file;
+// each failure logs a recovery warning naming the exact gap.
+
+test("parallel-research verify-fail logs a recovery warning when the roadmap is missing", () => {
+  const base = createFixtureBase("gsd-recovery-logs-prr-");
+  try {
+    // No roadmap file present → resolveExpectedArtifactPath("plan-milestone")
+    // returns null/missing → :445 warning.
+    const { result, logs } = verifyAndCaptureLogs("research-slice", "M001/parallel-research", base);
+
+    assert.equal(result, false, "missing roadmap must fail parallel-research verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(
+      recovery!.message,
+      /verify-fail research-slice M001\/parallel-research: roadmap missing/u,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("parallel-research verify-fail logs a recovery warning when a research-ready slice lacks RESEARCH", () => {
+  const base = createFixtureBase("gsd-recovery-logs-prrs-");
+  try {
+    const dir = milestoneDir(base, "M001");
+    // A roadmap with one not-done slice (S01) and no milestone-level RESEARCH.
+    // S01 is research-ready (no deps, not done) and has no RESEARCH file → :462.
+    writeFileSync(
+      join(dir, "M001-ROADMAP.md"),
+      ["# M001: Roadmap", "", "## Slices", "", "- [ ] **S01: First** `risk:low` `depends:[]`", ""].join("\n"),
+      "utf-8",
+    );
+
+    const { result, logs } = verifyAndCaptureLogs("research-slice", "M001/parallel-research", base);
+
+    assert.equal(result, false, "a research-ready slice without RESEARCH must fail verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(
+      recovery!.message,
+      /verify-fail research-slice M001\/parallel-research: slice S01 missing RESEARCH/u,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ─── gate-evaluate DB-degradation gate ─────────────────────────────────────
+// gate-evaluate verifies dispatched gates are no longer pending via a DB query.
+// When the DB is available but the query throws (e.g. quality_gates table
+// missing), the catch (auto-recovery.ts:411) logs a recovery warning and treats
+// the unit as verified to avoid blocking. This pins that degradation log.
+
+test("gate-evaluate verify logs a recovery warning when the pending-gates DB query throws", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-recovery-logs-gate-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  try {
+    // Open a DB then drop quality_gates so getPendingGatesForTurn throws inside
+    // the gate-evaluate DB branch → :411 warning. (getGateIdsForTurn returns
+    // default gate-evaluate ids, so the query path is reached.)
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    _getAdapter()!.exec("DROP TABLE quality_gates");
+
+    const previous = setStderrLoggingEnabled(false);
+    _resetLogs();
+    let result: boolean;
+    try {
+      // Batch unitId "M001/S01/gates+Q3" encodes one dispatched gate.
+      result = verifyExpectedArtifact("gate-evaluate", "M001/S01/gates+Q3", base);
+      const logs = drainLogs();
+      const recovery = logs.find((e) => e.component === "recovery" && /gate-evaluate DB check failed/u.test(e.message));
+      assert.ok(recovery, "a recovery warning must be logged when the gate DB check throws");
+      assert.match(recovery!.message, /gate-evaluate DB check failed/u);
+    } finally {
+      _resetLogs();
+      setStderrLoggingEnabled(previous);
+    }
+    // Per :411 comment, a DB failure is treated as verified (return true) to
+    // avoid blocking the loop — pin that resilience contract too.
+    assert.equal(result, true, "a gate-evaluate DB failure must not block verification");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ─── roadmap-parse-threw catches (:515 plan-milestone, :622 complete-slice) ─
+// parseLegacyRoadmap is internally defensive against every malformed input, so
+// these catches are unreachable without the _setRoadmapParserFnForTests seam.
+// We inject a throwing parser to pin both best-effort failure logs.
+
+test("plan-milestone verify logs a recovery warning when the roadmap parser throws (auto-recovery.ts:515)", () => {
+  const base = createFixtureBase("gsd-recovery-logs-parse-");
+  const restore = _setRoadmapParserFnForTests(() => {
+    throw new Error("forced roadmap parse failure");
+  });
+  try {
+    const dir = milestoneDir(base, "M001");
+    // A real ROADMAP file must exist so verification reaches the parser.
+    writeFileSync(join(dir, "M001-ROADMAP.md"), "# M001: x\n\n## Slices\n\n- [ ] **S01: A**\n", "utf-8");
+
+    const { result, logs } = verifyAndCaptureLogs("plan-milestone", "M001", base);
+
+    assert.equal(result, false, "a parser failure must fail plan-milestone verification");
+    const recovery = findRecovery(logs);
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(recovery!.message, /plan-milestone roadmap verification failed/u);
+    assert.match(recovery!.message, /forced roadmap parse failure/u);
+  } finally {
+    restore();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("complete-slice verify logs a recovery warning when the legacy roadmap parse fails (auto-recovery.ts:622)", () => {
+  const base = createFixtureBase("gsd-recovery-logs-cs-parse-");
+  const restore = _setRoadmapParserFnForTests(() => {
+    throw new Error("forced legacy roadmap parse failure");
+  });
+  try {
+    const dir = sliceDir(base, "M001", "S01");
+    // complete-slice verification: SUMMARY + UAT present, DB unavailable →
+    // legacy roadmap checkbox fallback → parser throws → :622 warning.
+    writeFileSync(join(dir, "S01-SUMMARY.md"), "# S01 done\n", "utf-8");
+    // UAT file required so the complete-slice guard (auto-recovery.ts:655) does
+    // not return false before reaching the legacy roadmap fallback.
+    writeFileSync(join(dir, "S01-UAT.md"), "# UAT\n", "utf-8");
+    // Legacy ROADMAP.md (unprefixed) under the milestone dir.
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "ROADMAP.md"), "# M001\n\n## Slices\n\n- [ ] **S01: A**\n", "utf-8");
+
+    const { result, logs } = verifyAndCaptureLogs("complete-slice", "M001/S01", base);
+
+    assert.equal(result, false, "a parser failure must fail complete-slice verification");
+    const recovery = logs.find((e) => e.component === "recovery" && /roadmap parse failed/u.test(e.message));
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(recovery!.message, /roadmap parse failed/u);
+    assert.match(recovery!.message, /forced legacy roadmap parse failure/u);
+  } finally {
+    restore();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("parallel-research verify logs a recovery warning when the roadmap parse throws (auto-recovery.ts:522)", () => {
+  const base = createFixtureBase("gsd-recovery-logs-prr-throw-");
+  const restore = _setRoadmapParserFnForTests(() => {
+    throw new Error("forced parallel-research parse failure");
+  });
+  try {
+    const dir = milestoneDir(base, "M001");
+    // A real ROADMAP with a research-ready slice so verification reaches the
+    // parser loop; the seam makes parseRoadmapForRecovery throw → :522 catch.
+    writeFileSync(
+      join(dir, "M001-ROADMAP.md"),
+      ["# M001: Roadmap", "", "## Slices", "", "- [ ] **S01: First** `risk:low` `depends:[]`", ""].join("\n"),
+      "utf-8",
+    );
+
+    const { result, logs } = verifyAndCaptureLogs("research-slice", "M001/parallel-research", base);
+
+    assert.equal(result, false, "a parser failure must fail parallel-research verification");
+    const recovery = logs.find((e) => e.component === "recovery" && /parallel-research verification failed/u.test(e.message));
+    assert.ok(recovery, "a recovery warning must be logged");
+    assert.match(recovery!.message, /parallel-research verification failed/u);
+    assert.match(recovery!.message, /forced parallel-research parse failure/u);
+  } finally {
+    restore();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/uok-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-audit.test.ts
@@ -1,0 +1,194 @@
+// gsd-pi UOK Audit Sink Tests
+//
+// Dedicated coverage for `uok/audit.ts` — the structured audit-event sink that
+// every workflow-logger / journal / metrics path funnels through when the
+// unified-audit toggle is on. The contract test (`uok-contracts.test.ts`)
+// exercises the happy DB+jsonl path and timeline precedence, but none of the
+// four error/control branches below:
+//   1. stale-turn write drop          (isStaleWrite early return)
+//   2. validation failure throw        (malformed envelope)
+//   3. DB authoritative write failure  (re-throw to caller)
+//   4. jsonl projection swallow        (best-effort, never throws)
+// These tests pin each branch so regressions surface as clear failures.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { AuditEventEnvelope } from "../uok/contracts.ts";
+import { CURRENT_UOK_CONTRACT_VERSION } from "../uok/contracts.ts";
+import { buildAuditEnvelope, emitUokAuditEvent } from "../uok/audit.ts";
+import { closeDatabase, openDatabase, _getAdapter } from "../gsd-db.ts";
+import {
+  bumpTurnGeneration,
+  runWithTurnGeneration,
+  _resetTurnEpoch,
+} from "../auto/turn-epoch.ts";
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function auditEventsPath(basePath: string): string {
+  return join(basePath, ".gsd", "audit", "events.jsonl");
+}
+
+function readAuditEvents(basePath: string): AuditEventEnvelope[] {
+  const path = auditEventsPath(basePath);
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf-8").trim();
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .map((line) => JSON.parse(line) as AuditEventEnvelope);
+}
+
+function makeBasePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-uok-audit-sink-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return dir;
+}
+
+function validEnvelope(overrides: Partial<AuditEventEnvelope> = {}): AuditEventEnvelope {
+  return buildAuditEnvelope({
+    traceId: "trace-sink",
+    turnId: "turn-sink",
+    category: "orchestration",
+    type: "audit-sink-test",
+    payload: {},
+    ...overrides,
+  });
+}
+
+test("buildAuditEnvelope stamps version, eventId, and ts", () => {
+  const event = buildAuditEnvelope({
+    traceId: "trace-1",
+    category: "orchestration",
+    type: "turn-start",
+    payload: { unitType: "execute-task" },
+  });
+
+  assert.equal(event.version, CURRENT_UOK_CONTRACT_VERSION);
+  assert.equal(typeof event.eventId, "string");
+  assert.ok(event.eventId.length > 0, "eventId must be populated");
+  assert.equal(event.traceId, "trace-1");
+  assert.equal(event.turnId, undefined, "turnId is optional and omitted");
+  assert.equal(event.causedBy, undefined, "causedBy is optional and omitted");
+  assert.equal(event.category, "orchestration");
+  assert.equal(event.type, "turn-start");
+  assert.deepEqual(event.payload, { unitType: "execute-task" });
+  assert.match(event.ts, ISO_RE);
+});
+
+test("buildAuditEnvelope defaults payload to empty object when omitted", () => {
+  const event = buildAuditEnvelope({
+    traceId: "trace-2",
+    category: "orchestration",
+    type: "minimal",
+  });
+  assert.deepEqual(event.payload, {});
+});
+
+test("buildAuditEnvelope mints a unique eventId per call", () => {
+  const a = buildAuditEnvelope({ traceId: "t", category: "orchestration", type: "x" });
+  const b = buildAuditEnvelope({ traceId: "t", category: "orchestration", type: "x" });
+  assert.notEqual(a.eventId, b.eventId, "each call must mint a fresh eventId");
+});
+
+test("emitUokAuditEvent writes the jsonl projection when DB is unavailable", () => {
+  const basePath = makeBasePath();
+  try {
+    // No openDatabase() call → isDbAvailable() is false → DB branch skipped,
+    // envelope lands only in the jsonl projection.
+    emitUokAuditEvent(basePath, validEnvelope({ traceId: "trace-jsonl-only" }));
+
+    const events = readAuditEvents(basePath);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].traceId, "trace-jsonl-only");
+    assert.equal(events[0].category, "orchestration");
+    assert.equal(events[0].type, "audit-sink-test");
+  } finally {
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("emitUokAuditEvent drops the write when the turn is stale", () => {
+  _resetTurnEpoch();
+  const basePath = makeBasePath();
+  try {
+    // Capture generation 0, then bump to 1 so the captured turn is superseded.
+    bumpTurnGeneration("test: simulate timeout recovery");
+    const emitted = runWithTurnGeneration(0, () => {
+      emitUokAuditEvent(basePath, validEnvelope({ traceId: "trace-stale" }));
+      return true;
+    });
+
+    assert.equal(emitted, true, "emit must return without throwing on a stale turn");
+    assert.equal(existsSync(auditEventsPath(basePath)), false, "stale write must not create the projection");
+    assert.equal(readAuditEvents(basePath).length, 0, "stale write must not persist anything");
+  } finally {
+    _resetTurnEpoch();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("emitUokAuditEvent throws on an invalid envelope", () => {
+  const basePath = makeBasePath();
+  try {
+    // Missing required string fields (traceId/category/type) → validator reports issues.
+    const invalid = {
+      version: CURRENT_UOK_CONTRACT_VERSION,
+      eventId: "evt-bad",
+      ts: new Date().toISOString(),
+      payload: {},
+    } as unknown as AuditEventEnvelope;
+
+    assert.throws(
+      () => emitUokAuditEvent(basePath, invalid),
+      /Invalid UOK audit event:.*traceId/u,
+      "validation failure must throw with the offending field path",
+    );
+    assert.equal(readAuditEvents(basePath).length, 0, "invalid event must not be persisted");
+  } finally {
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("emitUokAuditEvent re-throws when the authoritative DB write fails", (t) => {
+  const basePath = makeBasePath();
+  const dbPath = join(basePath, ".gsd", "gsd.db");
+  assert.equal(openDatabase(dbPath), true, "DB must open for this scenario");
+  t.after(() => {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  // Break the authoritative sink: drop the audit_events table so the prepared
+  // INSERT inside insertAuditEvent throws. This proves the DB failure surfaces
+  // to the caller as a wrapped error rather than being silently swallowed.
+  _getAdapter()!.exec("DROP TABLE audit_events");
+
+  assert.throws(
+    () => emitUokAuditEvent(basePath, validEnvelope({ traceId: "trace-db-fail" })),
+    /DB authoritative audit write failed/u,
+    "a failed authoritative DB write must re-throw to the caller",
+  );
+});
+
+test("emitUokAuditEvent swallows jsonl projection failures (best-effort)", (t) => {
+  const basePath = makeBasePath();
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+
+  // Point the envelope at a path whose parent directory cannot be created:
+  // gsdRoot() resolves under basePath, so a basePath whose .gsd is a regular
+  // file makes mkdirSync(audit/) throw — exercising the silent catch.
+  // We pre-create .gsd as a file so ensureAuditDir()'s recursive mkdir fails.
+  rmSync(join(basePath, ".gsd"), { recursive: true, force: true });
+  writeFileSync(join(basePath, ".gsd"), "not-a-directory");
+
+  // With no DB open and an unwritable projection path, emit must NOT throw —
+  // audit writes are explicitly best-effort and must never break orchestration.
+  assert.doesNotThrow(() => {
+    emitUokAuditEvent(basePath, validEnvelope({ traceId: "trace-swallow" }));
+  }, "jsonl projection failure must be swallowed, not propagated");
+});


### PR DESCRIPTION
## Summary

Adds log-assertion test coverage for every important error/warning path surfaced in the gsd extension logging audit, so regressions that drop or misroute an operator-facing log surface as test failures rather than going silent.

## Coverage added (10 new test files, ~53 tests)

| Path | Sites asserted |
|---|---|
| uok/audit sink | all 4 `emitUokAuditEvent` branches + builder |
| auto-recovery | 20 verify/blocker/parse/finalize call sites (`:203`, `:411`, `:445`, `:462`, `:487`, `:494`, `:502`, `:511`, `:515`, `:522`, `:543`, `:553`, `:559`, `:622`, `:755`, `:768`, `:837`, `:840`, `:843`, `:898`, `:908`) |
| db/engine | checkpoint/vacuum/close/snapshot/readTransaction-rollback failures (`:641`, `:648`, `:699`, `:707`, `:727`, `:772`) |
| reconcile | copy/realpath/unsafe-path/cannot-open-main-DB/reconcile-tx failures (`:22`, `:71`, `:76`, `:82`, `:494`) |
| auto-dispatch | discuss DB-degradation, reactive graph derivation, registry fallback (`:407`, `:1494`, `:1834`) |
| auto-worktree | shelter-restore failure (#2505 data-loss guard) (`:1809`, `:1816`) |
| orchestrator | uok gate emit, settlement projection rebuild, branch discovery (`:538`, `:637`, `:660`) |

## Production seams (6, all `@internal`, null by default, no production caller)

Six production-neutral injection seams make previously-unreachable defensive error paths deterministically testable. The wrapped code (`parseLegacyRoadmap`/`loadSliceTaskIO`/`saveJsonFile`) is internally defensive — it swallows all malformed-input errors — so test fixtures cannot trigger the catch branches without an injection point. Each seam returns a restore function and follows the existing `setReassessmentCheckerForTest` convention:

- `_setRestoreEntryFnForTests` (auto-worktree shelter restore)
- `_setProjectionRebuildFnForTests` (orchestrator settlement rebuild)
- `setReactiveGraphDeriveFnForTest` (auto-dispatch reactive derivation)
- `_setRoadmapParserFnForTests` (auto-recovery roadmap parse)
- `_setGithubFinalizeFnForTests` (auto-recovery detached finalize)
- `_setMainDbOpenerFnForTests` (reconcile main-DB open)

## Verification

- 76/76 of the new + modified logging tests pass off `main`.
- `tsc --noEmit -p tsconfig.extensions.json` clean.

## Scope note

This branch contains **only** the logging test coverage. It was split out of a larger feature branch (`feat/tui-visual-simplification`) that mixed it with unrelated TUI work; that unrelated work is deliberately excluded here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default production paths are unchanged when test hooks stay null; risk is limited to accidental misuse of `@internal` seams or subtle routing differences in injected GitHub finalize / restore copy wiring.
> 
> **Overview**
> Adds **log-assertion tests** across the GSD extension so regressions that drop or misroute `recovery`, `dispatch`, `engine`, `db`, and `worktree` warnings/errors fail CI instead of going silent in production.
> 
> To reach **best-effort catch branches** that are hard to trigger with fixtures alone, the PR wires **six `@internal` test seams** (null in production, restore-on-teardown): reactive graph derivation, roadmap parsing, detached GitHub finalize, shelter restore copy, post-settlement markdown projection rebuild, and main-DB open during worktree reconcile. Production call sites route through these hooks only when injected.
> 
> New coverage spans **UOK audit sink** branches, **auto-recovery** verify/blocker/parse/finalize paths, **db/engine** checkpoint/vacuum/close/snapshot/rollback, **reconcile** failure modes, **dispatch** registry fallback / DB degradation / reactive derivation, **orchestrator** `advance()` failure logs, and **milestone merge** shelter-retain behavior (#2505).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b07a02ae5deb27d709a548fa73b29da4b448822d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->