### PR TITLE
fix(issue): auto-pause: regenerable lockfiles (pnpm-lock, package-lock, etc.) are not auto-resolved, hard-pausing auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -423,10 +423,25 @@ export const SAFE_AUTO_RESOLVE_PATTERNS: RegExp[] = [
   /\/__pycache__\//,
   /\.DS_Store$/,
   /\.map$/,
+  // Regenerable dependency lockfiles. These are fully derivable from their
+  // manifests by the package manager, so accepting the merge side during
+  // auto-resolve clears the conflict markers without losing meaningful edits —
+  // and stops auto-mode from hard-pausing on a lockfile conflict (issue #828).
+  /(?:^|\/)pnpm-lock\.yaml$/,
+  /(?:^|\/)package-lock\.json$/,
+  /(?:^|\/)npm-shrinkwrap\.json$/,
+  /(?:^|\/)yarn\.lock$/,
+  /(?:^|\/)bun\.lockb?$/,
+  /(?:^|\/)Cargo\.lock$/,
+  /(?:^|\/)composer\.lock$/,
+  /(?:^|\/)Gemfile\.lock$/,
+  /(?:^|\/)Pipfile\.lock$/,
+  /(?:^|\/)poetry\.lock$/,
 ];
 
 /** Returns true if the file path is safe to auto-resolve during merge.
- * Covers `.gsd/` state files and common build artifacts. */
+ * Covers `.gsd/` state files, common build artifacts, and regenerable
+ * dependency lockfiles. */
 export const isSafeToAutoResolve = (filePath: string): boolean =>
   filePath.startsWith(".gsd/") ||
   SAFE_AUTO_RESOLVE_PATTERNS.some((re) => re.test(filePath));

--- a/src/resources/extensions/gsd/tests/auto-worktree-auto-resolve.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-auto-resolve.test.ts
@@ -47,6 +47,23 @@ describe("isSafeToAutoResolve", () => {
     assert.ok(isSafeToAutoResolve("out/bundle.css.map"));
   });
 
+  // ─── Regenerable dependency lockfiles ────────────────────────────────────
+  test("returns true for common lockfiles", () => {
+    assert.ok(isSafeToAutoResolve("pnpm-lock.yaml"));
+    assert.ok(isSafeToAutoResolve("packages/app/pnpm-lock.yaml"));
+    assert.ok(isSafeToAutoResolve("package-lock.json"));
+    assert.ok(isSafeToAutoResolve("npm-shrinkwrap.json"));
+    assert.ok(isSafeToAutoResolve("yarn.lock"));
+    assert.ok(isSafeToAutoResolve("bun.lockb"));
+    assert.ok(isSafeToAutoResolve("bun.lock"));
+    assert.ok(isSafeToAutoResolve("Cargo.lock"));
+    assert.ok(isSafeToAutoResolve("crates/core/Cargo.lock"));
+    assert.ok(isSafeToAutoResolve("composer.lock"));
+    assert.ok(isSafeToAutoResolve("Gemfile.lock"));
+    assert.ok(isSafeToAutoResolve("Pipfile.lock"));
+    assert.ok(isSafeToAutoResolve("poetry.lock"));
+  });
+
   // ─── Real source files (should NOT be auto-resolved) ─────────────────────
   test("returns false for .ts source files", () => {
     assert.ok(!isSafeToAutoResolve("src/index.ts"));


### PR DESCRIPTION
## Summary
- Added regenerable lockfile patterns (pnpm-lock, package-lock, Cargo.lock, etc.) to SAFE_AUTO_RESOLVE_PATTERNS so auto-mode auto-resolves lockfile conflicts instead of hard-pausing; verified with the auto-resolve and merge-conflict unit tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #828
- [#828 auto-pause: regenerable lockfiles (pnpm-lock, package-lock, etc.) are not auto-resolved, hard-pausing auto-mode](https://github.com/open-gsd/gsd-pi/issues/828)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/828-auto-pause-regenerable-lockfiles-pnpm-lo-1782340740`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to merge conflict classification; lockfiles are explicitly treated as regenerable, with tests and no change to source-file conflict handling.
> 
> **Overview**
> **Auto-mode** no longer hard-pauses when milestone merges only conflict on **regenerable dependency lockfiles** (pnpm, npm, yarn, bun, Cargo, Composer, Ruby, Python, etc.).
> 
> `SAFE_AUTO_RESOLVE_PATTERNS` and `isSafeToAutoResolve` now treat those lockfiles like other machine-generated artifacts, so `autoResolveSafeConflictPaths` can accept the merge side and clear markers instead of surfacing a blocking conflict (**#828**). Unit tests cover root and nested lockfile paths; real sources like `package.json` still do not auto-resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55fe20a63dcc81a66ee677027c6f95bb8c936996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->