### PR TITLE
fix(gsd): continue fallback chain on rate limits

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -156,7 +156,7 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
           switchedNotify(`${candidate.provider}/${candidate.id}`);
           pi.sendMessage(
             { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
-            { triggerTurn: true },
+            { triggerTurn: true, deliverAs: "steer" },
           );
           return true;
         }
@@ -183,7 +183,7 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
         switchedNotify(`${startModel.provider}/${startModel.id}`);
         pi.sendMessage(
           { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
-          { triggerTurn: true },
+          { triggerTurn: true, deliverAs: "steer" },
         );
         return true;
       }
@@ -732,58 +732,22 @@ export async function handleAgentEnd(
     // --- Transient errors: try model fallback first, then pause ---
     // Rate limits are often per-model, so switching models can bypass them.
     if (cls.kind === "rate-limit" || cls.kind === "network" || cls.kind === "server" || cls.kind === "connection" || cls.kind === "stream") {
-      // Try model fallback
       const dash = getAutoDashboardData();
-      if (dash.currentUnit) {
-        const modelConfig = resolveModelWithFallbacksForUnit(dash.currentUnit.type);
-        if (modelConfig && modelConfig.fallbacks.length > 0) {
-          const availableModels = ctx.modelRegistry.getAvailable();
-          const nextModelId = getNextFallbackModel(ctx.model?.id, modelConfig);
-          if (nextModelId) {
-            retryState.networkRetryCount = 0;
-            retryState.currentRetryModelId = undefined;
-            const modelToSet = resolveModelId(nextModelId, availableModels, ctx.model?.provider);
-            const modelUnavailable = dash.basePath && modelToSet
-              ? isModelBlocked(dash.basePath, modelToSet.provider, modelToSet.id) ||
-                isModelTemporarilyUnavailable(dash.basePath, modelToSet.provider, modelToSet.id)
-              : false;
-            if (modelToSet && !modelUnavailable) {
-              const ok = await pi.setModel(modelToSet, { persist: false });
-              if (ok) {
-                setCurrentUnitModelForRecovery(modelToSet);
-                setCurrentDispatchedModelId({ provider: modelToSet.provider, id: modelToSet.id });
-                ctx.ui.notify(`Model error${errorDetail}. Switched to fallback: ${nextModelId} and resuming.`, "warning");
-                pi.sendMessage({ customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false }, { triggerTurn: true });
-                return;
-              }
-            }
-          }
-        }
-      }
-
-      // Try restoring session model
-      const sessionModel = getAutoModeStartModel();
-      if (sessionModel) {
-        const dash = getAutoDashboardData();
-        const sessionModelUnavailable = dash.basePath
-          ? isModelBlocked(dash.basePath, sessionModel.provider, sessionModel.id) ||
-            isModelTemporarilyUnavailable(dash.basePath, sessionModel.provider, sessionModel.id)
-          : false;
-        if (!sessionModelUnavailable && (ctx.model?.id !== sessionModel.id || ctx.model?.provider !== sessionModel.provider)) {
-          const startModel = ctx.modelRegistry.getAvailable().find((m) => m.provider === sessionModel.provider && m.id === sessionModel.id);
-          if (startModel) {
-            const ok = await pi.setModel(startModel, { persist: false });
-            if (ok) {
-              setCurrentUnitModelForRecovery(startModel);
-              setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
-              retryState.networkRetryCount = 0;
-              retryState.currentRetryModelId = undefined;
-              ctx.ui.notify(`Model error${errorDetail}. Restored session model: ${sessionModel.provider}/${sessionModel.id} and resuming.`, "warning");
-              pi.sendMessage({ customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false }, { triggerTurn: true });
-              return;
-            }
-          }
-        }
+      const switched = await tryProviderModelFallback({
+        ctx,
+        pi,
+        rejectedProvider: ctx.model?.provider,
+        rejectedId: ctx.model?.id,
+        basePath: dash.basePath,
+        unitType: dash.currentUnit?.type,
+        switchedNotify: (label) => {
+          retryState.networkRetryCount = 0;
+          retryState.currentRetryModelId = undefined;
+          ctx.ui.notify(`Model error${errorDetail}. Switched to fallback: ${label} and resuming.`, "warning");
+        },
+      });
+      if (switched) {
+        return;
       }
     }
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -7,16 +7,21 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { classifyError, isTransient, isTransientNetworkError } from "../error-classifier.ts";
 import { pauseAutoForProviderError } from "../provider-error-pause.ts";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.ts";
 import {
   MAX_TRANSIENT_AUTO_RESUMES,
+  handleAgentEnd,
   isTerminalDeletedWorktreeProviderError,
   resetTransientRetryState,
   shouldDeferTransientErrorToCoreRetry,
   suppressTerminalDeletedWorktreeMessageEnd,
 } from "../bootstrap/agent-end-recovery.ts";
+import { blockModelUntil, clearTemporaryModelBlocksForTest } from "../blocked-models.ts";
 import { _buildCancelledUnitStopReason } from "../auto/phase-helpers.ts";
 import { _classifyZeroToolProviderMessageForTest } from "../auto/unit-phase.ts";
 import { autoSession } from "../auto-runtime-state.ts";
@@ -481,6 +486,100 @@ test("pauseAutoForProviderError falls back to indefinite pause when not rate lim
   assert.deepEqual(notifications, [
     { message: "Auto-mode paused due to provider error: connection refused", level: "warning" },
   ]);
+});
+
+test("rate-limit agent_end walks past unavailable fallback models before pausing (#716 follow-up)", async () => {
+  const originalCwd = process.cwd();
+  const originalSetTimeout = globalThis.setTimeout;
+  const base = mkdtempSync(join(tmpdir(), "gsd-rate-limit-agent-end-"));
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const setModelCalls: string[] = [];
+  const sendMessageCalls: unknown[][] = [];
+  const timers: Array<{ delay: number }> = [];
+
+  globalThis.setTimeout = ((_fn: (...args: unknown[]) => void, delay?: number) => {
+    timers.push({ delay: delay ?? 0 });
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    clearTemporaryModelBlocksForTest();
+    autoSession.reset();
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "models:",
+        "  execution:",
+        "    model: gpt-5.5",
+        "    provider: openai-codex",
+        "    fallbacks:",
+        "      - anthropic/claude-sonnet-4-6",
+        "      - google-gemini-cli/gemini-2.5-pro",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+    process.chdir(base);
+
+    autoSession.active = true;
+    autoSession.basePath = base;
+    autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+    autoSession.autoModeStartModel = { provider: "openai-codex", id: "gpt-5.5" };
+
+    blockModelUntil(base, "anthropic", "claude-sonnet-4-6", Date.now() + 60_000, "fallback also limited");
+
+    const availableModels = [
+      { id: "gpt-5.5", provider: "openai-codex", api: "responses" },
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+      { id: "gemini-2.5-pro", provider: "google-gemini-cli", api: "google-genai" },
+    ];
+    const ctx = {
+      model: availableModels[0],
+      modelRegistry: { getAvailable: () => availableModels },
+      ui: {
+        notify(message: string, level?: "info" | "warning" | "error" | "success") {
+          notifications.push({ message, level });
+        },
+        setStatus: () => {},
+        setWidget: () => {},
+        setWorkingMessage: () => {},
+      },
+    } as any;
+    const pi = {
+      setModel: async (model: { provider: string; id: string }) => {
+        setModelCalls.push(`${model.provider}/${model.id}`);
+        return true;
+      },
+      sendMessage: (...args: unknown[]) => {
+        sendMessageCalls.push(args);
+      },
+    } as any;
+
+    await handleAgentEnd(pi, {
+      messages: [{
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "You've hit your session limit · resets 7:20 pm (Europe/Rome)",
+      }],
+    } as any, ctx);
+
+    assert.deepEqual(setModelCalls, ["google-gemini-cli/gemini-2.5-pro"]);
+    assert.equal(sendMessageCalls.length, 1, "fallback recovery must immediately trigger a continuation turn");
+    assert.deepEqual(sendMessageCalls[0][1], { triggerTurn: true, deliverAs: "steer" });
+    assert.equal(timers.length, 0, "must not pause with a retry timer when a later fallback is available");
+    assert.ok(
+      notifications.some((n) => n.message.includes("google-gemini-cli/gemini-2.5-pro")),
+      "user-facing notification should name the fallback actually selected",
+    );
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    process.chdir(originalCwd);
+    clearTemporaryModelBlocksForTest();
+    autoSession.reset();
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("isTerminalDeletedWorktreeProviderError matches removed auto-worktree paths only", () => {


### PR DESCRIPTION
## TL;DR

**What:** Continue walking configured fallback models during mid-unit rate-limit recovery and resume through the steering path after a fallback switch.
**Why:** PR #717 covered pre-dispatch model selection, but #804 reproduced the bug in the mid-unit `agent_end` recovery path: GSD displayed the fallback switch but the work still did not resume.
**How:** Reuse the shared provider-model fallback walker in transient `agent_end` recovery, and send the continuation with `deliverAs: "steer"` so the selected fallback is actually used for the resumed turn.

## What

Updates `agent-end-recovery` so rate-limit, network, server, connection, and stream recovery use the same fallback walker as provider rejection recovery. The walker skips temporarily unavailable models and keeps trying configured fallbacks before pausing.

When a fallback is selected, the recovery continuation is delivered as steering input, matching the timeout-recovery path. This covers the #804 symptom where the UI reported the fallback switch but the unit remained stopped instead of continuing on the fallback model.

Adds a behavioral regression test where the primary model hits a session limit, the first fallback is temporarily unavailable, and the second fallback is selected and immediately resumed.

## Why

Refs #716, #804. The reporter confirmed #717 did not fix the live repro because the remaining failure was not only model selection. The mid-unit recovery path also needed to use the selected fallback for the next continuation turn.

## How

The transient recovery branch now delegates fallback selection to `tryProviderModelFallback`, which already updates current unit model state, dashboard model state, skips unavailable models, and triggers a continuation turn when a fallback is selected.

The triggered continuation now uses `{ triggerTurn: true, deliverAs: "steer" }`, consistent with `auto-timeout-recovery`, so the resumed turn is steered onto the updated model state instead of waiting for the retry timer.

## Verification

- [x] RED: `pnpm exec tsx --test src/resources/extensions/gsd/tests/provider-errors.test.ts` failed on the new regression assertion before the fix
- [x] GREEN: `pnpm exec tsx --test src/resources/extensions/gsd/tests/provider-errors.test.ts`
- [x] GREEN: `pnpm exec tsx --test src/resources/extensions/gsd/tests/provider-errors.test.ts src/resources/extensions/gsd/tests/auto-model-selection.test.ts src/resources/extensions/gsd/tests/blocked-models.test.ts`
- [x] SABOTAGE: temporarily disabled `tryProviderModelFallback` in transient recovery and confirmed the new regression test failed
- [x] `pnpm run build:core`
- [x] `git diff --check`

## Impact Analysis

- Blast radius: Moderate. This touches auto-mode provider recovery after transient model/provider failures.
- Affected workflows: `/gsd auto` mid-unit provider recovery, configured model fallbacks, temporary rate-limit model blocks.
- Compatibility notes: No config format or public API changes. Existing fallback state updates and continuation behavior are reused rather than duplicated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode mid-unit provider recovery and model switching; behavior is consolidated into existing fallback logic rather than new ad-hoc rules, but mis-selection could still affect live `/gsd auto` runs.
> 
> **Overview**
> Mid-unit **transient** provider recovery (rate limits, network, server, connection, stream) no longer stops after a single fallback attempt. That path now calls **`tryProviderModelFallback`**, the same walker used for provider/model rejection, so it skips temporarily blocked or unavailable models and keeps trying configured fallbacks (then the session start model) before pausing with auto-resume.
> 
> Recovery continuation messages sent after a successful switch now use **`deliverAs: "steer"`** alongside **`triggerTurn: true`**, matching the shared fallback helper.
> 
> A regression test covers a session-limit **`agent_end`**: primary rate-limited, first fallback temporarily blocked, second fallback selected with immediate resume and no pause timer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b230ee523a59d453c4a8b42ad34671b4c37af16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->