### PR TITLE
feat(gsd): show active memories in visualizer reports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Simplified Chinese translation: [`zh-CN/`](./zh-CN/).
 | [Token Optimization](./user-docs/token-optimization.md) | Token profiles, context compression, complexity routing, and adaptive learning |
 | [Dynamic Model Routing](./user-docs/dynamic-model-routing.md) | Complexity-based model selection, cost tables, escalation, and budget pressure |
 | [Captures & Triage](./user-docs/captures-triage.md) | Fire-and-forget thought capture during auto-mode with automated triage |
-| [Workflow Visualizer](./user-docs/visualizer.md) | Interactive TUI overlay for progress, dependencies, metrics, and timeline |
+| [Workflow Visualizer](./user-docs/visualizer.md) | Interactive TUI overlay for progress, dependencies, metrics, knowledge, memories, and exports |
 | [Cost Management](./user-docs/cost-management.md) | Budget ceilings, cost tracking, projections, and enforcement modes |
 | [Git Strategy](./user-docs/git-strategy.md) | Worktree isolation, branching model, and merge behavior |
 | [Parallel Orchestration](./user-docs/parallel-orchestration.md) | Run multiple milestones simultaneously with worker isolation and coordination |

--- a/docs/dev/ADR-013-memory-store-consolidation.md
+++ b/docs/dev/ADR-013-memory-store-consolidation.md
@@ -43,7 +43,7 @@ After PR #4469 landed, GSD has **two parallel knowledge persistence surfaces** t
 |---|---|---|---|---|---|
 | `decisions` table | DB-backed; `.gsd/DECISIONS.md` is a projection | Yes — `inlineDecisionsFromDb` (`src/resources/extensions/gsd/auto-prompts.ts:336`) | Structured: `scope`, `decision`, `choice`, `rationale`, `made_by`, `revisable` | `gsd_save_decision` | Yes (`gsd_knowledge`, `gsd_save_decision`) |
 | `.gsd/KNOWLEDGE.md` | File-canonical (no DB) | Yes — `loadKnowledgeBlock` (`src/resources/extensions/gsd/bootstrap/system-context.ts`) | Three markdown tables: Rules / Patterns / Lessons | Direct file append (no tool) | Yes (`gsd_knowledge`) |
-| `memories` table | DB-backed (`src/resources/extensions/gsd/bootstrap/memory-tools.ts`) | **No** | Flat: `category` (architecture / convention / gotcha / pattern / preference / environment), `content`, `confidence`, tags | `capture_thought`, `memory_query`, `gsd_graph` | **No** |
+| `memories` table | DB-backed (`src/resources/extensions/gsd/bootstrap/memory-tools.ts`) | Yes — relevant rows are injected by `loadMemoryBlock`; active rows are reviewable in the visualizer Knowledge tab and report/export payloads | Flat: `category` (architecture / convention / gotcha / pattern / preference / environment), `content`, `confidence`, tags | `capture_thought`, `memory_query`, `gsd_graph` | **No** |
 
 A 3-agent parallel audit (Issue #4495) found:
 
@@ -62,7 +62,7 @@ The two surfaces are not just redundant; they fragment durable knowledge across 
 
 | Artifact | Role |
 |---|---|
-| `memories` table | **Canonical** durable knowledge store. All `capture_thought` writes land here. All `memory_query` reads come from here. Auto-injected via a new `loadMemoryBlock` analogous to `loadKnowledgeBlock`. |
+| `memories` table | **Canonical** durable knowledge store. All `capture_thought` writes land here. All `memory_query` reads come from here. Auto-injected via a new `loadMemoryBlock` analogous to `loadKnowledgeBlock`; active rows are also reviewable in the visualizer Knowledge tab and report/export payloads. |
 | `.gsd/DECISIONS.md` | **Read-only projection** rendered from `memories` rows where `category = "architecture"`. Continues to satisfy human review and external MCP consumers. |
 | `.gsd/KNOWLEDGE.md` | **Hybrid projection**. The Rules table remains manually authored and preserved from the file. Existing Patterns and Lessons are backfilled into `memories`, then projected from memory rows that carry `structuredFields.sourceKnowledgeId`. Continues to satisfy human review, reports, and external MCP consumers. |
 | `.gsd/milestones/*/M*-LEARNINGS.md` | **Audit trail** of each extraction. Unchanged — written by `buildExtractionStepsBlock` Step 2; never read back by automation. |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -154,8 +154,8 @@ Model routing (complexity classification, budget pressure, routing history, capa
 | `captures.ts` | Fire-and-forget thought capture and triage classification |
 | `triage-resolution.ts` | Capture resolution (inject, defer, replan, quick-task) |
 | `visualizer-overlay.ts` | Workflow visualizer TUI overlay |
-| `visualizer-data.ts` | Data loading for visualizer tabs |
-| `visualizer-views.ts` | Tab renderers (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
+| `visualizer-data.ts` | Data loading for visualizer tabs, including active memory-store rows |
+| `visualizer-views.ts` | Tab renderers (progress, timeline, deps, metrics, health, agent, changes, knowledge, memories, captures, export) |
 | `metrics.ts` | Token and cost tracking ledger |
 | `state.ts` | DB-authoritative state derivation with explicit legacy markdown fallback for tests/recovery |
 | `session-lock.ts` | OS-level exclusive session locking (proper-lockfile) |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -311,7 +311,7 @@ Auto-mode pauses before each slice, presenting the slice context for discussion.
 
 ### HTML Reports
 
-After a milestone completes, GSD auto-generates a self-contained HTML report in `.gsd/reports/`. Reports include project summary, progress tree, slice dependency graph (SVG DAG), cost/token metrics with bar charts, execution timeline, changelog, and knowledge base. No external dependencies — all CSS and JS are inlined.
+After a milestone completes, GSD auto-generates a self-contained HTML report in `.gsd/reports/`. Reports include project summary, progress tree, slice dependency graph (SVG DAG), cost/token metrics with bar charts, execution timeline, changelog, knowledge base, and active memories. No external dependencies — all CSS and JS are inlined.
 
 ```yaml
 auto_report: true    # enabled by default
@@ -405,7 +405,7 @@ Fire-and-forget thought capture. Captures are triaged automatically between task
 /gsd visualize
 ```
 
-Open the workflow visualizer — interactive tabs for progress, dependencies, metrics, and timeline. See [Workflow Visualizer](./visualizer.md).
+Open the workflow visualizer — interactive tabs for progress, dependencies, metrics, timeline, knowledge, memories, captures, and export. See [Workflow Visualizer](./visualizer.md).
 
 ### Remote Control via Telegram
 

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -33,7 +33,7 @@
 | `/gsd cleanup` | Clean up GSD state files and stale worktrees |
 | `/gsd closeout` | Recover failed git closeout actions (`status`, `retry`, `resolve`) |
 | `/gsd worktree` (`/gsd wt`) | Manage GSD worktrees from the TUI |
-| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
+| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, memories, captures, export) |
 | `/gsd brief <mode> [topic] [--slides]` | Generate a self-contained visual HTML brief. Modes: `diagram`, `plan`, `diff`, `recap`, `table`, `slides`. |
 | `/gsd report` | Generate HTML reports for all milestones and open the reports index in a browser |
 | `/gsd report --html` | Generate self-contained HTML report for current or completed milestone |
@@ -547,4 +547,4 @@ If already up to date, it reports so and takes no action.
 /gsd report --html --all
 ```
 
-Reports are saved to `.gsd/reports/` with a browseable `index.html` that links to all generated snapshots.
+Reports are saved to `.gsd/reports/` with a browseable `index.html` that links to all generated snapshots. Each report includes the active memory feed in its Knowledge section when memory rows are available.

--- a/docs/user-docs/visualizer.md
+++ b/docs/user-docs/visualizer.md
@@ -1,6 +1,6 @@
 # Workflow Visualizer
 
-The workflow visualizer is an interactive view for project progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, captures, and exports.
+The workflow visualizer is an interactive view for project progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, memories, captures, and exports.
 
 ## Opening the Visualizer
 
@@ -84,7 +84,7 @@ Completed slice summaries, modified files, verification decisions, and establish
 
 ### 8. Knowledge
 
-Persistent project rules, patterns, and lessons from `.gsd/KNOWLEDGE.md`.
+Persistent project rules, patterns, and lessons from `.gsd/KNOWLEDGE.md`, plus active memory-store entries ranked by confidence and usage. Memory rows show their ID, category, scope, confidence, hit count, tags, and truncated content.
 
 ### 9. Captures
 
@@ -92,7 +92,7 @@ Captured notes grouped by pending, triaged, and resolved state.
 
 ### 0. Export
 
-Download Markdown, JSON, or a current-view snapshot from the visualizer data.
+Download Markdown, JSON, or a current-view snapshot from the visualizer data. Markdown and JSON exports include the same bounded active-memory feed that appears in the Knowledge tab.
 
 ## Controls
 
@@ -112,7 +112,7 @@ The visualizer refreshes data from disk every 2 seconds, so it stays current if 
 
 ## HTML Reports
 
-For shareable reports outside the terminal, use `/gsd report`. This generates HTML reports for all milestones, opens the reports index in a browser, and uses the same data as the TUI visualizer — progress tree, dependency graph (SVG DAG), cost/token bar charts, execution timeline, changelog, and knowledge base. All CSS and JS are inlined — no external dependencies. Printable to PDF from any browser.
+For shareable reports outside the terminal, use `/gsd report`. This generates HTML reports for all milestones, opens the reports index in a browser, and uses the same data as the TUI visualizer — progress tree, dependency graph (SVG DAG), cost/token bar charts, execution timeline, changelog, knowledge base, and active memories. All CSS and JS are inlined — no external dependencies. Printable to PDF from any browser.
 
 An auto-generated `index.html` shows all reports with progression metrics across milestones.
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -20,7 +20,7 @@
 | [Token 优化](./user-docs/token-optimization.md) | Token 配置、上下文压缩、复杂度路由和自适应学习 |
 | [动态模型路由](./user-docs/dynamic-model-routing.md) | 基于复杂度的模型选择、成本表、升级策略和预算压力 |
 | [捕获与分流](./user-docs/captures-triage.md) | 自动模式中的随手记录，以及自动分流处理 |
-| [工作流可视化器](./user-docs/visualizer.md) | 用于查看进度、依赖、指标和时间线的交互式 TUI 叠层 |
+| [工作流可视化器](./user-docs/visualizer.md) | 用于查看进度、依赖、指标、知识、记忆和导出的交互式 TUI 叠层 |
 | [成本管理](./user-docs/cost-management.md) | 预算上限、成本跟踪、成本预测和执行策略 |
 | [Git 策略](./user-docs/git-strategy.md) | 工作树隔离、分支模型和合并行为 |
 | [并行编排](./user-docs/parallel-orchestration.md) | 通过隔离的工作线程和协调机制同时运行多个 milestones |

--- a/docs/zh-CN/user-docs/auto-mode.md
+++ b/docs/zh-CN/user-docs/auto-mode.md
@@ -180,7 +180,7 @@ require_slice_discussion: true
 
 ### HTML 报告
 
-每当 milestone 完成后，GSD 都会在 `.gsd/reports/` 中自动生成一个自包含的 HTML 报告。报告包括项目摘要、进度树、slice 依赖图（SVG DAG）、成本 / Token 柱状图、执行时间线、变更日志和知识库。没有外部依赖，所有 CSS 和 JS 都会内联。
+每当 milestone 完成后，GSD 都会在 `.gsd/reports/` 中自动生成一个自包含的 HTML 报告。报告包括项目摘要、进度树、slice 依赖图（SVG DAG）、成本 / Token 柱状图、执行时间线、变更日志、知识库和活跃记忆。没有外部依赖，所有 CSS 和 JS 都会内联。
 
 ```yaml
 auto_report: true    # 默认开启
@@ -274,7 +274,7 @@ auto_report: true    # 默认开启
 /gsd visualize
 ```
 
-打开工作流可视化器，交互式查看进度、依赖、指标和时间线。详见 [工作流可视化器](./visualizer.md)。
+打开工作流可视化器，交互式查看进度、依赖、指标、时间线、知识、记忆、捕获和导出。详见 [工作流可视化器](./visualizer.md)。
 
 ## 仪表板
 

--- a/docs/zh-CN/user-docs/commands.md
+++ b/docs/zh-CN/user-docs/commands.md
@@ -26,7 +26,7 @@
 | `/gsd history` | 查看执行历史（支持 `--cost`、`--phase`、`--model` 过滤） |
 | `/gsd forensics` | 全访问 GSD 调试器：用于分析自动模式失败，支持结构化异常检测、单元追踪和 LLM 引导的根因分析 |
 | `/gsd cleanup` | 清理 GSD 状态文件和过期 worktrees |
-| `/gsd visualize` | 打开工作流可视化器（进度、依赖、指标、时间线） |
+| `/gsd visualize` | 打开工作流可视化器（进度、时间线、依赖、指标、健康、agent、变更、知识、记忆、捕获、导出） |
 | `/gsd brief <mode> [topic] [--slides]` | 生成自包含的可视化 HTML 简报。模式：`diagram`、`plan`、`diff`、`recap`、`table`、`slides`。 |
 | `/gsd export --html` | 为当前或已完成的 milestone 生成自包含 HTML 报告 |
 | `/gsd export --html --all` | 一次性为所有 milestones 生成回顾报告 |
@@ -385,4 +385,4 @@ gsd --mode mcp
 /gsd export --html --all
 ```
 
-报告会保存到 `.gsd/reports/`，并生成一个可浏览的 `index.html`，链接到所有已生成的快照。
+报告会保存到 `.gsd/reports/`，并生成一个可浏览的 `index.html`，链接到所有已生成的快照。存在记忆条目时，每个报告都会在 Knowledge 区域包含活跃记忆列表。

--- a/docs/zh-CN/user-docs/visualizer.md
+++ b/docs/zh-CN/user-docs/visualizer.md
@@ -1,6 +1,6 @@
 # 工作流可视化器
 
-工作流可视化器是一个全屏 TUI 叠层视图，以交互式四标签页的形式展示项目进度、依赖关系、成本指标和执行时间线。
+工作流可视化器是一个交互式视图，用于查看项目进度、执行历史、依赖关系、指标、健康状态、agent 活动、变更、知识、记忆、捕获和导出。
 
 ## 打开可视化器
 
@@ -8,7 +8,7 @@
 /gsd visualize
 ```
 
-或者配置为在 milestone 完成后自动显示：
+也可以配置为在 milestone 完成后自动显示：
 
 ```yaml
 auto_visualize: true
@@ -16,14 +16,14 @@ auto_visualize: true
 
 ## 标签页
 
-可通过 `Tab`、`1`-`4` 或方向键切换标签页。
+可通过 `Tab`、`Shift+Tab`、`1`-`9` 和 `0` 切换标签页。
 
 ### 1. 进度
 
 以树状视图展示 milestones、slices 和 tasks 的完成状态：
 
 ```
-M001: User Management                        3/6 tasks ⏳
+M001: User Management                        3/6 tasks
   ✅ S01: Auth module                         3/3 tasks
     ✅ T01: Core types
     ✅ T02: JWT middleware
@@ -31,14 +31,13 @@ M001: User Management                        3/6 tasks ⏳
   ⏳ S02: User dashboard                      1/2 tasks
     ✅ T01: Layout component
     ⬜ T02: Profile page
-  ⬜ S03: Admin panel                         0/1 tasks
 ```
 
-已完成项显示勾选，进行中项显示转圈，待处理项显示空框。每一层级也会显示 task 数量和完成百分比。
+### 2. 时间线
 
-如果某个 milestone 经过 discussion 阶段，还会显示**讨论状态**，用于表明需求是否已经记录，以及讨论停留在哪个状态。
+按时间顺序展示执行历史：单元类型、时间戳、持续时间、模型和 Token 数量。
 
-### 2. 依赖
+### 3. 依赖
 
 用 ASCII 依赖图展示 slices 之间的关系：
 
@@ -47,29 +46,40 @@ S01 ──→ S02 ──→ S04
   └───→ S03 ──↗
 ```
 
-它会把 roadmap 中的 `depends:` 字段可视化出来，便于快速判断哪些 slices 被阻塞、哪些可以继续推进。
+Slice 验证产物也会展示已完成 slices 之间的数据流。
 
-### 3. 指标
+### 4. 指标
 
 通过柱状图展示成本和 Token 使用情况：
 
-- **按阶段**：research、planning、execution、completion、reassessment
-- **按 slice**：每个 slice 的成本以及累计总额
-- **按模型**：哪些模型消耗了最多预算
+- 按阶段：research、planning、execution、completion、reassessment
+- 按 slice：每个 slice 的成本以及累计总额
+- 按模型：哪些模型消耗了最多预算
+- 按路由层级：light、standard、heavy 和降级单元数量
 
-数据来自 `.gsd/metrics.json`。
+### 5. 健康
 
-### 4. 时间线
+预算压力、Token 压力、环境问题、provider 检查、skill-health 摘要、进度评分和 doctor 历史。
 
-按时间顺序展示执行历史，包括：
+### 6. Agent
 
-- 单元类型和 ID
-- 开始 / 结束时间戳
-- 持续时间
-- 使用的模型
-- Token 数量
+当前 agent 活动、完成率、会话成本 / Token、压力信号、待处理捕获和最近完成的单元。
 
-条目按执行时间排序，因此可以看到自动模式的完整派发历史。
+### 7. 变更
+
+已完成 slice 摘要、修改文件、验证决策和已建立的模式。
+
+### 8. 知识
+
+来自 `.gsd/KNOWLEDGE.md` 的持久项目规则、模式和经验，以及按置信度和使用次数排序的活跃记忆。记忆条目会显示 ID、类别、scope、置信度、命中次数、标签和截断后的内容。
+
+### 9. 捕获
+
+按 pending、triaged 和 resolved 状态分组的捕获记录。
+
+### 0. 导出
+
+从可视化器数据下载 Markdown、JSON 或当前视图快照。Markdown 和 JSON 导出会包含与 Knowledge 标签页相同的有界活跃记忆列表。
 
 ## 控制
 
@@ -77,17 +87,19 @@ S01 ──→ S02 ──→ S04
 |------|------|
 | `Tab` | 下一个标签页 |
 | `Shift+Tab` | 上一个标签页 |
-| `1`-`4` | 直接跳转到标签页 |
+| `1`-`9`、`0` | 直接跳转到标签页 |
 | `↑` / `↓` | 在当前标签页内滚动 |
+| `/` | 搜索 / 过滤 |
+| `?` | 显示键盘帮助 |
 | `Escape` / `q` | 关闭可视化器 |
 
 ## 自动刷新
 
 可视化器每 2 秒从磁盘刷新一次数据，因此即使它和自动模式会话同时打开，也能保持最新状态。
 
-## HTML 导出
+## HTML 报告
 
-如果需要在终端外部分享报告，可以使用 `/gsd export --html`。它会在 `.gsd/reports/` 中生成一个自包含的 HTML 文件，包含与 TUI 可视化器相同的数据：进度树、依赖图（SVG DAG）、成本 / Token 柱状图、执行时间线、变更日志和知识库。所有 CSS 和 JS 都会内联，无外部依赖，也可以在任意浏览器中打印为 PDF。
+如果需要在终端外部分享报告，可以使用 `/gsd report`。它会为所有 milestones 生成 HTML 报告，打开报告索引，并使用与 TUI 可视化器相同的数据：进度树、依赖图（SVG DAG）、成本 / Token 柱状图、执行时间线、变更日志、知识库和活跃记忆。所有 CSS 和 JS 都会内联，无外部依赖，也可以在任意浏览器中打印为 PDF。
 
 自动生成的 `index.html` 会集中列出所有报告，并显示跨 milestones 的推进指标。
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -261,7 +261,7 @@ Every unit's token usage and cost is captured, broken down by phase, slice, and 
 
 ## HTML Reports
 
-After a milestone completes, GSD generates a self-contained HTML report in `.gsd/reports/` with project summary, progress tree, dependency graph, cost metrics, timeline, and changelog. Generate manually with:
+After a milestone completes, GSD generates a self-contained HTML report in `.gsd/reports/` with project summary, progress tree, dependency graph, cost metrics, timeline, changelog, knowledge, and active memories. Generate manually with:
 
 ```
 /gsd export --html

--- a/gitbook/features/visualizer.md
+++ b/gitbook/features/visualizer.md
@@ -1,6 +1,6 @@
 # Workflow Visualizer
 
-The workflow visualizer is an interactive view for project progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, captures, and export.
+The workflow visualizer is an interactive view for project progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, memories, captures, and export.
 
 ## Opening
 
@@ -71,7 +71,7 @@ Completed slice summaries, modified files, verification decisions, and establish
 
 ### 8. Knowledge
 
-Persistent project rules, patterns, and lessons.
+Persistent project rules, patterns, and lessons, plus active memory-store entries ranked by confidence and usage. Memory rows include their ID, category, scope, confidence, hit count, tags, and truncated content.
 
 ### 9. Captures
 
@@ -79,7 +79,7 @@ Captured notes grouped by pending, triaged, and resolved state.
 
 ### 0. Export
 
-Download Markdown, JSON, or a current-view snapshot.
+Download Markdown, JSON, or a current-view snapshot. Markdown and JSON exports include the same bounded active-memory feed that appears in the Knowledge tab.
 
 ## Controls
 
@@ -104,7 +104,7 @@ For shareable reports outside the terminal:
 /gsd export --html --all        # all milestones
 ```
 
-Generates self-contained HTML files in `.gsd/reports/` with progress tree, dependency graph, cost charts, timeline, and changelog. All CSS and JS are inlined — no external dependencies. Printable to PDF from any browser.
+Generates self-contained HTML files in `.gsd/reports/` with progress tree, dependency graph, cost charts, timeline, changelog, knowledge, and active memories. All CSS and JS are inlined — no external dependencies. Printable to PDF from any browser.
 
 ```yaml
 auto_report: true    # auto-generate after milestone completion (default)

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -26,7 +26,7 @@
 | `/gsd forensics` | Full debugger for auto-mode failures (includes worktree lifecycle telemetry) |
 | `/gsd cleanup` | Clean up state files and stale worktrees |
 | `/gsd worktree` (`/gsd wt`) | Manage GSD worktrees from the TUI |
-| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
+| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, memories, captures, export) |
 | `/gsd export --html` | Generate HTML report for current milestone |
 | `/gsd export --html --all` | Generate reports for all milestones |
 | `/gsd update` | Update GSD to the latest version |

--- a/src/resources/extensions/gsd/export-html.ts
+++ b/src/resources/extensions/gsd/export-html.ts
@@ -874,9 +874,10 @@ function buildChangelogSection(data: VisualizerData): string {
 
 function buildKnowledgeSection(data: VisualizerData): string {
   const k = data.knowledge;
-  if (!k.exists) return section('knowledge', 'Knowledge', '<p class="empty">No KNOWLEDGE.md found.</p>');
+  const memories = data.memories;
+  if (!k.exists && memories.entries.length === 0) return section('knowledge', 'Knowledge', '<p class="empty">No KNOWLEDGE.md found.</p>');
   const total = k.rules.length + k.patterns.length + k.lessons.length;
-  if (total === 0) return section('knowledge', 'Knowledge', '<p class="empty">KNOWLEDGE.md exists but no entries parsed.</p>');
+  if (total === 0 && memories.entries.length === 0) return section('knowledge', 'Knowledge', '<p class="empty">KNOWLEDGE.md exists but no entries parsed.</p>');
 
   const rulesHtml = k.rules.length > 0 ? `
     <h3>Rules <span class="count">${k.rules.length}</span></h3>
@@ -899,7 +900,14 @@ function buildKnowledgeSection(data: VisualizerData): string {
       <tbody>${k.lessons.map(l => `<tr><td class="mono">${esc(l.id)}</td><td>${esc(l.content)}</td></tr>`).join('')}</tbody>
     </table>` : '';
 
-  return section('knowledge', `Knowledge <span class="count">${total}</span>`, `${rulesHtml}${patternsHtml}${lessonsHtml}`);
+  const memoriesHtml = memories.entries.length > 0 ? `
+    <h3>Memories <span class="count">${memories.entries.length}/${memories.totalCount}</span></h3>
+    <table class="tbl">
+      <thead><tr><th>ID</th><th>Category</th><th>Scope</th><th>Memory</th></tr></thead>
+      <tbody>${memories.entries.map(m => `<tr><td class="mono">${esc(m.id)}</td><td>${esc(m.category)}</td><td>${esc(m.scope)}</td><td>${esc(m.content)}</td></tr>`).join('')}</tbody>
+    </table>` : '';
+
+  return section('knowledge', `Knowledge <span class="count">${total + memories.totalCount}</span>`, `${rulesHtml}${patternsHtml}${lessonsHtml}${memoriesHtml}`);
 }
 
 // ─── Section: Captures ────────────────────────────────────────────────────────
@@ -1005,4 +1013,3 @@ function hRow(label: string, value: string, status?: 'ok' | 'caution' | 'warn'):
 
 function shortModel(m: string) { return m.replace(/^claude-/, '').replace(/^anthropic\//, ''); }
 function truncStr(s: string, n: number) { return s.length > n ? s.slice(0, n - 1) + '\u2026' : s; }
-

--- a/src/resources/extensions/gsd/export.ts
+++ b/src/resources/extensions/gsd/export.ts
@@ -18,6 +18,7 @@ import { getActiveMemories, getActiveMemoriesRanked } from "./memory-store.js";
 import type { MemoryInfo } from "./visualizer-data.js";
 
 const EXPORT_MEMORY_LIMIT = 20;
+const EXPORT_MEMORY_CONTENT_LIMIT = 2000;
 
 interface ExportVisualizerData {
   totals: any;
@@ -40,7 +41,7 @@ function ensureExportDb(basePath: string): void {
 }
 
 function loadExportMemories(basePath: string, visualizerData?: ExportVisualizerData): MemoryInfo {
-  if (visualizerData?.memories) return visualizerData.memories;
+  if (visualizerData?.memories) return limitMemoryInfo(visualizerData.memories);
   ensureExportDb(basePath);
   try {
     const allActive = getActiveMemories();
@@ -50,7 +51,7 @@ function loadExportMemories(basePath: string, visualizerData?: ExportVisualizerD
       entries: ranked.map((memory) => ({
         id: memory.id,
         category: memory.category,
-        content: memory.content,
+        content: limitMemoryContent(memory.content),
         confidence: memory.confidence,
         hitCount: memory.hit_count,
         scope: memory.scope,
@@ -61,6 +62,21 @@ function loadExportMemories(basePath: string, visualizerData?: ExportVisualizerD
   } catch {
     return { entries: [], totalCount: 0 };
   }
+}
+
+function limitMemoryInfo(memories: MemoryInfo): MemoryInfo {
+  return {
+    totalCount: memories.totalCount,
+    entries: memories.entries.map((memory) => ({
+      ...memory,
+      content: limitMemoryContent(memory.content),
+    })),
+  };
+}
+
+function limitMemoryContent(content: string): string {
+  if (content.length <= EXPORT_MEMORY_CONTENT_LIMIT) return content;
+  return `${content.slice(0, EXPORT_MEMORY_CONTENT_LIMIT).trimEnd()}...`;
 }
 
 function formatMemoryLines(memories: MemoryInfo): string[] {
@@ -123,6 +139,7 @@ export function writeExportFile(
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
 
   if (format === "json") {
+    const memories = loadExportMemories(basePath, visualizerData);
     const report = {
       exportedAt: new Date().toISOString(),
       project: projectName,
@@ -130,6 +147,7 @@ export function writeExportFile(
       byPhase: visualizerData?.byPhase ?? aggregateByPhase(units),
       bySlice: visualizerData?.bySlice ?? aggregateBySlice(units),
       byModel: visualizerData?.byModel ?? aggregateByModel(units),
+      memories,
       units,
     };
     const outPath = join(exportDir, `export-${timestamp}.json`);
@@ -326,6 +344,7 @@ export async function handleExport(args: string, ctx: ExtensionCommandContext, b
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
 
   if (format === "json") {
+    const memories = loadExportMemories(basePath);
     const report = {
       exportedAt: new Date().toISOString(),
       project: projectName,
@@ -333,6 +352,7 @@ export async function handleExport(args: string, ctx: ExtensionCommandContext, b
       byPhase: aggregateByPhase(units),
       bySlice: aggregateBySlice(units),
       byModel: aggregateByModel(units),
+      memories,
       units,
     };
     const outPath = join(exportDir, `export-${timestamp}.json`);

--- a/src/resources/extensions/gsd/export.ts
+++ b/src/resources/extensions/gsd/export.ts
@@ -2,7 +2,7 @@
 // Generate shareable reports of milestone work in JSON or markdown format.
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import { execFile } from "node:child_process";
 import {
@@ -13,6 +13,71 @@ import type { UnitMetrics } from "./metrics.js";
 import { gsdRoot } from "./paths.js";
 import { formatDuration, fileLink } from "../shared/format-utils.js";
 import { getErrorMessage } from "./error-utils.js";
+import { isDbAvailable, openDatabase } from "./gsd-db.js";
+import { getActiveMemories, getActiveMemoriesRanked } from "./memory-store.js";
+import type { MemoryInfo } from "./visualizer-data.js";
+
+const EXPORT_MEMORY_LIMIT = 20;
+
+interface ExportVisualizerData {
+  totals: any;
+  byPhase: any[];
+  bySlice: any[];
+  byModel: any[];
+  units: any[];
+  criticalPath?: any;
+  remainingSliceCount?: number;
+  memories?: MemoryInfo;
+}
+
+function ensureExportDb(basePath: string): void {
+  if (isDbAvailable()) return;
+  const dbPath = join(gsdRoot(basePath), "gsd.db");
+  if (!existsSync(dbPath)) return;
+  try {
+    openDatabase(dbPath);
+  } catch { /* non-fatal */ }
+}
+
+function loadExportMemories(basePath: string, visualizerData?: ExportVisualizerData): MemoryInfo {
+  if (visualizerData?.memories) return visualizerData.memories;
+  ensureExportDb(basePath);
+  try {
+    const allActive = getActiveMemories();
+    const ranked = getActiveMemoriesRanked(EXPORT_MEMORY_LIMIT);
+    return {
+      totalCount: allActive.length,
+      entries: ranked.map((memory) => ({
+        id: memory.id,
+        category: memory.category,
+        content: memory.content,
+        confidence: memory.confidence,
+        hitCount: memory.hit_count,
+        scope: memory.scope,
+        tags: memory.tags,
+        updatedAt: memory.updated_at,
+      })),
+    };
+  } catch {
+    return { entries: [], totalCount: 0 };
+  }
+}
+
+function formatMemoryLines(memories: MemoryInfo): string[] {
+  if (memories.entries.length === 0) return [];
+  return [
+    `## Memories`,
+    ``,
+    `Active memories: ${memories.totalCount}`,
+    ``,
+    ...memories.entries.map((memory) => {
+      const scope = memory.scope ? `, scope ${memory.scope}` : "";
+      const tags = memory.tags.length > 0 ? `, tags ${memory.tags.join(", ")}` : "";
+      return `- **${memory.id}** (${memory.category}, confidence ${Math.round(memory.confidence * 100)}%, hits ${memory.hitCount}${scope}${tags}): ${memory.content}`;
+    }),
+    ``,
+  ];
+}
 
 /**
  * Open a file in the user's default browser.
@@ -37,7 +102,7 @@ export function openInBrowser(filePath: string): void {
 export function writeExportFile(
   basePath: string,
   format: "markdown" | "json",
-  visualizerData?: { totals: any; byPhase: any[]; bySlice: any[]; byModel: any[]; units: any[]; criticalPath?: any; remainingSliceCount?: number },
+  visualizerData?: ExportVisualizerData,
 ): string | null {
   const ledger = getLedger();
   let units: UnitMetrics[];
@@ -75,6 +140,8 @@ export function writeExportFile(
     const phases = visualizerData?.byPhase ?? aggregateByPhase(units);
     const slices = visualizerData?.bySlice ?? aggregateBySlice(units);
 
+    const memories = loadExportMemories(basePath, visualizerData);
+
     const md = [
       `# GSD Session Report — ${projectName}`,
       ``,
@@ -101,6 +168,7 @@ export function writeExportFile(
         `| ${s.sliceId} | ${s.units} | ${formatCost(s.cost)} | ${formatTokenCount(s.tokens.total)} | ${formatDuration(s.duration)} |`,
       ),
       ``,
+      ...formatMemoryLines(memories),
     ].join("\n");
 
     const outPath = join(exportDir, `export-${timestamp}.md`);
@@ -274,6 +342,7 @@ export async function handleExport(args: string, ctx: ExtensionCommandContext, b
     const totals = getProjectTotals(units);
     const phases = aggregateByPhase(units);
     const slices = aggregateBySlice(units);
+    const memories = loadExportMemories(basePath);
 
     const md = [
       `# GSD Session Report — ${projectName}`,
@@ -301,6 +370,7 @@ export async function handleExport(args: string, ctx: ExtensionCommandContext, b
         `| ${s.sliceId} | ${s.units} | ${formatCost(s.cost)} | ${formatTokenCount(s.tokens.total)} | ${formatDuration(s.duration)} |`,
       ),
       ``,
+      ...formatMemoryLines(memories),
       `## Unit History`,
       ``,
       `| Type | ID | Model | Cost | Tokens | Duration |`,

--- a/src/resources/extensions/gsd/export.ts
+++ b/src/resources/extensions/gsd/export.ts
@@ -2,7 +2,7 @@
 // Generate shareable reports of milestone work in JSON or markdown format.
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { join, basename } from "node:path";
 import { execFile } from "node:child_process";
 import {
@@ -13,7 +13,8 @@ import type { UnitMetrics } from "./metrics.js";
 import { gsdRoot } from "./paths.js";
 import { formatDuration, fileLink } from "../shared/format-utils.js";
 import { getErrorMessage } from "./error-utils.js";
-import { isDbAvailable, openDatabase } from "./gsd-db.js";
+import { isDbAvailable } from "./gsd-db.js";
+import { openExistingWorkflowDatabase } from "./db-workspace.js";
 import { getActiveMemories, getActiveMemoriesRanked } from "./memory-store.js";
 import type { MemoryInfo } from "./visualizer-data.js";
 
@@ -33,11 +34,7 @@ interface ExportVisualizerData {
 
 function ensureExportDb(basePath: string): void {
   if (isDbAvailable()) return;
-  const dbPath = join(gsdRoot(basePath), "gsd.db");
-  if (!existsSync(dbPath)) return;
-  try {
-    openDatabase(dbPath);
-  } catch { /* non-fatal */ }
+  openExistingWorkflowDatabase(basePath);
 }
 
 function loadExportMemories(basePath: string, visualizerData?: ExportVisualizerData): MemoryInfo {

--- a/src/resources/extensions/gsd/tests/export-html-enhancements.test.ts
+++ b/src/resources/extensions/gsd/tests/export-html-enhancements.test.ts
@@ -108,6 +108,7 @@ function mockData(overrides: Partial<VisualizerData> = {}): VisualizerData {
     changelog: { entries: [] },
     sliceVerifications: [],
     knowledge: { rules: [], patterns: [], lessons: [], exists: false },
+    memories: { entries: [], totalCount: 0 },
     captures: { entries: [], pendingCount: 0, totalCount: 0 },
     health: {
       budgetCeiling: undefined,
@@ -147,6 +148,30 @@ test("report uses the shared GSD HTML shell", () => {
   assert.ok(html.includes('<span class="kind-chip">Report</span>'), "should render report kind chip");
   assert.ok(html.includes('<nav class="toc" aria-label="Report sections">'), "should render shared shell TOC");
   assert.ok(html.includes('<main>'), "should render content inside shared shell main");
+});
+
+test("knowledge section renders active memories", () => {
+  const html = generateHtmlReport(mockData({
+    memories: {
+      totalCount: 1,
+      entries: [
+        {
+          id: "MEM001",
+          category: "gotcha",
+          content: "Memory rows must be visible in exported visualizer reports",
+          confidence: 0.9,
+          hitCount: 2,
+          scope: "project",
+          tags: ["visualizer"],
+          updatedAt: "2026-06-21T12:00:00.000Z",
+        },
+      ],
+    },
+  }), mockOpts());
+
+  assert.ok(html.includes("Memories"), "should render memories heading");
+  assert.ok(html.includes("MEM001"), "should render memory ID");
+  assert.ok(html.includes("Memory rows must be visible"), "should render memory content");
 });
 
 test("Feature 1: executive summary includes budget context when set", () => {

--- a/src/resources/extensions/gsd/tests/export-memory.test.ts
+++ b/src/resources/extensions/gsd/tests/export-memory.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { writeExportFile } from "../export.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
+import { createMemory } from "../memory-store.ts";
+
+function mockTokens() {
+  return { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 };
+}
+
+test("writeExportFile includes active memories in markdown exports", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-export-memory-"));
+  try {
+    const filePath = writeExportFile(base, "markdown", {
+      totals: {
+        units: 1,
+        tokens: mockTokens(),
+        cost: 0.01,
+        duration: 1000,
+        toolCalls: 1,
+        assistantMessages: 1,
+        userMessages: 1,
+      },
+      byPhase: [
+        { phase: "execution", units: 1, tokens: mockTokens(), cost: 0.01, duration: 1000 },
+      ],
+      bySlice: [
+        { sliceId: "M001/S01", units: 1, tokens: mockTokens(), cost: 0.01, duration: 1000 },
+      ],
+      byModel: [],
+      units: [
+        {
+          type: "execute-task",
+          id: "M001/S01/T01",
+          model: "claude-sonnet",
+          startedAt: 0,
+          finishedAt: 1000,
+          tokens: mockTokens(),
+          cost: 0.01,
+          toolCalls: 1,
+          assistantMessages: 1,
+          userMessages: 1,
+        },
+      ],
+      memories: {
+        totalCount: 1,
+        entries: [
+          {
+            id: "MEM001",
+            category: "gotcha",
+            content: "Exported reports should include memory rows",
+            confidence: 0.9,
+            hitCount: 2,
+            scope: "M001/S01",
+            tags: ["export", "memory"],
+            updatedAt: "2026-06-21T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    assert.ok(filePath);
+    const markdown = readFileSync(filePath, "utf-8");
+    assert.match(markdown, /## Memories/);
+    assert.match(markdown, /Active memories: 1/);
+    assert.match(markdown, /MEM001/);
+    assert.match(markdown, /Exported reports should include memory rows/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeExportFile reads project DB memories when no visualizer payload is supplied", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-export-memory-db-"));
+  try {
+    const gsdDir = join(base, ".gsd");
+    mkdirSync(gsdDir, { recursive: true });
+    writeFileSync(
+      join(gsdDir, "metrics.json"),
+      JSON.stringify({
+        version: 1,
+        projectStartedAt: Date.now(),
+        units: [
+          {
+            type: "execute-task",
+            id: "M001/S01/T01",
+            model: "claude-sonnet",
+            startedAt: 0,
+            finishedAt: 1000,
+            tokens: mockTokens(),
+            cost: 0.01,
+            toolCalls: 1,
+            assistantMessages: 1,
+            userMessages: 1,
+          },
+        ],
+      }),
+    );
+
+    openDatabase(join(gsdDir, "gsd.db"));
+    createMemory({
+      category: "pattern",
+      content: "Shared markdown export reads memories from the project DB",
+      confidence: 0.86,
+      tags: ["export"],
+    });
+    closeDatabase();
+
+    const filePath = writeExportFile(base, "markdown");
+
+    assert.ok(filePath);
+    const markdown = readFileSync(filePath, "utf-8");
+    assert.match(markdown, /## Memories/);
+    assert.match(markdown, /MEM001/);
+    assert.match(markdown, /Shared markdown export reads memories from the project DB/);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/export-memory.test.ts
+++ b/src/resources/extensions/gsd/tests/export-memory.test.ts
@@ -15,6 +15,7 @@ function mockTokens() {
 test("writeExportFile includes active memories in markdown exports", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-export-memory-"));
   try {
+    const largeContent = "Exported reports should include memory rows. " + "A".repeat(2500);
     const filePath = writeExportFile(base, "markdown", {
       totals: {
         units: 1,
@@ -52,7 +53,7 @@ test("writeExportFile includes active memories in markdown exports", () => {
           {
             id: "MEM001",
             category: "gotcha",
-            content: "Exported reports should include memory rows",
+            content: largeContent,
             confidence: 0.9,
             hitCount: 2,
             scope: "M001/S01",
@@ -69,6 +70,7 @@ test("writeExportFile includes active memories in markdown exports", () => {
     assert.match(markdown, /Active memories: 1/);
     assert.match(markdown, /MEM001/);
     assert.match(markdown, /Exported reports should include memory rows/);
+    assert.doesNotMatch(markdown, new RegExp(`A{${2500}}`));
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
@@ -117,6 +119,59 @@ test("writeExportFile reads project DB memories when no visualizer payload is su
     assert.match(markdown, /## Memories/);
     assert.match(markdown, /MEM001/);
     assert.match(markdown, /Shared markdown export reads memories from the project DB/);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeExportFile includes bounded memories in json exports", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-export-memory-json-"));
+  try {
+    const gsdDir = join(base, ".gsd");
+    mkdirSync(gsdDir, { recursive: true });
+    writeFileSync(
+      join(gsdDir, "metrics.json"),
+      JSON.stringify({
+        version: 1,
+        projectStartedAt: Date.now(),
+        units: [
+          {
+            type: "execute-task",
+            id: "M001/S01/T01",
+            model: "claude-sonnet",
+            startedAt: 0,
+            finishedAt: 1000,
+            tokens: mockTokens(),
+            cost: 0.01,
+            toolCalls: 1,
+            assistantMessages: 1,
+            userMessages: 1,
+          },
+        ],
+      }),
+    );
+
+    openDatabase(join(gsdDir, "gsd.db"));
+    const largeContent = "JSON export should carry memory rows. " + "B".repeat(2500);
+    createMemory({
+      category: "pattern",
+      content: largeContent,
+      confidence: 0.86,
+      tags: ["export"],
+    });
+    closeDatabase();
+
+    const filePath = writeExportFile(base, "json");
+
+    assert.ok(filePath);
+    const report = JSON.parse(readFileSync(filePath, "utf-8"));
+    assert.equal(report.memories.totalCount, 1);
+    assert.equal(report.memories.entries[0].id, "MEM001");
+    assert.match(report.memories.entries[0].content, /JSON export should carry memory rows/);
+    assert.ok(report.memories.entries[0].content.length < largeContent.length);
+    assert.ok(report.memories.entries[0].content.length <= 2003);
+    assert.ok(report.memories.entries[0].content.endsWith("..."));
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/visualizer-data.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-data.test.ts
@@ -11,6 +11,8 @@ import {
   loadVisualizerData,
   type VisualizerMilestone,
 } from "../visualizer-data.ts";
+import { _getAdapter, closeDatabase, openDatabase } from "../gsd-db.ts";
+import { createMemory } from "../memory-store.ts";
 
 test("computeCriticalPath follows milestone dependencies", () => {
   const milestones: VisualizerMilestone[] = [
@@ -79,6 +81,42 @@ test("loadVisualizerData hydrates milestones, captures, stats, and health fields
     assert.ok(data.health);
     assert.ok(data.criticalPath.milestonePath.length >= 1);
   } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("loadVisualizerData includes active memory-store entries", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-visualizer-memories-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(":memory:");
+
+    createMemory({
+      category: "gotcha",
+      content: "Visualizer memory rows must come from the memory store",
+      confidence: 0.92,
+      scope: "M001/S01",
+      tags: ["visualizer", "memory"],
+    });
+    createMemory({
+      category: "pattern",
+      content: "Superseded rows should stay out of the visualizer",
+      confidence: 0.2,
+    });
+
+    const adapter = _getAdapter();
+    adapter?.prepare("UPDATE memories SET superseded_by = 'MEM999' WHERE id = 'MEM002'").run();
+
+    const data = await loadVisualizerData(base);
+
+    assert.equal(data.memories.totalCount, 1);
+    assert.equal(data.memories.entries[0]?.id, "MEM001");
+    assert.equal(data.memories.entries[0]?.category, "gotcha");
+    assert.equal(data.memories.entries[0]?.content, "Visualizer memory rows must come from the memory store");
+    assert.equal(data.memories.entries[0]?.scope, "M001/S01");
+    assert.deepEqual(data.memories.entries[0]?.tags, ["visualizer", "memory"]);
+  } finally {
+    closeDatabase();
     rmSync(base, { recursive: true, force: true });
   }
 });

--- a/src/resources/extensions/gsd/tests/visualizer-data.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-data.test.ts
@@ -120,3 +120,27 @@ test("loadVisualizerData includes active memory-store entries", async () => {
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("loadVisualizerData opens the project DB for memory entries when none is open", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-visualizer-memories-db-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    createMemory({
+      category: "gotcha",
+      content: "Browser visualizer child processes must open the project DB",
+      confidence: 0.88,
+      tags: ["browser", "visualizer"],
+    });
+    closeDatabase();
+
+    const data = await loadVisualizerData(base);
+
+    assert.equal(data.memories.totalCount, 1);
+    assert.equal(data.memories.entries[0]?.id, "MEM001");
+    assert.equal(data.memories.entries[0]?.content, "Browser visualizer child processes must open the project DB");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/visualizer-data.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-data.test.ts
@@ -144,3 +144,28 @@ test("loadVisualizerData opens the project DB for memory entries when none is op
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("loadVisualizerData caps memory content for visualizer payloads", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-visualizer-memory-cap-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(":memory:");
+    const largeContent = "A".repeat(2500);
+    createMemory({
+      category: "gotcha",
+      content: largeContent,
+      confidence: 0.9,
+    });
+
+    const data = await loadVisualizerData(base);
+
+    const content = data.memories.entries[0]?.content ?? "";
+    assert.equal(data.memories.totalCount, 1);
+    assert.ok(content.length < largeContent.length);
+    assert.ok(content.length <= 2003);
+    assert.ok(content.endsWith("..."));
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/visualizer-views.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-views.test.ts
@@ -49,6 +49,7 @@ function makeVisualizerData(overrides: Partial<VisualizerData> = {}): Visualizer
     changelog: { entries: [] },
     sliceVerifications: [],
     knowledge: { rules: [], patterns: [], lessons: [], exists: false },
+    memories: { entries: [], totalCount: 0 },
     captures: { entries: [], pendingCount: 0, totalCount: 0 },
     health: {
       budgetCeiling: undefined,
@@ -615,6 +616,32 @@ console.log("\n=== renderKnowledgeView ===");
   });
   const lines = renderKnowledgeView(data, mockTheme, 80);
   assert.ok(lines.some(l => l.includes("No KNOWLEDGE.md found")), "shows no-knowledge message");
+}
+
+{
+  const data = makeVisualizerData({
+    memories: {
+      totalCount: 1,
+      entries: [
+        {
+          id: "MEM001",
+          category: "gotcha",
+          content: "Use memory store rows for durable project facts",
+          confidence: 0.91,
+          hitCount: 3,
+          scope: "M001/S01",
+          tags: ["visualizer"],
+          updatedAt: "2026-06-21T12:00:00.000Z",
+        },
+      ],
+    },
+  });
+  const lines = renderKnowledgeView(data, mockTheme, 100);
+  assert.ok(lines.some(l => l.includes("Memories")), "shows memories section");
+  assert.ok(lines.some(l => l.includes("MEM001")), "shows memory ID");
+  assert.ok(lines.some(l => l.includes("(gotcha")), "shows memory category");
+  assert.ok(lines.some(l => l.includes("Use memory store rows")), "shows memory content");
+  assert.ok(lines.some(l => l.includes("M001/S01")), "shows memory scope");
 }
 
 // ─── renderCapturesView ─────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/visualizer-data.ts
+++ b/src/resources/extensions/gsd/visualizer-data.ts
@@ -609,6 +609,7 @@ function loadKnowledge(basePath: string): KnowledgeInfo {
 // ─── Memory Loader ────────────────────────────────────────────────────────────
 
 const VISUALIZER_MEMORY_LIMIT = 20;
+const VISUALIZER_MEMORY_CONTENT_LIMIT = 2000;
 
 function ensureVisualizerDb(basePath: string): void {
   if (isDbAvailable()) return;
@@ -627,7 +628,7 @@ function loadMemories(): MemoryInfo {
     entries: ranked.map((memory) => ({
       id: memory.id,
       category: memory.category,
-      content: memory.content,
+      content: limitMemoryContent(memory.content),
       confidence: memory.confidence,
       hitCount: memory.hit_count,
       scope: memory.scope,
@@ -635,6 +636,11 @@ function loadMemories(): MemoryInfo {
       updatedAt: memory.updated_at,
     })),
   };
+}
+
+function limitMemoryContent(content: string): string {
+  if (content.length <= VISUALIZER_MEMORY_CONTENT_LIMIT) return content;
+  return `${content.slice(0, VISUALIZER_MEMORY_CONTENT_LIMIT).trimEnd()}...`;
 }
 
 // ─── Health Loader ────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/visualizer-data.ts
+++ b/src/resources/extensions/gsd/visualizer-data.ts
@@ -4,7 +4,8 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { deriveState } from './state.js';
 import { parseSummary, loadFile } from './files.js';
-import { isDbAvailable, getMilestoneSlices, getSliceTasks, openDatabase } from './gsd-db.js';
+import { isDbAvailable, getMilestoneSlices, getSliceTasks } from './gsd-db.js';
+import { openExistingWorkflowDatabase } from './db-workspace.js';
 import { parseRoadmap, parsePlan } from './parsers-legacy.js';
 import { findMilestoneIds } from './milestone-ids.js';
 import { resolveMilestoneFile, resolveSliceFile, resolveGsdRootFile, gsdRoot } from './paths.js';
@@ -613,11 +614,7 @@ const VISUALIZER_MEMORY_CONTENT_LIMIT = 2000;
 
 function ensureVisualizerDb(basePath: string): void {
   if (isDbAvailable()) return;
-  const dbPath = join(gsdRoot(basePath), "gsd.db");
-  if (!existsSync(dbPath)) return;
-  try {
-    openDatabase(dbPath);
-  } catch { /* non-fatal */ }
+  openExistingWorkflowDatabase(basePath);
 }
 
 function loadMemories(): MemoryInfo {

--- a/src/resources/extensions/gsd/visualizer-data.ts
+++ b/src/resources/extensions/gsd/visualizer-data.ts
@@ -26,6 +26,7 @@ import { generateSkillHealthReport } from './skill-health.js';
 import { runEnvironmentChecks, type EnvironmentCheckResult } from './doctor-environment.js';
 import { computeProgressScore } from './progress-score.js';
 import { getHealthHistory } from './doctor-proactive.js';
+import { getActiveMemories, getActiveMemoriesRanked } from './memory-store.js';
 
 import type { Phase } from './types.js';
 import type { CaptureEntry } from './captures.js';
@@ -144,6 +145,22 @@ export interface KnowledgeInfo {
   exists: boolean;
 }
 
+export interface VisualizerMemoryEntry {
+  id: string;
+  category: string;
+  content: string;
+  confidence: number;
+  hitCount: number;
+  scope: string;
+  tags: string[];
+  updatedAt: string;
+}
+
+export interface MemoryInfo {
+  entries: VisualizerMemoryEntry[];
+  totalCount: number;
+}
+
 export interface CapturesInfo {
   entries: CaptureEntry[];
   pendingCount: number;
@@ -222,6 +239,7 @@ export interface VisualizerData {
   changelog: ChangelogInfo;
   sliceVerifications: SliceVerification[];
   knowledge: KnowledgeInfo;
+  memories: MemoryInfo;
   captures: CapturesInfo;
   health: HealthInfo;
   discussion: VisualizerDiscussionState[];
@@ -588,6 +606,28 @@ function loadKnowledge(basePath: string): KnowledgeInfo {
   return { rules, patterns, lessons, exists: true };
 }
 
+// ─── Memory Loader ────────────────────────────────────────────────────────────
+
+const VISUALIZER_MEMORY_LIMIT = 20;
+
+function loadMemories(): MemoryInfo {
+  const allActive = getActiveMemories();
+  const ranked = getActiveMemoriesRanked(VISUALIZER_MEMORY_LIMIT);
+  return {
+    totalCount: allActive.length,
+    entries: ranked.map((memory) => ({
+      id: memory.id,
+      category: memory.category,
+      content: memory.content,
+      confidence: memory.confidence,
+      hitCount: memory.hit_count,
+      scope: memory.scope,
+      tags: memory.tags,
+      updatedAt: memory.updated_at,
+    })),
+  };
+}
+
 // ─── Health Loader ────────────────────────────────────────────────────────────
 
 function loadHealth(units: UnitMetrics[], totals: ProjectTotals | null, basePath: string): HealthInfo {
@@ -917,6 +957,7 @@ export async function loadVisualizerData(basePath: string): Promise<VisualizerDa
   const { changelog, verifications: sliceVerifications } = await loadChangelogAndVerifications(basePath, milestones);
 
   const knowledge = loadKnowledge(basePath);
+  const memories = loadMemories();
   const allCaptures = loadAllCaptures(basePath);
   const pendingCount = countPendingCaptures(basePath);
   const captures: CapturesInfo = {
@@ -945,6 +986,7 @@ export async function loadVisualizerData(basePath: string): Promise<VisualizerDa
     changelog,
     sliceVerifications,
     knowledge,
+    memories,
     captures,
     health,
     discussion,

--- a/src/resources/extensions/gsd/visualizer-data.ts
+++ b/src/resources/extensions/gsd/visualizer-data.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { deriveState } from './state.js';
 import { parseSummary, loadFile } from './files.js';
-import { isDbAvailable, getMilestoneSlices, getSliceTasks } from './gsd-db.js';
+import { isDbAvailable, getMilestoneSlices, getSliceTasks, openDatabase } from './gsd-db.js';
 import { parseRoadmap, parsePlan } from './parsers-legacy.js';
 import { findMilestoneIds } from './milestone-ids.js';
 import { resolveMilestoneFile, resolveSliceFile, resolveGsdRootFile, gsdRoot } from './paths.js';
@@ -610,6 +610,15 @@ function loadKnowledge(basePath: string): KnowledgeInfo {
 
 const VISUALIZER_MEMORY_LIMIT = 20;
 
+function ensureVisualizerDb(basePath: string): void {
+  if (isDbAvailable()) return;
+  const dbPath = join(gsdRoot(basePath), "gsd.db");
+  if (!existsSync(dbPath)) return;
+  try {
+    openDatabase(dbPath);
+  } catch { /* non-fatal */ }
+}
+
 function loadMemories(): MemoryInfo {
   const allActive = getActiveMemories();
   const ranked = getActiveMemoriesRanked(VISUALIZER_MEMORY_LIMIT);
@@ -823,6 +832,7 @@ function readFileCached(filePath: string): string | null {
 // ─── Loader ───────────────────────────────────────────────────────────────────
 
 export async function loadVisualizerData(basePath: string): Promise<VisualizerData> {
+  ensureVisualizerDb(basePath);
   const state = await deriveState(basePath);
   const milestoneIds = findMilestoneIds(basePath);
 

--- a/src/resources/extensions/gsd/visualizer-views.ts
+++ b/src/resources/extensions/gsd/visualizer-views.ts
@@ -935,13 +935,20 @@ export function renderKnowledgeView(
 ): string[] {
   const lines: string[] = [];
   const knowledge = data.knowledge;
+  const memories = data.memories;
 
-  if (!knowledge.exists) {
+  if (!knowledge.exists && memories.entries.length === 0) {
     lines.push(th.fg("dim", "No KNOWLEDGE.md found"));
     return lines;
   }
 
-  if (knowledge.rules.length === 0 && knowledge.patterns.length === 0 && knowledge.lessons.length === 0) {
+  if (
+    knowledge.exists &&
+    knowledge.rules.length === 0 &&
+    knowledge.patterns.length === 0 &&
+    knowledge.lessons.length === 0 &&
+    memories.entries.length === 0
+  ) {
     lines.push(th.fg("dim", "KNOWLEDGE.md exists but is empty"));
     return lines;
   }
@@ -981,6 +988,24 @@ export function renderKnowledgeView(
         `  ${th.fg("accent", lesson.id)}  ${lesson.content}`,
         width,
       ));
+    }
+    lines.push("");
+  }
+
+  if (memories.entries.length > 0) {
+    const countLabel = memories.totalCount > memories.entries.length
+      ? `${memories.entries.length}/${memories.totalCount}`
+      : `${memories.totalCount}`;
+    lines.push(th.fg("accent", th.bold(`Memories (${countLabel})`)));
+    lines.push("");
+    for (const memory of memories.entries) {
+      const scope = memory.scope && memory.scope !== "project" ? ` ${th.fg("dim", `[${memory.scope}]`)}` : "";
+      const tags = memory.tags.length > 0 ? ` ${th.fg("dim", `#${memory.tags.join(" #")}`)}` : "";
+      lines.push(truncateToWidth(
+        `  ${th.fg("accent", memory.id)}  (${memory.category}, ${memory.confidence.toFixed(2)}, hits ${memory.hitCount})${scope}${tags}`,
+        width,
+      ));
+      lines.push(truncateToWidth(`    ${memory.content}`, width));
     }
     lines.push("");
   }

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -39,6 +39,7 @@ export interface SerializedVisualizerData {
   changelog: unknown
   sliceVerifications: unknown[]
   knowledge: unknown
+  memories: unknown
   captures: unknown
   health: unknown
   discussion: unknown[]

--- a/web/components/gsd/visualizer-view.tsx
+++ b/web/components/gsd/visualizer-view.tsx
@@ -2021,9 +2021,12 @@ export function VisualizerView() {
   }, [projectCwd])
 
   useEffect(() => {
-    fetchData()
+    const timeout = setTimeout(fetchData, 0)
     const interval = setInterval(fetchData, 10_000)
-    return () => clearInterval(interval)
+    return () => {
+      clearTimeout(timeout)
+      clearInterval(interval)
+    }
   }, [fetchData])
 
   useEffect(() => {

--- a/web/components/gsd/visualizer-view.tsx
+++ b/web/components/gsd/visualizer-view.tsx
@@ -1566,22 +1566,34 @@ function ChangesTab({ data }: { data: VisualizerData }) {
 
 // ─── Knowledge Tab ────────────────────────────────────────────────────────────
 
-function KnowledgeTab({ data }: { data: VisualizerData }) {
+function KnowledgeTab({ data, unfilteredData }: { data: VisualizerData; unfilteredData: VisualizerData }) {
   const knowledge = data.knowledge
   const memories = data.memories
+  const sourceKnowledge = unfilteredData.knowledge
+  const sourceMemories = unfilteredData.memories
 
-  if (!knowledge.exists && memories.entries.length === 0) {
+  if (!sourceKnowledge.exists && sourceMemories.entries.length === 0) {
     return <EmptyState message="No project knowledge file found." icon={BookOpen} />
   }
 
   if (
-    knowledge.exists &&
-    knowledge.rules.length === 0 &&
-    knowledge.patterns.length === 0 &&
-    knowledge.lessons.length === 0 &&
-    memories.entries.length === 0
+    sourceKnowledge.exists &&
+    sourceKnowledge.rules.length === 0 &&
+    sourceKnowledge.patterns.length === 0 &&
+    sourceKnowledge.lessons.length === 0 &&
+    sourceMemories.entries.length === 0
   ) {
     return <EmptyState message="Project knowledge exists but has no entries yet." icon={BookOpen} />
+  }
+
+  const hasFilteredContent =
+    knowledge.rules.length > 0 ||
+    knowledge.patterns.length > 0 ||
+    knowledge.lessons.length > 0 ||
+    memories.entries.length > 0
+
+  if (!hasFilteredContent) {
+    return <EmptyState message="No knowledge entries match your search." icon={BookOpen} />
   }
 
   return (
@@ -2209,7 +2221,7 @@ export function VisualizerView() {
               <ChangesTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="knowledge" className="outline-none">
-              <KnowledgeTab data={visibleData} />
+              <KnowledgeTab data={visibleData} unfilteredData={data} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="captures" className="outline-none">
               <CapturesTab data={visibleData} />

--- a/web/components/gsd/visualizer-view.tsx
+++ b/web/components/gsd/visualizer-view.tsx
@@ -195,6 +195,10 @@ function filterVisualizerData(data: VisualizerData, rawQuery: string): Visualize
       patterns: filterRecord(data.knowledge.patterns, query),
       lessons: filterRecord(data.knowledge.lessons, query),
     },
+    memories: {
+      ...data.memories,
+      entries: filterRecord(data.memories.entries, query),
+    },
     captures: {
       ...data.captures,
       entries: captureEntries,
@@ -1564,12 +1568,19 @@ function ChangesTab({ data }: { data: VisualizerData }) {
 
 function KnowledgeTab({ data }: { data: VisualizerData }) {
   const knowledge = data.knowledge
+  const memories = data.memories
 
-  if (!knowledge.exists) {
+  if (!knowledge.exists && memories.entries.length === 0) {
     return <EmptyState message="No project knowledge file found." icon={BookOpen} />
   }
 
-  if (knowledge.rules.length === 0 && knowledge.patterns.length === 0 && knowledge.lessons.length === 0) {
+  if (
+    knowledge.exists &&
+    knowledge.rules.length === 0 &&
+    knowledge.patterns.length === 0 &&
+    knowledge.lessons.length === 0 &&
+    memories.entries.length === 0
+  ) {
     return <EmptyState message="Project knowledge exists but has no entries yet." icon={BookOpen} />
   }
 
@@ -1614,6 +1625,36 @@ function KnowledgeTab({ data }: { data: VisualizerData }) {
               <div key={lesson.id} className="rounded-lg bg-muted/50 px-4 py-3">
                 <p className="font-mono text-xs font-semibold text-info">{lesson.id}</p>
                 <p className="mt-2 text-sm text-muted-foreground">{lesson.content}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {memories.entries.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Memories</SectionLabel>
+          <div className="mt-5 space-y-3">
+            {memories.entries.map((memory) => (
+              <div key={memory.id} className="rounded-lg bg-muted/50 px-4 py-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-xs font-semibold text-info">{memory.id}</span>
+                  <span className="rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">{memory.category}</span>
+                  {memory.scope !== "project" && (
+                    <span className="rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">{memory.scope}</span>
+                  )}
+                  <span className="text-xs text-muted-foreground">
+                    {Math.round(memory.confidence * 100)}% confidence · {memory.hitCount} hits
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{memory.content}</p>
+                {memory.tags.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {memory.tags.map((tag) => (
+                      <span key={tag} className="text-xs text-muted-foreground">#{tag}</span>
+                    ))}
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -1787,6 +1828,14 @@ function ExportTab({ data }: { data: VisualizerData }) {
       for (const rule of data.knowledge.rules) lines.push(`- Rule ${rule.id} [${rule.scope}]: ${rule.content}`)
       for (const pattern of data.knowledge.patterns) lines.push(`- Pattern ${pattern.id}: ${pattern.content}`)
       for (const lesson of data.knowledge.lessons) lines.push(`- Lesson ${lesson.id}: ${lesson.content}`)
+      lines.push("")
+    }
+    if (data.memories.entries.length > 0) {
+      lines.push("## Memories")
+      lines.push("")
+      for (const memory of data.memories.entries) {
+        lines.push(`- ${memory.id} (${memory.category}, ${memory.scope}): ${memory.content}`)
+      }
       lines.push("")
     }
     if (data.captures.entries.length > 0) {

--- a/web/lib/__tests__/visualizer-types-contract.test.ts
+++ b/web/lib/__tests__/visualizer-types-contract.test.ts
@@ -30,6 +30,7 @@ function makeVisualizerData(overrides: Partial<VisualizerData> = {}): Visualizer
     changelog: { entries: [] },
     sliceVerifications: [],
     knowledge: { rules: [], patterns: [], lessons: [], exists: false },
+    memories: { entries: [], totalCount: 0 },
     captures: { entries: [], pendingCount: 0, totalCount: 0 },
     health: {
       budgetCeiling: undefined,
@@ -88,6 +89,21 @@ describe("visualizer browser payload contract", () => {
         patterns: [],
         lessons: [],
       },
+      memories: {
+        totalCount: 1,
+        entries: [
+          {
+            id: "MEM001",
+            category: "gotcha",
+            content: "Visualizer shows active memory-store rows.",
+            confidence: 0.9,
+            hitCount: 2,
+            scope: "project",
+            tags: ["visualizer"],
+            updatedAt: "2026-05-11T12:00:00Z",
+          },
+        ],
+      },
       captures: {
         pendingCount: 1,
         totalCount: 3,
@@ -135,6 +151,7 @@ describe("visualizer browser payload contract", () => {
     assert.equal(data.byTier[0]?.downgraded, 1);
     assert.equal(data.health.progressScore?.level, "green");
     assert.equal(data.knowledge.rules[0]?.scope, "web");
+    assert.equal(data.memories.entries[0]?.id, "MEM001");
     assert.equal(data.discussion[0]?.state, "discussed");
   });
 

--- a/web/lib/visualizer-types.ts
+++ b/web/lib/visualizer-types.ts
@@ -116,6 +116,22 @@ export interface KnowledgeInfo {
   exists: boolean
 }
 
+export interface VisualizerMemoryEntry {
+  id: string
+  category: string
+  content: string
+  confidence: number
+  hitCount: number
+  scope: string
+  tags: string[]
+  updatedAt: string
+}
+
+export interface MemoryInfo {
+  entries: VisualizerMemoryEntry[]
+  totalCount: number
+}
+
 export type CaptureClassification = "quick-task" | "inject" | "defer" | "replan" | "note" | "stop" | "backtrack"
 
 export interface CaptureEntry {
@@ -294,6 +310,7 @@ export interface VisualizerData {
   changelog: ChangelogInfo
   sliceVerifications: SliceVerification[]
   knowledge: KnowledgeInfo
+  memories: MemoryInfo
   captures: CapturesInfo
   health: HealthInfo
   discussion: VisualizerDiscussionState[]


### PR DESCRIPTION
## What Changed

- Added active memory-store entries to the GSD visualizer data contract and web Knowledge view so memories appear alongside parsed project knowledge.
- Included bounded memory data in visualizer HTML, Markdown, and JSON exports, with database fallback loading for export paths.
- Updated visualizer/export docs and focused tests for memory rendering, export payloads, and frontend type coverage.

## Risk Assessment

✅ Low: The change is bounded to visualizer/export memory display, uses existing memory-store read helpers with content/count limits, and includes focused coverage for terminal, HTML, JSON, and browser payload surfaces.

## Testing

After local dependency setup for the isolated worktree, I exercised the memory-feed data loader, terminal view, HTML/Markdown/JSON export paths, and web type contract; then I generated and screenshot a rendered visualizer report showing active memories in the Knowledge section, and cleaned up transient install/build outputs.

- Evidence: Rendered Knowledge section screenshot showing active memories (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KVP93HWFTAW2T5KQ7R5SD1PK/visualizer-memory-report-knowledge.png</code>)
<details>
<summary>Evidence: Self-contained visualizer memory report HTML</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1.0">
<title>GSD Report — GSD Visualizer Memory Evidence</title>
<style>
*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
:root{
  --bg-0:#0f1115;--bg-1:#16181d;--bg-2:#1e2028;--bg-3:#272a33;
  --border-1:#2b2e38;--border-2:#3b3f4c;
  --text-0:#ededef;--text-1:#a1a1aa;--text-2:#71717a;
  --accent:#5e6ad2;--accent-subtle:rgba(94,106,210,.12);
  --ok:#22c55e;--ok-subtle:rgba(34,197,94,.12);--warn:#ef4444;--caution:#eab308;
  /* Chart palette - 6 hues for bar charts */
  --c0:#5e6ad2;--c1:#e5796d;--c2:#14b8a6;--c3:#a78bfa;--c4:#f59e0b;--c5:#10b981;
  /* Token breakdown - 4 distinct hues */
  --tk-input:#5e6ad2;--tk-output:#e5796d;--tk-cache-r:#2dd4bf;--tk-cache-w:#64748b;
  --font:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
  --mono:'JetBrains Mono','Fira Code',ui-monospace,SFMono-Regular,monospace;
}
html{scroll-behavior:smooth;font-size:13px}
body{background:var(--bg-0);color:var(--text-0);font-family:var(--font);line-height:1.6;-webkit-font-smoothing:antialiased}
a{color:var(--accent);text-decoration:none}
a:hover{text-decoration:underline}
code{font-family:var(--mono);font-size:12px;background:var(--bg-3);padding:1px 5px;border-radius:3px}
.mono{font-family:var(--mono);font-size:12px}
.muted{color:var(--text-2)}
.accent{color:var(--accent)}
.sep{color:var(--border-2);margin:0 4px}
.empty{color:var(--text-2);padding:8px 0;font-size:13px}
.indent{padding-left:12px}
.num{font-variant-numeric:tabular-nums;text-align:right}
.dot{display:inline-block;width:8px;height:8px;border-radius:50%;flex-shrink:0;vertical-align:middle}
.dot-sm{width:6px;height:6px}
.dot-complete{background:var(--ok);opacity:.6}
.dot-active{background:var(--accent)}
.dot-pending{background:transparent;border:1.5px solid var(--border-2)}
.dot-parked{background:var(--warn);opacity:.5}
header{background:var(--bg-1);border-bottom:1px solid var(--border-1);padding:12px 32px;position:sticky;top:0;z-index:200}
.header-inner{display:flex;align-items:center;gap:16px;max-width:1280px;margin:0 auto}
.branding{display:flex;align-items:baseline;gap:6px;flex-shrink:0}
.logo{font-size:18px;font-weight:800;letter-spacing:-.5px;color:var(--text-0)}
.version{font-size:10px;color:var(--text-2);font-family:var(--mono)}
.header-meta{flex:1;min-width:0}
.header-meta h1{font-size:15px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
.header-path{font-size:11px;color:var(--text-2);font-family:var(--mono);display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
.header-right{text-align:right;flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:4px}
.generated{font-size:11px;color:var(--text-2)}
.kind-chip{font-size:10px;font-weight:600;color:var(--accent);background:var(--accent-subtle);border:1px solid rgba(94,106,210,.25);border-radius:3px;padding:2px 7px;text-transform:uppercase;letter-spacing:.4px}
.back-link{font-size:12px;color:var(--text-1)}
.back-link:hover{color:var(--accent)}
.toc{background:var(--bg-1);border-bottom:1px solid var(--border-1);overflow-x:auto}
.toc ul{display:flex;list-style:none;max-width:1280px;margin:0 auto;padding:0 32px}
.toc a{display:inline-block;padding:8px 12px;color:var(--text-2);font-size:12px;font-weight:500;border-bottom:2px solid transparent;transition:color .12s,border-color .12s;white-space:nowrap;text-decoration:none}
.toc a:hover{color:var(--text-0);border-bottom-color:var(--border-2)}
.toc a.active{color:var(--text-0);border-bottom-color:var(--accent)}
main{max-width:1280px;margin:0 auto;padding:32px;display:flex;flex-direction:column;gap:48px}
section{scroll-margin-top:82px}
section>h2{font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-1);margin-bottom:16px;padding-bottom:8px;border-bottom:1px solid var(--border-1);display:flex;align-items:center;gap:8px}
h3{font-size:13px;font-weight:600;color:var(--text-1);margin:20px 0 8px}
.count{font-size:11px;font-weight:500;color:var(--text-2);background:var(--bg-3);border-radius:3px;padding:1px 6px}
.count-warn{color:var(--caution)}
.kv-grid{display:flex;flex-wrap:wrap;gap:1px;background:var(--border-1);border:1px solid var(--border-1);border-radius:4px;overflow:hidden;margin-bottom:16px}
.kv{background:var(--bg-1);padding:10px 16px;display:flex;flex-direction:column;gap:2px;min-width:110px;flex:1}
.kv-val{font-size:18px;font-weight:600;color:var(--text-0);font-variant-numeric:tabular-nums}
.kv-lbl{font-size:10px;color:var(--text-2);text-transform:uppercase;letter-spacing:.4px}
.progress-wrap{display:flex;align-items:center;gap:10px;margin-bottom:12px}
.progress-track{flex:1;height:4px;background:var(--bg-3);border-radius:2px;overflow:hidden}
.progress-fill{height:100%;background:var(--accent);border-radius:2px}
.progress-label{font-size:12px;font-weight:600;color:var(--text-1);min-width:40px;text-align:right}
.active-info{font-size:12px;color:var(--text-1);margin-bottom:4px}
.activity-line{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-1);padding:6px 0}
.tbl{width:100%;border-collapse:collapse;font-size:12px}
.tbl th{color:var(--text-2);font-weight:500;padding:6px 12px;text-align:left;border-bottom:1px solid var(--border-1);font-size:11px;text-transform:uppercase;letter-spacing:.3px;white-space:nowrap}
.tbl td{padding:6px 12px;border-bottom:1px solid var(--border-1);vertical-align:top}
.tbl tr:last-child td{border-bottom:none}
.tbl tbody tr:hover td{background:var(--accent-subtle)}
.tbl-kv td:first-child{color:var(--text-2);width:180px}
.table-scroll{overflow-x:auto;border:1px solid var(--border-1);border-radius:4px}
.table-scroll .tbl{border:none}
.h-ok td:first-child{color:var(--text-1)}
.h-caution td{color:var(--caution)}
.h-warn td{color:var(--warn)}
.label{font-size:10px;font-weight:500;color:var(--accent);text-transform:uppercase;letter-spacing:.4px}
.risk{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.3px;flex-shrink:0}
.risk-low{color:var(--text-2)}
.risk-medium{color:var(--caution)}
.risk-high{color:var(--warn)}
.risk-unknown{color:var(--text-2)}
.tag-row{display:flex;flex-wrap:wrap;gap:4px;margin-bottom:8px}
.tag{font-size:11px;font-family:var(--mono);color:var(--text-2);background:var(--bg-3);border-radius:3px;padding:1px 6px}
.verif{font-size:12px;color:var(--text-1);padding:4px 0;margin-bottom:6px}
.verif-blocker{color:var(--warn)}
.detail-block{font-size:12px;color:var(--text-2);margin-bottom:6px}
.detail-label{font-weight:600;color:var(--text-1);display:block;margin-bottom:2px}
.detail-block ul{padding-left:16px;margin-top:2px}
.detail-block li{margin-bottom:1px}
.ms-block{border:1px solid var(--border-1);border-radius:4px;overflow:hidden;margin-bottom:8px}
.ms-summary{display:flex;align-items:center;gap:8px;padding:10px 14px;cursor:pointer;list-style:none;background:var(--bg-1);user-select:none;font-size:13px}
.ms-summary:hover{background:var(--bg-2)}
.ms-summary::-webkit-details-marker{display:none}
.ms-id{font-weight:600}
.ms-title{flex:1;font-weight:500;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
.ms-body{padding:6px 12px 8px 24px;display:flex;flex-direction:column;gap:4px}
.sl-block{border:1px solid var(--border-1);border-radius:3px;overflow:hidden}
.sl-summary{display:flex;align-items:center;gap:6px;padding:6px 10px;cursor:pointer;list-style:none;background:var(--bg-2);font-size:12px;user-select:none}
.sl-summary:hover{background:var(--bg-3)}
.sl-summary::-webkit-details-marker{display:none}
.sl-crit{border-left:2px solid var(--accent)}
.sl-deps::before{content:'\2190 ';color:var(--border-2)}
.sl-detail{padding:8px 12px;background:var(--bg-0);border-top:1px solid var(--border-1)}
.task-list{list-style:none;padding:4px 0 0;display:flex;flex-direction:column;gap:2px}
.task-row{display:flex;align-items:center;gap:6px;font-size:12px;padding:3px 6px;border-radius:2px}
.dep-block{margin-bottom:28px}
.dep-legend{display:flex;gap:14px;font-size:12px;color:var(--text-2);margin-bottom:8px;align-items:center}
.dep-legend span{display:flex;align-items:center;

... [12361 bytes truncated] ...

ies</h2>
  <p class="empty">No dependencies defined.</p>
</section>

<section id="metrics">
  <h2>Metrics</h2>
  
    <div class="kv-grid"><div class="kv"><span class="kv-val">$0.080</span><span class="kv-lbl">Total cost</span></div><div class="kv"><span class="kv-val">1.9k</span><span class="kv-lbl">Total tokens</span></div><div class="kv"><span class="kv-val">1.2k</span><span class="kv-lbl">Input</span></div><div class="kv"><span class="kv-val">450</span><span class="kv-lbl">Output</span></div><div class="kv"><span class="kv-val">300</span><span class="kv-lbl">Cache read</span></div><div class="kv"><span class="kv-val">0</span><span class="kv-lbl">Cache write</span></div><div class="kv"><span class="kv-val">4m 0s</span><span class="kv-lbl">Duration</span></div><div class="kv"><span class="kv-val">2</span><span class="kv-lbl">Units</span></div><div class="kv"><span class="kv-val">3</span><span class="kv-lbl">Tool calls</span></div><div class="kv"><span class="kv-val">undefined</span><span class="kv-lbl">Truncations</span></div></div>
    
    
    <div class="token-block">
      <h3>Token breakdown</h3>
      <div class="token-bar"><div class="tseg seg-1" style="width:61.54%" title="Input: 1.2k (61.5%)"></div><div class="tseg seg-2" style="width:23.08%" title="Output: 450 (23.1%)"></div><div class="tseg seg-3" style="width:15.38%" title="Cache read: 300 (15.4%)"></div></div>
      <div class="token-legend"><span class="leg-item"><span class="leg-dot seg-1"></span>Input: 1.2k (61.5%)</span><span class="leg-item"><span class="leg-dot seg-2"></span>Output: 450 (23.1%)</span><span class="leg-item"><span class="leg-dot seg-3"></span>Cache read: 300 (15.4%)</span></div>
    </div>
    
    
    <div class="chart-row">
      <div class="chart-block"><h3>Cost by phase</h3>
      <div class="bar-row">
        <div class="bar-lbl">execution</div>
        <div class="bar-track"><div class="bar-fill bar-c0" style="width:8.0%"></div></div>
        <div class="bar-val">$0.080</div>
      </div>
      <div class="bar-sub">2 units</div></div>
      <div class="chart-block"><h3>Tokens by phase</h3>
      <div class="bar-row">
        <div class="bar-lbl">execution</div>
        <div class="bar-track"><div class="bar-fill bar-c0" style="width:100.0%"></div></div>
        <div class="bar-val">1.9k</div>
      </div>
      <div class="bar-sub">$0.080</div></div>
    </div>
    
    <div class="chart-row">
      <div class="chart-block"><h3>Cost by slice</h3>
      <div class="bar-row">
        <div class="bar-lbl">M001/S01</div>
        <div class="bar-track"><div class="bar-fill bar-c0" style="width:8.0%"></div></div>
        <div class="bar-val">$0.080</div>
      </div>
      <div class="bar-sub">2 units</div></div>
      <div class="chart-block"><h3>Cost by model</h3>
      <div class="bar-row">
        <div class="bar-lbl">sonnet</div>
        <div class="bar-track"><div class="bar-fill bar-c0" style="width:8.0%"></div></div>
        <div class="bar-val">$0.080</div>
      </div>
      <div class="bar-sub">2 units</div></div>
      <div class="chart-block"><h3>Duration by slice</h3>
      <div class="bar-row">
        <div class="bar-lbl">M001/S01</div>
        <div class="bar-track"><div class="bar-fill bar-c0" style="width:100.0%"></div></div>
        <div class="bar-val">4m 0s</div>
      </div>
      <div class="bar-sub">$0.080</div></div>
    </div>
    
  
</section>

<section id="health">
  <h2>Health</h2>
  
    <table class="tbl tbl-kv"><tbody><tr><td>Token profile</td><td>standard</td></tr><tr class="h-ok"><td>Truncation rate</td><td>0.0% per unit (0 total)</td></tr><tr class="h-ok"><td>Continue-here rate</td><td>0.0% per unit (0 total)</td></tr><tr><td>Tool calls</td><td>3</td></tr><tr><td>Messages</td><td>2 assistant / 2 user</td></tr></tbody></table>
    
    
    
  
</section>

<section id="changelog">
  <h2>Changelog</h2>
  <p class="empty">No completed slices yet.</p>
</section>

<section id="knowledge">
  <h2>Knowledge <span class="count">3</span></h2>
  
    <h3>Memories <span class="count">2/3</span></h3>
    <table class="tbl">
      <thead><tr><th>ID</th><th>Category</th><th>Scope</th><th>Memory</th></tr></thead>
      <tbody><tr><td class="mono">MEM001</td><td>gotcha</td><td>project</td><td>Visualizer memory rows must come from active memory-store entries, not only KNOWLEDGE.md projection files.</td></tr><tr><td class="mono">MEM002</td><td>pattern</td><td>M001/S01</td><td>Exported reports should show active memories in the Knowledge section for reviewers.</td></tr></tbody>
    </table>
</section>

<section id="captures">
  <h2>Captures</h2>
  <p class="empty">No captures recorded.</p>
</section>

<section id="stats">
  <h2>Artifacts</h2>
  <p class="empty">All artifacts accounted for.</p>
</section>

<section id="discussion">
  <h2>Planning</h2>
  <p class="empty">No milestones.</p>
</section>
</main>
<footer>
  <div class="footer-inner">
    <span>GSD v1.3.0</span>
    <span class="sep">/</span>
    <span>Report</span>
    <span class="sep">/</span>
    <span>GSD Visualizer Memory Evidence</span>
    <span class="sep">/</span>
    <span>Sun, Jun 21, 2026, 06:51 PM CDT</span>
  </div>
</footer>
<script>
(function(){
  const sections=document.querySelectorAll('section[id]');
  const links=document.querySelectorAll('.toc a');
  if(!sections.length||!links.length)return;
  const obs=new IntersectionObserver(entries=>{
    for(const e of entries){
      if(!e.isIntersecting)continue;
      for(const l of links)l.classList.remove('active');
      const a=document.querySelector('.toc a[href="#'+e.target.id+'"]');
      if(a)a.classList.add('active');
    }
  },{rootMargin:'-10% 0px -80% 0px',threshold:0});
  for(const s of sections)obs.observe(s);
})();
(function(){
  var tl=document.getElementById('timeline');
  if(!tl)return;
  var table=tl.querySelector('.tbl');
  if(!table)return;
  var input=document.createElement('input');
  input.className='tl-filter';
  input.placeholder='Filter timeline\u2026';
  input.type='text';
  table.parentNode.insertBefore(input,table);
  var rows=table.querySelectorAll('tbody tr');
  input.addEventListener('input',function(){
    var q=this.value.toLowerCase();
    for(var i=0;i<rows.length;i++){
      rows[i].style.display=rows[i].textContent.toLowerCase().indexOf(q)>-1?'':'none';
    }
  });
})();
function safeLocalStorageSet(key,value){
  try{localStorage.setItem(key,value)}catch(e){}
}
function safeLocalStorageGet(key){
  try{return localStorage.getItem(key)}catch(e){return null}
}
(function(){
  var saved={};
  try{saved=JSON.parse(safeLocalStorageGet('gsd-collapsed')||'{}')}catch(e){}
  document.querySelectorAll('section[id]').forEach(function(sec){
    var h2=sec.querySelector('h2');
    if(!h2)return;
    var btn=document.createElement('button');
    btn.className='sec-toggle';
    btn.textContent=saved[sec.id]?'+':'-';
    btn.setAttribute('aria-label','Toggle section');
    h2.prepend(btn);
    if(saved[sec.id])toggleSection(sec,true);
    btn.addEventListener('click',function(e){
      e.preventDefault();
      var collapsed=btn.textContent==='-';
      toggleSection(sec,collapsed);
      btn.textContent=collapsed?'+':'-';
      saved[sec.id]=collapsed;
      safeLocalStorageSet('gsd-collapsed',JSON.stringify(saved));
    });
  });
  function toggleSection(sec,hide){
    var children=sec.children;
    for(var i=0;i<children.length;i++){
      if(children[i].tagName!=='H2')children[i].style.display=hide?'none':'';
    }
  }
})();
(function(){
  var hr=document.querySelector('.header-right');
  if(!hr)return;
  var stored=safeLocalStorageGet('gsd-theme');
  var btn=document.createElement('button');
  btn.className='theme-toggle';
  btn.textContent=stored==='light'?'Dark':'Light';
  if(stored==='light')document.documentElement.classList.add('light-theme');
  btn.addEventListener('click',function(){
    document.documentElement.classList.toggle('light-theme');
    var isLight=document.documentElement.classList.contains('light-theme');
    btn.textContent=isLight?'Dark':'Light';
    safeLocalStorageSet('gsd-theme',isLight?'light':'dark');
  });
  hr.prepend(btn);
})();
</script>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Baseline branch/worktree check: `git status --short --branch`, `git rev-parse HEAD`, and `git merge-base --is-ancestor HEAD origin/main` from the isolated worktree.</code>
- <code>Setup for isolated worktree: `pnpm install --frozen-lockfile --ignore-scripts`, then workspace dist setup with `pnpm --filter @gsd/agent-core run build` and `pnpm run build:contracts`.</code>
- <code>Focused automated validation: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/visualizer-data.test.ts src/resources/extensions/gsd/tests/visualizer-views.test.ts src/resources/extensions/gsd/tests/export-html-enhancements.test.ts src/resources/extensions/gsd/tests/export-memory.test.ts web/lib/__tests__/visualizer-types-contract.test.ts`.</code>
- <code>Generated reviewer-visible evidence HTML from `generateHtmlReport` with active memory entries and saved it under the requested evidence directory.</code>
- <code>Rendered the generated HTML with Playwright and captured `#knowledge`; verified the rendered page includes `Memories`, `MEM001`, and the expected memory content.</code>
- <code>Cleanup verification: removed transient `node_modules`, `packages/gsd-agent-core/dist`, and `packages/contracts/dist`; confirmed `git status --short --untracked-files=all` is clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only use of existing memory-store helpers with entry and content limits; no changes to memory writes or auth paths. Residual risk is mainly display parity if DB is missing or stale.
> 
> **Overview**
> **Active memory-store rows now appear wherever reviewers already inspect project knowledge**, not only via session auto-injection.
> 
> `loadVisualizerData` loads ranked active memories from the project DB (with DB open fallback), caps payload size, and exposes them on the shared visualizer contract. The **TUI Knowledge view**, **web Knowledge tab** (including search), **HTML milestone reports**, and **Markdown/JSON exports** all render the same bounded memory feed alongside `KNOWLEDGE.md` rules/patterns/lessons.
> 
> User-facing docs (English, Chinese, GitBook) and focused tests cover data loading, terminal/HTML/export payloads, and web type contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05422aa0caf25bb313a1b610fb0648c424aa132f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->