### PR TITLE
fix(issue): gsd worktree merge crashes: extension imports packages/pi-ai/src/ which doesn't ship in v1.3.0 tarball

### DIFF
--- a/src/jiti-workspace-aliases.ts
+++ b/src/jiti-workspace-aliases.ts
@@ -1,10 +1,30 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { resolvePackageRoot } from "./bundled-resource-path.js";
 
-/** jiti alias map for @gsd/* workspace packages (CJS require cannot load ESM file:// URLs). */
-export function getJitiWorkspaceAliases(importUrl: string): Record<string, string> {
+export type FileExists = (path: string) => boolean;
+
+/**
+ * jiti alias map for @gsd/* workspace packages (CJS require cannot load ESM file:// URLs).
+ *
+ * In the monorepo the canonical entry points are raw TypeScript under `packages/<name>/src/`,
+ * which jiti loads directly. The published tarball ships only the compiled `packages/<name>/dist/`
+ * (see each package's `files` field) — `src/` is absent. Resolve each alias to the `src/*.ts`
+ * entry when present, otherwise fall back to the compiled `dist/*.js`, so the merge CLI loads in
+ * both layouts instead of crashing with MODULE_NOT_FOUND on the missing source path.
+ */
+export function getJitiWorkspaceAliases(
+  importUrl: string,
+  fileExists: FileExists = existsSync,
+): Record<string, string> {
   const root = resolvePackageRoot(importUrl);
-  const pkg = (dir: string, ...segments: string[]) => join(root, "packages", dir, "src", ...segments);
+  // Prefer the source `.ts` entry (monorepo); fall back to the compiled `.js` (published tarball).
+  const pkg = (dir: string, ...segments: string[]) => {
+    const srcEntry = join(root, "packages", dir, "src", ...segments);
+    if (fileExists(srcEntry)) return srcEntry;
+    const distSegments = segments.map((s) => s.replace(/\.ts$/, ".js"));
+    return join(root, "packages", dir, "dist", ...distSegments);
+  };
 
   const piAi = pkg("pi-ai", "index.ts");
   const piAiOauth = pkg("pi-ai", "utils", "oauth", "index.ts");

--- a/src/tests/jiti-workspace-aliases.test.ts
+++ b/src/tests/jiti-workspace-aliases.test.ts
@@ -1,0 +1,29 @@
+// Project/App: gsd-pi
+// File Purpose: Verify @gsd/* jiti aliases fall back to dist when src is not shipped.
+
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { getJitiWorkspaceAliases } from "../jiti-workspace-aliases.js"
+
+// importUrl is a module file inside <root>/dist or <root>/src; resolvePackageRoot
+// climbs one level to the package root, so aliases live under <root>/packages/*.
+const importUrl = new URL("file:///pkg/dist/worktree-cli.js")
+
+test("aliases resolve to source .ts entries in the monorepo layout", () => {
+  const aliases = getJitiWorkspaceAliases(importUrl.href, () => true)
+
+  assert.equal(aliases["@gsd/pi-ai"], "/pkg/packages/pi-ai/src/index.ts")
+  assert.equal(aliases["@gsd/pi-ai/oauth"], "/pkg/packages/pi-ai/src/utils/oauth/index.ts")
+  assert.equal(aliases["@gsd/pi-coding-agent"], "/pkg/packages/pi-coding-agent/src/index.ts")
+})
+
+test("aliases fall back to compiled dist .js when src is absent (published tarball)", () => {
+  // Published tarball ships only packages/<name>/dist — src/ does not exist on disk.
+  const aliases = getJitiWorkspaceAliases(importUrl.href, () => false)
+
+  assert.equal(aliases["@gsd/pi-ai"], "/pkg/packages/pi-ai/dist/index.js")
+  assert.equal(aliases["@gsd/pi-ai/oauth"], "/pkg/packages/pi-ai/dist/utils/oauth/index.js")
+  assert.equal(aliases["@gsd/pi-coding-agent"], "/pkg/packages/pi-coding-agent/dist/index.js")
+  assert.equal(aliases["@earendil-works/pi-ai"], "/pkg/packages/pi-ai/dist/index.js")
+})


### PR DESCRIPTION
## Summary
- Made `getJitiWorkspaceAliases` fall back from missing `src/*.ts` to compiled `dist/*.js` (which is what the published tarball ships), fixing the `worktree merge` MODULE_NOT_FOUND crash; verified with a new unit test and tsc.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #822
- [#822 gsd worktree merge crashes: extension imports packages/pi-ai/src/ which doesn't ship in v1.3.0 tarball](https://github.com/open-gsd/gsd-pi/issues/822)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/822-gsd-worktree-merge-crashes-extension-imp-1782345439`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized alias resolution change with tests; monorepo still prefers src when present.
> 
> **Overview**
> Fixes **`worktree merge`** (and other jiti-backed CLI paths) failing with **MODULE_NOT_FOUND** on published installs where workspace packages only ship **`packages/*/dist`**, not **`src/*.ts`**.
> 
> **`getJitiWorkspaceAliases`** now resolves each `@gsd/*` (and legacy `@earendil-works/*`) alias to the monorepo **`src`** entry when that path exists, otherwise to the matching **`dist/*.js`** path (`.ts` segments rewritten to `.js`). An optional injectable **`fileExists`** hook defaults to **`existsSync`** so behavior is unchanged for normal callers like **`worktree-cli`**.
> 
> Adds unit tests for both monorepo (always prefer src) and tarball (always dist) layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13767298f65b2a2184228c41fd4353f4e604d559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->