### PR TITLE
fix(issue): Stranded-milestone recovery silently checks out milestone branch in project root instead of recreating worktree

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -488,6 +488,17 @@ export function auditOrphanedMilestoneBranches(
     mergedBranches = new Set();
   }
 
+  // Detect the branch currently checked out at the project root once — it
+  // does not change across loop iterations and is used below to avoid
+  // requesting a worktree creation for a branch that git already considers
+  // "in use" by the main worktree.
+  let currentRootBranch: string | null = null;
+  try {
+    currentRootBranch = nativeGetCurrentBranch(basePath) || null;
+  } catch {
+    currentRootBranch = null;
+  }
+
   for (const branch of milestoneBranches) {
     const milestoneId = branch.replace(/^milestone\//, "");
     const milestone = getMilestone(milestoneId);
@@ -525,14 +536,18 @@ export function auditOrphanedMilestoneBranches(
       // recover as "worktree" so adoptStrandedMilestone re-materializes the
       // worktree from the existing branch (createAutoWorktree with
       // reuseExistingBranch) instead of degrading to branch-mode-in-root.
-      // If the milestone branch is already checked out at the project root
-      // (leftover from the old #812 branch-mode recovery), stay on "branch" so
-      // adoption resumes the existing root checkout instead of failing worktree
-      // creation with "branch already in use".
-      const branchCheckedOutAtRoot = nativeGetCurrentBranch(basePath) === branch;
+      //
+      // Exception (#812-followup): if the milestone branch is already checked
+      // out at the project root (e.g. a leftover from the pre-fix #812 recovery
+      // that ran `git checkout milestone/<id>` in the root), git considers that
+      // branch "in use by another worktree" and will refuse `git worktree add`,
+      // causing bootstrap to abort. Degrade to "branch" in that case — the
+      // session resumes on the already-checked-out branch without worktree
+      // creation, same as pre-fix behavior, and the configured isolation is
+      // restored for subsequent milestones after merge/teardown.
+      const isBranchCheckedOutAtRoot = currentRootBranch === branch;
       const recoveryMode: StrandedWorkRecoveryMode =
-        worktreeEvidence.path ||
-        (isolationMode === "worktree" && !branchCheckedOutAtRoot)
+        worktreeEvidence.path || (isolationMode === "worktree" && !isBranchCheckedOutAtRoot)
           ? "worktree"
           : "branch";
       const message = strandedWorkMessage({

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -525,8 +525,14 @@ export function auditOrphanedMilestoneBranches(
       // recover as "worktree" so adoptStrandedMilestone re-materializes the
       // worktree from the existing branch (createAutoWorktree with
       // reuseExistingBranch) instead of degrading to branch-mode-in-root.
+      // If the milestone branch is already checked out at the project root
+      // (leftover from the old #812 branch-mode recovery), stay on "branch" so
+      // adoption resumes the existing root checkout instead of failing worktree
+      // creation with "branch already in use".
+      const branchCheckedOutAtRoot = nativeGetCurrentBranch(basePath) === branch;
       const recoveryMode: StrandedWorkRecoveryMode =
-        worktreeEvidence.path || isolationMode === "worktree"
+        worktreeEvidence.path ||
+        (isolationMode === "worktree" && !branchCheckedOutAtRoot)
           ? "worktree"
           : "branch";
       const message = strandedWorkMessage({

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -433,7 +433,7 @@ function formatStrandedWorkBlockerMessage(
 
 export function auditOrphanedMilestoneBranches(
   basePath: string,
-  _isolationMode: "worktree" | "branch" | "none",
+  isolationMode: "worktree" | "branch" | "none",
   gitDeps: {
     branchList?: typeof nativeBranchList;
     branchExists?: typeof nativeBranchExists;
@@ -516,9 +516,19 @@ export function auditOrphanedMilestoneBranches(
       }
       if ((isMerged || commitsAhead === 0) && !worktreeEvidence.dirty) continue;
 
-      const recoveryMode: StrandedWorkRecoveryMode = worktreeEvidence.path
-        ? "worktree"
-        : "branch";
+      // #812 — the worktree directory being absent on disk does NOT mean the
+      // project is branch-mode. getAutoWorktreePath() returns null whenever the
+      // directory is merely missing (transient/permanent loss after an
+      // interrupted session), which previously collapsed to recoveryMode:
+      // "branch" — silently checking out milestone/<id> in the project root with
+      // no worktree. When the project is *configured* for worktree isolation,
+      // recover as "worktree" so adoptStrandedMilestone re-materializes the
+      // worktree from the existing branch (createAutoWorktree with
+      // reuseExistingBranch) instead of degrading to branch-mode-in-root.
+      const recoveryMode: StrandedWorkRecoveryMode =
+        worktreeEvidence.path || isolationMode === "worktree"
+          ? "worktree"
+          : "branch";
       const message = strandedWorkMessage({
         milestoneId,
         branch,

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -189,6 +189,36 @@ describe("auditOrphanedMilestoneBranches", () => {
     assert.equal(result.blockingStrandedWork?.recoveryMode, "branch");
   });
 
+  test("#812-followup — worktree-mode project degrades to branch recovery when branch is already checked out at root", () => {
+    // Simulates the leftover state from the pre-fix #812 recovery path: the
+    // old code checked out milestone/<id> in the project root instead of
+    // creating a worktree. On the next bootstrap:
+    //   - isolationMode === "worktree"
+    //   - HEAD at project root === "milestone/M001"
+    //   - no linked worktree directory on disk
+    //
+    // Requesting worktree recovery in this state calls `git worktree add` for
+    // a branch git already considers "in use by another worktree" (the main
+    // worktree counts), causing bootstrap to abort with GSD_LOCK_HELD.
+    // The fix detects the root checkout and degrades to "branch" so the
+    // session resumes on the already-checked-out branch without failing.
+    run("git checkout -b milestone/M001", dir);
+    writeFileSync(join(dir, "feature.txt"), "in-progress work\n");
+    run("git add feature.txt", dir);
+    run("git commit -m \"in-progress work on M001\"", dir);
+    // NOTE: stay on milestone/M001 — do NOT check out main.
+    // This simulates the project root being on the milestone branch.
+
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree");
+
+    assert.equal(result.blockingStrandedWork?.milestoneId, "M001");
+    // Must degrade to "branch" — worktree creation would fail because the
+    // branch is already checked out at the project root.
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "branch");
+  });
+
   test("#4762 — also surfaces worktree directory for in-progress orphan when present", () => {
     // In-progress + unmerged + physical worktree directory — the full primary scenario.
     run("git checkout -b milestone/M001", dir);

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -160,12 +160,33 @@ describe("auditOrphanedMilestoneBranches", () => {
       `warning should mention stranded milestone/M001 and in-progress state; got: ${JSON.stringify(result.warnings)}`,
     );
     assert.equal(result.blockingStrandedWork?.milestoneId, "M001");
-    assert.equal(result.blockingStrandedWork?.recoveryMode, "branch");
+    // #812 — worktree-configured isolation must recover as "worktree" even when
+    // the worktree directory is absent on disk, so recovery re-materializes the
+    // worktree from the branch instead of checking it out in the project root.
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "worktree");
     assert.equal(result.blockingStrandedWork?.commitsAhead, 1);
 
     // Branch must still exist
     const branches = run("git branch --list milestone/M001", dir);
     assert.ok(branches.includes("milestone/M001"), "in-progress branch must be preserved");
+  });
+
+  test("#812 — in-progress orphan under branch isolation recovers as branch", () => {
+    // Same stranded scenario but the project is configured for branch-mode
+    // isolation, where there is never a worktree to re-materialize. Recovery
+    // must stay "branch".
+    run("git checkout -b milestone/M001", dir);
+    writeFileSync(join(dir, "feature.txt"), "in-progress work\n");
+    run("git add feature.txt", dir);
+    run("git commit -m \"in-progress work on M001\"", dir);
+    run("git checkout main", dir);
+
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const result = auditOrphanedMilestoneBranches(dir, "branch");
+
+    assert.equal(result.blockingStrandedWork?.milestoneId, "M001");
+    assert.equal(result.blockingStrandedWork?.recoveryMode, "branch");
   });
 
   test("#4762 — also surfaces worktree directory for in-progress orphan when present", () => {


### PR DESCRIPTION
## Summary
- Gated the stranded-milestone "branch" recovery fallback on configured isolation mode so worktree-mode projects re-materialize the worktree instead of checking out the milestone branch in the project root; verified with the orphaned-worktree-audit and orphan-bootstrap test suites.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #812
- [#812 Stranded-milestone recovery silently checks out milestone branch in project root instead of recreating worktree](https://github.com/open-gsd/gsd-pi/issues/812)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/812-stranded-milestone-recovery-silently-che-1782343146`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-bootstrap git/worktree recovery paths for interrupted milestones; wrong mode could still mis-adopt work, but scope is narrow and covered by audit tests.
> 
> **Overview**
> Fixes **#812**: when bootstrap finds stranded in-progress milestone work, **`recoveryMode` no longer defaults to `"branch"` just because the worktree directory is missing on disk**.
> 
> In `auditOrphanedMilestoneBranches`, stranded-work recovery now uses configured **`isolationMode`**: worktree projects get **`"worktree"`** so `adoptStrandedMilestone` can re-create the worktree from the existing branch instead of checking out `milestone/<id>` in the project root. **`"branch"`** is kept when isolation is branch-mode, when a worktree path is already detected, or when that milestone branch is already checked out at the repo root (legacy #812 recovery).
> 
> Tests update the worktree-isolation expectation and add a branch-isolation case so recovery mode stays **`"branch"`** there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e317a7058416bf56796d41ef6012d0e18a0f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->