### PR TITLE
fix(issue): unregistered-milestone drift hints at /gsd recover --confirm but that is a destructive full reimport, not a targeted import

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
@@ -9,7 +9,7 @@ import { existsSync } from "node:fs";
 
 import { getMilestone, isDbAvailable } from "../../gsd-db.js";
 import { findMilestoneIds } from "../../milestone-ids.js";
-import { resolveMilestoneFile } from "../../paths.js";
+import { resolveMilestoneFile, resolveMilestonePath } from "../../paths.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
@@ -46,16 +46,29 @@ export function detectUnregisteredMilestoneDrift(
 
 /**
  * Repair intentionally fails closed. The project-root DB is authoritative at
- * runtime; markdown-only milestones must be imported through an explicit
- * migration/recovery command so operators opt into changing canonical state.
+ * runtime; markdown-only milestones must be reconciled through an explicit,
+ * operator-controlled action so operators opt into changing canonical state.
+ *
+ * The hint deliberately leads with the *targeted*, non-destructive options. The
+ * common cause of this drift is a directory left under an old ID after a
+ * `unique_milestone_ids` rename, where the right fix is to rename (move) the
+ * directory — not a full DB reimport. `/gsd recover --confirm` is a destructive
+ * clear-and-reimport of the entire DB and is offered only as a last resort, so
+ * users do not reach for it expecting a targeted repair (see issue #826).
  */
 export function repairUnregisteredMilestone(
   record: UnregisteredMilestoneDrift,
-  _ctx: DriftContext,
+  ctx: DriftContext,
 ): void {
+  const dir = resolveMilestonePath(ctx.basePath, record.milestoneId);
+  const dirHint = dir ?? `the .gsd directory for ${record.milestoneId}`;
   throw new Error(
-    `Milestone ${record.milestoneId} exists only as markdown projection. ` +
-      "Runtime reconciliation will not import markdown into the authoritative DB; run `/gsd recover --confirm` if this markdown should repopulate the database.",
+    `Milestone ${record.milestoneId} exists only as markdown projection ` +
+      "(on-disk ROADMAP/CONTEXT/SUMMARY with no authoritative DB row). " +
+      "Runtime reconciliation will not import markdown into the DB. Choose one:\n" +
+      `  • Rename: if this directory is the same milestone under an old ID (e.g. a unique_milestone_ids rename), move \`${dirHint}\` to the current ID's directory and re-run.\n` +
+      `  • Discard: if this milestone is no longer relevant, delete \`${dirHint}\` and re-run.\n` +
+      "  • Last resort: `/gsd recover --confirm` performs a destructive full DB clear-and-reimport — it does NOT do a targeted import and can replace or duplicate existing DB milestones.",
   );
 }
 

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -925,7 +925,12 @@ test("ADR-017 (#5704): unregistered-milestone drift fails closed without importi
       assert.equal(err.failures[0]?.drift.kind, "unregistered-milestone");
       assert.match(String(err.failures[0]?.cause), /M042/);
       assert.match(String(err.failures[0]?.cause), /markdown projection/);
+      // Hint leads with targeted, non-destructive actions (rename/discard)...
+      assert.match(String(err.failures[0]?.cause), /Rename/);
+      assert.match(String(err.failures[0]?.cause), /Discard/);
+      // ...and reframes recover as a destructive last resort, not the fix (#826).
       assert.match(String(err.failures[0]?.cause), /\/gsd recover/);
+      assert.match(String(err.failures[0]?.cause), /last resort/i);
       return true;
     },
   );


### PR DESCRIPTION
## Summary
- Reworded the unregistered-milestone drift hint to lead with targeted, non-destructive rename/discard actions and demote `/gsd recover --confirm` to a labeled destructive last resort; updated its test and confirmed the changed files typecheck clean.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #826
- [#826 unregistered-milestone drift hints at /gsd recover --confirm but that is a destructive full reimport, not a targeted import](https://github.com/open-gsd/gsd-pi/issues/826)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/826-unregistered-milestone-drift-hints-at-gs-1782345667`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-facing error text and test expectations only; detection and fail-closed repair behavior are unchanged.
> 
> **Overview**
> When **unregistered-milestone** drift fails closed, the thrown error no longer steers operators toward `/gsd recover --confirm` as the primary fix. The message now lists **Rename** (move the on-disk milestone directory after an ID rename), **Discard** (delete the orphan directory), and only then **`/gsd recover --confirm`** as a destructive full DB clear-and-reimport that is not targeted.
> 
> `repairUnregisteredMilestone` now uses `resolveMilestonePath` and `DriftContext` so rename/discard lines include the actual `.gsd` directory path. ADR-017 contract tests assert the new Rename/Discard wording and that recover is framed as a last resort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a36c72eef4b3e6fc5af432da554aa1356fd1bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->