### PR TITLE
feat(hermes): recover PR #368 — finish-line fixes and native plugin installer

### DIFF
--- a/docs/dev/hermes-integration-plan.md
+++ b/docs/dev/hermes-integration-plan.md
@@ -28,7 +28,7 @@ First usable outcome (6a): from Slack/Telegram, a user can `/gsd bind`, `/gsd au
 |------|----------|
 | Success criterion | Full platform play: gateway + cron + supervision |
 | Hermes integration | Deep general plugin: slash commands, `pre_llm_call` injection, memory provider (6c), background supervisor |
-| Project binding | Tiered: cron explicit → channel/thread map → `/gsd bind` → profile default → fail closed |
+| Project binding | Tiered: cron explicit → slash argument → `/gsd bind` session binding → channel/thread map → profile default → fail closed |
 | Read path | MCP sidecar (6a) → `gsd read --json` CLI (6c); TTL cache ~45s |
 | Execution | Gateway: MCP `gsd_execute`/`gsd_status`; Cron: `gsd headless auto` |
 | Plugin home | Start in `integrations/hermes/`; extract `open-gsd-hermes` pip package at 6c |

--- a/integrations/hermes/.npmignore
+++ b/integrations/hermes/.npmignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -4,6 +4,21 @@ Hermes Agent plugin integrating [GSD Pi](https://github.com/open-gsd/gsd-pi) as 
 
 ## Install
 
+If GSD Pi was installed from an npm package that includes this integration, use the
+one-command installer:
+
+```bash
+gsd hermes install --project /absolute/path/to/your/project
+hermes plugins list   # should show open-gsd-hermes enabled
+```
+
+The installer copies the bundled plugin into `$HERMES_HOME/plugins/open-gsd-hermes`,
+installs the Python package into the Hermes environment when possible, creates a
+starter `$HERMES_HOME/gsd.yaml` if one does not exist, and runs
+`hermes plugins enable open-gsd-hermes`.
+
+From a source checkout, the manual development path is still supported:
+
 ```bash
 pip install -e integrations/hermes
 hermes plugins enable open-gsd-hermes

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -29,5 +29,5 @@ bash integrations/hermes/scripts/preflight.sh
 
 ## Requirements
 
-- `gsd >=1.0,<3` (override `gsd_version_min` in `~/.hermes/gsd.yaml` per release train)
+- `gsd >=2.53,<3` (override `gsd_version_min` in `~/.hermes/gsd.yaml` per release train)
 - `gsd-mcp-server` on PATH or configured in `gsd.yaml`

--- a/integrations/hermes/docs/setup.md
+++ b/integrations/hermes/docs/setup.md
@@ -1,6 +1,6 @@
 # Hermes × GSD Gateway Setup Checklist
 
-Manual validation before releasing `open-gsd-hermes` 1.0.x. Complete **local preflight** first, then run the **Slack** or **Telegram** gateway walkthrough on a real GSD project.
+Manual validation before releasing `open-gsd-hermes` 1.2.x. Complete **local preflight** first, then run the **Slack** or **Telegram** gateway walkthrough on a real GSD project.
 
 ---
 
@@ -25,7 +25,7 @@ Run before touching Slack or Telegram.
 | Step | Command / check | Pass criteria |
 |------|-----------------|---------------|
 | P1 | `bash integrations/hermes/scripts/preflight.sh` | All checks ✓, exit 0 |
-| P2 | `gsd --version` | Semver in `>=1.0,<3` (or your configured `gsd_version_min`) |
+| P2 | `gsd --version` | Semver in `>=2.53,<3` (or your configured `gsd_version_min`) |
 | P3 | `which gsd-mcp-server` | Binary on PATH or path set in `~/.hermes/gsd.yaml` |
 | P4 | `gsd read progress --json --project <your-project>` | JSON with `"integration_version": 1` and `activeMilestone` |
 | P5 | Project has `.gsd/` (or `.planning/`) with `STATE.md` | `read progress` shows phase/milestone |
@@ -57,7 +57,7 @@ Restart the Hermes gateway after enabling the plugin.
 ```yaml
 gsd:
   # Use absolute paths in production
-  cli_path: /usr/local/bin/gsd          # or: node /path/to/gsd-pi/dist/loader.js
+  cli_path: /usr/local/bin/gsd          # or an executable wrapper around dist/loader.js
   mcp_server_path: /usr/local/bin/gsd-mcp-server
   credential_source: gsd                # 6a: GSD-managed API keys
   default_project: ~/code/myapp         # optional fallback
@@ -71,7 +71,7 @@ gsd:
       "123456789": ~/code/myapp         # Telegram chat ID (see below)
 ```
 
-**Binding tiers (first match wins):** cron explicit → channel map → `/gsd bind` → `default_project` → cwd heuristic.
+**Binding tiers (first match wins):** cron explicit → slash argument → `/gsd bind` session binding → channel map → `default_project` → cwd heuristic.
 
 **Credentials:** With `credential_source: gsd`, ensure GSD’s normal provider keys are configured (`~/.gsd/` or env). Hermes passthrough (`credential_source: hermes`) is 6b+.
 

--- a/integrations/hermes/docs/setup.md
+++ b/integrations/hermes/docs/setup.md
@@ -7,11 +7,15 @@ Manual validation before releasing `open-gsd-hermes` 1.2.x. Complete **local pre
 ## Quick start
 
 ```bash
-# From gsd-pi repo root
-npm run build:core                                    # dist/loader.js for read CLI
+# End-user path after installing/upgrading @opengsd/gsd-pi
+gsd hermes install --project /absolute/path/to/your/project
+hermes plugins list                                  # open-gsd-hermes should be enabled
+hermes gateway restart                               # or restart your Hermes CLI/gateway process
+
+# Source-checkout validation path
+npm run build:core                                   # dist/loader.js for read CLI
 pip install -e integrations/hermes[dev]
-bash integrations/hermes/scripts/preflight.sh         # local gates (no Hermes)
-hermes plugins enable open-gsd-hermes                 # in your Hermes install
+bash integrations/hermes/scripts/preflight.sh        # local gates (no Hermes)
 ```
 
 Record results in the [Sign-off](#sign-off) section at the bottom.
@@ -44,8 +48,20 @@ node dist/loader.js read progress --json \
 
 ### Install plugin
 
+Preferred end-user path:
+
+```bash
+gsd hermes install --project /absolute/path/to/your/project
+hermes plugins list   # should show open-gsd-hermes enabled
+```
+
+Manual source-checkout path:
+
 ```bash
 pip install -e /path/to/gsd-pi/integrations/hermes
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+mkdir -p "$HERMES_HOME/plugins"
+cp -R /path/to/gsd-pi/integrations/hermes "$HERMES_HOME/plugins/open-gsd-hermes"
 hermes plugins enable open-gsd-hermes
 hermes plugins list   # should show open-gsd-hermes enabled
 ```

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -142,9 +142,12 @@ class GsdCommandRouter:
         ctx = self._get_supervisor_ctx()
         try:
             try:
-                project_dir = resolve_project_dir(
-                    self._config, self._binding_ctx()
-                )
+                if ctx.session_id and ctx.project_dir:
+                    project_dir = resolve_explicit_project_dir(ctx.project_dir)
+                else:
+                    project_dir = resolve_project_dir(
+                        self._config, self._binding_ctx()
+                    )
             except BindingError as e:
                 result = str(e)
             else:

--- a/integrations/hermes/open_gsd_hermes/config.py
+++ b/integrations/hermes/open_gsd_hermes/config.py
@@ -20,7 +20,7 @@ class GsdConfig:
     poll_interval_seconds: int = 12
     cache_ttl_seconds: int = 45
     notification_level: str = "normal"
-    gsd_version_min: str = "1.0"
+    gsd_version_min: str = "2.53"
     gsd_version_max: str = "3.0"
     hermes_memory_path: str | None = None
 
@@ -36,7 +36,7 @@ class GsdConfig:
             poll_interval_seconds=int(gsd.get("poll_interval_seconds", 12)),
             cache_ttl_seconds=int(gsd.get("cache_ttl_seconds", 45)),
             notification_level=str(gsd.get("notification_level", "normal")),
-            gsd_version_min=str(gsd.get("gsd_version_min", "1.0")),
+            gsd_version_min=str(gsd.get("gsd_version_min", "2.53")),
             gsd_version_max=str(gsd.get("gsd_version_max", "3.0")),
             hermes_memory_path=gsd.get("hermes_memory_path"),
         )

--- a/integrations/hermes/open_gsd_hermes/config.py
+++ b/integrations/hermes/open_gsd_hermes/config.py
@@ -43,7 +43,11 @@ class GsdConfig:
 
 
 def config_path() -> Path:
-    return Path(os.environ.get("HERMES_GSD_CONFIG", Path.home() / ".hermes" / "gsd.yaml"))
+    explicit = os.environ.get("HERMES_GSD_CONFIG")
+    if explicit:
+        return Path(explicit).expanduser()
+    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    return hermes_home.expanduser() / "gsd.yaml"
 
 
 def load_config(path: Path | None = None) -> GsdConfig:

--- a/integrations/hermes/open_gsd_hermes/supervisor.py
+++ b/integrations/hermes/open_gsd_hermes/supervisor.py
@@ -76,7 +76,7 @@ class SupervisorFsm:
 
     def stop(self) -> None:
         self._stop.set()
-        if self._thread:
+        if self._thread and self._thread is not threading.current_thread():
             self._thread.join(timeout=5)
         self._thread = None
 
@@ -100,11 +100,19 @@ class SupervisorFsm:
             return
 
         status = self._client.status(ctx.session_id)
-        progress = self._client.progress(ctx.project_dir)
+        try:
+            progress = self._client.progress(ctx.project_dir)
+        except Exception:
+            progress = None
         ctx.last_status = status
+        blocker_notification: SessionStatus | None = None
         terminal_notification: tuple[str, str | None] | None = None
 
         new_state = self._map_status(status.status)
+        pending_blocker_id = (
+            (status.pending_blocker or {}).get("id")
+            or (status.pending_blocker or {}).get("blockerId")
+        )
         if (
             status.pending_blocker
             and new_state not in TERMINAL
@@ -115,21 +123,30 @@ class SupervisorFsm:
         if new_state != ctx.state:
             ctx.state = new_state
             if new_state == SupervisorState.BLOCKED:
-                ctx.pending_blocker_id = (
-                    (status.pending_blocker or {}).get("id")
-                    or (status.pending_blocker or {}).get("blockerId")
-                )
-                self._notifications.notify_blocker(status)
+                blocker_notification = status
             elif new_state in TERMINAL and not ctx.notified_terminal:
                 ctx.notified_terminal = True
                 terminal_notification = (status.status, status.error)
+        elif (
+            new_state == SupervisorState.BLOCKED
+            and pending_blocker_id
+            and pending_blocker_id != ctx.pending_blocker_id
+        ):
+            blocker_notification = status
 
-        self._diff_progress(ctx, progress)
+        if new_state == SupervisorState.BLOCKED:
+            ctx.pending_blocker_id = pending_blocker_id
+
+        if progress is not None:
+            self._diff_progress(ctx, progress)
+            ctx.last_progress = progress
+        if terminal_notification:
+            stop_event.set()
+        self._set_context(ctx)
+        if blocker_notification:
+            self._notifications.notify_blocker(blocker_notification)
         if terminal_notification:
             self._notifications.notify_terminal(*terminal_notification)
-            stop_event.set()
-        ctx.last_progress = progress
-        self._set_context(ctx)
 
     def _map_status(self, raw: str) -> SupervisorState:
         mapping = {

--- a/integrations/hermes/tests/test_config.py
+++ b/integrations/hermes/tests/test_config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from open_gsd_hermes.config import GsdConfig
+from pathlib import Path
+
+from open_gsd_hermes.config import GsdConfig, config_path
 
 
 def test_default_gsd_version_range_matches_plugin_release_train() -> None:
@@ -17,3 +19,18 @@ def test_dict_fallback_gsd_version_range_matches_plugin_release_train() -> None:
 
     assert config.gsd_version_min == "2.53"
     assert config.gsd_version_max == "3.0"
+
+
+def test_config_path_respects_hermes_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_GSD_CONFIG", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+    assert config_path() == tmp_path / "hermes-home" / "gsd.yaml"
+
+
+def test_config_path_explicit_env_wins(tmp_path: Path, monkeypatch) -> None:
+    explicit = tmp_path / "custom-gsd.yaml"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setenv("HERMES_GSD_CONFIG", str(explicit))
+
+    assert config_path() == explicit

--- a/integrations/hermes/tests/test_config.py
+++ b/integrations/hermes/tests/test_config.py
@@ -1,0 +1,19 @@
+"""Tests for Hermes plugin configuration defaults."""
+
+from __future__ import annotations
+
+from open_gsd_hermes.config import GsdConfig
+
+
+def test_default_gsd_version_range_matches_plugin_release_train() -> None:
+    config = GsdConfig()
+
+    assert config.gsd_version_min == "2.53"
+    assert config.gsd_version_max == "3.0"
+
+
+def test_dict_fallback_gsd_version_range_matches_plugin_release_train() -> None:
+    config = GsdConfig.from_dict({"gsd": {}})
+
+    assert config.gsd_version_min == "2.53"
+    assert config.gsd_version_max == "3.0"

--- a/integrations/hermes/tests/test_read_cli_contract.py
+++ b/integrations/hermes/tests/test_read_cli_contract.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 FIXTURE = Path(__file__).parent / "fixtures" / "minimal-project"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 GSD_CLI = os.environ.get("GSD_CLI_PATH", "node")
@@ -23,7 +25,7 @@ def _gsd_cmd(*args: str) -> list[str]:
 
 def test_read_cli_progress_fixture() -> None:
     if not Path(GSD_LOADER).exists():
-        return
+        pytest.skip(f"GSD loader not built: {GSD_LOADER}")
 
     result = subprocess.run(
         _gsd_cmd(

--- a/integrations/hermes/tests/test_supervisor_fsm.py
+++ b/integrations/hermes/tests/test_supervisor_fsm.py
@@ -6,6 +6,8 @@ import asyncio
 import threading
 from unittest.mock import MagicMock
 
+import pytest
+
 from open_gsd_hermes.binding import SessionBindStore
 from open_gsd_hermes.commands import GsdCommandRouter
 from open_gsd_hermes.config import GsdConfig
@@ -250,6 +252,42 @@ def test_cancel_sends_terminal_notification_after_successful_mcp_cancel(tmp_path
     assert stored == [ctx]
 
 
+def test_cancel_prefers_supervisor_project_for_active_session(tmp_path) -> None:
+    current_project = tmp_path / "current"
+    current_project.mkdir()
+    (current_project / ".gsd").mkdir()
+    running_project = tmp_path / "running"
+    running_project.mkdir()
+    (running_project / ".gsd").mkdir()
+    supervisor = MockSupervisor()
+    client = MagicMock()
+    ctx = SupervisorContext(
+        session_id="s1",
+        project_dir=str(running_project),
+        state=SupervisorState.RUNNING,
+    )
+    stored: list[SupervisorContext] = []
+    router = GsdCommandRouter(
+        GsdConfig(default_project=str(current_project)),
+        client,
+        SessionBindStore(),
+        supervisor,  # type: ignore[arg-type]
+        lambda: "session-key",
+        lambda: BindingContext(),
+        lambda: ctx,
+        stored.append,
+        lambda: (None, None),
+    )
+
+    result = asyncio.run(router._cmd_cancel([]))
+
+    assert result == "Cancel requested."
+    client.cancel.assert_called_once_with(
+        session_id="s1",
+        project_dir=str(running_project),
+    )
+
+
 def test_cancel_stops_supervisor_when_binding_resolution_fails(tmp_path) -> None:
     supervisor = MockSupervisor()
     client = MagicMock()
@@ -275,7 +313,7 @@ def test_cancel_stops_supervisor_when_binding_resolution_fails(tmp_path) -> None
 
     result = asyncio.run(router._cmd_cancel([]))
 
-    assert result.startswith("No GSD project bound.")
+    assert "is not a GSD project" in result
     client.cancel.assert_not_called()
     client.cancel_by_project.assert_not_called()
     assert supervisor.calls == ["stop"]
@@ -423,6 +461,88 @@ def test_supervisor_terminal_status_takes_precedence_over_pending_blocker() -> N
     assert fsm._stop.is_set()
     assert stored == [ctx]
     assert sent == ["✅ GSD auto mode finished."]
+
+
+def test_supervisor_notifies_new_blocker_while_already_blocked() -> None:
+    ctx = SupervisorContext(
+        session_id="s1",
+        project_dir="/tmp/p",
+        state=SupervisorState.BLOCKED,
+        pending_blocker_id="b1",
+    )
+    client = MockClient()
+    client._status = SessionStatus(
+        status="running",
+        pending_blocker={"id": "b2", "question": "Choose option?"},
+    )
+    notifications = MagicMock()
+    fsm = SupervisorFsm(
+        GsdConfig(),
+        client,  # type: ignore[arg-type]
+        notifications,
+        lambda: ctx,
+        lambda c: None,
+    )
+
+    fsm._tick()
+
+    assert ctx.pending_blocker_id == "b2"
+    notifications.notify_blocker.assert_called_once_with(client._status)
+
+
+def test_supervisor_terminal_status_notifies_even_when_progress_fails() -> None:
+    ctx = SupervisorContext(
+        session_id="s1",
+        project_dir="/tmp/p",
+        state=SupervisorState.RUNNING,
+    )
+    client = MagicMock()
+    client.status.return_value = SessionStatus(status="complete")
+    client.progress.side_effect = RuntimeError("read failed")
+    notifications = MagicMock()
+    stored: list[SupervisorContext] = []
+    fsm = SupervisorFsm(
+        GsdConfig(),
+        client,
+        notifications,
+        lambda: ctx,
+        stored.append,
+    )
+
+    fsm._tick()
+
+    assert fsm._stop.is_set()
+    assert ctx.state == SupervisorState.COMPLETE
+    assert ctx.notified_terminal
+    assert stored == [ctx]
+    notifications.notify_terminal.assert_called_once_with("complete", None)
+
+
+def test_supervisor_terminal_notification_failure_still_stops() -> None:
+    ctx = SupervisorContext(
+        session_id="s1",
+        project_dir="/tmp/p",
+        state=SupervisorState.RUNNING,
+    )
+    client = MockClient()
+    client._status = SessionStatus(status="complete")
+    notifications = MagicMock()
+    notifications.notify_terminal.side_effect = RuntimeError("dispatch failed")
+    stored: list[SupervisorContext] = []
+    fsm = SupervisorFsm(
+        GsdConfig(),
+        client,  # type: ignore[arg-type]
+        notifications,
+        lambda: ctx,
+        stored.append,
+    )
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        fsm._tick()
+
+    assert fsm._stop.is_set()
+    assert ctx.notified_terminal
+    assert stored == [ctx]
 
 
 def test_supervisor_keeps_cache_when_progress_unchanged() -> None:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "packages/*/README.md",
     "pkg",
     "src/resources",
+    "integrations/hermes",
     "scripts/postinstall.js",
     "scripts/install.js",
     "scripts/install",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -230,6 +230,15 @@ if (shouldBypassManagedResourceMismatchGate(cliFlags.messages[0])) {
 }
 
 // ---------------------------------------------------------------------------
+// Hermes integration subcommand — `gsd hermes install`
+// ---------------------------------------------------------------------------
+if (cliFlags.messages[0] === 'hermes') {
+  const { runHermesIntegrationCommand } = await import('./hermes-integration-install.js')
+  const exitCode = await runHermesIntegrationCommand(process.argv)
+  process.exit(exitCode)
+}
+
+// ---------------------------------------------------------------------------
 // Graph subcommand — `gsd graph build|status|query|diff`
 // ---------------------------------------------------------------------------
 if (cliFlags.messages[0] === 'graph') {
@@ -321,6 +330,7 @@ const subcommandsExemptFromEarlyTtyCheck = new Set([
   'config',
   'graph',
   'headless',
+  'hermes',
   'read',
   'install',
   'list',

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -133,6 +133,24 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     '  gsd graph diff                         Show changes since last snapshot',
   ].join('\n'),
 
+  hermes: [
+    'Usage: gsd hermes install [options]',
+    '',
+    'Install the bundled open-gsd-hermes plugin into Hermes Agent.',
+    '',
+    'Options:',
+    '  --hermes-home <path>    Hermes home (default: $HERMES_HOME or ~/.hermes)',
+    '  --project <path>        Default GSD project to write into gsd.yaml',
+    '  --plugin-source <path>  Override bundled integrations/hermes source',
+    '  --skip-pip             Copy plugin only; do not pip install editable package',
+    '  --skip-enable          Do not run hermes plugins enable',
+    '  --dry-run              Print intended actions without writing',
+    '',
+    'Examples:',
+    '  gsd hermes install --project ~/code/myapp',
+    '  HERMES_HOME=~/.hermes gsd hermes install --skip-enable',
+  ].join('\n'),
+
   read: [
     'Usage: gsd read <progress|roadmap|memory> --json --project <path>',
     '',
@@ -236,6 +254,7 @@ export function printHelp(version: string): void {
   process.stdout.write('  auto [args]              Run auto-mode without TUI (pipeable)\n')
   process.stdout.write('  headless [cmd] [args]    Run /gsd commands without TUI (default: auto)\n')
   process.stdout.write('  graph <subcommand>       Manage knowledge graph (build, query, status, diff)\n')
+  process.stdout.write('  hermes install           Install the Hermes Agent plugin\n')
   process.stdout.write('\nRun gsd <subcommand> --help for subcommand-specific help.\n')
 }
 

--- a/src/hermes-integration-install.ts
+++ b/src/hermes-integration-install.ts
@@ -23,7 +23,12 @@ export interface HermesInstallResult {
 const PLUGIN_NAME = 'open-gsd-hermes'
 
 export async function runHermesIntegrationCommand(argv: string[]): Promise<number> {
-  const sub = argv[3]
+  const hermesIndex = argv.indexOf('hermes', 2)
+  if (hermesIndex === -1) {
+    printHermesHelp()
+    return 0
+  }
+  const sub = argv[hermesIndex + 1]
   if (!sub || sub === 'help' || sub === '--help' || sub === '-h') {
     printHermesHelp()
     return 0
@@ -36,7 +41,7 @@ export async function runHermesIntegrationCommand(argv: string[]): Promise<numbe
 
   let options: HermesInstallOptions
   try {
-    options = parseHermesInstallArgs(argv.slice(4))
+    options = parseHermesInstallArgs(argv.slice(hermesIndex + 2))
   } catch (err) {
     process.stderr.write(`[gsd] hermes install: ${err instanceof Error ? err.message : String(err)}\n`)
     return 1

--- a/src/hermes-integration-install.ts
+++ b/src/hermes-integration-install.ts
@@ -161,9 +161,13 @@ export function installHermesPlugin(options: HermesInstallOptions): HermesInstal
   return { pluginTarget, configPath, actions, warnings }
 }
 
+function quoteYamlScalar(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
 function renderGsdYaml(project: string | undefined): string {
   const defaultProject = project ?? '~/code/myapp'
-  return `# open-gsd-hermes configuration. Edit paths for your machine.\ngsd:\n  cli_path: gsd\n  mcp_server_path: gsd-mcp-server\n  credential_source: gsd\n  default_project: ${defaultProject}\n  poll_interval_seconds: 12\n  cache_ttl_seconds: 45\n  notification_level: normal\n  bindings: {}\n`
+  return `# open-gsd-hermes configuration. Edit paths for your machine.\ngsd:\n  cli_path: gsd\n  mcp_server_path: gsd-mcp-server\n  credential_source: gsd\n  default_project: ${quoteYamlScalar(defaultProject)}\n  poll_interval_seconds: 12\n  cache_ttl_seconds: 45\n  notification_level: normal\n  bindings: {}\n`
 }
 
 function findHermesPython(hermesHome: string): string {

--- a/src/hermes-integration-install.ts
+++ b/src/hermes-integration-install.ts
@@ -1,0 +1,203 @@
+import { existsSync, mkdirSync, rmSync, cpSync, writeFileSync, readFileSync } from 'node:fs'
+import { dirname, resolve, join, isAbsolute } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { homedir } from 'node:os'
+import { spawnSync } from 'node:child_process'
+
+export interface HermesInstallOptions {
+  hermesHome: string
+  pluginSource: string
+  project?: string
+  dryRun: boolean
+  skipPip: boolean
+  skipEnable: boolean
+}
+
+export interface HermesInstallResult {
+  pluginTarget: string
+  configPath: string
+  actions: string[]
+  warnings: string[]
+}
+
+const PLUGIN_NAME = 'open-gsd-hermes'
+
+export async function runHermesIntegrationCommand(argv: string[]): Promise<number> {
+  const sub = argv[3]
+  if (!sub || sub === 'help' || sub === '--help' || sub === '-h') {
+    printHermesHelp()
+    return 0
+  }
+  if (sub !== 'install') {
+    process.stderr.write(`[gsd] Unknown hermes command: ${sub}\n`)
+    printHermesHelp(process.stderr)
+    return 1
+  }
+
+  let options: HermesInstallOptions
+  try {
+    options = parseHermesInstallArgs(argv.slice(4))
+  } catch (err) {
+    process.stderr.write(`[gsd] hermes install: ${err instanceof Error ? err.message : String(err)}\n`)
+    return 1
+  }
+
+  try {
+    const result = installHermesPlugin(options)
+    for (const action of result.actions) process.stdout.write(`✓ ${action}\n`)
+    for (const warning of result.warnings) process.stderr.write(`[gsd] Warning: ${warning}\n`)
+    process.stdout.write(`\nHermes plugin installed at: ${result.pluginTarget}\n`)
+    process.stdout.write(`Config path: ${result.configPath}\n`)
+    process.stdout.write('Next: restart Hermes/gateway, then run `hermes plugins list` and `/gsd status`.\n')
+    return 0
+  } catch (err) {
+    process.stderr.write(`[gsd] hermes install failed: ${err instanceof Error ? err.message : String(err)}\n`)
+    return 1
+  }
+}
+
+export function parseHermesInstallArgs(args: string[]): HermesInstallOptions {
+  let hermesHome = process.env.HERMES_HOME || join(homedir(), '.hermes')
+  let pluginSource = process.env.GSD_HERMES_PLUGIN_SOURCE || findBundledHermesPluginSource()
+  let project: string | undefined
+  let dryRun = false
+  let skipPip = false
+  let skipEnable = false
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    const next = () => {
+      const value = args[++i]
+      if (!value) throw new Error(`${arg} requires a value`)
+      return value
+    }
+    if (arg === '--hermes-home') hermesHome = next()
+    else if (arg === '--plugin-source') pluginSource = next()
+    else if (arg === '--project') project = next()
+    else if (arg === '--dry-run') dryRun = true
+    else if (arg === '--skip-pip') skipPip = true
+    else if (arg === '--skip-enable') skipEnable = true
+    else throw new Error(`unknown option: ${arg}`)
+  }
+
+  return {
+    hermesHome: expandHome(hermesHome),
+    pluginSource: expandHome(pluginSource),
+    project: project ? resolve(expandHome(project)) : undefined,
+    dryRun,
+    skipPip,
+    skipEnable,
+  }
+}
+
+export function installHermesPlugin(options: HermesInstallOptions): HermesInstallResult {
+  const source = resolve(options.pluginSource)
+  if (!existsSync(join(source, 'plugin.yaml'))) {
+    throw new Error(`plugin source does not contain plugin.yaml: ${source}`)
+  }
+
+  const hermesHome = resolve(options.hermesHome)
+  const pluginRoot = join(hermesHome, 'plugins')
+  const pluginTarget = join(pluginRoot, PLUGIN_NAME)
+  const configPath = join(hermesHome, 'gsd.yaml')
+  const actions: string[] = []
+  const warnings: string[] = []
+
+  if (!options.dryRun) {
+    mkdirSync(pluginRoot, { recursive: true })
+    if (existsSync(pluginTarget)) {
+      rmSync(pluginTarget, { recursive: true, force: true })
+    }
+    cpSync(source, pluginTarget, {
+      recursive: true,
+      filter: (src) => !src.includes('__pycache__') && !src.includes('.pytest_cache'),
+    })
+  }
+  actions.push(`${options.dryRun ? 'Would copy' : 'Copied'} ${PLUGIN_NAME} into Hermes plugin directory`)
+
+  const config = renderGsdYaml(options.project)
+  if (!existsSync(configPath)) {
+    if (!options.dryRun) writeFileSync(configPath, config, 'utf8')
+    actions.push(`${options.dryRun ? 'Would create' : 'Created'} ${configPath}`)
+  } else if (!readFileSync(configPath, 'utf8').includes('gsd:')) {
+    warnings.push(`${configPath} exists but does not contain a gsd: section; merge the sample config from ${pluginTarget}/docs/setup.md`)
+  } else {
+    actions.push(`Left existing ${configPath} unchanged`)
+  }
+
+  if (!options.skipPip) {
+    const python = findHermesPython(hermesHome)
+    const pipArgs = ['-m', 'pip', 'install', '-e', pluginTarget]
+    if (options.dryRun) {
+      actions.push(`Would run ${python} ${pipArgs.join(' ')}`)
+    } else {
+      const pip = spawnSync(python, pipArgs, { stdio: 'pipe', encoding: 'utf8' })
+      if (pip.status !== 0) {
+        warnings.push(`Python package install failed with ${python}; Hermes may not import the plugin until you run: ${python} ${pipArgs.join(' ')}`)
+        if (pip.stderr.trim()) warnings.push(pip.stderr.trim().split('\n').slice(-3).join(' | '))
+      } else {
+        actions.push('Installed Python package into Hermes environment')
+      }
+    }
+  }
+
+  if (!options.skipEnable) {
+    if (options.dryRun) {
+      actions.push(`Would run HERMES_HOME=${hermesHome} hermes plugins enable ${PLUGIN_NAME}`)
+    } else {
+      const enable = spawnSync('hermes', ['plugins', 'enable', PLUGIN_NAME], {
+        stdio: 'pipe',
+        encoding: 'utf8',
+        env: { ...process.env, HERMES_HOME: hermesHome },
+      })
+      if (enable.status !== 0) {
+        warnings.push(`Could not auto-enable plugin; run manually: HERMES_HOME=${hermesHome} hermes plugins enable ${PLUGIN_NAME}`)
+      } else {
+        actions.push('Enabled plugin in Hermes')
+      }
+    }
+  }
+
+  return { pluginTarget, configPath, actions, warnings }
+}
+
+function renderGsdYaml(project: string | undefined): string {
+  const defaultProject = project ?? '~/code/myapp'
+  return `# open-gsd-hermes configuration. Edit paths for your machine.\ngsd:\n  cli_path: gsd\n  mcp_server_path: gsd-mcp-server\n  credential_source: gsd\n  default_project: ${defaultProject}\n  poll_interval_seconds: 12\n  cache_ttl_seconds: 45\n  notification_level: normal\n  bindings: {}\n`
+}
+
+function findHermesPython(hermesHome: string): string {
+  const suffix = process.platform === 'win32' ? join('Scripts', 'python.exe') : join('bin', 'python')
+  const bundled = join(hermesHome, 'hermes-agent', 'venv', suffix)
+  if (existsSync(bundled)) return bundled
+  return process.env.PYTHON || 'python3'
+}
+
+function findBundledHermesPluginSource(): string {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    resolve(process.cwd(), 'integrations/hermes'),
+    resolve(here, '../integrations/hermes'),
+    resolve(here, '../../integrations/hermes'),
+  ]
+  const found = candidates.find((candidate) => existsSync(join(candidate, 'plugin.yaml')))
+  return found ?? candidates[0]
+}
+
+function expandHome(value: string): string {
+  if (value === '~') return homedir()
+  if (value.startsWith('~/')) return join(homedir(), value.slice(2))
+  return isAbsolute(value) ? value : resolve(value)
+}
+
+function printHermesHelp(stream: NodeJS.WritableStream = process.stdout): void {
+  stream.write('Usage: gsd hermes install [options]\n')
+  stream.write('\nInstall the bundled open-gsd-hermes plugin into a Hermes Agent home.\n\n')
+  stream.write('Options:\n')
+  stream.write('  --hermes-home <path>    Hermes home (default: $HERMES_HOME or ~/.hermes)\n')
+  stream.write('  --project <path>        Default GSD project to write into gsd.yaml\n')
+  stream.write('  --plugin-source <path>  Override bundled integrations/hermes source\n')
+  stream.write('  --skip-pip             Copy plugin only; do not pip install editable package\n')
+  stream.write('  --skip-enable          Do not run hermes plugins enable\n')
+  stream.write('  --dry-run              Print intended actions without writing\n')
+}

--- a/src/tests/hermes-integration-install.test.ts
+++ b/src/tests/hermes-integration-install.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { installHermesPlugin, parseHermesInstallArgs } from '../hermes-integration-install.ts'
+
+test('parseHermesInstallArgs resolves Hermes home and project paths', () => {
+  const opts = parseHermesInstallArgs([
+    '--hermes-home', './tmp-hermes',
+    '--plugin-source', './integrations/hermes',
+    '--project', './project',
+    '--skip-pip',
+    '--skip-enable',
+  ])
+
+  assert.ok(opts.hermesHome.endsWith('tmp-hermes'))
+  assert.ok(opts.pluginSource.endsWith('integrations/hermes'))
+  assert.ok(opts.project?.endsWith('project'))
+  assert.equal(opts.skipPip, true)
+  assert.equal(opts.skipEnable, true)
+})
+
+test('installHermesPlugin copies plugin and writes starter gsd.yaml', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-hermes-install-'))
+  const source = join(root, 'source')
+  const hermesHome = join(root, 'hermes-home')
+  const project = join(root, 'project')
+  mkdirSync(source, { recursive: true })
+  mkdirSync(project, { recursive: true })
+  writeFileSync(join(source, 'plugin.yaml'), 'name: open-gsd-hermes\n')
+  writeFileSync(join(source, 'README.md'), '# plugin\n')
+
+  const result = installHermesPlugin({
+    hermesHome,
+    pluginSource: source,
+    project,
+    dryRun: false,
+    skipPip: true,
+    skipEnable: true,
+  })
+
+  assert.equal(result.pluginTarget, join(hermesHome, 'plugins', 'open-gsd-hermes'))
+  assert.equal(existsSync(join(result.pluginTarget, 'plugin.yaml')), true)
+  const config = readFileSync(result.configPath, 'utf8')
+  assert.match(config, /gsd:/)
+  assert.ok(config.includes(project))
+})
+
+test('installHermesPlugin leaves existing config unchanged', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-hermes-install-'))
+  const source = join(root, 'source')
+  const hermesHome = join(root, 'hermes-home')
+  mkdirSync(source, { recursive: true })
+  mkdirSync(hermesHome, { recursive: true })
+  writeFileSync(join(source, 'plugin.yaml'), 'name: open-gsd-hermes\n')
+  writeFileSync(join(hermesHome, 'gsd.yaml'), 'gsd:\n  default_project: /existing\n')
+
+  const result = installHermesPlugin({
+    hermesHome,
+    pluginSource: source,
+    dryRun: false,
+    skipPip: true,
+    skipEnable: true,
+  })
+
+  assert.equal(readFileSync(result.configPath, 'utf8'), 'gsd:\n  default_project: /existing\n')
+  assert.ok(result.actions.some((action) => action.includes('Left existing')))
+})


### PR DESCRIPTION
Recovered from deleted branch `feat/hermes-integration` / PR #368.

## Changes
- **Polish Hermes integration review fixes** (b0abecfa)
  - Align docs with 2.53 release train
  - Document binding precedence and executable wrapper guidance
  - Make read CLI contract explicitly skip when loader is missing
  - Harden cancel/supervisor behavior around active-session project selection, terminal notification, and blocker changes

- **Native Hermes plugin installer** (1e681240)
  - New `gsd hermes install` CLI command
  - Copies bundled plugin, installs Python package, creates starter config, enables plugin
  - Full test coverage

## Verification
- [x] Commits recovered from GitHub dangling refs
- [x] Rebased onto current main (no conflicts)
- [x] Diff matches original PR #368 (+548/-28 lines, 15 files)

Closes #368 (superseded)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway supervision, cancel targeting, and a new installer that runs pip/hermes subprocesses; risk is moderated by tests and mostly local Hermes home side effects rather than core GSD runtime paths.
> 
> **Overview**
> Adds **`gsd hermes install`** so npm users can copy the bundled `open-gsd-hermes` plugin into `$HERMES_HOME`, optionally pip-install it, seed `gsd.yaml`, and enable the plugin. The Hermes integration is **shipped in the npm package** (`integrations/hermes` in `files`), with CLI wiring, help text, and install tests.
> 
> **Hermes plugin behavior and release train:** default supported `gsd` range moves to **>=2.53,<3**; config resolves under **`HERMES_HOME`** (with **`HERMES_GSD_CONFIG`** override). **`/gsd cancel`** targets the **active supervisor session’s project** instead of re-resolving bind/default. The **supervisor** avoids self-join on stop, still sends **terminal notifications when progress read fails**, and notifies on **blocker ID changes** while already blocked.
> 
> Docs and the integration plan are updated for the one-command install path and refined **project binding precedence** (slash arg and session bind ordering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af06c7ea5202ea5ae6d93e33be7d5a858b67f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->