### PR TITLE
fix(issue): unmerged-milestone-guard uses diff instead of ancestor check: false-positive blocks every workflow command after a --no-ff merge

### DIFF
--- a/src/resources/extensions/gsd/tests/unmerged-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/unmerged-milestone-guard.test.ts
@@ -53,6 +53,34 @@ test("findUnmergedCompletedMilestones blocks completed milestone branch product 
   }
 });
 
+test("findUnmergedCompletedMilestones does not block after a --no-ff merge that diverges from the branch tip", async () => {
+  const base = makeTempRepo("gsd-unmerged-guard-");
+  try {
+    seedMilestone(base, "M011");
+    // Milestone branch adds a product file.
+    commitBranchFile(base, "milestone/M011", "index.html", "<h1>M011</h1>\n");
+
+    // Merge the branch into main with --no-ff, but resolve the file to main's
+    // (empty) side so the merge result diverges from the milestone branch tip.
+    // The branch is now an ancestor of main even though a raw diff is non-empty.
+    git(base, "merge", "--no-ff", "--no-commit", "milestone/M011");
+    writeFileSync(join(base, "index.html"), "<h1>main wins</h1>\n");
+    git(base, "add", "index.html");
+    git(base, "commit", "-m", "merge: take main side for index.html");
+
+    // Sanity: the diff between main and the branch tip is non-empty...
+    assert.notEqual(git(base, "diff", "--numstat", "main", "milestone/M011"), "");
+    // ...but the branch tip is an ancestor of main (merge is done).
+
+    const blockers = await findUnmergedCompletedMilestones(base);
+
+    assert.equal(blockers.length, 0);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("findUnmergedCompletedMilestones ignores projection-only branch diffs", async () => {
   const base = makeTempRepo("gsd-unmerged-guard-");
   try {

--- a/src/resources/extensions/gsd/unmerged-milestone-guard.ts
+++ b/src/resources/extensions/gsd/unmerged-milestone-guard.ts
@@ -5,6 +5,7 @@ import {
   nativeBranchExists,
   nativeDetectMainBranch,
   nativeDiffNumstat,
+  nativeIsAncestor,
 } from "./native-git-bridge.js";
 import { autoWorktreeBranch } from "./auto-worktree.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
@@ -141,6 +142,15 @@ export async function findUnmergedCompletedMilestones(base: string): Promise<Unm
 
     const integrationBranch = resolveIntegrationBranch(base, milestone.id);
     if (!integrationBranch || integrationBranch === branch) continue;
+
+    // The milestone is merged when its branch tip is reachable from the
+    // integration branch tip — true for fast-forward, --no-ff, and squash
+    // merges alike. A raw diff is the wrong predicate: a --no-ff merge that
+    // took main's side for some conflicts leaves the branch tip differing from
+    // main, which the diff check would misread as "unmerged" (#825). The diff
+    // below remains the correct fallback only when the branch is NOT yet an
+    // ancestor — i.e. the merge is genuinely still pending.
+    if (nativeIsAncestor(base, branch, integrationBranch)) continue;
 
     const files = nativeDiffNumstat(base, integrationBranch, branch)
       .map((entry) => entry.path)


### PR DESCRIPTION
## Summary
- Replaced the diff-only unmerged-milestone predicate with an ancestor check (nativeIsAncestor) so already-merged `--no-ff` branches no longer false-positive-block all workflow commands; verified with the guard test suite (7/7 pass, new regression test added).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #825
- [#825 unmerged-milestone-guard uses diff instead of ancestor check: false-positive blocks every workflow command after a --no-ff merge](https://github.com/open-gsd/gsd-pi/issues/825)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/825-unmerged-milestone-guard-uses-diff-inste-1782346028`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows a workflow guard predicate with an ancestor check and keeps diff for truly unmerged branches; covered by new regression test.
> 
> **Overview**
> Fixes **false-positive workflow blocks** after a completed milestone is merged with `--no-ff` when the merge result does not match the branch tip (e.g. conflicts resolved on the integration side). The unmerged-milestone guard previously treated any non-empty product diff between integration and `milestone/*` as “still unmerged,” which blocked commands like `/gsd next` even though the branch was already merged.
> 
> **`findUnmergedCompletedMilestones`** now skips closed milestones when **`nativeIsAncestor`** shows the milestone branch tip is reachable from the integration branch; the existing **`nativeDiffNumstat`** path still applies only when the branch is **not** yet an ancestor (genuinely pending merge). A regression test covers a `--no-ff` merge where `main` and the branch tip still differ but the branch is an ancestor of `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7075ba0564cc08653d2a39fb9e05cc29169496cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->