### PR TITLE
fix(issue): [Bug]: auto mode is broken in 1.3.0

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -664,7 +664,28 @@ export async function handleAgentEnd(
       return;
     }
 
+    // ── Tool-schema overload: the active model repeatedly emitted tool-call
+    //    arguments that fail schema validation (e.g. a model whose tool-call
+    //    grammar can't satisfy GSD's schemas). Before hard-pausing, try the
+    //    unit's configured fallbacks and the auto-mode start model — the model
+    //    the user actually selected. This lets auto-mode recover by switching
+    //    back to a schema-capable model instead of aborting outright (#813).
+    //    Do not persistently block the model: schema-overload is request-shape
+    //    specific, mirroring the model-error path above.
     if (cls.kind === "tool-schema") {
+      const dash = getAutoDashboardData();
+      const switched = await tryProviderModelFallback({
+        ctx,
+        pi,
+        rejectedProvider: ctx.model?.provider,
+        rejectedId: ctx.model?.id,
+        basePath: dash.basePath,
+        unitType: dash.currentUnit?.type,
+        switchedNotify: (label) =>
+          ctx.ui.notify(`Switched to ${label} after repeated tool schema validation failures.`, "warning"),
+      });
+      if (switched) return;
+
       await pauseAutoForProviderError(ctx.ui, errorDetail, () => pauseAuto(ctx, pi, {
         message: `Tool schema error${errorDetail}`,
         category: "tool-schema",

--- a/src/resources/extensions/gsd/tests/tool-schema-model-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-schema-model-fallback.test.ts
@@ -1,0 +1,64 @@
+/**
+ * tool-schema-model-fallback.test.ts — Regression test for #813.
+ *
+ * Auto mode aborted with "Schema overload: consecutive tool validation
+ * failures exceeded cap" instead of recovering. The tool-schema handler now
+ * attempts the unit's configured fallbacks and the auto-mode start model (the
+ * model the user actually selected) before hard-pausing, mirroring the
+ * model-error path.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { classifyError } from "../error-classifier.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RECOVERY_PATH = join(__dirname, "..", "bootstrap", "agent-end-recovery.ts");
+
+function getRecoverySource(): string {
+  return readFileSync(RECOVERY_PATH, "utf-8");
+}
+
+test("schema overload classifies as tool-schema (#813)", () => {
+  const cls = classifyError(
+    "Schema overload: consecutive tool validation failures exceeded cap",
+  );
+  assert.equal(cls.kind, "tool-schema");
+});
+
+test("tool-schema handler attempts model fallback before pausing (#813)", () => {
+  const src = getRecoverySource();
+
+  // Isolate the tool-schema branch body.
+  const branchStart = src.indexOf('if (cls.kind === "tool-schema")');
+  assert.ok(branchStart !== -1, "tool-schema branch must exist");
+  const branch = src.slice(branchStart, branchStart + 1200);
+
+  assert.ok(
+    branch.includes("tryProviderModelFallback"),
+    "tool-schema branch must attempt tryProviderModelFallback before pausing (#813)",
+  );
+  // Fallback success must short-circuit the pause so auto-mode continues.
+  assert.ok(
+    /if\s*\(switched\)\s*return;/.test(branch),
+    "tool-schema branch must return early when a fallback model is switched in (#813)",
+  );
+});
+
+test("tool-schema handler still pauses when no fallback succeeds (#813)", () => {
+  const src = getRecoverySource();
+
+  const branchStart = src.indexOf('if (cls.kind === "tool-schema")');
+  const branch = src.slice(branchStart, branchStart + 1200);
+
+  // The terminal pause must still classify as a tool-schema pause, not a
+  // generic provider pause.
+  assert.ok(
+    /category:\s*"tool-schema"/.test(branch),
+    "tool-schema branch must retain its tool-schema pause category when fallback fails (#813)",
+  );
+});


### PR DESCRIPTION
## Summary
- Made auto-mode's tool-schema "schema overload" handler attempt configured fallbacks and the user-selected start model before hard-pausing (instead of aborting immediately), verified by existing recovery suites plus a new #813 regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #813
- [#813 [Bug]: auto mode is broken in 1.3.0](https://github.com/open-gsd/gsd-pi/issues/813)

## User
- @mgerdov-igt

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/813-bug-auto-mode-is-broken-in-1-3-0-1782343866`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to auto-mode error recovery with existing fallback helper; no auth or data-path changes.
> 
> **Overview**
> Fixes auto-mode stopping immediately on **schema overload** (repeated tool argument validation failures) by trying **configured unit fallbacks** and the **auto-mode start model** via `tryProviderModelFallback` before hard-pausing—matching the existing **model-error** recovery path and **not** persistently blocking the rejected model.
> 
> On a successful switch, auto-mode continues with a warning notification and a steer to resume execution; if no fallback works, behavior is unchanged: pause with category `tool-schema`.
> 
> Adds regression tests (#813) for classification and that the handler calls fallback first and still pauses correctly when fallback fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1bbdc52a416ae590ee5b263fc5685f5637e20a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->