### PR TITLE
fix(mcp): stop terminal server failures retrying forever + reap spinning orphans (#783)

### DIFF
--- a/packages/mcp-server/src/cli-errors.ts
+++ b/packages/mcp-server/src/cli-errors.ts
@@ -5,6 +5,7 @@ interface GlobalErrorRuntime {
   stderr: {
     write(message: string): unknown;
   };
+  exit(code: number): never;
 }
 
 export function formatUnknownError(error: unknown): string {
@@ -14,12 +15,24 @@ export function formatUnknownError(error: unknown): string {
   return String(error);
 }
 
-export function installGlobalErrorHandlers(runtime: GlobalErrorRuntime = process as GlobalErrorRuntime): void {
+/**
+ * Install process-global error handlers that log and then terminate.
+ *
+ * A repeating throw against a dead stdio transport (e.g. an orphaned server
+ * whose parent pipe has closed) would otherwise log-and-loop, pegging the CPU
+ * indefinitely because the handler returns without exiting. Terminating after
+ * logging guarantees the process crashes out of the loop; the client (Claude
+ * Code) owns restart/backoff, and the PID registry sweep cleans up the stale
+ * entry on the next spawn. See #783.
+ */
+export function installGlobalErrorHandlers(runtime: GlobalErrorRuntime = process as unknown as GlobalErrorRuntime): void {
   runtime.on('uncaughtException', (error) => {
     runtime.stderr.write(`[gsd-mcp-server] Uncaught exception: ${formatUnknownError(error)}\n`);
+    runtime.exit(1);
   });
 
   runtime.on('unhandledRejection', (reason) => {
     runtime.stderr.write(`[gsd-mcp-server] Unhandled rejection: ${formatUnknownError(reason)}\n`);
+    runtime.exit(1);
   });
 }

--- a/packages/mcp-server/src/cli-runner.test.ts
+++ b/packages/mcp-server/src/cli-runner.test.ts
@@ -496,13 +496,100 @@ describe('runMcpServerCli', () => {
       isOrphaned: () => true,
     });
 
-    assert.equal(intervals.length, 1);
+    assert.equal(intervals.length, 2);
     stdin.write('{"jsonrpc":"2.0","method":"initialize"}\n');
     now = 1_000;
-    intervals[0]();
+    for (const tick of intervals) tick();
 
     assert.ok(!calls.includes('exit:0'));
     assert.ok(!calls.includes('unregister:/workspace/project'));
+  });
+
+  test('self-terminates on parent loss once stdin goes idle (#783)', async () => {
+    const calls: string[] = [];
+    const intervals: Array<() => void> = [];
+    const stdin = new PassThrough();
+    let now = 0;
+    let resolveExit!: (code: number) => void;
+    const exitPromise = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+
+    await runMcpServerCli({
+      cwd: () => '/workspace/project',
+      env: {},
+      exit(code) {
+        calls.push(`exit:${code}`);
+        resolveExit(code);
+        return undefined as never;
+      },
+      loadStoredCredentialEnvKeys() {},
+      registerMcpInstance(projectDir) {
+        calls.push(`register:${projectDir}`);
+      },
+      sweepProjectOrphanMcpServers() {},
+      unregisterMcpInstance(projectDir) {
+        calls.push(`unregister:${projectDir}`);
+      },
+      createSessionManager() {
+        return {
+          async cleanup() {
+            calls.push('cleanup-session-manager');
+          },
+        };
+      },
+      async createMcpServer() {
+        return {
+          server: {
+            async connect() {
+              calls.push('connect');
+            },
+            async close() {
+              calls.push('close-server');
+            },
+          },
+        };
+      },
+      async importStdioServerTransport() {
+        return {
+          StdioServerTransport: class {},
+        };
+      },
+      warmWorkflowToolBridges() {},
+      stdin,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      onSignal() {},
+      now: () => now,
+      setInterval(callback: Parameters<typeof setInterval>[0]) {
+        intervals.push(callback as () => void);
+        return { unref() {} } as ReturnType<typeof setInterval>;
+      },
+      clearInterval() {
+        calls.push('clear-interval');
+      },
+      isOrphaned: () => true,
+    });
+
+    // Two timers are scheduled: the idle watchdog and the orphan monitor.
+    assert.equal(intervals.length, 2);
+
+    // First, an active session must NOT exit even though the parent is gone.
+    stdin.write('{"jsonrpc":"2.0","method":"initialize"}\n');
+    now = 1_000;
+    for (const tick of intervals) tick();
+    assert.ok(!calls.includes('exit:0'), 'active session must survive parent loss');
+
+    // Then, once stdin has been idle past the 5-minute gate, the orphan monitor
+    // self-terminates the process — independent of the external sweep.
+    now = 1_000 + 6 * 60 * 1000;
+    for (const tick of intervals) tick();
+
+    assert.equal(await waitFor(exitPromise), 0);
+    assert.ok(calls.includes('unregister:/workspace/project'));
+    assert.ok(calls.includes('cleanup-session-manager'));
+    assert.ok(calls.includes('close-server'));
+    assert.ok(calls.includes('exit:0'));
   });
 
   test('exits shutdown when server close hangs', async () => {

--- a/packages/mcp-server/src/cli-runner.ts
+++ b/packages/mcp-server/src/cli-runner.ts
@@ -18,6 +18,19 @@ const STDIN_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const STDIN_IDLE_CHECK_INTERVAL_MS = 60 * 1000;
 const CLEANUP_STEP_TIMEOUT_MS = 2 * 1000;
 
+/**
+ * Cadence for the ref-held parent-liveness monitor.
+ *
+ * Separate from the `.unref()`'d idle watchdog: a process already pegged at
+ * ~100% CPU starves its event loop, so the watchdog timer may never fire and a
+ * spinning orphan lingers until the next spawn sweeps it. This monitor is
+ * ref-held (NOT `.unref()`'d) so the libuv loop keeps scheduling it under load,
+ * and it exits the process itself the moment the parent is gone — independent
+ * of the external PID-registry sweep that only runs on the next launch. See
+ * #783.
+ */
+const ORPHAN_PARENT_LOSS_CHECK_INTERVAL_MS = 10 * 1000;
+
 interface SessionManagerLike {
   cleanup(): Promise<void>;
 }
@@ -101,6 +114,7 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
   let registered = false;
   let cleaningUp = false;
   let idleWatchdog: ReturnType<typeof setInterval> | undefined;
+  let orphanMonitor: ReturnType<typeof setInterval> | undefined;
   let trackedStdin: ActivityTrackingInput | undefined;
   let sessionManager: SessionManagerLike | undefined;
   let server: McpServerLike | undefined;
@@ -126,6 +140,7 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
 
   async function stopRuntime(): Promise<void> {
     if (idleWatchdog) stopInterval(idleWatchdog);
+    if (orphanMonitor) stopInterval(orphanMonitor);
     trackedStdin?.close();
     if (registered) unregisterInstance(projectDir);
     await runCleanupStep('session manager cleanup', () => sessionManager?.cleanup());
@@ -171,6 +186,25 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
       }
     }, STDIN_IDLE_CHECK_INTERVAL_MS);
     idleWatchdog.unref();
+
+    // Ref-held parent-liveness monitor (#783). The idle watchdog above is
+    // `.unref()`'d, so a process pegged at ~100% CPU (e.g. a repeating throw
+    // against a dead stdio pipe) starves its event loop and the watchdog never
+    // fires — the orphan spins until the next launch sweeps it. This monitor is
+    // NOT unref'd: the loop keeps scheduling it under load, so parent loss is
+    // detected in seconds regardless of CPU state. It still requires the same
+    // idle gate as the watchdog so an active session whose parent briefly
+    // appears gone is not killed (#783 "stays alive when parent is gone but
+    // stdin is still active").
+    orphanMonitor = startInterval(() => {
+      if (!isOrphaned()) return;
+      const idleMs = trackedStdin ? now() - trackedStdin.lastActivityAt() : 0;
+      if (idleMs <= STDIN_IDLE_TIMEOUT_MS) return;
+      stderr.write(
+        `[gsd-mcp-server] Parent process is gone; shutting down to avoid orphan spin\n`,
+      );
+      void cleanup();
+    }, ORPHAN_PARENT_LOSS_CHECK_INTERVAL_MS);
 
     // Fail closed (ADR-036): warm the executor / write-gate bridges BEFORE
     // connecting the transport. If a bridge is broken we must not advertise the

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -30,10 +30,12 @@ import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
 
 describe('installGlobalErrorHandlers', () => {
-  it('logs uncaught exceptions and unhandled rejections to stderr', () => {
+  it('logs uncaught exceptions and unhandled rejections to stderr, then terminates (#783)', () => {
     const writes: string[] = [];
+    const exits: number[] = [];
     const runtime = new EventEmitter() as EventEmitter & {
       stderr: { write(message: string): boolean };
+      exit: (code: number) => never;
     };
     runtime.stderr = {
       write(message: string): boolean {
@@ -41,14 +43,23 @@ describe('installGlobalErrorHandlers', () => {
         return true;
       },
     };
+    runtime.exit = (code: number): never => {
+      exits.push(code);
+      // Throw to short-circuit the handler so assertions run, mirroring how
+      // process.exit never returns in the real process.
+      throw new Error(`exit:${code}`);
+    };
 
     installGlobalErrorHandlers(runtime);
-    runtime.emit('uncaughtException', new Error('boom'));
-    runtime.emit('unhandledRejection', 'bad rejection');
+    assert.throws(() => runtime.emit('uncaughtException', new Error('boom')), /exit:1/);
+    assert.throws(() => runtime.emit('unhandledRejection', 'bad rejection'), /exit:1/);
 
     const output = writes.join('');
     assert.match(output, /\[gsd-mcp-server\] Uncaught exception: Error: boom/);
     assert.match(output, /\[gsd-mcp-server\] Unhandled rejection: bad rejection/);
+    // Each handler must terminate after logging — a repeating throw against a
+    // dead stdio pipe would otherwise log-and-loop, pegging CPU (#783).
+    assert.deepEqual(exits, [1, 1]);
   });
 });
 

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -10,7 +10,7 @@
  * @see https://github.com/open-gsd/gsd-pi/issues/2577
  */
 
-import { TOOL_SURFACE_NOT_READY } from "./tool-surface-readiness.js";
+import { TOOL_SURFACE_NOT_READY, isTerminalToolSurfaceError } from "./tool-surface-readiness.js";
 
 // ── ErrorClass discriminated union ──────────────────────────────────────────
 
@@ -114,7 +114,20 @@ export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorCla
     return { kind: "tool-schema", retryAfterMs: 0 };
   }
 
+  // Terminal tool-surface failure: the workflow MCP server is in a
+  // non-self-healing status (failed / needs-auth / disabled). This is NOT
+  // transient — retrying the same model cannot repair a dead server, so it
+  // must escalate / pause rather than retrying every ~3s into the per-unit
+  // cost cap. Checked ahead of the transient readiness branch below, which
+  // shares the TOOL_SURFACE_NOT_READY prefix and would otherwise collapse the
+  // terminal case into a transient `network` retry. See #783.
+  if (isTerminalToolSurfaceError(errorMsg)) {
+    return { kind: "permanent" };
+  }
+
   // Tool-surface readiness abort — transient; retry the same model shortly.
+  // This covers the not-yet-connected variants (absent, pending, connected but
+  // not registered); terminal statuses were handled by the branch above.
   if (TOOL_SURFACE_NOT_READY_RE.test(errorMsg)) {
     return { kind: "network", retryAfterMs: retryAfterMs ?? 3_000 };
   }

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -4,6 +4,7 @@
 import { isToolUnavailableError } from "./auto-tool-tracking.js";
 import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
 import { recoveryRemediation } from "./guidance.js";
+import { isTerminalToolSurfaceError } from "./tool-surface-readiness.js";
 import { ReconciliationFailedError } from "./state-reconciliation.js";
 import { IllegalPhaseTransitionError } from "./state-transition-matrix.js";
 
@@ -94,6 +95,12 @@ const FAILURE_TAXONOMY: Record<
 };
 
 function inferFailureKind(message: string): RecoveryFailureKind {
+  // A terminal tool-surface failure (workflow MCP server in failed/needs-auth/
+  // disabled) will not self-heal, so it must escalate rather than retry the
+  // same model into the per-unit cost cap. Checked before the generic
+  // tool-unavailable branch, which matches the same readiness prefix and
+  // would otherwise route it to retry. See #783.
+  if (isTerminalToolSurfaceError(message)) return "runtime-unknown";
   if (isToolUnavailableError(message)) return "tool-unavailable";
   if (/tool contract|auto-unit tool scope|phase-boundary gate|not permitted.*own/i.test(message)) return "tool-contract";
   if (/lifecycle progression|required artifact|missing .*assessment|missing .*closeout|cannot legally (?:advance|progress)/i.test(message)) return "lifecycle-progression";

--- a/src/resources/extensions/gsd/tests/terminal-tool-surface-classification.test.ts
+++ b/src/resources/extensions/gsd/tests/terminal-tool-surface-classification.test.ts
@@ -1,0 +1,80 @@
+// Project/App: gsd-pi
+// File Purpose: Contract coverage for terminal tool-surface failure classification (#783).
+//
+// A terminal MCP server status (failed / needs-auth / disabled) must not be
+// classified as transient — retrying the same model cannot repair a dead
+// server and burns retries until the per-unit cost cap pauses auto-mode.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isTerminalToolSurfaceError, getToolSurfaceReadinessError, TOOL_SURFACE_NOT_READY } from "../tool-surface-readiness.ts";
+import { classifyError, isTransient } from "../error-classifier.ts";
+
+const SERVER = "gsd-workflow";
+
+function readinessFor(status: string): string {
+  return getToolSurfaceReadinessError({
+    unitType: "run-uat",
+    workflowServerName: SERVER,
+    observation: { tools: ["read"], mcpServers: [{ name: SERVER, status }] },
+  })!;
+}
+
+describe("isTerminalToolSurfaceError", () => {
+  test("recognizes every canonical terminal status", () => {
+    for (const status of ["failed", "needs-auth", "disabled"]) {
+      const error = readinessFor(status);
+      assert.ok(error, `expected a readiness error for status=${status}`);
+      assert.equal(
+        isTerminalToolSurfaceError(error),
+        true,
+        `status=${status} should be terminal`,
+      );
+    }
+  });
+
+  test("returns false for genuinely transient (not-yet-connected) variants", () => {
+    assert.equal(isTerminalToolSurfaceError(readinessFor("pending")), false);
+    assert.equal(isTerminalToolSurfaceError(readinessFor("connected")), false);
+    assert.equal(isTerminalToolSurfaceError(readinessFor("connecting")), false);
+  });
+
+  test("returns false for non-readiness and unrelated messages", () => {
+    assert.equal(isTerminalToolSurfaceError(null), false);
+    assert.equal(isTerminalToolSurfaceError(undefined), false);
+    assert.equal(isTerminalToolSurfaceError(""), false);
+    assert.equal(isTerminalToolSurfaceError("some unrelated network error"), false);
+    // A bare "(terminal)" without a real readiness prefix/status must not trip.
+    assert.equal(isTerminalToolSurfaceError("something (terminal) happened"), false);
+  });
+
+  test("the readiness prefix alone (without the terminal marker) is not terminal", () => {
+    const transientMessage = `${TOOL_SURFACE_NOT_READY} for run-uat: MCP server "${SERVER}" is absent from the init surface (not yet connected): gsd_uat_exec`;
+    assert.equal(isTerminalToolSurfaceError(transientMessage), false);
+  });
+});
+
+describe("classifyError terminal readiness contract (#783)", () => {
+  test("every terminal status classifies as non-transient permanent", () => {
+    for (const status of ["failed", "needs-auth", "disabled"]) {
+      const cls = classifyError(`Claude Code error: ${readinessFor(status)}`);
+      assert.equal(isTransient(cls), false, `status=${status} must not be transient`);
+      assert.equal(cls.kind, "permanent", `status=${status} must classify as permanent`);
+    }
+  });
+
+  test("transient not-yet-connected variants still classify as transient network", () => {
+    const cls = classifyError(`Claude Code error: ${readinessFor("pending")}`);
+    assert.equal(isTransient(cls), true);
+    assert.equal(cls.kind, "network");
+  });
+
+  test("terminal branch is matched ahead of the shared transient prefix branch", () => {
+    // The failed-status message shares the TOOL_SURFACE_NOT_READY prefix with
+    // the transient branches. If ordering regressed, this would be `network`.
+    const cls = classifyError(readinessFor("needs-auth"));
+    assert.notEqual(cls.kind, "network");
+    assert.equal(cls.kind, "permanent");
+  });
+});

--- a/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-surface-readiness.test.ts
@@ -305,23 +305,42 @@ describe("awaitWorkflowMcpToolRegistration", () => {
 });
 
 describe("readiness error classification contract", () => {
-  const readinessError = getToolSurfaceReadinessError({
+  const terminalReadinessError = getToolSurfaceReadinessError({
     unitType: "run-uat",
     workflowServerName: SERVER,
     observation: { tools: [], mcpServers: [{ name: SERVER, status: "failed" }] },
   })!;
+  const transientReadinessError = getToolSurfaceReadinessError({
+    unitType: "run-uat",
+    workflowServerName: SERVER,
+    observation: { tools: [], mcpServers: [{ name: SERVER, status: "pending" }] },
+  })!;
 
-  test("auto-tool-tracking treats the readiness error as tool-unavailable", () => {
-    assert.equal(isToolUnavailableError(readinessError), true);
+  test("auto-tool-tracking treats both readiness error variants as tool-unavailable", () => {
+    assert.equal(isToolUnavailableError(terminalReadinessError), true);
+    assert.equal(isToolUnavailableError(transientReadinessError), true);
   });
 
-  test("error-classifier treats the readiness error as transient", () => {
-    const cls = classifyError(`Claude Code error: ${readinessError}`);
+  test("error-classifier treats a TERMINAL readiness error as non-transient (#783)", () => {
+    const cls = classifyError(`Claude Code error: ${terminalReadinessError}`);
+    assert.equal(isTransient(cls), false);
+    assert.equal(cls.kind, "permanent");
+  });
+
+  test("error-classifier still treats a TRANSIENT readiness error as transient", () => {
+    const cls = classifyError(`Claude Code error: ${transientReadinessError}`);
     assert.equal(isTransient(cls), true);
+    assert.equal(cls.kind, "network");
   });
 
-  test("Recovery Classification maps the readiness error to tool-unavailable → retry", () => {
-    const recovery = classifyFailure({ error: new Error(readinessError), unitType: "run-uat", unitId: "M001" });
+  test("Recovery Classification escalates a TERMINAL readiness error instead of retrying (#783)", () => {
+    const recovery = classifyFailure({ error: new Error(terminalReadinessError), unitType: "run-uat", unitId: "M001" });
+    assert.equal(recovery.action, "escalate");
+    assert.notEqual(recovery.failureKind, "tool-unavailable");
+  });
+
+  test("Recovery Classification still retries a TRANSIENT readiness error", () => {
+    const recovery = classifyFailure({ error: new Error(transientReadinessError), unitType: "run-uat", unitId: "M001" });
     assert.equal(recovery.failureKind, "tool-unavailable");
     assert.equal(recovery.action, "retry");
     assert.equal(recovery.exitReason, "tool-unavailable");

--- a/src/resources/extensions/gsd/tool-surface-readiness.ts
+++ b/src/resources/extensions/gsd/tool-surface-readiness.ts
@@ -24,7 +24,39 @@ import { isWorkflowToolSurfaceName } from "./workflow-tool-surface.js";
 export const TOOL_SURFACE_NOT_READY = "workflow tool surface not ready";
 
 /** MCP server statuses that will not self-heal within the session. */
-const TERMINAL_MCP_SERVER_STATUSES = new Set(["failed", "needs-auth", "disabled"]);
+export const TERMINAL_MCP_SERVER_STATUSES = new Set(["failed", "needs-auth", "disabled"]);
+
+/**
+ * Marker embedded in the terminal readiness error message. The readiness layer
+ * appends it to the terminal branch so the classifier can distinguish a
+ * non-self-healing failure (failed/needs-auth/disabled) from the genuinely
+ * transient not-yet-connected branches, which all share the
+ * {@link TOOL_SURFACE_NOT_READY} prefix.
+ */
+export const TOOL_SURFACE_TERMINAL_MARKER = "(terminal)";
+
+/**
+ * True when a tool-surface readiness error describes a *terminal* MCP server
+ * failure (failed / needs-auth / disabled). These statuses will not self-heal
+ * within the session, so they must not be retried as transient — the caller
+ * should escalate / pause instead of same-model retrying indefinitely.
+ *
+ * Detection is driven by the embedded marker string and the terminal status
+ * set above (single source of truth), not by re-deriving either independently.
+ */
+export function isTerminalToolSurfaceError(errorMsg: string | null | undefined): boolean {
+  if (!errorMsg || !errorMsg.includes(TOOL_SURFACE_NOT_READY)) return false;
+  if (!/\bterminal\b/i.test(errorMsg)) return false;
+  // Belt-and-braces: confirm one of the canonical terminal statuses is present
+  // so a stray "(terminal)" in unrelated text doesn't trigger this.
+  return [...TERMINAL_MCP_SERVER_STATUSES].some(
+    (status) => new RegExp(`status is "${escapeRegExp(status)}"`, "i").test(errorMsg),
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 export interface LiveToolSurfaceObservation {
   /** Tool names the session reported at init (MCP tools appear as mcp__<server>__<tool>). */


### PR DESCRIPTION
Closes #783.

Implements both agent briefs posted on the issue.

## Brief A — terminal MCP failure misclassification

The readiness layer produced a distinct `(terminal)` message for `failed`/`needs-auth`/`disabled` server statuses, but `classifyError` matched the shared `workflow tool surface not ready` prefix *before* any terminal distinction and returned transient `network` → same-model retry every ~3s into the per-unit cost cap. The recovery path (`classifyFailure` → `inferFailureKind`) matched `isToolUnavailableError` on the same prefix and routed to `tool-unavailable → retry`.

Note: the stream-adapter pre-dispatch retry loop already refused to retry terminal errors (`!/\bterminal\b/`), so they were pushed as `{ type: "error" }` and misclassified only in the `agent_end`/recovery paths — which is why the bug was subtle.

**Changes:**
- `tool-surface-readiness.ts` — exported `TERMINAL_MCP_SERVER_STATUSES` (source of truth), `TOOL_SURFACE_TERMINAL_MARKER`, and `isTerminalToolSurfaceError(msg)` (detects marker + canonical status, so a stray `(terminal)` doesn't trip it).
- `error-classifier.ts` — terminal branch ahead of the transient `network` branch → terminal readiness errors classify as `permanent` (non-transient). Transient not-yet-connected variants unchanged.
- `recovery-classification.ts` — `inferFailureKind` checks `isTerminalToolSurfaceError` first → `runtime-unknown` (escalate), before the generic `tool-unavailable → retry` branch.

## Brief B — reliable self-exit / hot-loop termination

- `cli-errors.ts` — global `uncaughtException`/`unhandledRejection` handlers now log **and** `exit(1)` instead of returning. A repeating throw against a dead stdio pipe no longer log-and-loops. (`exit` added to the injectable `GlobalErrorRuntime` seam.)
- `cli-runner.ts` — added a **ref-held** (non-`.unref()`) parent-liveness monitor that self-terminates when the parent is gone *and* stdin has been idle past the 5-min gate. The existing `.unref()`'d idle watchdog is preserved; the new monitor is the starve-resistant path (under CPU saturation the ref-held timer still gets scheduled). `stdin` close/end/error cleanup and the external next-spawn sweep are unchanged (defence in depth); "stay alive when stdin is active" is preserved via the same idle gate.

## Tests
- New `terminal-tool-surface-classification.test.ts` — full terminal status set, transient negatives, non-readiness messages, ordering.
- Updated `tool-surface-readiness.test.ts` contract block — split into terminal (non-transient, escalate) and transient (still retries) cases.
- Updated `mcp-server.test.ts` — global handlers asserted to log + `exit(1)`.
- Updated `cli-runner.test.ts` — new "self-terminates on parent loss once stdin goes idle" test; updated "stays alive" test for the second timer.

## Verification
- Brief A suites: 30 (terminal+readiness) + 120 (recovery/provider) + 198 (stream-adapter) + 52 (orchestrator) — all green.
- Brief B: full mcp-server suite (199) — all green, including the two real-subprocess integration tests.

## Out of scope
- #822 (extension imports `packages/pi-ai/src/` which doesn't ship) still blocks downstream validation of these fixes on a real 1.3.0 install — worth landing alongside.
- The loop guard that only catches consecutive *identical* calls (original #783 contributing factor) is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode recovery and MCP process lifecycle (exit paths and timers); behavior is narrow and heavily tested but affects failure handling when the workflow server dies or the parent disconnects.
> 
> **Overview**
> Fixes **#783** along two tracks: auto-mode no longer retries dead workflow MCP servers forever, and orphaned MCP server processes stop CPU-spinning when the parent or stdio pipe is gone.
> 
> **Terminal tool-surface failures** — Readiness errors for `failed` / `needs-auth` / `disabled` shared the same prefix as transient “not yet connected” cases, so `classifyError` and recovery treated them as **network** / **tool-unavailable → retry**. The PR adds `isTerminalToolSurfaceError` (marker + canonical status), checks it **before** the transient readiness branch in `error-classifier` and `recovery-classification`, and routes terminal cases to **permanent** / **escalate** while pending/connecting behavior stays the same.
> 
> **Orphan / hot-loop termination** — Global `uncaughtException` / `unhandledRejection` handlers now **exit(1)** after logging so a throw loop on a dead stdio pipe cannot peg CPU. The CLI runner adds a **ref-held** parent-liveness monitor (10s) that shuts down when the parent is gone **and** stdin has been idle past the existing 5-minute gate, complementing the `.unref()` idle watchdog under event-loop starvation.
> 
> Tests cover terminal vs transient classification, recovery escalation, handler exit, and orphan self-termination after idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7272e549d422d218dff5678df3b00fb969e7a65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->