### PR TITLE
fix(issue): [Bug]: KV Cache Completely Invalidated on Every User Turn

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -71,6 +71,25 @@ export const BUNDLED_SKILL_TRIGGERS: Array<{ trigger: string; skill: string }> =
   { trigger: "Deep code optimization audit — perf anti-patterns, memory leaks, algorithmic complexity, bundle size, I/O, caching, dead code (parallel pattern-based hunt)", skill: "code-optimizer" },
 ];
 
+/**
+ * Remove the volatile lines from a CODEBASE.md map before it is injected into
+ * the cached system-prompt prefix: the human-readable `Generated: <timestamp>`
+ * header and the `<!-- gsd:codebase-meta {...} -->` comment. Both carry a
+ * per-regeneration timestamp (and fingerprint) that change whenever the map is
+ * refreshed, which would otherwise invalidate the provider KV cache prefix on
+ * every turn even when the underlying file structure is identical. (#847)
+ */
+export function stripVolatileCodebaseMetadata(content: string): string {
+  return content
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trimStart();
+      return !trimmed.startsWith("Generated:") && !trimmed.startsWith("<!-- gsd:codebase-meta");
+    })
+    .join("\n")
+    .trim();
+}
+
 function warnDeprecatedAgentInstructions(): void {
   const paths = [
     join(gsdHome(), "agent-instructions.md"),
@@ -213,16 +232,21 @@ export async function buildBeforeAgentStartResult(
   const rawCodebase = readCodebaseMap(process.cwd());
   if (existsSync(codebasePath) && rawCodebase) {
     try {
-      const rawContent = rawCodebase.trim();
+      // Strip the volatile `Generated: <timestamp>` header line and the
+      // machine-readable `gsd:codebase-meta` comment before injecting. Both
+      // embed a per-regeneration timestamp/fingerprint; because this block
+      // rides the cached system-prompt prefix, leaving the timestamp in would
+      // invalidate the provider KV cache on every map refresh even when the
+      // file structure is unchanged. The full map (with timestamp) remains at
+      // .gsd/CODEBASE.md. (#847)
+      const rawContent = stripVolatileCodebaseMetadata(rawCodebase.trim());
       if (rawContent) {
         // Cap injection size to ~2 000 tokens to avoid bloating every request.
         // Full map is always available at .gsd/CODEBASE.md.
-        const generatedMatch = rawContent.match(/Generated: (\S+)/);
-        const generatedAt = generatedMatch?.[1] ?? "unknown";
         const content = rawContent.length > DEFAULT_CODEBASE_MAX_CHARS
           ? rawContent.slice(0, DEFAULT_CODEBASE_MAX_CHARS) + "\n\n*(truncated — see .gsd/CODEBASE.md for full map)*"
           : rawContent;
-        codebaseBlock = `\n\n[PROJECT CODEBASE — File structure and descriptions (generated ${generatedAt}, auto-refreshed when GSD detects tracked file changes; use /gsd codebase stats for status)]\n\n${content}`;
+        codebaseBlock = `\n\n[PROJECT CODEBASE — File structure and descriptions (auto-refreshed when GSD detects tracked file changes; use /gsd codebase stats for status)]\n\n${content}`;
       }
     } catch (e) {
       logWarning("bootstrap", `CODEBASE file read failed: ${(e as Error).message}`);

--- a/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
@@ -4,7 +4,35 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildContextMessage } from "../bootstrap/system-context.ts";
+import { buildContextMessage, stripVolatileCodebaseMetadata } from "../bootstrap/system-context.ts";
+
+describe("stripVolatileCodebaseMetadata (#847 — KV cache stability)", () => {
+  const map = [
+    "# Codebase Map",
+    "",
+    "Generated: 2026-03-23T14:00:00Z | Files: 3 | Described: 2/3",
+    `<!-- gsd:codebase-meta {"generatedAt":"2026-03-23T14:00:00Z","fingerprint":"abc","fileCount":3,"truncated":false} -->`,
+    "",
+    "### src/",
+    "- `a.ts` — does a",
+    "- `b.ts`",
+  ].join("\n");
+
+  test("removes the Generated timestamp and meta comment lines", () => {
+    const stripped = stripVolatileCodebaseMetadata(map);
+    assert.ok(!stripped.includes("Generated:"));
+    assert.ok(!stripped.includes("gsd:codebase-meta"));
+    assert.ok(stripped.includes("- `a.ts` — does a"));
+    assert.ok(stripped.includes("### src/"));
+  });
+
+  test("is stable across regenerations that only change the timestamp", () => {
+    const later = map
+      .replace("2026-03-23T14:00:00Z | Files", "2026-03-24T09:30:00Z | Files")
+      .replace('"generatedAt":"2026-03-23T14:00:00Z"', '"generatedAt":"2026-03-24T09:30:00Z"');
+    assert.equal(stripVolatileCodebaseMetadata(map), stripVolatileCodebaseMetadata(later));
+  });
+});
 
 describe("buildContextMessage (#5019 — memory routing)", () => {
   const markedMemory = "[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]\nrule one";


### PR DESCRIPTION
## Summary
- Stripped the volatile CODEBASE timestamp/metadata lines from the cached system-prompt prefix so KV cache survives turns when file structure is unchanged; verified with new and existing unit tests (52 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #847
- [#847 [Bug]: KV Cache Completely Invalidated on Every User Turn](https://github.com/open-gsd/gsd-pi/issues/847)

## User
- @sbaechler

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/847-bug-kv-cache-completely-invalidated-on-e-1782373152`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Surgical bootstrap change with unit tests; agents lose the inline generation time in the prompt but can still read full metadata from `.gsd/CODEBASE.md` or `/gsd codebase stats`.
> 
> **Overview**
> Fixes provider KV cache invalidation on every turn when the codebase map is refreshed but the file tree is unchanged.
> 
> **`stripVolatileCodebaseMetadata`** drops the `Generated:` header and `<!-- gsd:codebase-meta ... -->` line from `.gsd/CODEBASE.md` content before it is appended to the cached system-prompt prefix in `buildBeforeAgentStartResult`. Those fields change on each regeneration even when structure is stable. The on-disk map is unchanged; only the injected excerpt is normalized. The injected wrapper no longer embeds a parsed generation timestamp.
> 
> Regression tests in `system-context-message-routing.test.ts` assert line removal and identical stripped output when only timestamps/fingerprints differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1787ca916ac9346e762932e6da824f2234e0ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->