### PR TITLE
fix(issue): Bug: worktree-unregistered stuck loop - orphaned directories not cleaned up by safety validation

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -307,22 +307,26 @@ describe("Worktree Safety module", () => {
     assert.equal(result.kind, "worktree-unregistered");
   });
 
-  test("attempts prune recovery once for unregistered worktrees and tracks failed roots", () => {
+  test("removes an orphaned worktree directory when prune cannot recover it", () => {
     let pruneCalls = 0;
-    let listCalls = 0;
+    let removeCalls = 0;
+    let removedUnitRoot: string | undefined;
+    let removedMilestoneId: string | undefined;
     const safety = createWorktreeSafetyModule({
       existsSync: () => true,
       lstatSync: () => ({ isFile: () => true }),
       pruneRegisteredWorktrees: () => {
         pruneCalls += 1;
       },
-      listRegisteredWorktrees: () => {
-        listCalls += 1;
-        return [];
+      listRegisteredWorktrees: () => [],
+      removeStaleWorktreeDirectory: (root, milestoneId) => {
+        removeCalls += 1;
+        removedUnitRoot = root;
+        removedMilestoneId = milestoneId;
       },
     });
 
-    const first = safety.validateUnitRoot({
+    const result = safety.validateUnitRoot({
       unitType: "execute-task",
       unitId: "M001/S01/T01",
       writeScope: "source-writing",
@@ -330,14 +334,32 @@ describe("Worktree Safety module", () => {
       unitRoot,
       milestoneId: "M001",
     });
-    assert.equal(first.ok, false);
-    assert.equal(first.kind, "worktree-unregistered");
-    assert.equal(first.details?.attemptedPrune, true);
-    assert.equal(first.details?.trackedAsFailed, true);
-    assert.equal(pruneCalls, 1);
-    assert.equal(listCalls, 2);
 
-    const second = safety.validateUnitRoot({
+    // Orphaned directory is cleaned up and the failure degrades to the
+    // recoverable worktree-missing kind so the next dispatch can recreate it,
+    // instead of looping forever on worktree-unregistered (#803).
+    assert.equal(result.ok, false);
+    assert.equal(result.kind, "worktree-missing");
+    assert.equal(result.details?.removedStaleDirectory, true);
+    assert.equal(result.details?.attemptedPrune, true);
+    assert.equal(pruneCalls, 1);
+    assert.equal(removeCalls, 1);
+    assert.equal(removedUnitRoot, unitRoot);
+    assert.equal(removedMilestoneId, "M001");
+  });
+
+  test("keeps worktree-unregistered when the orphaned directory cannot be removed", () => {
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => true,
+      lstatSync: () => ({ isFile: () => true }),
+      pruneRegisteredWorktrees: () => {},
+      listRegisteredWorktrees: () => [],
+      removeStaleWorktreeDirectory: () => {
+        throw new Error("directory may be locked by another process");
+      },
+    });
+
+    const result = safety.validateUnitRoot({
       unitType: "execute-task",
       unitId: "M001/S01/T01",
       writeScope: "source-writing",
@@ -345,12 +367,11 @@ describe("Worktree Safety module", () => {
       unitRoot,
       milestoneId: "M001",
     });
-    assert.equal(second.ok, false);
-    assert.equal(second.kind, "worktree-unregistered");
-    assert.equal(second.details?.attemptedPrune, false);
-    assert.equal(second.details?.trackedAsFailed, true);
-    assert.equal(pruneCalls, 1);
-    assert.equal(listCalls, 3);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.kind, "worktree-unregistered");
+    assert.equal(result.details?.removedStaleDirectory, false);
+    assert.match(String(result.details?.error), /locked by another process/);
   });
 
   test("converts registered worktree list failures into typed failures", () => {

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -287,7 +287,7 @@ export function pruneEphemeralGhostWorktreeDirectories(basePath: string): string
   return removed;
 }
 
-function removeStaleWorktreeDirectory(wtPath: string, name: string): void {
+export function removeStaleWorktreeDirectory(wtPath: string, name: string): void {
   logWarning(
     "reconcile",
     `Removing stale worktree directory (not registered with git): ${wtPath}`,

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -7,7 +7,7 @@ import { join, resolve } from "node:path";
 
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
 import { worktreesDirs } from "./worktree-placement.js";
-import { listWorktrees } from "./worktree-manager.js";
+import { listWorktrees, removeStaleWorktreeDirectory } from "./worktree-manager.js";
 import { getCurrentBranch } from "./worktree.js";
 
 export type WorktreeSafetyWriteScope = "planning-only" | "source-writing";
@@ -74,6 +74,7 @@ export interface WorktreeSafetyDeps {
   lstatSync(path: string): Pick<Stats, "isFile">;
   listRegisteredWorktrees?(projectRoot: string): readonly RegisteredWorktree[];
   pruneRegisteredWorktrees?(projectRoot: string): void;
+  removeStaleWorktreeDirectory?(unitRoot: string, milestoneId: string): void;
   getCurrentBranch?(unitRoot: string): string;
 }
 
@@ -100,6 +101,7 @@ const defaultDeps: WorktreeSafetyDeps = {
       stdio: "pipe",
     });
   },
+  removeStaleWorktreeDirectory,
   getCurrentBranch,
 };
 
@@ -127,8 +129,6 @@ function errorMessage(error: unknown): string {
 export function createWorktreeSafetyModule(
   deps: WorktreeSafetyDeps = defaultDeps,
 ): WorktreeSafetyModule {
-  const unregisteredRecoveryFailed = new Set<string>();
-
   return {
     validateUnitRoot(input) {
       if (input.writeScope === "planning-only") {
@@ -230,22 +230,17 @@ export function createWorktreeSafetyModule(
           );
         }
         if (registered && !registered.some((worktree) => samePath(worktree.path, unitRoot))) {
-          const wasPreviouslyTracked = unregisteredRecoveryFailed.has(unitRoot);
           let attemptedPrune = false;
 
-          if (!wasPreviouslyTracked && deps.pruneRegisteredWorktrees) {
+          if (deps.pruneRegisteredWorktrees) {
             attemptedPrune = true;
             try {
               deps.pruneRegisteredWorktrees(projectRoot);
               const rechecked = deps.listRegisteredWorktrees?.(projectRoot);
               if (rechecked?.some((worktree) => samePath(worktree.path, unitRoot))) {
-                unregisteredRecoveryFailed.delete(unitRoot);
                 registered = rechecked;
-              } else {
-                unregisteredRecoveryFailed.add(unitRoot);
               }
             } catch (error) {
-              unregisteredRecoveryFailed.add(unitRoot);
               return failure(
                 "worktree-git-probe-failed",
                 `Unable to recover unregistered worktree root ${unitRoot}.`,
@@ -256,13 +251,38 @@ export function createWorktreeSafetyModule(
           }
 
           if (!registered?.some((worktree) => samePath(worktree.path, unitRoot))) {
+            // The directory exists on disk with a .git marker but git no longer
+            // tracks it as a worktree (e.g. a prior removeWorktree crash left the
+            // directory while `git worktree prune` cleaned the registry). Remove
+            // the orphaned directory — the same cleanup createWorktree performs —
+            // so the next dispatch recreates the milestone worktree from scratch
+            // instead of looping forever on worktree-unregistered (#803, #590).
+            if (deps.removeStaleWorktreeDirectory) {
+              try {
+                deps.removeStaleWorktreeDirectory(unitRoot, milestoneId);
+                return failure(
+                  "worktree-missing",
+                  `Worktree root ${unitRoot} was not registered with git; removed the orphaned directory so it can be recreated.`,
+                  "Recreate the milestone worktree before dispatching the source-writing Unit. Auto-mode recreates it automatically on the next dispatch.",
+                  { unitRoot, attemptedPrune, removedStaleDirectory: true },
+                );
+              } catch (error) {
+                return failure(
+                  "worktree-unregistered",
+                  `Worktree root ${unitRoot} is not registered with git worktree list and the orphaned directory could not be removed.`,
+                  "Remove the orphaned worktree directory manually (it may be locked by another process), then recreate or re-register the milestone worktree before dispatching the source-writing Unit.",
+                  { unitRoot, attemptedPrune, removedStaleDirectory: false, error: errorMessage(error) },
+                );
+              }
+            }
+
             return failure(
               "worktree-unregistered",
               `Worktree root ${unitRoot} is not registered with git worktree list.`,
-              attemptedPrune || wasPreviouslyTracked
+              attemptedPrune
                 ? "Worktree recovery was attempted but the root is still unregistered. Recreate or re-register the milestone worktree before dispatching the source-writing Unit."
                 : "Run 'git worktree prune'. If still unregistered, recreate or re-register the milestone worktree before dispatching the source-writing Unit.",
-              { unitRoot, attemptedPrune, trackedAsFailed: unregisteredRecoveryFailed.has(unitRoot) },
+              { unitRoot, attemptedPrune },
             );
           }
         }


### PR DESCRIPTION
## Summary
- Worktree safety validation now removes orphaned unregistered worktree directories and returns the recoverable worktree-missing kind instead of permanently tracking the path as failed; verified via updated unit tests, manager/phase tests, and typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #803
- [#803 Bug: worktree-unregistered stuck loop - orphaned directories not cleaned up by safety validation](https://github.com/open-gsd/gsd-pi/issues/803)

## User
- @TerminalSausage

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/803-bug-worktree-unregistered-stuck-loop-orp-1782341706`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispatch-time worktree validation and can recursively delete milestone worktree directories on disk; incorrect triggers could remove data, though behavior mirrors existing `createWorktree` cleanup and is scoped to unregistered paths with a worktree `.git` file.
> 
> **Overview**
> Fixes a **stuck `worktree-unregistered` loop** when a milestone directory still exists with a `.git` marker but Git no longer lists it as a worktree (e.g. after a failed remove + prune).
> 
> **Worktree safety** now runs the same stale-directory cleanup as `createWorktree`: after `git worktree prune` if the path is still unregistered, it calls **`removeStaleWorktreeDirectory`** (new injectable dep, wired from `worktree-manager`, now **exported**). On success it returns **`worktree-missing`** so the next dispatch can recreate the worktree instead of failing forever. If removal fails (e.g. locked directory), it still returns **`worktree-unregistered`** with error details.
> 
> The previous **per-path “recovery failed” tracking** (`trackedAsFailed` / one-shot prune only) is removed; prune is attempted whenever listing shows an unregistered path. Tests cover successful orphan removal and the locked-directory path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f4f6e3113aee99b742b75e3846dff9bdac7b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->