### PR TITLE
fix(bootstrap): registerToolSearchShim tolerates pre-bind runtime

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/tool-search-shim.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-search-shim.ts
@@ -31,8 +31,26 @@ export function registerToolSearchShim(pi: ExtensionAPI): void {
 		},
 	});
 
-	const active = pi.getActiveTools();
-	if (!active.includes("ToolSearch")) {
-		pi.setActiveTools([...active, "ToolSearch"]);
+	// Ensure the shim is part of the active tool set. registerTool() is valid
+	// during extension loading, but getActiveTools()/setActiveTools() are stubs
+	// that throw "Extension runtime not initialized" until runner.bindCore() runs
+	// (after all registerExtension() calls return). When the throw was hit, the
+	// catch in register-extension.ts swallowed it — leaving the whole bootstrap
+	// partially failed and, under Claude Code CLI, the workflow tools could end
+	// up missing from the model's surface, which traps plan-milestone in a
+	// finalize-retry loop with no gsd_plan_milestone available.
+	//
+	// The activation here is also redundant post-bind: ToolSearch is in
+	// MINIMAL_AUTO_BASE_TOOL_NAMES, so buildMinimalAutoGsdToolSet adds it during
+	// adjust_tool_set (before_agent_start). Tolerate the loading-stub throw so
+	// the shim always registers; activation is completed by post-bind scoping.
+	try {
+		const active = pi.getActiveTools();
+		if (!active.includes("ToolSearch")) {
+			pi.setActiveTools([...active, "ToolSearch"]);
+		}
+	} catch {
+		// Pre-bind runtime: getActiveTools/setActiveTools are not yet wired.
+		// The tool is registered; activation happens at adjust_tool_set.
 	}
 }

--- a/src/resources/extensions/gsd/tests/tool-search-shim.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-search-shim.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { parseToolSearchSelectQuery } from "@gsd/pi-ai";
+import { registerToolSearchShim } from "../bootstrap/tool-search-shim.ts";
 
 test("parseToolSearchSelectQuery extracts MCP tool name", () => {
   assert.equal(
@@ -18,3 +19,73 @@ test("parseToolSearchSelectQuery returns null for non-select queries", () => {
   assert.equal(parseToolSearchSelectQuery("gsd_save_gate_result"), null);
   assert.equal(parseToolSearchSelectQuery(""), null);
 });
+
+// ── #852 follow-up: registerToolSearchShim tolerates the pre-bind runtime ──
+//
+// During extension loading, getActiveTools()/setActiveTools() are throwing
+// stubs ("Extension runtime not initialized"). The old shim called them
+// unconditionally, the throw propagated to register-extension.ts's catch,
+// and the whole "Extension setup partially failed" warning fired — which
+// under Claude Code CLI could leave workflow tools missing and trap
+// plan-milestone in a finalize-retry loop. The shim must register the tool
+// regardless and tolerate the pre-bind throw.
+
+function makeFakePi(opts: {
+  getActiveToolsThrows?: boolean;
+  setActiveToolsThrows?: boolean;
+  activeTools?: string[];
+}): {
+  registerTool(tool: { name: string }): void;
+  getActiveTools(): string[];
+  setActiveTools(tools: string[]): void;
+  registered: string[];
+  setCalls: string[][];
+} {
+  const registered: string[] = [];
+  const setCalls: string[][] = [];
+  const active = opts.activeTools ?? [];
+  return {
+    registerTool(tool) {
+      registered.push(tool.name);
+    },
+    getActiveTools() {
+      if (opts.getActiveToolsThrows) {
+        throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
+      }
+      return [...active];
+    },
+    setActiveTools(tools) {
+      if (opts.setActiveToolsThrows) {
+        throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
+      }
+      setCalls.push(tools);
+      active.length = 0;
+      active.push(...tools);
+    },
+    registered,
+    setCalls,
+  };
+}
+
+test("registerToolSearchShim registers the tool even when getActiveTools throws (pre-bind runtime)", () => {
+  const pi = makeFakePi({ getActiveToolsThrows: true, setActiveToolsThrows: true });
+  // Must not throw — the old code let this propagate.
+  assert.doesNotThrow(() => registerToolSearchShim(pi as any));
+  assert.ok(pi.registered.includes("ToolSearch"), "tool must be registered despite the pre-bind stubs");
+});
+
+test("registerToolSearchShim activates ToolSearch when the runtime is bound (no throw)", () => {
+  const pi = makeFakePi({ activeTools: ["bash", "read"] });
+  registerToolSearchShim(pi as any);
+  assert.ok(pi.registered.includes("ToolSearch"));
+  assert.equal(pi.setCalls.length, 1, "setActiveTools called once to add ToolSearch");
+  assert.ok(pi.setCalls[0]!.includes("ToolSearch"), "ToolSearch added to the active set");
+});
+
+test("registerToolSearchShim does not re-add ToolSearch if already active", () => {
+  const pi = makeFakePi({ activeTools: ["ToolSearch", "bash"] });
+  registerToolSearchShim(pi as any);
+  assert.ok(pi.registered.includes("ToolSearch"));
+  assert.equal(pi.setCalls.length, 0, "setActiveTools not called when ToolSearch is already active");
+});
+


### PR DESCRIPTION
## Problem

Auto-mode stops with a cascade of startup warnings that leave workflow tools missing:

```
Failed to register tool-search-shim: Extension runtime not initialized. Action methods cannot be called during extension loading.
Extension setup partially failed — /gsd commands are available but shortcuts/tools may be missing
```

When this happens under Claude Code CLI, the model runs without `gsd_plan_milestone` available, produces an empty/stub ROADMAP, and traps auto-mode in an opaque `finalize-retry` loop — **$14.67 / 2.70M tokens / 21 units** burned before the stuck-loop detector kills it.

## Root cause

During extension loading, the `pi` runtime's `getActiveTools()`/`setActiveTools()` are **throwing stubs** (`loader.ts:163-166`):

```ts
const notInitialized = () => {
  throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
};
```

They only become real implementations after `runner.bindCore()` runs (lines 311, 313) — which is **after all `registerExtension()` functions return**.

`registerToolSearchShim` (`tool-search-shim.ts:34-37`) called them **synchronously during load**:

```ts
const active = pi.getActiveTools();          // ← throws during load
if (!active.includes("ToolSearch")) {
  pi.setActiveTools([...active, "ToolSearch"]); // ← throws during load
}
```

The throw propagated to `register-extension.ts`'s catch (line 195-200), firing the "Failed to register tool-search-shim" warning — and, worse, the outer "Extension setup partially failed" catch (`index.ts:30`) swallowed the whole bootstrap.

## Fix

Wrap only the `setActiveTools` activation in `try/catch`. `registerTool()` IS valid during loading (`loader.ts:184`, `237`), so the shim registers unconditionally.

The activation is also **redundant post-bind**: `ToolSearch` is in `MINIMAL_AUTO_BASE_TOOL_NAMES` (`register-hooks.ts:195`), so `buildMinimalAutoGsdToolSet` adds it during `adjust_tool_set` (`before_agent_start`, which runs after `bindCore`). The shim now registers during load and lets post-bind scoping complete activation.

```ts
try {
  const active = pi.getActiveTools();
  if (!active.includes("ToolSearch")) {
    pi.setActiveTools([...active, "ToolSearch"]);
  }
} catch {
  // Pre-bind runtime: getActiveTools/setActiveTools are not yet wired.
  // The tool is registered; activation happens at adjust_tool_set.
}
```

## Testing

3 new tests (`tool-search-shim.test.ts`):
- registers the tool even when `getActiveTools` throws (pre-bind runtime) — the core regression
- activates `ToolSearch` when the runtime is bound (no throw)
- does not re-add `ToolSearch` if already active

All 6 shim tests pass, TypeScript clean.

Related to #856 (the `finalize-retry` diagnosability fix) — that PR makes the loop message actionable; this PR prevents the loop from happening in the first place when the root cause is the missing tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bootstrap error-handling change with targeted tests; no auth, data, or workflow logic changes beyond avoiding a load-time throw.
> 
> **Overview**
> **`registerToolSearchShim`** no longer fails extension bootstrap when **`getActiveTools` / `setActiveTools`** throw during load (pre-**`bindCore`** stubs). **`registerTool`** still runs unconditionally; only the optional “add **ToolSearch** to active set” path is wrapped in **`try/catch`**, with activation deferred to post-bind **`adjust_tool_set`** when stubs throw.
> 
> Adds **three** unit tests with a fake **`pi`**: shim registers without throwing when active-tool APIs throw; activates **ToolSearch** when bound; skips **`setActiveTools`** when **ToolSearch** is already active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807638f0eccbfeb2d4cbd273827c97efdf1fd296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->