### PR TITLE
fix(gsd): open workflow db during state derivation

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -68,7 +68,7 @@ import {
   getLatestAssessmentByScope,
   getPendingGateCountForTurn,
 } from './gsd-db.js';
-import { wasWorkflowDatabaseOpenAttempted } from './db-workspace.js';
+import { openExistingWorkflowDatabase, wasWorkflowDatabaseOpenAttempted } from './db-workspace.js';
 import { formatCompletePhaseNextAction, countUnmappedActiveRequirements } from './requirements-backlog.js';
 import type { MilestoneRow } from './db-milestone-artifact-rows.js';
 import type { SliceRow, TaskRow } from './db-task-slice-rows.js';
@@ -269,6 +269,26 @@ export function invalidateStateCache(): void {
   _stateCache = null;
 }
 
+function ensureExistingWorkflowDbOpen(basePath: string): boolean {
+  if (isDbAvailable()) return true;
+  return openExistingWorkflowDatabase(basePath).ok;
+}
+
+function buildDbUnavailableState(): GSDState {
+  return {
+    activeMilestone: null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "pre-planning",
+    recentDecisions: [],
+    blockers: ["DB unavailable — runtime markdown state derivation is disabled"],
+    nextAction: "Open or create the canonical GSD database before deriving workflow state. If this project only has markdown state, run /gsd migrate explicitly.",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 0 } },
+  };
+}
+
 /**
  * Returns the ID of the first incomplete milestone, or null if all are complete.
  */
@@ -382,6 +402,8 @@ export async function deriveState(
   // DB-backed derivation is authoritative whenever the DB is open. Runtime
   // degrade must not infer state from ROADMAP.md, PLAN.md, SUMMARY.md,
   // REQUIREMENTS.md, or flag files.
+  ensureExistingWorkflowDbOpen(basePath);
+
   if (isDbAvailable()) {
     const stopDbTimer = debugTime("derive-state-db");
     result = await deriveStateFromDb(basePath, opts?.projectRootForReads ?? basePath);
@@ -391,18 +413,7 @@ export async function deriveState(
     if (wasWorkflowDatabaseOpenAttempted()) {
       logWarning("state", "DB unavailable — refusing implicit markdown state derivation");
     }
-    result = {
-      activeMilestone: null,
-      activeSlice: null,
-      activeTask: null,
-      phase: "pre-planning",
-      recentDecisions: [],
-      blockers: ["DB unavailable — runtime markdown state derivation is disabled"],
-      nextAction: "Open or create the canonical GSD database before deriving workflow state. If this project only has markdown state, run /gsd migrate explicitly.",
-      registry: [],
-      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
-      progress: { milestones: { done: 0, total: 0 } },
-    };
+    result = buildDbUnavailableState();
   }
 
   result.recentDecisions = await loadRecentDecisions(cacheKey);
@@ -730,6 +741,10 @@ export async function deriveStateFromDb(
   basePath: string,
   artifactReadRoot: string = basePath,
 ): Promise<GSDState> {
+  if (!ensureExistingWorkflowDbOpen(basePath)) {
+    return buildDbUnavailableState();
+  }
+
   const requirements = getRequirementCounts();
 
   const allMilestones = getAllMilestones();

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -254,6 +254,29 @@ describe('derive-state-db', async () => {
     }
   });
 
+  test('derive-state-db: opens existing project DB before querying milestones', async (t) => {
+    const base = createFixtureBase();
+    t.after(() => {
+      closeDatabase();
+      cleanup(base);
+    });
+
+    const dbPath = join(base, '.gsd', 'gsd.db');
+    assert.equal(openDatabase(dbPath), true);
+    insertMilestone({ id: 'M001', title: 'Cold DB Milestone', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Ready Slice', status: 'active', risk: 'low', depends: [] });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Ready Task', status: 'pending' });
+    closeDatabase();
+    assert.equal(isDbAvailable(), false);
+
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone?.id, 'M001');
+    assert.equal(state.activeSlice?.id, 'S01');
+    assert.equal(state.activeTask?.id, 'T01');
+    assert.notEqual(state.nextAction, 'No milestones found. Run /gsd to create one.');
+  });
+
   // ─── Test 4: Partial DB content does not fill gaps from disk ──────────
   test('derive-state-db: partial DB does not fill requirements from disk', async () => {
     const base = createFixtureBase();

--- a/src/resources/extensions/gsd/tests/discuss-cold-start-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-cold-start-db-open.test.ts
@@ -1,16 +1,13 @@
 /**
  * Behavioural regression test for #5837.
  *
- * /gsd discuss silently exited on cold-start because showDiscuss() derived
- * workflow state before opening the DB. On a cold-start session the DB file
- * exists on disk but is not open in-process, so deriveState() takes the
- * "DB unavailable" branch, reports no active milestone, and showDiscuss()
- * exits as if the project had no milestones.
+ * /gsd discuss and /gsd auto can cold-start with a DB file on disk but no
+ * in-process connection yet. State derivation must open that existing DB
+ * before it decides whether DB-backed state is available.
  *
- * The fix moves `ensureDbOpen(basePath)` ahead of `deriveState()`. This test
- * pins that ordering contract at the behavioural level: with a milestone
- * living only in the DB, deriveState() surfaces nothing until the DB is
- * opened, and surfaces the milestone once ensureDbOpen() has run.
+ * This test pins that behavioural contract: with a milestone living only in
+ * the DB, deriveState() surfaces it even when the process begins with no DB
+ * handle open.
  */
 
 import { describe, test, afterEach } from "node:test";
@@ -19,7 +16,6 @@ import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { ensureDbOpen } from "../bootstrap/dynamic-tools.ts";
 import { openDatabase, closeDatabase, isDbAvailable, insertMilestone } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
 
@@ -29,7 +25,7 @@ afterEach(() => {
 });
 
 describe("discuss cold-start DB ordering (#5837)", () => {
-  test("deriveState only surfaces a DB-resident milestone after ensureDbOpen runs", async () => {
+  test("deriveState opens an existing DB before reading a DB-resident milestone", async () => {
     const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-discuss-cold-")));
     try {
       mkdirSync(join(base, ".gsd"), { recursive: true });
@@ -42,26 +38,13 @@ describe("discuss cold-start DB ordering (#5837)", () => {
       closeDatabase();
       invalidateStateCache();
 
-      // Before ensureDbOpen(): showDiscuss's pre-fix ordering. The DB is not
-      // open, so state derivation cannot see the milestone — the silent exit.
       const coldState = await deriveState(base);
       assert.equal(
-        coldState.activeMilestone,
-        null,
-        "without an open DB, deriveState must not surface the milestone — this is the cold-start silent-exit bug",
-      );
-      assert.equal(isDbAvailable(), false, "DB must still be closed before ensureDbOpen");
-
-      // The fix: ensureDbOpen(basePath) runs before deriveState.
-      assert.equal(await ensureDbOpen(base), true, "ensureDbOpen must open the cold-start DB");
-      invalidateStateCache();
-
-      const warmState = await deriveState(base);
-      assert.equal(
-        warmState.activeMilestone?.id,
+        coldState.activeMilestone?.id,
         "M001",
-        "after ensureDbOpen, deriveState must surface the DB-resident milestone so /gsd discuss does not silently exit",
+        "cold-start deriveState must open and read the existing workflow DB",
       );
+      assert.equal(isDbAvailable(), true, "deriveState must leave the existing DB open for downstream reads");
     } finally {
       if (isDbAvailable()) closeDatabase();
       invalidateStateCache();


### PR DESCRIPTION
## Linked issue

Closes #832

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Open an existing workflow DB before DB-backed state derivation queries milestones.
**Why:** Cold-start `/gsd auto` and related state reads could otherwise report a false "No milestones found" state when `.gsd/gsd.db` existed but no process handle was open.
**How:** State derivation now attempts to open the existing workflow DB before deciding DB availability, while preserving explicit DB-unavailable degradation when no DB can be opened.

## What

- Updates `src/resources/extensions/gsd/state.ts` to open an existing project workflow DB before `deriveState()` and `deriveStateFromDb()` make DB-backed milestone queries.
- Adds a regression in `src/resources/extensions/gsd/tests/derive-state-db.test.ts` for a cold DB file containing milestone/slice/task rows.
- Updates `src/resources/extensions/gsd/tests/discuss-cold-start-db-open.test.ts` so the cold-start test asserts the new intended behavior instead of the old silent-exit bug.

## Why

Issue #832 reports `/gsd auto` stopping with "No milestones found" even though a valid `.gsd/gsd.db` and milestone artifacts exist. The false empty state happens when DB-backed derivation reads before an existing DB file has been opened in-process.

## How

- Added a small `ensureExistingWorkflowDbOpen()` helper in state derivation.
- Reused the existing `openExistingWorkflowDatabase()` path so missing DBs still degrade explicitly instead of importing markdown implicitly at runtime.
- Added executable regression coverage, including red/green and sabotage validation locally.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test --test-name-pattern "opens existing project DB" src/resources/extensions/gsd/tests/derive-state-db.test.ts` (RED before fix, GREEN after fix)
- [x] Sabotage check: temporarily disabled `ensureExistingWorkflowDbOpen()` and confirmed the new regression failed on missing `M001`
- [x] `pnpm run build:contracts && node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/auto-start-cold-db-bootstrap.test.ts src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts src/resources/extensions/gsd/tests/discuss-cold-start-db-open.test.ts src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts`
- [x] `pnpm run build:pi && pnpm run build:rpc-client && pnpm run build:mcp-server && pnpm run typecheck:extensions`
- [x] `pnpm run verify:fast`

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->

## Notes

- `no-mistakes axi run` was attempted, but the tool refused to start a new run while another branch (`codex/issue-808-mcp-preflight`) has an active CI gate. Manual targeted tests, typecheck, and `verify:fast` were run instead.
