### PR TITLE
fix(issue): Evidence cross-reference flags WSL bash-spawn failures as falsified verification, hard-pausing auto-mode on Windows

### DIFF
--- a/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
+++ b/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
@@ -66,8 +66,28 @@ export function crossReferenceEvidence(
       continue;
     }
 
+    // A shell-spawn/infra failure means the command never ran (e.g. on Windows
+    // `gsd_exec runtime=bash` resolves to a WSL with no /bin/bash). The LLM
+    // typically recovers by re-running via another runtime, and that genuine
+    // run may not even be in the match set. Such a failure is inconclusive, not
+    // a falsified pass — exclude it before judging the exit code.
+    const commandRuns = matches.filter((m) => !isInfraSpawnFailure(m));
+    if (commandRuns.length === 0) {
+      if (claimed.exitCode === 0) {
+        mismatches.push({
+          severity: "warning",
+          claimed,
+          actual: latestMatch(matches),
+          reason:
+            `Matched execution failed to spawn (infrastructure error, not a command failure); ` +
+            `treating as inconclusive`,
+        });
+      }
+      continue;
+    }
+
     // Exit code mismatch: LLM claims success but actual command failed
-    const match = latestMatch(matches);
+    const match = latestMatch(commandRuns);
     if (claimed.exitCode === 0 && match.exitCode !== 0) {
       mismatches.push({
         severity: "error",
@@ -79,6 +99,30 @@ export function crossReferenceEvidence(
   }
 
   return mismatches;
+}
+
+/**
+ * Runtime-spawn / shell-infra failure signatures. When a bash-runtime call
+ * fails to *spawn* (rather than the command running and exiting non-zero), the
+ * recorded exitCode is an ordinary non-zero but the output carries one of these
+ * markers. Such a call is not evidence that a verification failed.
+ */
+const INFRA_SPAWN_FAILURE_SIGNATURES: readonly RegExp[] = [
+  /execvpe\([^)]*\)\s+failed/i,   // WSL: execvpe(/bin/bash) failed: No such file or directory
+  /WSL \(.*\) ERROR/i,            // WSL relay error banner
+  /command not found:\s*\S+/i,    // missing shell: command not found: bash
+];
+
+/**
+ * True when a non-zero bash call looks like a shell-spawn/infra failure (the
+ * command never started) rather than a real command failure. A successful run
+ * (exitCode 0) is never an infra failure.
+ */
+function isInfraSpawnFailure(call: BashEvidence): boolean {
+  if (call.exitCode === 0) return false;
+  const snippet = call.outputSnippet ?? "";
+  if (snippet.length === 0) return false;
+  return INFRA_SPAWN_FAILURE_SIGNATURES.some((re) => re.test(snippet));
 }
 
 // ─── Internals ──────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
+++ b/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
@@ -110,7 +110,7 @@ export function crossReferenceEvidence(
 const INFRA_SPAWN_FAILURE_SIGNATURES: readonly RegExp[] = [
   /execvpe\([^)]*\)\s+failed/i,   // WSL: execvpe(/bin/bash) failed: No such file or directory
   /WSL \(.*\) ERROR/i,            // WSL relay error banner
-  /command not found:\s*(?:bash|sh|zsh|dash|fish|ash|ksh)\b/i, // missing shell only
+  /command not found:\s*(?:bash|sh|zsh|dash|fish|ash|ksh|wsl)\b/i, // missing shell interpreter only
 ];
 
 /**

--- a/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
+++ b/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
@@ -110,7 +110,7 @@ export function crossReferenceEvidence(
 const INFRA_SPAWN_FAILURE_SIGNATURES: readonly RegExp[] = [
   /execvpe\([^)]*\)\s+failed/i,   // WSL: execvpe(/bin/bash) failed: No such file or directory
   /WSL \(.*\) ERROR/i,            // WSL relay error banner
-  /command not found:\s*\S+/i,    // missing shell: command not found: bash
+  /command not found:\s*(?:bash|sh|zsh|dash|fish|ash|ksh)\b/i, // missing shell only
 ];
 
 /**

--- a/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
+++ b/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
@@ -86,6 +86,32 @@ test("stale verification evidence batches are ignored when a newer completion ba
   assert.deepEqual(mismatches, []);
 });
 
+test("WSL bash-spawn failure is not flagged as a falsified passing verification", () => {
+  // Issue #814: on Windows, `gsd_exec runtime=bash` resolves to a WSL with no
+  // /bin/bash. The bash-runtime verification call exits 1 with a spawn-failure
+  // banner (the command never ran); the LLM re-ran via a node runtime (exit 0)
+  // that findMatches does not capture. The infra failure must not block.
+  const command = "npx playwright test e2e/m039-s05-comparison-legibility.spec.ts";
+  const mismatches = crossReferenceEvidence(
+    [{ command, exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command: `${command} --reporter=line 2>&1 | tail -40`,
+        exitCode: 1,
+        outputSnippet:
+          "<3>WSL (12 - Relay) ERROR: CreateProcessCommon:800: execvpe(/bin/bash) failed: No such file or directory",
+        timestamp: 1,
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "warning");
+  assert.match(mismatches[0].reason, /inconclusive/);
+});
+
 test("missing recorded bash evidence remains a warning", () => {
   const mismatches = crossReferenceEvidence(
     [{ command: "npm test", exitCode: 0, verdict: "passed" }],

--- a/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
+++ b/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
@@ -112,6 +112,75 @@ test("WSL bash-spawn failure is not flagged as a falsified passing verification"
   assert.match(mismatches[0].reason, /inconclusive/);
 });
 
+test("missing tool failure (command not found: eslint) is a real error, not an infra spawn failure", () => {
+  // Regression for overly-broad spawn signature: `command not found: eslint`
+  // is a genuine verification failure (eslint not installed), not a missing
+  // shell interpreter. It must produce a blocking error, not a warning.
+  const command = "eslint src/";
+  const mismatches = crossReferenceEvidence(
+    [{ command, exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command,
+        exitCode: 1,
+        outputSnippet: "zsh: command not found: eslint",
+        timestamp: Date.now(),
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "error");
+  assert.match(mismatches[0].reason, /Claimed exitCode=0/);
+});
+
+test("missing tool failure (command not found: node) is a real error, not an infra spawn failure", () => {
+  // node is not a shell interpreter; its absence is a genuine env problem,
+  // not a shell-spawn infra failure.
+  const command = "node --test tests/verify.test.js";
+  const mismatches = crossReferenceEvidence(
+    [{ command, exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command,
+        exitCode: 127,
+        outputSnippet: "bash: command not found: node",
+        timestamp: Date.now(),
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "error");
+  assert.match(mismatches[0].reason, /Claimed exitCode=0/);
+});
+
+test("missing shell interpreter (command not found: bash) is treated as an infra spawn failure", () => {
+  // bash itself missing is the shell-spawn infra case; must remain a warning.
+  const command = "npm test";
+  const mismatches = crossReferenceEvidence(
+    [{ command, exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command,
+        exitCode: 1,
+        outputSnippet: "command not found: bash",
+        timestamp: Date.now(),
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "warning");
+  assert.match(mismatches[0].reason, /inconclusive/);
+});
+
 test("missing recorded bash evidence remains a warning", () => {
   const mismatches = crossReferenceEvidence(
     [{ command: "npm test", exitCode: 0, verdict: "passed" }],


### PR DESCRIPTION
## Summary
- Taught evidence cross-reference to recognize WSL/shell-spawn infra failures and treat them as inconclusive (non-blocking warning) instead of a falsified passing verification; verified with focused unit tests (12/12 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #814
- [#814 Evidence cross-reference flags WSL bash-spawn failures as falsified verification, hard-pausing auto-mode on Windows](https://github.com/open-gsd/gsd-pi/issues/814)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/814-evidence-cross-reference-flags-wsl-bash--1782343625`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to auto-mode safety evidence matching with added tests; only relaxes false-positive blocks, not real command failures.
> 
> **Overview**
> **Evidence cross-reference** no longer treats WSL/shell **spawn** failures (command never ran) as proof that a claimed passing verification was falsified.
> 
> Matching bash evidence is filtered with **`isInfraSpawnFailure`** using output signatures (`execvpe(...) failed`, WSL relay errors, missing shell). Exit-code checks use only real command runs. When every match is infra-only and the claim is **exitCode 0**, the harness records a **warning** (“inconclusive”) instead of a blocking **error**, so auto-mode is not hard-paused on Windows when bash runtime fails but verification succeeded elsewhere.
> 
> A unit test covers the #814 WSL `/bin/bash` scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9043cce4c87773b994291c050bfb9d8293714d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->