### PR TITLE
fix(issue): Doctor unresolved_git_conflicts blocks auto-mode before attempting autoResolveSafeConflictPaths

### DIFF
--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -152,6 +152,7 @@ export async function checkGitHealth(
   fixesApplied: string[],
   shouldFix: (code: DoctorIssueCode) => boolean,
   isolationMode: "none" | "worktree" | "branch" = "none",
+  dryRun = false,
 ): Promise<void> {
   // Degrade gracefully if not a git repo
   if (!nativeIsRepo(basePath)) {
@@ -180,7 +181,7 @@ export async function checkGitHealth(
   // so only genuinely-manual conflicts remain. This also clears stale
   // merge-state markers (e.g. MERGE_HEAD) in the same pass when auto-resolve
   // empties the unmerged set (#849).
-  if (unmergedPaths.length > 0) {
+  if (unmergedPaths.length > 0 && !dryRun) {
     try {
       const reconcileFixes = reconcileGitConflictsOnSignal(basePath, probeGitConflictState(basePath));
       if (reconcileFixes.length > 0) {

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -15,7 +15,7 @@ import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegr
 import { nativeIsRepo, nativeWorktreeList, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeAddTracked, nativeCommit } from "./native-git-bridge.js";
 import { getAllWorktreeHealth } from "./worktree-health.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
-import { listUnmergedGitPaths } from "./git-conflict-state.js";
+import { listUnmergedGitPaths, probeGitConflictState, reconcileGitConflictsOnSignal } from "./git-conflict-state.js";
 import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 /**
@@ -159,7 +159,7 @@ export async function checkGitHealth(
   }
 
   const gitDir = resolveGitDir(basePath);
-  const unmergedPaths = listUnmergedGitPaths(basePath);
+  let unmergedPaths = listUnmergedGitPaths(basePath);
   if (unmergedPaths === null) {
     issues.push({
       severity: "error",
@@ -170,6 +170,27 @@ export async function checkGitHealth(
       fixable: false,
     });
     return;
+  }
+
+  // ── Auto-resolve safe conflicts before reporting ──────────────────────
+  // A failed worktree merge (e.g. during complete-slice) can leave conflict
+  // markers for paths that are always safe to accept from the milestone side
+  // (.gsd/ state and build artifacts). Run the same reconciliation the
+  // preflight/auto-worktree paths use before the doctor hard-blocks auto-mode,
+  // so only genuinely-manual conflicts remain. This also clears stale
+  // merge-state markers (e.g. MERGE_HEAD) in the same pass when auto-resolve
+  // empties the unmerged set (#849).
+  if (unmergedPaths.length > 0) {
+    try {
+      const reconcileFixes = reconcileGitConflictsOnSignal(basePath, probeGitConflictState(basePath));
+      if (reconcileFixes.length > 0) {
+        fixesApplied.push(...reconcileFixes);
+        const refreshed = listUnmergedGitPaths(basePath);
+        if (refreshed !== null) unmergedPaths = refreshed;
+      }
+    } catch {
+      // Non-fatal — fall through to report the unmerged paths as-is
+    }
   }
 
   // ── Orphaned auto-worktrees & Stale milestone branches ────────────────

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -365,7 +365,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
   const isolationMode: "none" | "worktree" | "branch" = options?.isolationMode ??
     (prefs?.preferences?.git?.isolation === "worktree" ? "worktree" :
     prefs?.preferences?.git?.isolation === "branch" ? "branch" : "none");
-  await checkGitHealth(basePath, issues, fixesApplied, shouldFix, isolationMode);
+  await checkGitHealth(basePath, issues, fixesApplied, shouldFix, isolationMode, dryRun);
   const gitMs = Date.now() - t0git;
 
   // Runtime health checks — timed

--- a/src/resources/extensions/gsd/tests/doctor-git-checks-autoresolve.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-git-checks-autoresolve.test.ts
@@ -108,3 +108,42 @@ test("doctor clears conflicts entirely when all unmerged paths are safe", async 
     "merge-state markers should be cleared in the same pass",
   );
 });
+
+test("doctor --dry-run does not mutate git state when safe conflicts are present", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-autoresolve-dryrun-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "STATE.md"), "base\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "chore: init"], base);
+
+  runGit(["checkout", "-b", "feature"], base);
+  writeFileSync(join(base, ".gsd", "STATE.md"), "feature\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "feat: edit"], base);
+
+  runGit(["checkout", "main"], base);
+  writeFileSync(join(base, ".gsd", "STATE.md"), "main\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "feat: edit"], base);
+
+  tryGit(["merge", "feature"], base);
+
+  // dry-run must not mutate git state even when all conflicts are safe
+  const report = await runGSDDoctor(base, { dryRun: true, isolationMode: "none" });
+
+  // MERGE_HEAD must still exist — dry-run is read-only
+  assert.ok(
+    existsSync(join(base, ".git", "MERGE_HEAD")),
+    "dry-run must not clear merge-state markers",
+  );
+  // The conflict should still be reported (unresolved paths are reported as-is)
+  assert.ok(
+    report.issues.some((issue) => issue.code === "unresolved_git_conflicts"),
+    "dry-run should still report the conflict without resolving it",
+  );
+});

--- a/src/resources/extensions/gsd/tests/doctor-git-checks-autoresolve.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-git-checks-autoresolve.test.ts
@@ -1,0 +1,110 @@
+// Project/App: gsd-pi
+// File Purpose: Doctor attempts safe conflict auto-resolution before hard-blocking auto-mode (#849).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runGSDDoctor } from "../doctor.ts";
+import { closeDatabase } from "../gsd-db.js";
+
+function runGit(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" });
+}
+
+function tryGit(args: string[], cwd: string): void {
+  try {
+    runGit(args, cwd);
+  } catch {
+    // Expected to fail for conflicting merges — the conflict state is what we want.
+  }
+}
+
+function makeRepoWithConflict(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-autoresolve-"));
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, "src"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "STATE.md"), "base state\n", "utf-8");
+  writeFileSync(join(base, "src", "app.js"), "base app\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "chore: init"], base);
+
+  runGit(["checkout", "-b", "feature"], base);
+  writeFileSync(join(base, ".gsd", "STATE.md"), "feature state\n", "utf-8");
+  writeFileSync(join(base, "src", "app.js"), "feature app\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "feat: feature edits"], base);
+
+  runGit(["checkout", "main"], base);
+  writeFileSync(join(base, ".gsd", "STATE.md"), "main state\n", "utf-8");
+  writeFileSync(join(base, "src", "app.js"), "main app\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "feat: main edits"], base);
+
+  // Conflicting merge — leaves unmerged paths + MERGE_HEAD.
+  tryGit(["merge", "feature"], base);
+  return base;
+}
+
+test.after(() => {
+  closeDatabase();
+});
+
+test("doctor auto-resolves safe .gsd/ conflicts and only blocks on manual paths", async (t) => {
+  const base = makeRepoWithConflict();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const report = await runGSDDoctor(base, { isolationMode: "none" });
+
+  const conflictIssue = report.issues.find((issue) => issue.code === "unresolved_git_conflicts");
+  assert.ok(conflictIssue, "manual conflict should still be reported");
+  assert.match(conflictIssue!.message, /src\/app\.js/, "manual path should be listed");
+  assert.doesNotMatch(
+    conflictIssue!.message,
+    /\.gsd\/STATE\.md/,
+    "safe .gsd/ path should have been auto-resolved out of the conflict list",
+  );
+});
+
+test("doctor clears conflicts entirely when all unmerged paths are safe", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-autoresolve-safe-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "STATE.md"), "base\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "chore: init"], base);
+
+  runGit(["checkout", "-b", "feature"], base);
+  writeFileSync(join(base, ".gsd", "STATE.md"), "feature\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "feat: edit"], base);
+
+  runGit(["checkout", "main"], base);
+  writeFileSync(join(base, ".gsd", "STATE.md"), "main\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "feat: edit"], base);
+
+  tryGit(["merge", "feature"], base);
+
+  const report = await runGSDDoctor(base, { isolationMode: "none" });
+
+  assert.ok(
+    !report.issues.some((issue) => issue.code === "unresolved_git_conflicts"),
+    "no manual conflicts should remain after safe auto-resolve",
+  );
+  assert.ok(
+    !existsSync(join(base, ".git", "MERGE_HEAD")),
+    "merge-state markers should be cleared in the same pass",
+  );
+});


### PR DESCRIPTION
## Summary
- Doctor now runs reconcileGitConflictsOnSignal to auto-resolve safe conflict paths and clear merge markers before reporting only genuinely-manual conflicts; verified with new and existing tests plus typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #849
- [#849 Doctor unresolved_git_conflicts blocks auto-mode before attempting autoResolveSafeConflictPaths](https://github.com/open-gsd/gsd-pi/issues/849)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/849-doctor-unresolved-git-conflicts-blocks-a-1782374236`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Doctor can mutate git index/working tree during audits (not dry-run), reusing existing reconciliation logic; behavior is covered by new tests but touches auto-mode gating.
> 
> **Overview**
> **Doctor git health** now runs the same `reconcileGitConflictsOnSignal` path used by preflight/auto-worktree **before** emitting `unresolved_git_conflicts`, so `.gsd/` and other safe paths can be cleared without hard-blocking auto-mode when only those paths were conflicted.
> 
> When unmerged paths remain after reconciliation, only those paths are reported; fixes are recorded in `fixesApplied`. Reconciliation is **skipped** when `dryRun` is true (`runGSDDoctor` passes `dryRun` into `checkGitHealth`). If all conflicts were safe, merge markers such as `MERGE_HEAD` can be cleared in the same pass (#849).
> 
> New integration tests cover mixed safe/manual conflicts and all-safe merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1277201e70b1cb9d7f70c28e383c6c67de0cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->