### PR TITLE
fix(browser-tools): fall back to PATH when bundled gsd-browser lacks native bin

### DIFF
--- a/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
@@ -1,7 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
 const {
+  resolveBundledGsdBrowserCliPath,
   resolveGsdBrowserDaemonStartInvocation,
   resolveGsdBrowserMcpLaunchConfig,
 } = await import("../../shared/gsd-browser-cli.ts");
@@ -54,6 +60,80 @@ describe("resolveGsdBrowserMcpLaunchConfig identity flags", () => {
     const projectId = args[args.indexOf("--identity-project") + 1];
     assert.equal(typeof projectId, "string");
     assert.doesNotMatch(projectId, /[\\/]/);
+  });
+});
+
+describe("bundled launcher without native binary", () => {
+  it("treats npm launcher-only explicit CLI paths as unavailable", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gsd-browser-launcher-only-"));
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const launcherPath = join(binDir, "gsd-browser");
+    writeFileSync(
+      launcherPath,
+      [
+        "#!/usr/bin/env node",
+        '"use strict";',
+        "process.exit(1);",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(launcherPath, 0o755);
+
+    const env = {
+      ...process.env,
+      GSD_BROWSER_CLI_PATH: launcherPath,
+    };
+
+    assert.equal(resolveBundledGsdBrowserCliPath(env), null);
+  });
+
+  it("prefers PATH launch when bundled npm launcher lacks native binary", (t) => {
+    const requireFromHere = createRequire(import.meta.url);
+    let bundledLauncher;
+    try {
+      const packageJsonPath = requireFromHere.resolve("@opengsd/gsd-browser/package.json");
+      bundledLauncher = join(dirname(packageJsonPath), "bin", "gsd-browser");
+    } catch {
+      return t.skip("bundled @opengsd/gsd-browser is not installed");
+    }
+
+    const nativePath = join(dirname(bundledLauncher), "gsd-browser-bin");
+    if (!existsSync(bundledLauncher) || existsSync(nativePath)) {
+      return t.skip("bundled launcher-only layout not present in this install");
+    }
+
+    const launch = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", process.env, { sessionSuffix: "pi-test" });
+    assert.equal(launch.command, "gsd-browser");
+    assert.equal(launch.args[0], "mcp");
+  });
+
+  it("accepts bundled launchers when the native binary is present", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gsd-browser-runnable-"));
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const launcherPath = join(binDir, "gsd-browser");
+    const nativePath = join(binDir, "gsd-browser-bin");
+    writeFileSync(
+      launcherPath,
+      [
+        "#!/usr/bin/env node",
+        '"use strict";',
+        "process.exit(0);",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(nativePath, "native");
+    chmodSync(launcherPath, 0o755);
+    chmodSync(nativePath, 0o755);
+
+    const env = {
+      ...process.env,
+      GSD_BROWSER_CLI_PATH: launcherPath,
+      GSD_BROWSER_PATH_VERSION: "0.1.0",
+    };
+
+    assert.equal(resolveBundledGsdBrowserCliPath(env), launcherPath);
   });
 });
 

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -117,15 +117,48 @@ function resolvePathGsdBrowserVersion(env: NodeJS.ProcessEnv): string | null {
   return cachedPathProbeVersion;
 }
 
+function resolveGsdBrowserNativeBinaryPath(launcherPath: string, platform: NodeJS.Platform = process.platform): string {
+  const binDir = resolve(launcherPath, "..");
+  const nativeName = platform === "win32" ? "gsd-browser.exe" : "gsd-browser-bin";
+  return resolve(binDir, nativeName);
+}
+
+function isNodeShLauncher(launcherPath: string): boolean {
+  try {
+    return readFileSync(launcherPath, "utf-8").startsWith("#!");
+  } catch {
+    // Non-text launchers (native binaries) are runnable without a sibling shim.
+    return false;
+  }
+}
+
+/**
+ * The npm package ships a node launcher that execs `gsd-browser-bin` beside it.
+ * pnpm can skip postinstall, leaving only the launcher — which exits immediately
+ * and surfaces as MCP "Connection closed". Treat that layout as unavailable.
+ */
+function isGsdBrowserPackageLauncherRunnable(launcherPath: string): boolean {
+  if (!existsSync(launcherPath)) return false;
+  const nativePath = resolveGsdBrowserNativeBinaryPath(launcherPath);
+  if (existsSync(nativePath)) return true;
+  return !isNodeShLauncher(launcherPath);
+}
+
 function shouldPreferPathGsdBrowser(env: NodeJS.ProcessEnv): boolean {
   const pathVersion = resolvePathGsdBrowserVersion(env);
   if (!pathVersion) return false;
 
   const bundledVersion = resolveBundledGsdBrowserPackageVersion();
-  return !bundledVersion || compareSemverLocal(pathVersion, bundledVersion) > 0;
+  if (!bundledVersion || compareSemverLocal(pathVersion, bundledVersion) > 0) {
+    return true;
+  }
+
+  // Same or newer bundled semver still loses when the package launcher cannot run.
+  const bundledLauncher = resolveBundledGsdBrowserLauncherPath(env);
+  return bundledLauncher !== null && !isGsdBrowserPackageLauncherRunnable(bundledLauncher);
 }
 
-export function resolveBundledGsdBrowserCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
+function resolveBundledGsdBrowserLauncherPath(env: NodeJS.ProcessEnv = process.env): string | null {
   const explicit = resolveExplicitGsdBrowserCliPath(env);
   if (explicit) return explicit;
 
@@ -148,6 +181,12 @@ export function resolveBundledGsdBrowserCliPath(env: NodeJS.ProcessEnv = process
   }
 
   return null;
+}
+
+export function resolveBundledGsdBrowserCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const launcher = resolveBundledGsdBrowserLauncherPath(env);
+  if (!launcher || !isGsdBrowserPackageLauncherRunnable(launcher)) return null;
+  return launcher;
 }
 
 export type GsdBrowserCliAvailability =


### PR DESCRIPTION
## Summary

- Detect when `@opengsd/gsd-browser` is installed as an npm launcher only (missing sibling `gsd-browser-bin`), which happens when pnpm skips postinstall.
- Treat that layout as unavailable for bundled resolution and prefer PATH `gsd-browser` when the bundled package cannot actually run.
- Add regression tests for launcher-only explicit paths, runnable bundled layouts, and PATH fallback when the local install is launcher-only.

Fixes the session-start warning: `gsd-browser engine unavailable (MCP error -32000: Connection closed); using Playwright browser tools for this session.`

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs`
- [ ] CI fast-gates
- [ ] Manual: remove `gsd-browser-bin` from bundled package, restart gsd-pi — should use PATH `gsd-browser` without Playwright fallback warning


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->