### PR TITLE
fix(issue): [Bug]: Switching to fallback models does not work correctly: switch but not start with new model

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -33,6 +33,7 @@ import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js
 import { resolveModelId } from "../auto-model-selection.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
+import { scheduleFallbackContinuation } from "./fallback-continuation.js";
 import { clearGuidedUnitContext } from "../guided-unit-context.js";
 import { resumeAutoAfterProviderDelay } from "./provider-error-resume.js";
 import {
@@ -154,10 +155,7 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
           setCurrentUnitModelForRecovery(candidate);
           setCurrentDispatchedModelId({ provider: candidate.provider, id: candidate.id });
           switchedNotify(`${candidate.provider}/${candidate.id}`);
-          pi.sendMessage(
-            { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
-            { triggerTurn: true, deliverAs: "steer" },
-          );
+          scheduleFallbackContinuation(pi);
           return true;
         }
       }
@@ -181,10 +179,7 @@ async function tryProviderModelFallback(params: ProviderModelFallbackParams): Pr
         setCurrentUnitModelForRecovery(startModel);
         setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
         switchedNotify(`${startModel.provider}/${startModel.id}`);
-        pi.sendMessage(
-          { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
-          { triggerTurn: true, deliverAs: "steer" },
-        );
+        scheduleFallbackContinuation(pi);
         return true;
       }
     }

--- a/src/resources/extensions/gsd/bootstrap/fallback-continuation.ts
+++ b/src/resources/extensions/gsd/bootstrap/fallback-continuation.ts
@@ -1,0 +1,31 @@
+// gsd-pi + src/resources/extensions/gsd/bootstrap/fallback-continuation.ts - Dispatches the post-fallback-switch continuation on a fresh turn.
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+/**
+ * Dispatch the post-fallback continuation on a *fresh* turn after the current
+ * run settles.
+ *
+ * #804: At `agent_end` time the agent's run is still tearing down — its
+ * `isStreaming` flag stays `true` until `finishRun()` clears it in the `finally`
+ * block that fires *after* the awaited `agent_end` listeners return (see
+ * pi-agent-core/src/agent.ts processEvents comment). A synchronous
+ * `sendMessage({ triggerTurn: true, deliverAs: "steer" })` from inside that
+ * listener is therefore routed down the `isStreaming` branch and queued as a
+ * steering message against the turn that just errored out — which is never
+ * consumed, so the fallback model is selected but no new turn ever starts (the
+ * reported symptom: "switched but work stays stopped").
+ *
+ * Deferring to a macrotask lets `finishRun()` flip `isStreaming` to `false`
+ * first; the plain `triggerTurn` (no `deliverAs`) then dispatches a fresh turn
+ * on the freshly-selected fallback model, mirroring the network-retry path.
+ */
+export function scheduleFallbackContinuation(pi: ExtensionAPI): void {
+  setTimeout(() => {
+    pi.sendMessage(
+      { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
+      { triggerTurn: true },
+    );
+  }, 0);
+}

--- a/src/resources/extensions/gsd/tests/fallback-continuation.test.ts
+++ b/src/resources/extensions/gsd/tests/fallback-continuation.test.ts
@@ -1,0 +1,36 @@
+// gsd-pi + src/resources/extensions/gsd/tests/fallback-continuation.test.ts - Regression test for #804 fallback continuation dispatch.
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { scheduleFallbackContinuation } from "../bootstrap/fallback-continuation.ts";
+
+/**
+ * #804: After switching to a fallback model in the agent_end recovery path, the
+ * continuation must be dispatched on a *fresh* turn — not as a steering message
+ * against the turn that just errored out (which `isStreaming` is still true for
+ * until finishRun() clears it). The fix defers the send to a macrotask and uses
+ * a plain `triggerTurn` with no `deliverAs: "steer"`.
+ */
+test("scheduleFallbackContinuation defers a plain triggerTurn dispatch (no steer)", async () => {
+  const calls: Array<{ message: unknown; options: unknown }> = [];
+  const pi = {
+    sendMessage: (message: unknown, options: unknown) => {
+      calls.push({ message, options });
+    },
+  } as any;
+
+  scheduleFallbackContinuation(pi);
+
+  // Synchronous within the awaited agent_end listener: nothing sent yet so the
+  // dispatch cannot be misrouted into the still-streaming dying turn.
+  assert.equal(calls.length, 0);
+
+  // After the macrotask (finishRun() has cleared isStreaming by now).
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].options, { triggerTurn: true });
+  assert.equal((calls[0].options as { deliverAs?: unknown }).deliverAs, undefined);
+});

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -498,7 +498,15 @@ test("rate-limit agent_end walks past unavailable fallback models before pausing
   const timers: Array<{ delay: number }> = [];
 
   globalThis.setTimeout = ((_fn: (...args: unknown[]) => void, delay?: number) => {
-    timers.push({ delay: delay ?? 0 });
+    if ((delay ?? 0) === 0) {
+      // delay-0 is a macrotask deferral (scheduleFallbackContinuation): invoke
+      // immediately in tests so sendMessage assertions can fire synchronously.
+      _fn();
+    } else {
+      // delay>0 is a pause/backoff timer: capture without firing so the test
+      // stays synchronous and can assert no pause was scheduled.
+      timers.push({ delay: delay ?? 0 });
+    }
     return 0 as unknown as ReturnType<typeof setTimeout>;
   }) as typeof setTimeout;
 
@@ -566,9 +574,9 @@ test("rate-limit agent_end walks past unavailable fallback models before pausing
     } as any, ctx);
 
     assert.deepEqual(setModelCalls, ["google-gemini-cli/gemini-2.5-pro"]);
-    assert.equal(sendMessageCalls.length, 1, "fallback recovery must immediately trigger a continuation turn");
-    assert.deepEqual(sendMessageCalls[0][1], { triggerTurn: true, deliverAs: "steer" });
-    assert.equal(timers.length, 0, "must not pause with a retry timer when a later fallback is available");
+    assert.equal(sendMessageCalls.length, 1, "fallback recovery must trigger a deferred continuation turn");
+    assert.deepEqual(sendMessageCalls[0][1], { triggerTurn: true }, "continuation must use plain triggerTurn — no deliverAs:steer — to start a fresh turn, not steer the dying one");
+    assert.equal(timers.length, 0, "must not schedule a delay-backoff pause timer when a fallback is available");
     assert.ok(
       notifications.some((n) => n.message.includes("google-gemini-cli/gemini-2.5-pro")),
       "user-facing notification should name the fallback actually selected",


### PR DESCRIPTION
## Summary
- Fixed fallback model switch not resuming auto-mode by deferring the post-switch continuation to a macrotask with plain `triggerTurn` (so it runs after `isStreaming` clears instead of being lost as a steer into the dying turn); verified via new and existing unit tests plus extensions typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #804
- [#804 [Bug]: Switching to fallback models does not work correctly: switch but not start with new model](https://github.com/open-gsd/gsd-pi/issues/804)

## User
- @efrembaraldohelinext

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/804-bug-switching-to-fallback-models-does-no-1782342307`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to auto-mode recovery dispatch timing after model fallback; covered by a focused unit test with no auth or data-path changes.
> 
> **Overview**
> Fixes **#804**, where auto-mode switched to a fallback model but never started a new turn (“switched but work stays stopped”).
> 
> After a successful fallback `setModel` in `tryProviderModelFallback`, the recovery path no longer calls `sendMessage` synchronously with `deliverAs: "steer"`. It now uses **`scheduleFallbackContinuation`**, which defers a hidden “Continue execution.” message via `setTimeout(0)` and dispatches with plain **`triggerTurn`** only. That avoids queuing the continuation as steer on the errored turn while `isStreaming` is still true during `agent_end` teardown.
> 
> A small **`fallback-continuation.ts`** helper centralizes this behavior (aligned with the existing deferred network-retry continuation), and a **regression test** asserts no synchronous send and no `deliverAs: "steer"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4712a0055fad954625e0e1dc133d94924a0f54cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->