### PR TITLE
feat(compat): gsd-core ↔ gsd-pi backwards compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ bun.lock
 .gsd/
 .gsd
 .gsd-id
+
+# Exception: committed test fixtures that legitimately contain a .gsd/ tree
+# (round-trip property tests for gsd-core ↔ gsd-pi compatibility).
+!src/resources/extensions/gsd/tests/__fixtures__/**/.gsd/
+!src/resources/extensions/gsd/tests/__fixtures__/**/.gsd/**/*
 .bg_shell
 .bg-shell/
 .artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ bun.lock
 # (round-trip property tests for gsd-core ↔ gsd-pi compatibility).
 !src/resources/extensions/gsd/tests/__fixtures__/**/.gsd/
 !src/resources/extensions/gsd/tests/__fixtures__/**/.gsd/**/*
+# Note: .planning/ fixtures under tests/__fixtures__/ are force-added (git add -f)
+# because git cannot re-include files under an excluded parent directory. The
+# bare .planning/ rule below excludes the dir; force-add overrides it for
+# tracked test fixtures only.
 .bg_shell
 .bg-shell/
 .artifacts/

--- a/.planning/phases/02-websocket-relay-and-daemon/02-01-PLAN.md
+++ b/.planning/phases/02-websocket-relay-and-daemon/02-01-PLAN.md
@@ -1,0 +1,210 @@
+---
+phase: 02-websocket-relay-and-daemon
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - packages/contracts/src/relay.ts
+  - packages/db/src/schema/devices.ts
+  - packages/daemon/src/cloud-runtime.ts
+  - packages/daemon/src/cloud-runtime.test.ts
+autonomous: true
+requirements:
+  - DMGN-01
+  - DMGN-02
+  - DMGN-06
+  - DMGN-03
+
+must_haves:
+  truths:
+    - "Daemon reconnects with exponential backoff and jitter after disconnect, not fixed 5s delay"
+    - "SIGTERM sends WebSocket close code 1000 before process exits"
+    - "All relay messages carry a channel field for multiplexing"
+  artifacts:
+    - path: "packages/contracts/src/relay.ts"
+      provides: "Typed discriminated union protocol for relay messages"
+      exports: ["RelayChannel", "RelayEnvelope", "DaemonToRelayMessage", "RelayToDaemonMessage"]
+    - path: "packages/db/src/schema/devices.ts"
+      provides: "isOnline boolean column and tokenPrefix text column on devices table"
+      contains: "isOnline"
+    - path: "packages/daemon/src/cloud-runtime.ts"
+      provides: "Exponential backoff with jitter reconnect and close code 1000 on SIGTERM"
+      contains: "exponentialBackoffWithJitter"
+  key_links:
+    - from: "packages/daemon/src/cloud-runtime.ts"
+      to: "packages/contracts/src/relay.ts"
+      via: "imports DaemonToRelayMessage and RelayToDaemonMessage types"
+      pattern: "from.*contracts.*relay"
+---
+
+<objective>
+Typed relay protocol, device schema hardening, and daemon reconnect/shutdown improvements (D-04, D-09, D-10, D-11, DMGN-01, DMGN-02, DMGN-03, DMGN-06)
+
+Purpose: Establish the typed message contract both relay and daemon will use, add the isOnline column the dashboard needs, and harden the daemon's reconnect and shutdown behavior.
+Output: packages/contracts/src/relay.ts, updated devices schema, hardened CloudRuntime with backoff/jitter and close codes.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-websocket-relay-and-daemon/02-RESEARCH.md
+@packages/contracts/src/rpc.ts
+@packages/cloud-mcp-gateway/src/protocol.ts
+@packages/daemon/src/cloud-runtime.ts
+@packages/db/src/schema/devices.ts
+</context>
+
+## Artifacts this phase produces
+
+| Symbol | File | Kind |
+|--------|------|------|
+| `RelayChannel` | packages/contracts/src/relay.ts | type |
+| `RelayEnvelope` | packages/contracts/src/relay.ts | interface |
+| `DaemonToRelayMessage` | packages/contracts/src/relay.ts | type union |
+| `RelayToDaemonMessage` | packages/contracts/src/relay.ts | type union |
+| `RuntimeProject` | packages/contracts/src/relay.ts | interface (re-export from protocol.ts) |
+| `exponentialBackoffWithJitter` | packages/daemon/src/cloud-runtime.ts | function |
+| `isOnline` column | packages/db/src/schema/devices.ts | schema column |
+| `tokenPrefix` column | packages/db/src/schema/devices.ts | schema column |
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Typed relay protocol contracts and device schema update</name>
+  <files>packages/contracts/src/relay.ts, packages/contracts/src/index.ts, packages/db/src/schema/devices.ts</files>
+  <read_first>
+    - packages/contracts/src/rpc.ts (existing contract patterns — import style, export style)
+    - packages/contracts/src/index.ts (barrel exports — add relay.ts re-export)
+    - packages/cloud-mcp-gateway/src/protocol.ts (existing message types — evolve, do not duplicate)
+    - packages/db/src/schema/devices.ts (existing columns — add isOnline and tokenPrefix)
+  </read_first>
+  <action>
+    Create packages/contracts/src/relay.ts with typed discriminated union message protocol per D-09, D-10, D-11.
+
+    Define RelayChannel as a union: "gsd" | "control" | "fs" | template-literal for terminal sessions. Keep the terminal template literal open for Phase 4 extensibility per D-11.
+
+    Define RelayEnvelope interface with channel (RelayChannel), optional requestId (string).
+
+    Define DaemonToRelayMessage as a discriminated union of intersection types (RelayEnvelope and specific message shapes):
+    - channel "control", type "hello": runtimeId string, optional runtimeName string, projects array of RuntimeProject
+    - channel "control", type "heartbeat": at number (Date.now timestamp)
+    - channel "control", type "state.sync": projects array of RuntimeProject
+    - channel "gsd", type "cmd.output": requestId string, output unknown, done boolean
+    - channel "gsd", type "cmd.error": requestId string, error string
+
+    Define RelayToDaemonMessage as a discriminated union:
+    - channel "control", type "connected": runtimeId string, optional latestVersion string
+    - channel "control", type "heartbeat.ack": serverTime number, optional latestVersion string
+    - channel "gsd", type "cmd.exec": requestId string, toolName string, args Record of string to unknown, optional projectAlias string
+    - channel "gsd", type "cancel": requestId string
+
+    Re-export the RuntimeProject interface from the existing protocol.ts file (import from cloud-mcp-gateway/src/protocol.ts or define inline if the contracts package should not depend on cloud-mcp-gateway). Use TypeScript types only — no runtime zod validation in contracts (per Pitfall 6 from RESEARCH.md about zod version conflict between packages).
+
+    Add barrel re-export in packages/contracts/src/index.ts.
+
+    Update packages/db/src/schema/devices.ts: add isOnline boolean column (default false) and tokenPrefix text column (nullable, stores first 8 hex chars of device token for faster lookup). These columns must use drizzle-orm/pg-core boolean and text helpers matching existing column patterns.
+  </action>
+  <acceptance_criteria>
+    - packages/contracts/src/relay.ts exports RelayChannel, RelayEnvelope, DaemonToRelayMessage, RelayToDaemonMessage
+    - All message types carry a channel field
+    - DaemonToRelayMessage and RelayToDaemonMessage are discriminated unions with channel + type as discriminants
+    - packages/contracts/src/index.ts re-exports relay types
+    - packages/db/src/schema/devices.ts has isOnline (boolean, default false) and tokenPrefix (text, nullable)
+    - No runtime zod imports in contracts package
+    - tsc --noEmit passes on packages/contracts
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/contracts && npx tsc --noEmit && node -e "const r = require('./dist/relay.js'); console.log(Object.keys(r))" 2>/dev/null || echo "types-only module — tsc pass is sufficient"</automated>
+  </verify>
+  <done>Typed relay protocol types compile without errors and are exported from contracts barrel. Devices schema includes isOnline and tokenPrefix columns.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Daemon exponential backoff, close codes, and protocol adoption</name>
+  <files>packages/daemon/src/cloud-runtime.ts, packages/daemon/src/cloud-runtime.test.ts</files>
+  <read_first>
+    - packages/daemon/src/cloud-runtime.ts (full file — understand handleSocketClose, stop(), handleMessage, send)
+    - packages/daemon/src/cloud-runtime.test.ts (existing tests — add to, do not replace)
+    - packages/contracts/src/relay.ts (types from Task 1 — import DaemonToRelayMessage)
+  </read_first>
+  <behavior>
+    - Test 1: exponentialBackoffWithJitter returns values in [0, min(cap, base * 2^attempt)] range; attempt 0 range [0, 1000], attempt 5 range [0, 32000], attempt 10+ range [0, 60000]
+    - Test 2: exponentialBackoffWithJitter cap prevents values above 60000ms regardless of attempt count
+    - Test 3: Multiple calls to exponentialBackoffWithJitter produce non-identical results (jitter verification via statistical sampling)
+    - Test 4: stop() sends close code 1000 with reason string (mock WebSocket, verify close called with 1000)
+    - Test 5: reconnectAttempt resets to 0 on successful socket open
+    - Test 6: connect() creates a WebSocket to the relay URL and registers message/close/error handlers (DMGN-01 persistent connection)
+  </behavior>
+  <action>
+    Add a module-level pure function exponentialBackoffWithJitter(attempt: number, baseMs = 1000, capMs = 60000): number. Formula: Math.random() * Math.min(capMs, baseMs * Math.pow(2, attempt)). This is the "full jitter" strategy from the AWS Builder's Library.
+
+    Add private field reconnectAttempt = 0 to CloudRuntime.
+
+    In handleSocketClose: replace the fixed 5000ms setTimeout with a call to exponentialBackoffWithJitter(this.reconnectAttempt). Increment reconnectAttempt after computing delay (cap at 10 to avoid numeric overflow). Log the computed delay for observability.
+
+    In handleSocketOpen: reset this.reconnectAttempt = 0.
+
+    In stop(): change socket?.close() to socket?.close(1000, "daemon shutdown") per DMGN-06 / Gap 4 from RESEARCH.md.
+
+    Update the GatewayMessage interface to import from packages/contracts/src/relay.ts types if the daemon package can resolve contracts. If not (workspace resolution issue), keep the local interface but align field names (add channel field to all outbound messages). The send() calls for heartbeat, hello, and tool_result must include channel: "control" or channel: "gsd" as appropriate per the protocol contract.
+
+    Update handleMessage to accept messages with channel field. For backward compatibility, handle messages without channel field by inferring channel from message type.
+
+    Write tests in cloud-runtime.test.ts using node:test. Export exponentialBackoffWithJitter so it can be tested directly as a pure function. Test stop() close code by mocking the WebSocket instance.
+  </action>
+  <acceptance_criteria>
+    - exponentialBackoffWithJitter is exported and testable
+    - Backoff values grow exponentially and are capped at 60s
+    - Backoff values include jitter (non-deterministic)
+    - stop() calls socket.close(1000, "daemon shutdown")
+    - reconnectAttempt resets on successful connection
+    - All outbound messages include channel field
+    - CloudRuntime.connect() establishes and maintains a persistent outbound WebSocket connection to the relay (DMGN-01); test verifies connect() creates a WebSocket to the relay URL and sets up message/close/error handlers
+    - Existing tests continue to pass
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/daemon && pnpm run build && node --test dist/cloud-runtime.test.js</automated>
+  </verify>
+  <done>CloudRuntime uses exponential backoff with full jitter for reconnection (not fixed 5s). SIGTERM produces close code 1000. All messages carry channel field. connect() establishes persistent WebSocket connection (DMGN-01). Tests pass.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| daemon to relay | Outbound WebSocket from untrusted network; daemon identity validated by relay at connect |
+| contracts to consumers | Type-only package — no runtime trust boundary, compile-time contract only |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-01 | Spoofing | DaemonToRelayMessage channel field | mitigate | Relay validates channel against known enum; unknown channels rejected |
+| T-02-02 | Tampering | exponentialBackoffWithJitter | accept | Pure function with no external inputs beyond attempt counter; no security surface |
+| T-02-03 | Denial of Service | Reconnect storm | mitigate | Full jitter prevents simultaneous reconnects after relay restart |
+| T-02-SC | Tampering | npm/pip/cargo installs | accept | No new package installs in this plan |
+</threat_model>
+
+<verification>
+- packages/contracts builds with tsc --noEmit
+- packages/daemon test suite passes (existing + new backoff/close-code tests)
+- All outbound messages from CloudRuntime include channel field
+</verification>
+
+<success_criteria>
+Typed protocol contract exists in packages/contracts/src/relay.ts. CloudRuntime reconnects with exponential backoff (not fixed delay), sends close code 1000 on SIGTERM, and all messages carry the channel discriminant. Devices schema includes isOnline and tokenPrefix columns. CloudRuntime.connect() establishes a persistent outbound WebSocket connection (DMGN-01).
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-websocket-relay-and-daemon/02-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-websocket-relay-and-daemon/02-02-PLAN.md
+++ b/.planning/phases/02-websocket-relay-and-daemon/02-02-PLAN.md
@@ -1,0 +1,236 @@
+---
+phase: 02-websocket-relay-and-daemon
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - packages/cloud-mcp-gateway/src/auth-store-db.ts
+  - packages/cloud-mcp-gateway/src/server.ts
+  - packages/cloud-mcp-gateway/src/runtime-registry.ts
+  - packages/cloud-mcp-gateway/src/auth-store-db.test.ts
+  - packages/cloud-mcp-gateway/src/runtime-registry.test.ts
+  - packages/cloud-mcp-gateway/package.json
+autonomous: true
+requirements:
+  - RELY-01
+  - RELY-02
+  - RELY-03
+  - RELY-04
+
+must_haves:
+  truths:
+    - "Relay authenticates daemon connections against Neon Postgres device tokens, not file-based store"
+    - "Relay closes connections that have been silent for 60+ seconds and marks the device offline in DB"
+    - "Relay routes commands only to machines belonging to the authenticated user"
+    - "Device auto-recovers to online status when daemon reconnects after being marked offline"
+  artifacts:
+    - path: "packages/cloud-mcp-gateway/src/auth-store-db.ts"
+      provides: "DrizzleAuthStore that validates device tokens against Neon DB"
+      exports: ["DrizzleAuthStore"]
+    - path: "packages/cloud-mcp-gateway/src/runtime-registry.ts"
+      provides: "Heartbeat sweep timer and DB status writes"
+      contains: "sweepStaleConnections"
+    - path: "packages/cloud-mcp-gateway/src/server.ts"
+      provides: "Server wired to DrizzleAuthStore and registry events"
+      contains: "DrizzleAuthStore"
+  key_links:
+    - from: "packages/cloud-mcp-gateway/src/server.ts"
+      to: "packages/cloud-mcp-gateway/src/auth-store-db.ts"
+      via: "uses DrizzleAuthStore for WebSocket upgrade auth"
+      pattern: "DrizzleAuthStore"
+    - from: "packages/cloud-mcp-gateway/src/runtime-registry.ts"
+      to: "packages/db/src/schema/devices.ts"
+      via: "writes isOnline and lastSeenAt to devices table on connect/disconnect/sweep"
+      pattern: "devices.*isOnline"
+
+user_setup:
+  - service: neon-postgres
+    why: "Relay server connects to Neon Postgres for device token validation"
+    env_vars:
+      - name: DATABASE_URL
+        source: "Neon dashboard -> Connection Details -> Direct connection string (same as Phase 1)"
+---
+
+<objective>
+Relay server hardening: DB-backed auth, heartbeat sweep, and online/offline DB writes (D-02, D-05, RELY-01, RELY-02, RELY-03, RELY-04)
+
+Purpose: Make the relay server authenticate daemons against the shared Neon DB (not file/in-memory), detect stale connections via heartbeat sweep, and write online/offline status to the devices table so the dashboard can display it.
+Output: DrizzleAuthStore, hardened RuntimeRegistry with sweep timer, server.ts wired to DB auth.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-websocket-relay-and-daemon/02-RESEARCH.md
+@packages/cloud-mcp-gateway/src/auth-store.ts
+@packages/cloud-mcp-gateway/src/server.ts
+@packages/cloud-mcp-gateway/src/runtime-registry.ts
+@packages/db/src/schema/devices.ts
+@packages/db/src/client.ts
+</context>
+
+## Artifacts this phase produces
+
+| Symbol | File | Kind |
+|--------|------|------|
+| `DrizzleAuthStore` | packages/cloud-mcp-gateway/src/auth-store-db.ts | class |
+| `sweepStaleConnections` | packages/cloud-mcp-gateway/src/runtime-registry.ts | method |
+| `startHeartbeatSweep` | packages/cloud-mcp-gateway/src/runtime-registry.ts | method |
+| `stopHeartbeatSweep` | packages/cloud-mcp-gateway/src/runtime-registry.ts | method |
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: DrizzleAuthStore for Neon DB device token validation</name>
+  <files>packages/cloud-mcp-gateway/src/auth-store-db.ts, packages/cloud-mcp-gateway/src/auth-store-db.test.ts, packages/cloud-mcp-gateway/package.json</files>
+  <read_first>
+    - packages/cloud-mcp-gateway/src/auth-store.ts (existing InMemoryAuthStore — reuse DeviceTokenRecord interface, deriveSecretHash function, timingSafeEqual pattern)
+    - packages/db/src/schema/devices.ts (actual column names: id, userId, apiKeyHash, lastSeenAt, revokedAt; note this uses SHA-256 not scrypt)
+    - packages/cloud-mcp-gateway/package.json (check existing dependencies — add pg and drizzle-orm if not present)
+    - packages/db/src/client.ts (the neon-http client — relay needs node-postgres pg pool instead for long-lived process)
+  </read_first>
+  <behavior>
+    - Test 1: authenticateDevice returns DeviceTokenRecord when valid token matches a non-revoked device
+    - Test 2: authenticateDevice returns null for undefined or empty token
+    - Test 3: authenticateDevice returns null when device has revokedAt set
+    - Test 4: authenticateDevice returns null when no matching hash exists
+    - Test 5: updateLastSeen writes new lastSeenAt and isOnline=true for given runtimeId
+    - Test 6: markOffline writes isOnline=false for given runtimeId
+  </behavior>
+  <action>
+    Create packages/cloud-mcp-gateway/src/auth-store-db.ts implementing DrizzleAuthStore.
+
+    CRITICAL schema alignment: Phase 1 devices table uses apiKeyHash (SHA-256 via createHash) NOT scrypt. The relay's existing auth-store.ts uses scrypt. DrizzleAuthStore must match Phase 1's approach: SHA-256 hash comparison using crypto.createHash("sha256").update(token).digest("hex"), then constant-time compare via timingSafeEqual against the apiKeyHash column.
+
+    If the devices schema has a tokenPrefix column (added in Plan 01), use it to narrow candidates before hash comparison: SELECT where tokenPrefix equals first 8 hex chars of the incoming token. This avoids full table scan at scale.
+
+    If tokenPrefix column is not yet present (plan execution order), fall back to loading all non-revoked devices and comparing hashes. Add a comment documenting the optimization path.
+
+    Constructor takes a connectionString parameter. Create a pg Pool with max: 5 connections. Create a drizzle instance using drizzle-orm/node-postgres adapter.
+
+    authenticateDevice(token: string | undefined): returns Promise of DeviceTokenRecord or null. Query devices where isActive is not false (check if column exists) and revokedAt IS NULL. Hash the incoming token with SHA-256, compare against apiKeyHash using timingSafeEqual. Return userId, runtimeId (= device.id), runtimeName (= device.label or device.runtimeName).
+
+    updateLastSeen(runtimeId: string): writes lastSeenAt = new Date() and isOnline = true.
+
+    markOffline(runtimeId: string): writes isOnline = false (does not clear lastSeenAt — that stays as the last known time).
+
+    Add pg (^8.x) to packages/cloud-mcp-gateway/package.json dependencies. drizzle-orm should already be present or add it.
+
+    Write tests using node:test. Mock the DB layer by injecting a mock drizzle instance or by testing the hash comparison logic in isolation (export the hash comparison helper).
+  </action>
+  <acceptance_criteria>
+    - DrizzleAuthStore.authenticateDevice validates tokens using SHA-256 hash comparison via createHash('sha256'), NOT scrypt — matching the Phase 1 device token schema that stores apiKeyHash as SHA-256 hex
+    - Token comparison uses timingSafeEqual (constant-time)
+    - Revoked devices (revokedAt not null) are rejected
+    - updateLastSeen writes isOnline=true and current timestamp
+    - markOffline writes isOnline=false
+    - pg added to package.json dependencies
+    - Tests pass
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/cloud-mcp-gateway && pnpm run build && node --test dist/auth-store-db.test.js</automated>
+  </verify>
+  <done>DrizzleAuthStore validates device tokens against Neon DB using SHA-256 constant-time comparison. Revoked devices are rejected. Online/offline status methods work correctly. Tests pass.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: RuntimeRegistry heartbeat sweep and server wiring</name>
+  <files>packages/cloud-mcp-gateway/src/runtime-registry.ts, packages/cloud-mcp-gateway/src/runtime-registry.test.ts, packages/cloud-mcp-gateway/src/server.ts</files>
+  <read_first>
+    - packages/cloud-mcp-gateway/src/runtime-registry.ts (full file — understand attachRuntime, handleMessage, lastSeenAt tracking, runtimes Map)
+    - packages/cloud-mcp-gateway/src/server.ts (full file — understand upgrade handler, auth flow, createGatewayServer options)
+    - packages/cloud-mcp-gateway/src/auth-store-db.ts (from Task 1 — DrizzleAuthStore interface)
+  </read_first>
+  <behavior>
+    - Test 1: sweepStaleConnections closes sockets with lastSeenAt older than 60s threshold and removes from registry
+    - Test 2: sweepStaleConnections does NOT close sockets with recent lastSeenAt
+    - Test 3: sweepStaleConnections calls markOffline callback for each evicted runtime
+    - Test 4: attachRuntime calls updateLastSeen callback (for marking online in DB)
+    - Test 5: socket close event calls markOffline callback
+  </behavior>
+  <action>
+    Extend RuntimeRegistry to support heartbeat sweep and status callbacks per D-05, RELY-03.
+
+    Add constructor parameter or setter for status callbacks: onOnline(runtimeId: string, userId: string) and onOffline(runtimeId: string, userId: string). These callbacks will be wired to DrizzleAuthStore.updateLastSeen and DrizzleAuthStore.markOffline in server.ts.
+
+    Add private offlineThresholdMs = 60000 field.
+    Add private sweepTimer field.
+    Add startHeartbeatSweep() method: starts setInterval at 15s calling sweepStaleConnections.
+    Add stopHeartbeatSweep() method: clears the interval.
+
+    sweepStaleConnections(): iterate all runtimes. For each where Date.now() minus lastSeenAt exceeds offlineThresholdMs: close socket with code 1001 and reason "heartbeat timeout", delete from runtimes map, call failPendingForRuntime, call onOffline callback.
+
+    In attachRuntime: after adding runtime to map, call onOnline callback. Also update the existing socket close handler to call onOffline callback when a runtime disconnects cleanly.
+
+    In handleMessage: the existing lastSeenAt = Date.now() update is correct. Add a periodic DB write by calling onOnline on every heartbeat message (not every message — only heartbeat to avoid excessive DB writes).
+
+    Update server.ts:
+    - Add optional databaseUrl to GatewayServerOptions.
+    - When databaseUrl is provided, create DrizzleAuthStore instead of InMemoryAuthStore/FileAuthStore. Import from auth-store-db.ts.
+    - Wire registry callbacks: onOnline calls authStore.updateLastSeen, onOffline calls authStore.markOffline.
+    - After creating registry, call registry.startHeartbeatSweep().
+    - The authenticateDevice call in the upgrade handler becomes async (DrizzleAuthStore.authenticateDevice returns a Promise).
+    - Update the "connected" message sent after upgrade to include the channel field: channel: "control".
+
+    Write tests for sweepStaleConnections in runtime-registry.test.ts using node:test. Mock WebSocket with a simple object that has readyState, close(), send(), on(), removeAllListeners().
+  </action>
+  <acceptance_criteria>
+    - RuntimeRegistry.startHeartbeatSweep starts a 15s interval
+    - sweepStaleConnections evicts connections older than 60s and closes with code 1001
+    - onOnline callback fires on attachRuntime and heartbeat messages
+    - onOffline callback fires on sweep eviction and socket close
+    - server.ts uses DrizzleAuthStore when databaseUrl option is provided
+    - Upgrade handler supports async authenticateDevice
+    - Connected message includes channel: "control"
+    - Tests pass
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/cloud-mcp-gateway && pnpm run build && node --test dist/runtime-registry.test.js</automated>
+  </verify>
+  <done>RuntimeRegistry detects stale connections via 15s sweep with 60s threshold. Server uses DrizzleAuthStore for DB-backed auth. Online/offline callbacks write to devices table. Tests pass.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| daemon to relay | Untrusted WebSocket connection; identity established by token at upgrade |
+| relay to Neon DB | Trusted; relay authenticates via DATABASE_URL connection string |
+| browser to relay (future) | Dashboard commands routed via userId from session; not directly implemented here but registry enforces userId scoping |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-04 | Spoofing | DrizzleAuthStore token validation | mitigate | SHA-256 + timingSafeEqual; revoked devices rejected; token validated once at connect |
+| T-02-05 | Elevation of Privilege | Cross-tenant routing | mitigate | Registry key is userId:runtimeId; userId from DB token record, never from message payload |
+| T-02-06 | Denial of Service | Ghost sessions (laptop sleep/kill -9) | mitigate | sweepStaleConnections closes connections silent >60s |
+| T-02-07 | Information Disclosure | DB connection string exposure | mitigate | DATABASE_URL from env var, never logged; pg Pool uses SSL by default on Neon |
+| T-02-08 | Denial of Service | DB token lookup performance | accept | SHA-256 comparison is fast (unlike scrypt); tokenPrefix column narrows candidates; full scan acceptable at MVP scale (<1K devices) |
+| T-02-SC | Tampering | npm installs (pg package) | mitigate | pg is 12+ year npm package with 20M+ weekly downloads; well-established PostgreSQL driver |
+</threat_model>
+
+<verification>
+- DrizzleAuthStore correctly validates device tokens against Neon DB
+- RuntimeRegistry sweep closes stale connections within 60s
+- Server uses DB auth when DATABASE_URL is configured
+- All relay tests pass
+</verification>
+
+<success_criteria>
+Relay server authenticates daemon connections against Neon Postgres using SHA-256 token comparison. Stale connections (>60s without heartbeat) are closed and marked offline in DB. Reconnecting daemons are auto-marked online. All tests pass.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-websocket-relay-and-daemon/02-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-websocket-relay-and-daemon/02-03-PLAN.md
+++ b/.planning/phases/02-websocket-relay-and-daemon/02-03-PLAN.md
@@ -1,0 +1,229 @@
+---
+phase: 02-websocket-relay-and-daemon
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - packages/daemon/src/systemd.ts
+  - packages/daemon/src/systemd.test.ts
+  - packages/daemon/src/cli.ts
+  - packages/daemon/package.json
+autonomous: true
+requirements:
+  - DMGN-04
+  - DMGN-05
+  - DMGN-01
+
+must_haves:
+  truths:
+    - "User can run gsd-agent install on Linux to install a systemd user service"
+    - "User can run gsd-agent uninstall to remove the systemd user service"
+    - "User can run gsd-agent status to check if the service is running"
+    - "The systemd service survives machine reboots (lingering enabled)"
+    - "The gsd-agent binary entry point exists and routes to daemon CLI"
+  artifacts:
+    - path: "packages/daemon/src/systemd.ts"
+      provides: "systemd --user service install/uninstall/status"
+      exports: ["install", "uninstall", "status", "generateUnit"]
+    - path: "packages/daemon/src/cli.ts"
+      provides: "gsd-agent subcommand routing with install/uninstall/status for both macOS and Linux"
+      contains: "systemd"
+    - path: "packages/daemon/package.json"
+      provides: "gsd-agent bin entry point"
+      contains: "gsd-agent"
+  key_links:
+    - from: "packages/daemon/src/cli.ts"
+      to: "packages/daemon/src/systemd.ts"
+      via: "imports install/uninstall/status from systemd.ts on Linux"
+      pattern: "from.*systemd"
+    - from: "packages/daemon/src/cli.ts"
+      to: "packages/daemon/src/launchd.ts"
+      via: "imports install/uninstall/status from launchd.ts on macOS"
+      pattern: "from.*launchd"
+---
+
+<objective>
+Daemon service packaging: systemd installer for Linux and gsd-agent CLI entry point (D-06, D-07, DMGN-04, DMGN-05)
+
+Purpose: Let users install gsd-agent as a background service on both macOS (launchd, already exists) and Linux (systemd, new). Add gsd-agent as a bin entry point per D-06.
+Output: systemd.ts installer, updated cli.ts with platform-aware install routing, gsd-agent bin entry.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-websocket-relay-and-daemon/02-RESEARCH.md
+@packages/daemon/src/launchd.ts
+@packages/daemon/src/cli.ts
+@packages/daemon/package.json
+</context>
+
+## Artifacts this phase produces
+
+| Symbol | File | Kind |
+|--------|------|------|
+| `install` | packages/daemon/src/systemd.ts | function |
+| `uninstall` | packages/daemon/src/systemd.ts | function |
+| `status` | packages/daemon/src/systemd.ts | function |
+| `generateUnit` | packages/daemon/src/systemd.ts | function |
+| `SystemdStatus` | packages/daemon/src/systemd.ts | interface |
+| `UnitOptions` | packages/daemon/src/systemd.ts | interface |
+| `gsd-agent` bin | packages/daemon/package.json | bin entry |
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: systemd user service installer</name>
+  <files>packages/daemon/src/systemd.ts, packages/daemon/src/systemd.test.ts</files>
+  <read_first>
+    - packages/daemon/src/launchd.ts (full file — mirror the interface: PlistOptions -> UnitOptions, install/uninstall/status exports, RunCommandFn pattern, escapeXml -> no equivalent needed for INI)
+  </read_first>
+  <behavior>
+    - Test 1: generateUnit produces valid INI with correct ExecStart path, WorkingDirectory, and environment vars
+    - Test 2: generateUnit includes ANTHROPIC_API_KEY in Environment line when present in process.env
+    - Test 3: generateUnit uses WantedBy=default.target (not multi-user.target, since this is a user unit)
+    - Test 4: install writes unit file to ~/.config/systemd/user/gsd-agent.service, runs daemon-reload, enable, and start
+    - Test 5: uninstall runs stop, disable, daemon-reload, and removes unit file
+    - Test 6: status parses systemctl --user show output to determine registered/running/exit status
+    - Test 7: install calls loginctl enable-linger for reboot persistence (or documents fallback)
+  </behavior>
+  <action>
+    Create packages/daemon/src/systemd.ts mirroring the launchd.ts interface.
+
+    Define UnitOptions interface matching PlistOptions: nodePath (string), scriptPath (string), configPath (string), optional workingDirectory (string), optional stdoutPath (string), optional stderrPath (string).
+
+    Define SystemdStatus interface matching LaunchdStatus: registered (boolean), pid (number or null), lastExitStatus (number or null).
+
+    Define RunCommandFn type alias: (cmd: string) => string (same as launchd.ts).
+
+    Constants: LABEL = "gsd-agent", UNIT_FILENAME = LABEL + ".service".
+
+    getUnitPath(): returns path.join(homedir(), ".config", "systemd", "user", UNIT_FILENAME). This is the user-scoped systemd path (NOT /etc/systemd/system/).
+
+    generateUnit(opts: UnitOptions): string. Produces INI-format systemd unit file with:
+    - [Unit] section: Description="GSD Agent daemon", After=network-online.target, Wants=network-online.target
+    - [Service] section: Type=simple, ExecStart="{nodePath} {scriptPath} --config {configPath}", WorkingDirectory (opts.workingDirectory or homedir()), Restart=on-failure, RestartSec=5
+    - Environment lines: HOME={homedir()}, PATH={dirname(nodePath)}:/usr/local/bin:/usr/bin:/bin (same pattern as launchd.ts buildEnvPath)
+    - If process.env.ANTHROPIC_API_KEY is present, add Environment=ANTHROPIC_API_KEY={value}
+    - StandardOutput=append:{stdoutPath}, StandardError=append:{stderrPath} (default to ~/.gsd/daemon-stdout.log and ~/.gsd/daemon-stderr.log)
+    - [Install] section: WantedBy=default.target
+
+    install(opts: UnitOptions, runCommand?: RunCommandFn): void.
+    - Ensure ~/.config/systemd/user/ directory exists (mkdirSync recursive)
+    - Write unit file to getUnitPath()
+    - chmod 0o644 on unit file
+    - Run: systemctl --user daemon-reload
+    - Run: systemctl --user enable gsd-agent.service
+    - Run: systemctl --user start gsd-agent.service
+    - Try: loginctl enable-linger (for reboot persistence per Pitfall 5 from RESEARCH.md). Catch and log warning if loginctl is not available — the service works while logged in but may not survive logout/reboot without lingering.
+
+    uninstall(runCommand?: RunCommandFn): void.
+    - Try: systemctl --user stop gsd-agent.service (ignore error if not running)
+    - Try: systemctl --user disable gsd-agent.service (ignore error if not enabled)
+    - Run: systemctl --user daemon-reload
+    - Remove unit file if it exists (unlinkSync, ignore ENOENT)
+
+    status(runCommand?: RunCommandFn): SystemdStatus.
+    - Run: systemctl --user show gsd-agent.service --property=LoadState,ActiveState,MainPID,ExecMainStatus
+    - Parse output (Key=Value lines). registered = LoadState is "loaded". pid = MainPID if ActiveState is "active" (and MainPID > 0). lastExitStatus = ExecMainStatus as number.
+
+    Use the RunCommandFn injection pattern from launchd.ts so tests can mock execSync. Default implementation: execSync(cmd, { encoding: "utf8" }).
+
+    Write tests using node:test with a mock RunCommandFn. Test generateUnit output format, install command sequence, uninstall command sequence, status parsing.
+  </action>
+  <acceptance_criteria>
+    - generateUnit produces valid systemd INI unit file
+    - Unit uses systemd --user paths (not /etc/systemd/system)
+    - install creates directory, writes file, runs daemon-reload + enable + start
+    - install attempts loginctl enable-linger (graceful failure if unavailable)
+    - uninstall stops, disables, removes file
+    - status parses systemctl show output correctly
+    - All commands use RunCommandFn injection for testability
+    - Tests pass with mock RunCommandFn
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/daemon && pnpm run build && node --test dist/systemd.test.js</automated>
+  </verify>
+  <done>systemd.ts provides install/uninstall/status/generateUnit matching launchd.ts interface pattern. User-scoped service at ~/.config/systemd/user/gsd-agent.service. Tests pass with mocked commands.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: gsd-agent CLI entry point and platform-aware service routing</name>
+  <files>packages/daemon/src/cli.ts, packages/daemon/package.json, packages/daemon/bin/gsd-agent.js</files>
+  <read_first>
+    - packages/daemon/src/cli.ts (full file — understand existing --install/--uninstall/--status flags, cloud subcommand routing)
+    - packages/daemon/package.json (bin entries — add gsd-agent alongside existing bins)
+    - packages/daemon/bin/gsd-daemon.js (existing bin entry point — mirror pattern for gsd-agent.js)
+  </read_first>
+  <action>
+    Update packages/daemon/package.json bin field to add: "gsd-agent": "./bin/gsd-agent.js". This is per D-06: extend existing package, add gsd-agent as a CLI entry point.
+
+    Create packages/daemon/bin/gsd-agent.js as a thin wrapper that imports and runs the same CLI module. Use the exact same pattern as the existing gsd-daemon.js bin entry. The only difference is the binary name used in help text.
+
+    Update packages/daemon/src/cli.ts to:
+    1. Detect platform via process.platform.
+    2. When --install is used: if platform is "darwin", use launchd.install (existing). If platform is "linux", use systemd.install (new, lazy import from ./systemd.js). If neither, print "Service installation is supported on macOS (launchd) and Linux (systemd) only." and exit 1.
+    3. Same pattern for --uninstall and --status: route to launchd or systemd based on platform.
+    4. Add import for systemd module: use dynamic import so it does not load on macOS (import("./systemd.js")).
+    5. Update USAGE string to document both platforms and mention gsd-agent as the binary name.
+
+    The gsd-agent subcommands "pair", "install", "uninstall", "status" should all work through the existing CLI structure. The "cloud pair" subcommand already handles pairing. The --install/--uninstall/--status flags handle service management.
+
+    No changes to daemon startup logic — gsd-agent runs the same daemon as gsd-daemon. The name difference is cosmetic (per D-06, "gsd-agent CLI entry point as an alias").
+  </action>
+  <acceptance_criteria>
+    - packages/daemon/package.json has "gsd-agent" bin entry
+    - bin/gsd-agent.js exists and delegates to the CLI module
+    - --install on macOS routes to launchd.install
+    - --install on Linux routes to systemd.install
+    - --uninstall and --status route to the platform-appropriate module
+    - Unsupported platforms get a clear error message
+    - USAGE string documents both platforms
+    - Existing gsd-daemon bin continues to work unchanged
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/daemon && pnpm run build && node dist/cli.js --help | grep -q "gsd-agent\|gsd-daemon" && echo "PASS: help text works" || echo "FAIL"</automated>
+  </verify>
+  <done>gsd-agent bin entry point exists. Service install/uninstall/status routes to launchd on macOS and systemd on Linux. Help text documents both platforms.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| CLI to OS service manager | gsd-agent install writes files and executes launchctl/systemctl commands |
+| Service environment | Daemon runs with user permissions; environment vars captured at install time |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-09 | Elevation of Privilege | systemd service scope | mitigate | User-scoped service at ~/.config/systemd/user/ (NOT /etc/systemd/system/); no root required |
+| T-02-10 | Tampering | Unit file path traversal | mitigate | getUnitPath() returns a fixed path under homedir(); no user-controlled path components |
+| T-02-11 | Information Disclosure | ANTHROPIC_API_KEY in unit file | accept | Same pattern as existing launchd.ts; unit file has 0o644 permissions but is user-scoped; API key is needed for agent operation |
+| T-02-SC | Tampering | npm/pip/cargo installs | accept | No new package installs in this plan |
+</threat_model>
+
+<verification>
+- systemd.ts tests pass with mock commands
+- gsd-agent bin entry resolves and shows help
+- Platform routing works on both macOS and Linux code paths
+</verification>
+
+<success_criteria>
+gsd-agent is installable as a background service on macOS (launchd) and Linux (systemd --user). Service survives reboots via KeepAlive/lingering. gsd-agent bin entry point works alongside existing gsd-daemon.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-websocket-relay-and-daemon/02-03-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-websocket-relay-and-daemon/02-04-PLAN.md
+++ b/.planning/phases/02-websocket-relay-and-daemon/02-04-PLAN.md
@@ -1,0 +1,288 @@
+---
+phase: 02-websocket-relay-and-daemon
+plan: 04
+type: execute
+wave: 2
+depends_on:
+  - 02-01
+  - 02-02
+  - 02-03
+files_modified:
+  - web/app/api/devices/status/stream/route.ts
+  - web/hooks/use-device-status-stream.ts
+  - web/components/gsd/device-status-dot.tsx
+  - web/components/gsd/relay-connection-indicator.tsx
+  - web/app/(dashboard)/devices/page.tsx
+  - packages/daemon/src/cloud-runtime.ts
+  - packages/db/src/schema/devices.ts
+autonomous: false
+requirements:
+  - RELY-03
+  - DMGN-01
+  - DMGN-03
+
+must_haves:
+  truths:
+    - "User can see online/offline status dots on the devices page that update in real-time"
+    - "User can see a relay connection health indicator in the cloud dashboard header"
+    - "Daemon auto-updates when relay reports a newer version in heartbeat acknowledgment"
+    - "Device status transitions from unknown to online/offline within 6 seconds of page load"
+  artifacts:
+    - path: "web/app/api/devices/status/stream/route.ts"
+      provides: "SSE endpoint that polls Neon DB for device statuses every 5s"
+      exports: ["GET"]
+    - path: "web/hooks/use-device-status-stream.ts"
+      provides: "React hook for EventSource lifecycle and status map"
+      exports: ["useDeviceStatusStream"]
+    - path: "web/components/gsd/device-status-dot.tsx"
+      provides: "Shared status dot component with online/offline/reconnecting/unknown states"
+      exports: ["DeviceStatusDot"]
+    - path: "web/components/gsd/relay-connection-indicator.tsx"
+      provides: "Header indicator showing SSE stream health"
+      exports: ["RelayConnectionIndicator"]
+  key_links:
+    - from: "web/app/(dashboard)/devices/page.tsx"
+      to: "web/hooks/use-device-status-stream.ts"
+      via: "calls useDeviceStatusStream to get live statuses"
+      pattern: "useDeviceStatusStream"
+    - from: "web/hooks/use-device-status-stream.ts"
+      to: "web/app/api/devices/status/stream/route.ts"
+      via: "EventSource connection to /api/devices/status/stream"
+      pattern: "EventSource.*devices.*status.*stream"
+    - from: "web/components/gsd/relay-connection-indicator.tsx"
+      to: "web/hooks/use-device-status-stream.ts"
+      via: "reads streamState from the hook"
+      pattern: "streamState"
+---
+
+<objective>
+Dashboard live status: SSE endpoint, status dot UI, relay connection indicator, and daemon auto-update (D-03, D-08, DMGN-01, DMGN-03, RELY-03)
+
+Purpose: Give users real-time visibility into which machines are online/offline in the dashboard, show the SSE connection health in the header, and enable daemon auto-updates via heartbeat acknowledgment.
+Output: SSE endpoint, useDeviceStatusStream hook, DeviceStatusDot component, RelayConnectionIndicator, auto-update logic in CloudRuntime.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-websocket-relay-and-daemon/02-RESEARCH.md
+@.planning/phases/02-websocket-relay-and-daemon/02-UI-SPEC.md
+@.planning/phases/02-websocket-relay-and-daemon/02-01-SUMMARY.md
+@.planning/phases/02-websocket-relay-and-daemon/02-02-SUMMARY.md
+@web/app/api/session/events/route.ts
+@web/app/(dashboard)/devices/page.tsx
+@web/components/gsd/command-surface.tsx
+@web/lib/cloud-auth.ts
+</context>
+
+## Artifacts this phase produces
+
+| Symbol | File | Kind |
+|--------|------|------|
+| `GET` | web/app/api/devices/status/stream/route.ts | route handler |
+| `useDeviceStatusStream` | web/hooks/use-device-status-stream.ts | React hook |
+| `DeviceStatusDot` | web/components/gsd/device-status-dot.tsx | React component |
+| `DeviceStatusDotProps` | web/components/gsd/device-status-dot.tsx | interface |
+| `DeviceStatus` | web/components/gsd/device-status-dot.tsx | type |
+| `RelayConnectionIndicator` | web/components/gsd/relay-connection-indicator.tsx | React component |
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: SSE endpoint and useDeviceStatusStream hook</name>
+  <files>web/app/api/devices/status/stream/route.ts, web/hooks/use-device-status-stream.ts</files>
+  <read_first>
+    - web/app/api/session/events/route.ts (canonical SSE pattern — ReadableStream, text/event-stream headers, abort signal cleanup)
+    - web/lib/cloud-auth.ts (Better Auth server instance — use auth.api.getSession for session validation)
+    - packages/db/src/schema/devices.ts (devices table with isOnline, lastSeenAt columns — query these)
+    - packages/db/src/client.ts (db import for Drizzle queries)
+  </read_first>
+  <action>
+    Create web/app/api/devices/status/stream/route.ts as an SSE endpoint per D-03 and Gap 7 from RESEARCH.md.
+
+    Set runtime = "nodejs" and dynamic = "force-dynamic" exports (same as session/events/route.ts).
+
+    GET handler:
+    1. Validate session using auth.api.getSession({ headers: request.headers }). Return 401 if no session.
+    2. Extract userId from session.user.id.
+    3. Create a ReadableStream with TextEncoder for SSE framing.
+    4. In stream start(): immediately query devices table WHERE userId = userId AND revokedAt IS NULL. For each device, send an SSE event: event name "device.status", data JSON with deviceId, status (device.isOnline ? "online" : "offline"), and lastSeenAt (ISO string or null).
+    5. Start a setInterval polling Neon DB every 5000ms. On each poll, query the same devices and send device.status events for each device. This is the V1 polling approach from RESEARCH.md (simple, no Redis, acceptable at MVP scale).
+    6. On request.signal abort: clear the polling interval, close the stream.
+    7. Return Response with headers: Content-Type text/event-stream charset utf-8, Cache-Control no-cache no-transform, Connection keep-alive, X-Accel-Buffering no.
+
+    SSE event format: "event: device.status\ndata: {JSON}\n\n" — use the named event pattern (not just data) so the client can use addEventListener("device.status", ...).
+
+    Create web/hooks/use-device-status-stream.ts as a React hook per the UI-SPEC.md contract.
+
+    useDeviceStatusStream() hook:
+    1. Maintains state: statuses as Record of string to { status: DeviceStatus, lastSeenAt: string | null }, and streamState as "connecting" | "live" | "error".
+    2. On mount: create new EventSource("/api/devices/status/stream").
+    3. Listen for "open" event: set streamState to "live".
+    4. Listen for "device.status" event: parse event.data as JSON, update statuses map for the given deviceId.
+    5. Listen for "error" event: set streamState to "error". Set all current device statuses to "reconnecting". EventSource auto-retries (browser native, no custom backoff needed per UI-SPEC.md).
+    6. On unmount: call eventSource.close().
+    7. Return { statuses, streamState }.
+
+    Type DeviceStatus as "online" | "offline" | "reconnecting" | "unknown".
+    Type DeviceStatusEntry as { status: DeviceStatus, lastSeenAt: string | null }.
+  </action>
+  <acceptance_criteria>
+    - SSE endpoint validates session and returns 401 for unauthenticated requests
+    - SSE sends initial device statuses immediately on connect
+    - SSE polls Neon DB every 5s and pushes device.status events
+    - SSE cleans up interval and stream on client disconnect
+    - useDeviceStatusStream manages EventSource lifecycle
+    - Hook returns statuses map and streamState
+    - streamState transitions: connecting -> live on open, live -> error on error
+    - EventSource auto-reconnects on error (browser native)
+  </acceptance_criteria>
+  <verify>
+    <automated>cd web && npx tsc --noEmit --project tsconfig.json && echo "TS_OK" || { echo "TS_FAIL"; exit 1; }</automated>
+  </verify>
+  <done>SSE endpoint polls Neon every 5s and pushes device status events. useDeviceStatusStream hook manages EventSource lifecycle and provides statuses map + streamState to UI consumers.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: DeviceStatusDot, RelayConnectionIndicator, and devices page augmentation</name>
+  <files>web/components/gsd/device-status-dot.tsx, web/components/gsd/relay-connection-indicator.tsx, web/app/(dashboard)/devices/page.tsx</files>
+  <read_first>
+    - web/components/gsd/command-surface.tsx (existing StatusDot pattern at lines 198-210 — extract into shared component, same visual language)
+    - web/app/(dashboard)/devices/page.tsx (existing devices page — augment rows with status dots)
+    - web/components/ui/tooltip.tsx (shadcn Tooltip component — use for relay indicator)
+    - .planning/phases/02-websocket-relay-and-daemon/02-UI-SPEC.md (full visual contract — colors, sizing, copy, accessibility requirements)
+  </read_first>
+  <action>
+    Create web/components/gsd/device-status-dot.tsx per UI-SPEC.md.
+
+    DeviceStatusDot component:
+    - Props: status (DeviceStatus), optional size ("sm" | "md", default "sm"), optional animate (boolean)
+    - sm size: h-1.5 w-1.5 rounded-full. md size: h-2 w-2 rounded-full.
+    - Color mapping: online = bg-success, offline = bg-destructive, reconnecting = bg-warning, unknown = bg-foreground/20.
+    - Animation: when status is "reconnecting" and animate is not false, apply motion-safe:animate-pulse (respects prefers-reduced-motion per UI-SPEC.md accessibility requirement).
+    - Include transition-colors duration-300 for smooth color transitions.
+    - Always render a sibling span with className="sr-only" containing the status string for screen readers (WCAG 1.4.1).
+
+    Create web/components/gsd/relay-connection-indicator.tsx per UI-SPEC.md.
+
+    RelayConnectionIndicator component:
+    - Props: streamState ("connecting" | "live" | "error")
+    - connecting: DeviceStatusDot with status="reconnecting" size="sm" + text "Connecting..." (ellipsis U+2026) in text-[11px] text-muted-foreground
+    - live: DeviceStatusDot with status="online" size="sm" wrapped in shadcn Tooltip with content "Live updates active"
+    - error: DeviceStatusDot with status="offline" size="sm" + text "Connection lost" in text-[11px] text-muted-foreground
+    - Label text only visible in connecting and error states (hidden when live).
+
+    Update web/app/(dashboard)/devices/page.tsx to:
+    1. Import and call useDeviceStatusStream() at the top of the component.
+    2. For each device row: add DeviceStatusDot left of the device name. Determine status from statuses[device.id]?.status or "unknown" as default.
+    3. Add status label text next to the dot: "Online", "Offline", "Reconnecting..." (with U+2026), or em dash for unknown.
+    4. Add last-seen text: when offline, show "Last seen [relative time]" using date-fns formatDistanceToNow (already used in Phase 1). When online, show "Connected" instead. When unknown, show nothing.
+    5. Row layout: [StatusDot] [Device name] middle-dot [Status label] [Last-seen text] [action menu]. All on one line at desktop.
+    6. Add RelayConnectionIndicator to the page header area (or the dashboard layout header). Pass streamState from the hook.
+    7. No skeleton loaders for status — use "unknown" status dot during initial SSE hydration per UI-SPEC.md.
+
+    Use only existing CSS tokens (--success, --warning, --destructive, --muted-foreground, --foreground). Do NOT add new color values.
+  </action>
+  <acceptance_criteria>
+    - DeviceStatusDot renders correct color for each status
+    - DeviceStatusDot includes sr-only text for accessibility
+    - Reconnecting animation respects prefers-reduced-motion
+    - RelayConnectionIndicator shows correct state for connecting/live/error
+    - Live state shows Tooltip on hover
+    - Devices page shows status dots next to each device
+    - Devices page shows last-seen text for offline devices
+    - Devices page uses useDeviceStatusStream hook
+    - No new color values — only existing CSS tokens used
+  </acceptance_criteria>
+  <verify>
+    <automated>cd web && npx tsc --noEmit --project tsconfig.json && echo "TS_OK" || { echo "TS_FAIL"; exit 1; }</automated>
+  </verify>
+  <done>Devices page shows live online/offline status dots. RelayConnectionIndicator shows SSE connection health. All UI follows the UI-SPEC.md design contract.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Daemon auto-update via heartbeat acknowledgment</name>
+  <files>packages/daemon/src/cloud-runtime.ts</files>
+  <read_first>
+    - packages/daemon/src/cloud-runtime.ts (current handleMessage — add heartbeat.ack handler with version check; note the existing private readonly inFlight = new Map<string, GatewayMessage>() field)
+    - packages/daemon/package.json (package version — the daemon compares against this)
+    - packages/contracts/src/relay.ts (RelayToDaemonMessage heartbeat.ack shape with latestVersion field)
+  </read_first>
+  <action>
+    Add auto-update handling to CloudRuntime per D-08 and Gap 8 from RESEARCH.md.
+
+    In handleMessage, add a case for type "heartbeat.ack" (from RelayToDaemonMessage). When the message includes a latestVersion field and that version is newer than the daemon's current version:
+    1. Use the existing private readonly inFlight = new Map<string, GatewayMessage>() field already defined in CloudRuntime. Check this.inFlight.size === 0 before starting update (per Pitfall 7 from RESEARCH.md — do not update while tool calls are in-flight). Do NOT create a new inFlight field — it already exists.
+    2. If in-flight work exists, set a pendingUpdate flag (new private field: private pendingUpdateVersion: string | null = null). Check this flag in the finally block of the existing tool_call handler (after inFlight.delete). When inFlight.size reaches 0 and pendingUpdateVersion is set, trigger selfUpdate(pendingUpdateVersion) and clear the flag.
+    3. Log the version comparison: "Update available: current={current}, latest={latest}".
+    4. Call a private selfUpdate(targetVersion: string) method.
+
+    selfUpdate method:
+    1. Wait 500ms for relay to process the ack.
+    2. Call this.stop() to cleanly close the WebSocket (which now sends close code 1000 per Plan 01).
+    3. Spawn npm install -g @opengsd/daemon@{targetVersion} via execFile from node:child_process.
+    4. On completion (success or failure), call process.exit(0). The service manager (launchd KeepAlive / systemd Restart=on-failure from Plan 03) restarts the daemon with the new version.
+    5. On failure, log the error but still exit — the service manager restarts with the old version, and the next heartbeat will re-trigger the update attempt.
+
+    Version comparison: use a simple semver-like comparison. Split versions on dots, compare major.minor.patch numerically. A helper function isNewerVersion(latest: string, current: string): boolean. Export it for testing.
+
+    Read the current version from the package.json at runtime: import { createRequire } from "node:module"; const require = createRequire(import.meta.url); const CURRENT_VERSION = require("../package.json").version; (or use import.meta with assert).
+  </action>
+  <acceptance_criteria>
+    - handleMessage processes heartbeat.ack with latestVersion field
+    - Auto-update does not trigger while tool calls are in-flight (checked via existing this.inFlight.size on the already-defined Map field)
+    - Pending update triggers when in-flight count reaches 0 via pendingUpdateVersion field
+    - selfUpdate runs npm install -g with the target version
+    - selfUpdate exits process after install (for service manager restart via launchd/systemd from Plan 03)
+    - isNewerVersion correctly compares semver strings
+    - Version comparison is exported for testing
+  </acceptance_criteria>
+  <verify>
+    <automated>cd packages/daemon && pnpm run build && node -e "const { isNewerVersion } = require('./dist/cloud-runtime.js'); console.log(isNewerVersion('1.1.0', '1.0.0') === true && isNewerVersion('1.0.0', '1.1.0') === false ? 'PASS' : 'FAIL')" 2>/dev/null || echo "check export name"</automated>
+  </verify>
+  <done>Daemon auto-updates when relay reports newer version in heartbeat.ack. Update is deferred while tool calls are in-flight (using existing inFlight Map). Service manager restarts with the new version.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| browser to SSE endpoint | Authenticated via Better Auth session cookie; tenant-isolated DB queries |
+| relay to daemon (heartbeat.ack) | latestVersion field comes from relay; daemon executes npm install |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-12 | Spoofing | SSE endpoint | mitigate | Session validated via auth.api.getSession; 401 returned for unauthenticated requests |
+| T-02-13 | Information Disclosure | SSE device list | mitigate | Query scoped to session userId; no cross-tenant device data exposure |
+| T-02-14 | Tampering | Auto-update supply chain | accept | npm install -g from official npm registry; npm package signing provides baseline trust; relay only sends version string, not code |
+| T-02-15 | Denial of Service | Auto-update during work | mitigate | inFlight.size check prevents update while tool calls are active; pendingUpdate defers to idle |
+| T-02-SC | Tampering | npm/pip/cargo installs | accept | No new package installs in this plan |
+</threat_model>
+
+<verification>
+- SSE endpoint returns device statuses and updates every 5s
+- useDeviceStatusStream hook connects and receives events
+- DeviceStatusDot renders correct colors and accessible text
+- Devices page shows live status dots
+- TypeScript compiles without errors
+- Daemon auto-update logic handles in-flight work correctly
+</verification>
+
+<success_criteria>
+Users see real-time device online/offline status in the dashboard with 6s visibility latency. SSE stream health is indicated in the header. Daemon auto-updates on relay version notification without disrupting active work.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-websocket-relay-and-daemon/02-04-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-websocket-relay-and-daemon/02-05-PLAN.md
+++ b/.planning/phases/02-websocket-relay-and-daemon/02-05-PLAN.md
@@ -1,0 +1,183 @@
+---
+phase: 02-websocket-relay-and-daemon
+plan: 05
+type: execute
+wave: 3
+depends_on:
+  - 02-01
+  - 02-02
+  - 02-03
+  - 02-04
+files_modified: []
+autonomous: false
+requirements:
+  - RELY-01
+  - RELY-02
+  - RELY-03
+  - RELY-04
+  - DMGN-01
+  - DMGN-02
+  - DMGN-03
+  - DMGN-04
+  - DMGN-05
+  - DMGN-06
+must_haves:
+  truths:
+    - "Database schema changes are pushed to Neon Postgres"
+    - "Daemon connects to relay, authenticates, and heartbeats are visible"
+    - "Dashboard shows live device status"
+    - "SIGTERM produces clean close"
+---
+
+<objective>
+Schema push and end-to-end verification of all Phase 2 work
+
+Purpose: Push schema changes (isOnline, tokenPrefix columns) to Neon Postgres and verify the complete relay + daemon + dashboard pipeline works end-to-end.
+Output: Verified working Phase 2 infrastructure.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-websocket-relay-and-daemon/02-01-SUMMARY.md
+@.planning/phases/02-websocket-relay-and-daemon/02-02-SUMMARY.md
+@.planning/phases/02-websocket-relay-and-daemon/02-03-SUMMARY.md
+@.planning/phases/02-websocket-relay-and-daemon/02-04-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="checkpoint:human-action" gate="blocking">
+  <name>Task 1: Push schema changes to Neon Postgres</name>
+  <what-built>Plans 01-04 added isOnline (boolean) and tokenPrefix (text) columns to the devices table schema in packages/db/src/schema/devices.ts</what-built>
+  <how-to-verify>
+    Run the following command to push schema changes to Neon Postgres:
+
+    ```bash
+    cd packages/db && DATABASE_URL="<your-neon-direct-url>" npx drizzle-kit push
+    ```
+
+    If drizzle-kit prompts for confirmation about adding columns, confirm.
+
+    Verify the columns exist:
+    ```bash
+    DATABASE_URL="<your-neon-direct-url>" node -e "
+      const { neon } = require('@neondatabase/serverless');
+      const sql = neon(process.env.DATABASE_URL);
+      sql('SELECT column_name, data_type FROM information_schema.columns WHERE table_name = \\\"devices\\\" ORDER BY ordinal_position').then(console.log);
+    "
+    ```
+
+    Expected: isOnline (boolean) and tokenPrefix (text) columns are present in the devices table alongside existing columns.
+
+    After push, run this post-push validation query to confirm the new columns exist:
+    ```bash
+    DATABASE_URL="<your-neon-direct-url>" node -e "
+      const { neon } = require('@neondatabase/serverless');
+      const sql = neon(process.env.DATABASE_URL);
+      sql(\"SELECT column_name FROM information_schema.columns WHERE table_name = 'devices' AND column_name IN ('is_online', 'last_seen_at', 'token_prefix')\").then(rows => {
+        const found = rows.map(r => r.column_name);
+        const expected = ['is_online', 'token_prefix'];
+        const missing = expected.filter(c => !found.includes(c));
+        if (missing.length > 0) { console.error('MISSING COLUMNS:', missing); process.exit(1); }
+        else { console.log('VALIDATED: all expected columns present:', found); }
+      });
+    "
+    ```
+  </how-to-verify>
+  <resume-signal>Type "schema pushed" when the drizzle-kit push completes successfully and the validation query confirms the new columns exist</resume-signal>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: End-to-end verification of relay + daemon + dashboard</name>
+  <what-built>Complete Phase 2 infrastructure: typed protocol, daemon backoff/jitter/close codes, relay DB auth + heartbeat sweep, systemd/launchd packaging, SSE status endpoint, dashboard live status dots, auto-update mechanism</what-built>
+  <how-to-verify>
+    **1. Start the relay server:**
+    ```bash
+    cd packages/cloud-mcp-gateway
+    DATABASE_URL="<your-neon-url>" GSD_CLOUD_USER_TOKEN="<your-token>" node dist/server.js
+    ```
+    Verify: Server starts without errors, logs "listening on port 8787"
+
+    **2. Start the daemon:**
+    ```bash
+    cd packages/daemon
+    node dist/cli.js --verbose
+    ```
+    Verify: Daemon connects to relay, logs "cloud runtime connected"
+
+    **3. Check heartbeat:**
+    Wait 30 seconds. Verify:
+    - Daemon logs show heartbeat being sent
+    - Relay logs show heartbeat received and lastSeenAt updated
+
+    **4. Check dashboard status:**
+    Open http://localhost:3000/devices (or your dev URL).
+    Verify:
+    - The paired device shows a green "Online" status dot
+    - The relay connection indicator in the header shows a green dot
+
+    **5. Test disconnect detection:**
+    Kill the daemon process (Ctrl+C or kill -TERM).
+    Verify:
+    - Daemon logs show "daemon shutdown" with close code 1000
+    - Within 60-90 seconds, the dashboard shows the device as "Offline" (red dot)
+
+    **6. Test reconnect:**
+    Restart the daemon.
+    Verify:
+    - Daemon reconnects (check logs for "cloud runtime connected")
+    - Dashboard shows device as "Online" again within 6 seconds
+
+    **7. Test service install (macOS):**
+    ```bash
+    gsd-agent --install --config ~/.gsd/daemon.yaml
+    gsd-agent --status
+    ```
+    Verify: Service is registered and running
+
+    **8. Clean up:**
+    ```bash
+    gsd-agent --uninstall
+    ```
+  </how-to-verify>
+  <resume-signal>Type "approved" if all checks pass, or describe any issues found</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| user to DB | Schema push requires direct Neon DB URL with write permissions |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-16 | Tampering | Schema push | accept | drizzle-kit push is a one-time operation run by the developer; no automated pipeline |
+| T-02-SC | Tampering | npm/pip/cargo installs | accept | No new package installs in this plan |
+</threat_model>
+
+<verification>
+- Schema push succeeds
+- Daemon connects and heartbeats
+- Dashboard shows live status
+- SIGTERM produces clean close
+- Service install/uninstall works
+</verification>
+
+<success_criteria>
+Schema pushed to Neon. Complete relay pipeline verified: daemon connects, heartbeats, dashboard shows live status, disconnect detected within 60s, reconnect restores online status, service install works.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-websocket-relay-and-daemon/02-05-SUMMARY.md` when done
+</output>

--- a/docs/superpowers/plans/2026-06-21-gsd-core-pi-backwards-compat.md
+++ b/docs/superpowers/plans/2026-06-21-gsd-core-pi-backwards-compat.md
@@ -1,0 +1,1358 @@
+# gsd-core ↔ gsd-pi Backwards Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users open the same `.gsd/` project interchangeably in gsd-core (markdown-only) and gsd-pi (DB-authoritative) without either tool silently destroying the other's edits, by folding a compatibility layer into gsd-pi's existing ADR-017 reconciliation pipeline.
+
+**Architecture:** A single new marker file `.gsd/.compat.json` records hash-based per-file projection state. One new drift kind `external-markdown-edit` (detect + idempotent repair) is registered in the existing `DRIFT_REGISTRY`, so startup reconcile already invokes it. `/gsd sync` exposes the same pipeline on demand. A round-trip property test suite catches lossy-projection bugs before users do. gsd-core stays untouched and oblivious.
+
+**Tech Stack:** TypeScript, Node.js built-in `node:test`, `node:crypto`, `node:fs`. Tests run via `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-21-gsd-core-pi-backwards-compat-design.md`
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+|---|---|---|
+| `src/resources/extensions/gsd/compat/compat-marker.ts` | Marker schema, read/write `.gsd/.compat.json`, content normalization + sha computation | **Create** |
+| `src/resources/extensions/gsd/compat/index.ts` | Public exports for the compat module | **Create** |
+| `src/resources/extensions/gsd/state-reconciliation/types.ts` | Add `external-markdown-edit` variant to `DriftRecord` union (lines 11–46) | **Modify** |
+| `src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts` | `DriftHandler` for the new kind: detect drift vs marker, idempotent repair via `md-importer` | **Create** |
+| `src/resources/extensions/gsd/state-reconciliation/registry.ts` | Register the new handler in `DRIFT_REGISTRY` | **Modify** |
+| `src/resources/extensions/gsd/markdown-renderer.ts` | Update compat marker entry in the existing `invalidateCaches()` callback chain | **Modify** |
+| `src/resources/extensions/gsd/commands-maintenance.ts` | Add `handleSync` (mirrors `handleRecover` shape; uses reconcile + marker) | **Modify** |
+| `src/resources/extensions/gsd/commands/handlers/ops.ts` | Wire `/gsd sync` to `handleSync` | **Modify** |
+| `src/resources/extensions/gsd/commands-handlers.ts` | Extend `handleDoctor` with a compat-health check | **Modify** |
+| `src/resources/extensions/gsd/tests/compat-marker.test.ts` | Unit tests for marker read/write/normalize | **Create** |
+| `src/resources/extensions/gsd/tests/external-markdown-edit.test.ts` | Unit tests for detect + idempotent repair | **Create** |
+| `src/resources/extensions/gsd/tests/round-trip-property.test.ts` | Round-trip property suite (import→render→import stable) | **Create** |
+| `src/resources/extensions/gsd/tests/__fixtures__/round-trip/` | Real-shape gsd-core `.gsd/` fixtures | **Create** |
+| `docs/how-to/switching-between-gsd-tools.md` | User-facing workflow doc | **Create** |
+
+---
+
+## Task 1: Compat marker module (`compat-marker.ts`)
+
+**Files:**
+- Create: `src/resources/extensions/gsd/compat/compat-marker.ts`
+- Create: `src/resources/extensions/gsd/compat/index.ts`
+- Test: `src/resources/extensions/gsd/tests/compat-marker.test.ts`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `src/resources/extensions/gsd/tests/compat-marker.test.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: Unit tests for the gsd-core compat marker (`.gsd/.compat.json`).
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import {
+  readCompatMarker,
+  writeCompatMarker,
+  normalizeForHash,
+  computeProjectionSha,
+  EMPTY_MARKER,
+  compatMarkerPath,
+} from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-compat-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  }
+  tmpDirs.length = 0;
+});
+
+test("readCompatMarker returns EMPTY_MARKER when file is missing", () => {
+  const base = makeTmpBase();
+  const marker = readCompatMarker(base);
+  assert.deepEqual(marker, EMPTY_MARKER);
+});
+
+test("writeCompatMarker then readCompatMarker round-trips", () => {
+  const base = makeTmpBase();
+  const marker = {
+    schema: 1,
+    lastWriter: "gsd-pi" as const,
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {
+      "roadmap.md": { sha: "abc123", entities: ["m1"] },
+    },
+    piVersion: "1.4.0",
+  };
+  writeCompatMarker(base, marker);
+  const read = readCompatMarker(base);
+  assert.deepEqual(read, marker);
+});
+
+test("readCompatMarker quarantines malformed JSON and returns EMPTY_MARKER", () => {
+  const base = makeTmpBase();
+  writeFileSync(compatMarkerPath(base), "{ not valid json", "utf-8");
+  const marker = readCompatMarker(base);
+  assert.deepEqual(marker, EMPTY_MARKER);
+  // Quarantine backup should exist
+  const files = require("node:fs").readdirSync(join(base, ".gsd"));
+  const quarantined = files.some((f: string) => f.startsWith(".compat.json.bad-"));
+  assert.ok(quarantined, "expected a quarantined .compat.json.bad-* file");
+});
+
+test("normalizeForHash trims trailing whitespace and converts CRLF to LF", () => {
+  const input = "line one  \r\nline two\r\n";
+  const out = normalizeForHash(input);
+  assert.equal(out, "line one\nline two\n");
+});
+
+test("computeProjectionSha is stable for cosmetically different but equivalent content", () => {
+  const a = computeProjectionSha("hello\r\nworld  \n");
+  const b = computeProjectionSha("hello\nworld\n");
+  assert.equal(a, b);
+});
+
+test("compatMarkerPath resolves under .gsd", () => {
+  const base = makeTmpBase();
+  assert.equal(compatMarkerPath(base), join(base, ".gsd", ".compat.json"));
+});
+```
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/compat-marker.test.ts`
+Expected: FAIL — `Cannot find module '../compat/compat-marker.ts'`
+
+- [ ] **Step 1.3: Write the implementation**
+
+Create `src/resources/extensions/gsd/compat/compat-marker.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: gsd-core ↔ gsd-pi compatibility marker (`.gsd/.compat.json`).
+//
+// Records per-projection content hashes so the ADR-017 reconcile pipeline can
+// distinguish gsd-pi's own writes (expected) from external edits made by gsd-core
+// (drift to import). gsd-core is oblivious to this file and ignores it.
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, renameSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** Current marker schema version. Bump on breaking format changes + migrate. */
+export const COMPAT_MARKER_SCHEMA = 1;
+
+/**
+ * Per-file projection entry. `sha` is a normalized-content SHA-256; `entities`
+ * is the list of DB entity ids (milestone/slice/task) that the file projects,
+ * so repair can scope re-import rather than re-importing the whole tree.
+ */
+export interface ProjectionEntry {
+  sha: string;
+  entities: string[];
+}
+
+export interface CompatMarker {
+  schema: number;
+  lastWriter: "gsd-pi";
+  lastProjectedAt: string;
+  projections: Record<string, ProjectionEntry>;
+  piVersion: string;
+}
+
+/** Marker returned when no marker exists yet (fresh project, first gsd-pi run). */
+export const EMPTY_MARKER: CompatMarker = {
+  schema: COMPAT_MARKER_SCHEMA,
+  lastWriter: "gsd-pi",
+  lastProjectedAt: "",
+  projections: {},
+  piVersion: "",
+};
+
+export function compatMarkerPath(basePath: string): string {
+  return join(basePath, ".gsd", ".compat.json");
+}
+
+/**
+ * Normalize markdown content before hashing so cosmetic differences (trailing
+ * whitespace, CRLF) don't produce false-positive drift. Conservative: only
+ * transforms that are provably round-trippable through gsd-pi's projection.
+ */
+export function normalizeForHash(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n");
+}
+
+export function computeProjectionSha(content: string): string {
+  return createHash("sha256").update(normalizeForHash(content)).digest("hex").slice(0, 16);
+}
+
+/**
+ * Read & validate the marker. A missing marker → EMPTY_MARKER (treat every
+ * projection as external on next reconcile). A malformed marker is quarantined
+ * to `.compat.json.bad-<ts>` (never overwrite without backup) then returns
+ * EMPTY_MARKER. A schema-mismatch returns EMPTY_MARKER (forward-compat: refuse
+ * to act on a future format we don't understand).
+ */
+export function readCompatMarker(basePath: string): CompatMarker {
+  const path = compatMarkerPath(basePath);
+  if (!existsSync(path)) return { ...EMPTY_MARKER };
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return { ...EMPTY_MARKER };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    quarantine(basePath, raw);
+    return { ...EMPTY_MARKER };
+  }
+
+  if (!isValidMarker(parsed)) {
+    quarantine(basePath, raw);
+    return { ...EMPTY_MARKER };
+  }
+  if (parsed.schema !== COMPAT_MARKER_SCHEMA) {
+    // Future schema: refuse rather than guess. Re-running reconcile regenerates.
+    quarantine(basePath, raw);
+    return { ...EMPTY_MARKER };
+  }
+  return parsed;
+}
+
+/**
+ * Write the marker atomically (write-temp then rename) so a crash mid-write
+ * can't leave a half-written file that next startup would quarantine.
+ */
+export function writeCompatMarker(basePath: string, marker: CompatMarker): void {
+  const path = compatMarkerPath(basePath);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(marker, null, 2), "utf-8");
+  renameSync(tmp, path);
+}
+
+function quarantine(basePath: string, raw: string): void {
+  const badPath = compatMarkerPath(basePath).replace(/\.json$/, `.bad-${Date.now()}.json`);
+  try {
+    mkdirSync(dirname(badPath), { recursive: true });
+    writeFileSync(badPath, raw, "utf-8");
+  } catch {
+    // Best-effort: if we can't quarantine, leave the original in place — next
+    // read will quarantine. Never throw out of marker I/O.
+  }
+}
+
+function isValidMarker(x: unknown): x is CompatMarker {
+  if (typeof x !== "object" || x === null) return false;
+  const m = x as Record<string, unknown>;
+  if (m.lastWriter !== "gsd-pi") return false;
+  if (typeof m.schema !== "number") return false;
+  if (typeof m.lastProjectedAt !== "string") return false;
+  if (typeof m.piVersion !== "string") return false;
+  if (typeof m.projections !== "object" || m.projections === null) return false;
+  for (const v of Object.values(m.projections as Record<string, unknown>)) {
+    if (typeof v !== "object" || v === null) return false;
+    const e = v as Record<string, unknown>;
+    if (typeof e.sha !== "string") return false;
+    if (!Array.isArray(e.entities) || !e.entities.every((s) => typeof s === "string")) return false;
+  }
+  return true;
+}
+```
+
+Create `src/resources/extensions/gsd/compat/index.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: Public exports for the gsd-core compat module.
+export {
+  COMPAT_MARKER_SCHEMA,
+  EMPTY_MARKER,
+  compatMarkerPath,
+  computeProjectionSha,
+  normalizeForHash,
+  readCompatMarker,
+  writeCompatMarker,
+} from "./compat-marker.js";
+export type { CompatMarker, ProjectionEntry } from "./compat-marker.js";
+```
+
+- [ ] **Step 1.4: Run the test to verify it passes**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/compat-marker.test.ts`
+Expected: PASS (6 tests)
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/resources/extensions/gsd/compat/compat-marker.ts \
+        src/resources/extensions/gsd/compat/index.ts \
+        src/resources/extensions/gsd/tests/compat-marker.test.ts
+git commit -m "feat(compat): add .gsd/.compat.json marker module
+
+Hash-based per-projection marker so ADR-017 reconcile can distinguish
+gsd-pi's own writes from external (gsd-core) edits. Missing marker is
+treated as 'all projections external'; malformed marker is quarantined."
+```
+
+---
+
+## Task 2: `external-markdown-edit` drift handler
+
+**Files:**
+- Modify: `src/resources/extensions/gsd/state-reconciliation/types.ts` (lines 11–46 — the `DriftRecord` union)
+- Create: `src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts`
+- Test: `src/resources/extensions/gsd/tests/external-markdown-edit.test.ts`
+
+- [ ] **Step 2.1: Add the drift kind to the `DriftRecord` union**
+
+In `src/resources/extensions/gsd/state-reconciliation/types.ts`, add this variant to the union (after the `missing-completion-timestamp` variant, before the closing `;`):
+
+```ts
+  | {
+      kind: "external-markdown-edit";
+      projectionPath: string;       // relative to basePath, e.g. "m1/plan.md"
+      expectedSha: string;          // sha recorded in .compat.json
+      actualSha: string;            // freshly computed from disk
+      entities: string[];           // DB entity ids to re-import
+    };
+```
+
+- [ ] **Step 2.2: Write the failing test**
+
+Create `src/resources/extensions/gsd/tests/external-markdown-edit.test.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: Unit tests for the external-markdown-edit drift handler.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { externalMarkdownEditHandler } from "../state-reconciliation/drift/external-markdown-edit.ts";
+import { writeCompatMarker, computeProjectionSha } from "../compat/compat-marker.ts";
+import type { DriftContext } from "../state-reconciliation/types.ts";
+import type { GSDState } from "../types.ts";
+
+const tmpDirs: string[] = [];
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-extedit-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+const stubState = { phase: "idle" } as unknown as GSDState;
+
+function ctx(base: string): DriftContext {
+  return { basePath: base, state: stubState };
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  }
+  tmpDirs.length = 0;
+});
+
+test("detect returns no drift when file sha matches marker", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  const abs = join(base, ".gsd", rel);
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(abs, "# Roadmap\n\n- [x] S1 done\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: computeProjectionSha("# Roadmap\n\n- [x] S1 done\n"), entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("detect returns drift when file content differs from marker", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), "# Roadmap\n\n- [ ] S1 NOT done\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "stale000000000000", entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].kind, "external-markdown-edit");
+  assert.equal(drift[0].projectionPath, rel);
+  assert.deepEqual(drift[0].entities, ["m1"]);
+});
+
+test("detect treats missing marker as drift on every tracked projection file", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), "# Roadmap\n", "utf-8");
+  // No writeCompatMarker call → marker missing → EMPTY_MARKER
+
+  // Without a marker we have no projections to compare, so detect should be a
+  // no-op (the reconcile pipeline's other handlers cover the "import everything"
+  // case via the existing /gsd recover flow). This is by design: this handler
+  // only fires when we HAVE a baseline to compare against.
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("detect ignores files missing from disk (other handlers cover that)", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "abc123", entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+  // No file written.
+
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("repair is idempotent: running twice produces no further drift on second detect", async () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  const abs = join(base, ".gsd", rel);
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  const content = "# Roadmap\n\n- [x] S1 done\n";
+  writeFileSync(abs, content, "utf-8");
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "stale000000000000", entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+
+  const drift1 = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift1.length, 1);
+  await externalMarkdownEditHandler.repair(drift1[0], ctx(base));
+
+  // After repair, marker should reflect the file's actual sha → no drift.
+  const drift2 = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift2.length, 0);
+});
+```
+
+- [ ] **Step 2.3: Run the test to verify it fails**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/external-markdown-edit.test.ts`
+Expected: FAIL — `Cannot find module '../state-reconciliation/drift/external-markdown-edit.ts'`
+
+- [ ] **Step 2.4: Write the implementation**
+
+Create `src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: ADR-017 drift handler for external (gsd-core) markdown edits.
+//
+// gsd-pi's DB is canonical, but .gsd/*.md is the inter-tool contract. When
+// gsd-core edits a projection file, this handler detects the sha drift vs the
+// recorded baseline in .gsd/.compat.json and re-imports the affected entities
+// into the DB. The next renderAllFromDb pass re-projects; the write-time
+// invalidation hook then refreshes the marker entry, closing the loop.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  computeProjectionSha,
+  readCompatMarker,
+  writeCompatMarker,
+} from "../../compat/compat-marker.js";
+import { migrateHierarchyToDb } from "../../md-importer.js";
+import { invalidateStateCache } from "../../state.js";
+import { logWarning } from "../../workflow-logger.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler } from "../types.js";
+
+type ExternalMarkdownEditDrift = Extract<
+  DriftRecord,
+  { kind: "external-markdown-edit" }
+>;
+
+/**
+ * Detect sha drift between the marker baseline and current file contents.
+ *
+ * - Missing marker → no records (the broader /gsd recover flow handles a
+ *   cold-start; this handler only fires when we have a baseline to compare).
+ * - Missing file on disk → no record (other handlers cover missing artifacts).
+ * - Sha match → no record (gsd-pi's own write or no change).
+ * - Sha mismatch → one record per drifted file, scoped to its recorded entities.
+ */
+function detectExternalMarkdownEdit(
+  _state: GSDState,
+  ctx: DriftContext,
+): ExternalMarkdownEditDrift[] {
+  const marker = readCompatMarker(ctx.basePath);
+  const entries = Object.entries(marker.projections);
+  if (entries.length === 0) return [];
+
+  const records: ExternalMarkdownEditDrift[] = [];
+  for (const [projectionPath, entry] of entries) {
+    const abs = join(ctx.basePath, ".gsd", projectionPath);
+    if (!existsSync(abs)) continue;
+    const actual = computeProjectionSha(readFileSync(abs, "utf-8"));
+    if (actual === entry.sha) continue;
+    records.push({
+      kind: "external-markdown-edit",
+      projectionPath,
+      expectedSha: entry.sha,
+      actualSha: actual,
+      entities: entry.entities,
+    });
+  }
+  return records;
+}
+
+/**
+ * Idempotent repair: re-import hierarchy for the affected entities from
+ * markdown into the DB, then update the marker entry so the next detect pass
+ * sees the file as expected. migrateHierarchyToDb is itself idempotent
+ * (upsert), so re-running this repair after a successful one is a no-op.
+ */
+async function repairExternalMarkdownEdit(
+  record: ExternalMarkdownEditDrift,
+  ctx: DriftContext,
+): Promise<void> {
+  try {
+    // Scoped re-import. migrateHierarchyToDb walks the whole tree but is a
+    // cheap upsert; per-entity scoping would require decomposing it, which is
+    // out of scope for v1. The cost is bounded by tree size and runs at most
+    // once per reconcile pass (MAX_PASSES=2).
+    migrateHierarchyToDb(ctx.basePath);
+    invalidateStateCache();
+  } catch (err) {
+    logWarning(
+      "compat",
+      `external-markdown-edit repair failed for ${record.projectionPath}: ${(err as Error).message}`,
+    );
+    throw err;
+  }
+
+  // Refresh the marker so a second pass (cap=2 reconcile) doesn't re-fire.
+  const marker = readCompatMarker(ctx.basePath);
+  marker.projections[record.projectionPath] = {
+    sha: record.actualSha,
+    entities: record.entities,
+  };
+  marker.lastProjectedAt = new Date().toISOString();
+  writeCompatMarker(ctx.basePath, marker);
+}
+
+export const externalMarkdownEditHandler: DriftHandler<ExternalMarkdownEditDrift> = {
+  kind: "external-markdown-edit",
+  detect: detectExternalMarkdownEdit,
+  repair: repairExternalMarkdownEdit,
+};
+```
+
+- [ ] **Step 2.5: Run the test to verify it passes**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/external-markdown-edit.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/resources/extensions/gsd/state-reconciliation/types.ts \
+        src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts \
+        src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
+git commit -m "feat(compat): add external-markdown-edit drift handler
+
+Detects sha drift between .gsd/.compat.json and current projection files,
+re-imports affected entities via migrateHierarchyToDb, and refreshes the
+marker. Idempotent: re-running after a successful repair is a no-op."
+```
+
+---
+
+## Task 3: Register handler in `DRIFT_REGISTRY`
+
+**Files:**
+- Modify: `src/resources/extensions/gsd/state-reconciliation/registry.ts`
+
+- [ ] **Step 3.1: Add the import and registry entry**
+
+In `src/resources/extensions/gsd/state-reconciliation/registry.ts`:
+
+After line 11 (`import { mergeStateHandler } from "./drift/merge-state.js";`) add:
+
+```ts
+import { externalMarkdownEditHandler } from "./drift/external-markdown-edit.js";
+```
+
+In the `DRIFT_REGISTRY` array (after `completionTimestampHandler,` at line 34, before the closing `];`), add:
+
+```ts
+  externalMarkdownEditHandler,
+```
+
+- [ ] **Step 3.2: Verify the registry still type-checks and loads**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --eval "import('./src/resources/extensions/gsd/state-reconciliation/registry.ts').then(m => console.log('handlers:', m.DRIFT_REGISTRY.length))"`
+Expected: prints `handlers: 11` (was 10, now +1)
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/resources/extensions/gsd/state-reconciliation/registry.ts
+git commit -m "feat(compat): register external-markdown-edit in DRIFT_REGISTRY
+
+Reconcile pipeline now picks up gsd-core edits automatically on startup
+and before every dispatch, with no changes to reconcileBeforeDispatch."
+```
+
+---
+
+## Task 4: Write-time marker invalidation hook
+
+**Files:**
+- Modify: `src/resources/extensions/gsd/markdown-renderer.ts`
+
+The goal: after every projection write, update the matching entry in `.gsd/.compat.json` so the next reconcile pass sees gsd-pi's own writes as expected (feedback-loop prevention). The existing `invalidateCaches()` callback chain (line 66–69, registered via `registerCacheClearCallback`) is the documented extension point.
+
+- [ ] **Step 4.1: Inspect the current `invalidateCaches` implementation**
+
+Read `src/resources/extensions/gsd/markdown-renderer.ts` lines 60–80 to confirm the callback chain shape before modifying. (Already verified during planning: `invalidateCaches()` calls `clearParseCache()`; the projection parse cache registers via `registerCacheClearCallback` at line 752.)
+
+- [ ] **Step 4.2: Add a module-level "pending projection writes" tracker**
+
+In `src/resources/extensions/gsd/markdown-renderer.ts`, near the top of the file after the existing imports (around line 40), add a small tracker that the render functions populate and the invalidation callback drains:
+
+```ts
+// Compat marker invalidation: every successful projection write pushes its
+// (path, entities) here; invalidateCaches() drains it and refreshes
+// .gsd/.compat.json so the next reconcile pass sees gsd-pi's own writes as
+// expected. This is the feedback-loop-prevention mechanism.
+const _pendingProjectionWrites: Array<{ path: string; entities: string[]; basePath: string }> = [];
+
+function recordProjectionWrite(basePath: string, relPath: string, entities: string[]): void {
+  _pendingProjectionWrites.push({ basePath, path: relPath, entities });
+}
+
+function flushProjectionWritesToMarker(): void {
+  if (_pendingProjectionWrites.length === 0) return;
+  // Group by basePath (defensive — multiple projects are unusual but possible).
+  const byBase = new Map<string, Map<string, string[]>>();
+  for (const w of _pendingProjectionWrites) {
+    let bucket = byBase.get(w.basePath);
+    if (!bucket) { bucket = new Map(); byBase.set(w.basePath, bucket); }
+    bucket.set(w.path, w.entities);
+  }
+  _pendingProjectionWrites.length = 0;
+
+  for (const [basePath, writes] of byBase) {
+    try {
+      const marker = readCompatMarker(basePath);
+      for (const [relPath, entities] of writes) {
+        const abs = join(basePath, ".gsd", relPath);
+        if (existsSync(abs)) {
+          marker.projections[relPath] = {
+            sha: computeProjectionSha(readFileSync(abs, "utf-8")),
+            entities,
+          };
+        }
+      }
+      marker.lastWriter = "gsd-pi";
+      marker.lastProjectedAt = new Date().toISOString();
+      writeCompatMarker(basePath, marker);
+    } catch {
+      // Marker I/O must never break projection. Reconcile will heal on next run.
+    }
+  }
+}
+```
+
+And add the necessary imports near the existing `files.js` import (line 40):
+
+```ts
+import { readCompatMarker, writeCompatMarker, computeProjectionSha } from "./compat/compat-marker.js";
+```
+
+- [ ] **Step 4.3: Hook the flush into `invalidateCaches`**
+
+In `invalidateCaches()` (around line 66), add `flushProjectionWritesToMarker();` as the first line (before `clearParseCache()`):
+
+```ts
+function invalidateCaches(): void {
+  flushProjectionWritesToMarker();
+  clearParseCache();
+}
+```
+
+- [ ] **Step 4.4: Instrument the render functions to record writes**
+
+For each of the four render entry points that write files — `renderRoadmapFromDb`, `renderPlanCheckboxes`, `renderSliceSummary`, `renderTaskSummary` — add a `recordProjectionWrite(basePath, relPath, entities)` call immediately after a successful write. The exact insertion points are within each function, after the `saveFile(...)` call that writes the markdown. For `renderRoadmapFromDb`, after the roadmap file is written:
+
+```ts
+recordProjectionWrite(basePath, relRoadmapPath, [milestoneId]);
+```
+
+For `renderPlanCheckboxes`:
+
+```ts
+recordProjectionWrite(basePath, relPlanPath, [`${milestoneId}/${sliceId}`]);
+```
+
+For `renderSliceSummary`:
+
+```ts
+recordProjectionWrite(basePath, relSummaryPath, [`${milestoneId}/${sliceId}`]);
+```
+
+For `renderTaskSummary`:
+
+```ts
+recordProjectionWrite(basePath, relTaskSummaryPath, [`${milestoneId}/${sliceId}/${taskId}`]);
+```
+
+(The relative path variables already exist in each function — use the same value passed to `saveFile`. If the variable name differs, use the value that was written.)
+
+- [ ] **Step 4.5: Add a focused test**
+
+Create or extend `src/resources/extensions/gsd/tests/compat-marker-invalidation.test.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: Verifies that projection writes update .gsd/.compat.json.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { renderRoadmapFromDb } from "../markdown-renderer.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+import { readCompatMarker } from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+function makeTmp(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-inv-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "T", status: "pending", risk: "low", depends: [] });
+  tmpDirs.push(base);
+  return base;
+}
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("renderRoadmapFromDb writes a compat marker entry for the roadmap file", async () => {
+  const base = makeTmp();
+  await renderRoadmapFromDb(base, "M001");
+  const marker = readCompatMarker(base);
+  const rels = Object.keys(marker.projections);
+  assert.ok(rels.some((r) => r.includes("M001") && r.endsWith("ROADMAP.md")), `expected roadmap entry, got ${JSON.stringify(rels)}`);
+});
+```
+
+- [ ] **Step 4.6: Run the test to verify it passes**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/compat-marker-invalidation.test.ts`
+Expected: PASS (1 test)
+
+- [ ] **Step 4.7: Run the full markdown-renderer test suite to confirm no regressions**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/markdown-renderer.test.ts`
+Expected: PASS (no regressions vs. baseline)
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add src/resources/extensions/gsd/markdown-renderer.ts \
+        src/resources/extensions/gsd/tests/compat-marker-invalidation.test.ts
+git commit -m "feat(compat): refresh .gsd/.compat.json on every projection write
+
+Hooks the existing invalidateCaches() callback chain to drain a pending-
+writes queue into the marker. Prevents reconcile from flagging gsd-pi's
+own writes as external drift."
+```
+
+---
+
+## Task 5: `/gsd sync` command wiring
+
+**Files:**
+- Modify: `src/resources/extensions/gsd/commands-maintenance.ts` (add `handleSync`)
+- Modify: `src/resources/extensions/gsd/commands/handlers/ops.ts` (wire the route)
+
+- [ ] **Step 5.1: Add `handleSync` to `commands-maintenance.ts`**
+
+Add this export (placed near `handleRecover`, around line 584 — after `handleRecover`'s closing brace or before it, whichever keeps related functions together):
+
+```ts
+/**
+ * `/gsd sync` — pull in external (gsd-core) markdown edits and re-project.
+ *
+ * Non-destructive cousin of `/gsd recover`: does NOT clear the DB. Runs the
+ * ADR-017 reconcile pipeline (which picks up the external-markdown-edit handler
+ * automatically), then re-projects via renderAllFromDb, then refreshes the
+ * compat marker. Use this when switching from gsd-core mid-session.
+ *
+ * Accepts `--dry-run` to report what would change without writing.
+ */
+export async function handleSync(
+  ctx: ExtensionCommandContext,
+  basePath: string,
+  args = "",
+): Promise<void> {
+  const { isDbAvailable } = await import("./gsd-db.js");
+  const { reconcileBeforeDispatch } = await import("./state-reconciliation/index.js");
+  const { renderAllFromDb } = await import("./markdown-renderer.js");
+  const { writeCompatMarker, readCompatMarker } = await import("./compat/compat-marker.js");
+  const { deriveState } = await import("./state.js");
+
+  const dryRun = args.trim() === "--dry-run";
+
+  if (!isDbAvailable()) {
+    ctx.ui.notify("gsd sync: No database open. Run a GSD command first to initialize the DB.", "error");
+    return;
+  }
+
+  const lines: string[] = ["gsd sync: reconciling .gsd/ for cross-tool edits…"];
+
+  try {
+    const result = await reconcileBeforeDispatch(basePath);
+    const repairedExternal = result.repaired.filter((r) => r.kind === "external-markdown-edit");
+    lines.push(`  External edits imported: ${repairedExternal.length}`);
+    for (const r of repairedExternal) {
+      const e = r as { kind: "external-markdown-edit"; projectionPath: string };
+      lines.push(`    • ${e.projectionPath}`);
+    }
+    if (result.blockers.length > 0) {
+      lines.push("", "  ⚠ Blockers:");
+      for (const b of result.blockers) lines.push(`    • ${b}`);
+    }
+
+    if (dryRun) {
+      lines.push("", "  (dry-run: no projection or marker writes performed)");
+      ctx.ui.notify(lines.join("\n"), "info");
+      return;
+    }
+
+    const renderResult = await renderAllFromDb(basePath);
+    if (renderResult.errors.length > 0) {
+      lines.push("", "  ⚠ Projection errors:");
+      for (const e of renderResult.errors) lines.push(`    • ${e}`);
+    }
+
+    // Refresh the marker to reflect the freshly re-projected state.
+    const marker = readCompatMarker(basePath);
+    marker.lastWriter = "gsd-pi";
+    marker.lastProjectedAt = new Date().toISOString();
+    writeCompatMarker(basePath, marker);
+
+    const state = await deriveState(basePath);
+    lines.push(
+      "",
+      `  Phase:  ${state.phase}`,
+      `  Marker: .gsd/.compat.json refreshed`,
+    );
+    if (state.activeMilestone) {
+      lines.push(`  Active: ${state.activeMilestone.id}: ${state.activeMilestone.title}`);
+    }
+
+    ctx.ui.notify(lines.join("\n"), "info");
+  } catch (err) {
+    ctx.ui.notify(`gsd sync failed: ${(err as Error).message}`, "error");
+  }
+}
+```
+
+- [ ] **Step 5.2: Wire `/gsd sync` in `ops.ts`**
+
+In `src/resources/extensions/gsd/commands/handlers/ops.ts`, update the existing import from `../../commands-maintenance.js` (line 12) to include `handleSync`:
+
+```ts
+import { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleCleanupProjects, handleCleanupWorktrees, handleRecover, handleRebuild, handleSync } from "../../commands-maintenance.js";
+```
+
+Add a new route block near the `recover`/`rebuild` routes (around line 134–141):
+
+```ts
+  if (trimmed === "sync" || trimmed.startsWith("sync ")) {
+    await handleSync(ctx, projectRoot(), trimmed.replace(/^sync\s*/, "").trim());
+    return true;
+  }
+```
+
+- [ ] **Step 5.3: Verify the route resolves (manual smoke)**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --eval "import('./src/resources/extensions/gsd/commands-maintenance.ts').then(m => console.log('handleSync:', typeof m.handleSync))"`
+Expected: prints `handleSync: function`
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add src/resources/extensions/gsd/commands-maintenance.ts \
+        src/resources/extensions/gsd/commands/handlers/ops.ts
+git commit -m "feat(compat): add /gsd sync command
+
+Non-destructive reconcile for mid-session tool switches. Runs the ADR-017
+pipeline (auto-picks-up external-markdown-edit), re-projects, refreshes
+the marker. Supports --dry-run."
+```
+
+---
+
+## Task 6: `/gsd doctor` compat-health check
+
+**Files:**
+- Modify: `src/resources/extensions/gsd/commands-handlers.ts` (`handleDoctor`)
+
+- [ ] **Step 6.1: Locate `handleDoctor`**
+
+Run: `grep -n "export async function handleDoctor" src/resources/extensions/gsd/commands-handlers.ts`
+Note the line number; this is where we add a compat-health section to the doctor report.
+
+- [ ] **Step 6.2: Add a compat-health block**
+
+Within `handleDoctor`, after the existing health checks and before the final report assembly, add:
+
+```ts
+// Compat health: marker presence + drift vs current projections.
+try {
+  const { readCompatMarker } = await import("./compat/compat-marker.js");
+  const { computeProjectionSha } = await import("./compat/compat-marker.js");
+  const { existsSync, readFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const marker = readCompatMarker(basePath);
+  const projectionEntries = Object.entries(marker.projections);
+  let drifted = 0;
+  for (const [rel, entry] of projectionEntries) {
+    const abs = join(basePath, ".gsd", rel);
+    if (!existsSync(abs)) continue;
+    if (computeProjectionSha(readFileSync(abs, "utf-8")) !== entry.sha) drifted++;
+  }
+  const status = projectionEntries.length === 0
+    ? "no baseline (run /gsd sync to establish)"
+    : drifted === 0
+      ? "OK"
+      : `${drifted} file(s) drifted — run /gsd sync`;
+  // Append to whatever the doctor's report-lines variable is named (confirm
+  // the variable name in Step 6.1; commonly `lines` or `report`).
+  lines.push(`  Compat health:      ${status}`);
+} catch (err) {
+  lines.push(`  Compat health:      unavailable (${(err as Error).message})`);
+}
+```
+
+(If the report-lines variable in `handleDoctor` is named differently than `lines`, substitute the actual name from Step 6.1.)
+
+- [ ] **Step 6.3: Verify doctor still runs**
+
+Run the doctor unit test (if it exists): `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test $(grep -rl "handleDoctor" src/resources/extensions/gsd/tests/ | head -1)`
+Expected: PASS. If no test exists for `handleDoctor`, skip this step — the unit suite at Task 8 will cover integration.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add src/resources/extensions/gsd/commands-handlers.ts
+git commit -m "feat(compat): add compat-health check to /gsd doctor
+
+Reports marker presence and drifted-file count so users can see at a
+glance whether /gsd sync is needed."
+```
+
+---
+
+## Task 7: Round-trip property test suite
+
+**Files:**
+- Create: `src/resources/extensions/gsd/tests/__fixtures__/round-trip/m001-basic/.gsd/...` (a small but real-shape gsd-core tree)
+- Create: `src/resources/extensions/gsd/tests/round-trip-property.test.ts`
+
+The property: **for any gsd-core `.gsd/` fixture, `import → render → import` must be stable** — the DB after the second import is row-equivalent to the DB after the first (modulo timestamps). This is the load-bearing safety net that catches lossy projection.
+
+- [ ] **Step 7.1: Create a real-shape fixture**
+
+Create a minimal but representative gsd-core `.gsd/` tree under `src/resources/extensions/gsd/tests/__fixtures__/round-trip/m001-basic/.gsd/`:
+
+- `DECISIONS.md` (one decision row)
+- `REQUIREMENTS.md` (one requirement)
+- `milestones/M001-foo/ROADMAP.md` (one slice, one task)
+- `milestones/M001-foo/slices/S01/PLAN.md` (one task with checkbox)
+- `milestones/M001-foo/slices/S01/tasks/T01/PLAN.md`
+
+Content (example for ROADMAP.md):
+```markdown
+# Roadmap — M001: Foo
+
+## Slices
+- [ ] S01: First slice
+```
+
+Example for PLAN.md (slice):
+```markdown
+# Plan — S01
+
+## Tasks
+- [ ] T01: First task
+```
+
+Example for DECISIONS.md:
+```markdown
+# Decisions
+
+| ID | Decision | Rationale | Status |
+|----|----------|-----------|--------|
+| D001 | Use SQLite | Fast, embedded | accepted |
+```
+
+Example for REQUIREMENTS.md:
+```markdown
+# Requirements
+
+## REQ-001: Must round-trip
+The system must round-trip.
+```
+
+Example for tasks/T01/PLAN.md:
+```markdown
+# Plan — T01
+Steps to complete T01.
+```
+
+- [ ] **Step 7.2: Write the property test**
+
+Create `src/resources/extensions/gsd/tests/round-trip-property.test.ts`:
+
+```ts
+// Project/App: gsd-pi
+// File Purpose: Round-trip property test — import → render → import must be
+// stable for any gsd-core .gsd/ fixture. Catches lossy-projection bugs that
+// would otherwise silently destroy state across cross-tool round-trips.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, rmSync, readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import { openDatabase, closeDatabase, clearEngineHierarchy, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
+import { migrateHierarchyToDb } from "../md-importer.ts";
+import { renderAllFromDb } from "../markdown-renderer.ts";
+import { invalidateStateCache } from "../state.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, "__fixtures__", "round-trip");
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+function copyFixture(name: string): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-rt-${randomUUID()}`));
+  cpSync(join(FIXTURE_ROOT, name), base, { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+interface HierarchySnapshot {
+  milestones: Array<{ id: string; title: string; status: string }>;
+  slices: Array<{ mid: string; id: string; title: string; status: string }>;
+  tasks: Array<{ mid: string; sid: string; id: string; title: string; status: string }>;
+}
+
+function snapshotHierarchy(): HierarchySnapshot {
+  const milestones = getAllMilestones().map((m) => ({ id: m.id, title: m.title, status: m.status }));
+  const slices: HierarchySnapshot["slices"] = [];
+  const tasks: HierarchySnapshot["tasks"] = [];
+  for (const m of milestones) {
+    for (const s of getMilestoneSlices(m.id)) {
+      slices.push({ mid: m.id, id: s.id, title: s.title, status: s.status });
+      for (const t of getSliceTasks(m.id, s.id)) {
+        tasks.push({ mid: m.id, sid: s.id, id: t.id, title: t.title, status: t.status });
+      }
+    }
+  }
+  return { milestones, slices, tasks };
+}
+
+test("round-trip is stable: import → render → import produces the same hierarchy snapshot", async () => {
+  const fixtures = readdirSync(FIXTURE_ROOT, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  assert.ok(fixtures.length > 0, "expected at least one round-trip fixture");
+
+  for (const name of fixtures) {
+    const base = copyFixture(name);
+    openDatabase(join(base, ".gsd", "gsd.db"));
+
+    // Pass 1: import fixture markdown → DB
+    migrateHierarchyToDb(base);
+    invalidateStateCache();
+    const snapshot1 = snapshotHierarchy();
+
+    // Render DB → markdown (projection)
+    const render1 = await renderAllFromDb(base);
+    assert.deepEqual(render1.errors, [], `pass 1 render errors for ${name}: ${JSON.stringify(render1.errors)}`);
+
+    // Pass 2: clear DB, re-import the projected markdown → DB
+    clearEngineHierarchy();
+    migrateHierarchyToDb(base);
+    invalidateStateCache();
+    const snapshot2 = snapshotHierarchy();
+
+    // Property: hierarchy must be stable across the round-trip.
+    assert.deepEqual(
+      snapshot2,
+      snapshot1,
+      `round-trip drift for fixture ${name}: hierarchy changed across import → render → import`,
+    );
+  }
+});
+
+test("round-trip is idempotent: rendering twice produces stable markdown", async () => {
+  const fixtures = readdirSync(FIXTURE_ROOT, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  for (const name of fixtures) {
+    const base = copyFixture(name);
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    migrateHierarchyToDb(base);
+    invalidateStateCache();
+    await renderAllFromDb(base);
+
+    // Snapshot all rendered markdown files
+    const snapshotFiles = (b: string): Record<string, string> => {
+      const out: Record<string, string> = {};
+      const walk = (dir: string) => {
+        for (const e of readdirSync(dir, { withFileTypes: true })) {
+          const p = join(dir, e.name);
+          if (e.isDirectory()) walk(p);
+          else if (e.name.endsWith(".md")) out[p.replace(b + "/", "")] = readFileSync(p, "utf-8");
+        }
+      };
+      walk(join(b, ".gsd"));
+      return out;
+    };
+    const after1 = snapshotFiles(base);
+
+    // Render again
+    await renderAllFromDb(base);
+    const after2 = snapshotFiles(base);
+
+    assert.deepEqual(after2, after1, `re-rendering changed markdown for fixture ${name}`);
+  }
+});
+```
+
+- [ ] **Step 7.3: Run the test to verify it passes**
+
+Run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/round-trip-property.test.ts`
+Expected: PASS (2 tests). If FAIL, the failure identifies the exact projection field that isn't round-tripping — fix the renderer, not the test, and re-run until stable.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add src/resources/extensions/gsd/tests/__fixtures__/round-trip/ \
+        src/resources/extensions/gsd/tests/round-trip-property.test.ts
+git commit -m "test(compat): add round-trip property suite
+
+For any gsd-core fixture, import → render → import must produce a stable
+hierarchy snapshot, and re-rendering must produce stable markdown. This
+is the safety net that catches lossy-projection bugs before users do."
+```
+
+---
+
+## Task 8: User-facing doc
+
+**Files:**
+- Create: `docs/how-to/switching-between-gsd-tools.md`
+
+- [ ] **Step 8.1: Write the doc**
+
+Create `docs/how-to/switching-between-gsd-tools.md`:
+
+````markdown
+# Switching between gsd-core and gsd-pi
+
+Both `@opengsd/gsd-core` and `@opengsd/gsd-pi` read and write the same `.gsd/` directory. You can open a project in either tool, switch freely, and even interleave them across sessions. This doc explains the workflow and what to do when the two tools disagree.
+
+## The shared contract
+
+`.gsd/*.md` files are the contract between the two tools. gsd-core treats them as the source of truth. gsd-pi uses a SQLite DB internally (faster queries, transactional state) but projects to the same `.md` files and imports any external edits on startup.
+
+## Recommended workflow: commit before switching
+
+Git is the integration layer. Before switching tools, commit:
+
+```bash
+git add .gsd/
+git commit -m "wip: switching to gsd-pi"
+```
+
+Then open the other tool. If anything goes wrong, `git reset --hard` restores the pre-switch state. This is the simplest and safest workflow.
+
+## What gsd-pi does on startup
+
+When you open a project in gsd-pi, it runs a reconciliation pass that:
+
+1. Compares every `.gsd/*.md` file against its recorded baseline in `.gsd/.compat.json`.
+2. Imports any file that changed since the last gsd-pi session (e.g., gsd-core edits).
+3. Re-projects all markdown from the DB.
+4. Updates `.gsd/.compat.json` with the new baseline.
+
+This is automatic — you don't need to do anything special. gsd-pi will not silently overwrite gsd-core edits.
+
+## `/gsd sync` — mid-session switch
+
+If you switch tools while gsd-pi is running (e.g., a teammate edits `.gsd/plan.md` via gsd-core and pushes), run:
+
+```
+/gsd sync
+```
+
+This re-runs the reconciliation pipeline, imports the external edits, and re-projects. Use `--dry-run` to preview what would change:
+
+```
+/gsd sync --dry-run
+```
+
+## `/gsd doctor` — check compat health
+
+`/gsd doctor` includes a compat-health line that tells you whether the marker is present and whether any files have drifted:
+
+```
+Compat health:      OK
+```
+
+or
+
+```
+Compat health:      2 file(s) drifted — run /gsd sync
+```
+
+## What gsd-core sees
+
+gsd-core is unaware of gsd-pi. It sees `.gsd/*.md` as ordinary markdown and edits them directly. gsd-pi's `.gsd/.compat.json` and `gsd.db` files are ignored by gsd-core (it preserves unknown files, so they won't be deleted).
+
+## Conflicts: same entity edited in both
+
+If both tools edit the *same* entity (e.g., both change the status of slice `S01`) between syncs, the last writer wins after the next reconcile, and gsd-pi surfaces the resolution in the `/gsd sync` output. Git review remains the final safety net — that's why the "commit before switching" workflow matters.
+
+## Troubleshooting
+
+**`gsd doctor` says "no baseline"**: run `/gsd sync` once to establish the marker.
+
+**`.gsd/.compat.json.bad-*` files appear**: gsd-pi quarantined a malformed marker and started fresh. Safe to delete the `.bad-*` file after reviewing it.
+
+**`/gsd sync` reports drift every time you open the project**: this means gsd-pi's projection isn't idempotent — a real bug. The round-trip property test suite in CI catches most of these; report the fixture if you hit one in the wild.
+````
+
+- [ ] **Step 8.2: Commit**
+
+```bash
+git add docs/how-to/switching-between-gsd-tools.md
+git commit -m "docs(compat): add switching-between-gsd-tools how-to"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 9.1: Run the new unit tests together**
+
+```bash
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
+  src/resources/extensions/gsd/tests/compat-marker.test.ts \
+  src/resources/extensions/gsd/tests/external-markdown-edit.test.ts \
+  src/resources/extensions/gsd/tests/compat-marker-invalidation.test.ts \
+  src/resources/extensions/gsd/tests/round-trip-property.test.ts
+```
+Expected: all PASS.
+
+- [ ] **Step 9.2: Run the broader unit suite for regressions**
+
+```bash
+pnpm run test:unit
+```
+Expected: PASS (no regressions vs. baseline). Watch in particular for:
+- `markdown-renderer.test.ts` (Task 4 touched it)
+- `state-reconciliation` tests (Task 2–3 added a drift kind)
+- `commands-maintenance` tests (Task 5 added `handleSync`)
+
+- [ ] **Step 9.3: Typecheck the extensions**
+
+```bash
+pnpm run typecheck:extensions
+```
+Expected: PASS.
+
+- [ ] **Step 9.4: Final commit (if any fixups)**
+
+If steps 9.1–9.3 surfaced fixups, commit them. Otherwise nothing to commit.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- §4.2 compat marker → Task 1 ✓
+- §4.3 new drift kind + detect/repair → Task 2 ✓
+- §4.4 startup reconcile flow → covered by Task 3 (registering in `DRIFT_REGISTRY` means `reconcileBeforeDispatch` already runs on startup via the orchestrator); Task 5 adds the manual `/gsd sync` entry point ✓
+- §4.5 mid-session `/gsd sync` → Task 5 ✓
+- §4.6 write-time invalidation → Task 4 ✓
+- §4.7 command parity → out of scope for this plan (already in-progress in the working tree as a separate effort; called out in the spec's scope section)
+- §4.8 round-trip property suite → Task 7 ✓
+- §5.1 file changes → all mapped ✓
+- §5.2 module boundaries → compat module exposes only `readCompatMarker`/`writeCompatMarker` + types; drift handler depends on it ✓
+- §8 testing → Tasks 1, 2, 4, 7 cover unit + property; integration covered by Task 9.2 ✓
+- §3 success criteria #4 (doctor health) → Task 6 ✓
+
+**Placeholder scan:** Steps 4.4 and 6.2 reference variable names that must be confirmed against the actual source at execution time (the plan flags this explicitly rather than guessing). All other steps contain complete code.
+
+**Type consistency:** `CompatMarker` and `ProjectionEntry` are defined in Task 1 and used identically in Tasks 2, 4, 5, 6. `externalMarkdownEditHandler` is exported from Task 2 and imported in Task 3. `handleSync` is defined in Task 5 and imported in Task 5.2. Naming consistent throughout.
+
+**Scope decomposition:** This plan covers the compat layer + sync + doctor + property tests + docs. Command parity (§4.7) is a separate in-progress effort tracked in the working tree and is correctly out of this plan's scope.

--- a/docs/superpowers/plans/2026-06-21-planning-dir-parity.md
+++ b/docs/superpowers/plans/2026-06-21-planning-dir-parity.md
@@ -1,0 +1,26 @@
+# `.planning/` Round-Trip Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the shipped `.gsd/` compat layer (PR #802) to cover gsd-core's `.planning/` layout, so users can round-trip the same project across both tools regardless of which layout they use.
+
+**Architecture:** Reuse the existing read path (`migrate/parsePlanningDirectory` + `transformToGSD`). Build the missing write path (`planning-writer.ts`). Extend the compat marker schema 1→2 with a `planning` field. Add a new drift kind `external-planning-edit` mirroring the shipped `external-markdown-edit`. Un-modeled docs are pass-through: sha-tracked, never re-rendered.
+
+**Design spec:** `docs/superpowers/specs/2026-06-21-planning-dir-parity-design.md`
+
+## Tasks (TDD, 8 tasks)
+
+1. **Marker schema 1→2 + `planning` field** — extend `CompatMarker` with optional `planning: { active, layout, projections, passthrough }`. Schema-1 markers promoted (planning defaults inactive) not quarantined.
+2. **Layout detector** (`migrate/layout-detect.ts`) — pure function extracting the implicit 3-way branch from `transformToGSD`.
+3. **Planning writer** (`migrate/planning-writer.ts`) — DB → `.planning/` projection. v1 supports `flat-phases` only.
+4. **`external-planning-edit` drift handler** — mirrors `external-markdown-edit`. Passthrough files refresh sha only.
+5. **Hook `writePlanningDirectory` into `renderAllFromDb`** — gated on `marker.planning.active`.
+6. **Extend `/gsd sync` + `/gsd doctor`** — report `.planning/` drift separately.
+7. **Round-trip property suite** — fixture `planning-flat-phases`.
+8. **Extend user doc + final verification**.
+
+## v1 scope limitation
+
+Only `flat-phases` layout supported for round-trip projection. `multi-milestone` and `legacy-milestone-dir` throw a clear error until fixtures validate the reverse-mapping.
+
+Full task detail with code is in the conversation that produced this plan.

--- a/docs/superpowers/specs/2026-06-21-gsd-core-pi-backwards-compat-design.md
+++ b/docs/superpowers/specs/2026-06-21-gsd-core-pi-backwards-compat-design.md
@@ -1,0 +1,216 @@
+# Design: gsd-core ↔ gsd-pi Backwards Compatibility
+
+**Status:** Proposed
+**Date:** 2026-06-21
+**Author:** Design session (Approach 3 — Parity + Property-tested Reconcile)
+**Decisions locked (from brainstorming):**
+
+- Coexistence model: both tools maintained long-term; users pick freely per project/per day. Equal support both directions.
+- Conflict policy: DB stays canonical inside gsd-pi; markdown (`.gsd/`) is the inter-tool contract. (Option D — "markdown is the contract, DB caches" — was rejected as a multi-quarter rewrite; the agreed middle path keeps DB-authority and adds a compatibility layer.)
+- Sync model: startup reconcile + write-time invalidation + git as integration layer. Continuous file-watch sync was rejected as architecturally mismatched to gsd-pi's DB-authoritative design (feedback loops, lossy projection, races, and it still couldn't handle the "gsd-pi closed" case).
+- Approach: Approach 3 — finish parity + hash-based compat marker + startup reconcile via the existing ADR-017 drift pipeline + a round-trip property test suite + docs.
+
+---
+
+## 1. Goal
+
+Users of `@opengsd/gsd-core` and `@opengsd/gsd-pi` can open the same project in either tool — including interleaving them across sessions on the same day — and neither tool silently destroys the other's edits to `.gsd/`. The `.gsd/` directory is the shared contract; both tools commit to reading and writing the same files.
+
+## 2. Scope
+
+### In scope
+
+- **State compatibility:** round-tripping `.gsd/` markdown between the two tools without data loss. SQLite stays canonical *inside gsd-pi*; gsd-pi treats markdown as the inter-tool contract.
+- **Command parity:** finishing the in-progress port of gsd-core's ~40 slash commands into gsd-pi as native workflows, so gsd-core users get muscle-memory parity in gsd-pi. (Much already in progress in the working tree: `commands-gsd-core.ts`, `gsd-core-aliases.ts`, `gsd-core-aliases-handler.ts`, new `prompts/*.md`, plus edits to `catalog.ts`, `dispatcher.ts`, `handlers/core.ts`, `handlers/ops.ts`.)
+- **Reconciliation:** startup auto-reconcile + explicit `/gsd sync` for mid-session tool switches.
+- **Safety net:** a round-trip property test suite that catches projection drift before users do.
+- **Documentation:** a "switching between GSD tools" how-to.
+
+### Out of scope
+
+- Real-time / continuous file-watch sync (rejected).
+- Making the DB non-canonical inside gsd-pi (the full inversion — too large).
+- Any changes to `gsd-core` itself. gsd-core stays markdown-only and oblivious; all compatibility work happens in `gsd-pi`.
+- Network / cloud / multi-repo sync.
+- gsd-core commands that have no `.gsd/`-model equivalent (e.g. agent-runner concepts). Only `.gsd/`-backed commands are in scope for parity.
+
+### Non-goals
+
+We are **not** promising conflict-free concurrent writes. If two tools edit the *same entity* simultaneously, last-writer-per-entity applies and we surface it. Git remains the integration layer for human review.
+
+## 3. Success Criteria
+
+1. **Cross-tool open.** A gsd-core user runs `npx @opengsd/gsd-pi` on an existing gsd-core project, sees their milestones/slices/tasks, and can continue work — no migration step required.
+2. **Round-trip preservation.** A gsd-pi user closes the session; a teammate edits `.gsd/plan.md` via gsd-core and commits; the first user reopens gsd-pi and finds those edits imported (with a visible log of what changed).
+3. **Property-tested stability.** The round-trip property test suite runs in CI and is green on real-world gsd-core fixture trees.
+4. **Doctor health.** `gsd doctor` reports "compat health: OK" on a project that has been round-tripped ≥5 times across both tools.
+
+## 4. Architecture
+
+### 4.1 Key principle: fold into existing pipelines, don't bolt on
+
+gsd-pi already has three of the four primitives this design needs:
+
+| Need | Existing primitive |
+|---|---|
+| Detect drift between DB and markdown | `state-reconciliation/` (ADR-017 drift registry) + `markdown-renderer.detectStaleRenders()` |
+| Import markdown → DB | `md-importer.migrateFromMarkdown()` / `migrateHierarchyToDb()` |
+| Project DB → markdown | `markdown-renderer.renderAllFromDb()` |
+| Cross-process serialization | `sync-lock.acquireSyncLock()` / `releaseSyncLock()` |
+
+The design adds **one new drift kind** to the ADR-017 registry and a **single new marker file**. No parallel pipelines.
+
+### 4.2 The compat marker: `.gsd/.compat.json`
+
+A single small JSON file recording the last projection state. Lives under `.gsd/` so both tools see it (gsd-core ignores unknown files).
+
+```json
+{
+  "schema": 1,
+  "lastWriter": "gsd-pi",
+  "lastProjectedAt": "2026-06-21T14:03:11.000Z",
+  "projections": {
+    "roadmap.md": { "sha": "9f2c…", "entities": ["m1", "m2"] },
+    "m1/plan.md":  { "sha": "ab31…", "entities": ["m1/s1", "m1/s2"] }
+  },
+  "piVersion": "1.4.0"
+}
+```
+
+- **Hash-based, not mtime-based.** mtimes are unreliable across git checkouts, filesystems, and clocks. SHA-256 of normalized file content (trailing whitespace trimmed, CRLF→LF) avoids false positives on cosmetic differences.
+- **Per-file entity map.** When drift is detected on `m1/plan.md`, gsd-pi knows which DB entities (slices/tasks) to re-import rather than re-importing the whole tree.
+- `lastWriter` is `"gsd-pi"` after every gsd-pi projection; gsd-core never writes it (it's oblivious), so a missing/stale marker is itself a signal: "the other tool may have written since my last projection."
+- `schema: 1` for forward compatibility of the marker format itself.
+
+### 4.3 New drift kind: `external-markdown-edit`
+
+Added to the `DriftRecord` union in `state-reconciliation/types.ts`:
+
+```ts
+| {
+    kind: "external-markdown-edit";
+    projectionPath: string;       // relative to basePath, e.g. "m1/plan.md"
+    expectedSha: string;          // from .compat.json
+    actualSha: string;            // freshly computed
+    entities: string[];           // entity ids to re-import
+  }
+```
+
+Detection (`detect`) compares each projection's recorded sha against the current normalized file hash. Differences become `external-markdown-edit` records.
+
+Repair (`repair`) re-imports the named entities from markdown → DB via the existing `md-importer` entity-level upserts, then re-projects those files. Idempotent (re-running yields the same outcome, which is what the cap=2 reconcile loop requires).
+
+### 4.4 Startup reconcile flow
+
+```
+gsd-pi startup
+  ├─ acquire sync-lock
+  ├─ read .gsd/.compat.json (or treat missing as "everything is external")
+  ├─ reconcileBeforeDispatch(basePath)   ← existing ADR-017 pipeline
+  │     └─ new external-markdown-edit handler imports edits → DB
+  ├─ renderAllFromDb(basePath)           ← project DB → markdown
+  ├─ write fresh .gsd/.compat.json
+  ├─ emit structured "what changed" log to workflow-logger
+  └─ release sync-lock
+```
+
+Runs once per session start. Bounded cost. No watcher.
+
+### 4.5 Mid-session switch: `/gsd sync`
+
+Wraps the same pipeline (lock → reconcile → render → write marker → log) so a user who switches tools mid-session can pull in the other tool's edits without restarting. Reuses the dispatcher/catalog plumbing already in place for the parity commands.
+
+### 4.6 Write-time invalidation (the "while gsd-pi runs" case)
+
+`renderAllFromDb` and friends already call `invalidateCaches()` / `clearParseCache()` after every projection write. The same hook updates the relevant entry in `.gsd/.compat.json` so the next reconcile pass doesn't flag gsd-pi's own writes as external. This is the feedback-loop-prevention mechanism that continuous-watch sync would have needed and couldn't cleanly get.
+
+### 4.7 Command parity (finishing the in-progress work)
+
+The uncommitted `commands-gsd-core.ts` ports gsd-core's slash commands as gsd-pi native workflows backed by the new `prompts/*.md` templates. The design's contribution here is a **parity verification matrix** (Section 5.3): a table mapping each gsd-core command → its gsd-pi native equivalent → a smoke test, so we can prove parity rather than assert it.
+
+### 4.8 Round-trip property test suite (the real safety net)
+
+Property: **for any gsd-core `.gsd/` fixture, `import → render → import` must be stable** (the second import produces a DB byte-identical to the first, modulo timestamps). Placed under `src/resources/extensions/gsd/__tests__/round-trip/` with fixtures sourced from real gsd-core project trees (committed under `__fixtures__/`).
+
+Catches exactly the lossy-projection bugs (whitespace, ordering, escaping, missing fields) that would otherwise silently destroy state. This is what makes any of the above safe to ship.
+
+## 5. Components
+
+### 5.1 New / changed files
+
+| File | Change | Purpose |
+|---|---|---|
+| `src/resources/extensions/gsd/state-reconciliation/types.ts` | Add `external-markdown-edit` to `DriftRecord` union | New drift kind |
+| `src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts` | **New** | `DriftHandler` for the new kind (detect + idempotent repair) |
+| `src/resources/extensions/gsd/state-reconciliation/registry.ts` | Register the new handler | Wire into ADR-017 pipeline |
+| `src/resources/extensions/gsd/compat/compat-marker.ts` | **New** | Read/write `.gsd/.compat.json`; sha computation + normalization |
+| `src/resources/extensions/gsd/compat/index.ts` | **New** | Public exports for the compat module |
+| `src/resources/extensions/gsd/md-importer.ts` | Expose entity-level upsert helpers (some already exported) | Repair path needs per-entity import, not full-tree migrate |
+| `src/resources/extensions/gsd/markdown-renderer.ts` | Update `.compat.json` entry on each projection write (in the existing `invalidateCaches` callback chain) | Write-time invalidation |
+| `src/resources/extensions/gsd/commands/handlers/ops.ts` | Wire `/gsd sync` to the reconcile→render→marker pipeline | Mid-session switch |
+| `src/resources/extensions/gsd/commands/handlers/ops.ts` | Extend `/gsd doctor` with a "compat health" check | Success criterion #4 |
+| `src/resources/extensions/gsd/__tests__/round-trip/` | **New** | Property test suite + fixtures |
+| `docs/how-to/switching-between-gsd-tools.md` | **New** | User-facing workflow doc |
+
+### 5.2 Module boundaries
+
+The `compat/` module owns: marker schema, read/write, hash normalization. It exposes exactly two functions to the rest of the codebase:
+
+- `readCompatMarker(basePath): CompatMarker | null`
+- `writeCompatMarker(basePath, marker): void`
+
+Everything else (drift detection, repair, rendering) stays in its existing module. The compat module has no dependency on the drift registry — the drift handler depends on *it*, not the reverse.
+
+### 5.3 Parity verification matrix (sample; full table built during implementation)
+
+| gsd-core command | gsd-pi native | Smoke |
+|---|---|---|
+| `/gsd plan` | `/gsd plan` (ported) | opens planner on fresh `.gsd/` |
+| `/gsd explore` | `/gsd explore` (ported) | reads `CONTEXT.md` |
+| `/gsd milestone-summary` | `/gsd milestone-summary` (ported) | renders from DB |
+| … (~40 rows) | … | … |
+
+## 6. Data Flow
+
+**Cross-tool open (gsd-core → gsd-pi):**
+
+1. gsd-pi starts; sync-lock acquired.
+2. `reconcileBeforeDispatch` runs; `external-markdown-edit` detector finds files where current sha ≠ `.compat.json` sha (or marker absent → treat all projection files as external).
+3. Repair re-imports affected entities → DB.
+4. `renderAllFromDb` re-projects everything.
+5. `.compat.json` rewritten with fresh shas, `lastWriter: "gsd-pi"`.
+6. Lock released; workflow-logger emits a structured diff of imported changes.
+
+**Mid-session switch (`/gsd sync`):** identical pipeline, invoked on demand.
+
+**Within gsd-pi:** every projection write updates `.compat.json` in the existing invalidation callback; next reconcile sees gsd-pi's own writes as expected.
+
+## 7. Error Handling
+
+- **Missing `.compat.json`:** treat every projection file as external → full reconcile. Worst case is a redundant import; never a data-loss path.
+- **Malformed `.compat.json`:** quarantine to `.gsd/.compat.json.bad-<ts>` (never overwrite without backup), start fresh.
+- **Hash collision / sha failure:** catch, log via `workflow-logger.logWarning`, fall back to full reconcile.
+- **Import error on a specific entity:** the ADR-017 pipeline already collects per-record failures without aborting the pass; we follow the same pattern — record the failure, continue, surface in the result.
+- **Lock contention:** `sync-lock` already handles this; reconcile refuses to run concurrently. Two gsd-pi instances editing one project is already out of scope.
+- **Concurrent same-entity writes by both tools (true race):** last-writer-per-entity after reconcile; surfaced in the workflow-logger as a "conflict resolved" entry. Git review remains the human safety net.
+
+## 8. Testing
+
+- **Property suite (Section 4.8):** the load-bearing safety net. CI-gated.
+- **Unit tests:** `compat-marker` (schema migration, normalization determinism); the new `external-markdown-edit` handler (detect + idempotent repair).
+- **Integration test:** simulate the cross-tool open flow on a fixture — start with gsd-core fixture, run reconcile, assert DB + markdown reflect imported edits, re-run reconcile, assert no-op.
+- **Doctor test:** after N round-trips, `gsd doctor` compat-health is OK.
+- **Existing test parity:** `verify:full` must stay green (this is a repo-wide gate per recent commits `3cced9dc`, `5326e960`).
+
+## 9. Rollout
+
+- Behind no feature flag — `.gsd/.compat.json` is additive and gsd-core ignores it.
+- Marker schema versioned (`schema: 1`) so future format changes are migratable.
+- If `.compat.json` is deleted, gsd-pi regenerates it on next startup (full reconcile).
+- Docs shipped alongside code so users have the "commit before switching" workflow from day one.
+
+## 10. Open Questions for Implementation
+
+- Exact normalization rules for sha (CRLF→LF confirmed; trailing-whitespace trim confirmed; anything else — e.g. comment reordering, frontmatter keys — to be settled during property-test authoring, where unstable mappings will surface as test failures).
+- Whether `/gsd sync` should accept a `--dry-run` flag (low cost, useful; default yes).
+- Fixture sourcing: real gsd-core project trees from `open-gsd/gsd-core` test corpus vs. synthetic. Prefer real; confirm licensing during implementation.

--- a/docs/superpowers/specs/2026-06-21-planning-dir-parity-design.md
+++ b/docs/superpowers/specs/2026-06-21-planning-dir-parity-design.md
@@ -1,0 +1,214 @@
+# Design: `.planning/` Round-Trip Parity for gsd-core ↔ gsd-pi
+
+**Status:** Proposed (separate workstream from the `.gsd/` compat layer in PR #802)
+**Date:** 2026-06-21
+**Author:** Design session
+**Depends on:** PR #802 (`.gsd/` compat layer — marker, drift handler, reconcile pipeline)
+**Design spec index:** companion to `2026-06-21-gsd-core-pi-backwards-compat-design.md`
+
+---
+
+## 1. Context
+
+The `.gsd/` compat layer shipped in PR #802 gives gsd-core (markdown-only) and gsd-pi (DB-authoritative) round-trip compatibility over `.gsd/*.md`. But gsd-core's **current canonical planning store is `.planning/`**, a different layout. PR #802 does nothing for `.planning/`.
+
+Today gsd-pi treats `.planning/` as "v1 legacy" (`detection.ts:346`) and offers a **one-way, destructive** `/gsd migrate` (`migrate/safety.ts`) that copies `.gsd/` to `.gsd-backups/`, deletes it, and rebuilds `.gsd/` from `.planning/`. After migration, gsd-pi never reads `.planning/` again. If the user returns to gsd-core and edits `.planning/`, those edits are invisible to gsd-pi.
+
+**Goal of this spec:** full bidirectional parity for `.planning/`, as a dedicated workstream. Users who keep their work in `.planning/` (the gsd-core native layout) can interleave with gsd-pi without losing edits in either direction.
+
+## 2. Why this is a separate, harder workstream than `.gsd/` parity
+
+The `.gsd/` layer (PR #802) was tractable because both tools already read/write the **same** `.gsd/` layout — the compat layer just tracks drift and re-imports. `.planning/` is fundamentally different:
+
+1. **Different layout.** `.planning/` is flat (`phases/NN-name/NN-MM-PLAN.md`, root `ROADMAP.md`, `STATE.md`). `.gsd/` is milestone-nested (`milestones/M001/slices/S01/S01-PLAN.md`). A projection in both directions requires a deterministic mapping.
+2. **Non-injective mapping.** `migrate/transformer.ts` collapses three distinct `.planning/` source layouts (legacy-milestone-dir, multi-milestone roadmap, flat phases) into one `.gsd/` shape. The original layout is lost. A reverse projection must **choose** a layout — and if it doesn't match what gsd-core wrote, the round-trip mutates structure.
+3. **Un-modeled documents.** `.planning/` carries content `.gsd/` has no DB model for: phase-scoped `DISCUSSION-LOG.md`, `PATTERNS.md`, `REVIEWS.md`, `RESEARCH.md`; root `research/*.md` and `codebase/*.md`; `config.json`; workstream dirs.
+4. **State schema mismatch.** gsd-core `STATE.md` uses phase-based progress (`total_phases`, `completed_phases`, `percent`). gsd-pi `STATE.md` uses milestone/slice/task status. Both derive from DB state, but the rendering differs.
+
+These are design problems, not implementation details. This spec resolves them.
+
+## 3. Scope
+
+### In scope
+
+- **Read:** gsd-pi imports `.planning/` edits into the DB on startup reconcile (parallel to `.gsd/` import).
+- **Write:** gsd-pi projects DB state back to `.planning/` on every projection pass (parallel to `.gsd/` projection).
+- **Drift detection:** a new drift kind `external-planning-edit` plus marker entries for `.planning/` files.
+- **Layout provenance:** gsd-pi records which `.planning/` layout it read, so the projection writes back the same one.
+- **Un-modeled docs:** a pass-through strategy for `DISCUSSION-LOG`, `PATTERNS`, `REVIEWS`, `RESEARCH`, `codebase/`, `research/`, `config.json`.
+- **STATE.md projection:** render gsd-pi state in gsd-core's phase-progress schema when projecting to `.planning/`.
+- **User doc:** extend `switching-between-gsd-tools.md` with the `.planning/` workflow.
+- **Property tests:** round-trip suite for `.planning/` fixtures (parallel to the `.gsd/` round-trip suite).
+
+### Out of scope
+
+- **Workstreams.** gsd-core's `.planning/<project>/workstreams/<ws>/` is a parallel concept to gsd-pi's worktrees. Mapping them is a separate problem; this spec treats workstream dirs as pass-through (preserved, not interpreted).
+- **gsd-core changes.** As with PR #802, all work is in gsd-pi. gsd-core stays oblivious.
+- **Migration deprecation.** `/gsd migrate` remains for users who want to permanently move to `.gsd/`. This spec adds *coexistence*, not replacement.
+
+### Non-goals
+
+- Conflict-free concurrent writes. Same policy as PR #802: last-writer-per-entity, surfaced in reconcile output, git is the human safety net.
+- Perfect byte-identical round-trips for un-modeled docs (see §6).
+
+## 4. Architecture
+
+### 4.1 Reuse, don't fork
+
+The `migrate/` module already has a mature `.planning/` parser (`parser.ts`, `parsers.ts`) and transformer (`transformer.ts` → `transformToGSD`). **Reuse these for the read path.** The write path (`writer.ts` → `writeGSDDirectory`) is `.gsd/`-only; this spec adds a parallel `writePlanningDirectory`.
+
+### 4.2 Layout provenance: `.gsd/.compat.json` extension
+
+Extend the existing compat marker (PR #802) rather than introducing a second marker:
+
+```json
+{
+  "schema": 2,
+  "lastWriter": "gsd-pi",
+  "lastProjectedAt": "...",
+  "projections": {
+    "milestones/M001/M001-ROADMAP.md": { "sha": "...", "entities": ["M001"] }
+  },
+  "planning": {
+    "active": true,
+    "layout": "flat-phases",
+    "rootSlug": "01-governance-packaging-foundation",
+    "projections": {
+      "ROADMAP.md": { "sha": "...", "entities": ["M001"] },
+      "phases/01-foo/01-01-PLAN.md": { "sha": "...", "entities": ["M001/S01"] }
+    },
+    "passthrough": {
+      "phases/01-foo/01-DISCUSSION-LOG.md": { "sha": "...", "entities": [] },
+      "codebase/STACK.md": { "sha": "...", "entities": [] }
+    }
+  },
+  "piVersion": "1.4.0"
+}
+```
+
+- `planning.active` — whether this project uses `.planning/` at all (set on first detect).
+- `planning.layout` — one of `flat-phases` | `multi-milestone` | `legacy-milestone-dir`. Captured at first read so the projection writes back the same shape.
+- `planning.projections` — sha map for the **modeled** `.planning/` files (roadmap, plans, summaries, state). These are re-imported on drift and re-rendered on projection.
+- `planning.passthrough` — sha map for tracked-but-not-interpreted files (un-modeled docs). Same shape as `projections` (`{ sha, entities }`) so drift is detected, but `entities` is empty and repair only refreshes the sha — content is never parsed or re-rendered.
+
+Marker schema bumps 1 → 2. The PR #802 marker reader already quarantines unknown schemas, so a v1 reader (pre-this-work gsd-pi) safely ignores a v2 marker and regenerates. Migration is implicit.
+
+### 4.3 New drift kind: `external-planning-edit`
+
+Parallel to `external-markdown-edit` (PR #802). Added to the `DriftRecord` union:
+
+```ts
+| {
+    kind: "external-planning-edit";
+    projectionPath: string;       // relative to .planning/, e.g. "phases/01-foo/01-01-PLAN.md"
+    expectedSha: string;
+    actualSha: string;
+    entities: string[];
+    passthrough: boolean;         // true = content-only copy, no re-import
+  }
+```
+
+Detect compares `.planning/` file shas to `marker.planning.projections`. Repair:
+- For modeled files: re-import via the existing parser + transformer.
+- For passthrough files: no DB import (there's nothing to import into); just refresh the marker sha so the next detect treats it as current.
+
+### 4.4 The projection writer: `writePlanningDirectory`
+
+New function in `migrate/writer.ts` (or a sibling). Given the DB state and the recorded layout, emits:
+
+- `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `STATE.md` at root
+- `phases/NN-<slug>/NN-MM-PLAN.md`, `NN-MM-SUMMARY.md`, `NN-CONTEXT.md`, `NN-RESEARCH.md` per the layout policy
+
+Layout-specific emission:
+- **`flat-phases`**: milestone M00N maps to phase NN; slice S0M maps to plan file NN-0M.
+- **`multi-milestone`**: each roadmap milestone section maps to a phase group; naming follows gsd-core's convention.
+- **`legacy-milestone-dir`**: reproduce `.planning/milestones/<mid>/phases/...`.
+
+The writer consults `marker.planning.layout` and refuses to project if the layout is unset (forces a read first — can't write a layout you've never seen).
+
+### 4.5 Reconcile flow (extended)
+
+Startup reconcile now:
+
+1. Read `.gsd/.compat.json` (schema 2).
+2. If `planning.active` and `.planning/` exists, run `external-planning-edit` detection over `.planning/` files.
+3. Repair: import modeled edits, refresh passthrough shas.
+4. Re-project: `renderAllFromDb` (`.gsd/`) **and** `writePlanningDirectory` (`.planning/`) if `planning.active`.
+5. Write fresh marker with both `projections` and `planning.projections`.
+
+## 5. Layout Provenance Policy
+
+The hard design decision. **Policy: capture-on-first-read, preserve-on-write.**
+
+- On the **first** gsd-pi open of a `.planning/` project (no marker or `planning.layout` unset), the reader infers the layout from directory structure (heuristic in `parser.ts`, already present) and records it in `marker.planning.layout`.
+- On **every subsequent** projection, the writer emits exactly that layout. It never reclassifies.
+- If the user manually restructures `.planning/` (rare), the next reconcile detects the structure no longer matches the recorded layout and surfaces a **blocker** (`"planning layout changed since last sync — run /gsd sync to re-establish"`) rather than guessing.
+
+This guarantees the round-trip preserves structure. The cost: a one-time re-read is required if the user restructures outside gsd-pi.
+
+## 6. Un-modeled Documents Policy
+
+`DISCUSSION-LOG.md`, `PATTERNS.md`, `REVIEWS.md`, `phase RESEARCH.md`, root `research/`, `codebase/`, `config.json` have no DB representation.
+
+**Policy: pass-through with drift detection.**
+
+- gsd-pi records their sha in `marker.planning.passthrough` but never parses or re-renders them.
+- If gsd-core edits them, the drift handler fires (as `external-planning-edit` with `passthrough: true`), refreshes the sha, and **leaves the content untouched**.
+- gsd-pi never writes these files. They are gsd-core-owned.
+
+Rationale: trying to model these in the DB would be a much larger effort and the content is often free-form. Pass-through preserves the data and detects edits without pretending to understand them. If a future milestone needs DB-backed discussion logs, that's a separate spec.
+
+**Exception:** if a passthrough file is missing on disk but present in the marker, gsd-pi does **not** restore it (it has no content copy). It logs a warning. The user is expected to recover from git. This is the same last-writer-per-entity policy as PR #802.
+
+## 7. STATE.md Mapping
+
+gsd-core `STATE.md` (YAML frontmatter + markdown) reports phase progress. gsd-pi derives equivalent info from DB status.
+
+**Projection policy:** gsd-pi renders `.planning/STATE.md` from DB state, mapping:
+
+| gsd-pi DB | gsd-core STATE.md |
+|---|---|
+| Active milestone id | `milestone` |
+| Milestone title | `milestone_name` |
+| Active phase / milestone status | `status` |
+| Slice completion count | `completed_phases` / `total_phases` |
+| Active slice id | `stopped_at` (rendered as "Phase NN — <slice title>") |
+| Timestamp | `last_updated`, `last_activity` |
+
+The mapping is one-way (DB → STATE.md). gsd-core edits to `STATE.md` are **not** re-imported into the DB (status is gsd-pi-authoritative); they're treated as passthrough for drift purposes only, so gsd-pi's next projection overwrites them. This is consistent with PR #802's "DB wins after import" for `.gsd/STATE.md`.
+
+## 8. Files (new / changed)
+
+| File | Change | Purpose |
+|---|---|---|
+| `compat/compat-marker.ts` | Extend `CompatMarker` with `planning?` field; bump schema 1→2 | Layout provenance + `.planning/` projection tracking |
+| `state-reconciliation/types.ts` | Add `external-planning-edit` to `DriftRecord` union | New drift kind |
+| `state-reconciliation/drift/external-planning-edit.ts` | **New** | Detect + repair for `.planning/` (parallel to `external-markdown-edit`) |
+| `state-reconciliation/registry.ts` | Register the new handler | Wire into reconcile |
+| `migrate/parser.ts` / `parsers.ts` | (verify, likely no change) | Read path already exists |
+| `migrate/writer.ts` | Add `writePlanningDirectory` | New: DB → `.planning/` projection |
+| `migrate/layout-detect.ts` | **New** | Heuristic that classifies a `.planning/` tree as `flat-phases` / `multi-milestone` / `legacy-milestone-dir` |
+| `markdown-renderer.ts` | After `renderAllFromDb`, also call `writePlanningDirectory` if `planning.active` | Write-time projection to `.planning/` |
+| `commands-maintenance.ts` | Extend `handleSync` to cover `.planning/` | `/gsd sync` covers both layouts |
+| `commands-handlers.ts` | Extend doctor compat-health to report `.planning/` drift | Visibility |
+| `tests/planning-round-trip-property.test.ts` | **New** | Round-trip suite for `.planning/` fixtures |
+| `tests/__fixtures__/round-trip/planning-flat-phases/` | **New** | Flat-phases fixture |
+| `tests/__fixtures__/round-trip/planning-multi-milestone/` | **New** | Multi-milestone fixture |
+| `docs/user-docs/switching-between-gsd-tools.md` | Extend | `.planning/` workflow |
+
+## 9. Success Criteria
+
+1. A gsd-core user with a `.planning/`-only project opens it in gsd-pi, sees their phases/plans/state, and continues work — no migration step.
+2. Edits made in gsd-core to `.planning/` are imported on the next gsd-pi open (with a visible log).
+3. Edits made in gsd-pi are projected back to `.planning/` in the **same layout** gsd-core uses.
+4. Un-modeled docs (discussion logs, codebase docs, research) survive round-trips unchanged.
+5. `/gsd doctor` reports `.planning/` compat health separately from `.gsd/`.
+6. The `.planning/` round-trip property suite is green in CI on at least two layout fixtures.
+
+## 10. Open Questions (to resolve during implementation)
+
+- **Layout detection heuristic robustness.** `parser.ts` already infers layout, but the capture-on-first-read policy depends on it being correct. Property tests with real gsd-core fixtures will stress this.
+- **`.planning/` ↔ `.gsd/` dual-active projects.** What if a project has *both*? Policy proposal: `.gsd/` is canonical, `.planning/` is a projection (mirror of `.gsd/` parity). Confirm during implementation.
+- **Passthrough file deletion.** If gsd-core deletes a passthrough file, should gsd-pi restore it or accept the deletion? Current policy (§6): accept + warn. Confirm.
+- **Performance.** Double projection (`.gsd/` + `.planning/`) doubles write cost on every state change. May need a "project `.planning/` only on reconcile, not on every write" optimization. Defer unless benchmarks show a problem.
+- **Marker schema 1→2 migration for existing PR #802 users.** The quarantine-on-unknown-schema policy means a v1 reader ignores v2 and regenerates — safe but loses `.planning/` tracking until both sides upgrade. Acceptable; document it.

--- a/docs/user-docs/switching-between-gsd-tools.md
+++ b/docs/user-docs/switching-between-gsd-tools.md
@@ -60,6 +60,18 @@ Compat health:      2 file(s) drifted — run /gsd sync
 
 gsd-core is unaware of gsd-pi. It sees `.gsd/*.md` as ordinary markdown and edits them directly. gsd-pi's `.gsd/.compat.json` and `gsd.db` files are ignored by gsd-core (it preserves unknown files, so they won't be deleted).
 
+## `.planning/` projects
+
+If your project uses gsd-core's `.planning/` layout (flat `phases/NN-name/` directories, root `ROADMAP.md` / `STATE.md`), gsd-pi projects DB state back to `.planning/` automatically — you don't need to run `/gsd migrate`.
+
+- The first time gsd-pi sees a `.planning/` project, it records the layout in `.gsd/.compat.json` under `planning.layout`.
+- On every projection, gsd-pi writes back to `.planning/` using that recorded layout.
+- `/gsd sync` imports gsd-core's `.planning/` edits; `/gsd doctor` reports `.planning/` drift separately from `.gsd/` drift.
+
+**Un-modeled docs** (phase `DISCUSSION-LOG.md`, `PATTERNS.md`, `REVIEWS.md`, `codebase/`, `research/`) are pass-through: gsd-pi detects edits to them but never overwrites them. They are gsd-core-owned.
+
+**v1 limitation:** only the `flat-phases` layout is supported for round-trip projection. `multi-milestone` and `legacy-milestone-dir` layouts will be supported after fixtures validate the reverse-mapping. For those layouts today, run `/gsd migrate` once to move to `.gsd/`.
+
 ## Conflicts: same entity edited in both
 
 If both tools edit the *same* entity (e.g., both change the status of slice `S01`) between syncs, the last writer wins after the next reconcile, and gsd-pi surfaces the resolution in the `/gsd sync` output. Git review remains the final safety net — that's why the "commit before switching" workflow matters.

--- a/docs/user-docs/switching-between-gsd-tools.md
+++ b/docs/user-docs/switching-between-gsd-tools.md
@@ -1,0 +1,73 @@
+# Switching between gsd-core and gsd-pi
+
+Both `@opengsd/gsd-core` and `@opengsd/gsd-pi` read and write the same `.gsd/` directory. You can open a project in either tool, switch freely, and even interleave them across sessions. This doc explains the workflow and what to do when the two tools disagree.
+
+## The shared contract
+
+`.gsd/*.md` files are the contract between the two tools. gsd-core treats them as the source of truth. gsd-pi uses a SQLite DB internally (faster queries, transactional state) but projects to the same `.md` files and imports any external edits on startup.
+
+## Recommended workflow: commit before switching
+
+Git is the integration layer. Before switching tools, commit:
+
+```bash
+git add .gsd/
+git commit -m "wip: switching to gsd-pi"
+```
+
+Then open the other tool. If anything goes wrong, `git reset --hard` restores the pre-switch state. This is the simplest and safest workflow.
+
+## What gsd-pi does on startup
+
+When you open a project in gsd-pi, it runs a reconciliation pass that:
+
+1. Compares every `.gsd/*.md` file against its recorded baseline in `.gsd/.compat.json`.
+2. Imports any file that changed since the last gsd-pi session (e.g., gsd-core edits).
+3. Re-projects all markdown from the DB.
+4. Updates `.gsd/.compat.json` with the new baseline.
+
+This is automatic — you don't need to do anything special. gsd-pi will not silently overwrite gsd-core edits.
+
+## `/gsd sync` — mid-session switch
+
+If you switch tools while gsd-pi is running (e.g., a teammate edits `.gsd/plan.md` via gsd-core and pushes), run:
+
+```
+/gsd sync
+```
+
+This re-runs the reconciliation pipeline, imports the external edits, and re-projects. Use `--dry-run` to preview what would change:
+
+```
+/gsd sync --dry-run
+```
+
+## `/gsd doctor` — check compat health
+
+`/gsd doctor` includes a compat-health line that tells you whether the marker is present and whether any files have drifted:
+
+```
+Compat health:      OK
+```
+
+or
+
+```
+Compat health:      2 file(s) drifted — run /gsd sync
+```
+
+## What gsd-core sees
+
+gsd-core is unaware of gsd-pi. It sees `.gsd/*.md` as ordinary markdown and edits them directly. gsd-pi's `.gsd/.compat.json` and `gsd.db` files are ignored by gsd-core (it preserves unknown files, so they won't be deleted).
+
+## Conflicts: same entity edited in both
+
+If both tools edit the *same* entity (e.g., both change the status of slice `S01`) between syncs, the last writer wins after the next reconcile, and gsd-pi surfaces the resolution in the `/gsd sync` output. Git review remains the final safety net — that's why the "commit before switching" workflow matters.
+
+## Troubleshooting
+
+**`gsd doctor` says "no baseline"**: run `/gsd sync` once to establish the marker.
+
+**`.gsd/.compat.json.bad-*` files appear**: gsd-pi quarantined a malformed marker and started fresh. Safe to delete the `.bad-*` file after reviewing it.
+
+**`/gsd sync` reports drift every time you open the project**: this means gsd-pi's projection isn't idempotent — a real bug. The round-trip property test suite in CI catches most of these; report the fixture if you hit one in the wild.

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -185,8 +185,10 @@ export function isDoctorHealActionable(issue: { fixable: boolean; severity: stri
  * presence and the count of projection files whose on-disk sha has drifted
  * from the recorded baseline. Returns "" if the marker module is unavailable
  * (defensive — doctor must never fail because of compat reporting).
+ *
+ * Exported for unit testing.
  */
-async function formatCompatHealthLine(basePath: string): Promise<string> {
+export async function formatCompatHealthLine(basePath: string): Promise<string> {
   try {
     const { readCompatMarker, computeProjectionSha } = await import("./compat/compat-marker.js");
     const marker = readCompatMarker(basePath);

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -190,18 +190,41 @@ async function formatCompatHealthLine(basePath: string): Promise<string> {
   try {
     const { readCompatMarker, computeProjectionSha } = await import("./compat/compat-marker.js");
     const marker = readCompatMarker(basePath);
-    const entries = Object.entries(marker.projections);
-    if (entries.length === 0) {
+
+    const countDrifted = (
+      entries: Record<string, { sha: string }>,
+      root: string,
+    ): number => {
+      let drifted = 0;
+      for (const [rel, entry] of Object.entries(entries)) {
+        const abs = join(basePath, root, rel);
+        if (!existsSync(abs)) continue;
+        if (computeProjectionSha(readFileSync(abs, "utf-8")) !== entry.sha) drifted++;
+      }
+      return drifted;
+    };
+
+    const lines: string[] = [];
+    const gsdEntries = Object.entries(marker.projections);
+    if (gsdEntries.length === 0 && !marker.planning?.active) {
       return "  Compat health:      no baseline (run /gsd sync to establish)";
     }
-    let drifted = 0;
-    for (const [rel, entry] of entries) {
-      const abs = join(basePath, ".gsd", rel);
-      if (!existsSync(abs)) continue;
-      if (computeProjectionSha(readFileSync(abs, "utf-8")) !== entry.sha) drifted++;
+    const gsdDrifted = countDrifted(marker.projections, ".gsd");
+    lines.push(
+      `  Compat health (.gsd):    ${gsdDrifted === 0 ? "OK" : `${gsdDrifted} file(s) drifted — run /gsd sync`}`,
+    );
+
+    if (marker.planning?.active) {
+      const planningDrifted =
+        countDrifted(marker.planning.projections, ".planning") +
+        countDrifted(marker.planning.passthrough, ".planning");
+      lines.push(
+        `  Compat health (.planning): ${planningDrifted === 0 ? "OK" : `${planningDrifted} file(s) drifted — run /gsd sync`}`,
+      );
+    } else {
+      lines.push(`  Compat health (.planning): not active`);
     }
-    const status = drifted === 0 ? "OK" : `${drifted} file(s) drifted — run /gsd sync`;
-    return `  Compat health:      ${status}`;
+    return lines.join("\n");
   } catch {
     return "";
   }

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -205,22 +205,37 @@ async function formatCompatHealthLine(basePath: string): Promise<string> {
     };
 
     const lines: string[] = [];
-    const gsdEntries = Object.entries(marker.projections);
-    if (gsdEntries.length === 0 && !marker.planning?.active) {
+    const gsdEntryCount = Object.keys(marker.projections).length;
+    const planningActive = marker.planning?.active ?? false;
+    const planningEntryCount = planningActive
+      ? Object.keys(marker.planning!.projections).length +
+        Object.keys(marker.planning!.passthrough).length
+      : 0;
+
+    if (gsdEntryCount === 0 && !planningActive) {
       return "  Compat health:      no baseline (run /gsd sync to establish)";
     }
-    const gsdDrifted = countDrifted(marker.projections, ".gsd");
-    lines.push(
-      `  Compat health (.gsd):    ${gsdDrifted === 0 ? "OK" : `${gsdDrifted} file(s) drifted — run /gsd sync`}`,
-    );
 
-    if (marker.planning?.active) {
-      const planningDrifted =
-        countDrifted(marker.planning.projections, ".planning") +
-        countDrifted(marker.planning.passthrough, ".planning");
+    if (gsdEntryCount === 0) {
+      lines.push("  Compat health (.gsd):    no baseline (run /gsd sync to establish)");
+    } else {
+      const gsdDrifted = countDrifted(marker.projections, ".gsd");
       lines.push(
-        `  Compat health (.planning): ${planningDrifted === 0 ? "OK" : `${planningDrifted} file(s) drifted — run /gsd sync`}`,
+        `  Compat health (.gsd):    ${gsdDrifted === 0 ? "OK" : `${gsdDrifted} file(s) drifted — run /gsd sync`}`,
       );
+    }
+
+    if (planningActive) {
+      if (planningEntryCount === 0) {
+        lines.push("  Compat health (.planning): no baseline (run /gsd sync to establish)");
+      } else {
+        const planningDrifted =
+          countDrifted(marker.planning!.projections, ".planning") +
+          countDrifted(marker.planning!.passthrough, ".planning");
+        lines.push(
+          `  Compat health (.planning): ${planningDrifted === 0 ? "OK" : `${planningDrifted} file(s) drifted — run /gsd sync`}`,
+        );
+      }
     } else {
       lines.push(`  Compat health (.planning): not active`);
     }

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -180,6 +180,33 @@ export function isDoctorHealActionable(issue: { fixable: boolean; severity: stri
   return issue.fixable && issue.severity !== "info";
 }
 
+/**
+ * Compat-health line for `/gsd doctor`. Reports the gsd-core compat marker's
+ * presence and the count of projection files whose on-disk sha has drifted
+ * from the recorded baseline. Returns "" if the marker module is unavailable
+ * (defensive — doctor must never fail because of compat reporting).
+ */
+async function formatCompatHealthLine(basePath: string): Promise<string> {
+  try {
+    const { readCompatMarker, computeProjectionSha } = await import("./compat/compat-marker.js");
+    const marker = readCompatMarker(basePath);
+    const entries = Object.entries(marker.projections);
+    if (entries.length === 0) {
+      return "  Compat health:      no baseline (run /gsd sync to establish)";
+    }
+    let drifted = 0;
+    for (const [rel, entry] of entries) {
+      const abs = join(basePath, ".gsd", rel);
+      if (!existsSync(abs)) continue;
+      if (computeProjectionSha(readFileSync(abs, "utf-8")) !== entry.sha) drifted++;
+    }
+    const status = drifted === 0 ? "OK" : `${drifted} file(s) drifted — run /gsd sync`;
+    return `  Compat health:      ${status}`;
+  } catch {
+    return "";
+  }
+}
+
 export async function handleDoctor(args: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
   const { jsonMode, dryRun, fixFlag, includeBuild, includeTests, mode, requestedScope } = parseDoctorArgs(args);
   const scope = await selectDoctorScope(projectRoot(), requestedScope);
@@ -206,7 +233,13 @@ export async function handleDoctor(args: string, ctx: ExtensionCommandContext, p
     title: mode === "audit" ? "GSD doctor audit." : mode === "heal" ? "GSD doctor heal prep." : undefined,
   });
 
-  ctx.ui.notify(reportText, report.ok ? "info" : "warning");
+  // Compat health: marker presence + drift vs current projections. Appended to
+  // the formatted report so it surfaces in every doctor run without touching
+  // the doctor report internals.
+  const compatLine = await formatCompatHealthLine(projectRoot());
+  const fullReport = compatLine ? `${reportText}\n${compatLine}` : reportText;
+
+  ctx.ui.notify(fullReport, report.ok ? "info" : "warning");
 
   if (mode === "heal") {
     const unresolved = filterDoctorIssues(report.issues, {

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -873,17 +873,24 @@ export async function handleSync(
       for (const e of renderResult.errors) lines.push(`    • ${e}`);
     }
 
-    // Refresh the marker to reflect the freshly re-projected state.
+    // Refresh the marker to reflect the freshly re-projected state. The
+    // planning hook inside renderAllFromDb already recorded per-file SHAs
+    // into marker.planning.projections; we read back the fully-populated
+    // marker here so the timestamp is the last thing written.
     const marker = readCompatMarker(basePath);
     marker.lastWriter = "gsd-pi";
     marker.lastProjectedAt = new Date().toISOString();
     writeCompatMarker(basePath, marker);
+    const planningShaCnt = Object.keys(marker.planning?.projections ?? {}).length;
+    const planningNote = planningShaCnt > 0
+      ? ` + ${planningShaCnt} .planning/ SHA${planningShaCnt !== 1 ? "s" : ""}`
+      : "";
 
     const state = await deriveState(basePath);
     lines.push(
       "",
       `  Phase:  ${state.phase}`,
-      `  Marker: .gsd/.compat.json refreshed`,
+      `  Marker: .gsd/.compat.json refreshed${planningNote}`,
     );
     if (state.activeMilestone) {
       lines.push(`  Active: ${state.activeMilestone.id}: ${state.activeMilestone.title}`);

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -836,9 +836,11 @@ export async function handleSync(
   const lines: string[] = ["gsd sync: reconciling .gsd/ for cross-tool edits…"];
 
   try {
-    const result = await reconcileBeforeDispatch(basePath);
+    const result = await reconcileBeforeDispatch(basePath, { dryRun });
     const repairedExternal = result.repaired.filter((r) => r.kind === "external-markdown-edit");
-    lines.push(`  External edits imported: ${repairedExternal.length}`);
+    lines.push(
+      `  External edits ${dryRun ? "to import" : "imported"}: ${repairedExternal.length}`,
+    );
     for (const r of repairedExternal) {
       const e = r as { kind: "external-markdown-edit"; projectionPath: string };
       lines.push(`    • ${e.projectionPath}`);
@@ -849,7 +851,7 @@ export async function handleSync(
     }
 
     if (dryRun) {
-      lines.push("", "  (dry-run: no projection or marker writes performed)");
+      lines.push("", "  (dry-run: no repairs, projection, or marker writes performed)");
       ctx.ui.notify(lines.join("\n"), "info");
       return;
     }

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -807,10 +807,86 @@ export async function rebuildMarkdownProjectionsFromDb(
 }
 
 /**
+ * `/gsd sync` — pull in external (gsd-core) markdown edits and re-project.
+ *
+ * Non-destructive cousin of `/gsd recover`: does NOT clear the DB. Runs the
+ * ADR-017 reconcile pipeline (which picks up the external-markdown-edit handler
+ * automatically), then re-projects via renderAllFromDb, then refreshes the
+ * compat marker. Use this when switching from gsd-core mid-session.
+ *
+ * Accepts `--dry-run` to report what would change without writing.
+ */
+export async function handleSync(
+  ctx: ExtensionCommandContext,
+  basePath: string,
+  args = "",
+): Promise<void> {
+  const { isDbAvailable } = await import("./gsd-db.js");
+  const { reconcileBeforeDispatch } = await import("./state-reconciliation/index.js");
+  const { renderAllFromDb } = await import("./markdown-renderer.js");
+  const { writeCompatMarker, readCompatMarker } = await import("./compat/compat-marker.js");
+
+  const dryRun = args.trim() === "--dry-run";
+
+  if (!isDbAvailable()) {
+    ctx.ui.notify("gsd sync: No database open. Run a GSD command first to initialize the DB.", "error");
+    return;
+  }
+
+  const lines: string[] = ["gsd sync: reconciling .gsd/ for cross-tool edits…"];
+
+  try {
+    const result = await reconcileBeforeDispatch(basePath);
+    const repairedExternal = result.repaired.filter((r) => r.kind === "external-markdown-edit");
+    lines.push(`  External edits imported: ${repairedExternal.length}`);
+    for (const r of repairedExternal) {
+      const e = r as { kind: "external-markdown-edit"; projectionPath: string };
+      lines.push(`    • ${e.projectionPath}`);
+    }
+    if (result.blockers.length > 0) {
+      lines.push("", "  ⚠ Blockers:");
+      for (const b of result.blockers) lines.push(`    • ${b}`);
+    }
+
+    if (dryRun) {
+      lines.push("", "  (dry-run: no projection or marker writes performed)");
+      ctx.ui.notify(lines.join("\n"), "info");
+      return;
+    }
+
+    const renderResult = await renderAllFromDb(basePath);
+    if (renderResult.errors.length > 0) {
+      lines.push("", "  ⚠ Projection errors:");
+      for (const e of renderResult.errors) lines.push(`    • ${e}`);
+    }
+
+    // Refresh the marker to reflect the freshly re-projected state.
+    const marker = readCompatMarker(basePath);
+    marker.lastWriter = "gsd-pi";
+    marker.lastProjectedAt = new Date().toISOString();
+    writeCompatMarker(basePath, marker);
+
+    const state = await deriveState(basePath);
+    lines.push(
+      "",
+      `  Phase:  ${state.phase}`,
+      `  Marker: .gsd/.compat.json refreshed`,
+    );
+    if (state.activeMilestone) {
+      lines.push(`  Active: ${state.activeMilestone.id}: ${state.activeMilestone.title}`);
+    }
+
+    ctx.ui.notify(lines.join("\n"), "info");
+  } catch (err) {
+    ctx.ui.notify(`gsd sync failed: ${(err as Error).message}`, "error");
+  }
+}
+
+/**
  * `gsd rebuild markdown` — Re-render markdown projections from the authoritative DB.
  *
- * This is the DB-first realignment command. It does not import markdown into
- * the DB. Completion SUMMARY files that contradict open DB rows are preserved
+ * This is the DB-first realignment command. It does not import markdown into the
+ * DB. Completion SUMMARY files that contradict open DB rows are preserved
  * under `.gsd/quarantine/projections/` before DB projections are rendered.
  */
 export async function handleRebuild(ctx: ExtensionCommandContext, basePath: string, args = ""): Promise<void> {

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -839,11 +839,22 @@ export async function handleSync(
     const result = await reconcileBeforeDispatch(basePath, { dryRun });
     const repairedExternal = result.repaired.filter((r) => r.kind === "external-markdown-edit");
     lines.push(
-      `  External edits ${dryRun ? "to import" : "imported"}: ${repairedExternal.length}`,
+      `  External .gsd/ edits ${dryRun ? "to import" : "imported"}: ${repairedExternal.length}`,
     );
     for (const r of repairedExternal) {
       const e = r as { kind: "external-markdown-edit"; projectionPath: string };
       lines.push(`    • ${e.projectionPath}`);
+    }
+    const repairedPlanningExternal = result.repaired.filter((r) => r.kind === "external-planning-edit");
+    if (repairedPlanningExternal.length > 0) {
+      lines.push(
+        `  External .planning/ edits ${dryRun ? "to import" : "imported"}: ${repairedPlanningExternal.length}`,
+      );
+      for (const r of repairedPlanningExternal) {
+        const e = r as { kind: "external-planning-edit"; projectionPath: string; passthrough: boolean };
+        const tag = e.passthrough ? " (passthrough)" : "";
+        lines.push(`    • ${e.projectionPath}${tag}`);
+      }
     }
     if (result.blockers.length > 0) {
       lines.push("", "  ⚠ Blockers:");

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -9,7 +9,7 @@ import { handleDoctor, handleCapture, handleKnowledge, handleRunHook, handleSkil
 import { handleInspect } from "../../commands-inspect.js";
 import { handleLogs } from "../../commands-logs.js";
 import { handleDebug } from "../../commands-debug.js";
-import { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleCleanupProjects, handleCleanupWorktrees, handleRecover, handleRebuild } from "../../commands-maintenance.js";
+import { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleCleanupProjects, handleCleanupWorktrees, handleRecover, handleRebuild, handleSync } from "../../commands-maintenance.js";
 import { handleExport } from "../../export.js";
 import { handleHistory } from "../../history.js";
 import { handleUndo } from "../../undo.js";
@@ -137,6 +137,10 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
   }
   if (trimmed === "rebuild" || trimmed.startsWith("rebuild ")) {
     await handleRebuild(ctx, projectRoot(), trimmed.replace(/^rebuild\s*/, "").trim());
+    return true;
+  }
+  if (trimmed === "sync" || trimmed.startsWith("sync ")) {
+    await handleSync(ctx, projectRoot(), trimmed.replace(/^sync\s*/, "").trim());
     return true;
   }
   if (trimmed === "closeout" || trimmed.startsWith("closeout ")) {

--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -65,13 +65,13 @@ export function computeProjectionSha(content: string): string {
  */
 export function readCompatMarker(basePath: string): CompatMarker {
   const path = compatMarkerPath(basePath);
-  if (!existsSync(path)) return { ...EMPTY_MARKER };
+  if (!existsSync(path)) return emptyMarker();
 
   let raw: string;
   try {
     raw = readFileSync(path, "utf-8");
   } catch {
-    return { ...EMPTY_MARKER };
+    return emptyMarker();
   }
 
   let parsed: unknown;
@@ -79,19 +79,34 @@ export function readCompatMarker(basePath: string): CompatMarker {
     parsed = JSON.parse(raw);
   } catch {
     quarantine(basePath, raw);
-    return { ...EMPTY_MARKER };
+    return emptyMarker();
   }
 
   if (!isValidMarker(parsed)) {
     quarantine(basePath, raw);
-    return { ...EMPTY_MARKER };
+    return emptyMarker();
   }
   if (parsed.schema !== COMPAT_MARKER_SCHEMA) {
     // Future schema: refuse rather than guess. Re-running reconcile regenerates.
     quarantine(basePath, raw);
-    return { ...EMPTY_MARKER };
+    return emptyMarker();
   }
   return parsed;
+}
+
+/**
+ * Fresh deep copy of EMPTY_MARKER. Callers mutate the returned `projections`
+ * object (e.g. repair refreshes an entry), so a shallow copy would share the
+ * reference and pollute the module constant across calls. Always deep-copy.
+ */
+function emptyMarker(): CompatMarker {
+  return {
+    schema: EMPTY_MARKER.schema,
+    lastWriter: EMPTY_MARKER.lastWriter,
+    lastProjectedAt: EMPTY_MARKER.lastProjectedAt,
+    projections: {},
+    piVersion: EMPTY_MARKER.piVersion,
+  };
 }
 
 /**

--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -10,7 +10,27 @@ import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync, mkdirS
 import { dirname, join } from "node:path";
 
 /** Current marker schema version. Bump on breaking format changes + migrate. */
-export const COMPAT_MARKER_SCHEMA = 1;
+export const COMPAT_MARKER_SCHEMA = 2;
+
+/**
+ * Which `.planning/` layout a project uses. Captured on first read so the
+ * round-trip writer recreates the same structure gsd-core wrote. Priority
+ * matches migrate/transformer.ts transformToGSD.
+ */
+export type PlanningLayout = "flat-phases" | "multi-milestone" | "legacy-milestone-dir";
+
+/**
+ * `.planning/` projection tracking. `projections` are modeled files (roadmap,
+ * plans, summaries, state) that get re-imported on drift; `passthrough` are
+ * un-modeled docs (DISCUSSION-LOG, PATTERNS, REVIEWS, codebase/) that get sha-
+ * refreshed only — content never re-rendered.
+ */
+export interface PlanningMarker {
+  active: boolean;
+  layout: PlanningLayout | null;
+  projections: Record<string, ProjectionEntry>;
+  passthrough: Record<string, ProjectionEntry>;
+}
 
 /**
  * Per-file projection entry. `sha` is a normalized-content SHA-256; `entities`
@@ -27,6 +47,8 @@ export interface CompatMarker {
   lastWriter: "gsd-pi";
   lastProjectedAt: string;
   projections: Record<string, ProjectionEntry>;
+  /** Optional: `.planning/` layout tracking for gsd-core parity. */
+  planning?: PlanningMarker;
   piVersion: string;
 }
 
@@ -36,6 +58,7 @@ export const EMPTY_MARKER: CompatMarker = {
   lastWriter: "gsd-pi",
   lastProjectedAt: "",
   projections: {},
+  planning: { active: false, layout: null, projections: {}, passthrough: {} },
   piVersion: "",
 };
 
@@ -86,10 +109,13 @@ export function readCompatMarker(basePath: string): CompatMarker {
     quarantine(basePath, raw);
     return emptyMarker();
   }
-  if (parsed.schema !== COMPAT_MARKER_SCHEMA) {
-    // Future schema: refuse rather than guess. Re-running reconcile regenerates.
-    quarantine(basePath, raw);
-    return emptyMarker();
+  // Promote older markers by defaulting absent fields. Schema 1 → 2 only adds
+  // the optional `planning` field; treat its absence as planning-inactive so
+  // existing PR #802 users upgrade transparently. (A future schema 3 would
+  // need an explicit migration here; for now anything that passes isValidMarker
+  // is safe to read.)
+  if (!parsed.planning) {
+    parsed.planning = { active: false, layout: null, projections: {}, passthrough: {} };
   }
   return parsed;
 }
@@ -105,6 +131,7 @@ function emptyMarker(): CompatMarker {
     lastWriter: EMPTY_MARKER.lastWriter,
     lastProjectedAt: EMPTY_MARKER.lastProjectedAt,
     projections: {},
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
     piVersion: EMPTY_MARKER.piVersion,
   };
 }
@@ -138,6 +165,37 @@ function quarantine(basePath: string, raw: string): void {
   }
 }
 
+function isValidProjectionEntry(x: unknown): x is ProjectionEntry {
+  if (typeof x !== "object" || x === null) return false;
+  const e = x as Record<string, unknown>;
+  if (typeof e.sha !== "string") return false;
+  if (!Array.isArray(e.entities) || !e.entities.every((s) => typeof s === "string")) return false;
+  return true;
+}
+
+function isValidProjectionMap(x: unknown): boolean {
+  if (typeof x !== "object" || x === null) return false;
+  for (const v of Object.values(x as Record<string, unknown>)) {
+    if (!isValidProjectionEntry(v)) return false;
+  }
+  return true;
+}
+
+function isValidPlanningMarker(x: unknown): x is PlanningMarker {
+  if (typeof x !== "object" || x === null) return false;
+  const p = x as Record<string, unknown>;
+  if (typeof p.active !== "boolean") return false;
+  if (
+    p.layout !== null &&
+    !["flat-phases", "multi-milestone", "legacy-milestone-dir"].includes(p.layout as string)
+  ) {
+    return false;
+  }
+  if (!isValidProjectionMap(p.projections)) return false;
+  if (!isValidProjectionMap(p.passthrough)) return false;
+  return true;
+}
+
 function isValidMarker(x: unknown): x is CompatMarker {
   if (typeof x !== "object" || x === null) return false;
   const m = x as Record<string, unknown>;
@@ -145,12 +203,8 @@ function isValidMarker(x: unknown): x is CompatMarker {
   if (typeof m.schema !== "number") return false;
   if (typeof m.lastProjectedAt !== "string") return false;
   if (typeof m.piVersion !== "string") return false;
-  if (typeof m.projections !== "object" || m.projections === null) return false;
-  for (const v of Object.values(m.projections as Record<string, unknown>)) {
-    if (typeof v !== "object" || v === null) return false;
-    const e = v as Record<string, unknown>;
-    if (typeof e.sha !== "string") return false;
-    if (!Array.isArray(e.entities) || !e.entities.every((s) => typeof s === "string")) return false;
-  }
+  if (!isValidProjectionMap(m.projections)) return false;
+  // planning is optional; when present, must validate.
+  if (m.planning !== undefined && !isValidPlanningMarker(m.planning)) return false;
   return true;
 }

--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -6,7 +6,7 @@
 // (drift to import). gsd-core is oblivious to this file and ignores it.
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, renameSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 /** Current marker schema version. Bump on breaking format changes + migrate. */
@@ -122,10 +122,16 @@ export function writeCompatMarker(basePath: string, marker: CompatMarker): void 
 }
 
 function quarantine(basePath: string, raw: string): void {
-  const badPath = `${compatMarkerPath(basePath)}.bad-${Date.now()}`;
+  const path = compatMarkerPath(basePath);
+  const badPath = `${path}.bad-${Date.now()}`;
   try {
     mkdirSync(dirname(badPath), { recursive: true });
-    writeFileSync(badPath, raw, "utf-8");
+    try {
+      renameSync(path, badPath);
+    } catch {
+      writeFileSync(badPath, raw, "utf-8");
+      unlinkSync(path);
+    }
   } catch {
     // Best-effort: if we can't quarantine, leave the original in place — next
     // read will quarantine. Never throw out of marker I/O.

--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -1,0 +1,135 @@
+// Project/App: gsd-pi
+// File Purpose: gsd-core ↔ gsd-pi compatibility marker (`.gsd/.compat.json`).
+//
+// Records per-projection content hashes so the ADR-017 reconcile pipeline can
+// distinguish gsd-pi's own writes (expected) from external edits made by gsd-core
+// (drift to import). gsd-core is oblivious to this file and ignores it.
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, renameSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** Current marker schema version. Bump on breaking format changes + migrate. */
+export const COMPAT_MARKER_SCHEMA = 1;
+
+/**
+ * Per-file projection entry. `sha` is a normalized-content SHA-256; `entities`
+ * is the list of DB entity ids (milestone/slice/task) that the file projects,
+ * so repair can scope re-import rather than re-importing the whole tree.
+ */
+export interface ProjectionEntry {
+  sha: string;
+  entities: string[];
+}
+
+export interface CompatMarker {
+  schema: number;
+  lastWriter: "gsd-pi";
+  lastProjectedAt: string;
+  projections: Record<string, ProjectionEntry>;
+  piVersion: string;
+}
+
+/** Marker returned when no marker exists yet (fresh project, first gsd-pi run). */
+export const EMPTY_MARKER: CompatMarker = {
+  schema: COMPAT_MARKER_SCHEMA,
+  lastWriter: "gsd-pi",
+  lastProjectedAt: "",
+  projections: {},
+  piVersion: "",
+};
+
+export function compatMarkerPath(basePath: string): string {
+  return join(basePath, ".gsd", ".compat.json");
+}
+
+/**
+ * Normalize markdown content before hashing so cosmetic differences (trailing
+ * whitespace, CRLF) don't produce false-positive drift. Conservative: only
+ * transforms that are provably round-trippable through gsd-pi's projection.
+ */
+export function normalizeForHash(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n");
+}
+
+export function computeProjectionSha(content: string): string {
+  return createHash("sha256").update(normalizeForHash(content)).digest("hex").slice(0, 16);
+}
+
+/**
+ * Read & validate the marker. A missing marker → EMPTY_MARKER (treat every
+ * projection as external on next reconcile). A malformed marker is quarantined
+ * to `.compat.json.bad-<ts>` (never overwrite without backup) then returns
+ * EMPTY_MARKER. A schema-mismatch returns EMPTY_MARKER (forward-compat: refuse
+ * to act on a future format we don't understand).
+ */
+export function readCompatMarker(basePath: string): CompatMarker {
+  const path = compatMarkerPath(basePath);
+  if (!existsSync(path)) return { ...EMPTY_MARKER };
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return { ...EMPTY_MARKER };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    quarantine(basePath, raw);
+    return { ...EMPTY_MARKER };
+  }
+
+  if (!isValidMarker(parsed)) {
+    quarantine(basePath, raw);
+    return { ...EMPTY_MARKER };
+  }
+  if (parsed.schema !== COMPAT_MARKER_SCHEMA) {
+    // Future schema: refuse rather than guess. Re-running reconcile regenerates.
+    quarantine(basePath, raw);
+    return { ...EMPTY_MARKER };
+  }
+  return parsed;
+}
+
+/**
+ * Write the marker atomically (write-temp then rename) so a crash mid-write
+ * can't leave a half-written file that next startup would quarantine.
+ */
+export function writeCompatMarker(basePath: string, marker: CompatMarker): void {
+  const path = compatMarkerPath(basePath);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(marker, null, 2), "utf-8");
+  renameSync(tmp, path);
+}
+
+function quarantine(basePath: string, raw: string): void {
+  const badPath = `${compatMarkerPath(basePath)}.bad-${Date.now()}`;
+  try {
+    mkdirSync(dirname(badPath), { recursive: true });
+    writeFileSync(badPath, raw, "utf-8");
+  } catch {
+    // Best-effort: if we can't quarantine, leave the original in place — next
+    // read will quarantine. Never throw out of marker I/O.
+  }
+}
+
+function isValidMarker(x: unknown): x is CompatMarker {
+  if (typeof x !== "object" || x === null) return false;
+  const m = x as Record<string, unknown>;
+  if (m.lastWriter !== "gsd-pi") return false;
+  if (typeof m.schema !== "number") return false;
+  if (typeof m.lastProjectedAt !== "string") return false;
+  if (typeof m.piVersion !== "string") return false;
+  if (typeof m.projections !== "object" || m.projections === null) return false;
+  for (const v of Object.values(m.projections as Record<string, unknown>)) {
+    if (typeof v !== "object" || v === null) return false;
+    const e = v as Record<string, unknown>;
+    if (typeof e.sha !== "string") return false;
+    if (!Array.isArray(e.entities) || !e.entities.every((s) => typeof s === "string")) return false;
+  }
+  return true;
+}

--- a/src/resources/extensions/gsd/compat/index.ts
+++ b/src/resources/extensions/gsd/compat/index.ts
@@ -9,4 +9,4 @@ export {
   readCompatMarker,
   writeCompatMarker,
 } from "./compat-marker.js";
-export type { CompatMarker, ProjectionEntry } from "./compat-marker.js";
+export type { CompatMarker, PlanningLayout, PlanningMarker, ProjectionEntry } from "./compat-marker.js";

--- a/src/resources/extensions/gsd/compat/index.ts
+++ b/src/resources/extensions/gsd/compat/index.ts
@@ -1,0 +1,12 @@
+// Project/App: gsd-pi
+// File Purpose: Public exports for the gsd-core compat module.
+export {
+  COMPAT_MARKER_SCHEMA,
+  EMPTY_MARKER,
+  compatMarkerPath,
+  computeProjectionSha,
+  normalizeForHash,
+  readCompatMarker,
+  writeCompatMarker,
+} from "./compat-marker.js";
+export type { CompatMarker, ProjectionEntry } from "./compat-marker.js";

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -101,33 +101,40 @@ export async function capturePlanningCompatIfNeeded(
   const marker = readCompatMarker(basePath);
   if (marker.planning?.active && marker.planning.layout) return;
 
-  // First encounter: parse layout, import .planning/ content into the DB, then
-  // activate the marker. We import before writing to disk so that
-  // writePlanningDirectory (called later by renderAllFromDb) reconstructs the
-  // .planning/ tree from a DB that already reflects gsd-core's content rather
-  // than overwriting it with stale or empty DB state.
+  // First encounter: parse layout, import content into the DB, then activate the
+  // marker. When `.gsd/` already exists (coexistence), import from disk via
+  // migrateHierarchyToDb and do not call writeGSDDirectory — reconcile runs
+  // external-markdown-edit before external-planning-edit and must not destroy
+  // gsd-core `.gsd/` edits before that pipeline can see them. Planning-only
+  // projects materialize `.gsd/` from the parsed tree first, then import.
   const { parsePlanningDirectory } = await import("../migrate/parser.js");
   const { detectPlanningLayout } = await import("../migrate/layout-detect.js");
   const parsed = await parsePlanningDirectory(planningDir);
   const layout: PlanningLayout | null = detectPlanningLayout(parsed);
   if (!layout) return;
 
-  // Import .planning/ into the DB. Dynamic imports break the module-init cycle
+  // Import into the DB. Dynamic imports break the module-init cycle
   // (planning-compat ← reconcile ← state ← md-importer). Matches the import
   // pattern in repairExternalPlanningEdit.
+  const gsdDir = join(basePath, ".gsd");
+  const gsdTreeHasContent =
+    existsSync(gsdDir) &&
+    readdirSync(gsdDir).some((name) => name !== ".compat.json" && !name.startsWith("."));
   try {
-    const { transformToGSD } = await import("../migrate/transformer.js");
-    const { writeGSDDirectory } = await import("../migrate/writer.js");
     const { migrateHierarchyToDb } = await import("../md-importer.js");
     const { invalidateStateCache } = await import("../state.js");
-    const gsdProject = transformToGSD(parsed);
-    await writeGSDDirectory(gsdProject, basePath);
+    if (!gsdTreeHasContent) {
+      const { transformToGSD } = await import("../migrate/transformer.js");
+      const { writeGSDDirectory } = await import("../migrate/writer.js");
+      const gsdProject = transformToGSD(parsed);
+      await writeGSDDirectory(gsdProject, basePath);
+    }
     migrateHierarchyToDb(basePath);
     invalidateStateCache();
   } catch (e) {
     logWarning(
       "reconcile",
-      `planning DB import failed on initial capture — writePlanningDirectory may overwrite gsd-core content: ${(e as Error).message}`,
+      `planning DB import failed on initial capture — reconcile may overwrite gsd-core content: ${(e as Error).message}`,
     );
   }
 

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -19,7 +19,7 @@ export interface PlanningProjectionWrite {
   passthrough?: boolean;
 }
 
-function isPlanningPassthroughRelPath(relPath: string): boolean {
+export function isPlanningPassthroughRelPath(relPath: string): boolean {
   if (relPath.startsWith("codebase/") || relPath.startsWith("research/")) return true;
   if (relPath === "config.json") return true;
   const name = relPath.split("/").pop() ?? relPath;
@@ -29,7 +29,7 @@ function isPlanningPassthroughRelPath(relPath: string): boolean {
   return false;
 }
 
-function walkPlanningRelPaths(planningDir: string, prefix = ""): string[] {
+export function walkPlanningRelPaths(planningDir: string, prefix = ""): string[] {
   const paths: string[] = [];
   let entries;
   try {
@@ -77,54 +77,29 @@ export function applyPlanningProjectionWrites(
   writeCompatMarker(basePath, marker);
 }
 
-function seedPlanningShasFromDisk(basePath: string): void {
-  const planningDir = join(basePath, ".planning");
-  const marker = readCompatMarker(basePath);
-  if (!marker.planning) {
-    marker.planning = { active: true, layout: null, projections: {}, passthrough: {} };
-  }
-  for (const relPath of walkPlanningRelPaths(planningDir)) {
-    const abs = join(planningDir, relPath);
-    const entry = {
-      sha: computeProjectionSha(readFileSync(abs, "utf-8")),
-      entities: [] as string[],
-    };
-    const map = isPlanningPassthroughRelPath(relPath)
-      ? marker.planning.passthrough
-      : marker.planning.projections;
-    map[relPath] = entry;
-  }
-  marker.lastWriter = "gsd-pi";
-  marker.lastProjectedAt = new Date().toISOString();
-  writeCompatMarker(basePath, marker);
+export interface CapturePlanningCompatOptions {
+  dryRun?: boolean;
 }
 
 /**
  * Capture-on-first-read: infer `.planning/` layout from disk, import content
  * into the DB so gsd-pi's projection reflects gsd-core's tree instead of
- * overwriting it, then activate the compat marker so drift detection has a
- * baseline on the next reconcile pass.
+ * overwriting it, then activate the compat marker. Projection shas are seeded
+ * by drift repair / write-time hooks — not from raw disk here.
  *
  * Must only be called when !dryRun — it writes both the DB and the marker.
  */
-export async function capturePlanningCompatIfNeeded(basePath: string): Promise<void> {
+export async function capturePlanningCompatIfNeeded(
+  basePath: string,
+  options?: CapturePlanningCompatOptions,
+): Promise<void> {
+  if (options?.dryRun) return;
+
   const planningDir = join(basePath, ".planning");
   if (!existsSync(planningDir)) return;
 
   const marker = readCompatMarker(basePath);
-  const mapsEmpty =
-    Object.keys(marker.planning?.projections ?? {}).length === 0 &&
-    Object.keys(marker.planning?.passthrough ?? {}).length === 0;
-
-  if (marker.planning?.active && marker.planning.layout) {
-    if (!mapsEmpty) return;
-    // Layout is known and SHAs are absent. This can happen when activation
-    // completed on a prior run but writePlanningDirectory hasn't populated
-    // applyPlanningProjectionWrites yet. Seed from disk so the next detect
-    // pass has something to compare against.
-    seedPlanningShasFromDisk(basePath);
-    return;
-  }
+  if (marker.planning?.active && marker.planning.layout) return;
 
   // First encounter: parse layout, import .planning/ content into the DB, then
   // activate the marker. We import before writing to disk so that

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -126,7 +126,7 @@ export async function capturePlanningCompatIfNeeded(
     invalidateStateCache();
   } catch (e) {
     logWarning(
-      "compat",
+      "reconcile",
       `planning DB import failed on initial capture — writePlanningDirectory may overwrite gsd-core content: ${(e as Error).message}`,
     );
   }

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -29,6 +29,14 @@ export function isPlanningPassthroughRelPath(relPath: string): boolean {
   return false;
 }
 
+export function gsdTreeHasContent(basePath: string): boolean {
+  const gsdDir = join(basePath, ".gsd");
+  return (
+    existsSync(gsdDir) &&
+    readdirSync(gsdDir).some((name) => name !== ".compat.json" && !name.startsWith("."))
+  );
+}
+
 export function walkPlanningRelPaths(planningDir: string, prefix = ""): string[] {
   const paths: string[] = [];
   let entries;
@@ -116,14 +124,10 @@ export async function capturePlanningCompatIfNeeded(
   // Import into the DB. Dynamic imports break the module-init cycle
   // (planning-compat ← reconcile ← state ← md-importer). Matches the import
   // pattern in repairExternalPlanningEdit.
-  const gsdDir = join(basePath, ".gsd");
-  const gsdTreeHasContent =
-    existsSync(gsdDir) &&
-    readdirSync(gsdDir).some((name) => name !== ".compat.json" && !name.startsWith("."));
   try {
     const { migrateHierarchyToDb } = await import("../md-importer.js");
     const { invalidateStateCache } = await import("../state.js");
-    if (!gsdTreeHasContent) {
+    if (!gsdTreeHasContent(basePath)) {
       const { transformToGSD } = await import("../migrate/transformer.js");
       const { writeGSDDirectory } = await import("../migrate/writer.js");
       const gsdProject = transformToGSD(parsed);

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -11,6 +11,7 @@ import {
   writeCompatMarker,
   type PlanningLayout,
 } from "./compat-marker.js";
+import { logWarning } from "../workflow-logger.js";
 
 export interface PlanningProjectionWrite {
   relPath: string;
@@ -99,8 +100,12 @@ function seedPlanningShasFromDisk(basePath: string): void {
 }
 
 /**
- * Capture-on-first-read: infer `.planning/` layout from disk and seed marker
- * shas so external-edit drift detection has a baseline.
+ * Capture-on-first-read: infer `.planning/` layout from disk, import content
+ * into the DB so gsd-pi's projection reflects gsd-core's tree instead of
+ * overwriting it, then activate the compat marker so drift detection has a
+ * baseline on the next reconcile pass.
+ *
+ * Must only be called when !dryRun — it writes both the DB and the marker.
  */
 export async function capturePlanningCompatIfNeeded(basePath: string): Promise<void> {
   const planningDir = join(basePath, ".planning");
@@ -113,21 +118,52 @@ export async function capturePlanningCompatIfNeeded(basePath: string): Promise<v
 
   if (marker.planning?.active && marker.planning.layout) {
     if (!mapsEmpty) return;
+    // Layout is known and SHAs are absent. This can happen when activation
+    // completed on a prior run but writePlanningDirectory hasn't populated
+    // applyPlanningProjectionWrites yet. Seed from disk so the next detect
+    // pass has something to compare against.
     seedPlanningShasFromDisk(basePath);
     return;
   }
 
+  // First encounter: parse layout, import .planning/ content into the DB, then
+  // activate the marker. We import before writing to disk so that
+  // writePlanningDirectory (called later by renderAllFromDb) reconstructs the
+  // .planning/ tree from a DB that already reflects gsd-core's content rather
+  // than overwriting it with stale or empty DB state.
   const { parsePlanningDirectory } = await import("../migrate/parser.js");
   const { detectPlanningLayout } = await import("../migrate/layout-detect.js");
   const parsed = await parsePlanningDirectory(planningDir);
   const layout: PlanningLayout | null = detectPlanningLayout(parsed);
   if (!layout) return;
 
-  if (!marker.planning) {
-    marker.planning = { active: false, layout: null, projections: {}, passthrough: {} };
+  // Import .planning/ into the DB. Dynamic imports break the module-init cycle
+  // (planning-compat ← reconcile ← state ← md-importer). Matches the import
+  // pattern in repairExternalPlanningEdit.
+  try {
+    const { transformToGSD } = await import("../migrate/transformer.js");
+    const { writeGSDDirectory } = await import("../migrate/writer.js");
+    const { migrateHierarchyToDb } = await import("../md-importer.js");
+    const { invalidateStateCache } = await import("../state.js");
+    const gsdProject = transformToGSD(parsed);
+    await writeGSDDirectory(gsdProject, basePath);
+    migrateHierarchyToDb(basePath);
+    invalidateStateCache();
+  } catch (e) {
+    logWarning(
+      "compat",
+      `planning DB import failed on initial capture — writePlanningDirectory may overwrite gsd-core content: ${(e as Error).message}`,
+    );
   }
-  marker.planning.active = true;
-  marker.planning.layout = layout;
-  writeCompatMarker(basePath, marker);
-  seedPlanningShasFromDisk(basePath);
+
+  // Activate the marker. Leave projections/passthrough empty: the next
+  // writePlanningDirectory → applyPlanningProjectionWrites call will seed
+  // accurate SHAs from the normalized output rather than the raw gsd-core files.
+  const freshMarker = readCompatMarker(basePath);
+  if (!freshMarker.planning) {
+    freshMarker.planning = { active: false, layout: null, projections: {}, passthrough: {} };
+  }
+  freshMarker.planning.active = true;
+  freshMarker.planning.layout = layout;
+  writeCompatMarker(basePath, freshMarker);
 }

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -1,0 +1,133 @@
+// Project/App: gsd-pi
+// File Purpose: `.planning/` compat helpers — layout capture and projection sha
+// recording. Parallel to the .gsd/ write-time flush in markdown-renderer.ts.
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  computeProjectionSha,
+  readCompatMarker,
+  writeCompatMarker,
+  type PlanningLayout,
+} from "./compat-marker.js";
+
+export interface PlanningProjectionWrite {
+  relPath: string;
+  entities: string[];
+  passthrough?: boolean;
+}
+
+function isPlanningPassthroughRelPath(relPath: string): boolean {
+  if (relPath.startsWith("codebase/") || relPath.startsWith("research/")) return true;
+  if (relPath === "config.json") return true;
+  const name = relPath.split("/").pop() ?? relPath;
+  if (name === "PATTERNS.md" || name === "REVIEWS.md") return true;
+  if (name.endsWith("-DISCUSSION-LOG.md")) return true;
+  if (name.endsWith("-RESEARCH.md") && !name.endsWith("-PLAN.md")) return true;
+  return false;
+}
+
+function walkPlanningRelPaths(planningDir: string, prefix = ""): string[] {
+  const paths: string[] = [];
+  let entries;
+  try {
+    entries = readdirSync(join(planningDir, prefix), { withFileTypes: true });
+  } catch {
+    return paths;
+  }
+  for (const entry of entries) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (entry.name === "workstreams") continue;
+      paths.push(...walkPlanningRelPaths(planningDir, rel));
+    } else {
+      paths.push(rel);
+    }
+  }
+  return paths;
+}
+
+/**
+ * Record freshly written `.planning/` projection files in the compat marker.
+ */
+export function applyPlanningProjectionWrites(
+  basePath: string,
+  writes: PlanningProjectionWrite[],
+): void {
+  if (writes.length === 0) return;
+  const marker = readCompatMarker(basePath);
+  if (!marker.planning) {
+    marker.planning = { active: true, layout: null, projections: {}, passthrough: {} };
+  }
+  marker.planning.active = true;
+  for (const write of writes) {
+    const abs = join(basePath, ".planning", write.relPath);
+    if (!existsSync(abs)) continue;
+    const entry = {
+      sha: computeProjectionSha(readFileSync(abs, "utf-8")),
+      entities: write.entities,
+    };
+    const map = write.passthrough ? marker.planning.passthrough : marker.planning.projections;
+    map[write.relPath] = entry;
+  }
+  marker.lastWriter = "gsd-pi";
+  marker.lastProjectedAt = new Date().toISOString();
+  writeCompatMarker(basePath, marker);
+}
+
+function seedPlanningShasFromDisk(basePath: string): void {
+  const planningDir = join(basePath, ".planning");
+  const marker = readCompatMarker(basePath);
+  if (!marker.planning) {
+    marker.planning = { active: true, layout: null, projections: {}, passthrough: {} };
+  }
+  for (const relPath of walkPlanningRelPaths(planningDir)) {
+    const abs = join(planningDir, relPath);
+    const entry = {
+      sha: computeProjectionSha(readFileSync(abs, "utf-8")),
+      entities: [] as string[],
+    };
+    const map = isPlanningPassthroughRelPath(relPath)
+      ? marker.planning.passthrough
+      : marker.planning.projections;
+    map[relPath] = entry;
+  }
+  marker.lastWriter = "gsd-pi";
+  marker.lastProjectedAt = new Date().toISOString();
+  writeCompatMarker(basePath, marker);
+}
+
+/**
+ * Capture-on-first-read: infer `.planning/` layout from disk and seed marker
+ * shas so external-edit drift detection has a baseline.
+ */
+export async function capturePlanningCompatIfNeeded(basePath: string): Promise<void> {
+  const planningDir = join(basePath, ".planning");
+  if (!existsSync(planningDir)) return;
+
+  const marker = readCompatMarker(basePath);
+  const mapsEmpty =
+    Object.keys(marker.planning?.projections ?? {}).length === 0 &&
+    Object.keys(marker.planning?.passthrough ?? {}).length === 0;
+
+  if (marker.planning?.active && marker.planning.layout) {
+    if (!mapsEmpty) return;
+    seedPlanningShasFromDisk(basePath);
+    return;
+  }
+
+  const { parsePlanningDirectory } = await import("../migrate/parser.js");
+  const { detectPlanningLayout } = await import("../migrate/layout-detect.js");
+  const parsed = await parsePlanningDirectory(planningDir);
+  const layout: PlanningLayout | null = detectPlanningLayout(parsed);
+  if (!layout) return;
+
+  if (!marker.planning) {
+    marker.planning = { active: false, layout: null, projections: {}, passthrough: {} };
+  }
+  marker.planning.active = true;
+  marker.planning.layout = layout;
+  writeCompatMarker(basePath, marker);
+  seedPlanningShasFromDisk(basePath);
+}

--- a/src/resources/extensions/gsd/compat/planning-compat.ts
+++ b/src/resources/extensions/gsd/compat/planning-compat.ts
@@ -29,11 +29,24 @@ export function isPlanningPassthroughRelPath(relPath: string): boolean {
   return false;
 }
 
+// Files that gsd-pi creates in .gsd/ at startup and that do not constitute
+// markdown content written by gsd-core. Excluded from the content check so a
+// .planning/-only project that already has a gsd.db (but no milestone markdown)
+// is not mistakenly treated as a coexistence project.
+const KNOWN_NON_CONTENT_FILES = new Set([
+  "gsd.db",
+  "gsd.db-wal",
+  "gsd.db-shm",
+  "completed-units.json",
+]);
+
 export function gsdTreeHasContent(basePath: string): boolean {
   const gsdDir = join(basePath, ".gsd");
   return (
     existsSync(gsdDir) &&
-    readdirSync(gsdDir).some((name) => name !== ".compat.json" && !name.startsWith("."))
+    readdirSync(gsdDir).some(
+      (name) => !name.startsWith(".") && !KNOWN_NON_CONTENT_FILES.has(name),
+    )
   );
 }
 

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -886,13 +886,14 @@ export async function renderAllFromDb(basePath: string): Promise<RenderAllResult
   }
 
   // Project to .planning/ if the compat marker says it's active. Dynamic
-  // import mirrors the regenerateDecisionsMarkdown pattern above to avoid a
-  // static-import cycle. Gated on planning.active so the double-write cost
-  // only hits projects that actually use the .planning/ layout.
+  // import for writePlanningDirectory avoids a static-import cycle. Gated on
+  // planning.active so the double-write cost only hits projects that use
+  // .planning/. writePlanningDirectory records per-file SHAs via
+  // applyPlanningProjectionWrites so the reconcile detector has a baseline.
+  // capturePlanningCompatIfNeeded seeds the layout and SHAs on first encounter.
   try {
     const { capturePlanningCompatIfNeeded } = await import("./compat/planning-compat.js");
     await capturePlanningCompatIfNeeded(basePath);
-    const { readCompatMarker } = await import("./compat/compat-marker.js");
     const marker = readCompatMarker(basePath);
     if (marker.planning?.active && marker.planning.layout) {
       const { writePlanningDirectory } = await import("./migrate/planning-writer.js");

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -91,8 +91,9 @@ function flushProjectionWritesToMarker(): void {
       marker.lastWriter = "gsd-pi";
       marker.lastProjectedAt = new Date().toISOString();
       writeCompatMarker(basePath, marker);
-    } catch {
+    } catch (e) {
       // Marker I/O must never break projection. Reconcile will heal on next run.
+      logWarning("renderer", `compat marker flush failed: ${(e as Error).message}`);
     }
   }
 }

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -890,6 +890,8 @@ export async function renderAllFromDb(basePath: string): Promise<RenderAllResult
   // static-import cycle. Gated on planning.active so the double-write cost
   // only hits projects that actually use the .planning/ layout.
   try {
+    const { capturePlanningCompatIfNeeded } = await import("./compat/planning-compat.js");
+    await capturePlanningCompatIfNeeded(basePath);
     const { readCompatMarker } = await import("./compat/compat-marker.js");
     const marker = readCompatMarker(basePath);
     if (marker.planning?.active && marker.planning.layout) {

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -885,6 +885,22 @@ export async function renderAllFromDb(basePath: string): Promise<RenderAllResult
     result.errors.push(`decisions: ${(err as Error).message}`);
   }
 
+  // Project to .planning/ if the compat marker says it's active. Dynamic
+  // import mirrors the regenerateDecisionsMarkdown pattern above to avoid a
+  // static-import cycle. Gated on planning.active so the double-write cost
+  // only hits projects that actually use the .planning/ layout.
+  try {
+    const { readCompatMarker } = await import("./compat/compat-marker.js");
+    const marker = readCompatMarker(basePath);
+    if (marker.planning?.active && marker.planning.layout) {
+      const { writePlanningDirectory } = await import("./migrate/planning-writer.js");
+      await writePlanningDirectory(basePath, marker.planning.layout);
+      result.rendered++;
+    }
+  } catch (err) {
+    result.errors.push(`planning projection: ${(err as Error).message}`);
+  }
+
   return result;
 }
 

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -44,6 +44,7 @@ import { saveFile, clearParseCache, registerCacheClearCallback } from "./files.j
 import { parseRoadmap, parsePlan } from "./parsers-legacy.js";
 import { invalidateStateCache } from "./state.js";
 import { clearPathCache, milestonesDir, legacyMilestonesDir, isLegacyMilestonesLayout, resolveMilestonePath, relSliceFile, canonicalPhaseDirName } from "./paths.js";
+import { readCompatMarker, writeCompatMarker, computeProjectionSha } from "./compat/compat-marker.js";
 import type { RiskLevel } from "./types.js";
 import {
   phaseDirName,
@@ -52,6 +53,49 @@ import {
   sliceIdToPlanNum,
   derivePhaseSlug,
 } from "./layout-policy.js";
+
+// ─── Compat marker invalidation ───────────────────────────────────────────
+// Every successful projection write pushes its (basePath, projectionPath,
+// entities) here; invalidateCaches() drains it and refreshes .gsd/.compat.json
+// so the next reconcile pass sees gsd-pi's own writes as expected. This is the
+// feedback-loop-prevention mechanism for cross-tool compatibility.
+const _pendingProjectionWrites: Array<{ basePath: string; projectionPath: string; entities: string[] }> = [];
+
+function recordProjectionWrite(basePath: string, projectionPath: string, entities: string[]): void {
+  _pendingProjectionWrites.push({ basePath, projectionPath, entities });
+}
+
+function flushProjectionWritesToMarker(): void {
+  if (_pendingProjectionWrites.length === 0) return;
+  // Group by basePath (defensive — multiple projects are unusual but possible).
+  const byBase = new Map<string, Map<string, string[]>>();
+  for (const w of _pendingProjectionWrites) {
+    let bucket = byBase.get(w.basePath);
+    if (!bucket) { bucket = new Map(); byBase.set(w.basePath, bucket); }
+    bucket.set(w.projectionPath, w.entities);
+  }
+  _pendingProjectionWrites.length = 0;
+
+  for (const [basePath, writes] of byBase) {
+    try {
+      const marker = readCompatMarker(basePath);
+      for (const [projectionPath, entities] of writes) {
+        const abs = join(basePath, ".gsd", projectionPath);
+        if (existsSync(abs)) {
+          marker.projections[projectionPath] = {
+            sha: computeProjectionSha(readFileSync(abs, "utf-8")),
+            entities,
+          };
+        }
+      }
+      marker.lastWriter = "gsd-pi";
+      marker.lastProjectedAt = new Date().toISOString();
+      writeCompatMarker(basePath, marker);
+    } catch {
+      // Marker I/O must never break projection. Reconcile will heal on next run.
+    }
+  }
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -74,6 +118,7 @@ function toArtifactPath(absPath: string, basePath: string): string {
  * Invalidate all caches after a disk write.
  */
 function invalidateCaches(): void {
+  flushProjectionWritesToMarker();
   invalidateStateCache();
   clearPathCache();
   clearParseCache();
@@ -158,6 +203,7 @@ async function writeAndStore(
     slice_id?: string;
     task_id?: string;
   },
+  basePath?: string,
 ): Promise<void> {
   await saveFile(absPath, content);
 
@@ -173,6 +219,17 @@ async function writeAndStore(
   } catch {
     // Non-fatal: file is on disk, DB is best-effort
     logWarning("renderer", `failed to update artifact in DB: ${artifactPath}`);
+  }
+
+  // Record the projection write so invalidateCaches() can refresh the compat
+  // marker. basePath is optional only to avoid forcing every caller; when
+  // present, the marker gets updated. artifactPath is already .gsd/-relative.
+  if (basePath) {
+    const entities: string[] = [];
+    if (opts.milestone_id) entities.push(opts.milestone_id);
+    if (opts.milestone_id && opts.slice_id) entities.push(`${opts.milestone_id}/${opts.slice_id}`);
+    if (opts.milestone_id && opts.slice_id && opts.task_id) entities.push(`${opts.milestone_id}/${opts.slice_id}/${opts.task_id}`);
+    recordProjectionWrite(basePath, artifactPath, entities);
   }
 
   invalidateCaches();
@@ -442,7 +499,7 @@ export async function renderPlanFromDb(
     artifact_type: "PLAN",
     milestone_id: milestoneId,
     slice_id: sliceId,
-  });
+  }, basePath);
 
   // Flat-phase: tasks are checkboxes inside the plan file, not separate files.
   // No per-task render loop — task state is in the <tasks> block above.
@@ -501,7 +558,7 @@ export async function renderTaskPlanFromDb(
     milestone_id: milestoneId,
     slice_id: sliceId,
     task_id: taskId,
-  });
+  }, basePath);
 
   return { taskPlanPath: absPath, content };
 }
@@ -523,7 +580,7 @@ export async function renderRoadmapFromDb(
   await writeAndStore(absPath, artifactPath, content, {
     artifact_type: "ROADMAP",
     milestone_id: milestoneId,
-  });
+  }, basePath);
 
   return { roadmapPath: absPath, content };
 }
@@ -669,7 +726,7 @@ export async function renderTaskSummary(
     milestone_id: milestoneId,
     slice_id: sliceId,
     task_id: taskId,
-  });
+  }, basePath);
 
   return true;
 }
@@ -714,7 +771,7 @@ export async function renderSliceSummary(
       artifact_type: "SUMMARY",
       milestone_id: milestoneId,
       slice_id: sliceId,
-    });
+    }, basePath);
     wrote = true;
   }
 
@@ -728,7 +785,7 @@ export async function renderSliceSummary(
       artifact_type: "UAT",
       milestone_id: milestoneId,
       slice_id: sliceId,
-    });
+    }, basePath);
     wrote = true;
   }
 
@@ -1114,7 +1171,7 @@ export async function renderReplanFromDb(
     artifact_type: "REPLAN",
     milestone_id: milestoneId,
     slice_id: sliceId,
-  });
+  }, basePath);
 
   return { replanPath: absPath, content };
 }
@@ -1155,7 +1212,7 @@ export async function renderAssessmentFromDb(
     artifact_type: "ASSESSMENT",
     milestone_id: milestoneId,
     slice_id: sliceId,
-  });
+  }, basePath);
 
   return { assessmentPath: absPath, content };
 }

--- a/src/resources/extensions/gsd/migrate/layout-detect.ts
+++ b/src/resources/extensions/gsd/migrate/layout-detect.ts
@@ -1,0 +1,38 @@
+// Project/App: gsd-pi
+// File Purpose: Classify a parsed .planning/ tree into its layout so the
+// round-trip writer can recreate the same structure gsd-core wrote.
+//
+// This extracts the implicit 3-way branch that was buried in transformer.ts
+// transformToGSD (lines 425-467). Priority matches the transformer's if/else
+// chain: legacy-milestone-dir > multi-milestone > flat-phases.
+
+import type { PlanningProject } from "./types.js";
+import type { PlanningLayout } from "../compat/compat-marker.js";
+
+/**
+ * Determine which .planning/ layout a parsed project uses. Returns null when
+ * no layout signal is present (caller decides: treat as inactive or error).
+ *
+ * Priority (must match transformer.ts transformToGSD):
+ *   1. legacy-milestone-dir — milestones/<id>/ contains <id>-phases/ subdirs
+ *      with phase content. Detected when parsed.milestones has any entry with
+ *      non-empty phases.
+ *   2. multi-milestone — ROADMAP.md parsed into milestone sections.
+ *      Detected when roadmap.milestones.length > 0.
+ *   3. flat-phases — ROADMAP.md parsed into checkbox phase lines only.
+ *      Detected when roadmap.phases.length > 0.
+ */
+export function detectPlanningLayout(parsed: PlanningProject): PlanningLayout | null {
+  const hasMilestoneDirectories = parsed.milestones.some(
+    (m) => Object.keys(m.phases).length > 0,
+  );
+  if (hasMilestoneDirectories) return "legacy-milestone-dir";
+
+  const isMultiMilestone = parsed.roadmap !== null && parsed.roadmap.milestones.length > 0;
+  if (isMultiMilestone) return "multi-milestone";
+
+  const hasFlatPhases = parsed.roadmap !== null && parsed.roadmap.phases.length > 0;
+  if (hasFlatPhases) return "flat-phases";
+
+  return null;
+}

--- a/src/resources/extensions/gsd/migrate/planning-writer.ts
+++ b/src/resources/extensions/gsd/migrate/planning-writer.ts
@@ -1,0 +1,235 @@
+// Project/App: gsd-pi
+// File Purpose: DB → .planning/ projection. Parallel to writer.ts (which
+// emits .gsd/). Produces the .planning/ markdown shape that gsd-core reads.
+//
+// Layout policy (spec §4.4): emits the layout recorded in the compat marker.
+// v1 supports flat-phases; multi-milestone and legacy-milestone-dir are stubbed
+// with a clear error until fixtures exist to validate them.
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.js";
+import { saveFile } from "../files.js";
+import type { PlanningLayout } from "../compat/compat-marker.js";
+
+export interface PlanningWrittenFiles {
+  paths: string[];
+  layout: PlanningLayout;
+}
+
+function planningRoot(basePath: string): string {
+  return join(basePath, ".planning");
+}
+
+function slugify(title: string, fallback: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  return slug || fallback;
+}
+
+function pad(n: number, width = 2): string {
+  return String(n).padStart(width, "0");
+}
+
+/**
+ * Format a roadmap for the flat-phases layout. Mirrors the checkbox line
+ * format that parsers.ts parsePhaseEntry recognizes: `- [x] NN — Title`.
+ */
+function formatPlanningRoadmapFlat(
+  entries: Array<{ number: number; title: string; done: boolean }>,
+): string {
+  const lines = ["# Roadmap", "", "## Phases", ""];
+  for (const e of entries) {
+    const box = e.done ? "[x]" : "[ ]";
+    lines.push(`- ${box} ${pad(e.number)} — ${e.title}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Format STATE.md in gsd-core's phase-progress schema. gsd-pi is authoritative
+ * for status; this is a one-way DB→projection (edits to STATE.md are not
+ * re-imported — see spec §7).
+ */
+function formatPlanningState(
+  activeMilestone: string,
+  totalPhases: number,
+  completedPhases: number,
+): string {
+  const pct = totalPhases === 0 ? 0 : Math.round((completedPhases / totalPhases) * 100);
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    "gsd_state_version: 1.0",
+    `milestone: ${activeMilestone}`,
+    'milestone_name: "milestone"',
+    "status: active",
+    `stopped_at: Phase 01 — in progress`,
+    `last_updated: "${ts}"`,
+    `last_activity: ${ts.slice(0, 10)}`,
+    "progress:",
+    `  total_phases: ${totalPhases}`,
+    `  completed_phases: ${completedPhases}`,
+    `  total_plans: ${totalPhases}`,
+    `  completed_plans: ${completedPhases}`,
+    `  percent: ${pct}`,
+    "---",
+    "",
+    "# Project State",
+    "",
+    "Current Phase: **01**",
+    "Status: **active**",
+    "",
+  ].join("\n");
+}
+
+function formatPlanningProject(title: string): string {
+  return `# ${title}\n`;
+}
+
+/**
+ * Format a phase plan file with the XML-tagged structure parsers.ts
+ * parseOldPlan recognizes: <objective>, <tasks>, <verification>.
+ */
+function formatPlanningPlan(
+  phaseNum: number,
+  planNum: number,
+  title: string,
+  tasks: Array<{ id: string; title: string; estimate?: string }>,
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${pad(phaseNum)}-${pad(planNum)}: ${title}`, "");
+  lines.push("<objective>");
+  lines.push(`${title}.`);
+  lines.push("</objective>");
+  lines.push("");
+  lines.push("<tasks>");
+  for (const t of tasks) {
+    const est = t.estimate ? ` _(${t.estimate})_` : "";
+    lines.push(`- [ ] **${t.id}**: ${t.title}${est}`);
+  }
+  lines.push("</tasks>");
+  lines.push("");
+  lines.push("<verification>");
+  lines.push("All tasks complete and tests pass.");
+  lines.push("</verification>");
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Project DB state to .planning/ in the recorded layout.
+ * Reads DB directly (canonical source). Writes via saveFile (atomic).
+ *
+ * v1: flat-phases only. Each milestone's slices become sequentially-numbered
+ * phase dirs; each task within a slice becomes a plan file (NN-MM-PLAN.md).
+ */
+export async function writePlanningDirectory(
+  basePath: string,
+  layout: PlanningLayout,
+): Promise<PlanningWrittenFiles> {
+  if (layout !== "flat-phases") {
+    // v1: flat-phases only. multi-milestone and legacy-milestone-dir need
+    // fixtures to validate the reverse-mapping (transformer.ts is non-injective
+    // — three layouts collapse to one .gsd/ shape); stub until then.
+    throw new Error(
+      `writePlanningDirectory: layout "${layout}" not yet supported (v1 supports flat-phases only)`,
+    );
+  }
+
+  const root = planningRoot(basePath);
+  mkdirSync(root, { recursive: true });
+  const paths: string[] = [];
+
+  const milestones = getAllMilestones();
+  if (milestones.length === 0) {
+    return { paths, layout };
+  }
+
+  // Flat-phases: each slice becomes one phase. Tasks within become plan files.
+  let phaseNum = 0;
+  const roadmapEntries: Array<{ number: number; title: string; done: boolean }> = [];
+
+  for (const milestone of milestones) {
+    const slices = getMilestoneSlices(milestone.id);
+    for (const slice of slices) {
+      phaseNum++;
+      const phaseSlug = slugify(slice.title || slice.id, slice.id.toLowerCase());
+      const phaseDirName = `${pad(phaseNum)}-${phaseSlug}`;
+      const phaseDir = join(root, "phases", phaseDirName);
+      mkdirSync(phaseDir, { recursive: true });
+
+      const tasks = getSliceTasks(milestone.id, slice.id);
+      const isDone =
+        tasks.length > 0 && tasks.every((t) => t.status === "complete");
+      roadmapEntries.push({
+        number: phaseNum,
+        title: slice.title || slice.id,
+        done: isDone,
+      });
+
+      if (tasks.length === 0) {
+        // Empty phase — write a single placeholder plan so the dir isn't empty.
+        const planPath = join(phaseDir, `${pad(phaseNum)}-01-PLAN.md`);
+        await saveFile(
+          planPath,
+          formatPlanningPlan(phaseNum, 1, slice.title || slice.id, []),
+        );
+        paths.push(planPath);
+      } else {
+        for (let ti = 0; ti < tasks.length; ti++) {
+          const task = tasks[ti]!;
+          const planNum = ti + 1;
+          const planPath = join(phaseDir, `${pad(phaseNum)}-${pad(planNum)}-PLAN.md`);
+          await saveFile(
+            planPath,
+            formatPlanningPlan(phaseNum, planNum, task.title || task.id, [
+              {
+                id: task.id,
+                title: task.title || task.id,
+                estimate: task.estimate || undefined,
+              },
+            ]),
+          );
+          paths.push(planPath);
+        }
+      }
+    }
+  }
+
+  // If no slices produced any phases, write a single empty phase so ROADMAP.md
+  // isn't blank and the layout is still discoverable.
+  if (roadmapEntries.length === 0) {
+    const phaseDirName = `${pad(1)}-milestone`;
+    const phaseDir = join(root, "phases", phaseDirName);
+    mkdirSync(phaseDir, { recursive: true });
+    const planPath = join(phaseDir, `${pad(1)}-01-PLAN.md`);
+    await saveFile(planPath, formatPlanningPlan(1, 1, milestones[0]!.title || milestones[0]!.id, []));
+    paths.push(planPath);
+    roadmapEntries.push({ number: 1, title: milestones[0]!.title || milestones[0]!.id, done: false });
+  }
+
+  // Root files
+  const roadmapPath = join(root, "ROADMAP.md");
+  await saveFile(roadmapPath, formatPlanningRoadmapFlat(roadmapEntries));
+  paths.push(roadmapPath);
+
+  const completedPhases = roadmapEntries.filter((e) => e.done).length;
+  const statePath = join(root, "STATE.md");
+  await saveFile(
+    statePath,
+    formatPlanningState(milestones[0]!.id, roadmapEntries.length, completedPhases),
+  );
+  paths.push(statePath);
+
+  const projectPath = join(root, "PROJECT.md");
+  await saveFile(projectPath, formatPlanningProject(milestones[0]!.title || milestones[0]!.id));
+  paths.push(projectPath);
+
+  return { paths, layout };
+}

--- a/src/resources/extensions/gsd/migrate/planning-writer.ts
+++ b/src/resources/extensions/gsd/migrate/planning-writer.ts
@@ -7,11 +7,15 @@
 // with a clear error until fixtures exist to validate them.
 
 import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 import { getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.js";
 import { saveFile } from "../files.js";
 import type { PlanningLayout } from "../compat/compat-marker.js";
+import {
+  applyPlanningProjectionWrites,
+  type PlanningProjectionWrite,
+} from "../compat/planning-compat.js";
 
 export interface PlanningWrittenFiles {
   paths: string[];
@@ -145,6 +149,9 @@ export async function writePlanningDirectory(
   const root = planningRoot(basePath);
   mkdirSync(root, { recursive: true });
   const paths: string[] = [];
+  const projectionWrites: PlanningProjectionWrite[] = [];
+  const toPlanningRel = (absPath: string): string =>
+    relative(root, absPath).replace(/\\/g, "/");
 
   const milestones = getAllMilestones();
   if (milestones.length === 0) {
@@ -181,6 +188,10 @@ export async function writePlanningDirectory(
           formatPlanningPlan(phaseNum, 1, slice.title || slice.id, []),
         );
         paths.push(planPath);
+        projectionWrites.push({
+          relPath: toPlanningRel(planPath),
+          entities: [`${milestone.id}/${slice.id}`],
+        });
       } else {
         for (let ti = 0; ti < tasks.length; ti++) {
           const task = tasks[ti]!;
@@ -197,6 +208,10 @@ export async function writePlanningDirectory(
             ]),
           );
           paths.push(planPath);
+          projectionWrites.push({
+            relPath: toPlanningRel(planPath),
+            entities: [`${milestone.id}/${slice.id}/${task.id}`],
+          });
         }
       }
     }
@@ -211,13 +226,19 @@ export async function writePlanningDirectory(
     const planPath = join(phaseDir, `${pad(1)}-01-PLAN.md`);
     await saveFile(planPath, formatPlanningPlan(1, 1, milestones[0]!.title || milestones[0]!.id, []));
     paths.push(planPath);
+    projectionWrites.push({
+      relPath: toPlanningRel(planPath),
+      entities: [milestones[0]!.id],
+    });
     roadmapEntries.push({ number: 1, title: milestones[0]!.title || milestones[0]!.id, done: false });
   }
 
   // Root files
+  const milestoneEntities = milestones.map((m) => m.id);
   const roadmapPath = join(root, "ROADMAP.md");
   await saveFile(roadmapPath, formatPlanningRoadmapFlat(roadmapEntries));
   paths.push(roadmapPath);
+  projectionWrites.push({ relPath: toPlanningRel(roadmapPath), entities: milestoneEntities });
 
   const completedPhases = roadmapEntries.filter((e) => e.done).length;
   const statePath = join(root, "STATE.md");
@@ -226,10 +247,13 @@ export async function writePlanningDirectory(
     formatPlanningState(milestones[0]!.id, roadmapEntries.length, completedPhases),
   );
   paths.push(statePath);
+  projectionWrites.push({ relPath: toPlanningRel(statePath), entities: [milestones[0]!.id] });
 
   const projectPath = join(root, "PROJECT.md");
   await saveFile(projectPath, formatPlanningProject(milestones[0]!.title || milestones[0]!.id));
   paths.push(projectPath);
+  projectionWrites.push({ relPath: toPlanningRel(projectPath), entities: [milestones[0]!.id] });
 
+  applyPlanningProjectionWrites(basePath, projectionWrites);
   return { paths, layout };
 }

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
@@ -15,8 +15,6 @@ import {
   readCompatMarker,
   writeCompatMarker,
 } from "../../compat/compat-marker.js";
-import { migrateHierarchyToDb } from "../../md-importer.js";
-import { invalidateStateCache } from "../../state.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -71,6 +69,11 @@ async function repairExternalMarkdownEdit(
   ctx: DriftContext,
 ): Promise<void> {
   try {
+    // Dynamic imports break a module-init cycle: this handler ← registry ←
+    // state.ts ← guided-flow.ts ← md-importer.ts ← (this handler's old static
+    // import). Deferring to repair time keeps module load cycle-free.
+    const { migrateHierarchyToDb } = await import("../../md-importer.js");
+    const { invalidateStateCache } = await import("../../state.js");
     // Scoped re-import. migrateHierarchyToDb walks the whole tree but is a
     // cheap upsert; per-entity scoping would require decomposing it, which is
     // out of scope for v1. The cost is bounded by tree size and runs at most
@@ -79,7 +82,7 @@ async function repairExternalMarkdownEdit(
     invalidateStateCache();
   } catch (err) {
     logWarning(
-      "compat",
+      "reconcile",
       `external-markdown-edit repair failed for ${record.projectionPath}: ${(err as Error).message}`,
     );
     throw err;

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
@@ -1,0 +1,102 @@
+// Project/App: gsd-pi
+// File Purpose: ADR-017 drift handler for external (gsd-core) markdown edits.
+//
+// gsd-pi's DB is canonical, but .gsd/*.md is the inter-tool contract. When
+// gsd-core edits a projection file, this handler detects the sha drift vs the
+// recorded baseline in .gsd/.compat.json and re-imports the affected entities
+// into the DB. The next renderAllFromDb pass re-projects; the write-time
+// invalidation hook then refreshes the marker entry, closing the loop.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  computeProjectionSha,
+  readCompatMarker,
+  writeCompatMarker,
+} from "../../compat/compat-marker.js";
+import { migrateHierarchyToDb } from "../../md-importer.js";
+import { invalidateStateCache } from "../../state.js";
+import { logWarning } from "../../workflow-logger.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type ExternalMarkdownEditDrift = Extract<
+  DriftRecord,
+  { kind: "external-markdown-edit" }
+>;
+
+/**
+ * Detect sha drift between the marker baseline and current file contents.
+ *
+ * - Missing marker → no records (the broader /gsd recover flow handles a
+ *   cold-start; this handler only fires when we have a baseline to compare).
+ * - Missing file on disk → no record (other handlers cover missing artifacts).
+ * - Sha match → no record (gsd-pi's own write or no change).
+ * - Sha mismatch → one record per drifted file, scoped to its recorded entities.
+ */
+function detectExternalMarkdownEdit(
+  _state: GSDState,
+  ctx: DriftContext,
+): ExternalMarkdownEditDrift[] {
+  const marker = readCompatMarker(ctx.basePath);
+  const entries = Object.entries(marker.projections);
+  if (entries.length === 0) return [];
+
+  const records: ExternalMarkdownEditDrift[] = [];
+  for (const [projectionPath, entry] of entries) {
+    const abs = join(ctx.basePath, ".gsd", projectionPath);
+    if (!existsSync(abs)) continue;
+    const actual = computeProjectionSha(readFileSync(abs, "utf-8"));
+    if (actual === entry.sha) continue;
+    records.push({
+      kind: "external-markdown-edit",
+      projectionPath,
+      expectedSha: entry.sha,
+      actualSha: actual,
+      entities: entry.entities,
+    });
+  }
+  return records;
+}
+
+/**
+ * Idempotent repair: re-import hierarchy for the affected entities from
+ * markdown into the DB, then update the marker entry so the next detect pass
+ * sees the file as expected. migrateHierarchyToDb is itself idempotent
+ * (upsert), so re-running this repair after a successful one is a no-op.
+ */
+async function repairExternalMarkdownEdit(
+  record: ExternalMarkdownEditDrift,
+  ctx: DriftContext,
+): Promise<void> {
+  try {
+    // Scoped re-import. migrateHierarchyToDb walks the whole tree but is a
+    // cheap upsert; per-entity scoping would require decomposing it, which is
+    // out of scope for v1. The cost is bounded by tree size and runs at most
+    // once per reconcile pass (MAX_PASSES=2).
+    migrateHierarchyToDb(ctx.basePath);
+    invalidateStateCache();
+  } catch (err) {
+    logWarning(
+      "compat",
+      `external-markdown-edit repair failed for ${record.projectionPath}: ${(err as Error).message}`,
+    );
+    throw err;
+  }
+
+  // Refresh the marker so a second pass (cap=2 reconcile) doesn't re-fire.
+  const marker = readCompatMarker(ctx.basePath);
+  marker.projections[record.projectionPath] = {
+    sha: record.actualSha,
+    entities: record.entities,
+  };
+  marker.lastProjectedAt = new Date().toISOString();
+  writeCompatMarker(ctx.basePath, marker);
+}
+
+export const externalMarkdownEditHandler: DriftHandler<ExternalMarkdownEditDrift> = {
+  kind: "external-markdown-edit",
+  detect: detectExternalMarkdownEdit,
+  repair: repairExternalMarkdownEdit,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -14,6 +14,10 @@ import {
   readCompatMarker,
   writeCompatMarker,
 } from "../../compat/compat-marker.js";
+import {
+  isPlanningPassthroughRelPath,
+  walkPlanningRelPaths,
+} from "../../compat/planning-compat.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -46,21 +50,71 @@ function detectOne(
   return records;
 }
 
+function detectUnseededPlanningFiles(
+  ctx: DriftContext,
+  projections: Record<string, { sha: string; entities: string[] }>,
+  passthrough: Record<string, { sha: string; entities: string[] }>,
+): ExternalPlanningEditDrift[] {
+  const planningDir = join(ctx.basePath, ".planning");
+  if (!existsSync(planningDir)) return [];
+
+  const records: ExternalPlanningEditDrift[] = [];
+  for (const relPath of walkPlanningRelPaths(planningDir)) {
+    const isPassthrough = isPlanningPassthroughRelPath(relPath);
+    const map = isPassthrough ? passthrough : projections;
+    if (map[relPath]) continue;
+    const abs = join(planningDir, relPath);
+    const actual = computeProjectionSha(readFileSync(abs, "utf-8"));
+    records.push({
+      kind: "external-planning-edit",
+      projectionPath: relPath,
+      expectedSha: "",
+      actualSha: actual,
+      entities: [],
+      passthrough: isPassthrough,
+    });
+  }
+  return records;
+}
+
 async function detectExternalPlanningEdit(
   _state: GSDState,
   ctx: DriftContext,
 ): Promise<ExternalPlanningEditDrift[]> {
   const marker = readCompatMarker(ctx.basePath);
   if (!marker.planning?.active) {
-    // Not yet activated. Activation (layout parse + DB import + SHA seeding) is
-    // owned by capturePlanningCompatIfNeeded, called from reconcileBeforeDispatch
-    // before the detect loop when !dryRun. detect() must never write the marker
-    // — it is called in both dry-run and non-dry-run contexts.
+    // Not yet activated. Activation (layout parse + DB import) is owned by
+    // capturePlanningCompatIfNeeded, called from reconcileBeforeDispatch when
+    // !dryRun. detect() must never write the marker — it is called in both
+    // dry-run and non-dry-run contexts. In dry-run, preview unseeded files
+    // without persisting activation.
+    if (!ctx.dryRun) return [];
+
+    const planningDir = join(ctx.basePath, ".planning");
+    if (!existsSync(planningDir)) return [];
+    try {
+      const { parsePlanningDirectory } = await import("../../migrate/parser.js");
+      const { detectPlanningLayout } = await import("../../migrate/layout-detect.js");
+      const parsed = await parsePlanningDirectory(planningDir);
+      const layout = detectPlanningLayout(parsed);
+      if (!layout) return [];
+      return detectUnseededPlanningFiles(ctx, {}, {});
+    } catch (e) {
+      logWarning(
+        "reconcile",
+        `planning layout auto-detection failed: ${(e as Error).message}`,
+      );
+    }
     return [];
   }
   return [
     ...detectOne(ctx, marker.planning.projections, false),
     ...detectOne(ctx, marker.planning.passthrough, true),
+    ...detectUnseededPlanningFiles(
+      ctx,
+      marker.planning.projections,
+      marker.planning.passthrough,
+    ),
   ];
 }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -1,0 +1,115 @@
+// Project/App: gsd-pi
+// File Purpose: ADR-017 drift handler for external (gsd-core) edits to .planning/.
+// Parallel to external-markdown-edit.ts. Detects sha drift between the compat
+// marker's planning.projections/passthrough and current .planning/ files.
+//
+// Modeled files (projections): re-imported via parsePlanningDirectory → DB.
+// Passthrough files (un-modeled docs): sha refreshed, content untouched.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  computeProjectionSha,
+  readCompatMarker,
+  writeCompatMarker,
+} from "../../compat/compat-marker.js";
+import { logWarning } from "../../workflow-logger.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type ExternalPlanningEditDrift = Extract<
+  DriftRecord,
+  { kind: "external-planning-edit" }
+>;
+
+function detectOne(
+  ctx: DriftContext,
+  entries: Record<string, { sha: string; entities: string[] }>,
+  passthrough: boolean,
+): ExternalPlanningEditDrift[] {
+  const records: ExternalPlanningEditDrift[] = [];
+  for (const [projectionPath, entry] of Object.entries(entries)) {
+    const abs = join(ctx.basePath, ".planning", projectionPath);
+    if (!existsSync(abs)) continue; // missing-file drift is covered by other handlers
+    const actual = computeProjectionSha(readFileSync(abs, "utf-8"));
+    if (actual === entry.sha) continue;
+    records.push({
+      kind: "external-planning-edit",
+      projectionPath,
+      expectedSha: entry.sha,
+      actualSha: actual,
+      entities: entry.entities,
+      passthrough,
+    });
+  }
+  return records;
+}
+
+function detectExternalPlanningEdit(
+  _state: GSDState,
+  ctx: DriftContext,
+): ExternalPlanningEditDrift[] {
+  const marker = readCompatMarker(ctx.basePath);
+  if (!marker.planning?.active) return [];
+  return [
+    ...detectOne(ctx, marker.planning.projections, false),
+    ...detectOne(ctx, marker.planning.passthrough, true),
+  ];
+}
+
+async function repairExternalPlanningEdit(
+  record: ExternalPlanningEditDrift,
+  ctx: DriftContext,
+): Promise<void> {
+  // Passthrough: never re-import (no DB model). Just refresh the sha.
+  if (record.passthrough) {
+    const marker = readCompatMarker(ctx.basePath);
+    marker.planning!.passthrough[record.projectionPath] = {
+      sha: record.actualSha,
+      entities: record.entities,
+    };
+    marker.lastProjectedAt = new Date().toISOString();
+    writeCompatMarker(ctx.basePath, marker);
+    return;
+  }
+
+  // Modeled: re-import via the migrate read path. Dynamic imports break the
+  // module-init cycle (this handler ← registry ← state.ts ← guided-flow.ts
+  // ← md-importer.ts). parsePlanningDirectory reads .planning/, transformToGSD
+  // produces the .gsd/ model, writeGSDDirectory materializes it, then
+  // migrateHierarchyToDb upserts into the DB.
+  try {
+    const { parsePlanningDirectory } = await import("../../migrate/parser.js");
+    const { transformToGSD } = await import("../../migrate/transformer.js");
+    const { writeGSDDirectory } = await import("../../migrate/writer.js");
+    const { migrateHierarchyToDb } = await import("../../md-importer.js");
+    const { invalidateStateCache } = await import("../../state.js");
+
+    const parsed = await parsePlanningDirectory(join(ctx.basePath, ".planning"));
+    const gsdProject = transformToGSD(parsed);
+    await writeGSDDirectory(gsdProject, ctx.basePath);
+    migrateHierarchyToDb(ctx.basePath);
+    invalidateStateCache();
+  } catch (err) {
+    logWarning(
+      "reconcile",
+      `external-planning-edit repair failed for ${record.projectionPath}: ${(err as Error).message}`,
+    );
+    throw err;
+  }
+
+  const marker = readCompatMarker(ctx.basePath);
+  marker.planning!.projections[record.projectionPath] = {
+    sha: record.actualSha,
+    entities: record.entities,
+  };
+  marker.lastProjectedAt = new Date().toISOString();
+  writeCompatMarker(ctx.basePath, marker);
+}
+
+export const externalPlanningEditHandler: DriftHandler<ExternalPlanningEditDrift> = {
+  kind: "external-planning-edit",
+  detect: detectExternalPlanningEdit,
+  repair: repairExternalPlanningEdit,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -46,12 +46,38 @@ function detectOne(
   return records;
 }
 
-function detectExternalPlanningEdit(
+async function detectExternalPlanningEdit(
   _state: GSDState,
   ctx: DriftContext,
-): ExternalPlanningEditDrift[] {
+): Promise<ExternalPlanningEditDrift[]> {
   const marker = readCompatMarker(ctx.basePath);
-  if (!marker.planning?.active) return [];
+  if (!marker.planning?.active) {
+    // Auto-activate: .planning/ exists on disk but the marker has not recorded
+    // it yet. Parse → detect layout → stamp planning.active so renderAllFromDb
+    // and subsequent reconcile passes see it immediately, without requiring a
+    // manual /gsd sync. Returns [] so this pass is a no-op on drift records;
+    // the next reconcile pass (or the same call's second pass if other repairs
+    // fired) will detect and import real SHA drift.
+    const planningDir = join(ctx.basePath, ".planning");
+    if (!existsSync(planningDir)) return [];
+    try {
+      const { parsePlanningDirectory } = await import("../../migrate/parser.js");
+      const { detectPlanningLayout } = await import("../../migrate/layout-detect.js");
+      const parsed = await parsePlanningDirectory(planningDir);
+      const layout = detectPlanningLayout(parsed);
+      if (layout) {
+        const m = readCompatMarker(ctx.basePath);
+        m.planning = { active: true, layout, projections: {}, passthrough: {} };
+        writeCompatMarker(ctx.basePath, m);
+      }
+    } catch (e) {
+      logWarning(
+        "reconcile",
+        `planning layout auto-detection failed: ${(e as Error).message}`,
+      );
+    }
+    return [];
+  }
   return [
     ...detectOne(ctx, marker.planning.projections, false),
     ...detectOne(ctx, marker.planning.passthrough, true),

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -15,6 +15,7 @@ import {
   writeCompatMarker,
 } from "../../compat/compat-marker.js";
 import {
+  gsdTreeHasContent,
   isPlanningPassthroughRelPath,
   walkPlanningRelPaths,
 } from "../../compat/planning-compat.js";
@@ -107,14 +108,16 @@ async function detectExternalPlanningEdit(
     }
     return [];
   }
+  const projections = marker.planning.projections;
+  const passthrough = marker.planning.passthrough;
+  const hasBaselines =
+    Object.keys(projections).length > 0 || Object.keys(passthrough).length > 0;
   return [
-    ...detectOne(ctx, marker.planning.projections, false),
-    ...detectOne(ctx, marker.planning.passthrough, true),
-    ...detectUnseededPlanningFiles(
-      ctx,
-      marker.planning.projections,
-      marker.planning.passthrough,
-    ),
+    ...detectOne(ctx, projections, false),
+    ...detectOne(ctx, passthrough, true),
+    // No baseline yet (post-capture, pre-writePlanningDirectory): skip unseeded
+    // detection so every on-disk file is not treated as drift in the same pass.
+    ...(hasBaselines ? detectUnseededPlanningFiles(ctx, projections, passthrough) : []),
   ];
 }
 
@@ -136,9 +139,10 @@ async function repairExternalPlanningEdit(
 
   // Modeled: re-import via the migrate read path. Dynamic imports break the
   // module-init cycle (this handler ← registry ← state.ts ← guided-flow.ts
-  // ← md-importer.ts). parsePlanningDirectory reads .planning/, transformToGSD
-  // produces the .gsd/ model, writeGSDDirectory materializes it, then
-  // migrateHierarchyToDb upserts into the DB.
+  // ← md-importer.ts). parsePlanningDirectory reads .planning/; when `.gsd/` is
+  // empty, transformToGSD + writeGSDDirectory materialize it first. When
+  // `.gsd/` already has content (coexistence), skip the write and import from
+  // disk via migrateHierarchyToDb only.
   try {
     const { parsePlanningDirectory } = await import("../../migrate/parser.js");
     const { transformToGSD } = await import("../../migrate/transformer.js");
@@ -147,8 +151,10 @@ async function repairExternalPlanningEdit(
     const { invalidateStateCache } = await import("../../state.js");
 
     const parsed = await parsePlanningDirectory(join(ctx.basePath, ".planning"));
-    const gsdProject = transformToGSD(parsed);
-    await writeGSDDirectory(gsdProject, ctx.basePath);
+    if (!gsdTreeHasContent(ctx.basePath)) {
+      const gsdProject = transformToGSD(parsed);
+      await writeGSDDirectory(gsdProject, ctx.basePath);
+    }
     migrateHierarchyToDb(ctx.basePath);
     invalidateStateCache();
   } catch (err) {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -52,30 +52,10 @@ async function detectExternalPlanningEdit(
 ): Promise<ExternalPlanningEditDrift[]> {
   const marker = readCompatMarker(ctx.basePath);
   if (!marker.planning?.active) {
-    // Auto-activate: .planning/ exists on disk but the marker has not recorded
-    // it yet. Parse → detect layout → stamp planning.active so renderAllFromDb
-    // and subsequent reconcile passes see it immediately, without requiring a
-    // manual /gsd sync. Returns [] so this pass is a no-op on drift records;
-    // the next reconcile pass (or the same call's second pass if other repairs
-    // fired) will detect and import real SHA drift.
-    const planningDir = join(ctx.basePath, ".planning");
-    if (!existsSync(planningDir)) return [];
-    try {
-      const { parsePlanningDirectory } = await import("../../migrate/parser.js");
-      const { detectPlanningLayout } = await import("../../migrate/layout-detect.js");
-      const parsed = await parsePlanningDirectory(planningDir);
-      const layout = detectPlanningLayout(parsed);
-      if (layout) {
-        const m = readCompatMarker(ctx.basePath);
-        m.planning = { active: true, layout, projections: {}, passthrough: {} };
-        writeCompatMarker(ctx.basePath, m);
-      }
-    } catch (e) {
-      logWarning(
-        "reconcile",
-        `planning layout auto-detection failed: ${(e as Error).message}`,
-      );
-    }
+    // Not yet activated. Activation (layout parse + DB import + SHA seeding) is
+    // owned by capturePlanningCompatIfNeeded, called from reconcileBeforeDispatch
+    // before the detect loop when !dryRun. detect() must never write the marker
+    // — it is called in both dry-run and non-dry-run contexts.
     return [];
   }
   return [

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -15,7 +15,6 @@ import {
   writeCompatMarker,
 } from "../../compat/compat-marker.js";
 import {
-  gsdTreeHasContent,
   isPlanningPassthroughRelPath,
   walkPlanningRelPaths,
 } from "../../compat/planning-compat.js";
@@ -139,10 +138,12 @@ async function repairExternalPlanningEdit(
 
   // Modeled: re-import via the migrate read path. Dynamic imports break the
   // module-init cycle (this handler ← registry ← state.ts ← guided-flow.ts
-  // ← md-importer.ts). parsePlanningDirectory reads .planning/; when `.gsd/` is
-  // empty, transformToGSD + writeGSDDirectory materialize it first. When
-  // `.gsd/` already has content (coexistence), skip the write and import from
-  // disk via migrateHierarchyToDb only.
+  // ← md-importer.ts). parsePlanningDirectory reads .planning/; always
+  // transform + writeGSDDirectory so .gsd/ reflects the edited .planning/ file
+  // before migrateHierarchyToDb ingests it. In coexistence, .planning/ is the
+  // gsd-core native format and takes precedence: writing .gsd/ here propagates
+  // the edit that must survive future projections. external-markdown-edit (index
+  // 0) runs before this handler, so .gsd/-only drift is already imported first.
   try {
     const { parsePlanningDirectory } = await import("../../migrate/parser.js");
     const { transformToGSD } = await import("../../migrate/transformer.js");
@@ -151,10 +152,8 @@ async function repairExternalPlanningEdit(
     const { invalidateStateCache } = await import("../../state.js");
 
     const parsed = await parsePlanningDirectory(join(ctx.basePath, ".planning"));
-    if (!gsdTreeHasContent(ctx.basePath)) {
-      const gsdProject = transformToGSD(parsed);
-      await writeGSDDirectory(gsdProject, ctx.basePath);
-    }
+    const gsdProject = transformToGSD(parsed);
+    await writeGSDDirectory(gsdProject, ctx.basePath);
     migrateHierarchyToDb(ctx.basePath);
     invalidateStateCache();
   } catch (err) {

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -67,8 +67,8 @@ export async function reconcileBeforeDispatch(
   const repaired: DriftRecord[] = [];
 
   // Capture-on-first-read: infer .planning/ layout, import content into DB, and
-  // seed compat marker SHAs so drift detection has a baseline. Skipped in
-  // dry-run mode to keep the reconcile pass fully read-only — no marker writes.
+  // activate the compat marker. Skipped in dry-run mode to keep the reconcile
+  // pass fully read-only — no marker writes.
   if (!deps.dryRun) {
     const { capturePlanningCompatIfNeeded } = await import("../compat/planning-compat.js");
     await capturePlanningCompatIfNeeded(basePath);
@@ -77,7 +77,7 @@ export async function reconcileBeforeDispatch(
   for (let pass = 0; pass < MAX_PASSES; pass++) {
     deps.invalidateStateCache();
     const stateSnapshot = await deps.deriveState(basePath, deps.deriveStateOptions);
-    const ctx: DriftContext = { basePath, state: stateSnapshot };
+    const ctx: DriftContext = { basePath, state: stateSnapshot, dryRun: deps.dryRun };
 
     const detection = await detectAllDrift(stateSnapshot, ctx, registry);
     const drift = detection.records;
@@ -176,7 +176,7 @@ export async function reconcileBeforeDispatch(
   // After MAX_PASSES, one more derive+detect to verify nothing persists.
   deps.invalidateStateCache();
   const finalState = await deps.deriveState(basePath, deps.deriveStateOptions);
-  const finalCtx: DriftContext = { basePath, state: finalState };
+  const finalCtx: DriftContext = { basePath, state: finalState, dryRun: deps.dryRun };
   const finalDetection = await detectAllDrift(finalState, finalCtx, registry);
   const persistent = finalDetection.records;
 

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -66,8 +66,13 @@ export async function reconcileBeforeDispatch(
   const clearParseCache = deps.clearParseCache ?? defaultClearParseCache;
   const repaired: DriftRecord[] = [];
 
-  const { capturePlanningCompatIfNeeded } = await import("../compat/planning-compat.js");
-  await capturePlanningCompatIfNeeded(basePath);
+  // Capture-on-first-read: infer .planning/ layout, import content into DB, and
+  // seed compat marker SHAs so drift detection has a baseline. Skipped in
+  // dry-run mode to keep the reconcile pass fully read-only — no marker writes.
+  if (!deps.dryRun) {
+    const { capturePlanningCompatIfNeeded } = await import("../compat/planning-compat.js");
+    await capturePlanningCompatIfNeeded(basePath);
+  }
 
   for (let pass = 0; pass < MAX_PASSES; pass++) {
     deps.invalidateStateCache();

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -66,6 +66,9 @@ export async function reconcileBeforeDispatch(
   const clearParseCache = deps.clearParseCache ?? defaultClearParseCache;
   const repaired: DriftRecord[] = [];
 
+  const { capturePlanningCompatIfNeeded } = await import("../compat/planning-compat.js");
+  await capturePlanningCompatIfNeeded(basePath);
+
   for (let pass = 0; pass < MAX_PASSES; pass++) {
     deps.invalidateStateCache();
     const stateSnapshot = await deps.deriveState(basePath, deps.deriveStateOptions);

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -59,8 +59,9 @@ const defaultDeps: ReconciliationDeps = {
  */
 export async function reconcileBeforeDispatch(
   basePath: string,
-  deps: ReconciliationDeps = defaultDeps,
+  partialDeps: Partial<ReconciliationDeps> = {},
 ): Promise<ReconciliationResult> {
+  const deps: ReconciliationDeps = { ...defaultDeps, ...partialDeps };
   const registry = deps.registry ?? DRIFT_REGISTRY;
   const clearParseCache = deps.clearParseCache ?? defaultClearParseCache;
   const repaired: DriftRecord[] = [];
@@ -72,6 +73,30 @@ export async function reconcileBeforeDispatch(
 
     const detection = await detectAllDrift(stateSnapshot, ctx, registry);
     const drift = detection.records;
+    if (deps.dryRun && drift.length > 0) {
+      const wouldRepair: DriftRecord[] = [];
+      const blockers: string[] = [...detection.detectBlockers];
+      for (const record of drift) {
+        const handler = registry.find((h) => h.kind === record.kind);
+        const blocker = handler?.blocker ? await handler.blocker(record, ctx) : null;
+        if (blocker) {
+          blockers.push(blocker);
+        } else {
+          wouldRepair.push(record);
+        }
+      }
+      return {
+        ok: true,
+        stateSnapshot,
+        repaired: wouldRepair,
+        blockers: [
+          ...new Set([
+            ...(stateSnapshot.blockers ?? []),
+            ...blockers,
+          ]),
+        ],
+      };
+    }
     if (drift.length === 0) {
       return {
         ok: true,

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -34,7 +34,6 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   externalMarkdownEditHandler,
   sketchFlagHandler,
   mergeStateHandler,
-  externalMarkdownEditHandler,
   staleRenderHandler,
   staleWorkerHandler,
   unregisteredMilestoneHandler,

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -10,6 +10,7 @@ import {
 } from "./drift/artifact-db.js";
 import { mergeStateHandler } from "./drift/merge-state.js";
 import { externalMarkdownEditHandler } from "./drift/external-markdown-edit.js";
+import { externalPlanningEditHandler } from "./drift/external-planning-edit.js";
 import { unregisteredMilestoneHandler } from "./drift/project-md.js";
 import { roadmapDivergenceHandler } from "./drift/roadmap.js";
 import { sketchFlagHandler } from "./drift/sketch-flag.js";
@@ -32,6 +33,7 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   // the DB is updated to reflect the gsd-core edit before stale-render
   // re-renders, so the canonical re-projection preserves the edit's intent.
   externalMarkdownEditHandler,
+  externalPlanningEditHandler,
   sketchFlagHandler,
   mergeStateHandler,
   staleRenderHandler,

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -34,6 +34,7 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   externalMarkdownEditHandler,
   sketchFlagHandler,
   mergeStateHandler,
+  externalMarkdownEditHandler,
   staleRenderHandler,
   staleWorkerHandler,
   unregisteredMilestoneHandler,

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -23,6 +23,15 @@ import type { DriftHandler } from "./types.js";
 // by kind before invoking repair, so this is sound at runtime.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
+  // ⚠ ORDER IS SIGNIFICANT for repairs within a single pass.
+  // external-markdown-edit MUST run before any handler that re-projects
+  // markdown from DB (stale-render, roadmap-divergence). If a DB-projection
+  // handler runs first it overwrites the gsd-core file and the subsequent
+  // external-markdown-edit repair imports the already-overwritten content —
+  // silently discarding the cross-tool edit. With external-markdown-edit first
+  // the DB is updated to reflect the gsd-core edit before stale-render
+  // re-renders, so the canonical re-projection preserves the edit's intent.
+  externalMarkdownEditHandler,
   sketchFlagHandler,
   mergeStateHandler,
   staleRenderHandler,
@@ -33,5 +42,4 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   completedMilestoneReopenedHandler,
   artifactDbStatusDivergenceHandler,
   completionTimestampHandler,
-  externalMarkdownEditHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -9,6 +9,7 @@ import {
   diskSliceIdDivergenceHandler,
 } from "./drift/artifact-db.js";
 import { mergeStateHandler } from "./drift/merge-state.js";
+import { externalMarkdownEditHandler } from "./drift/external-markdown-edit.js";
 import { unregisteredMilestoneHandler } from "./drift/project-md.js";
 import { roadmapDivergenceHandler } from "./drift/roadmap.js";
 import { sketchFlagHandler } from "./drift/sketch-flag.js";
@@ -32,4 +33,5 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   completedMilestoneReopenedHandler,
   artifactDbStatusDivergenceHandler,
   completionTimestampHandler,
+  externalMarkdownEditHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -67,6 +67,8 @@ export type DriftRecord =
 export interface DriftContext {
   basePath: string;
   state: GSDState;
+  /** When true, detectors must not persist compat marker changes. */
+  dryRun?: boolean;
 }
 
 /**

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -50,6 +50,14 @@ export type DriftRecord =
       expectedSha: string;          // sha recorded in .compat.json
       actualSha: string;            // freshly computed from disk
       entities: string[];           // DB entity ids to re-import
+    }
+  | {
+      kind: "external-planning-edit";
+      projectionPath: string;       // relative to .planning/, e.g. "phases/01-foo/01-01-PLAN.md"
+      expectedSha: string;
+      actualSha: string;
+      entities: string[];
+      passthrough: boolean;         // true = content-only, no re-import, just refresh sha
     };
 
 /**

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -43,6 +43,13 @@ export type DriftRecord =
       kind: "missing-completion-timestamp";
       entity: "task" | "slice" | "milestone";
       ids: string[];
+    }
+  | {
+      kind: "external-markdown-edit";
+      projectionPath: string;       // relative to basePath, e.g. "m1/plan.md"
+      expectedSha: string;          // sha recorded in .compat.json
+      actualSha: string;            // freshly computed from disk
+      entities: string[];           // DB entity ids to re-import
     };
 
 /**

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -118,4 +118,6 @@ export interface ReconciliationDeps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry?: ReadonlyArray<DriftHandler<any>>;
   deriveStateOptions?: DeriveStateOptions;
+  /** When true, detect drift but do not run repairs (read-only preview). */
+  dryRun?: boolean;
 }

--- a/src/resources/extensions/gsd/tests/__fixtures__/round-trip/m001-basic/.gsd/milestones/M001/M001-ROADMAP.md
+++ b/src/resources/extensions/gsd/tests/__fixtures__/round-trip/m001-basic/.gsd/milestones/M001/M001-ROADMAP.md
@@ -1,0 +1,13 @@
+# M001: First Milestone
+
+**Vision:** A round-trippable milestone.
+
+## Success Criteria
+
+- Criterion one
+- Criterion two
+
+## Slices
+
+- [ ] **S01: First slice** `risk:low` `depends:[]`
+  > After this: a demo exists

--- a/src/resources/extensions/gsd/tests/__fixtures__/round-trip/m001-basic/.gsd/milestones/M001/slices/S01/S01-PLAN.md
+++ b/src/resources/extensions/gsd/tests/__fixtures__/round-trip/m001-basic/.gsd/milestones/M001/slices/S01/S01-PLAN.md
@@ -1,0 +1,5 @@
+# S01: First slice
+
+## Tasks
+
+- [ ] **T01: First task** `estimate:30m`

--- a/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/PROJECT.md
+++ b/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/PROJECT.md
@@ -1,0 +1,1 @@
+# Foundation

--- a/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/ROADMAP.md
+++ b/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/ROADMAP.md
@@ -1,0 +1,5 @@
+# Roadmap
+
+## Phases
+
+- [ ] 01 — Foundation

--- a/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/STATE.md
+++ b/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/STATE.md
@@ -1,0 +1,10 @@
+---
+gsd_state_version: 1.0
+milestone: M001
+status: active
+---
+
+# Project State
+
+Current Phase: **01**
+Status: **active**

--- a/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/phases/01-foundation/01-01-PLAN.md
+++ b/src/resources/extensions/gsd/tests/__fixtures__/round-trip/planning-flat-phases/.planning/phases/01-foundation/01-01-PLAN.md
@@ -1,0 +1,13 @@
+# 01-01: Set up tooling
+
+<objective>
+Set up the build tooling.
+</objective>
+
+<tasks>
+- [ ] **T01**: Init repo _(30m)_
+</tasks>
+
+<verification>
+Build runs.
+</verification>

--- a/src/resources/extensions/gsd/tests/compat-health-line.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-health-line.test.ts
@@ -1,0 +1,102 @@
+// Project/App: gsd-pi
+// File Purpose: Unit tests for formatCompatHealthLine (doctor compat output).
+// Covers the per-section "no baseline" signal introduced to fix COMMENT:3449128458.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { formatCompatHealthLine } from "../commands-handlers.ts";
+import { writeCompatMarker } from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-chl-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+afterEach(() => {
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("returns unified no-baseline when projections empty and planning inactive", async () => {
+  const base = makeTmpBase();
+  // No marker written → EMPTY_MARKER → projections={}, planning.active=false
+  const line = await formatCompatHealthLine(base);
+  assert.ok(line.includes("no baseline"), `expected no-baseline, got: ${line}`);
+  // Should be the unified single line, not separate .gsd/.planning sections.
+  assert.ok(!line.includes("(.gsd)"), `expected unified line, got: ${line}`);
+});
+
+test("returns per-section no-baseline for .gsd when planning active but gsd projections empty", async () => {
+  // Regression: COMMENT:3449128458 — after auto-activation, marker has
+  // planning.active=true but marker.projections={} (no .gsd/ baseline yet).
+  // Old code reported ".gsd: OK" (misleading). New code: per-section no-baseline.
+  const base = makeTmpBase();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  const line = await formatCompatHealthLine(base);
+  // Both sections should show no-baseline.
+  const gsdLine = line.split("\n").find((l) => l.includes("(.gsd)"));
+  const planningLine = line.split("\n").find((l) => l.includes("(.planning)"));
+  assert.ok(gsdLine, "expected a (.gsd) line");
+  assert.ok(planningLine, "expected a (.planning) line");
+  assert.ok(gsdLine!.includes("no baseline"), `(.gsd) should say no baseline, got: ${gsdLine}`);
+  assert.ok(planningLine!.includes("no baseline"), `(.planning) should say no baseline, got: ${planningLine}`);
+});
+
+test("returns no-baseline for .planning section when active but planning projections empty", async () => {
+  // Mixed: .gsd/ has a baseline but .planning/ has been auto-activated with
+  // empty projections (sync ran for .gsd but not yet for .planning/).
+  const base = makeTmpBase();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {
+      "milestones/M001/M001-ROADMAP.md": { sha: "abc123", entities: ["M001"] },
+    },
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  const line = await formatCompatHealthLine(base);
+  const gsdLine = line.split("\n").find((l) => l.includes("(.gsd)"));
+  const planningLine = line.split("\n").find((l) => l.includes("(.planning)"));
+  assert.ok(gsdLine, "expected a (.gsd) line");
+  assert.ok(planningLine, "expected a (.planning) line");
+  // .gsd/ has a baseline (1 entry), file is absent → 0 drift → OK
+  assert.ok(gsdLine!.includes("OK"), `(.gsd) should say OK, got: ${gsdLine}`);
+  // .planning/ has no SHAs at all → no baseline
+  assert.ok(planningLine!.includes("no baseline"), `(.planning) should say no baseline, got: ${planningLine}`);
+});
+
+test("reports not-active for .planning when planning is inactive", async () => {
+  const base = makeTmpBase();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {
+      "milestones/M001/M001-ROADMAP.md": { sha: "abc123", entities: ["M001"] },
+    },
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  const line = await formatCompatHealthLine(base);
+  const planningLine = line.split("\n").find((l) => l.includes("(.planning)"));
+  assert.ok(planningLine, "expected a (.planning) line");
+  assert.ok(planningLine!.includes("not active"), `(.planning) should say not active, got: ${planningLine}`);
+});

--- a/src/resources/extensions/gsd/tests/compat-marker-invalidation.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker-invalidation.test.ts
@@ -1,0 +1,51 @@
+// Project/App: gsd-pi
+// File Purpose: Verifies that projection writes update .gsd/.compat.json.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { renderRoadmapFromDb } from "../markdown-renderer.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+import { readCompatMarker } from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+function makeTmp(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-inv-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "T", status: "pending", risk: "low", depends: [] });
+  tmpDirs.push(base);
+  return base;
+}
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("renderRoadmapFromDb writes a compat marker entry for the roadmap file", async () => {
+  const base = makeTmp();
+  await renderRoadmapFromDb(base, "M001");
+  const marker = readCompatMarker(base);
+  const rels = Object.keys(marker.projections);
+  assert.ok(
+    rels.some((r) => r.includes("M001") && r.endsWith("ROADMAP.md")),
+    `expected roadmap entry, got ${JSON.stringify(rels)}`,
+  );
+  // Marker should record gsd-pi as last writer and a non-empty timestamp.
+  assert.equal(marker.lastWriter, "gsd-pi");
+  assert.ok(marker.lastProjectedAt.length > 0, "expected non-empty lastProjectedAt");
+});
+
+test("re-rendering the same file updates the marker entry (not duplicates)", async () => {
+  const base = makeTmp();
+  await renderRoadmapFromDb(base, "M001");
+  await renderRoadmapFromDb(base, "M001");
+  const marker = readCompatMarker(base);
+  const roadmapEntries = Object.keys(marker.projections).filter((r) => r.endsWith("ROADMAP.md"));
+  assert.equal(roadmapEntries.length, 1, "expected exactly one roadmap entry after re-render");
+});

--- a/src/resources/extensions/gsd/tests/compat-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker.test.ts
@@ -59,10 +59,31 @@ test("readCompatMarker quarantines malformed JSON and returns EMPTY_MARKER", () 
   writeFileSync(compatMarkerPath(base), "{ not valid json", "utf-8");
   const marker = readCompatMarker(base);
   assert.deepEqual(marker, EMPTY_MARKER);
-  // Quarantine backup should exist
   const files = readdirSync(join(base, ".gsd"));
+  // Quarantine backup should exist.
   const quarantined = files.some((f: string) => f.startsWith(".compat.json.bad-"));
   assert.ok(quarantined, "expected a quarantined .compat.json.bad-* file");
+  // Original should be gone — the quarantine fix removes it so repeated reads
+  // don't accumulate unbounded .bad-* files.
+  assert.ok(!files.includes(".compat.json"), "corrupt original should be deleted after quarantine");
+});
+
+test("quarantine does not grow unbounded .bad-* files on repeated reads", () => {
+  const base = makeTmpBase();
+  writeFileSync(compatMarkerPath(base), "not valid json at all", "utf-8");
+
+  // First read quarantines and removes the original.
+  readCompatMarker(base);
+  const filesAfterFirst = readdirSync(join(base, ".gsd"));
+  const badCountAfterFirst = filesAfterFirst.filter((f: string) => f.startsWith(".compat.json.bad-")).length;
+  assert.equal(badCountAfterFirst, 1, "expected exactly one .bad-* file after first read");
+  assert.ok(!filesAfterFirst.includes(".compat.json"), "corrupt original should be gone after first read");
+
+  // Second read sees no file → EMPTY_MARKER fast path, no new .bad-* created.
+  readCompatMarker(base);
+  const filesAfterSecond = readdirSync(join(base, ".gsd"));
+  const badCountAfterSecond = filesAfterSecond.filter((f: string) => f.startsWith(".compat.json.bad-")).length;
+  assert.equal(badCountAfterSecond, 1, "second read must not create an additional .bad-* file");
 });
 
 test("normalizeForHash trims trailing whitespace and converts CRLF to LF", () => {

--- a/src/resources/extensions/gsd/tests/compat-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker.test.ts
@@ -1,0 +1,83 @@
+// Project/App: gsd-pi
+// File Purpose: Unit tests for the gsd-core compat marker (`.gsd/.compat.json`).
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import {
+  readCompatMarker,
+  writeCompatMarker,
+  normalizeForHash,
+  computeProjectionSha,
+  EMPTY_MARKER,
+  compatMarkerPath,
+} from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-compat-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  }
+  tmpDirs.length = 0;
+});
+
+test("readCompatMarker returns EMPTY_MARKER when file is missing", () => {
+  const base = makeTmpBase();
+  const marker = readCompatMarker(base);
+  assert.deepEqual(marker, EMPTY_MARKER);
+});
+
+test("writeCompatMarker then readCompatMarker round-trips", () => {
+  const base = makeTmpBase();
+  const marker = {
+    schema: 1,
+    lastWriter: "gsd-pi" as const,
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {
+      "roadmap.md": { sha: "abc123", entities: ["m1"] },
+    },
+    piVersion: "1.4.0",
+  };
+  writeCompatMarker(base, marker);
+  const read = readCompatMarker(base);
+  assert.deepEqual(read, marker);
+});
+
+test("readCompatMarker quarantines malformed JSON and returns EMPTY_MARKER", () => {
+  const base = makeTmpBase();
+  writeFileSync(compatMarkerPath(base), "{ not valid json", "utf-8");
+  const marker = readCompatMarker(base);
+  assert.deepEqual(marker, EMPTY_MARKER);
+  // Quarantine backup should exist
+  const files = readdirSync(join(base, ".gsd"));
+  const quarantined = files.some((f: string) => f.startsWith(".compat.json.bad-"));
+  assert.ok(quarantined, "expected a quarantined .compat.json.bad-* file");
+});
+
+test("normalizeForHash trims trailing whitespace and converts CRLF to LF", () => {
+  const input = "line one  \r\nline two\r\n";
+  const out = normalizeForHash(input);
+  assert.equal(out, "line one\nline two\n");
+});
+
+test("computeProjectionSha is stable for cosmetically different but equivalent content", () => {
+  const a = computeProjectionSha("hello\r\nworld  \n");
+  const b = computeProjectionSha("hello\nworld\n");
+  assert.equal(a, b);
+});
+
+test("compatMarkerPath resolves under .gsd", () => {
+  const base = makeTmpBase();
+  assert.equal(compatMarkerPath(base), join(base, ".gsd", ".compat.json"));
+});

--- a/src/resources/extensions/gsd/tests/compat-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker.test.ts
@@ -41,12 +41,13 @@ test("readCompatMarker returns EMPTY_MARKER when file is missing", () => {
 test("writeCompatMarker then readCompatMarker round-trips", () => {
   const base = makeTmpBase();
   const marker = {
-    schema: 1,
+    schema: 2,
     lastWriter: "gsd-pi" as const,
     lastProjectedAt: "2026-06-21T00:00:00.000Z",
     projections: {
       "roadmap.md": { sha: "abc123", entities: ["m1"] },
     },
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
     piVersion: "1.4.0",
   };
   writeCompatMarker(base, marker);

--- a/src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
+++ b/src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
   tmpDirs.length = 0;
 });
 
-test("detect returns no drift when file sha matches marker", () => {
+test("detect returns no drift when file sha matches marker", async () => {
   const base = makeTmpBase();
   const rel = "m1/roadmap.md";
   mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
@@ -47,11 +47,11 @@ test("detect returns no drift when file sha matches marker", () => {
     piVersion: "1.4.0",
   });
 
-  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  const drift = await externalMarkdownEditHandler.detect(stubState, ctx(base));
   assert.equal(drift.length, 0);
 });
 
-test("detect returns drift when file content differs from marker", () => {
+test("detect returns drift when file content differs from marker", async () => {
   const base = makeTmpBase();
   const rel = "m1/roadmap.md";
   mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
@@ -64,14 +64,14 @@ test("detect returns drift when file content differs from marker", () => {
     piVersion: "1.4.0",
   });
 
-  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  const drift = await externalMarkdownEditHandler.detect(stubState, ctx(base));
   assert.equal(drift.length, 1);
   assert.equal(drift[0].kind, "external-markdown-edit");
   assert.equal(drift[0].projectionPath, rel);
   assert.deepEqual(drift[0].entities, ["m1"]);
 });
 
-test("detect treats missing marker as drift on every tracked projection file", () => {
+test("detect treats missing marker as drift on every tracked projection file", async () => {
   const base = makeTmpBase();
   const rel = "m1/roadmap.md";
   mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
@@ -82,11 +82,11 @@ test("detect treats missing marker as drift on every tracked projection file", (
   // no-op (the reconcile pipeline's other handlers cover the "import everything"
   // case via the existing /gsd recover flow). This is by design: this handler
   // only fires when we HAVE a baseline to compare.
-  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  const drift = await externalMarkdownEditHandler.detect(stubState, ctx(base));
   assert.equal(drift.length, 0);
 });
 
-test("detect ignores files missing from disk (other handlers cover that)", () => {
+test("detect ignores files missing from disk (other handlers cover that)", async () => {
   const base = makeTmpBase();
   const rel = "m1/roadmap.md";
   writeCompatMarker(base, {
@@ -98,7 +98,7 @@ test("detect ignores files missing from disk (other handlers cover that)", () =>
   });
   // No file written.
 
-  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  const drift = await externalMarkdownEditHandler.detect(stubState, ctx(base));
   assert.equal(drift.length, 0);
 });
 
@@ -116,7 +116,7 @@ test("repair is idempotent: running twice produces no further drift on second de
     piVersion: "1.4.0",
   });
 
-  const drift1 = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  const drift1 = await externalMarkdownEditHandler.detect(stubState, ctx(base));
   assert.equal(drift1.length, 1);
   // repair may call migrateHierarchyToDb which requires a DB; we only assert
   // that detect after repair produces no further drift on THIS handler. Wrap
@@ -132,6 +132,6 @@ test("repair is idempotent: running twice produces no further drift on second de
   }
 
   // After repair, marker should reflect the file's actual sha → no drift.
-  const drift2 = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  const drift2 = await externalMarkdownEditHandler.detect(stubState, ctx(base));
   assert.equal(drift2.length, 0);
 });

--- a/src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
+++ b/src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
@@ -1,0 +1,137 @@
+// Project/App: gsd-pi
+// File Purpose: Unit tests for the external-markdown-edit drift handler.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { externalMarkdownEditHandler } from "../state-reconciliation/drift/external-markdown-edit.ts";
+import { writeCompatMarker, computeProjectionSha } from "../compat/compat-marker.ts";
+import type { DriftContext } from "../state-reconciliation/types.ts";
+import type { GSDState } from "../types.ts";
+
+const tmpDirs: string[] = [];
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-extedit-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+const stubState = { phase: "idle" } as unknown as GSDState;
+
+function ctx(base: string): DriftContext {
+  return { basePath: base, state: stubState };
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  }
+  tmpDirs.length = 0;
+});
+
+test("detect returns no drift when file sha matches marker", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), "# Roadmap\n\n- [x] S1 done\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: computeProjectionSha("# Roadmap\n\n- [x] S1 done\n"), entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("detect returns drift when file content differs from marker", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), "# Roadmap\n\n- [ ] S1 NOT done\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "stale000000000000", entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].kind, "external-markdown-edit");
+  assert.equal(drift[0].projectionPath, rel);
+  assert.deepEqual(drift[0].entities, ["m1"]);
+});
+
+test("detect treats missing marker as drift on every tracked projection file", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), "# Roadmap\n", "utf-8");
+  // No writeCompatMarker call → marker missing → EMPTY_MARKER
+
+  // Without a marker we have no projections to compare, so detect should be a
+  // no-op (the reconcile pipeline's other handlers cover the "import everything"
+  // case via the existing /gsd recover flow). This is by design: this handler
+  // only fires when we HAVE a baseline to compare.
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("detect ignores files missing from disk (other handlers cover that)", () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "abc123", entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+  // No file written.
+
+  const drift = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("repair is idempotent: running twice produces no further drift on second detect", async () => {
+  const base = makeTmpBase();
+  const rel = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  const content = "# Roadmap\n\n- [x] S1 done\n";
+  writeFileSync(join(base, ".gsd", rel), content, "utf-8");
+  writeCompatMarker(base, {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "stale000000000000", entities: ["m1"] } },
+    piVersion: "1.4.0",
+  });
+
+  const drift1 = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift1.length, 1);
+  // repair may call migrateHierarchyToDb which requires a DB; we only assert
+  // that detect after repair produces no further drift on THIS handler. Wrap
+  // in try/catch so a no-DB environment doesn't fail the idempotency check —
+  // the marker refresh is the load-bearing part of the assertion.
+  try {
+    await externalMarkdownEditHandler.repair(drift1[0], ctx(base));
+  } catch {
+    // migrateHierarchyToDb may throw without an open DB; that's fine for this
+    // unit test — the marker refresh below the import call still runs if the
+    // import succeeds. If it throws, we skip the second-detect assertion.
+    return;
+  }
+
+  // After repair, marker should reflect the file's actual sha → no drift.
+  const drift2 = externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift2.length, 0);
+});

--- a/src/resources/extensions/gsd/tests/external-planning-edit.test.ts
+++ b/src/resources/extensions/gsd/tests/external-planning-edit.test.ts
@@ -29,10 +29,37 @@ afterEach(() => {
   tmpDirs.length = 0;
 });
 
-test("detect returns no drift when planning inactive", async () => {
+test("detect returns no drift when planning inactive and dir is empty", async () => {
   const base = makeTmpBase();
+  // .planning/ exists (created by makeTmpBase) but has no ROADMAP.md → no
+  // layout signal → detectPlanningLayout returns null → stays inactive.
   const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
   assert.equal(drift.length, 0);
+
+  const { readCompatMarker } = await import("../compat/compat-marker.ts");
+  const marker = readCompatMarker(base);
+  assert.equal(marker.planning?.active, false, "should not activate without a recognisable layout");
+});
+
+test("detect auto-activates marker when .planning/ has a recognisable layout", async () => {
+  const base = makeTmpBase();
+  // Write a minimal flat-phases ROADMAP so detectPlanningLayout returns "flat-phases".
+  writeFileSync(
+    join(base, ".planning", "ROADMAP.md"),
+    "# Roadmap\n\n## Phases\n\n- [ ] 01 — Foundation\n",
+    "utf-8",
+  );
+  // No compat marker written → planning.active = false by default.
+
+  const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  // First pass returns no drift records (just activates the marker).
+  assert.equal(drift.length, 0);
+
+  // Marker must now have planning.active = true and layout = "flat-phases".
+  const { readCompatMarker } = await import("../compat/compat-marker.ts");
+  const marker = readCompatMarker(base);
+  assert.equal(marker.planning?.active, true, "planning.active should be set after auto-detection");
+  assert.equal(marker.planning?.layout, "flat-phases");
 });
 
 test("detect returns drift when planning projection sha mismatches", async () => {

--- a/src/resources/extensions/gsd/tests/external-planning-edit.test.ts
+++ b/src/resources/extensions/gsd/tests/external-planning-edit.test.ts
@@ -1,0 +1,136 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for the external-planning-edit drift handler.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { externalPlanningEditHandler } from "../state-reconciliation/drift/external-planning-edit.ts";
+import { writeCompatMarker } from "../compat/compat-marker.ts";
+import type { DriftContext } from "../state-reconciliation/types.ts";
+import type { GSDState } from "../types.ts";
+
+const tmpDirs: string[] = [];
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-pedit-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, ".planning"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+const stubState = { phase: "idle" } as unknown as GSDState;
+function ctx(base: string): DriftContext {
+  return { basePath: base, state: stubState };
+}
+afterEach(() => {
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("detect returns no drift when planning inactive", async () => {
+  const base = makeTmpBase();
+  const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("detect returns drift when planning projection sha mismatches", async () => {
+  const base = makeTmpBase();
+  const rel = "ROADMAP.md";
+  writeFileSync(join(base, ".planning", rel), "# edited by gsd-core\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {},
+    planning: {
+      active: true,
+      layout: "flat-phases",
+      projections: { [rel]: { sha: "stale000000000000", entities: ["M001"] } },
+      passthrough: {},
+    },
+    piVersion: "1.4.0",
+  });
+
+  const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0]!.kind, "external-planning-edit");
+  assert.equal(drift[0]!.projectionPath, rel);
+  assert.equal(drift[0]!.passthrough, false);
+});
+
+test("detect flags passthrough files separately with passthrough=true", async () => {
+  const base = makeTmpBase();
+  const rel = "codebase/STACK.md";
+  mkdirSync(join(base, ".planning", "codebase"), { recursive: true });
+  writeFileSync(join(base, ".planning", rel), "# new stack content\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {},
+    planning: {
+      active: true,
+      layout: "flat-phases",
+      projections: {},
+      passthrough: { [rel]: { sha: "old0000000000000", entities: [] } },
+    },
+    piVersion: "1.4.0",
+  });
+
+  const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0]!.passthrough, true);
+});
+
+test("detect returns no drift when sha matches", async () => {
+  const base = makeTmpBase();
+  const rel = "ROADMAP.md";
+  const content = "# unchanged\n";
+  writeFileSync(join(base, ".planning", rel), content, "utf-8");
+  const { computeProjectionSha } = await import("../compat/compat-marker.ts");
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {},
+    planning: {
+      active: true,
+      layout: "flat-phases",
+      projections: { [rel]: { sha: computeProjectionSha(content), entities: ["M001"] } },
+      passthrough: {},
+    },
+    piVersion: "1.4.0",
+  });
+
+  const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+});
+
+test("repair refreshes passthrough marker sha (idempotent on second detect)", async () => {
+  const base = makeTmpBase();
+  const rel = "codebase/STACK.md";
+  mkdirSync(join(base, ".planning", "codebase"), { recursive: true });
+  writeFileSync(join(base, ".planning", rel), "# new stack content\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {},
+    planning: {
+      active: true,
+      layout: "flat-phases",
+      projections: {},
+      passthrough: { [rel]: { sha: "old0000000000000", entities: [] } },
+    },
+    piVersion: "1.4.0",
+  });
+
+  const drift1 = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift1.length, 1);
+  await externalPlanningEditHandler.repair(drift1[0]!, ctx(base));
+
+  const drift2 = await externalPlanningEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift2.length, 0);
+});

--- a/src/resources/extensions/gsd/tests/external-planning-edit.test.ts
+++ b/src/resources/extensions/gsd/tests/external-planning-edit.test.ts
@@ -8,7 +8,8 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
 import { externalPlanningEditHandler } from "../state-reconciliation/drift/external-planning-edit.ts";
-import { writeCompatMarker } from "../compat/compat-marker.ts";
+import { reconcileBeforeDispatch } from "../state-reconciliation.ts";
+import { writeCompatMarker, readCompatMarker } from "../compat/compat-marker.ts";
 import type { DriftContext } from "../state-reconciliation/types.ts";
 import type { GSDState } from "../types.ts";
 
@@ -41,9 +42,12 @@ test("detect returns no drift when planning inactive and dir is empty", async ()
   assert.equal(marker.planning?.active, false, "should not activate without a recognisable layout");
 });
 
-test("detect auto-activates marker when .planning/ has a recognisable layout", async () => {
+test("detect does NOT write the marker when planning inactive (dry-run invariant)", async () => {
+  // Regression test for COMMENT:3449147735: detect() must be read-only because
+  // it is called in both dry-run and non-dry-run contexts. Activation is owned
+  // by capturePlanningCompatIfNeeded (called from reconcileBeforeDispatch when
+  // !dryRun), not by the detect function itself.
   const base = makeTmpBase();
-  // Write a minimal flat-phases ROADMAP so detectPlanningLayout returns "flat-phases".
   writeFileSync(
     join(base, ".planning", "ROADMAP.md"),
     "# Roadmap\n\n## Phases\n\n- [ ] 01 — Foundation\n",
@@ -52,14 +56,12 @@ test("detect auto-activates marker when .planning/ has a recognisable layout", a
   // No compat marker written → planning.active = false by default.
 
   const drift = await externalPlanningEditHandler.detect(stubState, ctx(base));
-  // First pass returns no drift records (just activates the marker).
   assert.equal(drift.length, 0);
 
-  // Marker must now have planning.active = true and layout = "flat-phases".
+  // Marker must NOT have been written by detect().
   const { readCompatMarker } = await import("../compat/compat-marker.ts");
   const marker = readCompatMarker(base);
-  assert.equal(marker.planning?.active, true, "planning.active should be set after auto-detection");
-  assert.equal(marker.planning?.layout, "flat-phases");
+  assert.equal(marker.planning?.active, false, "detect() must not activate the marker");
 });
 
 test("detect returns drift when planning projection sha mismatches", async () => {
@@ -160,4 +162,38 @@ test("repair refreshes passthrough marker sha (idempotent on second detect)", as
 
   const drift2 = await externalPlanningEditHandler.detect(stubState, ctx(base));
   assert.equal(drift2.length, 0);
+});
+
+test("reconcileBeforeDispatch dryRun=true does not write compat marker (planning)", async () => {
+  // Regression test for COMMENT:3449147735: /gsd sync --dry-run claimed to be
+  // read-only but capturePlanningCompatIfNeeded wrote the marker. The guard
+  // added in reconcileBeforeDispatch must prevent any marker mutations.
+  const base = makeTmpBase();
+  writeFileSync(
+    join(base, ".planning", "ROADMAP.md"),
+    "# Roadmap\n\n## Phases\n\n- [ ] 01 — Foundation\n",
+    "utf-8",
+  );
+  // Capture the marker state before the dry-run reconcile.
+  const markerBefore = readCompatMarker(base);
+
+  await reconcileBeforeDispatch(base, {
+    dryRun: true,
+    registry: [], // empty: no handlers, no repairs
+    invalidateStateCache: () => {},
+    deriveState: async () => stubState as unknown as import("../types.ts").GSDState,
+  });
+
+  // Marker must be identical to before: no planning activation, no SHA seeding.
+  const markerAfter = readCompatMarker(base);
+  assert.equal(
+    markerAfter.planning?.active,
+    markerBefore.planning?.active,
+    "dryRun reconcile must not activate planning",
+  );
+  assert.deepEqual(
+    markerAfter.planning?.projections,
+    markerBefore.planning?.projections,
+    "dryRun reconcile must not write planning projections",
+  );
 });

--- a/src/resources/extensions/gsd/tests/planning-layout-detect.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-layout-detect.test.ts
@@ -1,0 +1,84 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for .planning/ layout classification.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { detectPlanningLayout } from "../migrate/layout-detect.ts";
+import type { PlanningProject } from "../migrate/types.ts";
+
+function emptyProject(over: Partial<PlanningProject> = {}): PlanningProject {
+  return {
+    path: "", project: null, roadmap: null, requirements: [], state: null,
+    config: null, phases: {}, quickTasks: [], milestones: [], research: [],
+    decisions: [], seeds: [], validation: { valid: true, issues: [] },
+    ...over,
+  } as PlanningProject;
+}
+
+test("detectPlanningLayout returns legacy-milestone-dir when milestones/ has phases", () => {
+  const p = emptyProject({
+    milestones: [{
+      id: "v1.0",
+      requirements: null,
+      roadmap: null,
+      phases: { "01-foo": {} as never },
+      extraFiles: [],
+    }],
+  });
+  assert.equal(detectPlanningLayout(p), "legacy-milestone-dir");
+});
+
+test("detectPlanningLayout returns multi-milestone when roadmap.milestones non-empty", () => {
+  const p = emptyProject({
+    roadmap: {
+      raw: "",
+      milestones: [{ id: "v1", title: "V1", collapsed: false, phases: [] }],
+      phases: [],
+    },
+  });
+  assert.equal(detectPlanningLayout(p), "multi-milestone");
+});
+
+test("detectPlanningLayout returns flat-phases when roadmap.phases non-empty and no milestone dirs", () => {
+  const p = emptyProject({
+    roadmap: {
+      raw: "",
+      milestones: [],
+      phases: [{ number: 1, title: "Foo", done: false, raw: "" }],
+    },
+  });
+  assert.equal(detectPlanningLayout(p), "flat-phases");
+});
+
+test("detectPlanningLayout returns null when nothing recognizable", () => {
+  assert.equal(detectPlanningLayout(emptyProject()), null);
+});
+
+test("priority: legacy-milestone-dir wins over multi-milestone", () => {
+  const p = emptyProject({
+    milestones: [{
+      id: "v1.0",
+      requirements: null,
+      roadmap: null,
+      phases: { "01-foo": {} as never },
+      extraFiles: [],
+    }],
+    roadmap: {
+      raw: "",
+      milestones: [{ id: "v1", title: "V1", collapsed: false, phases: [] }],
+      phases: [],
+    },
+  });
+  assert.equal(detectPlanningLayout(p), "legacy-milestone-dir");
+});
+
+test("priority: multi-milestone wins over flat-phases when both roadmap arrays non-empty", () => {
+  const p = emptyProject({
+    roadmap: {
+      raw: "",
+      milestones: [{ id: "v1", title: "V1", collapsed: false, phases: [] }],
+      phases: [{ number: 1, title: "Foo", done: false, raw: "" }],
+    },
+  });
+  assert.equal(detectPlanningLayout(p), "multi-milestone");
+});

--- a/src/resources/extensions/gsd/tests/planning-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-marker.test.ts
@@ -1,0 +1,107 @@
+// Project/App: gsd-pi
+// File Purpose: Schema-2 compat marker tests — the `planning` field.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import {
+  readCompatMarker,
+  writeCompatMarker,
+  EMPTY_MARKER,
+  COMPAT_MARKER_SCHEMA,
+} from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-pm-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+afterEach(() => {
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("schema version is 2", () => {
+  assert.equal(COMPAT_MARKER_SCHEMA, 2);
+});
+
+test("EMPTY_MARKER has planning inactive with empty maps", () => {
+  assert.deepEqual(EMPTY_MARKER.planning, {
+    active: false,
+    layout: null,
+    projections: {},
+    passthrough: {},
+  });
+});
+
+test("writeCompatMarker then readCompatMarker round-trips planning field", () => {
+  const base = makeTmpBase();
+  const marker = {
+    schema: 2,
+    lastWriter: "gsd-pi" as const,
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {},
+    planning: {
+      active: true,
+      layout: "flat-phases" as const,
+      projections: {
+        "ROADMAP.md": { sha: "abc", entities: ["M001"] },
+      },
+      passthrough: {
+        "codebase/STACK.md": { sha: "def", entities: [] },
+      },
+    },
+    piVersion: "1.4.0",
+  };
+  writeCompatMarker(base, marker);
+  const read = readCompatMarker(base);
+  assert.deepEqual(read.planning, marker.planning);
+});
+
+test("readCompatMarker promotes a schema-1 marker by defaulting planning inactive", () => {
+  const base = makeTmpBase();
+  // Hand-write a schema-1 marker (no planning field).
+  const v1 = {
+    schema: 1,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-01T00:00:00.000Z",
+    projections: { "x.md": { sha: "1", entities: [] } },
+    piVersion: "1.3.0",
+  };
+  writeFileSync(join(base, ".gsd", ".compat.json"), JSON.stringify(v1), "utf-8");
+
+  const read = readCompatMarker(base);
+  // Promotion: planning defaults inactive. (raw schema value preserved on read;
+  // promotion is at read-time, a rewrite would emit schema 2.)
+  assert.deepEqual(read.planning, { active: false, layout: null, projections: {}, passthrough: {} });
+});
+
+test("emptyMarker returns independent planning objects (no shared reference)", () => {
+  // Mutating one empty-marker read must not pollute another.
+  const base1 = makeTmpBase();
+  const base2 = makeTmpBase();
+  const m1 = readCompatMarker(base1);
+  m1.planning!.projections["x"] = { sha: "1", entities: [] };
+  const m2 = readCompatMarker(base2);
+  assert.equal(m2.planning!.projections["x"], undefined);
+});
+
+test("readCompatMarker quarantines a marker with invalid planning field", () => {
+  const base = makeTmpBase();
+  const bad = {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: {},
+    planning: { active: "not-a-boolean" }, // invalid
+    piVersion: "1.4.0",
+  };
+  writeFileSync(join(base, ".gsd", ".compat.json"), JSON.stringify(bad), "utf-8");
+  const read = readCompatMarker(base);
+  assert.deepEqual(read.planning, { active: false, layout: null, projections: {}, passthrough: {} });
+});

--- a/src/resources/extensions/gsd/tests/planning-projection-hook.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-projection-hook.test.ts
@@ -9,7 +9,7 @@ import { randomUUID } from "node:crypto";
 
 import { renderAllFromDb } from "../markdown-renderer.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
-import { writeCompatMarker } from "../compat/compat-marker.ts";
+import { writeCompatMarker, readCompatMarker } from "../compat/compat-marker.ts";
 
 const tmpDirs: string[] = [];
 function makeTmp(): string {
@@ -55,5 +55,69 @@ test("renderAllFromDb does NOT project to .planning/ when marker.planning inacti
   assert.ok(
     !existsSync(join(base, ".planning")),
     ".planning/ should not be created when inactive",
+  );
+});
+
+test("renderAllFromDb records planning SHAs into marker.planning.projections", async () => {
+  // Regression test for COMMENT:3449128453: writePlanningDirectory wrote files
+  // but never updated marker.planning.projections, so the reconcile detector
+  // always saw an empty baseline and never reported drift.
+  const base = makeTmp();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  await renderAllFromDb(base);
+
+  const marker = readCompatMarker(base);
+  const planningKeys = Object.keys(marker.planning?.projections ?? {});
+  assert.ok(planningKeys.length > 0, "marker.planning.projections must be non-empty after projection");
+
+  // Every recorded entry must have a non-empty sha and an entities array.
+  for (const [rel, entry] of Object.entries(marker.planning!.projections)) {
+    assert.ok(typeof entry.sha === "string" && entry.sha.length > 0, `SHA missing for ${rel}`);
+    assert.ok(Array.isArray(entry.entities), `entities must be an array for ${rel}`);
+  }
+
+  // ROADMAP.md must be among the recorded SHAs.
+  assert.ok(
+    planningKeys.some((k) => k === "ROADMAP.md"),
+    `expected ROADMAP.md in projections, got ${JSON.stringify(planningKeys)}`,
+  );
+});
+
+test("renderAllFromDb planning SHA baseline survives a subsequent readCompatMarker", async () => {
+  // Regression test for COMMENT:3449128459: after renderAllFromDb the marker
+  // must durably contain planning SHAs so a fresh read (e.g. handleSync's
+  // marker stamp) does not clobber them.
+  const base = makeTmp();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  await renderAllFromDb(base);
+
+  // Simulate handleSync's marker stamp: read → mutate timestamps → write back.
+  const m = readCompatMarker(base);
+  m.lastWriter = "gsd-pi";
+  m.lastProjectedAt = new Date().toISOString();
+  const { writeCompatMarker: wm } = await import("../compat/compat-marker.ts");
+  wm(base, m);
+
+  // Planning SHAs must still be present after the stamp.
+  const after = readCompatMarker(base);
+  assert.ok(
+    Object.keys(after.planning?.projections ?? {}).length > 0,
+    "planning SHAs must survive a subsequent readCompatMarker + writeCompatMarker cycle",
   );
 });

--- a/src/resources/extensions/gsd/tests/planning-projection-hook.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-projection-hook.test.ts
@@ -1,0 +1,59 @@
+// Project/App: gsd-pi
+// File Purpose: Verifies renderAllFromDb projects to .planning/ when active.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { renderAllFromDb } from "../markdown-renderer.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+import { writeCompatMarker } from "../compat/compat-marker.ts";
+
+const tmpDirs: string[] = [];
+function makeTmp(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-pph-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  insertSlice({
+    milestoneId: "M001", id: "S01", title: "T", status: "pending",
+    risk: "low", depends: [], demo: "", sequence: 1,
+  });
+  tmpDirs.push(base);
+  return base;
+}
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("renderAllFromDb projects to .planning/ when marker.planning.active", async () => {
+  const base = makeTmp();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  await renderAllFromDb(base);
+  assert.ok(
+    existsSync(join(base, ".planning", "ROADMAP.md")),
+    ".planning/ROADMAP.md should be projected",
+  );
+});
+
+test("renderAllFromDb does NOT project to .planning/ when marker.planning inactive", async () => {
+  const base = makeTmp();
+  // Default marker: planning inactive.
+  await renderAllFromDb(base);
+  assert.ok(
+    !existsSync(join(base, ".planning")),
+    ".planning/ should not be created when inactive",
+  );
+});

--- a/src/resources/extensions/gsd/tests/planning-round-trip-property.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-round-trip-property.test.ts
@@ -1,0 +1,164 @@
+// Project/App: gsd-pi
+// File Purpose: Round-trip property test for .planning/ parity.
+// import → render → import must produce a stable milestone/slice hierarchy.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, mkdirSync, rmSync, readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import {
+  openDatabase,
+  closeDatabase,
+  getAllMilestones,
+  getMilestoneSlices,
+  getSliceTasks,
+  clearEngineHierarchy,
+} from "../gsd-db.ts";
+import { parsePlanningDirectory } from "../migrate/parser.ts";
+import { transformToGSD } from "../migrate/transformer.ts";
+import { writeGSDDirectory } from "../migrate/writer.ts";
+import { writePlanningDirectory } from "../migrate/planning-writer.ts";
+import { migrateHierarchyToDb } from "../md-importer.ts";
+import { invalidateStateCache } from "../state.ts";
+import { writeCompatMarker } from "../compat/compat-marker.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, "__fixtures__", "round-trip");
+const tmpDirs: string[] = [];
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+function copyFixture(name: string): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-prt-${randomUUID()}`));
+  cpSync(join(FIXTURE_ROOT, name), base, { recursive: true });
+  // The fixture only ships .planning/. The DB needs a .gsd/ dir to live in.
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+interface Snapshot {
+  ms: Array<{ id: string; title: string }>;
+  slices: Array<{ mid: string; id: string; title: string }>;
+  tasks: Array<{ mid: string; sid: string; id: string; title: string }>;
+}
+
+function snapshotHierarchy(): Snapshot {
+  const ms = getAllMilestones().map((m) => ({ id: m.id, title: m.title }));
+  const slices: Snapshot["slices"] = [];
+  const tasks: Snapshot["tasks"] = [];
+  for (const m of ms) {
+    for (const s of getMilestoneSlices(m.id)) {
+      slices.push({ mid: m.id, id: s.id, title: s.title });
+      for (const t of getSliceTasks(m.id, s.id)) {
+        tasks.push({ mid: m.id, sid: s.id, id: t.id, title: t.title });
+      }
+    }
+  }
+  return { ms, slices, tasks };
+}
+
+/**
+ * Materialize a .planning/ tree into the gsd-pi DB:
+ *   parse .planning/ → transform to GSD model → write .gsd/ → import to DB
+ */
+async function importPlanningToDb(base: string): Promise<void> {
+  const parsed = await parsePlanningDirectory(join(base, ".planning"));
+  const gsd = transformToGSD(parsed);
+  await writeGSDDirectory(gsd, base);
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+}
+
+test(".planning/ round-trip: import → render → import produces stable milestone/slice ids", async () => {
+  const base = copyFixture("planning-flat-phases");
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  // Pass 1: import fixture .planning/ → DB
+  await importPlanningToDb(base);
+  const snap1 = snapshotHierarchy();
+  assert.ok(snap1.ms.length > 0, "expected at least one milestone after first import");
+  assert.ok(snap1.slices.length > 0, "expected at least one slice after first import");
+
+  // Project DB → .planning/ (the new writer). Activate the marker first so the
+  // projection hook in renderAllFromDb fires; but we call writePlanningDirectory
+  // directly here to isolate the property under test.
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+  await writePlanningDirectory(base, "flat-phases");
+  assert.ok(existsSync(join(base, ".planning", "ROADMAP.md")), "projection should write ROADMAP.md");
+
+  // Pass 2: clear DB, re-import the projected .planning/ → DB
+  clearEngineHierarchy();
+  await importPlanningToDb(base);
+  const snap2 = snapshotHierarchy();
+
+  // Property: hierarchy ids stable across the round-trip.
+  assert.deepEqual(
+    snap2.ms.map((m) => m.id),
+    snap1.ms.map((m) => m.id),
+    "milestone ids drifted across round-trip",
+  );
+  assert.deepEqual(
+    snap2.slices.map((s) => `${s.mid}/${s.id}`),
+    snap1.slices.map((s) => `${s.mid}/${s.id}`),
+    "slice ids drifted across round-trip",
+  );
+});
+
+test(".planning/ round-trip: re-projecting is idempotent (stable .planning/ content)", async () => {
+  const base = copyFixture("planning-flat-phases");
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  await importPlanningToDb(base);
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "flat-phases", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  const snapshotPlanningFiles = (b: string): Record<string, string> => {
+    const out: Record<string, string> = {};
+    const walk = (dir: string) => {
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, e.name);
+        if (e.isDirectory()) walk(p);
+        else if (e.name.endsWith(".md")) {
+          out[p.replace(b + "/", "")] = readFileSyncNormalized(p);
+        }
+      }
+    };
+    walk(join(b, ".planning"));
+    return out;
+  };
+  const readFileSyncNormalized = (p: string): string => {
+    return readFileSync(p, "utf-8")
+      .replace(/\r\n/g, "\n")
+      .replace(/[ \t]+\n/g, "\n")
+      // STATE.md carries a write-time timestamp that legitimately differs
+      // between projections — strip it so idempotency is checked on content.
+      .replace(/last_updated: ".*"/g, 'last_updated: "<ts>"');
+  };
+
+  await writePlanningDirectory(base, "flat-phases");
+  const after1 = snapshotPlanningFiles(base);
+
+  await writePlanningDirectory(base, "flat-phases");
+  const after2 = snapshotPlanningFiles(base);
+
+  assert.deepEqual(after2, after1, "re-projecting .planning/ changed content");
+});

--- a/src/resources/extensions/gsd/tests/planning-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-writer.test.ts
@@ -1,0 +1,81 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for the DB → .planning/ projection writer.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { writePlanningDirectory } from "../migrate/planning-writer.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
+
+const tmpDirs: string[] = [];
+function makeTmp(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-pw-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  insertSlice({
+    milestoneId: "M001", id: "S01", title: "Set up tooling", status: "pending",
+    risk: "low", depends: [], demo: "build runs", sequence: 1,
+  });
+  insertTask({
+    milestoneId: "M001", sliceId: "S01", id: "T01", title: "Init repo",
+    status: "pending", estimate: "30m", sequence: 1,
+  });
+  tmpDirs.push(base);
+  return base;
+}
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+test("writePlanningDirectory emits flat-phases layout: ROADMAP.md + phases/NN-slug/", async () => {
+  const base = makeTmp();
+  await writePlanningDirectory(base, "flat-phases");
+
+  assert.ok(existsSync(join(base, ".planning", "ROADMAP.md")), "ROADMAP.md missing");
+  assert.ok(existsSync(join(base, ".planning", "STATE.md")), "STATE.md missing");
+  assert.ok(existsSync(join(base, ".planning", "PROJECT.md")), "PROJECT.md missing");
+
+  const phaseDirs = readdirSync(join(base, ".planning", "phases"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  assert.ok(phaseDirs.length >= 1, `expected ≥1 phase dir, got ${JSON.stringify(phaseDirs)}`);
+  assert.ok(/^01-/.test(phaseDirs[0]!), `phase dir should start with 01-, got ${phaseDirs[0]}`);
+});
+
+test("writePlanningDirectory emits phase plan file with XML structure", async () => {
+  const base = makeTmp();
+  await writePlanningDirectory(base, "flat-phases");
+
+  const phaseDir = readdirSync(join(base, ".planning", "phases"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)[0]!;
+  const planFiles = readdirSync(join(base, ".planning", "phases", phaseDir))
+    .filter((f) => f.endsWith("PLAN.md"));
+  assert.ok(planFiles.length >= 1, "expected ≥1 plan file");
+  const plan = readFileSync(join(base, ".planning", "phases", phaseDir, planFiles[0]!), "utf-8");
+  // Planning plans use XML tags per parsers.ts extractXmlTag
+  assert.match(plan, /<objective>/);
+  assert.match(plan, /<tasks>/);
+});
+
+test("writePlanningDirectory is idempotent: writing twice produces stable content", async () => {
+  const base = makeTmp();
+  await writePlanningDirectory(base, "flat-phases");
+  const snap = (p: string) => readFileSync(p, "utf-8").replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n");
+  const roadmap1 = snap(join(base, ".planning", "ROADMAP.md"));
+  await writePlanningDirectory(base, "flat-phases");
+  const roadmap2 = snap(join(base, ".planning", "ROADMAP.md"));
+  assert.equal(roadmap2, roadmap1);
+});
+
+test("writePlanningDirectory throws for unsupported layouts", async () => {
+  const base = makeTmp();
+  await assert.rejects(() => writePlanningDirectory(base, "multi-milestone"), /not yet supported/);
+  await assert.rejects(() => writePlanningDirectory(base, "legacy-milestone-dir"), /not yet supported/);
+});

--- a/src/resources/extensions/gsd/tests/planning-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-writer.test.ts
@@ -22,7 +22,8 @@ function makeTmp(): string {
   });
   insertTask({
     milestoneId: "M001", sliceId: "S01", id: "T01", title: "Init repo",
-    status: "pending", estimate: "30m", sequence: 1,
+    status: "pending", sequence: 1,
+    planning: { estimate: "30m" },
   });
   tmpDirs.push(base);
   return base;

--- a/src/resources/extensions/gsd/tests/round-trip-property.test.ts
+++ b/src/resources/extensions/gsd/tests/round-trip-property.test.ts
@@ -1,0 +1,135 @@
+// Project/App: gsd-pi
+// File Purpose: Round-trip property test — for any gsd-core .gsd/ fixture,
+// import → render → import must produce a stable hierarchy snapshot, and
+// re-rendering must produce stable markdown. Catches lossy-projection bugs
+// that would otherwise silently destroy state across cross-tool round-trips.
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import { openDatabase, closeDatabase, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
+import { migrateHierarchyToDb } from "../md-importer.ts";
+import { renderAllFromDb } from "../markdown-renderer.ts";
+import { invalidateStateCache } from "../state.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, "__fixtures__", "round-trip");
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+function copyFixture(name: string): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-rt-${randomUUID()}`));
+  cpSync(join(FIXTURE_ROOT, name), base, { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+interface HierarchySnapshot {
+  milestones: Array<{ id: string; title: string; status: string }>;
+  slices: Array<{ mid: string; id: string; title: string; status: string }>;
+  tasks: Array<{ mid: string; sid: string; id: string; title: string; status: string }>;
+}
+
+function snapshotHierarchy(): HierarchySnapshot {
+  const milestones = getAllMilestones().map((m) => ({ id: m.id, title: m.title, status: m.status }));
+  const slices: HierarchySnapshot["slices"] = [];
+  const tasks: HierarchySnapshot["tasks"] = [];
+  for (const m of milestones) {
+    for (const s of getMilestoneSlices(m.id)) {
+      slices.push({ mid: m.id, id: s.id, title: s.title, status: s.status });
+      for (const t of getSliceTasks(m.id, s.id)) {
+        tasks.push({ mid: m.id, sid: s.id, id: t.id, title: t.title, status: t.status });
+      }
+    }
+  }
+  // Sort for stable comparison across DB row-order variations.
+  const cmp = <T extends { id: string }>(a: T, b: T) => a.id.localeCompare(b.id);
+  milestones.sort(cmp);
+  slices.sort((a, b) => `${a.mid}/${a.id}`.localeCompare(`${b.mid}/${b.id}`));
+  tasks.sort((a, b) => `${a.mid}/${a.sid}/${a.id}`.localeCompare(`${b.mid}/${b.sid}/${b.id}`));
+  return { milestones, slices, tasks };
+}
+
+test("round-trip is stable: import → render → import produces the same hierarchy snapshot", async () => {
+  const fixtures = readdirSync(FIXTURE_ROOT, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  assert.ok(fixtures.length > 0, "expected at least one round-trip fixture");
+
+  for (const name of fixtures) {
+    const base = copyFixture(name);
+    openDatabase(join(base, ".gsd", "gsd.db"));
+
+    // Pass 1: import fixture markdown → DB
+    migrateHierarchyToDb(base);
+    invalidateStateCache();
+    const snapshot1 = snapshotHierarchy();
+    assert.ok(snapshot1.milestones.length > 0, `fixture ${name}: expected at least one milestone after import`);
+
+    // Render DB → markdown (projection)
+    const render1 = await renderAllFromDb(base);
+    assert.deepEqual(render1.errors, [], `pass 1 render errors for ${name}: ${JSON.stringify(render1.errors)}`);
+
+    // Pass 2: re-import the projected markdown → DB. migrateHierarchyToDb is
+    // an idempotent upsert (INSERT OR IGNORE), so this simulates a second tool
+    // opening the re-projected files and importing them.
+    migrateHierarchyToDb(base);
+    invalidateStateCache();
+    const snapshot2 = snapshotHierarchy();
+
+    // Property: hierarchy must be stable across the round-trip.
+    assert.deepEqual(
+      snapshot2,
+      snapshot1,
+      `round-trip drift for fixture ${name}: hierarchy changed across import → render → import`,
+    );
+  }
+});
+
+test("round-trip is idempotent: rendering twice produces stable markdown", async () => {
+  const fixtures = readdirSync(FIXTURE_ROOT, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  for (const name of fixtures) {
+    const base = copyFixture(name);
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    migrateHierarchyToDb(base);
+    invalidateStateCache();
+    await renderAllFromDb(base);
+
+    // Snapshot all rendered markdown files (normalized: CRLF→LF, trailing
+    // whitespace trimmed) so cosmetic differences don't false-positive.
+    const snapshotFiles = (b: string): Record<string, string> => {
+      const out: Record<string, string> = {};
+      const walk = (dir: string) => {
+        for (const e of readdirSync(dir, { withFileTypes: true })) {
+          const p = join(dir, e.name);
+          if (e.isDirectory()) walk(p);
+          else if (e.name.endsWith(".md")) {
+            out[p.replace(b + "/", "")] = readFileSync(p, "utf-8").replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n");
+          }
+        }
+      };
+      walk(join(b, ".gsd"));
+      return out;
+    };
+    const after1 = snapshotFiles(base);
+
+    // Render again
+    await renderAllFromDb(base);
+    const after2 = snapshotFiles(base);
+
+    assert.deepEqual(after2, after1, `re-rendering changed markdown for fixture ${name}`);
+  }
+});

--- a/src/resources/extensions/gsd/tests/round-trip-property.test.ts
+++ b/src/resources/extensions/gsd/tests/round-trip-property.test.ts
@@ -5,7 +5,7 @@
 // that would otherwise silently destroy state across cross-tool round-trips.
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { cpSync, mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { cpSync, mkdtempSync, rmSync, readdirSync, readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -60,8 +60,10 @@ function snapshotHierarchy(): HierarchySnapshot {
 }
 
 test("round-trip is stable: import → render → import produces the same hierarchy snapshot", async () => {
+  // Only .gsd/-bearing fixtures — the .planning/ fixtures belong to the
+  // planning round-trip suite (different layout, no .gsd/ to import from).
   const fixtures = readdirSync(FIXTURE_ROOT, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
+    .filter((d) => d.isDirectory() && existsSync(join(FIXTURE_ROOT, d.name, ".gsd")))
     .map((d) => d.name);
 
   assert.ok(fixtures.length > 0, "expected at least one round-trip fixture");
@@ -98,7 +100,7 @@ test("round-trip is stable: import → render → import produces the same hiera
 
 test("round-trip is idempotent: rendering twice produces stable markdown", async () => {
   const fixtures = readdirSync(FIXTURE_ROOT, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
+    .filter((d) => d.isDirectory() && existsSync(join(FIXTURE_ROOT, d.name, ".gsd")))
     .map((d) => d.name);
 
   for (const name of fixtures) {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1697,7 +1697,7 @@ test("ADR-017 (#5707): reconcileBeforeSpawn reports repaired drift in ok=true re
 });
 
 test("ADR-017 (#6238): reconcileBeforeSpawn does not pass reconcile-only deps object", async () => {
-  let receivedDeps: ReconciliationDeps | undefined;
+  let receivedDeps: Partial<ReconciliationDeps> | undefined;
   const result = await reconcileBeforeSpawn("/project", {
     reconcile: async (_basePath, deps) => {
       receivedDeps = deps;


### PR DESCRIPTION
## Summary

Lets users open the same \`.gsd/\` project interchangeably in **gsd-core** (markdown-only) and **gsd-pi** (DB-authoritative) without either tool silently destroying the other's edits. Implements the approach from the design spec: fold a compatibility layer into gsd-pi's existing ADR-017 reconciliation pipeline rather than bolting on a parallel sync system. **gsd-core stays untouched and oblivious.**

Design spec: \`docs/superpowers/specs/2026-06-21-gsd-core-pi-backwards-compat-design.md\`
Implementation plan: \`docs/superpowers/plans/2026-06-21-gsd-core-pi-backwards-compat.md\`

## How it works

- **\`.gsd/.compat.json\`** — a hash-based per-projection marker (\`compat/compat-marker.ts\`) records what gsd-pi last projected, so reconcile can tell gsd-pi's own writes apart from gsd-core's external edits. Missing marker → treat all as external; malformed → quarantined to \`.compat.json.bad-<ts>\`.
- **One new drift kind** \`external-markdown-edit\` registered in the existing \`DRIFT_REGISTRY\`. Startup reconcile picks up gsd-core edits automatically — no new pipeline, no changes to \`reconcileBeforeDispatch\`.
- **Write-time invalidation**: the single projection-write chokepoint (\`writeAndStore\`) records to a pending queue that \`invalidateCaches()\` drains into the marker — preventing the feedback loops that would plague a file-watch approach.

## User-facing surfaces

- \`/gsd sync\` — non-destructive mid-session reconcile (supports \`--dry-run\`).
- \`/gsd doctor\` — appends a \`Compat health:\` line.
- \`docs/user-docs/switching-between-gsd-tools.md\` — workflow doc (commit-before-switch + git as the integration layer).

## Safety net

Round-trip property suite (\`round-trip-property.test.ts\`): for any gsd-core \`.gsd/\` fixture, \`import → render → import\` must produce a stable hierarchy snapshot, and re-rendering must produce stable markdown. Catches lossy-projection bugs before users do. Fixture: \`m001-basic\`.

## Two bugs found & fixed during implementation

1. **Module-init cycle** — the handler's static imports (\`md-importer\` → \`guided-flow\` → \`state\` → \`state-reconciliation/registry\` → handler) created a TDZ \`ReferenceError\` at load. Fixed with dynamic imports at repair time.
2. **Shared-reference pollution** — \`readCompatMarker\` returned a shallow copy of \`EMPTY_MARKER\`, so the \`projections\` object was shared across all callers; the first mutation polluted every subsequent read. This would have caused **false drift detection across unrelated projects in production**, not just tests. Fixed with a deep-copy helper.

## Verification

- ✅ **15 new tests pass** (marker: 6, handler: 5, invalidation: 2, round-trip: 2)
- ✅ **115 affected-surface tests pass** together (markdown-renderer, state-reconciliation-drift, recover, rebuild, + the new suites)
- ✅ **16 broader reconcile/doctor tests pass**
- ✅ \`pnpm run typecheck:extensions\` clean
- ⚠️ Full \`pnpm run test:unit\` not run in this shell (times out interactively); localized coverage above spans everything these commits touch. Recommend CI run.

## Commits (13)

Spec + plan + 9 feature/test/docs commits + 2 fixup commits. Each is self-contained and independently reviewable.

## Out of scope (per spec)

- Real-time / continuous file-watch sync (rejected as architecturally mismatched)
- Making the DB non-canonical inside gsd-pi (too large)
- Changes to gsd-core itself
- gsd-core command parity (separate in-progress effort in the working tree, not part of this PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconcile, import, and dual-layout projection paths—incorrect SHAs or import order could mis-sync or overwrite user markdown; mitigated by property tests, dry-run, and passthrough rules for unmodeled `.planning/` files.
> 
> **Overview**
> Introduces a **gsd-core ↔ gsd-pi compatibility layer** in gsd-pi only: **`.gsd/.compat.json`** (schema **2**) stores normalized SHA baselines for `.gsd/` projections and optional **`.planning/`** layout, modeled files, and passthrough docs.
> 
> **Reconcile:** New ADR-017 drift kinds **`external-markdown-edit`** and **`external-planning-edit`** detect gsd-core edits vs the marker, re-import into the DB (passthrough files only refresh SHAs), and integrate with existing **`reconcileBeforeDispatch`** (including **`--dry-run`**). **`external-markdown-edit`** uses dynamic imports to avoid module cycles; marker reads return **deep copies** so shared `EMPTY_MARKER` state cannot leak across callers.
> 
> **Projection:** **`markdown-renderer`** records writes and flushes SHAs on **`invalidateCaches()`**; **`renderAllFromDb`** can **`capturePlanningCompatIfNeeded`**, then **`writePlanningDirectory`** for **`flat-phases`** (via **`layout-detect`** / **`planning-writer`**). **`.gitignore`** now allows committed **`.gsd/`** (and notes **`.planning/`**) test fixtures.
> 
> **UX:** **`/gsd sync`** reconciles and re-projects; **`/gsd doctor`** reports separate **`.gsd`** and **`.planning`** compat health via **`formatCompatHealthLine`**. User docs and superpowers design/plan markdown describe switching workflows and **`.planning/`** parity; large **Phase 02** websocket/daemon planning files are added as execution plans (not runtime code in this diff snippet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e709ee66198955d55480e842479398013462e879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->