### PR TITLE
fix(issue): doctor stale_crash_lock hint is wrong: 'Run /gsd doctor' doesn't clear; needs /gsd doctor fix

### DIFF
--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -192,8 +192,8 @@ export function crashResumeHint(unitType: string, unitId: string): string | unde
 const DOCTOR_FIX_HINTS: Partial<Record<DoctorIssueCode, string>> = {
   db_unavailable:
     "The workflow database could not be opened — state derivation is degraded. Restart the session; if it persists, run `/gsd doctor` from the project root.",
-  stale_crash_lock: "Run `/gsd doctor` to clear the stale lock, then `/gsd auto` to resume.",
-  stale_parallel_session: "Run `/gsd doctor` to clear the stale session registration.",
+  stale_crash_lock: "Run `/gsd doctor fix` to clear the stale lock, then `/gsd auto` to resume.",
+  stale_parallel_session: "Run `/gsd doctor fix` to clear the stale session registration.",
   unresolved_git_conflicts:
     "Resolve the conflict markers, commit, then re-run `/gsd auto`.",
   conflict_markers_in_tracked_files:
@@ -201,14 +201,14 @@ const DOCTOR_FIX_HINTS: Partial<Record<DoctorIssueCode, string>> = {
   worktree_dirty:
     "Commit or merge the worktree's changes (`gsd worktree merge <name>`) before removing it.",
   worktree_branch_merged: "The branch is merged — remove the worktree to reclaim space.",
-  orphaned_auto_worktree: "Run `/gsd doctor` to fix, or merge salvageable work with `gsd worktree merge <name>`.",
-  gitignore_missing_patterns: "Run `/gsd doctor` to append the missing .gitignore patterns.",
+  orphaned_auto_worktree: "Run `/gsd doctor fix` to fix, or merge salvageable work with `gsd worktree merge <name>`.",
+  gitignore_missing_patterns: "Run `/gsd doctor fix` to append the missing .gitignore patterns.",
   invalid_preferences: "Edit .gsd/PREFERENCES.md to fix the invalid field, then re-run the command.",
   provider_key_missing: "Add the provider API key to your environment or provider config, then retry.",
   provider_key_backedoff: "The key is cooling down after repeated failures — wait, or switch the phase model in .gsd/PREFERENCES.md.",
-  state_file_stale: "Run `/gsd doctor` to rebuild the projection from the database.",
-  state_file_missing: "Run `/gsd doctor` to rebuild the projection from the database.",
-  projection_drift: "Run `/gsd doctor` to rebuild markdown projections from the database (DB is the source of truth).",
+  state_file_stale: "Run `/gsd doctor fix` to rebuild the projection from the database.",
+  state_file_missing: "Run `/gsd doctor fix` to rebuild the projection from the database.",
+  projection_drift: "Run `/gsd doctor fix` to rebuild markdown projections from the database (DB is the source of truth).",
   uat_retry_exhausted: "Review the failing UAT criteria via `/gsd status`, fix the issue, then re-run `/gsd auto`.",
 };
 

--- a/src/resources/extensions/gsd/tests/guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/guidance.test.ts
@@ -145,4 +145,29 @@ describe("doctor fix hints", () => {
   test("codes without authored guidance resolve to undefined", () => {
     assert.equal(doctorFixHint("delimiter_in_title"), undefined);
   });
+
+  test("fixable issue codes instruct /gsd doctor fix, not bare /gsd doctor", () => {
+    const fixableCodes = [
+      "stale_crash_lock",
+      "stale_parallel_session",
+      "orphaned_auto_worktree",
+      "gitignore_missing_patterns",
+      "state_file_stale",
+      "state_file_missing",
+      "projection_drift",
+    ] as const;
+
+    for (const code of fixableCodes) {
+      const hint = doctorFixHint(code);
+      assert.ok(hint, `expected a hint for ${code}`);
+      assert.match(hint, /\/gsd doctor fix/, `hint for ${code} must use /gsd doctor fix`);
+    }
+  });
+
+  test("db_unavailable uses bare /gsd doctor (diagnostic only, no auto-fix)", () => {
+    const hint = doctorFixHint("db_unavailable");
+    assert.ok(hint);
+    assert.match(hint, /\/gsd doctor/);
+    assert.doesNotMatch(hint, /\/gsd doctor fix/);
+  });
 });


### PR DESCRIPTION
## Summary
- Corrected the seven misleading `DOCTOR_FIX_HINTS` rows in guidance.ts to instruct `/gsd doctor fix` (not bare `/gsd doctor`, which is read-only); verified with the guidance unit tests (15/15 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #821
- [#821 doctor stale_crash_lock hint is wrong: 'Run /gsd doctor' doesn't clear; needs /gsd doctor fix](https://github.com/open-gsd/gsd-pi/issues/821)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/821-doctor-stale-crash-lock-hint-is-wrong-ru-1782344947`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing guidance text only; no doctor or fix behavior changes.
> 
> **Overview**
> **Updates seven `DOCTOR_FIX_HINTS` entries** so fixable doctor issues tell users to run **`/gsd doctor fix`** instead of bare **`/gsd doctor`**, which only reports problems and does not apply repairs.
> 
> Affected codes include stale crash/parallel-session locks, orphaned auto-worktrees, missing `.gitignore` patterns, and state/projection drift rebuilds. **`db_unavailable`** is unchanged—it still suggests **`/gsd doctor`** for diagnosis when a restart is not enough.
> 
> Hints surface in doctor report output via `doctorFixHint` in `doctor-format.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb7d994c7580299a0bac1456a0ea7717c68f678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->