### PR TITLE
fix(issue): complete-slice LLM does project work after gsd_task_reopen, hits HARD BLOCK on gsd_plan_slice, then loops until context-window pressure

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -236,7 +236,6 @@ function completeSliceReopenReplanHandoffDetected(
   return (
     agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_task_reopen") ||
     agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_task_reopen") ||
-    agentEndMessagesMentionTool(agentEndMessages, "gsd_task_reopen") ||
     unitActivityMentionsTool(s.basePath, unitType, unitId, "gsd_task_reopen") ||
     unitActivityMentionsTool(s.canonicalProjectRoot, unitType, unitId, "gsd_task_reopen")
   );
@@ -250,7 +249,6 @@ function completeSliceReplanSignalDetected(
   return (
     agentEndMessagesIncludeSuccessfulToolResult(agentEndMessages, "gsd_replan_slice") ||
     agentEndMessagesIncludeToolCall(agentEndMessages, "gsd_replan_slice") ||
-    agentEndMessagesMentionTool(agentEndMessages, "gsd_replan_slice") ||
     unitActivityMentionsTool(s.basePath, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice") ||
     unitActivityMentionsTool(s.canonicalProjectRoot, s.currentUnit.type, s.currentUnit.id, "gsd_replan_slice")
   );

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -29,12 +29,17 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 1. Use the inlined Slice Summary and UAT templates.
 2. {{skillActivation}}
 3. Run all slice-level verification through `gsd_exec` / Context Mode evidence; refresh current state if needed. Do not use direct `bash` for verification commands. See the prepended **Tool Surface** block for unavailable tools.
-4. Complete only when every required check passes. If verification fails or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
+4. Complete only when every required check passes. If verification fails or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete` for normal slice completion.
 5. If verification fails:
    - Task-specific regressions: if the failure is in files the task touched and pre-task verification evidence shows it was absent before that task ran, call `gsd_task_reopen` with that task and reason.
    - Inherited/out-of-scope failures, including failures present before the task ran or failures without pre-task evidence: do **not** reopen completed tasks; call `gsd_replan_slice` with adjusted verification scope or follow-up tasks.
    - Other plan-invalidating failures: call `gsd_replan_slice` with the blocker and updated execution tasks.
-   Then stop with: "Slice {{sliceId}} needs execution follow-up."
+   After any failure-handoff tool call, the unit is done. The `gsd_task_reopen` or `gsd_replan_slice` call is the handoff signal for the orchestrator to dispatch the next unit.
+   - Never call `gsd_replan_slice` after calling `gsd_task_reopen`; reopened tasks are pending, and replan requires a complete blocker task.
+   - Do not call `gsd_plan_slice`; that tool belongs to `plan-slice` and is hard-blocked here.
+   - Do not read source code, run `gsd_exec`, invoke subagents, or do implementation/planning work after the first `gsd_task_reopen` or `gsd_replan_slice` handoff call.
+   - Terminal reopen sequence: call `gsd_task_reopen` for the unfinished task(s), then stop with: "Slice {{sliceId}} needs execution follow-up."
+   - Terminal replan sequence: call `gsd_replan_slice` once, then stop with: "Slice {{sliceId}} needs execution follow-up."
 6. Task summaries use a flat file layout under `tasks/` such as `T01-SUMMARY.md`, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. Never use `tasks/*/SUMMARY.md`.
 7. If observability/diagnostics were planned, verify them unless the slice is simple.
 8. Address every Gate to Close. Q8 = **Operational Readiness**: health signal, failure signal, recovery, monitoring gaps. Omit empty sections.

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -28,7 +28,7 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 
 1. Use the inlined Slice Summary and UAT templates.
 2. {{skillActivation}}
-3. Run slice-level verification only through `gsd_exec` / Context Mode evidence; refresh state if needed. Do not use direct `bash` for verification commands. Tool availability is in **Tool Surface**.
+3. Run slice-level verification only through `gsd_exec` / Context Mode evidence; refresh current state if needed. Do not use direct `bash` for verification commands. Tool availability is in **Tool Surface**.
 4. Complete only after every required check passes. Exactly one terminal workflow tool is required: pass -> `gsd_slice_complete`; task follow-up -> `gsd_task_reopen`; planning follow-up -> `gsd_replan_slice`. A text-only stop, even one mentioning a tool, is invalid. If checks fail or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
 5. If verification fails:
    - Task-specific regression: if pre-task verification evidence shows it was absent before that task ran, call `gsd_task_reopen` with task and reason.
@@ -47,7 +47,7 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 10. Prepare `gsd_slice_complete` camelCase fields: `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, `uatContent`.
 11. Draft concrete UAT: preconditions, steps, expected outcomes, edge cases, and UAT Type. Declare type under `## UAT Type` exactly like `- UAT mode: browser-executable`.
     **Web apps:** when inlined Web App UAT guidance is present, declare `browser-executable` or `runtime-executable` (not `artifact-driven`) for localhost/browser/screenshot steps; include dev-server preconditions and name Playwright specs when they exist.
-12. Review inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions/gotchas. Read full `*-SUMMARY.md` only if needed. Capture with MCP-scoped `gsd_capture_thought`, not bare `capture_thought`; do not append knowledge files.
+12. Review the inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions/gotchas. Read full `*-SUMMARY.md` only if needed. Capture with MCP-scoped `gsd_capture_thought`, not bare `capture_thought`; do not append knowledge files.
 13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes.
 14. Do not run git commands.
 15. If project state needs refresh, call `gsd_summary_save` with `artifact_type: "PROJECT"` and full updated project markdown as `content`; omit `milestone_id`. Do not edit `.gsd/PROJECT.md` directly.

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -6,7 +6,7 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
-If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+If inlined context names an absolute path outside `{{workingDirectory}}`, treat it as stale. Convert to the relative path under `{{workingDirectory}}` before use. If none exists, record a verification failure and stop; do not edit or run commands in another checkout.
 
 ## Your Role in the Pipeline
 
@@ -14,13 +14,13 @@ You are the closer: verify assembled task work delivers the slice goal, then com
 
 ### Closeout messaging (auto-mode)
 
-You write closeout artifacts; **GSD auto-mode** decides when the slice is actually **done**. Never say "Slice {{sliceId}} complete" in this unit — not even after `gsd_slice_complete` succeeds. GSD announces completion only after post-unit verification passes.
+You write closeout artifacts; **GSD auto-mode** decides when the slice is actually **done**. Never say "Slice {{sliceId}} complete" in this unit. GSD announces completion only after post-unit verification passes.
 
 {{inlinedContext}}
 
 {{gatesToClose}}
 
-Match effort to complexity. Simple slices need brief summary and light verification; multi-subsystem slices need stronger verification and detail.
+Match complexity: simple slices need brief summary/light verification; multi-subsystem slices need stronger verification/detail.
 
 Use `subagent` only when useful: reviewer, security, or tester. Apply findings before completion.
 
@@ -28,34 +28,34 @@ Use `subagent` only when useful: reviewer, security, or tester. Apply findings b
 
 1. Use the inlined Slice Summary and UAT templates.
 2. {{skillActivation}}
-3. Run all slice-level verification through `gsd_exec` / Context Mode evidence; refresh current state if needed. Do not use direct `bash` for verification commands. See the prepended **Tool Surface** block for unavailable tools.
-4. Complete only when every required check passes. If verification fails or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete` for normal slice completion.
+3. Run slice-level verification only through `gsd_exec` / Context Mode evidence; refresh state if needed. Do not use direct `bash` for verification commands. Tool availability is in **Tool Surface**.
+4. Complete only after every required check passes. Exactly one terminal workflow tool is required: pass -> `gsd_slice_complete`; task follow-up -> `gsd_task_reopen`; planning follow-up -> `gsd_replan_slice`. A text-only stop, even one mentioning a tool, is invalid. If checks fail or source changes are needed, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
 5. If verification fails:
-   - Task-specific regressions: if the failure is in files the task touched and pre-task verification evidence shows it was absent before that task ran, call `gsd_task_reopen` with that task and reason.
-   - Inherited/out-of-scope failures, including failures present before the task ran or failures without pre-task evidence: do **not** reopen completed tasks; call `gsd_replan_slice` with adjusted verification scope or follow-up tasks.
-   - Other plan-invalidating failures: call `gsd_replan_slice` with the blocker and updated execution tasks.
-   After any failure-handoff tool call, the unit is done. The `gsd_task_reopen` or `gsd_replan_slice` call is the handoff signal for the orchestrator to dispatch the next unit.
-   - Never call `gsd_replan_slice` after calling `gsd_task_reopen`; reopened tasks are pending, and replan requires a complete blocker task.
+   - Task-specific regression: if pre-task verification evidence shows it was absent before that task ran, call `gsd_task_reopen` with task and reason.
+   - Inherited/out-of-scope failure, including failures present before the task ran or no pre-task evidence: do **not** reopen tasks; call `gsd_replan_slice`.
+   - Other plan-invalidating failure: call `gsd_replan_slice` with blocker and updated tasks.
+   After any successful failure-handoff tool call, the unit is done. The `gsd_task_reopen` or `gsd_replan_slice` call is the handoff signal for the orchestrator.
+   - Never call `gsd_replan_slice` after calling `gsd_task_reopen`; reopened tasks are pending.
    - Do not call `gsd_plan_slice`; that tool belongs to `plan-slice` and is hard-blocked here.
    - Do not read source code, run `gsd_exec`, invoke subagents, or do implementation/planning work after the first `gsd_task_reopen` or `gsd_replan_slice` handoff call.
-   - Terminal reopen sequence: call `gsd_task_reopen` for the unfinished task(s), then stop with: "Slice {{sliceId}} needs execution follow-up."
-   - Terminal replan sequence: call `gsd_replan_slice` once, then stop with: "Slice {{sliceId}} needs execution follow-up."
+   - Terminal reopen sequence: call `gsd_task_reopen`; after success, final text may only be: "Slice {{sliceId}} needs execution follow-up."
+   - Terminal replan sequence: call `gsd_replan_slice` once; after it succeeds, final text may only be: "Slice {{sliceId}} needs execution follow-up."
 6. Task summaries use a flat file layout under `tasks/` such as `T01-SUMMARY.md`, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. Never use `tasks/*/SUMMARY.md`.
 7. If observability/diagnostics were planned, verify them unless the slice is simple.
 8. Address every Gate to Close. Q8 = **Operational Readiness**: health signal, failure signal, recovery, monitoring gaps. Omit empty sections.
 9. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
-10. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
-11. Draft concrete UAT with preconditions, steps, expected outcomes, edge cases, and UAT Type. Declare the type as a bullet under a `## UAT Type` heading, exactly like `- UAT mode: browser-executable`.
+10. Prepare `gsd_slice_complete` camelCase fields: `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, `uatContent`.
+11. Draft concrete UAT: preconditions, steps, expected outcomes, edge cases, and UAT Type. Declare type under `## UAT Type` exactly like `- UAT mode: browser-executable`.
     **Web apps:** when inlined Web App UAT guidance is present, declare `browser-executable` or `runtime-executable` (not `artifact-driven`) for localhost/browser/screenshot steps; include dev-server preconditions and name Playwright specs when they exist.
-12. Review the inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions and gotchas. Read full `*-SUMMARY.md` only if needed. Capture with `gsd_capture_thought` (MCP-scoped `mcp__...__gsd_capture_thought`), not bare `capture_thought`; do not append knowledge files.
+12. Review inlined task-summary excerpts for DECISIONS.md/KNOWLEDGE.md-worthy decisions/gotchas. Read full `*-SUMMARY.md` only if needed. Capture with MCP-scoped `gsd_capture_thought`, not bare `capture_thought`; do not append knowledge files.
 13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes.
 14. Do not run git commands.
-15. If the current project state needs refresh, call `gsd_summary_save` with `artifact_type: "PROJECT"` and the full updated project markdown as `content`; omit `milestone_id`. Do not write or edit `.gsd/PROJECT.md` directly.
+15. If project state needs refresh, call `gsd_summary_save` with `artifact_type: "PROJECT"` and full updated project markdown as `content`; omit `milestone_id`. Do not edit `.gsd/PROJECT.md` directly.
 
 **Autonomous execution:** no human is available. Do not call `ask_user_questions` or `secure_env_collect`; make reasonable assumptions and document them.
 
-**File system safety:** if re-reading task summaries, use `find .gsd/milestones/{{milestoneId}}/slices/{{sliceId}}/tasks -name "*-SUMMARY.md"`. Never pass `{{slicePath}}` or any directory path directly to the `read` tool.
+**File system safety:** to re-read task summaries, use `find .gsd/milestones/{{milestoneId}}/slices/{{sliceId}}/tasks -name "*-SUMMARY.md"`. Never pass `{{slicePath}}` or any directory path directly to the `read` tool.
 
-**You MUST call `gsd_slice_complete` with summary and UAT content only after verification passes.**
+**You MUST call `gsd_slice_complete` after verification passes. If not, MUST call `gsd_task_reopen` or `gsd_replan_slice`. Never finish this unit with plain text only.**
 
-When done, say: "Slice {{sliceId}} closeout submitted." Do not say the slice is complete. Say this exactly once — if you already said it in a prior message, do not repeat it.
+When done, say exactly once: "Slice {{sliceId}} closeout submitted." Do not say the slice is complete.

--- a/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
@@ -67,6 +67,46 @@ test("complete-slice with gsd_task_reopen handoff continues instead of artifact-
   }
 });
 
+test("complete-slice text mentioning gsd_task_reopen does not count as a handoff", async () => {
+  const base = makeTempRepo("gsd-complete-slice-reopen-text-");
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+    const notifications: string[] = [];
+    const result = await postUnitPreVerification(
+      makePostUnitContext(base, s, notifications),
+      {
+        skipSettleDelay: true,
+        skipWorktreeSync: true,
+        agentEndMessages: [
+          {
+            role: "assistant",
+            content: "I should call gsd_task_reopen for T01, then stop.",
+          },
+        ],
+      },
+    );
+
+    assert.equal(result, "continue");
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.ok(
+      notifications.every((message) => !message.includes("handed off via reopen/replan")),
+      `plain text must not be treated as handoff, got: ${notifications.join("\n")}`,
+    );
+    assert.ok(
+      notifications.some((message) => message.includes("DB unavailable")),
+      `expected DB-unavailable fallback, got: ${notifications.join("\n")}`,
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("complete-slice with gsd_replan_slice tool result continues instead of artifact-retrying", async () => {
   const base = makeTempRepo("gsd-complete-slice-replan-");
   try {
@@ -105,6 +145,48 @@ test("complete-slice with gsd_replan_slice tool result continues instead of arti
     assert.ok(
       notifications.some((message) => message.includes("valid replan outcome")),
       `expected handoff notification, got: ${notifications.join("\n")}`,
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("complete-slice text mentioning gsd_replan_slice does not count as a valid replan outcome", async () => {
+  const base = makeTempRepo("gsd-complete-slice-replan-text-");
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(sliceDir, { recursive: true });
+    writeFileSync(join(sliceDir, "S01-REPLAN.md"), "# Replan\n");
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+    const notifications: string[] = [];
+    const result = await postUnitPreVerification(
+      makePostUnitContext(base, s, notifications),
+      {
+        skipSettleDelay: true,
+        skipWorktreeSync: true,
+        agentEndMessages: [
+          {
+            role: "assistant",
+            content: "I will use gsd_replan_slice and let execution follow up.",
+          },
+        ],
+      },
+    );
+
+    assert.equal(result, "continue");
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.ok(
+      notifications.every((message) => !message.includes("valid replan outcome")),
+      `plain text must not be treated as replan outcome, got: ${notifications.join("\n")}`,
+    );
+    assert.ok(
+      notifications.some((message) => message.includes("DB unavailable")),
+      `expected DB-unavailable fallback, got: ${notifications.join("\n")}`,
     );
   } finally {
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -467,6 +467,18 @@ test("complete-slice prompt keeps source fixes in execution units", () => {
   assert.doesNotMatch(prompt, /Fix failures before marking done/i);
 });
 
+test("complete-slice prompt terminates after reopen or replan handoff", () => {
+  const prompt = readPrompt("complete-slice");
+  assert.match(prompt, /After any failure-handoff tool call, the unit is done/i);
+  assert.match(prompt, /`gsd_task_reopen` or `gsd_replan_slice` call is the handoff signal/i);
+  assert.match(prompt, /Never call `gsd_replan_slice` after calling `gsd_task_reopen`/i);
+  assert.match(prompt, /reopened tasks are pending/i);
+  assert.match(prompt, /Do not call `gsd_plan_slice`/i);
+  assert.match(prompt, /Do not read source code, run `gsd_exec`, invoke subagents/i);
+  assert.match(prompt, /Terminal reopen sequence/i);
+  assert.match(prompt, /Terminal replan sequence/i);
+});
+
 test("complete-slice prompt binds all file operations to workingDirectory", () => {
   const prompt = readPrompt("complete-slice");
   assert.match(prompt, /Your working directory is `\{\{workingDirectory\}\}`/);

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -469,7 +469,9 @@ test("complete-slice prompt keeps source fixes in execution units", () => {
 
 test("complete-slice prompt terminates after reopen or replan handoff", () => {
   const prompt = readPrompt("complete-slice");
-  assert.match(prompt, /After any failure-handoff tool call, the unit is done/i);
+  assert.match(prompt, /exactly one terminal workflow tool/i);
+  assert.match(prompt, /A text-only stop, even one mentioning a tool, is invalid/i);
+  assert.match(prompt, /After any successful failure-handoff tool call, the unit is done/i);
   assert.match(prompt, /`gsd_task_reopen` or `gsd_replan_slice` call is the handoff signal/i);
   assert.match(prompt, /Never call `gsd_replan_slice` after calling `gsd_task_reopen`/i);
   assert.match(prompt, /reopened tasks are pending/i);
@@ -477,6 +479,7 @@ test("complete-slice prompt terminates after reopen or replan handoff", () => {
   assert.match(prompt, /Do not read source code, run `gsd_exec`, invoke subagents/i);
   assert.match(prompt, /Terminal reopen sequence/i);
   assert.match(prompt, /Terminal replan sequence/i);
+  assert.match(prompt, /Never finish this unit with plain text only/i);
 });
 
 test("complete-slice prompt binds all file operations to workingDirectory", () => {

--- a/src/tests/fixtures/prompt-golden-fixtures.ts
+++ b/src/tests/fixtures/prompt-golden-fixtures.ts
@@ -30,10 +30,12 @@ export const promptGoldenUnits = [
   },
   {
     unitType: "complete-slice",
-    // Tool Surface guidance and subsequent feature additions have grown this
-    // prompt; the baseline is adjusted so the gate still tracks shrinkage from
-    // the original oversized prompts while allowing today's ~8613-char fixture.
-    phase2StartChars: 14400,
+    // Tool Surface guidance and subsequent feature additions (most recently,
+    // explicit terminal-handoff stop rules for gsd_task_reopen/gsd_replan_slice
+    // per issue #846) have grown this prompt; the baseline is adjusted so the
+    // gate still tracks shrinkage from the original oversized prompts while
+    // allowing today's ~9154-char fixture.
+    phase2StartChars: 15400,
     requiredMarkers: [
       "UNIT: Complete Slice S01",
       "Tool Surface",

--- a/src/tests/fixtures/prompt-golden-fixtures.ts
+++ b/src/tests/fixtures/prompt-golden-fixtures.ts
@@ -16,8 +16,8 @@ export const promptGoldenUnits = [
     unitType: "execute-task",
     // Tool Surface guidance and related prompt additions have grown this prompt;
     // the baseline is adjusted so the gate still tracks shrinkage from the
-    // original oversized prompts while allowing today's ~8536-char fixture.
-    phase2StartChars: 14230,
+    // original oversized prompts while allowing today's ~8586-char fixture.
+    phase2StartChars: 14320,
     requiredMarkers: [
       "UNIT: Execute Task T01",
       "Inlined Task Plan",


### PR DESCRIPTION
## Summary
- Updated the complete-slice prompt to make reopen/replan handoffs terminal and verified the prompt contract with dependency-free checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #846
- [#846 complete-slice LLM does project work after gsd_task_reopen, hits HARD BLOCK on gsd_plan_slice, then loops until context-window pressure](https://github.com/open-gsd/gsd-pi/issues/846)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/846-complete-slice-llm-does-project-work-aft-1782387727`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes complete-slice auto-mode exit detection and agent instructions for failure paths; mis-detection could affect handoff vs retry, but behavior is covered by new regression and prompt-contract tests.
> 
> **Overview**
> Fixes **complete-slice** agents continuing implementation/planning after a reopen/replan intent was only described in chat (#846), which led to **`gsd_plan_slice` hard blocks** and retry loops.
> 
> **Orchestration:** `completeSliceReopenReplanHandoffDetected` and `completeSliceReplanSignalDetected` no longer use substring/`JSON.stringify` **mention** detection on agent end messages. Handoff/replan is recognized only from **successful tool results**, **tool calls**, or **unit activity** logs—so “I should call `gsd_task_reopen`…” does not skip artifact verification as if the handoff succeeded.
> 
> **Prompt (`complete-slice.md`):** Requires exactly one **terminal** workflow tool (`gsd_slice_complete`, `gsd_task_reopen`, or `gsd_replan_slice`); **text-only stops are invalid**. After a successful failure-handoff tool, the unit ends: no `gsd_plan_slice`, no further `gsd_exec`/subagents/source reads, fixed closing phrase for reopen vs replan, and no replan after reopen.
> 
> **Tests:** Regression cases for plain-text tool names; prompt-contract assertions for the new rules; golden `complete-slice` char baseline bumped for the longer prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26382f5139fcea3d08bf4a21b857ac02f00ce440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->