### PR TITLE
fix(claude-code-cli): stop ad-hoc turns being misclassified as workflow units

### DIFF
--- a/src/resources/extensions/claude-code-cli/index.ts
+++ b/src/resources/extensions/claude-code-cli/index.ts
@@ -14,9 +14,16 @@
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { CLAUDE_CODE_MODELS } from "./models.js";
 import { isClaudeCodeReady } from "./readiness.js";
-import { streamViaClaudeCode } from "./stream-adapter.js";
+import { setClaudeCodeUIContext, streamViaClaudeCode } from "./stream-adapter.js";
 
 export default function claudeCodeCli(pi: ExtensionAPI) {
+	// Core calls `streamSimple` with a plain `SimpleStreamOptions` (no UI
+	// context), so the elicitation handler used by `ask_user_questions` is
+	// otherwise never wired and self-cancels. Capture the live UI context here.
+	pi.on("before_provider_request", (_event, ctx) => {
+		setClaudeCodeUIContext(ctx.hasUI ? ctx.ui : undefined);
+	});
+
 	pi.registerProvider("claude-code", {
 		authMode: "externalCli",
 		api: "anthropic-messages",

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -74,7 +74,7 @@ import {
 	endWorkflowMcpSdkSession,
 } from "../gsd/workflow-mcp-readiness-cache.js";
 import { getGuidedUnitContext } from "../gsd/guided-unit-context.js";
-import { isAutoActive } from "../gsd/auto-runtime-state.js";
+import { getActiveAutoUnitType, isAutoActive } from "../gsd/auto-runtime-state.js";
 import { hasBrowserContractPrefix } from "../shared/browser-contract.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
@@ -394,6 +394,9 @@ const GSD_PHASE_PATTERNS: Array<[string, RegExp]> = [
 	["discuss-requirements", /\bUNIT:\s*Discuss Requirements\b/i],
 ];
 
+/** The set of GSD phases this adapter recognises, derived from the patterns above. */
+const KNOWN_GSD_PHASES = new Set(GSD_PHASE_PATTERNS.map(([phase]) => phase));
+
 export function inferGsdPhaseFromContext(context: Context): string | undefined {
 	// Scan only the system prompt and the most recent user directive. Scanning
 	// the entire scrollback let a phase header that merely appeared in history
@@ -427,16 +430,24 @@ export function resolveGsdPhaseForSdk(context: Context, projectRoot: string): st
 			return guided.unitType;
 		}
 	}
-	// No authoritative guided/auto context for this root → this is an ad-hoc
-	// turn. Do NOT regex-infer a phase from prose: that would fire the workflow
-	// MCP preflight and, for run-uat, strip Bash/Write/Edit/gsd_exec for the
-	// rest of the session the moment the conversation happened to mention a
-	// phase header. An ad-hoc turn keeps the full tool surface.
+	// Auto-mode records the dispatched unit type before each turn — that is the
+	// authoritative phase, so prefer it over any inference. (Guided interactive
+	// dispatch is handled above via getGuidedUnitContext.) Ignore `hook/*`
+	// pseudo-units and anything not a recognised GSD phase.
+	const autoUnit = getActiveAutoUnitType();
+	if (autoUnit && KNOWN_GSD_PHASES.has(autoUnit)) {
+		return autoUnit;
+	}
+
+	// No authoritative guided/auto signal → ad-hoc turn. Do NOT regex-infer a
+	// phase from prose: that would fire the workflow MCP preflight and, for
+	// run-uat, strip Bash/Write/Edit/gsd_exec for the rest of the session the
+	// moment the conversation (or the GSD system prompt itself) happened to
+	// mention a phase token. An ad-hoc turn keeps the full tool surface.
 	//
-	// Only fall back to header inference while auto-mode is genuinely running
-	// (defence in depth for a dispatched unit whose guided context was not
-	// recorded for this root); even then the patterns match the `UNIT:` header
-	// only, never bare slugs in scrollback.
+	// The header-anchored inference remains only as a last resort while auto is
+	// running but the current unit wasn't recorded for some reason; even then it
+	// matches the `UNIT:` dispatch header only, never bare slugs in scrollback.
 	if (!isAutoActive()) {
 		return undefined;
 	}

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -74,6 +74,7 @@ import {
 	endWorkflowMcpSdkSession,
 } from "../gsd/workflow-mcp-readiness-cache.js";
 import { getGuidedUnitContext } from "../gsd/guided-unit-context.js";
+import { isAutoActive } from "../gsd/auto-runtime-state.js";
 import { hasBrowserContractPrefix } from "../shared/browser-contract.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
@@ -365,31 +366,43 @@ function extractMessageText(msg: { role: string; content: unknown }): string {
 	return "";
 }
 
+// Patterns are anchored to the `UNIT: <Phase>` dispatch header ONLY. The old
+// patterns also matched bare slugs (`run-uat`, `plan-slice`, `gsd_plan_slice`,
+// …) anywhere in the text, so any incidental occurrence — a branch name like
+// `milestone/M039`, an untracked file `m039-s05-…spec.ts`, a forensic report,
+// or the user literally typing "slice"/"UAT" while describing a problem — would
+// misclassify the turn as a dispatched unit. Only the dispatch header is an
+// authoritative phase signal, so match nothing else.
 const GSD_PHASE_PATTERNS: Array<[string, RegExp]> = [
-	["run-uat", /\b(?:UNIT:\s*Run UAT|run-uat)\b/i],
-	["complete-milestone", /\b(?:UNIT:\s*Complete Milestone|complete-milestone)\b/i],
-	["validate-milestone", /\b(?:UNIT:\s*Validate Milestone|validate-milestone)\b/i],
-	["reassess-roadmap", /\b(?:UNIT:\s*Reassess Roadmap|reassess-roadmap)\b/i],
-	["complete-slice", /\b(?:UNIT:\s*Complete Slice|complete-slice)\b/i],
-	["replan-slice", /\b(?:UNIT:\s*Replan Slice|replan-slice)\b/i],
-	["refine-slice", /\b(?:UNIT:\s*Refine Slice|refine-slice)\b/i],
-	["plan-slice", /\b(?:UNIT:\s*Plan Slice|plan-slice|gsd_plan_slice)\b/i],
-	["plan-milestone", /\b(?:UNIT:\s*Plan Milestone|plan-milestone|gsd_plan_milestone)\b/i],
-	["execute-task", /\b(?:UNIT:\s*Execute Task|execute-task|execute-task-simple|reactive-execute)\b/i],
-	["gate-evaluate", /\b(?:UNIT:\s*Gate Evaluate|gate-evaluate|gsd_save_gate_result)\b/i],
-	["research-milestone", /\b(?:UNIT:\s*Research Milestone|research-milestone)\b/i],
-	["research-slice", /\b(?:UNIT:\s*Research Slice|research-slice)\b/i],
-	["research-decision", /\b(?:research decision|research-decision)\b/i],
-	["discuss-milestone", /\b(?:Discuss milestone|discuss-milestone)\b/i],
-	["discuss-slice", /\b(?:Discuss slice|discuss-slice)\b/i],
-	["discuss-project", /\b(?:discuss-project|Discuss project)\b/i],
-	["discuss-requirements", /\b(?:discuss-requirements|Discuss requirements)\b/i],
+	["run-uat", /\bUNIT:\s*Run UAT\b/i],
+	["complete-milestone", /\bUNIT:\s*Complete Milestone\b/i],
+	["validate-milestone", /\bUNIT:\s*Validate Milestone\b/i],
+	["reassess-roadmap", /\bUNIT:\s*Reassess Roadmap\b/i],
+	["complete-slice", /\bUNIT:\s*Complete Slice\b/i],
+	["replan-slice", /\bUNIT:\s*Replan Slice\b/i],
+	["refine-slice", /\bUNIT:\s*Refine Slice\b/i],
+	["plan-slice", /\bUNIT:\s*Plan Slice\b/i],
+	["plan-milestone", /\bUNIT:\s*Plan Milestone\b/i],
+	["execute-task", /\bUNIT:\s*Execute Task\b/i],
+	["gate-evaluate", /\bUNIT:\s*Gate Evaluate\b/i],
+	["research-milestone", /\bUNIT:\s*Research Milestone\b/i],
+	["research-slice", /\bUNIT:\s*Research Slice\b/i],
+	["research-decision", /\bUNIT:\s*Research Decision\b/i],
+	["discuss-milestone", /\bUNIT:\s*Discuss Milestone\b/i],
+	["discuss-slice", /\bUNIT:\s*Discuss Slice\b/i],
+	["discuss-project", /\bUNIT:\s*Discuss Project\b/i],
+	["discuss-requirements", /\bUNIT:\s*Discuss Requirements\b/i],
 ];
 
 export function inferGsdPhaseFromContext(context: Context): string | undefined {
+	// Scan only the system prompt and the most recent user directive. Scanning
+	// the entire scrollback let a phase header that merely appeared in history
+	// (e.g. a SUMMARY the agent read, or a pasted prior dispatch) re-classify
+	// every subsequent turn.
+	const lastUser = [...context.messages].reverse().find((m) => m.role === "user");
 	const text = [
 		context.systemPrompt ?? "",
-		...context.messages.map((message) => extractMessageText(message)),
+		lastUser ? extractMessageText(lastUser) : "",
 	].join("\n");
 	for (const [phase, pattern] of GSD_PHASE_PATTERNS) {
 		if (pattern.test(text)) return phase;
@@ -413,6 +426,19 @@ export function resolveGsdPhaseForSdk(context: Context, projectRoot: string): st
 		if (guidedRoot === resolvedRoot) {
 			return guided.unitType;
 		}
+	}
+	// No authoritative guided/auto context for this root → this is an ad-hoc
+	// turn. Do NOT regex-infer a phase from prose: that would fire the workflow
+	// MCP preflight and, for run-uat, strip Bash/Write/Edit/gsd_exec for the
+	// rest of the session the moment the conversation happened to mention a
+	// phase header. An ad-hoc turn keeps the full tool surface.
+	//
+	// Only fall back to header inference while auto-mode is genuinely running
+	// (defence in depth for a dispatched unit whose guided context was not
+	// recorded for this root); even then the patterns match the `UNIT:` header
+	// only, never bare slugs in scrollback.
+	if (!isAutoActive()) {
+		return undefined;
 	}
 	return inferGsdPhaseFromContext(context);
 }
@@ -2103,6 +2129,19 @@ export function buildSdkOptions(
 // streamSimple implementation
 // ---------------------------------------------------------------------------
 
+let capturedClaudeCodeUIContext: ExtensionUIContext | undefined;
+
+/**
+ * Capture the active extension UI context from `before_provider_request`. Core
+ * invokes `streamSimple` with a plain `SimpleStreamOptions` (no
+ * `extensionUIContext`), so without this the elicitation handler is never wired
+ * and `ask_user_questions` immediately returns cancelled. See index.ts, which
+ * registers the hook that calls this.
+ */
+export function setClaudeCodeUIContext(ui: ExtensionUIContext | undefined): void {
+	capturedClaudeCodeUIContext = ui;
+}
+
 /**
  * GSD streamSimple function that delegates to the Claude Agent SDK.
  *
@@ -2152,7 +2191,7 @@ async function pumpSdkMessages(
 	try {
 		const permissionMode = await resolveClaudePermissionMode();
 		const claudeOptions = options as ClaudeCodeStreamOptions | undefined;
-		const uiContext = claudeOptions?.extensionUIContext;
+		const uiContext = claudeOptions?.extensionUIContext ?? capturedClaudeCodeUIContext;
 		const onExternalToolCall = claudeOptions?.onExternalToolCall;
 		const onExternalToolResult = claudeOptions?.onExternalToolResult;
 		const sdkQueryForTest = claudeOptions?._sdkQueryForTest;

--- a/src/resources/extensions/claude-code-cli/tests/index.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/index.test.ts
@@ -1,0 +1,47 @@
+// gsd-pi - Claude Code CLI extension wiring tests
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import claudeCodeCli from "../index.ts";
+
+type Handler = (event: unknown, ctx: unknown) => unknown;
+
+function makeMockPi() {
+	const handlers = new Map<string, Handler[]>();
+	const providers: Array<{ name: string; config: Record<string, unknown> }> = [];
+	const pi = {
+		on(event: string, handler: Handler) {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		},
+		registerProvider(name: string, config: Record<string, unknown>) {
+			providers.push({ name, config });
+		},
+	};
+	return { pi, handlers, providers };
+}
+
+test("registers the claude-code provider with a streamSimple delegate", () => {
+	const { pi, providers } = makeMockPi();
+	claudeCodeCli(pi as never);
+
+	assert.equal(providers.length, 1);
+	assert.equal(providers[0].name, "claude-code");
+	assert.equal(typeof providers[0].config.streamSimple, "function");
+});
+
+test("registers a before_provider_request hook to capture the UI context", () => {
+	const { pi, handlers } = makeMockPi();
+	claudeCodeCli(pi as never);
+
+	const registered = handlers.get("before_provider_request");
+	assert.ok(registered && registered.length === 1, "before_provider_request handler must be registered");
+
+	// Without this hook, core calls streamSimple with no UI context and
+	// ask_user_questions self-cancels. The handler must accept both UI states
+	// without throwing and must not mutate the provider payload.
+	const handler = registered[0];
+	const sentinelUi = { kind: "ui" };
+	assert.equal(handler({ type: "before_provider_request" }, { hasUI: true, ui: sentinelUi }), undefined);
+	assert.equal(handler({ type: "before_provider_request" }, { hasUI: false, ui: sentinelUi }), undefined);
+});

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,7 +1,6 @@
 // gsd-pi - Claude Code stream adapter regression tests
 import { describe, test } from "node:test";
 import { clearGuidedUnitContext, setGuidedUnitContext } from "../../gsd/guided-unit-context.ts";
-import { _setAutoActiveForTest } from "../../gsd/auto.ts";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -51,6 +50,7 @@ import { CLAUDE_CODE_MODELS } from "../models.ts";
 import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
 import type { SDKUserMessage } from "../sdk-types.ts";
 import { _setAutoActiveForTest } from "../../gsd/auto.ts";
+import { autoSession } from "../../gsd/auto-runtime-state.ts";
 import { getInFlightToolCount, hasInteractiveToolInFlight, clearInFlightTools, isInteractiveElicitationInFlight } from "../../gsd/auto-tool-tracking.ts";
 import { clearMcpConfigCache } from "../../mcp-client/manager.ts";
 import { UNIT_TOOL_CONTRACTS } from "../../gsd/unit-tool-contracts.ts";
@@ -1624,12 +1624,43 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		}
 	});
 
-	test("resolveGsdPhaseForSdk infers from the UNIT header only while auto-mode is active", () => {
-		// Defence-in-depth fallback: a genuinely dispatched unit whose guided
-		// context was not recorded for this root can still be classified from its
-		// UNIT header — but only while auto is running.
+	test("resolveGsdPhaseForSdk uses the authoritative auto currentUnit, even with no UNIT header in the prompt", () => {
+		// gate-evaluate / validate-milestone dispatch prompts have no `UNIT:`
+		// header, so header inference alone would drop their phase (and their
+		// workflow-MCP preflight). The dispatched unit type is authoritative.
 		clearGuidedUnitContext();
 		_setAutoActiveForTest(true);
+		autoSession.currentUnit = { type: "gate-evaluate", id: "M001/S001", startedAt: 0, workspaceRoot: "/tmp/p" } as never;
+		try {
+			const context = {
+				messages: [{ role: "user", content: "Quality Gate Evaluation — Parallel Dispatch. Call gsd_save_gate_result." }],
+			} as Context;
+			assert.equal(resolveGsdPhaseForSdk(context, "/tmp/p"), "gate-evaluate");
+		} finally {
+			autoSession.currentUnit = null;
+			_setAutoActiveForTest(false);
+		}
+	});
+
+	test("resolveGsdPhaseForSdk ignores hook/* pseudo-units from currentUnit", () => {
+		clearGuidedUnitContext();
+		_setAutoActiveForTest(true);
+		autoSession.currentUnit = { type: "hook/agent-end", id: "x", startedAt: 0, workspaceRoot: "/tmp/p" } as never;
+		try {
+			const context = { messages: [{ role: "user", content: "no phase here" }] } as Context;
+			assert.equal(resolveGsdPhaseForSdk(context, "/tmp/p"), undefined);
+		} finally {
+			autoSession.currentUnit = null;
+			_setAutoActiveForTest(false);
+		}
+	});
+
+	test("resolveGsdPhaseForSdk infers from the UNIT header only while auto-mode is active and no currentUnit is recorded", () => {
+		// Last-resort fallback: auto running but currentUnit unexpectedly absent.
+		// Classifies from the `UNIT:` dispatch header only.
+		clearGuidedUnitContext();
+		_setAutoActiveForTest(true);
+		autoSession.currentUnit = null;
 		try {
 			const context = {
 				messages: [{ role: "user", content: "## UNIT: Run UAT — M001/S001" }],

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,6 +1,7 @@
 // gsd-pi - Claude Code stream adapter regression tests
 import { describe, test } from "node:test";
 import { clearGuidedUnitContext, setGuidedUnitContext } from "../../gsd/guided-unit-context.ts";
+import { _setAutoActiveForTest } from "../../gsd/auto.ts";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -1543,16 +1544,41 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		assert.equal(inferGsdPhaseFromContext(context), "plan-milestone");
 	});
 
-	test("inferGsdPhaseFromContext recognizes discuss-slice and refine-slice prompts", () => {
-		const discussSlice = {
-			messages: [{ role: "user", content: "Discuss slice S001 in milestone M001." }],
-		} as Context;
+	test("inferGsdPhaseFromContext recognizes the refine-slice UNIT header", () => {
 		const refineSlice = {
 			messages: [{ role: "user", content: "## UNIT: Refine Slice S001 (\"Auth\") - Milestone M001" }],
 		} as Context;
 
-		assert.equal(inferGsdPhaseFromContext(discussSlice), "discuss-slice");
 		assert.equal(inferGsdPhaseFromContext(refineSlice), "refine-slice");
+	});
+
+	test("inferGsdPhaseFromContext ignores bare phase slugs and prose (only the UNIT header counts)", () => {
+		// Prose mentioning a phase must NOT classify the turn — this was the leak
+		// that stripped tools the moment a user said "slice" or "UAT".
+		const prose = {
+			messages: [{ role: "user", content: "Can you discuss the slice S001 and then run UAT for me?" }],
+		} as Context;
+		const bareSlug = {
+			messages: [{ role: "user", content: "I edited e2e/m039-s05-comparison-legibility.spec.ts (plan-slice, run-uat)" }],
+		} as Context;
+
+		assert.equal(inferGsdPhaseFromContext(prose), undefined);
+		assert.equal(inferGsdPhaseFromContext(bareSlug), undefined);
+	});
+
+	test("inferGsdPhaseFromContext does not match a UNIT header buried in scrollback", () => {
+		// A UNIT header from a prior turn (e.g. a SUMMARY the agent read) must not
+		// re-classify later ad-hoc turns. Only the system prompt + latest user
+		// message are scanned.
+		const context = {
+			messages: [
+				{ role: "user", content: "## UNIT: Run UAT — M001/S001" },
+				{ role: "assistant", content: "Done." },
+				{ role: "user", content: "Thanks, now what files changed?" },
+			],
+		} as Context;
+
+		assert.equal(inferGsdPhaseFromContext(context), undefined);
 	});
 
 	test("resolveGsdPhaseForSdk prefers guided unit context over prompt inference", () => {
@@ -1582,12 +1608,36 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		}
 	});
 
-	test("resolveGsdPhaseForSdk falls back to prompt inference when guided context is absent", () => {
+	test("resolveGsdPhaseForSdk returns undefined for ad-hoc turns (no guided context, auto inactive)", () => {
+		// The core bug: an ad-hoc turn must keep the full tool surface even when
+		// its text contains a UNIT header (e.g. pasted from a prior unit). No
+		// guided context + auto inactive => no phase, no preflight, no stripping.
 		clearGuidedUnitContext();
-		const context = {
-			messages: [{ role: "user", content: "## UNIT: Run UAT — M001/S001" }],
-		} as Context;
-		assert.equal(resolveGsdPhaseForSdk(context, "/tmp/unrelated-project"), "run-uat");
+		_setAutoActiveForTest(false);
+		try {
+			const context = {
+				messages: [{ role: "user", content: "## UNIT: Run UAT — M001/S001 (pasted from earlier)" }],
+			} as Context;
+			assert.equal(resolveGsdPhaseForSdk(context, "/tmp/unrelated-project"), undefined);
+		} finally {
+			_setAutoActiveForTest(false);
+		}
+	});
+
+	test("resolveGsdPhaseForSdk infers from the UNIT header only while auto-mode is active", () => {
+		// Defence-in-depth fallback: a genuinely dispatched unit whose guided
+		// context was not recorded for this root can still be classified from its
+		// UNIT header — but only while auto is running.
+		clearGuidedUnitContext();
+		_setAutoActiveForTest(true);
+		try {
+			const context = {
+				messages: [{ role: "user", content: "## UNIT: Run UAT — M001/S001" }],
+			} as Context;
+			assert.equal(resolveGsdPhaseForSdk(context, "/tmp/unrelated-project"), "run-uat");
+		} finally {
+			_setAutoActiveForTest(false);
+		}
 	});
 
 	test("buildSdkOptions presents ask_user_questions for discuss phases", () => {

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -65,6 +65,19 @@ export function isAutoActive(): boolean {
   return autoSession.active;
 }
 
+/**
+ * The unit type of the unit auto-mode is currently dispatching, or undefined
+ * when auto is inactive or between units. This is the authoritative phase
+ * signal for auto-mode (set in auto/unit-phase.ts before each dispatch), so
+ * consumers never have to regex-infer the phase from prompt text. Can be a
+ * `hook/<name>` pseudo-type during hook dispatch — callers that need a real
+ * GSD phase should validate against their known phase set.
+ */
+export function getActiveAutoUnitType(): string | undefined {
+  if (!autoSession.active) return undefined;
+  return autoSession.currentUnit?.type ?? undefined;
+}
+
 export function isAutoPaused(): boolean {
   return autoSession.paused;
 }


### PR DESCRIPTION
## Linked issue

Closes #815

- [x] I have linked an issue above.

---

## TL;DR

**What:** Stop the `claude-code-cli` provider classifying ad-hoc chat turns as dispatched workflow units.
**Why:** The old phase regex matched bare slugs anywhere in context — including the GSD system prompt's own tool/phase docs — so it fired on every first turn, running the workflow preflight and stripping Bash/Write/Edit/gsd_exec (the `run-uat` branch).
**How:** Guided context first; in auto-mode use the authoritative dispatched unit type (`autoSession.currentUnit`); ad-hoc turns get no phase. Header inference is a last resort only.

## What

`extensions/claude-code-cli/stream-adapter.ts`:
- `resolveGsdPhaseForSdk` resolution order is now: (1) guided unit context for the root (interactive dispatch), (2) `getActiveAutoUnitType()` validated against the known phase set (auto-mode), (3) `undefined` for ad-hoc turns, (4) header-anchored inference only as a last resort while auto is active.
- `GSD_PHASE_PATTERNS` anchored to the `UNIT: <Phase>` dispatch header only (bare-slug alternatives removed), and `inferGsdPhaseFromContext` scans only `systemPrompt` + the most recent user message.
- Adds `setClaudeCodeUIContext` + a captured-context fallback for the elicitation UI context (Bug 1: `ask_user_questions` self-cancelled).

`extensions/gsd/auto-runtime-state.ts`:
- Adds `getActiveAutoUnitType()` — the authoritative auto-mode phase, read from `autoSession.currentUnit.type` (set in `auto/unit-phase.ts` before each dispatch).

`extensions/claude-code-cli/index.ts`:
- Registers a `before_provider_request` hook feeding the live UI context to `setClaudeCodeUIContext`.

Tests: `tests/stream-adapter.test.ts` (anchored/scrollback inference, ad-hoc→undefined, `currentUnit` drives phase with no UNIT header, `hook/*` ignored, last-resort header path) and `tests/index.test.ts` (provider + hook wiring).

## Why

`resolveGsdPhaseForSdk` fell through to `inferGsdPhaseFromContext` whenever no guided context was recorded. That regex scanned `systemPrompt` + the entire history for bare phase slugs (`run-uat`, `plan-slice`, `gsd_plan_slice`, `gsd_save_gate_result`, ...) with no auto-mode gate.

The dominant trigger turned out to be the **GSD system prompt itself** — it documents workflow tool names and phase slugs, so the regex matched on the system prompt alone, on the **first turn of every brand-new session**. Observed: `Starting gsd-workflow MCP for plan-slice…` on turn one in an empty project, which then ran the preflight and (for `run-uat`) stripped `Bash`/`Write`/`Edit`/`gsd_exec`. Incidental tokens (a `milestone/M###` branch, an `m###-s##-*.spec.ts` file, the user typing "slice"/"UAT") compounded it. Codex has no equivalent path, matching the report that only `claude-code` misclassifies.

## How

Guided/auto dispatch already know the unit type authoritatively:
- Interactive guided dispatch records it via `setGuidedUnitContext` (handled first).
- Auto-mode records it in `autoSession.currentUnit` in `auto/unit-phase.ts` before every turn — but it does **not** call `setGuidedUnitContext`. So auto-mode previously depended on the regex. Reading `currentUnit.type` removes that dependency entirely and, crucially, avoids a regression: `gate-evaluate` and `validate-milestone` dispatch prompts have **no** `UNIT:` header and previously only matched via bare slugs (e.g. `gsd_save_gate_result`); anchoring alone would have dropped their phase + preflight. `currentUnit` covers them correctly. `hook/*` pseudo-units are filtered out via the known-phase set.

If there is no authoritative signal, the turn is ad-hoc and keeps the full tool surface. Header inference survives only as a last resort while auto is active but `currentUnit` is somehow absent, and even then matches the `UNIT:` header only.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Testing notes

Resolution logic verified in isolation (guided precedence, `currentUnit` phase, `hook/*` rejection, ad-hoc→undefined, last-resort header). I could not run the full `verify:merge` locally — the workspace toolchain hits `ERR_UNSUPPORTED_ESM_URL_SCHEME` under Node v25 (the `resolve-ts.mjs` loader). Tests use the existing `node:test` harness and should run under CI's Node 22 matrix; please flag anything that needs adjusting.
