### PR TITLE
fix(gsd): open db before knowledge projection

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -134,6 +134,16 @@ export async function buildBeforeAgentStartResult(
     }
   }
 
+  // DB-backed memory backfills and projections run below. On a cold session
+  // the database file may exist without an active in-process adapter, so open
+  // the canonical project DB before those best-effort operations inspect it.
+  try {
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    await ensureDbOpen(basePath);
+  } catch (e) {
+    logWarning("bootstrap", `project DB open failed before memory projection: ${(e as Error).message}`);
+  }
+
   // ADR-013 step 5: opportunistic decisions->memories backfill. Idempotent
   // and best-effort — first run absorbs the existing decisions table into
   // the memory store; subsequent runs are a single sentinel SELECT.

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -499,6 +499,8 @@ export async function handleKnowledge(args: string, ctx: ExtensionCommandContext
 
   const type = typeArg as "rule" | "pattern" | "lesson";
   const basePath = currentDirectoryRoot();
+  const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+  await ensureDbOpen(basePath);
   const state = await deriveState(basePath);
   const scope = state.activeMilestone?.id
     ? `${state.activeMilestone.id}${state.activeSlice ? `/${state.activeSlice.id}` : ""}`

--- a/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import type { ExtensionCommandContext, ExtensionContext } from "@gsd/pi-coding-agent";
+
+import { buildBeforeAgentStartResult } from "../bootstrap/system-context.ts";
+import { handleKnowledge } from "../commands-handlers.ts";
+import { withCommandCwd } from "../commands/context.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  isDbAvailable,
+  openDatabase,
+} from "../gsd-db.ts";
+import { createMemory } from "../memory-store.ts";
+import { invalidateStateCache } from "../state.ts";
+
+test("#830 startup opens the project DB before projecting KNOWLEDGE.md", async (t) => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-knowledge-startup-")));
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const gsdDir = join(base, ".gsd");
+  const knowledgePath = join(gsdDir, "KNOWLEDGE.md");
+  mkdirSync(gsdDir, { recursive: true });
+  execFileSync("git", ["init", "-q"], { cwd: base, stdio: "ignore" });
+  process.chdir(base);
+  process.env.GSD_HOME = join(base, ".gsd-home");
+
+  t.after(() => {
+    if (isDbAvailable()) closeDatabase();
+    invalidateStateCache();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  const memoryId = createMemory({
+    category: "pattern",
+    content: "Cold-start projections open the canonical DB first",
+    scope: "project",
+    confidence: 0.9,
+    structuredFields: {
+      sourceKnowledgeId: "P001",
+      sourceKnowledgeTable: "patterns",
+      pattern: "Cold-start projections open the canonical DB first",
+      where: "bootstrap",
+      notes: "regression coverage",
+    },
+  });
+  assert.ok(memoryId);
+  closeDatabase();
+  assert.equal(isDbAvailable(), false);
+  assert.equal(existsSync(knowledgePath), false);
+
+  const ctx = {
+    projectRoot: base,
+    ui: { notify: () => undefined },
+  } as unknown as ExtensionContext;
+  await buildBeforeAgentStartResult(
+    { prompt: "Inspect project knowledge", systemPrompt: "base system prompt" },
+    ctx,
+  );
+
+  assert.equal(isDbAvailable(), true, "startup should open the project DB");
+  assert.equal(existsSync(knowledgePath), true, "startup should write KNOWLEDGE.md");
+  assert.match(
+    readFileSync(knowledgePath, "utf-8"),
+    /\| P001 \| Cold-start projections open the canonical DB first \| bootstrap \| regression coverage \|/,
+  );
+});
+
+test("#830 knowledge command opens the project DB before capturing patterns", async (t) => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-knowledge-command-")));
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  t.after(() => {
+    if (isDbAvailable()) closeDatabase();
+    invalidateStateCache();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  closeDatabase();
+  invalidateStateCache();
+  assert.equal(isDbAvailable(), false);
+
+  const notifications: Array<{ message: string; level: string }> = [];
+  const ctx = {
+    cwd: base,
+    ui: {
+      notify: (message: string, level: string) => notifications.push({ message, level }),
+    },
+  } as unknown as ExtensionCommandContext;
+
+  await withCommandCwd(base, async () => {
+    await handleKnowledge("pattern Capture works on a cold session", ctx);
+  });
+
+  assert.equal(isDbAvailable(), true, "knowledge command should open the project DB");
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  const row = adapter
+    .prepare(
+      "SELECT category, content, structured_fields FROM memories WHERE superseded_by IS NULL ORDER BY seq DESC LIMIT 1",
+    )
+    .get() as { category: string; content: string; structured_fields: string } | undefined;
+  assert.ok(row, "knowledge command should persist a memory");
+  assert.equal(row.category, "pattern");
+  assert.equal(row.content, "Capture works on a cold session");
+  assert.equal(JSON.parse(row.structured_fields).sourceKnowledgeId, "P001");
+  assert.deepEqual(notifications.at(-1), {
+    message: "Captured pattern P001 to memories; KNOWLEDGE.md will render it on next session start.",
+    level: "success",
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Open the canonical project DB before startup knowledge projection and `/gsd knowledge` capture.
**Why:** Cold sessions silently skipped `KNOWLEDGE.md` projection and could not persist pattern/lesson captures because no DB adapter was open.
**How:** Call the existing `ensureDbOpen(basePath)` lifecycle boundary before both DB-backed paths and cover them with behavioral cold-start regressions.

## What

- Opens the project DB before decision/knowledge backfill and `KNOWLEDGE.md` projection in `buildBeforeAgentStartResult`.
- Opens the project DB before `handleKnowledge` derives scope or captures a pattern/lesson memory.
- Adds behavioral regression tests for the real startup context builder and knowledge command, both beginning with a closed in-process DB adapter.

## Why

Closes #830.

`backfillKnowledgeToMemories`, `renderKnowledgeProjection`, and `captureKnowledgeEntry` intentionally degrade to no-ops when `isDbAvailable()` is false. Their callers did not establish the required DB lifecycle on a cold session, so the documented “render on next session start” behavior could silently fail and direct pattern/lesson capture could return `written: false`.

Rules remain file-canonical and otherwise unchanged.

## How

The fix reuses the existing `ensureDbOpen(basePath)` boundary rather than teaching the lower-level projection and capture functions to own workspace DB lifecycle. This keeps those functions deterministic for callers that already manage the adapter and ensures state derivation uses the same canonical project DB.

The regression tests seed a file-backed DB, close the global adapter to model a fresh process, then:

1. Invoke `buildBeforeAgentStartResult` and verify that `KNOWLEDGE.md` is rendered from the seeded memory.
2. Invoke `handleKnowledge` and verify that the pattern memory is persisted and the success notification is emitted.

Both tests failed before the implementation change and pass afterward.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] New/updated tests included
- [x] Focused knowledge suites: 48 passed
- [x] `pnpm run verify:fast`
- [x] Build, extension typecheck, packaging/installability, workspace coverage, and extension coverage stages passed under `pnpm run verify:merge`
- [ ] `pnpm run verify:merge` fully passes

`verify:pr` and `verify:merge` both reached the full unit suite and stopped on the same 31 unrelated baseline failures after 11,243 tests passed. The failures are in existing orchestrator advance behavior, worktree path normalization, lifecycle test doubles, prompt heading expectations, and journal-event assertions. The new knowledge tests were not among the failures.

## AI disclosure

- [x] This PR includes AI-assisted code. Implemented with Codex, reviewed for scope, and verified with the commands above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784904305&installation_id=134682257&pr_number=831&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F831&signature=b220d3130955ae5199a6df0976e9c499f30ae4b61880607dccbc55f0d3c0faef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->