### PR TITLE
fix(issue): depth-verification gate for milestone CONTEXT.md is permanent block: user confirmation does not unlock it

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -25,6 +25,12 @@ export const MILESTONE_CONTEXT_RE = /M\d+(?:-[a-z0-9]{6})?-CONTEXT\.md$/;
 const CONTEXT_MILESTONE_RE = /(?:^|[/\\])(M\d+(?:-[a-z0-9]{6})?)-CONTEXT\.md$/i;
 const DEPTH_VERIFICATION_MILESTONE_RE = /depth_verification[_-](M\d+(?:-[a-z0-9]{6})?)/i;
 
+function normalizeMilestoneId(milestoneId: string): string {
+  const match = milestoneId.match(/^(M)(\d+)(?:-([a-z0-9]{6}))?$/i);
+  if (!match) return milestoneId;
+  return `M${match[2]}${match[3] ? `-${match[3].toLowerCase()}` : ""}`;
+}
+
 /**
  * Path segment that identifies .gsd/ planning artifacts.
  * Writes to these paths are allowed during queue mode.
@@ -228,7 +234,9 @@ function clearPersistedWriteGateSnapshot(basePath: string): void {
 function normalizeWriteGateSnapshot(value: unknown): WriteGateSnapshot {
   const record = value && typeof value === "object" ? value as Record<string, unknown> : {};
   const verified = Array.isArray(record.verifiedDepthMilestones)
-    ? record.verifiedDepthMilestones.filter((item): item is string => typeof item === "string")
+    ? record.verifiedDepthMilestones
+        .filter((item): item is string => typeof item === "string")
+        .map(normalizeMilestoneId)
     : [];
   const verifiedGates = Array.isArray(record.verifiedApprovalGates)
     ? record.verifiedApprovalGates.filter((item): item is string => typeof item === "string")
@@ -289,7 +297,7 @@ export function loadWriteGateSnapshot(basePath: string): WriteGateSnapshot {
  *     guard that previously protected only the tool_execution_start window.
  */
 function mergeSnapshotIntoState(state: InMemoryWriteGateState, disk: WriteGateSnapshot): void {
-  for (const milestone of disk.verifiedDepthMilestones) state.verifiedDepthMilestones.add(milestone);
+  for (const milestone of disk.verifiedDepthMilestones) state.verifiedDepthMilestones.add(normalizeMilestoneId(milestone));
   for (const gate of disk.verifiedApprovalGates ?? []) state.verifiedApprovalGates.add(gate);
   state.activeQueuePhase = disk.activeQueuePhase;
   state.pendingGateId = disk.pendingGateId;
@@ -395,7 +403,7 @@ export function isMilestoneDepthVerified(
 ): boolean {
   if (!milestoneId) return false;
   refreshWriteGateStateFromDisk(basePath);
-  return getWriteGateState(basePath).verifiedDepthMilestones.has(milestoneId);
+  return getWriteGateState(basePath).verifiedDepthMilestones.has(normalizeMilestoneId(milestoneId));
 }
 
 export function isMilestoneDepthVerifiedInSnapshot(
@@ -403,7 +411,7 @@ export function isMilestoneDepthVerifiedInSnapshot(
   milestoneId: string | null | undefined,
 ): boolean {
   if (!milestoneId) return false;
-  return snapshot.verifiedDepthMilestones.includes(milestoneId);
+  return snapshot.verifiedDepthMilestones.includes(normalizeMilestoneId(milestoneId));
 }
 
 export function isQueuePhaseActive(basePath: string = process.cwd()): boolean {
@@ -466,7 +474,7 @@ export function isGateQuestionId(questionId: string): boolean {
  */
 export function extractDepthVerificationMilestoneId(questionId: string): string | null {
   const match = questionId.match(DEPTH_VERIFICATION_MILESTONE_RE);
-  return match?.[1] ?? null;
+  return match?.[1] ? normalizeMilestoneId(match[1]) : null;
 }
 
 /**
@@ -474,7 +482,7 @@ export function extractDepthVerificationMilestoneId(questionId: string): string 
  */
 function extractContextMilestoneId(inputPath: string): string | null {
   const match = inputPath.match(CONTEXT_MILESTONE_RE);
-  return match?.[1] ?? null;
+  return match?.[1] ? normalizeMilestoneId(match[1]) : null;
 }
 
 /**
@@ -560,7 +568,7 @@ export const hostWriteGateAdapter: WriteGateStateAdapter = {
   markDepthVerified(milestoneId, basePath): void {
     if (!milestoneId) return;
     mutateWriteGateState(basePath, (state) => {
-      state.verifiedDepthMilestones.add(milestoneId);
+      state.verifiedDepthMilestones.add(normalizeMilestoneId(milestoneId));
     }, { writer: "host" });
   },
   markApprovalGateVerified(gateId, basePath): void {
@@ -601,7 +609,7 @@ export const childWriteGateAdapter: WriteGateStateAdapter = {
   markDepthVerified(milestoneId, basePath): void {
     if (!milestoneId) return;
     childMutate(basePath, (state) => {
-      state.verifiedDepthMilestones.add(milestoneId);
+      state.verifiedDepthMilestones.add(normalizeMilestoneId(milestoneId));
     });
   },
   markApprovalGateVerified(gateId, basePath): void {
@@ -865,7 +873,7 @@ export function shouldBlockContextWrite(
   if (toolName !== "write") return { block: false };
   if (!MILESTONE_CONTEXT_RE.test(inputPath)) return { block: false };
 
-  const targetMilestoneId = extractContextMilestoneId(inputPath) ?? milestoneId;
+  const targetMilestoneId = extractContextMilestoneId(inputPath) ?? (milestoneId ? normalizeMilestoneId(milestoneId) : null);
   if (!targetMilestoneId) {
     return {
       block: true,
@@ -884,8 +892,8 @@ export function shouldBlockContextWrite(
     reason: [
       `HARD BLOCK: Cannot write to milestone CONTEXT.md without depth verification.`,
       `This is a mechanical gate — you MUST NOT proceed, retry, or rationalize past this block.`,
-      `Required action: call ask_user_questions with question id containing "depth_verification".`,
-      `The user MUST select the "(Recommended)" confirmation option to unlock this gate.`,
+      `Required action: call ask_user_questions with question id "depth_verification_${targetMilestoneId}_confirm".`,
+      `The user MUST select the first "(Recommended)" confirmation option to unlock this gate.`,
       `If the user declines, cancels, or the tool fails, you must re-ask — not bypass.`,
     ].join(" "),
   };

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -19,6 +19,7 @@ import {
   resetWriteGateState,
   setPendingGate,
   shouldBlockContextArtifactSave,
+  shouldBlockContextWrite,
 } from "../bootstrap/write-gate.ts";
 import { classifyCommand } from "../safety/destructive-guard.ts";
 import { toRoundResultResponse } from "../../remote-questions/manager.ts";
@@ -198,6 +199,80 @@ test("register-hooks unlocks milestone depth verification from question id witho
     shouldBlockContextArtifactSave("CONTEXT", "M001").block,
     false,
     "question-id milestone inference should unlock the matching milestone context write",
+  );
+});
+
+test("register-hooks canonicalizes lower-case milestone ids in depth-verification question ids", async (t) => {
+  const dir = makeTempDir("lowercase-mid");
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  resetWriteGateState(dir);
+
+  t.after(() => {
+    try {
+      resetWriteGateState(dir);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<void> | void>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<void> | void) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const questionId = "depth_verification_m001_confirm";
+  const questions = [
+    {
+      id: questionId,
+      question: "Do you agree?",
+      options: [
+        { label: "Yes, you got it (Recommended)" },
+        { label: "Needs adjustment" },
+      ],
+    },
+  ];
+
+  await armDepthGate(handlers, "ask_user_questions", questions);
+  assert.equal(getPendingGate(), questionId);
+
+  for (const handler of handlers.get("tool_result") ?? []) {
+    await handler({
+      toolName: "ask_user_questions",
+      input: { questions },
+      details: {
+        response: {
+          answers: {
+            [questionId]: { selected: "Yes, you got it (Recommended)" },
+          },
+        },
+      },
+    });
+  }
+
+  assert.equal(getPendingGate(), null, "confirming lower-case m001 gate should clear pending state");
+  assert.deepEqual(
+    loadWriteGateSnapshot(dir).verifiedDepthMilestones,
+    ["M001"],
+    "verified milestone id should be stored canonically",
+  );
+  assert.equal(
+    shouldBlockContextWrite(
+      "write",
+      ".gsd/milestones/M001/M001-CONTEXT.md",
+      null,
+      false,
+      dir,
+    ).block,
+    false,
+    "lower-case question id should unlock the matching upper-case CONTEXT.md path",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -140,6 +140,7 @@ test('write-gate: blocked reason contains depth_verification keyword and anti-by
   );
   assert.strictEqual(result.block, true);
   assert.ok(result.reason!.includes('depth_verification'), 'reason should mention depth_verification question id');
+  assert.ok(result.reason!.includes('depth_verification_M999_confirm'), 'reason should mention the exact milestone gate id');
   assert.ok(result.reason!.includes('ask_user_questions'), 'reason should mention ask_user_questions tool');
   assert.ok(result.reason!.includes('MUST NOT'), 'reason should include anti-bypass language');
   assert.ok(result.reason!.includes('(Recommended)'), 'reason should specify the required confirmation option');


### PR DESCRIPTION
## Summary
- Fixed milestone depth-verification ID normalization and exact gate guidance; verified diff hygiene, with tests blocked by unavailable npm dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #827
- [#827 depth-verification gate for milestone CONTEXT.md is permanent block: user confirmation does not unlock it](https://github.com/open-gsd/gsd-pi/issues/827)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/827-depth-verification-gate-for-milestone-co-1782387768`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mechanical write gate and persisted verification state; scope is narrow (ID normalization) but incorrect behavior would still block or wrongly allow milestone CONTEXT writes.
> 
> **Overview**
> Fixes milestone **CONTEXT.md** staying blocked after the user confirms depth verification when milestone IDs differ only by casing (e.g. `depth_verification_m001_confirm` vs stored `M001`).
> 
> Adds **`normalizeMilestoneId`** and applies it across write-gate persistence and checks: loading/merging snapshots, marking depth verified (host and child adapters), extracting IDs from question IDs and CONTEXT paths, and **`isMilestoneDepthVerified`** lookups.
> 
> **`shouldBlockContextWrite`** block messages now name the exact gate id (`depth_verification_${milestone}_confirm`) and the first “(Recommended)” option. Tests cover lowercase question ids end-to-end via register-hooks and the updated error text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bbc865b1b93a77c633a29cf322194d2e4593c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->