### PR TITLE
fix(cc-cli): distinguish ask_user_questions host timeout from cancel

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -24,6 +24,7 @@ import {
   buildAskUserQuestionsElicitRequest,
   createMcpServer,
   formatAskUserQuestionsElicitResult,
+  isLocalElicitTimeoutError,
   withElicitTimeout,
 } from './server.js';
 import { MAX_EVENTS } from './types.js';
@@ -1410,6 +1411,79 @@ describe('createMcpServer tool registration', () => {
     assert.match(result.content[0]?.text ?? '', /schema validation blew up/);
   });
 
+  it('ask_user_questions returns a timeout result and does NOT fall through to remote on a local host timeout (#852)', async () => {
+    // A host-side elicitation timeout means the user is at the host but didn't
+    // answer. Falling through to remote would be wrong (no one is there to
+    // answer it either) and would lose the timeout signal that the gate hook
+    // needs to pause-and-wait. The handler returns a `timed_out` result instead.
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    let remoteCalls = 0;
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        // The Claude Agent SDK's internal ~60s timeout surfaces as this error.
+        throw new Error('MCP error -32001: Request timed out');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        remoteCalls++;
+        return { content: [{ type: 'text', text: 'remote response' }] };
+      },
+    });
+
+    assert.equal(remoteCalls, 0, 'host timeout must NOT fall through to remote');
+    assert.equal('isError' in result && result.isError, false, 'timeout is not an error result');
+    assert.match(result.content[0]?.text ?? '', /timed out/i);
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true, timed_out: true },
+    );
+  });
+
+  it('ask_user_questions recognizes the 10-minute withElicitTimeout error as a host timeout (#852)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new Error('ask_user_questions timed out after 10 minutes — no user response received');
+      },
+      isRemoteConfigured() {
+        return false;
+      },
+      async tryRemoteQuestions() {
+        throw new Error('should not be called');
+      },
+    });
+
+    assert.equal('isError' in result && result.isError, false);
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true, timed_out: true },
+    );
+  });
+
   it('ask_user_questions reports both local and remote errors when both paths fail', async () => {
     const questions = [
       {
@@ -1425,7 +1499,8 @@ describe('createMcpServer tool registration', () => {
 
     const result = await askUserQuestionsHandler(questions, undefined, {
       async elicitInput() {
-        throw new Error('ask_user_questions timed out after 10 minutes');
+        // Non-timeout fallback error → falls through to remote, which also fails.
+        throw new Error('MCP host does not support elicitation');
       },
       isRemoteConfigured() {
         return true;
@@ -1438,6 +1513,42 @@ describe('createMcpServer tool registration', () => {
     assert.equal('isError' in result && result.isError, true);
     assert.match(result.content[0]?.text ?? '', /Local elicitation failed/);
     assert.match(result.content[0]?.text ?? '', /remote transport failed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLocalElicitTimeoutError (#852)
+// ---------------------------------------------------------------------------
+
+describe('isLocalElicitTimeoutError', () => {
+  it('recognizes the Claude Agent SDK -32001 timeout', () => {
+    assert.equal(
+      isLocalElicitTimeoutError(new Error('MCP error -32001: Request timed out')),
+      true,
+    );
+    assert.equal(
+      isLocalElicitTimeoutError(new Error('Request timed out')),
+      true,
+    );
+  });
+
+  it('recognizes the 10-minute withElicitTimeout error', () => {
+    assert.equal(
+      isLocalElicitTimeoutError(new Error('ask_user_questions timed out after 10 minutes — no user response received')),
+      true,
+    );
+  });
+
+  it('does not misclassify non-timeout elicitation errors', () => {
+    assert.equal(isLocalElicitTimeoutError(new Error('MCP host does not support elicitation')), false);
+    assert.equal(isLocalElicitTimeoutError(new Error('-32601 method not found')), false);
+    assert.equal(isLocalElicitTimeoutError(new Error('schema validation blew up')), false);
+  });
+
+  it('does not misclassify non-Error values', () => {
+    assert.equal(isLocalElicitTimeoutError('timed out'), false);
+    assert.equal(isLocalElicitTimeoutError(undefined), false);
+    assert.equal(isLocalElicitTimeoutError(null), false);
   });
 });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -417,6 +417,13 @@ interface AskUserQuestionsStructuredContent {
   questions: AskUserQuestion[];
   response: AskUserQuestionsRoundResult | null;
   cancelled: boolean;
+  /**
+   * True when the host elicitation timed out before the user answered.
+   * Distinct from `cancelled` (deliberate user dismissal): a timeout must not
+   * be laundered into a re-ask loop, so the gate hook treats it as "waiting"
+   * and pauses auto-mode (#852).
+   */
+  timed_out?: boolean;
 }
 
 interface AskUserQuestionsWriteGateModule {
@@ -539,6 +546,24 @@ export function formatAskUserQuestionsElicitResult(
   }
 
   return JSON.stringify({ answers });
+}
+
+/**
+ * Format the user-visible message returned when the host elicitation times out
+ * before the user answers. The message is LLM-facing: it tells the model the
+ * question was not answered, that it must NOT re-ask in the same turn, and that
+ * auto-mode is paused until the user responds. The gate hook routes this to a
+ * `timed_out` verdict so the depth-verification gate stays pending (fail-closed)
+ * without becoming a permanent block (#852).
+ */
+export function formatAskUserQuestionsTimeoutMessage(err: unknown): string {
+  const reason = err instanceof Error ? err.message : 'host elicitation timed out';
+  return [
+    `ask_user_questions timed out waiting for a response (${reason}).`,
+    'The user did not answer within the host elicitation window.',
+    'Do not re-ask the same question in this turn — that will only time out again.',
+    'Auto-mode is paused. Wait for the user to respond, or re-ask on a new turn once they confirm readiness.',
+  ].join(' ');
 }
 
 /**
@@ -675,11 +700,33 @@ async function recordAskUserQuestionsGateResult(
   }
 }
 
-function isLocalElicitFallbackError(err: unknown): boolean {
+/**
+ * Detect an elicitation-side timeout error so the handler returns a clean
+ * "timed_out" result rather than a raw error the model will retry.
+ *
+ * The Claude Agent SDK enforces its own ~60s elicitation timeout
+ * (`MCP error -32001: Request timed out`); `withElicitTimeout` enforces a
+ * longer 10-minute timeout (`… timed out after … minutes`). Both surface as
+ * elicitation fallback errors that should never become a raw `errorContent`
+ * response — without recognition they re-throw, skip
+ * `recordAskUserQuestionsGateResult`, leave the depth-verification gate
+ * pending, and the model loops on the blocked call (#852).
+ */
+export function isLocalElicitTimeoutError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const message = err.message.toLowerCase();
   return (
-    message.includes('timed out after') ||
+    message.includes('-32001') ||
+    message.includes('request timed out') ||
+    message.includes('timed out after')
+  );
+}
+
+function isLocalElicitFallbackError(err: unknown): boolean {
+  if (isLocalElicitTimeoutError(err)) return true;
+  if (!(err instanceof Error)) return false;
+  const message = err.message.toLowerCase();
+  return (
     message.includes('elicit') ||
     message.includes('elicitation') ||
     message.includes('host') ||
@@ -720,6 +767,7 @@ export async function askUserQuestionsHandler(
     // remote (e.g. expired Discord token returning 401) must not block the
     // depth-verification gate when the user is sitting in front of the host.
     let localElicitError: unknown;
+    let localElicitTimedOut = false;
     try {
       const elicitation = await withElicitTimeout(
         deps.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
@@ -740,7 +788,32 @@ export async function askUserQuestionsHandler(
     } catch (err) {
       if (!isLocalElicitFallbackError(err)) throw err;
       localElicitError = err;
-      console.warn(`[gsd:mcp] ask_user_questions local elicitation unavailable; trying remote fallback: ${formatErrorMessage(err)}`);
+      // A timeout is the host user not answering, not a channel failure.
+      // Returning here (instead of falling through to remote) gives the gate
+      // hook a clean `timed_out` signal so it pauses auto-mode and waits for
+      // the user instead of looping on the blocked call (#852).
+      if (isLocalElicitTimeoutError(err)) {
+        localElicitTimedOut = true;
+      } else {
+        console.warn(`[gsd:mcp] ask_user_questions local elicitation unavailable; trying remote fallback: ${formatErrorMessage(err)}`);
+      }
+    }
+
+    // Host-side timeout: the user is at the host but didn't respond. Do not
+    // fall through to remote (no one is there to answer it either). Return a
+    // clean `timed_out` result so the gate hook pauses and the model stops
+    // retrying the blocked call.
+    if (localElicitTimedOut) {
+      const timedOutStructured: AskUserQuestionsStructuredContent = {
+        questions,
+        response: null,
+        cancelled: true,
+        timed_out: true,
+      };
+      return {
+        content: [{ type: 'text' as const, text: formatAskUserQuestionsTimeoutMessage(localElicitError) }],
+        structuredContent: timedOutStructured as unknown as Record<string, unknown>,
+      };
     }
 
     // Local cancelled / unavailable — fall back to the configured remote

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -13,7 +13,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
 import { buildMilestoneFileName, canonicalPhaseDirName, clearPathCache, milestonesDir, legacyMilestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { applyAskUserQuestionsGateResult, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, hostWriteGateAdapter, isApprovalGateVerifiedInSnapshot, isDepthConfirmationAnswer, isMilestoneDepthVerified, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeBash, shouldBlockWorktreeWrite, isGateQuestionId, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
+import { applyAskUserQuestionsGateResult, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, formatTimedOutAskUserQuestionsGateMessage, hostWriteGateAdapter, isApprovalGateVerifiedInSnapshot, isDepthConfirmationAnswer, isMilestoneDepthVerified, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeBash, shouldBlockWorktreeWrite, isGateQuestionId, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { canonicalToolName } from "../engine-hook-contract.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
@@ -680,7 +680,7 @@ function isContextDraftSummarySave(toolName: string, input: unknown): boolean {
 function resolveAskUserQuestionsGateDetails(event: { details?: unknown; result?: unknown }): any {
   const hasRoundShape = (value: any): boolean =>
     !!value && typeof value === "object" &&
-    (value.cancelled !== undefined || value.response !== undefined);
+    (value.cancelled !== undefined || value.timed_out !== undefined || value.response !== undefined);
 
   const details = event.details as any;
   if (hasRoundShape(details)) return details;
@@ -1621,6 +1621,28 @@ export function registerHooks(
         }],
       };
     }
+    if (gateResult.status === "timeout") {
+      // Host elicitation timed out before the user answered. The gate stays
+      // pending (fail-closed), but we reset the loop guard and return a
+      // timeout-specific message so the model does NOT immediately re-ask —
+      // that would just hit the same timeout again. Auto-mode pauses and
+      // waits for the user to respond on a new turn (#852).
+      resetToolCallLoopGuard();
+      if (ctx) {
+        await maybePauseAutoForApprovalGate(
+          ctx,
+          pi,
+          true,
+          "Depth confirmation timed out waiting for a response — pausing auto-mode. Reply to resume.",
+        );
+      }
+      return {
+        content: [{
+          type: "text" as const,
+          text: formatTimedOutAskUserQuestionsGateMessage(gateResult.pendingGateId),
+        }],
+      };
+    }
     if (gateResult.status === "verified") {
       clearDeferredApprovalGate(basePath);
     }
@@ -1640,6 +1662,21 @@ export function registerHooks(
           pi,
           true,
           "ask_user_questions was cancelled before receiving a response — pausing auto-mode until you respond.",
+        );
+      }
+      return;
+    }
+    if (roundOutcome === "timeout") {
+      // Non-gate (consent/decision) question timed out at the host elicitation.
+      // Same policy as the gate-timeout branch above: reset the loop guard and
+      // pause-and-wait so the model does not re-ask into the same timeout (#852).
+      resetToolCallLoopGuard();
+      if (ctx) {
+        await maybePauseAutoForApprovalGate(
+          ctx,
+          pi,
+          true,
+          "A user question timed out waiting for a response — pausing auto-mode. Reply to resume.",
         );
       }
       return;

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -743,6 +743,13 @@ export interface AskUserQuestionsGateQuestion {
 export interface AskUserQuestionsGateDetails {
   cancelled?: boolean;
   interrupted?: boolean;
+  /**
+   * True when the host elicitation channel timed out before the user answered.
+   * Distinct from `cancelled` (deliberate dismissal): the gate verdict maps
+   * this to "timeout" so callers pause-and-wait instead of letting the model
+   * re-ask into the same timeout loop (#852).
+   */
+  timed_out?: boolean;
   response?: {
     answers?: Record<string, { selected?: unknown } | undefined>;
   } | null;
@@ -752,7 +759,8 @@ export type AskUserQuestionsGateResult =
   | { status: "not-gate" }
   | { status: "waiting"; pendingGateId: string; interrupted: boolean }
   | { status: "verified"; gateId: string; milestoneId: string | null }
-  | { status: "declined"; gateId: string };
+  | { status: "declined"; gateId: string }
+  | { status: "timeout"; pendingGateId: string; interrupted: boolean };
 
 function findGateQuestion(
   questions: AskUserQuestionsGateQuestion[],
@@ -776,11 +784,22 @@ function verifyAnsweredGate(
 
 /** Map an unresolved (non-verified) gate verdict to the caller-facing result. */
 function unresolvedGateResult(
-  verdict: "declined" | "waiting" | "cancelled",
+  verdict: "declined" | "waiting" | "cancelled" | "timeout",
   gateId: string,
   details: AskUserQuestionsGateDetails,
 ): AskUserQuestionsGateResult {
   if (verdict === "declined") return { status: "declined", gateId };
+  if (verdict === "timeout") {
+    // Host elicitation expired before the user answered. The gate stays
+    // pending (fail-closed — a timeout is never approval), but the status is
+    // "timeout" so the caller pauses-and-waits instead of re-asking into the
+    // same timeout loop (#852).
+    return {
+      status: "timeout",
+      pendingGateId: gateId,
+      interrupted: details.interrupted === true,
+    };
+  }
   // "waiting" (and the unreachable post-cancel case): an empty selection is
   // not an answer — keep the gate pending and make the caller pause.
   return {
@@ -811,6 +830,16 @@ export function applyAskUserQuestionsGateResult(options: {
   const { basePath, questions, details, fallbackMilestoneId } = options;
   const currentPendingGate = getPendingGate(basePath);
   if (currentPendingGate) {
+    if (details.timed_out) {
+      // Host elicitation timed out before the user answered. Keep the gate
+      // pending (fail-closed) but report "timeout" so the caller pauses-and-
+      // waits instead of re-asking into the same timeout loop (#852).
+      return {
+        status: "timeout",
+        pendingGateId: currentPendingGate,
+        interrupted: details.interrupted === true,
+      };
+    }
     if (details.cancelled || !details.response) {
       return {
         status: "waiting",
@@ -829,6 +858,7 @@ export function applyAskUserQuestionsGateResult(options: {
     }
   }
 
+  if (details.timed_out) return { status: "not-gate" };
   if (details.cancelled || !details.response) return { status: "not-gate" };
 
   for (const question of questions) {
@@ -860,6 +890,24 @@ export function formatPendingAskUserQuestionsGateMessage(
     "Do not infer approval from earlier or prior messages.",
     "Do not proceed, write files, save artifacts, or call other tools.",
     `Re-call ask_user_questions with the same gate question id ("${pendingGateId}") and wait for the user's response.`,
+  ].join(" ");
+}
+
+/**
+ * Format the LLM-facing message returned when a depth-confirmation gate
+ * elicitation times out. Distinct from {@link formatPendingAskUserQuestionsGateMessage}:
+ * a timeout must NOT tell the model to immediately re-ask (that re-triggers
+ * the same timeout loop). Instead it tells the model to stop, that auto-mode
+ * is paused, and that the user will respond on their own (#852).
+ */
+export function formatTimedOutAskUserQuestionsGateMessage(
+  pendingGateId: string,
+): string {
+  return [
+    `Depth confirmation on gate "${pendingGateId}" timed out waiting for a response.`,
+    "The user did not answer within the host elicitation window — do not re-ask in this turn, it will time out again.",
+    "Auto-mode is paused. Stop calling tools and wait for the user to respond on a new turn.",
+    "When the user replies with confirmation, the gate will be satisfied and work will resume.",
   ].join(" ");
 }
 

--- a/src/resources/extensions/gsd/consent-question.ts
+++ b/src/resources/extensions/gsd/consent-question.ts
@@ -44,7 +44,7 @@ export type GateSubKind = "depth-verification" | "approval" | "destructive-confi
 
 export type FailPolicy = "closed" | "open";
 
-export type AnswerOutcome = "waiting" | "answered" | "verified" | "declined" | "cancelled";
+export type AnswerOutcome = "waiting" | "answered" | "verified" | "declined" | "cancelled" | "timeout";
 
 export interface ClassifiedQuestion {
   kind: QuestionKind;
@@ -234,6 +234,9 @@ export type ConsentAnswerDetails = VerdictAnswerDetails;
 /**
  * THE single policy point for whether a question's answer counts as answered.
  *
+ * - timed_out rounds → "timeout" for every kind (host elicitation expired
+ *   before the user answered; fail-closed, but the caller pauses-and-waits
+ *   instead of re-asking into the same timeout loop, #852).
  * - cancelled rounds → "cancelled" for every kind.
  * - gate: delegates to evaluateGateAnswer in the consent-verdict leaf — the
  *   same verdict engine write-gate's applyAskUserQuestionsGateResult consumes;
@@ -248,6 +251,7 @@ export function evaluateAnswer(options: {
   details: ConsentAnswerDetails;
 }): AnswerOutcome {
   const { question, details } = options;
+  if (details.timed_out) return "timeout";
   if (details.cancelled) return "cancelled";
 
   const { kind } = classifyQuestion({ id: question.id, options: question.options });
@@ -271,6 +275,7 @@ export function evaluateAnswer(options: {
 
 const OUTCOME_PRECEDENCE: AnswerOutcome[] = [
   "cancelled",
+  "timeout",
   "waiting",
   "declined",
   "verified",
@@ -289,6 +294,11 @@ export function evaluateAskUserQuestionsRound(
   questions: ConsentQuestionShape[],
   details: ConsentAnswerDetails,
 ): AnswerOutcome {
+  // timed_out is checked before cancelled: a host elicitation timeout is a
+  // more specific signal than the deliberate-dismissal cancelled it is also
+  // marked with, and callers must pause-and-wait instead of treating it as a
+  // re-ask-able cancel (#852).
+  if (details.timed_out) return "timeout";
   if (details.cancelled) return "cancelled";
   let worst: AnswerOutcome = "answered";
   for (const question of questions) {

--- a/src/resources/extensions/gsd/consent-verdict.ts
+++ b/src/resources/extensions/gsd/consent-verdict.ts
@@ -9,7 +9,20 @@
  * cycle. It must not import from either module (ADR-039).
  */
 
-export type GateAnswerVerdict = "waiting" | "verified" | "declined" | "cancelled";
+/**
+ * Per-question verdict for a gate answer.
+ *
+ *   - "verified" — the confirmation option was selected (depth unlocked).
+ *   - "declined" — a real but non-confirming selection (gate stays pending,
+ *     model should not treat as approval).
+ *   - "cancelled" — the round was cancelled by the user (deliberate dismissal).
+ *   - "waiting" — no answer (fail-closed; not an answer).
+ *   - "timeout" — the host elicitation timed out before the user answered.
+ *     Distinct from "waiting" so callers can pause-and-wait instead of letting
+ *     the model re-ask into the same timeout loop (#852). Still fail-closed:
+ *     the gate stays pending — a timeout is never approval.
+ */
+export type GateAnswerVerdict = "waiting" | "verified" | "declined" | "cancelled" | "timeout";
 
 export interface VerdictQuestionShape {
   id?: unknown;
@@ -19,6 +32,13 @@ export interface VerdictQuestionShape {
 export interface VerdictAnswerDetails {
   cancelled?: boolean;
   interrupted?: boolean;
+  /**
+   * True when the host elicitation channel timed out before the user answered.
+   * Distinct from `cancelled` (deliberate dismissal): a timeout must not be
+   * laundered into a re-ask loop. Gate verdicts map this to "timeout" so the
+   * caller pauses-and-waits instead of looping on the blocked call (#852).
+   */
+  timed_out?: boolean;
   response?: {
     answers?: Record<string, { selected?: unknown; notes?: unknown } | undefined>;
   } | null;
@@ -67,16 +87,25 @@ export function hasNotesValue(notes: unknown): boolean {
 /**
  * THE per-question verdict for gate questions (fail-closed):
  *
+ * - timed_out rounds → "timeout" (host elicitation expired before the user
+ *   answered; fail-closed — the gate stays pending — but the caller pauses
+ *   instead of re-asking into the same timeout loop, #852).
  * - cancelled rounds → "cancelled".
  * - the confirmation option (structural match) → "verified".
  * - any other real selection → "declined".
  * - empty/missing selection → "waiting" — an empty answer is NEVER an answer,
  *   so notes can never satisfy a gate either.
+ *
+ * `timed_out` is checked first: the handler marks a timed-out round with both
+ * `cancelled: true` and `timed_out: true` (see
+ * `askUserQuestionsHandler`), so the timeout must win to avoid the cancelled
+ * branch's re-ask semantics.
  */
 export function evaluateGateAnswer(
   question: VerdictQuestionShape,
   details: VerdictAnswerDetails,
 ): GateAnswerVerdict {
+  if (details.timed_out) return "timeout";
   if (details.cancelled) return "cancelled";
   const questionId = typeof question.id === "string" ? question.id : "";
   const answer = details.response?.answers?.[questionId];

--- a/src/resources/extensions/gsd/tests/consent-question.test.ts
+++ b/src/resources/extensions/gsd/tests/consent-question.test.ts
@@ -83,6 +83,8 @@ const POLICY_TABLE: Row[] = [
   { name: "gate × missing response → waiting", question: gateQ, details: {}, expected: "waiting" },
   { name: "gate × notes-only → waiting (notes never satisfy a gate)", question: gateQ, details: { response: { answers: { [gateQ.id]: { notes: "looks fine" } } } }, expected: "waiting" },
   { name: "gate × cancelled → cancelled", question: gateQ, details: { cancelled: true, response: null }, expected: "cancelled" },
+  { name: "gate × timed_out → timeout (#852)", question: gateQ, details: { cancelled: true, timed_out: true, response: null }, expected: "timeout" },
+  { name: "gate × timed_out + interrupted → timeout (timeout wins, #852)", question: gateQ, details: { cancelled: true, timed_out: true, interrupted: true, response: null }, expected: "timeout" },
   // consent
   { name: "consent × valid selected → answered", question: consentQ, details: { response: { answers: { [consentQ.id]: { selected: "Option B" } } } }, expected: "answered" },
   { name: "consent × empty selected → waiting (#528)", question: consentQ, details: { response: { answers: { [consentQ.id]: { selected: "" } } } }, expected: "waiting" },
@@ -90,6 +92,7 @@ const POLICY_TABLE: Row[] = [
   { name: "consent × missing response → waiting", question: consentQ, details: {}, expected: "waiting" },
   { name: "consent × notes-only → answered (a real user utterance)", question: consentQ, details: { response: { answers: { [consentQ.id]: { notes: "neither — keep it simple" } } } }, expected: "answered" },
   { name: "consent × cancelled → cancelled", question: consentQ, details: { cancelled: true, response: null }, expected: "cancelled" },
+  { name: "consent × timed_out → timeout (#852)", question: consentQ, details: { cancelled: true, timed_out: true, response: null }, expected: "timeout" },
 ];
 
 for (const row of POLICY_TABLE) {
@@ -122,6 +125,48 @@ test("evaluateAskUserQuestionsRound: most blocking outcome wins", () => {
   );
   // Empty round with no response is a no-op for callers.
   assert.equal(evaluateAskUserQuestionsRound([], {}), "answered");
+});
+
+// ── #852: host elicitation timeout → "timeout" round outcome ────────────────
+
+test("#852: timed_out round → timeout (does NOT become waiting/answered)", () => {
+  // A timeout must not be laundered into "waiting" (which tells the model to
+  // re-ask — that just hits the same timeout again) or "answered".
+  assert.equal(
+    evaluateAskUserQuestionsRound([consentQ], { cancelled: true, timed_out: true, response: null }),
+    "timeout",
+  );
+  assert.equal(
+    evaluateAskUserQuestionsRound([gateQ], { cancelled: true, timed_out: true, response: null }),
+    "timeout",
+  );
+});
+
+test("#852: timeout wins over answered in a mixed round (most blocking)", () => {
+  // One answered question + one timed_out question → the whole round is timeout.
+  const details = {
+    timed_out: true,
+    cancelled: true,
+    response: null,
+  };
+  assert.equal(
+    evaluateAskUserQuestionsRound(
+      [consentQ, { id: "other", options: CONSENT_OPTIONS }],
+      // The timed_out flag is round-level, so even if one question "answered"
+      // the timeout on the round dominates.
+      details,
+    ),
+    "timeout",
+  );
+});
+
+test("#852: cancelled still beats timeout when both flags absent on the round", () => {
+  // Round-level cancelled without timed_out stays cancelled (deliberate user
+  // dismissal is a stronger signal than a host timeout).
+  assert.equal(
+    evaluateAskUserQuestionsRound([consentQ], { cancelled: true, response: null }),
+    "cancelled",
+  );
 });
 
 // ── Regression: #528 empty selected on a consent question never answers ─────

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -348,6 +348,7 @@ test('write-gate: reopening a gate revokes its previous verified approval', () =
 import {
   applyAskUserQuestionsGateResult,
   formatPendingAskUserQuestionsGateMessage,
+  formatTimedOutAskUserQuestionsGateMessage,
   isGateQuestionId,
   shouldBlockPendingGate,
   shouldBlockPendingGateBash,
@@ -518,6 +519,107 @@ test('write-gate: applyAskUserQuestionsGateResult keeps empty-selection pending 
     assert.deepEqual(result, { status: 'waiting', pendingGateId: gateId, interrupted: false });
     assert.strictEqual(getPendingGate(base), gateId, 'unanswered gate must stay pending');
     assert.strictEqual(isMilestoneDepthVerified('M001', base), false, 'unanswered gate must not verify depth');
+  } finally {
+    clearDiscussionFlowState(base);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ─── Scenario 20d: applyAskUserQuestionsGateResult reports timed_out gate (#852) ──
+//
+// A host elicitation timeout must NOT be laundered into "waiting" (which tells
+// the model to re-ask — that just hits the same timeout again) nor into
+// "verified" (a timeout is never approval). The gate stays pending (fail-
+// closed) but the status is "timeout" so the caller pauses-and-waits.
+
+test('write-gate: applyAskUserQuestionsGateResult reports timed_out pending gate (#852)', () => {
+  const base = join(tmpdir(), `gsd-write-gate-ask-timeout-${randomUUID()}`);
+  const gateId = 'depth_verification_M001_confirm';
+
+  try {
+    mkdirSync(base, { recursive: true });
+    clearDiscussionFlowState(base);
+    setPendingGate(gateId, base);
+
+    const result = applyAskUserQuestionsGateResult({
+      basePath: base,
+      questions: [{
+        id: gateId,
+        options: [{ label: 'Confirm depth (Recommended)' }, { label: 'Needs adjustment' }],
+      }],
+      // A timed-out round is marked cancelled:true + timed_out:true (the
+      // structuredContent the MCP child returns on host timeout).
+      details: { cancelled: true, timed_out: true, interrupted: false },
+    });
+
+    assert.deepEqual(result, {
+      status: 'timeout',
+      pendingGateId: gateId,
+      interrupted: false,
+    });
+    assert.strictEqual(getPendingGate(base), gateId, 'timed-out gate must stay pending (fail-closed)');
+    assert.strictEqual(isMilestoneDepthVerified('M001', base), false, 'timed-out gate must not verify depth');
+    // The timeout message must NOT tell the model to immediately re-ask.
+    const message = formatTimedOutAskUserQuestionsGateMessage(gateId);
+    assert.match(message, /timed out/, 'message says timed out');
+    assert.doesNotMatch(message, /Re-call ask_user_questions/, 'message must NOT invite immediate re-ask');
+    assert.match(message, /do not re-ask/i, 'message explicitly says do not re-ask');
+  } finally {
+    clearDiscussionFlowState(base);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('write-gate: applyAskUserQuestionsGateResult reports timed_out even with interrupted:true', () => {
+  // timed_out wins over the interrupted flag — both are host-side failures,
+  // but timeout is the more specific signal and must reach the caller.
+  const base = join(tmpdir(), `gsd-write-gate-ask-timeout-interrupted-${randomUUID()}`);
+  const gateId = 'depth_verification_M002_confirm';
+
+  try {
+    mkdirSync(base, { recursive: true });
+    clearDiscussionFlowState(base);
+    setPendingGate(gateId, base);
+
+    const result = applyAskUserQuestionsGateResult({
+      basePath: base,
+      questions: [{
+        id: gateId,
+        options: [{ label: 'Confirm depth (Recommended)' }, { label: 'Needs adjustment' }],
+      }],
+      details: { cancelled: true, timed_out: true, interrupted: true },
+    });
+
+    assert.deepEqual(result, {
+      status: 'timeout',
+      pendingGateId: gateId,
+      interrupted: true,
+    });
+  } finally {
+    clearDiscussionFlowState(base);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('write-gate: timed_out gate with no pending gate returns not-gate', () => {
+  // A timed-out round arriving when no gate is armed (e.g. informational
+  // question) is not a gate concern — fail-open here, matching cancelled.
+  const base = join(tmpdir(), `gsd-write-gate-ask-timeout-nogate-${randomUUID()}`);
+
+  try {
+    mkdirSync(base, { recursive: true });
+    clearDiscussionFlowState(base);
+
+    const result = applyAskUserQuestionsGateResult({
+      basePath: base,
+      questions: [{
+        id: 'depth_verification_M001_confirm',
+        options: [{ label: 'Confirm depth (Recommended)' }, { label: 'Needs adjustment' }],
+      }],
+      details: { cancelled: true, timed_out: true },
+    });
+
+    assert.deepEqual(result, { status: 'not-gate' });
   } finally {
     clearDiscussionFlowState(base);
     rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Under Claude Code CLI, when `ask_user_questions` times out (the user doesn't respond within the SDK's ~60s elicitation window), the **depth-verification gate becomes permanently pending** and the model is trapped in a retry loop with no escape.

The session transcript showed the exact failure: `ask_user_questions` timing out 4 times in a row, each leaving the gate pending, every retry hitting either the deferred-gate block or the strict tool-call loop guard (`ask_user_questions` cap = 1). The user had to manually intervene to break the loop.

## Root cause

Under CC-CLI, `ask_user_questions` runs in the **workflow MCP child process** and bridges to the host via the Claude Agent SDK's elicitation channel. The child's `isLocalElicitFallbackError` only recognized the 10-minute `withElicitTimeout` message (`"timed out after"`), **not** the SDK's own `-32001: "Request timed out"`.

So when the SDK's ~60s timeout fired:
1. The `-32001` error was **not** recognized as a fallback error → **re-thrown** as a raw error
2. `recordAskUserQuestionsGateResult` was **skipped** (it only runs on accept/cancel)
3. The depth-verification gate stayed **permanently pending**
4. The model received a raw error and retried → loop

## Fix

Distinguish **host timeout** from **deliberate cancel** throughout the elicitation → gate → hook pipeline. A timeout stays **fail-closed** (the gate remains pending — a timeout is never approval) but is reported as a distinct `"timeout"` verdict so the model is told **not to re-ask** (it will just time out again) and auto-mode pauses for the user.

### Changes

| File | Change |
|------|--------|
| `packages/mcp-server/src/server.ts` | New `isLocalElicitTimeoutError()` recognizes `-32001`, `"request timed out"`, `"timed out after"`. `askUserQuestionsHandler` returns a clean `timed_out` structuredContent on host timeout instead of re-throwing — and **does not fall through to remote** (the user is at the host but didn't answer; no one is at the remote either). New `formatAskUserQuestionsTimeoutMessage()`. |
| `src/.../consent-verdict.ts` | Added `"timeout"` to `GateAnswerVerdict` and `timed_out?: boolean` to `VerdictAnswerDetails`. `evaluateGateAnswer` returns `"timeout"` when set (checked before `cancelled`). |
| `src/.../consent-question.ts` | Added `"timeout"` to `AnswerOutcome`. `evaluateAnswer` + `evaluateAskUserQuestionsRound` return `"timeout"` for timed-out rounds; `timed_out` checked before `cancelled`. |
| `src/.../bootstrap/write-gate.ts` | Added `timed_out` to `AskUserQuestionsGateDetails`, `"timeout"` status to `AskUserQuestionsGateResult`. `applyAskUserQuestionsGateResult` returns `{ status: "timeout" }`. New `formatTimedOutAskUserQuestionsGateMessage()` (explicitly tells the model NOT to re-ask). |
| `src/.../bootstrap/register-hooks.ts` | Handles `"timeout"` gate status + round outcome: resets loop guard, pauses auto-mode, returns timeout-specific message. `resolveAskUserQuestionsGateDetails` propagates `timed_out` from structuredContent. |

### Behavior after fix

When `ask_user_questions` times out under CC-CLI:
1. The gate stays **pending** (fail-closed — a timeout is never approval)
2. The loop guard is **reset** (no permanent block)
3. Auto-mode **pauses** with: *"Depth confirmation timed out waiting for a response — pausing auto-mode. Reply to resume."*
4. The model receives a message saying **do not re-ask** — it will time out again
5. The user can reply on a new turn to resume

### Design decisions

- **New `"timeout"` verdict, not reused `cancelled`.** A timeout is fail-closed (like `waiting`) but must NOT invite re-ask (unlike `waiting`, whose message says "re-call ask_user_questions"). It's also not a deliberate dismissal (unlike `cancelled`). A distinct verdict lets each caller respond correctly.
- **`timed_out` checked before `cancelled`.** The handler marks a timed-out round with both `cancelled: true` and `timed_out: true` (so existing cancelled-handling paths still fire); timeout must win to get the right message.
- **No remote fallthrough on timeout.** A host timeout means the user is present but didn't answer — falling through to remote would lose the timeout signal and find no one there anyway.

### Approaches considered and ruled out

- ❌ **Increase the SDK elicitation timeout** — not configurable in the Claude Agent SDK.
- ❌ **Relax the strict tool-call loop guard** — doesn't fix the root cause (gate still pending).
- ❌ **Auto-clear / auto-approve the gate on timeout** — violates the fail-closed safety guarantee (a timeout must never unlock a write gate).

## Testing

- New tests: `isLocalElicitTimeoutError` recognition (SDK `-32001`, 10-min `withElicitTimeout`, non-timeout rejection), `applyAskUserQuestionsGateResult` timeout status (with/without pending gate, `interrupted:true`), consent-verdict timeout policy-table rows + round-evaluation precedence, MCP handler returns `timed_out` structuredContent and skips remote.
- **All tests pass:** 43 write-gate, 36 consent-question, 28 mcp-server package tests (incl. 7 new timeout tests), 198 stream-adapter.
- **TypeScript clean** (main package + `mcp-server`).
- The one failing test in the repo (`plan-slice.test.js`) is **pre-existing** — a macOS `/var` vs `/private/var` symlink issue that fails on unmodified `main` (verified via `git stash`).

Closes #852.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval-gate and auto-mode behavior on elicitation timeouts across MCP and extension hooks; mistakes could pause workflows incorrectly or weaken fail-closed gating, though gates remain pending on timeout.
> 
> **Overview**
> Fixes a **Claude Code CLI** failure mode where host elicitation timeouts on `ask_user_questions` were treated like hard errors or generic “waiting” states, leaving depth-verification gates pending and trapping the model in re-ask / loop-guard retries.
> 
> The **MCP handler** now recognizes SDK `-32001` and 10-minute `withElicitTimeout` errors via `isLocalElicitTimeoutError`, returns structured `timed_out: true` (with an LLM-facing “do not re-ask this turn” message), and **skips remote fallback** on host timeout. Non-timeout elicitation failures still fall through to remote as before.
> 
> Downstream, **`timed_out`** is threaded through consent verdicts, write-gate (`status: "timeout"`, gate stays pending fail-closed), and **register-hooks**: loop guard reset, auto-mode pause, and timeout-specific messages instead of “re-call ask_user_questions.” `timed_out` is evaluated before `cancelled` so rounds marked both flags route to timeout behavior.
> 
> Tests cover timeout detection, handler structured content, gate application, and consent round precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d4fcf3ae325c527ed645d12413c9b286ab0a9ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->