### PR TITLE
fix(issue): [Bug] Tier resolver ignores session model: standard units get cheapest, light units hop to claude-haiku

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -407,8 +407,9 @@ export function resolvePreferredModelConfig(
   isAutoMode = true,
   basePath?: string,
   availableModelIds?: string[],
+  preferredModelId?: string,
 ): PreferredModelConfig | undefined {
-  const explicitConfig = resolveModelWithFallbacksForUnit(unitType, basePath, availableModelIds);
+  const explicitConfig = resolveModelWithFallbacksForUnit(unitType, basePath, availableModelIds, preferredModelId);
   if (explicitConfig) {
     return {
       ...explicitConfig,
@@ -527,6 +528,9 @@ export async function selectAndApplyModel(
       flatRateCtx: buildFlatRateContext(autoModeStartModel.provider, ctx, prefs),
     };
   }
+  const preferredModelId = autoModeStartModel
+    ? `${autoModeStartModel.provider}/${autoModeStartModel.id}`
+    : ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
   const modelConfig = effectiveSessionModelOverride
     ? undefined
     : resolvePreferredModelConfig(
@@ -535,6 +539,7 @@ export async function selectAndApplyModel(
       isAutoMode,
       basePath,
       profileResolutionIds,
+      preferredModelId,
     );
   let routing: { tier: string; modelDowngraded: boolean } | null = null;
   let appliedModel: Model<Api> | null = null;
@@ -737,6 +742,7 @@ export async function selectAndApplyModel(
             classification.tier,
             availableModelIds,
             routingConfig,
+            preferredModelId,
           );
           const hookResult = await pi.emitBeforeModelSelect({
             unitType,
@@ -781,6 +787,7 @@ export async function selectAndApplyModel(
             unitType,
             classification.taskMetadata,
             capabilityOverrides,
+            preferredModelId,
           );
         }
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1055,7 +1055,7 @@ export async function bootstrapAutoSession(
   );
   const preferredModel = sessionProviderIsCustom
     ? null
-    : resolveDefaultSessionModel(ctx.model?.provider, base, profileModelIds);
+    : resolveDefaultSessionModel(ctx.model?.provider, base, profileModelIds, ctx.model?.id);
   // Validate the preferred model against the live registry + provider auth so
   // an unconfigured PREFERENCES.md entry (no API key / OAuth) can't become the
   // start-model snapshot. Without this, every subsequent unit would try to
@@ -1501,6 +1501,7 @@ export async function bootstrapAutoSession(
       ctx.modelRegistry,
       base,
       resolveProfileAnchorProvider(ctx.model?.provider, startModelSnapshot?.provider),
+      startModelSnapshot ? `${startModelSnapshot.provider}/${startModelSnapshot.id}` : undefined,
     )?.preferences;
     const { shouldRunDeepProjectSetup } = await import("./auto-dispatch.js");
     const deepProjectStagePending = shouldRunDeepProjectSetup(
@@ -1857,6 +1858,7 @@ export async function bootstrapAutoSession(
       ctx.modelRegistry,
       base,
       resolveProfileAnchorProvider(ctx.model?.provider, s.autoModeStartModel?.provider),
+      s.autoModeStartModel ? `${s.autoModeStartModel.provider}/${s.autoModeStartModel.id}` : undefined,
     )?.preferences;
     const effectiveProvider = s.autoModeStartModel?.provider ?? ctx.model?.provider;
     const effectivelyEnabled = routingConfig.enabled

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2358,6 +2358,7 @@ function buildLoopDeps(pi: ExtensionAPI, ctx: ExtensionContext): LoopDeps {
         ctx.modelRegistry,
         s.basePath || undefined,
         resolveProfileAnchorProvider(ctx.model?.provider, s.autoModeStartModel?.provider),
+        s.autoModeStartModel ? `${s.autoModeStartModel.provider}/${s.autoModeStartModel.id}` : undefined,
       ),
 
     // Pre-dispatch health gate

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -211,6 +211,9 @@ export async function decideOrchestratorDispatch(
     ctx.modelRegistry,
     activeDispatchBasePath,
     resolveProfileAnchorProvider(ctx.model?.provider, session?.autoModeStartModel?.provider),
+    activeSession?.autoModeStartModel
+      ? `${activeSession.autoModeStartModel.provider}/${activeSession.autoModeStartModel.id}`
+      : undefined,
   )?.preferences;
   if (!active) {
     if (state.phase !== "pre-planning") return null;
@@ -528,6 +531,9 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       this.ctx.modelRegistry,
       activeBasePath,
       resolveProfileAnchorProvider(this.ctx.model?.provider, this.s.autoModeStartModel?.provider),
+      this.s.autoModeStartModel
+        ? `${this.s.autoModeStartModel.provider}/${this.s.autoModeStartModel.id}`
+        : undefined,
     )?.preferences;
     const uokFlags = resolveUokFlags(prefs);
     if (!uokFlags.gates) return;

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -579,6 +579,7 @@ export async function handleCoreCommand(
     const configOptions = {
       basePath,
       ...(availableModelIds && availableModelIds.length > 0 ? { availableModelIds } : {}),
+      ...(ctx.model ? { preferredModelId: `${ctx.model.provider}/${ctx.model.id}` } : {}),
     };
     const result = await ctx.ui.custom<boolean>(
       (tui, theme, _kb, done) => new GSDConfigOverlay(tui, theme, () => done(true), configOptions),

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -35,6 +35,7 @@ interface ConfigSection {
 export interface CollectConfigOptions {
   basePath?: string;
   availableModelIds?: string[];
+  preferredModelId?: string;
 }
 
 function collectConfigSections(options?: CollectConfigOptions): ConfigSection[] {
@@ -43,7 +44,7 @@ function collectConfigSections(options?: CollectConfigOptions): ConfigSection[] 
   const globalPrefs = loadGlobalGSDPreferences();
   const projectPrefs = loadProjectGSDPreferences(options?.basePath);
   const loadOpts = options?.availableModelIds
-    ? { availableModelIds: options.availableModelIds }
+    ? { availableModelIds: options.availableModelIds, preferredModelId: options.preferredModelId }
     : undefined;
   const effective = loadEffectiveGSDPreferences(options?.basePath, loadOpts);
   const prefs = effective?.preferences;
@@ -81,6 +82,7 @@ function collectConfigSections(options?: CollectConfigOptions): ConfigSection[] 
       unitType,
       options?.basePath,
       options?.availableModelIds,
+      options?.preferredModelId,
     );
     if (resolved) {
       let val = resolved.primary;

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -500,7 +500,7 @@ export function resolveModelForComplexity(
       modelId: preferred,
       fallbacks,
       tier: requestedTier,
-      wasDowngraded: preferred !== configuredPrimary,
+      wasDowngraded: bareModelId(preferred) !== bareModelId(configuredPrimary),
       reason: `preferred session model ${preferred} satisfies ${requestedTier} tier`,
       selectionMethod: "tier-only",
     };

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -500,7 +500,7 @@ export function resolveModelForComplexity(
       modelId: preferred,
       fallbacks,
       tier: requestedTier,
-      wasDowngraded: bareModelId(preferred) !== bareModelId(configuredPrimary),
+      wasDowngraded: !isModelAvailable(configuredPrimary, [preferred]),
       reason: `preferred session model ${preferred} satisfies ${requestedTier} tier`,
       selectionMethod: "tier-only",
     };

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -312,6 +312,8 @@ export function scoreEligibleModels(
 
 /**
  * Return all models eligible for a given tier, sorted cheapest first.
+ * A runtime preferred model (the user's selected/session model) is returned
+ * first when it is available and satisfies the requested tier.
  * If routingConfig.tier_models[tier] is set and available, returns only that
  * model. Otherwise filters availableModelIds by tier from MODEL_CAPABILITY_TIER.
  */
@@ -319,6 +321,7 @@ export function getEligibleModels(
   tier: ComplexityTier,
   availableModelIds: string[],
   routingConfig: DynamicRoutingConfig,
+  preferredModelId?: string,
 ): string[] {
   // 1. Check explicit tier_models config
   const explicitModel = routingConfig.tier_models?.[tier];
@@ -332,13 +335,17 @@ export function getEligibleModels(
   }
 
   // 2. Auto-detect: filter by tier, sort cheapest first
-  return availableModelIds
+  const tierMatches = availableModelIds
     .filter(id => getModelTier(id) === tier)
     .sort((a, b) => {
       const costA = getModelCost(a);
       const costB = getModelCost(b);
       return costA - costB;
     });
+
+  const preferred = findPreferredModelForTier(tier, availableModelIds, preferredModelId);
+  if (!preferred) return tierMatches;
+  return [preferred, ...tierMatches.filter(id => id !== preferred)];
 }
 
 /**
@@ -398,6 +405,7 @@ export function resolveModelForComplexity(
   unitType?: string,
   taskMetadata?: TaskMetadata,
   capabilityOverrides?: Record<string, Partial<ModelCapabilities>>,
+  preferredModelId?: string,
 ): RoutingDecision {
   // If no phase config or routing disabled, pass through
   if (!phaseConfig || !routingConfig.enabled) {
@@ -453,6 +461,7 @@ export function resolveModelForComplexity(
       routingConfig,
       availableModelIds,
       routingConfig.cross_provider !== false,
+      preferredModelId,
     );
 
     return {
@@ -470,7 +479,7 @@ export function resolveModelForComplexity(
   }
 
   // STEP 1: Get all eligible models for the requested tier
-  const eligible = getEligibleModels(requestedTier, availableModelIds, routingConfig);
+  const eligible = getEligibleModels(requestedTier, availableModelIds, routingConfig, preferredModelId);
 
   if (eligible.length === 0) {
     // No suitable model found — use configured primary
@@ -480,6 +489,19 @@ export function resolveModelForComplexity(
       tier: requestedTier,
       wasDowngraded: false,
       reason: `no ${requestedTier}-tier model available`,
+      selectionMethod: "tier-only",
+    };
+  }
+
+  const preferred = findPreferredModelForTier(requestedTier, availableModelIds, preferredModelId);
+  if (preferred && eligible.includes(preferred)) {
+    const fallbacks = buildFallbackChain(preferred, phaseConfig);
+    return {
+      modelId: preferred,
+      fallbacks,
+      tier: requestedTier,
+      wasDowngraded: preferred !== configuredPrimary,
+      reason: `preferred session model ${preferred} satisfies ${requestedTier} tier`,
       selectionMethod: "tier-only",
     };
   }
@@ -551,15 +573,15 @@ export function defaultRoutingConfig(): DynamicRoutingConfig {
 // ─── Tier-Based Model Resolution (for profile defaults) ─────────────────────
 
 /**
- * Fallback-only canonical model IDs per tier. Returned when the
+ * Fallback-only canonical model IDs per tier. Returned only when the
  * available-model list is empty (e.g., preferences are loaded before the
- * model registry is populated at bootstrap), or when a non-empty registry has
- * no model at the requested tier.
+ * model registry is populated at bootstrap).
  *
  * Precedence (resolveModelForTier):
  *   1. configured `tier_models[tier]` (via getEligibleModels) — exact/bare match
- *   2. cheapest available model whose tier matches `tier`
- *   3. CANONICAL_TIER_MODELS[tier] as last-resort fallback
+ *   2. preferred/session model when it is available and satisfies `tier`
+ *   3. cheapest available model whose tier matches `tier`
+ *   4. CANONICAL_TIER_MODELS[tier] when the registry is empty
  */
 const CANONICAL_TIER_MODELS: Record<ComplexityTier, string> = {
   light: "claude-haiku-4-5",
@@ -573,9 +595,10 @@ export function canonicalModelForTier(tier: ComplexityTier): string {
 
 /**
  * Single source of truth for tier-based model selection.
- * Returns the cheapest available model whose capability tier matches `tier`,
- * honoring `routingConfig.tier_models[tier]` when set. Returns undefined when
- * no available model matches the tier.
+ * Returns the preferred/session model when it satisfies `tier`, otherwise the
+ * cheapest available model whose capability tier matches `tier`, honoring
+ * `routingConfig.tier_models[tier]` when set. Returns undefined when no
+ * available model satisfies the tier.
  *
  * `crossProvider`: when false, restricts the search to models that share the
  * canonical (Anthropic) provider for the tier. When true, any provider is
@@ -586,13 +609,17 @@ function findModelForTier(
   routingConfig: DynamicRoutingConfig,
   availableModelIds: string[],
   crossProvider: boolean,
+  preferredModelId?: string,
 ): string | undefined {
-  const eligible = getEligibleModels(tier, availableModelIds, routingConfig);
+  const eligible = getEligibleModels(tier, availableModelIds, routingConfig, preferredModelId);
   if (eligible.length === 0) return undefined;
 
   if (crossProvider) {
     return eligible[0];
   }
+
+  const preferred = findPreferredModelForTier(tier, availableModelIds, preferredModelId);
+  if (preferred && eligible.includes(preferred)) return preferred;
 
   // Same-provider only: keep models whose bare ID matches a canonical
   // Anthropic ID at this tier (i.e., a claude-* model in the tier map).
@@ -610,9 +637,11 @@ function findModelForTier(
  *
  * Precedence:
  *   1. configured `tier_models[tier]`, if provided and available
- *   2. tier-matching model from any provider in `availableModelIds`
- *   3. canonical Anthropic ID as a fallback only when nothing else matches
- *      (or `availableModelIds` is empty, e.g., during early bootstrap)
+ *   2. preferred/session model when available and satisfying the tier
+ *   3. tier-matching model from any provider in `availableModelIds`
+ *   4. preferred/session model, then first available model, when the registry
+ *      is non-empty but has no tier match
+ *   5. canonical Anthropic ID only when `availableModelIds` is empty
  *
  * @param tier              The capability tier to resolve
  * @param availableModelIds List of available model IDs (REQUIRED for
@@ -620,6 +649,7 @@ function findModelForTier(
  *                          the model registry is genuinely unavailable)
  * @param routingConfig     Optional routing config, or legacy crossProvider boolean
  * @param crossProvider     Whether to consider models from other providers
+ * @param preferredModelId  Optional selected/session model ID to prefer
  */
 export function resolveModelForTier(
   tier: ComplexityTier,
@@ -631,12 +661,14 @@ export function resolveModelForTier(
   availableModelIds: string[],
   routingConfig?: DynamicRoutingConfig,
   crossProvider?: boolean,
+  preferredModelId?: string,
 ): string;
 export function resolveModelForTier(
   tier: ComplexityTier,
   availableModelIds: string[],
   routingConfigOrCrossProvider: DynamicRoutingConfig | boolean = defaultRoutingConfig(),
   crossProvider?: boolean,
+  preferredModelId?: string,
 ): string {
   const routingConfig = typeof routingConfigOrCrossProvider === "boolean"
     ? defaultRoutingConfig()
@@ -652,16 +684,57 @@ export function resolveModelForTier(
   }
 
   // Cross-provider tier search
-  const resolved = findModelForTier(tier, routingConfig, availableModelIds, allowCrossProvider);
+  const resolved = findModelForTier(tier, routingConfig, availableModelIds, allowCrossProvider, preferredModelId);
   if (resolved) {
     return normalizeResolvedTierModelId(resolved, tier, routingConfig);
   }
 
-  incrementLegacyTelemetry("legacy.providerDefaultUsed");
-  return canonicalModelForTier(tier);
+  const providerLocalFallback = findAvailableModelId(preferredModelId, availableModelIds)
+    ?? availableModelIds[0]
+    ?? canonicalModelForTier(tier);
+  return normalizeResolvedTierModelId(providerLocalFallback, tier, routingConfig);
 }
 
 // ─── Internal ────────────────────────────────────────────────────────────────
+
+function modelProvider(modelId: string): string | undefined {
+  const slash = modelId.indexOf("/");
+  return slash > 0 ? modelId.slice(0, slash) : undefined;
+}
+
+function findAvailableModelId(
+  preferredModelId: string | undefined,
+  availableModelIds: string[],
+): string | undefined {
+  if (!preferredModelId) return undefined;
+  if (availableModelIds.includes(preferredModelId)) return preferredModelId;
+
+  const preferredBare = bareModelId(preferredModelId);
+  if (!preferredBare) return undefined;
+  const preferredProvider = modelProvider(preferredModelId)?.toLowerCase();
+  if (preferredProvider) {
+    const providerMatch = availableModelIds.find(id =>
+      modelProvider(id)?.toLowerCase() === preferredProvider && bareModelId(id) === preferredBare
+    );
+    if (providerMatch) return providerMatch;
+  }
+
+  return availableModelIds.find(id => bareModelId(id) === preferredBare);
+}
+
+function modelSatisfiesTier(modelId: string, tier: ComplexityTier): boolean {
+  return tierOrdinal(getModelTier(modelId)) >= tierOrdinal(tier);
+}
+
+function findPreferredModelForTier(
+  tier: ComplexityTier,
+  availableModelIds: string[],
+  preferredModelId: string | undefined,
+): string | undefined {
+  const preferred = findAvailableModelId(preferredModelId, availableModelIds);
+  if (!preferred) return undefined;
+  return modelSatisfiesTier(preferred, tier) ? preferred : undefined;
+}
 
 /**
  * Check whether a model ID is present in the available models list.

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -677,8 +677,11 @@ export function resolveModelForTier(
     ? routingConfigOrCrossProvider
     : crossProvider ?? routingConfig.cross_provider !== false;
 
-  // No available models known — return canonical fallback
+  // No available models known — prefer the session model when provided, else canonical
   if (availableModelIds.length === 0) {
+    if (preferredModelId) {
+      return normalizeResolvedTierModelId(preferredModelId, tier, routingConfig);
+    }
     incrementLegacyTelemetry("legacy.providerDefaultUsed");
     return canonicalModelForTier(tier);
   }

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -618,15 +618,19 @@ function findModelForTier(
     return eligible[0];
   }
 
-  const preferred = findPreferredModelForTier(tier, availableModelIds, preferredModelId);
-  if (preferred && eligible.includes(preferred)) return preferred;
-
   // Same-provider only: keep models whose bare ID matches a canonical
   // Anthropic ID at this tier (i.e., a claude-* model in the tier map).
   const sameProvider = eligible.filter(id => {
     const bare = bareModelId(id);
     return MODEL_CAPABILITY_TIER[bare] === tier && bare.startsWith("claude-");
   });
+
+  // Honor the preferred/session model only when it is itself a same-provider
+  // (Anthropic/Claude) model. A non-Anthropic session model must not bypass
+  // the cross_provider:false restriction.
+  const preferred = findPreferredModelForTier(tier, availableModelIds, preferredModelId);
+  if (preferred && sameProvider.includes(preferred)) return preferred;
+
   return sameProvider[0];
 }
 

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -98,8 +98,11 @@ export function resolveModelWithFallbacksForUnit(
   unitType: string,
   basePath?: string,
   availableModelIds?: string[],
+  preferredModelId?: string,
 ): ResolvedModelConfig | undefined {
-  const loadOpts = availableModelIds !== undefined ? { availableModelIds } : undefined;
+  const loadOpts = availableModelIds !== undefined || preferredModelId !== undefined
+    ? { availableModelIds, preferredModelId }
+    : undefined;
   const prefs = loadEffectiveGSDPreferences(basePath, loadOpts);
   const chain = phaseChainForUnit(unitType);
   if (!chain) return undefined;
@@ -188,7 +191,9 @@ export function resolveThinkingLevelForUnit(
  * `openai-codex/gpt-5.4`).  When a bare ID is found and sessionProvider
  * is available, the session provider is used.  Without sessionProvider,
  * bare IDs are still returned with provider set to the bare ID itself
- * so downstream resolution (resolveModelId) can match it.
+ * so downstream resolution (resolveModelId) can match it. Accepts an optional
+ * `sessionModelId` so token-profile defaults can preserve the selected model
+ * before auto-mode captures its start snapshot.
  *
  * Returns `{ provider, id }` or `undefined` if no model preference is
  * configured.
@@ -197,8 +202,14 @@ export function resolveDefaultSessionModel(
   sessionProvider?: string,
   basePath?: string,
   availableModelIds?: string[],
+  sessionModelId?: string,
 ): { provider: string; id: string } | undefined {
-  const loadOpts = availableModelIds !== undefined ? { availableModelIds } : undefined;
+  const preferredModelId = sessionModelId && sessionProvider
+    ? `${sessionProvider}/${sessionModelId}`
+    : sessionModelId;
+  const loadOpts = availableModelIds !== undefined || preferredModelId !== undefined
+    ? { availableModelIds, preferredModelId }
+    : undefined;
   const prefs = loadEffectiveGSDPreferences(basePath, loadOpts);
   const models = prefs?.preferences?.models;
   if (!models) return undefined;
@@ -477,18 +488,21 @@ const PROFILE_TIER_MAP: Record<TokenProfile, Record<string, ComplexityTier>> = {
  * the best match on the anchor provider (session / auto-start model). Callers
  * scope the available-model list via `modelIdsForProfileResolution` so token
  * profiles do not hop to a cheaper provider (e.g. Gemini Flash) when the user
- * is working on OpenAI or Anthropic. When not known (e.g., early startup),
- * falls back to canonical Anthropic model IDs.
+ * is working on OpenAI or Anthropic. When the selected/session model is known,
+ * it is preferred for tiers it can satisfy. When the registry is unavailable
+ * (e.g., early startup), falls back to canonical Anthropic model IDs.
  *
  * @param profile           The token profile to resolve
  * @param availableModelIds Optional list of available model IDs for cross-provider resolution.
  *                          Undefined means the registry is unavailable.
  * @param routingConfig     Optional routing config for tier model pins.
+ * @param preferredModelId  Optional selected/session model ID to prefer.
  */
 export function resolveProfileDefaults(
   profile: TokenProfile,
   availableModelIds?: string[],
   routingConfig: DynamicRoutingConfig = defaultRoutingConfig(),
+  preferredModelId?: string,
 ): Partial<GSDPreferences> {
   // burn-max never writes model defaults — preserve user-selected models.
   // For the other three profiles, derive concrete model IDs from the tier map
@@ -496,7 +510,7 @@ export function resolveProfileDefaults(
   // omit the registry entirely, use canonical fallbacks explicitly.
   const tierMap = PROFILE_TIER_MAP[profile];
   const resolveTierModel = (tier: ComplexityTier): string => Array.isArray(availableModelIds)
-    ? resolveModelForTier(tier, availableModelIds, routingConfig)
+    ? resolveModelForTier(tier, availableModelIds, routingConfig, undefined, preferredModelId)
     : canonicalModelForTier(tier);
   const models: GSDModelConfigV2 | undefined = profile === "burn-max"
     ? undefined

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -509,9 +509,10 @@ export function resolveProfileDefaults(
   // against the available-model list when the registry is provided. If callers
   // omit the registry entirely, use canonical fallbacks explicitly.
   const tierMap = PROFILE_TIER_MAP[profile];
-  const resolveTierModel = (tier: ComplexityTier): string => Array.isArray(availableModelIds)
-    ? resolveModelForTier(tier, availableModelIds, routingConfig, undefined, preferredModelId)
-    : canonicalModelForTier(tier);
+  const resolveTierModel = (tier: ComplexityTier): string =>
+    Array.isArray(availableModelIds) || preferredModelId
+      ? resolveModelForTier(tier, availableModelIds ?? [], routingConfig, undefined, preferredModelId)
+      : canonicalModelForTier(tier);
   const models: GSDModelConfigV2 | undefined = profile === "burn-max"
     ? undefined
     : {

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -220,6 +220,7 @@ export function loadEffectiveGSDPreferencesWithRegistry(
   registry: PreferencesModelRegistry | undefined,
   basePath?: string,
   anchorProvider?: string,
+  preferredModelId?: string,
 ): LoadedGSDPreferences | null {
   if (!registry) {
     return loadEffectiveGSDPreferences(basePath);
@@ -229,7 +230,7 @@ export function loadEffectiveGSDPreferencesWithRegistry(
   if (!availableModelIds) {
     return loadEffectiveGSDPreferences(basePath);
   }
-  return loadEffectiveGSDPreferences(basePath, { availableModelIds });
+  return loadEffectiveGSDPreferences(basePath, { availableModelIds, preferredModelId });
 }
 
 /**
@@ -280,7 +281,7 @@ export function loadProjectGSDPreferences(basePath?: string): LoadedGSDPreferenc
 
 export function loadEffectiveGSDPreferences(
   basePath?: string,
-  opts?: { availableModelIds?: string[] },
+  opts?: { availableModelIds?: string[]; preferredModelId?: string },
 ): LoadedGSDPreferences | null {
   const globalPreferences = loadGlobalGSDPreferences();
   const projectPreferences = loadProjectGSDPreferences(basePath);
@@ -323,6 +324,7 @@ export function loadEffectiveGSDPreferences(
       profileForDefaults,
       opts?.availableModelIds,
       result.preferences.dynamic_routing,
+      opts?.preferredModelId,
     );
     const defaultsToApply = explicitProfile
       ? profileDefaults

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -222,13 +222,16 @@ export function loadEffectiveGSDPreferencesWithRegistry(
   anchorProvider?: string,
   preferredModelId?: string,
 ): LoadedGSDPreferences | null {
+  const preferenceOpts = preferredModelId !== undefined
+    ? { preferredModelId }
+    : undefined;
   if (!registry) {
-    return loadEffectiveGSDPreferences(basePath);
+    return loadEffectiveGSDPreferences(basePath, preferenceOpts);
   }
   const disabledProviders = resolveDisabledModelProvidersFromPreferences();
   const availableModelIds = modelIdsForProfileResolution(registry, anchorProvider, disabledProviders);
   if (!availableModelIds) {
-    return loadEffectiveGSDPreferences(basePath);
+    return loadEffectiveGSDPreferences(basePath, preferenceOpts);
   }
   return loadEffectiveGSDPreferences(basePath, { availableModelIds, preferredModelId });
 }

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -313,6 +313,25 @@ test("resolveModelForComplexity: preferred GLM session model wins over cheaper s
   assert.equal(result.selectionMethod, "tier-only");
 });
 
+test("resolveModelForComplexity: wasDowngraded is false when preferred session model matches configuredPrimary with different ID format", () => {
+  // configuredPrimary is bare ("claude-opus-4-6"), preferred comes back as provider-prefixed
+  // ("anthropic/claude-opus-4-6") from availableModelIds. They refer to the same model —
+  // wasDowngraded must NOT be true, which would otherwise trigger a spurious UI notification.
+  const config: DynamicRoutingConfig = { ...defaultRoutingConfig(), enabled: true, capability_routing: false };
+  const result = resolveModelForComplexity(
+    makeClassification("standard"),
+    { primary: "claude-opus-4-6", fallbacks: [] },
+    config,
+    ["anthropic/claude-opus-4-6"],
+    "execute-task",
+    undefined,
+    undefined,
+    "anthropic/claude-opus-4-6",
+  );
+  assert.equal(result.modelId, "anthropic/claude-opus-4-6");
+  assert.equal(result.wasDowngraded, false);
+});
+
 // ─── resolveModelForTier (provider-agnostic tier resolution) ────────────────
 
 test("resolveModelForTier: returns canonical Anthropic model when no available models", () => {

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -297,6 +297,22 @@ test("cross-provider: configured primary available by bare ID wins over equivale
   assert.equal(result.wasDowngraded, false);
 });
 
+test("resolveModelForComplexity: preferred GLM session model wins over cheaper standard-tier GLM models", () => {
+  const config: DynamicRoutingConfig = { ...defaultRoutingConfig(), enabled: true, capability_routing: false };
+  const result = resolveModelForComplexity(
+    makeClassification("standard"),
+    { primary: "claude-opus-4-6", fallbacks: [] },
+    config,
+    ["zai/glm-4.5-air", "zai/glm-5.1", "zai/glm-5.2"],
+    "execute-task",
+    undefined,
+    undefined,
+    "zai/glm-5.2",
+  );
+  assert.equal(result.modelId, "zai/glm-5.2");
+  assert.equal(result.selectionMethod, "tier-only");
+});
+
 // ─── resolveModelForTier (provider-agnostic tier resolution) ────────────────
 
 test("resolveModelForTier: returns canonical Anthropic model when no available models", () => {
@@ -355,15 +371,40 @@ test("resolveModelForTier: picks light-tier cross-provider model", () => {
   assert.equal(result, "gpt-4o-mini");
 });
 
-test("resolveModelForTier: falls back to canonical when no tier match available", () => {
+test("resolveModelForTier: preserves selected standard-tier model over cheaper same-tier provider models", () => {
+  const result = resolveModelForTier(
+    "standard",
+    ["zai/glm-4.5-air", "zai/glm-5.1", "zai/glm-5.2"],
+    defaultRoutingConfig(),
+    true,
+    "zai/glm-5.2",
+  );
+  assert.equal(result, "zai/glm-5.2");
+});
+
+test("resolveModelForTier: light tier with no light provider model stays on selected provider model", () => {
   try {
     resetLegacyTelemetry();
-    // Only unknown models available — getModelTier classifies unknowns as
-    // "standard", so a request for "heavy" finds no match and the canonical
-    // Anthropic ID is returned as a documented fallback.
-    const result = resolveModelForTier("heavy", ["some-custom-model"]);
-    assert.equal(result, "claude-opus-4-6");
-    assert.equal(getLegacyTelemetry()["legacy.providerDefaultUsed"], 1);
+    const result = resolveModelForTier(
+      "light",
+      ["zai/glm-4.5-air", "zai/glm-5.1", "zai/glm-5.2"],
+      defaultRoutingConfig(),
+      true,
+      "zai/glm-5.2",
+    );
+    assert.equal(result, "zai/glm-5.2");
+    assert.equal(getLegacyTelemetry()["legacy.providerDefaultUsed"], 0);
+  } finally {
+    resetLegacyTelemetry();
+  }
+});
+
+test("resolveModelForTier: non-empty provider list without a tier match does not fall back to canonical", () => {
+  try {
+    resetLegacyTelemetry();
+    const result = resolveModelForTier("heavy", ["zai/glm-5.2"]);
+    assert.equal(result, "zai/glm-5.2");
+    assert.equal(getLegacyTelemetry()["legacy.providerDefaultUsed"], 0);
   } finally {
     resetLegacyTelemetry();
   }
@@ -429,6 +470,20 @@ test("resolveProfileDefaults: empty availableModelIds falls back to canonical An
   assert.ok(typeof planningModel === "string" && planningModel.startsWith("claude-"));
 });
 
+test("resolveProfileDefaults: selected GLM model wins for standard and light profile slots", async () => {
+  const { resolveProfileDefaults } = await import("../preferences-models.js");
+  const defaults = resolveProfileDefaults(
+    "balanced",
+    ["zai/glm-4.5-air", "zai/glm-5.1", "zai/glm-5.2"],
+    defaultRoutingConfig(),
+    "zai/glm-5.2",
+  );
+  assert.equal(defaults.models?.planning, "zai/glm-5.2");
+  assert.equal(defaults.models?.execution, "zai/glm-5.2");
+  assert.equal(defaults.models?.completion, "zai/glm-5.2");
+  assert.equal(defaults.models?.subagent, "zai/glm-5.2");
+});
+
 test("loadEffectiveGSDPreferences: balanced profile resolves OpenAI tiers from registry", async () => {
   const oldHome = process.env.GSD_HOME;
   const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
@@ -489,6 +544,35 @@ test("loadEffectiveGSDPreferences: implicit balanced (D046) resolves tiers from 
       undefined,
       "implicit balanced model defaults must not silently skip slice research",
     );
+  } finally {
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("loadEffectiveGSDPreferences: implicit balanced preserves selected GLM model", async () => {
+  const oldHome = process.env.GSD_HOME;
+  const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const home = mkdtempSync(join(tmpdir(), "gsd-profile-selected-glm-"));
+  try {
+    process.env.GSD_HOME = home;
+    writeFileSync(join(home, "PREFERENCES.md"), "---\nmode: solo\n---\n");
+    const { loadEffectiveGSDPreferencesWithRegistry } = await import("../preferences.ts");
+    const registry = {
+      getAvailable: () => [
+        { provider: "zai", id: "glm-4.5-air" },
+        { provider: "zai", id: "glm-5.1" },
+        { provider: "zai", id: "glm-5.2" },
+      ],
+    };
+    const loaded = loadEffectiveGSDPreferencesWithRegistry(registry, undefined, "zai", "zai/glm-5.2");
+    const models = loaded?.preferences.models as Record<string, string> | undefined;
+    assert.equal(models?.planning, "zai/glm-5.2");
+    assert.equal(models?.execution, "zai/glm-5.2");
+    assert.equal(models?.completion, "zai/glm-5.2");
   } finally {
     if (oldHome === undefined) delete process.env.GSD_HOME;
     else process.env.GSD_HOME = oldHome;

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -418,6 +418,34 @@ test("resolveModelForTier: light tier with no light provider model stays on sele
   }
 });
 
+test("resolveModelForTier: cross_provider:false ignores non-Anthropic preferred model and returns Claude", () => {
+  // When dynamic_routing.cross_provider is false, the sameProvider (Claude-only) filter must
+  // win over a non-Anthropic session model — the preferred model must not bypass the restriction.
+  const config: DynamicRoutingConfig = { ...defaultRoutingConfig(), cross_provider: false };
+  const result = resolveModelForTier(
+    "standard",
+    ["zai/glm-5.2", "claude-sonnet-4-6"],
+    config,
+    false, // crossProvider=false
+    "zai/glm-5.2",
+  );
+  assert.equal(result, "claude-sonnet-4-6");
+});
+
+test("resolveModelForTier: cross_provider:false honors preferred model when it is a Claude model", () => {
+  // When the session model itself is a Claude model, it should still win within the
+  // same-provider restriction.
+  const config: DynamicRoutingConfig = { ...defaultRoutingConfig(), cross_provider: false };
+  const result = resolveModelForTier(
+    "standard",
+    ["anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"],
+    config,
+    false,
+    "anthropic/claude-sonnet-4-6",
+  );
+  assert.equal(result, "claude-sonnet-4-6");
+});
+
 test("resolveModelForTier: non-empty provider list without a tier match does not fall back to canonical", () => {
   try {
     resetLegacyTelemetry();

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -489,6 +489,20 @@ test("resolveProfileDefaults: empty availableModelIds falls back to canonical An
   assert.ok(typeof planningModel === "string" && planningModel.startsWith("claude-"));
 });
 
+test("resolveProfileDefaults: empty availableModelIds preserves selected model when provided", async () => {
+  const { resolveProfileDefaults } = await import("../preferences-models.js");
+  const defaults = resolveProfileDefaults(
+    "balanced",
+    [],
+    defaultRoutingConfig(),
+    "zai/glm-5.2",
+  );
+  assert.equal(defaults.models?.planning, "zai/glm-5.2");
+  assert.equal(defaults.models?.execution, "zai/glm-5.2");
+  assert.equal(defaults.models?.completion, "zai/glm-5.2");
+  assert.equal(defaults.models?.subagent, "zai/glm-5.2");
+});
+
 test("resolveProfileDefaults: selected GLM model wins for standard and light profile slots", async () => {
   const { resolveProfileDefaults } = await import("../preferences-models.js");
   const defaults = resolveProfileDefaults(
@@ -592,6 +606,58 @@ test("loadEffectiveGSDPreferences: implicit balanced preserves selected GLM mode
     assert.equal(models?.planning, "zai/glm-5.2");
     assert.equal(models?.execution, "zai/glm-5.2");
     assert.equal(models?.completion, "zai/glm-5.2");
+  } finally {
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("loadEffectiveGSDPreferences: implicit balanced preserves selected model when scoped registry is empty", async () => {
+  const oldHome = process.env.GSD_HOME;
+  const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const home = mkdtempSync(join(tmpdir(), "gsd-profile-empty-scope-selected-"));
+  try {
+    process.env.GSD_HOME = home;
+    writeFileSync(join(home, "PREFERENCES.md"), "---\nmode: solo\n---\n");
+    const { loadEffectiveGSDPreferencesWithRegistry } = await import("../preferences.ts");
+    const registry = {
+      getAvailable: () => [
+        { provider: "google", id: "gemini-2.0-flash" },
+        { provider: "openai-codex", id: "gpt-4o" },
+      ],
+    };
+    const loaded = loadEffectiveGSDPreferencesWithRegistry(registry, undefined, "zai", "zai/glm-5.2");
+    const models = loaded?.preferences.models as Record<string, string> | undefined;
+    assert.equal(models?.planning, "zai/glm-5.2");
+    assert.equal(models?.execution, "zai/glm-5.2");
+    assert.equal(models?.completion, "zai/glm-5.2");
+    assert.equal(models?.subagent, "zai/glm-5.2");
+  } finally {
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("loadEffectiveGSDPreferences: implicit balanced preserves selected model when registry is missing", async () => {
+  const oldHome = process.env.GSD_HOME;
+  const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const home = mkdtempSync(join(tmpdir(), "gsd-profile-missing-registry-selected-"));
+  try {
+    process.env.GSD_HOME = home;
+    writeFileSync(join(home, "PREFERENCES.md"), "---\nmode: solo\n---\n");
+    const { loadEffectiveGSDPreferencesWithRegistry } = await import("../preferences.ts");
+    const loaded = loadEffectiveGSDPreferencesWithRegistry(undefined, undefined, undefined, "zai/glm-5.2");
+    const models = loaded?.preferences.models as Record<string, string> | undefined;
+    assert.equal(models?.planning, "zai/glm-5.2");
+    assert.equal(models?.execution, "zai/glm-5.2");
+    assert.equal(models?.completion, "zai/glm-5.2");
+    assert.equal(models?.subagent, "zai/glm-5.2");
   } finally {
     if (oldHome === undefined) delete process.env.GSD_HOME;
     else process.env.GSD_HOME = oldHome;


### PR DESCRIPTION
## Summary
- Fixed session-model-aware tier/profile routing and verified syntax/whitespace; full tests were blocked by missing dependencies and offline npm.

## Bugs Addressed
- [x] **Standard-tier routing ignores the selected session model**
- [x] **Light-tier fallback silently switches to Anthropic**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #810
- [#810 [Bug] Tier resolver ignores session model: standard units get cheapest, light units hop to claude-haiku](https://github.com/open-gsd/gsd-pi/issues/810)

## User
- @DragonSigh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/810-bug-tier-resolver-ignores-session-model--1782391321`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core auto-mode model selection and profile default merging across many call sites; behavior shifts for multi-model providers and empty-registry edge cases, though coverage is added in model-router tests.
> 
> **Overview**
> Fixes **#810**: tier-based model selection now honors the user's **selected/session model** (`provider/id`) instead of always choosing the cheapest same-tier option or falling back to canonical Claude IDs when the registry has no tier match.
> 
> **Routing** — `getEligibleModels`, `resolveModelForComplexity`, and `resolveModelForTier` take an optional `preferredModelId`. When that model is available and meets the requested complexity tier, it is ranked first and can win over cheaper alternatives (e.g. GLM 5.2 over lighter GLM variants). `wasDowngraded` stays false when the preferred model matches the configured primary under different ID formatting.
> 
> **Preferences & bootstrap** — `preferredModelId` flows through `loadEffectiveGSDPreferences`, profile defaults, per-unit model resolution, auto `selectAndApplyModel`, orchestrator prefs, `resolveDefaultSessionModel` (with `sessionModelId`), and the config overlay so token profiles and implicit **balanced** defaults align with the session/auto-start snapshot.
> 
> **Fallback behavior** — With a non-empty provider list but no tier match, resolution prefers the session model or first available model rather than silently switching to Anthropic (notably for **light** tier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfce28af62abcea9590fd407e021ef6b3d7e986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->