### PR TITLE
fix(issue): Auto-mode pause: PROJECT.md registers phantom bare-ID milestone colliding with planner's unique-ID milestone (unique_milestone_ids)

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -12,6 +12,7 @@ import {
   getArtifact,
   getAssessment,
   insertAssessment,
+  insertMilestone,
   upsertRequirement,
   getAllMilestones,
 } from "../gsd-db.ts";
@@ -2042,6 +2043,60 @@ test("executeSummarySave registers PROJECT milestone sequence for the next run",
     assert.equal(state.phase, "pre-planning");
     assert.equal(state.registry[0]?.status, "active");
     assert.equal(state.registry[1]?.status, "pending");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave reconciles bare PROJECT milestone IDs onto existing unique-ID rows (no phantom row) (#807)", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    // Planner already minted a unique-ID milestone for sequence 1.
+    insertMilestone({ id: "M001-b1nole", title: "Foundation", status: "active" });
+
+    // A faithfully-authored PROJECT.md uses the template's bare sequence IDs.
+    const result = await inProjectDir(base, () => executeSummarySave({
+      artifact_type: "PROJECT",
+      content: [
+        "# Project",
+        "",
+        "## What This Is",
+        "",
+        "Deep project setup output.",
+        "",
+        "## Project Shape",
+        "",
+        "**Complexity:** complex",
+        "**Why:** It spans multiple delivery steps.",
+        "",
+        "## Capability Contract",
+        "",
+        "See .gsd/REQUIREMENTS.md.",
+        "",
+        "## Milestone Sequence",
+        "",
+        "- [ ] M001: Foundation - Establish the first runnable slice.",
+        "- [ ] M002: Polish - Follow-up experience work.",
+        "",
+      ].join("\n"),
+    }, base));
+
+    assert.equal(result.isError, undefined);
+    // Bare M001 maps onto the planner's canonical row; M002 is genuinely new.
+    assert.deepEqual(result.details.registeredMilestones, ["M001-b1nole", "M002"]);
+
+    const milestones = getAllMilestones();
+    // No phantom bare "M001" row — the unique-ID row is preserved and not demoted.
+    assert.deepEqual(
+      milestones.map((m) => [m.id, m.title, m.status]).sort(),
+      [
+        ["M001-b1nole", "Foundation", "active"],
+        ["M002", "Polish", "queued"],
+      ].sort(),
+    );
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -15,8 +15,10 @@ import {
   insertGateRun,
   readTransaction,
   saveGateResult,
+  upsertMilestonePlanning,
   upsertQualityGate,
 } from "../gsd-db.js";
+import { extractMilestoneSeq } from "../milestone-ids.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
 import { clearPathCache, normalizeRealPath, relMilestoneFile, relSliceFile, relSlicePath, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
@@ -143,7 +145,34 @@ export interface SummarySaveParams {
 function registerProjectMilestoneSequence(content: string): string[] {
   const parsed = parseProject(content);
   const registered: string[] = [];
+  // Reconcile parsed IDs against existing DB milestones before inserting (#807).
+  // Under unique_milestone_ids the planner mints suffixed IDs (e.g. "M001-b1nole"),
+  // while PROJECT.md's template uses bare sequence IDs (e.g. "M001"). Inserting the
+  // bare ID verbatim mints a phantom milestone row that collides with the planner's
+  // canonical one: the bare row gets its own git worktree, and at dispatch time the
+  // worktree/session scope ("M001") disagrees with ctx.mid ("M001-b1nole"), pausing
+  // auto-mode with "Dispatch milestone mismatch". A project DB holds at most one
+  // milestone per sequence number, so map each parsed line onto the existing row
+  // that shares its sequence number instead of minting a duplicate bare-ID row.
+  const existingBySeq = new Map<number, string>();
+  for (const existing of getAllMilestones()) {
+    const seq = extractMilestoneSeq(existing.id);
+    if (seq > 0 && !existingBySeq.has(seq)) existingBySeq.set(seq, existing.id);
+  }
   for (const milestone of parsed.milestones) {
+    const canonicalId = existingBySeq.get(extractMilestoneSeq(milestone.id));
+    if (canonicalId && canonicalId !== milestone.id) {
+      // An existing milestone already owns this sequence number. Treat the markdown
+      // line as referring to it: refresh the human title, and promote to complete
+      // when the line is checked — but never demote an in-flight milestone back to
+      // "queued" (the planner's row stays the single source of truth).
+      upsertMilestonePlanning(canonicalId, {
+        title: milestone.title,
+        ...(milestone.done ? { status: "complete" } : {}),
+      });
+      registered.push(canonicalId);
+      continue;
+    }
     insertMilestone({
       id: milestone.id,
       title: milestone.title,


### PR DESCRIPTION
## Summary
- Reconciled PROJECT.md milestone IDs against existing DB rows by sequence number so bare IDs map onto the planner's unique-ID milestone instead of minting a phantom colliding row; verified via new regression test and existing suites.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #807
- [#807 Auto-mode pause: PROJECT.md registers phantom bare-ID milestone colliding with planner's unique-ID milestone (unique_milestone_ids)](https://github.com/open-gsd/gsd-pi/issues/807)

## User
- @Miltonian66

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/807-auto-mode-pause-project-md-registers-pha-1782341107`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches milestone registration on every PROJECT save and could mis-associate lines if sequence numbers collide across unrelated rows; mitigated by one-milestone-per-sequence assumption and targeted regression test.
> 
> **Overview**
> Fixes auto-mode pausing with **Dispatch milestone mismatch** when saving `PROJECT.md` after the planner already created suffixed milestone rows (e.g. `M001-b1nole`) while the template still lists bare IDs (`M001`).
> 
> **`registerProjectMilestoneSequence`** (used by `executeSummarySave` for `PROJECT` artifacts) now builds a sequence-number index from existing DB milestones and, for each parsed line, maps onto the canonical row when the sequence matches but the ID string differs. It updates title via **`upsertMilestonePlanning`**, can mark **complete** when the checkbox is checked, and **does not demote** in-flight milestones to `queued`. Unmatched lines still **`insertMilestone`** as before.
> 
> Adds regression test **`executeSummarySave reconciles bare PROJECT milestone IDs onto existing unique-ID rows`** asserting no phantom `M001` row and preserved `active` status on the planner row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e899e06234948989fde8fe704a55709541c71d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->