### PR TITLE
fix(auto): stop finalize-retry loop masking the real verification failure

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1331,7 +1331,17 @@ export async function autoLoop(
         finalizeResult.action === "break"
           ? { action: "break", reason: finalizeResult.reason }
           : finalizeResult.action === "continue"
-            ? { action: "continue" }
+            ? {
+                action: "continue",
+                // Surface the specific verification failure (e.g. "roadmap has
+                // zero slices") in the ledger/stuck-loop reason instead of the
+                // opaque bare "finalize-retry" token. The retry paths in
+                // runFinalize set s.pendingVerificationRetry.failureContext
+                // from describeArtifactVerificationFailure before returning
+                // continue; it is cleared on the next dispatch, so reading it
+                // here captures the reason for THIS finalize (#852 follow-up).
+                failureDetail: s.pendingVerificationRetry?.failureContext,
+              }
             : { action: "next" },
       );
       if (finalizeDecision.action === "stop") {

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -302,6 +302,16 @@ function isCompleteAndBreakReason(
   );
 }
 
+/** Strip per-attempt counter suffixes so detect-stuck Rule 1 can match repeats. */
+const FAILURE_DETAIL_ATTEMPT_SUFFIX_RE = /\s*\(attempt\s+\d+(?:\/\d+)?\)\.?$/i;
+
+function failureDetailForLedger(detail: string | undefined): string | undefined {
+  const trimmed = detail?.trim();
+  if (!trimmed) return undefined;
+  const normalized = trimmed.replace(FAILURE_DETAIL_ATTEMPT_SUFFIX_RE, "").trim();
+  return normalized || undefined;
+}
+
 export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
   if (input.action === "break") {
     const reason = input.reason ?? "unknown";
@@ -321,7 +331,7 @@ export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
     // "15-SUMMARY.md was not found on disk") into the ledger summary so the
     // stuck-loop kill message is actionable. The `finalize-retry` prefix is
     // preserved so legacy ledger filters and dashboards still match (#852).
-    const detail = input.failureDetail?.trim();
+    const detail = failureDetailForLedger(input.failureDetail);
     return {
       action: "retry",
       ledgerErrorSummary: detail ? `finalize-retry: ${detail}` : "finalize-retry",

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -34,7 +34,7 @@ export type EngineDispatchDecision =
 
 export type FinalizeInput =
   | { action: "break"; reason?: string }
-  | { action: "continue" }
+  | { action: "continue"; failureDetail?: string }
   | { action: "next" };
 
 export type FinalizeDecision =
@@ -46,7 +46,14 @@ export type FinalizeDecision =
     }
   | {
       action: "retry";
-      ledgerErrorSummary: "finalize-retry";
+      /**
+       * Stable `"finalize-retry"` prefix plus, when available, the specific
+       * verification failure (e.g. `finalize-retry: roadmap has zero slices`).
+       * The prefix keeps legacy ledger filters matching; the suffix makes a
+       * stuck-loop kill message actionable instead of the opaque bare token
+       * that forced a full forensics dive to diagnose (#852 follow-up).
+       */
+      ledgerErrorSummary: string;
     }
   | { action: "complete" }
   | { action: "complete-and-break" };
@@ -310,9 +317,14 @@ export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
   }
 
   if (input.action === "continue") {
+    // Carry the specific verification failure (e.g. "roadmap has zero slices",
+    // "15-SUMMARY.md was not found on disk") into the ledger summary so the
+    // stuck-loop kill message is actionable. The `finalize-retry` prefix is
+    // preserved so legacy ledger filters and dashboards still match (#852).
+    const detail = input.failureDetail?.trim();
     return {
       action: "retry",
-      ledgerErrorSummary: "finalize-retry",
+      ledgerErrorSummary: detail ? `finalize-retry: ${detail}` : "finalize-retry",
     };
   }
 

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -11,6 +11,7 @@ import { migrateFromMarkdown } from "./md-importer.js";
 import { countDbHierarchy } from "./migration-auto-check.js";
 import { logWarning } from "./workflow-logger.js";
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
+import { canonicalPhaseDirName, milestonesDir, resolveMilestonePath } from "./paths.js";
 
 const LEGACY_MIGRATING_SEGMENT = "milestones.migrating";
 
@@ -138,7 +139,13 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
     // Slice-less milestones still need a phase directory for flat-phase layout.
     for (const milestone of getAllMilestones()) {
       if (getMilestoneSlices(milestone.id).length > 0) continue;
-      await renderRoadmapFromDb(basePath, milestone.id);
+      const roadmapResult = await renderRoadmapFromDb(basePath, milestone.id);
+      if ("skipped" in roadmapResult) {
+        const phaseDir = resolveMilestonePath(basePath, milestone.id) ??
+          join(milestonesDir(basePath), canonicalPhaseDirName(milestone.id, milestone.title));
+        mkdirSync(phaseDir, { recursive: true });
+        continue;
+      }
       renderResult.rendered++;
     }
   } catch (err) {

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -9,7 +9,7 @@
 // Critical invariant: rendered markdown must round-trip through
 // parseRoadmap(), parsePlan(), parseSummary() in files.ts.
 
-import { readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, statSync, unlinkSync } from "node:fs";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus } from "./status-guards.js";
 import { dirname, join, relative } from "node:path";
@@ -22,6 +22,7 @@ import {
   getTask,
   getSlice,
   insertArtifact,
+  deleteArtifactByPath,
   getGateResults,
 } from "./gsd-db.js";
 import type { MilestoneRow, ArtifactRow } from "./db-milestone-artifact-rows.js";
@@ -590,6 +591,17 @@ export async function renderRoadmapFromDb(
       "projection",
       `renderRoadmapFromDb skipped unplanned milestone ${milestoneId} (zero slices, empty vision) — refusing to write a stub ROADMAP`,
     );
+    const absPath = resolveRoadmapProjectionPath(basePath, milestoneId);
+    if (existsSync(absPath)) {
+      const artifactPath = toArtifactPath(absPath, basePath);
+      unlinkSync(absPath);
+      try {
+        deleteArtifactByPath(artifactPath);
+      } catch {
+        logWarning("renderer", `failed to remove artifact from DB: ${artifactPath}`);
+      }
+      invalidateCaches();
+    }
     return { skipped: "unplanned-milestone" };
   }
 

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -567,13 +567,32 @@ export async function renderTaskPlanFromDb(
 export async function renderRoadmapFromDb(
   basePath: string,
   milestoneId: string,
-): Promise<{ roadmapPath: string; content: string }> {
+): Promise<{ roadmapPath: string; content: string } | { skipped: "unplanned-milestone" }> {
   const milestone = getMilestone(milestoneId);
   if (!milestone) {
     throw new Error(`milestone ${milestoneId} not found`);
   }
 
   const slices = getMilestoneSlices(milestoneId);
+
+  // Refuse to render a stub ROADMAP for an unplanned milestone (#852).
+  // A milestone row created by gsd_milestone_generate_id / ensureMilestoneDbRow
+  // starts with title="" / vision="" and zero slices. Rendering that produces a
+  // 38-byte stub (`# M015: M015\n\n**Vision:** \n\n## Slices`) which passes
+  // existsSync but fails the plan-milestone "zero slices" content check —
+  // trapping auto-mode in a finalize-retry loop. A real plan (written by
+  // gsd_plan_milestone via writePlanRows) always sets a non-empty vision AND at
+  // least one slice, so zero-slice + empty-vision is a reliable "never planned"
+  // signal. Skip the write so verification sees a genuinely missing file (a
+  // clear "write the ROADMAP" failure) instead of a misleading stub.
+  if (slices.length === 0 && !milestone.vision.trim()) {
+    logWarning(
+      "projection",
+      `renderRoadmapFromDb skipped unplanned milestone ${milestoneId} (zero slices, empty vision) — refusing to write a stub ROADMAP`,
+    );
+    return { skipped: "unplanned-milestone" };
+  }
+
   const absPath = resolveRoadmapProjectionPath(basePath, milestoneId);
   const artifactPath = toArtifactPath(absPath, basePath);
   const content = renderRoadmapMarkdown(milestone, slices);

--- a/src/resources/extensions/gsd/milestone-planning-persistence.ts
+++ b/src/resources/extensions/gsd/milestone-planning-persistence.ts
@@ -161,6 +161,14 @@ async function renderPlanArtifacts(
 ): Promise<string | { error: string }> {
   try {
     const renderResult = await renderRoadmapFromDb(basePath, params.milestoneId);
+    // renderRoadmapFromDb only skips for unplanned milestones (zero slices +
+    // empty vision); persistMilestonePlan always populates both via writePlanRows
+    // before this render, so the skipped branch is unreachable here. Fall back to
+    // resolving the projected path so a future invariant still surfaces a clear
+    // render failure rather than an undefined dereference.
+    if ("skipped" in renderResult) {
+      return { error: `render skipped: milestone ${params.milestoneId} has no planned slices` };
+    }
     return renderResult.roadmapPath;
   } catch (renderErr) {
     logWarning("tool", `plan_milestone — render failed (DB rows preserved for debugging): ${(renderErr as Error).message}`);

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -1555,6 +1555,41 @@ test('── markdown-renderer: renderRoadmapFromDb skips unplanned milestone (z
   }
 });
 
+test('── markdown-renderer: renderRoadmapFromDb removes a pre-existing stub ROADMAP for unplanned milestone ──', async () => {
+  // Brownfield scenario: a previous run (before the unplanned-milestone guard
+  // existed) already wrote a stub ROADMAP to disk. renderRoadmapFromDb must
+  // delete it so plan-milestone verification sees a genuinely missing file
+  // rather than failing on "zero slices" again (#852 follow-up).
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    insertMilestone({ id: 'M015', title: '', status: 'queued' });
+    scaffoldDirs(tmpDir, 'M015', []);
+
+    // Simulate a stub ROADMAP written by an older run.
+    const phaseDir = path.join(tmpDir, '.gsd', 'phases', '15-m015');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    const stubRoadmapPath = path.join(phaseDir, '15-ROADMAP.md');
+    fs.writeFileSync(stubRoadmapPath, '# M015: M015\n\n**Vision:** \n\n## Slices\n');
+    assert.equal(fs.existsSync(stubRoadmapPath), true, 'stub exists before guard runs');
+
+    const result = await renderRoadmapFromDb(tmpDir, 'M015');
+
+    assert.deepEqual(result, { skipped: 'unplanned-milestone' });
+    assert.equal(
+      fs.existsSync(stubRoadmapPath),
+      false,
+      'renderRoadmapFromDb must delete the pre-existing stub ROADMAP',
+    );
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 test('── markdown-renderer: renderRoadmapFromDb renders a planned milestone (≥1 slice) ──', async () => {
   const tmpDir = makeTmpDir();
   const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -32,6 +32,7 @@ import {
   renderAllFromDb,
   renderPlanFromDb,
   renderTaskPlanFromDb,
+  renderRoadmapFromDb,
   detectStaleRenders,
 } from '../markdown-renderer.ts';
 import { repairStaleRenders } from '../state-reconciliation/drift/stale-render.ts';
@@ -1505,6 +1506,101 @@ test('── markdown-renderer: detectStaleRenders finds missing slice summary a
 
     assert.ok(!!summaryStale, 'should detect missing S01-SUMMARY.md');
     assert.ok(!!uatStale, 'should detect missing S01-UAT.md');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// renderRoadmapFromDb — unplanned-milestone guard (#852 follow-up)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// A milestone row created by gsd_milestone_generate_id / ensureMilestoneDbRow
+// starts with title="" / vision="" and zero slices. Rendering that produced a
+// 38-byte stub (`# M015: M015\n\n**Vision:** \n\n## Slices`) that passed
+// existsSync but failed the plan-milestone "zero slices" content check —
+// trapping auto-mode in a finalize-retry loop. The guard now refuses to render
+// a ROADMAP for a milestone with zero slices AND empty vision, so verification
+// sees a genuinely missing file (clear "write the ROADMAP" failure) instead of
+// a misleading stub.
+
+test('── markdown-renderer: renderRoadmapFromDb skips unplanned milestone (zero slices, empty vision) ──', async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    // Reserved placeholder row — exactly what ensureMilestoneDbRow creates: no
+    // title, no vision, no slices (the never-planned state).
+    insertMilestone({ id: 'M015', title: '', status: 'queued' });
+    scaffoldDirs(tmpDir, 'M015', []);
+
+    const result = await renderRoadmapFromDb(tmpDir, 'M015');
+
+    assert.deepEqual(result, { skipped: 'unplanned-milestone' });
+
+    // No stub ROADMAP must land on disk — that's the whole point of the guard.
+    const phaseDir = path.join(tmpDir, '.gsd', 'phases', '15-m015');
+    const roadmapPath = path.join(phaseDir, '15-ROADMAP.md');
+    assert.equal(
+      fs.existsSync(roadmapPath),
+      false,
+      'renderRoadmapFromDb must NOT write a stub ROADMAP for an unplanned milestone',
+    );
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
+test('── markdown-renderer: renderRoadmapFromDb renders a planned milestone (≥1 slice) ──', async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    insertMilestone({ id: 'M016', title: 'Planned', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M016', title: 'First slice', status: 'pending' });
+    scaffoldDirs(tmpDir, 'M016', ['S01']);
+
+    const result = await renderRoadmapFromDb(tmpDir, 'M016');
+
+    assert.ok(!('skipped' in result), 'planned milestone must not be skipped');
+    assert.ok('roadmapPath' in result && result.roadmapPath, 'returns a roadmapPath');
+    assert.ok('content' in result && result.content.includes('## Slices'), 'content has a Slices section');
+    assert.ok(
+      'content' in result && result.content.includes('S01'),
+      'content includes the planned slice',
+    );
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
+test('── markdown-renderer: renderRoadmapFromDb renders milestone with vision but zero slices ──', async () => {
+  // A milestone with a non-empty vision but zero slices is NOT unplanned — it
+  // may be mid-plan or intentionally slice-less. The guard must not skip it.
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    insertMilestone({ id: 'M017', title: 'Visionary', status: 'active' });
+    // upsertMilestonePlanning sets the vision; insertMilestone leaves it "".
+    // Simulate a planned-but-not-yet-sliced milestone via the planning upsert.
+    const { upsertMilestonePlanning } = await import('../gsd-db.ts');
+    upsertMilestonePlanning('M017', { vision: 'A slice-less milestone', title: 'Visionary', status: 'active', depends_on: [] });
+    scaffoldDirs(tmpDir, 'M017', []);
+
+    const result = await renderRoadmapFromDb(tmpDir, 'M017');
+
+    assert.ok(!('skipped' in result), 'milestone with vision must not be skipped even with zero slices');
+    assert.ok('content' in result && result.content.includes('A slice-less milestone'), 'vision is rendered');
   } finally {
     closeDatabase();
     cleanupDir(tmpDir);

--- a/src/resources/extensions/gsd/tests/planning-crossval.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-crossval.test.ts
@@ -90,6 +90,8 @@ console.log('\n=== planning-crossval Test 1: ROADMAP round-trip parity ===');
 
     // Render ROADMAP.md from DB
     const rendered = await renderRoadmapFromDb(base, 'M001');
+    // Milestone has planned slices — skipped variant is unreachable here.
+    if ('skipped' in rendered) throw new Error('unexpected: milestone has planned slices');
     const content = readFileSync(rendered.roadmapPath, 'utf-8');
 
     // Parse back
@@ -279,6 +281,8 @@ console.log('\n=== planning-crossval Test 3: Sequence ordering parity ===');
 
     // Render ROADMAP from DB — should produce slices in sequence order
     const rendered = await renderRoadmapFromDb(base, 'M001');
+    // Milestone has planned slices — skipped variant is unreachable here.
+    if ('skipped' in rendered) throw new Error('unexpected: milestone has planned slices');
     const content = readFileSync(rendered.roadmapPath, 'utf-8');
 
     // Parse back
@@ -341,6 +345,8 @@ console.log('\n=== planning-crossval Test 4: ROADMAP worktree projection path ==
     });
 
     const rendered = await renderRoadmapFromDb(worktreeBase, 'M001');
+    // Milestone has a planned slice — skipped variant is unreachable here.
+    if ('skipped' in rendered) throw new Error('unexpected: milestone has planned slices');
 
     assertEq(rendered.roadmapPath, worktreeRoadmapPath, 'T4: roadmap path uses worktree projection');
     assertTrue(existsSync(worktreeRoadmapPath), 'T4: worktree roadmap exists');
@@ -379,6 +385,8 @@ console.log('\n=== planning-crossval Test 5: ROADMAP existing projection file pa
     });
 
     const rendered = await renderRoadmapFromDb(worktreeBase, 'M001');
+    // Milestone has a non-empty vision — skipped variant is unreachable here.
+    if ('skipped' in rendered) throw new Error('unexpected: milestone has non-empty vision');
 
     assertEq(rendered.roadmapPath, worktreeRoadmapPath, 'T5: existing roadmap path remains absolute');
     assertTrue(existsSync(worktreeRoadmapPath), 'T5: worktree roadmap still exists');
@@ -417,6 +425,8 @@ console.log('\n=== planning-crossval Test 6: ROADMAP descriptor projection dir =
     });
 
     const rendered = await renderRoadmapFromDb(worktreeBase, 'M001');
+    // Milestone has a non-empty vision — skipped variant is unreachable here.
+    if ('skipped' in rendered) throw new Error('unexpected: milestone has non-empty vision');
 
     assertEq(rendered.roadmapPath, descriptorRoadmapPath, 'T6: roadmap path uses descriptor milestone dir');
     assertTrue(existsSync(descriptorRoadmapPath), 'T6: descriptor roadmap exists');
@@ -458,6 +468,8 @@ console.log('\n=== planning-crossval Test 7: renderer recovers bracket-wrapped d
       .run('["[S01]"]', 'S02', 'M001');
 
     const rendered = await renderRoadmapFromDb(base, 'M001');
+    // Milestone has planned slices — skipped variant is unreachable here.
+    if ('skipped' in rendered) throw new Error('unexpected: milestone has planned slices');
     const content = readFileSync(rendered.roadmapPath, 'utf-8');
     const parsed = parseRoadmapSlices(content);
 

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -203,6 +203,38 @@ test("decideFinalizeResult maps continue and next results", () => {
   assert.deepEqual(decideFinalizeResult({ action: "next" }), { action: "complete" });
 });
 
+// ── #852 follow-up: carry the specific verification failure into the ledger ──
+//
+// A bare "finalize-retry" ledger summary makes the stuck-loop kill message
+// ("Same error repeated: finalize-retry") opaque — it took a full forensics
+// dive to learn the real reason was "roadmap has zero slices". The retry
+// decision now appends the failureDetail so the summary is actionable while
+// preserving the stable "finalize-retry" prefix for legacy filters.
+
+test("decideFinalizeResult appends failureDetail to the retry ledger summary (#852)", () => {
+  assert.deepEqual(
+    decideFinalizeResult({ action: "continue", failureDetail: "roadmap has zero slices" }),
+    { action: "retry", ledgerErrorSummary: "finalize-retry: roadmap has zero slices" },
+  );
+  // The prefix is preserved so dashboards/filters matching "finalize-retry" still hit.
+  assert.match(
+    decideFinalizeResult({ action: "continue", failureDetail: "15-SUMMARY.md was not found on disk" })
+      .ledgerErrorSummary,
+    /^finalize-retry:/,
+  );
+});
+
+test("decideFinalizeResult collapses whitespace-only / empty failureDetail to the bare token (#852)", () => {
+  assert.deepEqual(
+    decideFinalizeResult({ action: "continue", failureDetail: "   " }),
+    { action: "retry", ledgerErrorSummary: "finalize-retry" },
+  );
+  assert.deepEqual(
+    decideFinalizeResult({ action: "continue", failureDetail: "" }),
+    { action: "retry", ledgerErrorSummary: "finalize-retry" },
+  );
+});
+
 test("decideEngineReconcile maps terminal outcomes", () => {
   assert.deepEqual(
     decideEngineReconcile({ outcome: "milestone-complete" }),

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -217,9 +217,11 @@ test("decideFinalizeResult appends failureDetail to the retry ledger summary (#8
     { action: "retry", ledgerErrorSummary: "finalize-retry: roadmap has zero slices" },
   );
   // The prefix is preserved so dashboards/filters matching "finalize-retry" still hit.
+  // Narrow to the retry arm before accessing ledgerErrorSummary (FinalizeDecision is a union).
+  const suffixed = decideFinalizeResult({ action: "continue", failureDetail: "15-SUMMARY.md was not found on disk" });
+  assert.strictEqual(suffixed.action, "retry");
   assert.match(
-    decideFinalizeResult({ action: "continue", failureDetail: "15-SUMMARY.md was not found on disk" })
-      .ledgerErrorSummary,
+    (suffixed as { action: "retry"; ledgerErrorSummary: string }).ledgerErrorSummary,
     /^finalize-retry:/,
   );
 });

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -235,6 +235,23 @@ test("decideFinalizeResult collapses whitespace-only / empty failureDetail to th
   );
 });
 
+test("decideFinalizeResult strips per-attempt suffixes for stable repeat-error detection (#852)", () => {
+  const base = "Artifact verification failed: roadmap has zero slices";
+  const attempt1 = decideFinalizeResult({
+    action: "continue",
+    failureDetail: `${base} (attempt 1/3).`,
+  });
+  const attempt2 = decideFinalizeResult({
+    action: "continue",
+    failureDetail: `${base} (attempt 2/3).`,
+  });
+  assert.deepEqual(attempt1, attempt2);
+  assert.deepEqual(attempt1, {
+    action: "retry",
+    ledgerErrorSummary: `finalize-retry: ${base}`,
+  });
+});
+
 test("decideEngineReconcile maps terminal outcomes", () => {
   assert.deepEqual(
     decideEngineReconcile({ outcome: "milestone-complete" }),

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -476,6 +476,12 @@ export async function handleCompleteSlice(
 
     const roadmap = await renderRoadmapFromDb(artifactBasePath, params.milestoneId);
     clearParseCache();
+    // complete-slice runs after a slice is committed in the DB, so the milestone
+    // always has ≥1 slice — the skipped (unplanned) branch is unreachable. Guard
+    // for type-safety so a future invariant surfaces a clear error.
+    if ("skipped" in roadmap) {
+      throw new Error(`roadmap render skipped: milestone ${params.milestoneId} has no planned slices`);
+    }
     // Render verification (ADR-017): confirms the just-written projection
     // reflects the DB completion; the DB row is already committed.
     if (!roadmapRenderMarksSliceDone(roadmap.content, params.sliceId)) {

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -274,6 +274,9 @@ export async function handleReassessRoadmap(
   // ── Render artifacts ──────────────────────────────────────────────
   try {
     const roadmapResult = await renderRoadmapFromDb(basePath, params.milestoneId);
+    if ("skipped" in roadmapResult) {
+      return { error: `roadmap render skipped: milestone ${params.milestoneId} has no planned slices` };
+    }
     const assessmentResult = await renderAssessmentFromDb(basePath, params.milestoneId, params.completedSliceId, {
       verdict: params.verdict,
       assessment: params.assessment,


### PR DESCRIPTION
## Problem

Auto-mode gets trapped in an opaque `finalize-retry` loop when `plan-milestone` verification fails. The session transcript showed **$16.58 / 2.90M tokens / 26 units** burned before the stuck-loop detector killed it — with the useless message:

```
stuck-loop: Same error repeated: finalize-retry
```

That message tells you *nothing* about what actually went wrong. It took a full forensics investigation to find the real reason.

## Root cause (verified on disk)

Two compounding defects:

### Defect 1 — the empty ROADMAP stub

A `plan-milestone` turn ended without `gsd_plan_milestone` having run, but `renderRoadmapFromDb` still rendered the **reserved placeholder milestone row** (`title=""`, `vision=""`, zero slices) into a 38-byte stub ROADMAP:

```
# M015: M015

**Vision:** 

## Slices
```

This is a byte-exact match with `renderRoadmapMarkdown` over an unplanned row — the `title || milestone.id` fallback (line 242) is why the header reads `M015: M015`. The stub **passed `existsSync`** but **failed** the `plan-milestone` content check (`auto-recovery.ts:566`: *"roadmap has zero slices"*), so verification retried → model produced the same stub → identical failure → loop.

The placeholder row is created by `gsd_milestone_generate_id` / `ensureMilestoneDbRow` (`title=""`, `vision=""`); a real plan always sets both via `writePlanRows`.

### Defect 2 — the opaque ledger summary

`decideFinalizeResult` (`workflow-kernel.ts:315`) hardcoded `ledgerErrorSummary: "finalize-retry"` and **dropped the specific failure detail**. The detailed message (`describeArtifactVerificationFailure` → *"roadmap has zero slices"*) was computed but never reached the ledger or the stuck-loop reason.

## Fix

### Fix 1 — diagnosability: carry the real reason into the ledger

`decideFinalizeResult` now appends the specific verification failure to the ledger summary, preserving the stable `finalize-retry` prefix for legacy filters:

- Before: `Same error repeated: finalize-retry`
- After: `Same error repeated: finalize-retry: roadmap has zero slices`

The detail flows from `s.pendingVerificationRetry.failureContext` (already set by the retry path) → `FinalizeInput.failureDetail` → `ledgerErrorSummary`.

### Fix 2 — root cause: refuse to render an unplanned milestone

`renderRoadmapFromDb` now skips milestones with **zero slices AND empty vision** (the reliable never-planned signal — a real plan always sets both via `writePlanRows`). The stub no longer lands on disk, so verification sees a **genuinely missing file** (a clear *"write the ROADMAP"* failure the model can act on) instead of a misleading empty stub that exists but is content-invalid.

### Changes

| File | Change |
|------|--------|
| `auto/workflow-kernel.ts` | `FinalizeInput` `continue` arm carries `failureDetail?`; `FinalizeDecision` retry `ledgerErrorSummary` generalized to `string` |
| `auto/loop.ts` | Thread `s.pendingVerificationRetry?.failureContext` as the detail |
| `markdown-renderer.ts` | `renderRoadmapFromDb` skips unplanned milestones, returns `{ skipped: "unplanned-milestone" }` |
| `milestone-planning-persistence.ts` | Handle the `skipped` variant (logically unreachable post-plan; type-safe) |
| `tools/reassess-roadmap.ts` | Handle the `skipped` variant |
| `tools/complete-slice.ts` | Handle the `skipped` variant |

## Testing

- **3 new `renderRoadmapFromDb` tests**: skips unplanned milestone (asserts no file written); renders planned milestone (≥1 slice); renders milestone with vision but zero slices (guard doesn't over-fire)
- **3 new `decideFinalizeResult` tests**: appends detail, preserves prefix, collapses whitespace-only to bare token
- **All existing tests pass**: 96 projection/workflow-kernel tests, 21 closeout/complete-slice tests, 0 failures
- **TypeScript clean**

The pre-existing `tool-call-loop-guard` modifications and untracked script in the working tree are unrelated and were excluded from this PR.

Follow-up to #852.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-mode finalize/ledger behavior and roadmap projection invariants; mistakes could change retry/stuck-loop semantics or skip legitimate roadmap renders, but changes are narrow and well-tested.
> 
> **Overview**
> Fixes auto-mode getting stuck in opaque **`finalize-retry`** loops when plan-milestone verification fails (#852 follow-up).
> 
> **Diagnosability:** `decideFinalizeResult` now builds ledger summaries like `finalize-retry: roadmap has zero slices` instead of the bare token, threading `s.pendingVerificationRetry?.failureContext` from `loop.ts`. Per-attempt suffixes are stripped so stuck-loop repeat detection stays stable.
> 
> **Root cause:** `renderRoadmapFromDb` skips milestones with **zero slices and empty vision** (placeholder rows), returns `{ skipped: "unplanned-milestone" }`, and removes any existing stub ROADMAP on disk so verification fails on a missing file rather than a misleading empty stub.
> 
> Call sites (`milestone-planning-persistence`, `complete-slice`, `reassess-roadmap`, `flat-phase-migration`) handle the new union; tests cover the guard and ledger formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c09d80d75cf240608b710f1fbe8b2123766c412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->