### PR TITLE
fix(test): restore verify:full unit test parity

### DIFF
--- a/scripts/dist-test-resolve.mjs
+++ b/scripts/dist-test-resolve.mjs
@@ -81,6 +81,7 @@ function toResolveSpecifier(target, context) {
   const parent = context.parentURL ?? '';
   const needsFilesystemPath =
     isJitiCjsParent(context) ||
+    parent.includes('/dist-test/') ||
     parent.includes('/dist/') ||
     parent.endsWith('.cjs');
   return needsFilesystemPath ? fileURLToPath(target) : target;

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -607,6 +607,7 @@ test("runProviderChecks reports ok for Google via google-gemini-cli auth.json (#
 
   withEnv({
     HOME: tmpHome,
+    PATH: tmpHome,
     GEMINI_API_KEY: undefined,
     GOOGLE_API_KEY: undefined,
   }, () => {

--- a/src/tests/fixtures/prompt-golden-fixtures.ts
+++ b/src/tests/fixtures/prompt-golden-fixtures.ts
@@ -16,8 +16,8 @@ export const promptGoldenUnits = [
     unitType: "execute-task",
     // Tool Surface guidance and related prompt additions have grown this prompt;
     // the baseline is adjusted so the gate still tracks shrinkage from the
-    // original oversized prompts while allowing today's ~8259-char fixture.
-    phase2StartChars: 13770,
+    // original oversized prompts while allowing today's ~8536-char fixture.
+    phase2StartChars: 14230,
     requiredMarkers: [
       "UNIT: Execute Task T01",
       "Inlined Task Plan",
@@ -32,8 +32,8 @@ export const promptGoldenUnits = [
     unitType: "complete-slice",
     // Tool Surface guidance and subsequent feature additions have grown this
     // prompt; the baseline is adjusted so the gate still tracks shrinkage from
-    // the original oversized prompts while allowing today's ~8349-char fixture.
-    phase2StartChars: 13940,
+    // the original oversized prompts while allowing today's ~8613-char fixture.
+    phase2StartChars: 14400,
     requiredMarkers: [
       "UNIT: Complete Slice S01",
       "Tool Surface",


### PR DESCRIPTION
## Summary
- Isolate the Google Gemini CLI doctor provider check from host PATH so Antigravity CLI on PATH no longer masks `google-gemini-cli` auth routing (#2922).
- Refresh prompt golden Phase 2 baselines for current `execute-task` and `complete-slice` fixture sizes.
- Fix `dist-test-resolve.mjs` to return filesystem paths (not `file://` URLs) when resolving packages from `dist-test/`, fixing Typebox module resolution in compiled extension loader tests.

## Test plan
- [x] `pnpm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/doctor-providers.test.js --test-name-pattern "google-gemini-cli auth"`
- [x] `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/prompt-golden-fixtures.test.js --test-name-pattern "Phase 2"`
- [x] `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/search-tool-registration-gating.test.js`
- [ ] `pnpm run verify:full`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->