### PR TITLE
fix(issue): [Bug]: GSD TUI hangs/freezes, tool fails, when trying to execute gsd_plan_slice function during auto-mode

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -338,6 +338,36 @@ test('handlePlanSlice renders plan artifacts under worktree-local .gsd while usi
   }
 });
 
+test('handlePlanSlice does not regenerate unrelated completed-task summaries during planning', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Finished slice', status: 'complete', demo: 'Existing work.' });
+    insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Planning slice', status: 'pending', demo: 'Rendered plans exist.' });
+    insertTask({
+      id: 'T99',
+      sliceId: 'S01',
+      milestoneId: 'M001',
+      title: 'Already complete',
+      status: 'complete',
+      fullSummaryMd: '# T99 Summary\n\nAlready done.\n',
+    });
+
+    const unrelatedSummaryPath = join(base, '.gsd', 'phases', '01-test', 'T99-SUMMARY.md');
+    assert.equal(existsSync(unrelatedSummaryPath), false, 'fixture should start without unrelated summary projection');
+
+    const result = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    assert.equal(existsSync(unrelatedSummaryPath), false, 'plan-slice should not flush all milestone summaries');
+    assert.ok(existsSync(join(base, '.gsd', 'phases', '01-test', '01-02-PLAN.md')), 'current slice plan still renders');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice preserves completed task closeout state when replanning the same task', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -21,7 +21,6 @@ import {
 import type { GateEvaluationConfig, GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
 import { renderPlanFromDb } from "../markdown-renderer.js";
-import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -466,9 +465,8 @@ export async function handlePlanSlice(
     invalidateStateCache();
     clearParseCache();
 
-    // ── Post-mutation hook: projections, manifest, event log ─────────────
+    // ── Post-mutation hook: manifest, event log ─────────────────────────
     try {
-      await flushWorkflowProjections(basePath, { milestoneId: params.milestoneId });
       writeManifest(basePath);
       appendEvent(basePath, {
         cmd: "plan-slice",


### PR DESCRIPTION
## Summary
- Removed the plan-slice milestone-wide projection flush, added a regression test, and verified diff hygiene while test execution was blocked by missing uncached dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #861
- [#861 [Bug]: GSD TUI hangs/freezes, tool fails, when trying to execute gsd_plan_slice function during auto-mode](https://github.com/open-gsd/gsd-pi/issues/861)

## User
- @astark-uni

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/861-bug-gsd-tui-hangs-freezes-tool-fails-whe-1782416720`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow workflow-hook change with targeted slice rendering preserved; regression test covers the removed side effect. Milestone-wide projection flush remains available on other paths (e.g. plan-milestone, doctor).
> 
> **Overview**
> **Fixes `gsd_plan_slice` hangs/freezes in auto-mode** by dropping the post-plan **milestone-wide** `flushWorkflowProjections` call from `handlePlanSlice`. Planning one slice still runs `renderPlanFromDb` for that slice and updates manifest/event log, but no longer re-flushes every projection in the milestone (including unrelated completed-task summaries).
> 
> A regression test asserts that planning slice `S02` does **not** materialize `T99-SUMMARY.md` for a completed task on another slice while the current slice plan still renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe983b171373b13b24d88f44571fb5d12c3eca4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->