### PR TITLE
[codex] Fix cloud runtime stale connection sweep

### DIFF
--- a/packages/cloud-mcp-gateway/src/runtime-registry.test.ts
+++ b/packages/cloud-mcp-gateway/src/runtime-registry.test.ts
@@ -9,9 +9,9 @@ class FakeSocket extends EventEmitter {
   send(payload: string): void {
     this.sent.push(JSON.parse(payload) as unknown);
   }
-  close(): void {
+  close(code?: number, reason?: string): void {
     this.readyState = 3;
-    this.emit("close");
+    this.emit("close", code, reason);
   }
 }
 
@@ -79,4 +79,87 @@ test("runtime registry rejects in-flight calls when runtime disconnects", async 
   const rejection = assert.rejects(call, /Local GSD Runtime disconnected: rt1 while waiting for gsd_status/);
   socket.close();
   await rejection;
+});
+
+test("sweepStaleConnections closes sockets with lastSeenAt older than 60s and removes from registry", () => {
+  const offlineCalls: string[] = [];
+  const registry = new RuntimeRegistry({
+    onOffline: (runtimeId) => offlineCalls.push(runtimeId),
+  });
+  const socket = new FakeSocket();
+  registry.attachRuntime({ userId: "u1", runtimeId: "rt1", socket: socket as never });
+  socket.emit("message", JSON.stringify({
+    type: "hello",
+    runtimeId: "rt1",
+    projects: [{ alias: "app", repoIdentity: "abc123" }],
+  }));
+  const lastSeenAt = registry.listProjects("u1")[0]!.lastSeenAt;
+
+  registry.sweepStaleConnections(60_000, lastSeenAt + 60_001);
+
+  assert.equal(socket.readyState, 3, "Socket should be closed");
+  assert.deepEqual(registry.listProjects("u1"), [], "Runtime should be removed from registry");
+  assert.deepEqual(offlineCalls, ["rt1"], "onOffline should be called for evicted runtime");
+});
+
+test("sweepStaleConnections does NOT close sockets with recent lastSeenAt", () => {
+  const offlineCalls: string[] = [];
+  const registry = new RuntimeRegistry({
+    onOffline: (runtimeId) => offlineCalls.push(runtimeId),
+  });
+  const socket = new FakeSocket();
+  registry.attachRuntime({ userId: "u1", runtimeId: "rt1", socket: socket as never });
+  socket.emit("message", JSON.stringify({
+    type: "hello",
+    runtimeId: "rt1",
+    projects: [{ alias: "app", repoIdentity: "abc123" }],
+  }));
+  const lastSeenAt = registry.listProjects("u1")[0]!.lastSeenAt;
+
+  registry.sweepStaleConnections(60_000, lastSeenAt + 59_999);
+
+  assert.equal(socket.readyState, 1, "Socket should remain open");
+  assert.equal(offlineCalls.length, 0, "onOffline should NOT be called");
+});
+
+test("sweepStaleConnections calls onOffline callback for each evicted runtime", () => {
+  const offlineCalls: string[] = [];
+  const registry = new RuntimeRegistry({
+    onOffline: (runtimeId) => offlineCalls.push(runtimeId),
+  });
+  const s1 = new FakeSocket();
+  const s2 = new FakeSocket();
+  registry.attachRuntime({ userId: "u1", runtimeId: "rt1", socket: s1 as never });
+  registry.attachRuntime({ userId: "u1", runtimeId: "rt2", socket: s2 as never });
+  const sweepAt = Date.now() + 60_001;
+
+  registry.sweepStaleConnections(60_000, sweepAt);
+
+  assert.equal(offlineCalls.length, 2);
+  assert.ok(offlineCalls.includes("rt1"));
+  assert.ok(offlineCalls.includes("rt2"));
+});
+
+test("attachRuntime calls onOnline callback", () => {
+  const onlineCalls: string[] = [];
+  const registry = new RuntimeRegistry({
+    onOnline: (runtimeId) => onlineCalls.push(runtimeId),
+  });
+  const socket = new FakeSocket();
+  registry.attachRuntime({ userId: "u1", runtimeId: "rt1", socket: socket as never });
+
+  assert.deepEqual(onlineCalls, ["rt1"], "onOnline should be called with runtimeId on attachRuntime");
+});
+
+test("socket close event calls onOffline callback", () => {
+  const offlineCalls: string[] = [];
+  const registry = new RuntimeRegistry({
+    onOffline: (runtimeId) => offlineCalls.push(runtimeId),
+  });
+  const socket = new FakeSocket();
+  registry.attachRuntime({ userId: "u1", runtimeId: "rt1", socket: socket as never });
+
+  socket.close();
+
+  assert.deepEqual(offlineCalls, ["rt1"], "onOffline should be called on socket close");
 });

--- a/packages/cloud-mcp-gateway/src/runtime-registry.ts
+++ b/packages/cloud-mcp-gateway/src/runtime-registry.ts
@@ -34,10 +34,17 @@ export interface GatewayToolCall {
   signal?: AbortSignal;
 }
 
+export interface RuntimeRegistryOptions {
+  onOnline?: (runtimeId: string) => void;
+  onOffline?: (runtimeId: string) => void;
+}
+
 export class RuntimeRegistry {
   private readonly runtimes = new Map<string, RuntimeConnection>();
   private readonly pending = new Map<string, PendingCall>();
   private readonly projectQueues = new Map<string, Promise<unknown>>();
+
+  constructor(private readonly options: RuntimeRegistryOptions = {}) {}
 
   attachRuntime(params: {
     userId: string;
@@ -60,16 +67,24 @@ export class RuntimeRegistry {
       lastSeenAt: Date.now(),
     };
     this.runtimes.set(params.runtimeId, runtime);
+    this.options.onOnline?.(params.runtimeId);
 
     params.socket.on("message", (data) => {
       this.handleMessage(params.runtimeId, data.toString("utf8"));
     });
     params.socket.on("close", () => {
       if (this.runtimes.get(params.runtimeId)?.socket === params.socket) {
-        this.runtimes.delete(params.runtimeId);
-        this.failPendingForRuntime(params.runtimeId, `Local GSD Runtime disconnected: ${params.runtimeId}`);
+        this.detachRuntime(params.runtimeId);
       }
     });
+  }
+
+  sweepStaleConnections(maxIdleMs: number, now = Date.now()): void {
+    for (const runtime of this.runtimes.values()) {
+      if (now - runtime.lastSeenAt < maxIdleMs) continue;
+      this.detachRuntime(runtime.runtimeId);
+      runtime.socket.close(4000, "stale");
+    }
   }
 
   listProjects(userId: string): CloudProjectRecord[] {
@@ -243,5 +258,11 @@ export class RuntimeRegistry {
       pending.removeAbortListener();
       pending.reject(new Error(`${message} while waiting for ${pending.toolName}`));
     }
+  }
+
+  private detachRuntime(runtimeId: string): void {
+    this.runtimes.delete(runtimeId);
+    this.failPendingForRuntime(runtimeId, `Local GSD Runtime disconnected: ${runtimeId}`);
+    this.options.onOffline?.(runtimeId);
   }
 }


### PR DESCRIPTION
## TL;DR

**What:** Adds runtime registry lifecycle callbacks and stale connection sweeping for the cloud MCP gateway.
**Why:** The heartbeat sweep tests expected typed online/offline hooks and stale runtime eviction, but the registry did not expose that contract.
**How:** Adds optional registry callbacks, centralizes runtime detachment cleanup, and sweeps runtimes whose `lastSeenAt` exceeds the configured idle threshold.

## What

This updates `packages/cloud-mcp-gateway/src/runtime-registry.ts` to support optional `onOnline` and `onOffline` callbacks, expose `sweepStaleConnections`, and share disconnect cleanup through a private `detachRuntime` helper.

It also updates `packages/cloud-mcp-gateway/src/runtime-registry.test.ts` to cover stale eviction, recent runtime preservation, multi-runtime offline callbacks, online callbacks, and socket close offline callbacks.

## Why

The package build failed because the tests exercised a registry constructor option and `sweepStaleConnections` method that did not exist. The runtime registry also duplicated some disconnect cleanup logic, making lifecycle notification a natural fit for one shared detach path.

## How

`sweepStaleConnections(maxIdleMs, now = Date.now())` compares each runtime's `lastSeenAt` against the threshold, detaches stale runtimes, closes their sockets, rejects pending calls, and fires `onOffline` once through shared cleanup. The optional `now` parameter keeps tests deterministic while preserving the default runtime behavior.

## Validation

- `pnpm --filter @opengsd/cloud-mcp-gateway run build` failed before the fix with the reported TypeScript errors.
- `pnpm --filter @opengsd/cloud-mcp-gateway run test` passes after the fix: 20/20 tests.
- Sabotage check: temporarily inverted the stale sweep predicate; the three sweep tests failed, then passed again after restoring the implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway WebSocket lifecycle and can forcibly disconnect idle runtimes and reject in-flight tool calls; scope is limited to cloud-mcp-gateway registry behavior.
> 
> **Overview**
> Adds **stale runtime eviction** and **lifecycle hooks** to `RuntimeRegistry` so the gateway can drop idle local runtimes and notify when they connect or disconnect.
> 
> `RuntimeRegistry` now accepts optional `onOnline` / `onOffline` callbacks, calls `onOnline` on `attachRuntime`, and routes socket close and stale eviction through a shared `detachRuntime` helper that removes the runtime, rejects pending tool calls, and invokes `onOffline`. New **`sweepStaleConnections(maxIdleMs, now?)`** evicts runtimes whose `lastSeenAt` exceeds the idle threshold, closes their WebSockets with code `4000` (`"stale"`), and uses an injectable `now` for tests.
> 
> Tests cover stale vs. recent `lastSeenAt`, multi-runtime offline notifications, and online/offline callbacks on attach and close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb09d71badaad1d8c1da3dada0ff30c9dfa3216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->