### PR TITLE
fix(auto-artifact-paths): resolveProjectMilestonePath ignores META-only dir

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -19,7 +19,7 @@ import {
   buildTaskFileName,
   resolveSlicePath,
   resolveTasksDir,
-  dirIsContentBearingLegacyMilestone,
+  dirIsMetaOnlyLegacyMilestone,
 } from "./paths.js";
 import { milestoneIdToPhaseNum } from "./layout-policy.js";
 import { parseUnitId } from "./unit-id.js";
@@ -70,14 +70,16 @@ function resolveProjectMilestonePath(base: string, mid: string): string | null {
   const dir = resolveDir(milestonesDir, mid);
   if (!dir) return null;
   // git-service.ts creates milestones/<MID>/ for integration-branch metadata
-  // (<MID>-META.json) even in flat-phase projects. A metadata-only dir must not
-  // be treated as a real legacy milestone dir — otherwise this early-return path
-  // resolves CONTEXT/ROADMAP/SUMMARY to milestones/<MID>/<MID>-<SUFFIX>.md (a
-  // path that never exists in a flat-phase project) before the flat-phase
-  // fallback runs, trapping the unit in a finalize-retry loop (#852 follow-up).
-  // This guard mirrors the one in paths.ts resolvePhaseDir/resolveMilestonePath;
-  // without it the project-root legacy lookup bypassed those fixes.
-  if (!dirIsContentBearingLegacyMilestone(join(milestonesDir, dir))) return null;
+  // (<MID>-META.json) even in flat-phase projects. A dir that holds ONLY
+  // *-META.json files must not be treated as a real legacy milestone dir —
+  // otherwise this early-return resolves CONTEXT/ROADMAP/SUMMARY to the legacy
+  // path (milestones/<MID>/<MID>-<SUFFIX>.md) before the flat-phase fallback
+  // can run, trapping the unit in a finalize-retry loop (#852 follow-up).
+  //
+  // We use dirIsMetaOnlyLegacyMilestone rather than !dirIsContentBearingLegacyMilestone
+  // so that an EMPTY dir (a new milestone before any content is written) is NOT
+  // blocked — it is a valid legacy target that write-paths should resolve to.
+  if (dirIsMetaOnlyLegacyMilestone(join(milestonesDir, dir))) return null;
   return join(milestonesDir, dir);
 }
 

--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -19,6 +19,7 @@ import {
   buildTaskFileName,
   resolveSlicePath,
   resolveTasksDir,
+  dirIsContentBearingLegacyMilestone,
 } from "./paths.js";
 import { milestoneIdToPhaseNum } from "./layout-policy.js";
 import { parseUnitId } from "./unit-id.js";
@@ -67,7 +68,17 @@ function resolveSliceArtifactPath(
 function resolveProjectMilestonePath(base: string, mid: string): string | null {
   const milestonesDir = join(gsdRoot(base), "milestones");
   const dir = resolveDir(milestonesDir, mid);
-  return dir ? join(milestonesDir, dir) : null;
+  if (!dir) return null;
+  // git-service.ts creates milestones/<MID>/ for integration-branch metadata
+  // (<MID>-META.json) even in flat-phase projects. A metadata-only dir must not
+  // be treated as a real legacy milestone dir — otherwise this early-return path
+  // resolves CONTEXT/ROADMAP/SUMMARY to milestones/<MID>/<MID>-<SUFFIX>.md (a
+  // path that never exists in a flat-phase project) before the flat-phase
+  // fallback runs, trapping the unit in a finalize-retry loop (#852 follow-up).
+  // This guard mirrors the one in paths.ts resolvePhaseDir/resolveMilestonePath;
+  // without it the project-root legacy lookup bypassed those fixes.
+  if (!dirIsContentBearingLegacyMilestone(join(milestonesDir, dir))) return null;
+  return join(milestonesDir, dir);
 }
 
 function resolveProjectMilestoneFile(base: string, mid: string, suffix: string): string | null {

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -613,7 +613,7 @@ function legacyMilestonesHasSubdirs(basePath: string): boolean {
  * See the matching TODO in markdown-renderer.ts detectStaleRenders, which
  * disabled stale-render detection for the same reason.
  */
-function dirIsContentBearingLegacyMilestone(dir: string): boolean {
+export function dirIsContentBearingLegacyMilestone(dir: string): boolean {
   try {
     const entries = readdirSync(dir);
     // Any non-meta file means this is a real legacy milestone dir with content.

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -623,6 +623,26 @@ export function dirIsContentBearingLegacyMilestone(dir: string): boolean {
   }
 }
 
+/**
+ * Returns true iff the directory exists, is non-empty, and ALL entries are
+ * `*-META.json` files (git-service integration-branch metadata pollution in a
+ * flat-phase project). Used by resolveProjectMilestonePath to skip dirs that
+ * only hold metadata — not as a layout-detection guard.
+ *
+ * Deliberately distinct from dirIsContentBearingLegacyMilestone: an EMPTY dir
+ * (new milestone, no content written yet) returns false here because it is not
+ * META-only — it is a valid placeholder that a writer may target.
+ */
+export function dirIsMetaOnlyLegacyMilestone(dir: string): boolean {
+  try {
+    const entries = readdirSync(dir);
+    if (entries.length === 0) return false; // empty = not META-only
+    return entries.every(name => name.endsWith("-META.json"));
+  } catch {
+    return false;
+  }
+}
+
 export function isLegacyMilestonesLayout(basePath: string): boolean {
   return legacyMilestonesHasSubdirs(basePath);
 }

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -104,3 +104,85 @@ test("content-bearing milestones/<MID>/ still resolves to legacy (#852 regressio
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// ── #852 follow-up: the EXACT failure path that survived #858 ────────────────
+//
+// #858 fixed legacyMilestonesHasSubdirs/resolvePhaseDir/resolveMilestonePath in
+// paths.ts, but resolveMilestoneArtifactPath (auto-artifact-paths.ts:35) has an
+// EARLY-RETURN legacy check via resolveProjectMilestonePath that bypassed all of
+// those. With a flat-phase project + a META-only milestones/M015/ dir (created
+// by git-service.ts), the early-return resolved CONTEXT to
+// milestones/M015/M015-CONTEXT.md (never exists) instead of
+// phases/15-m015/15-CONTEXT.md — reproducing the production loop:
+//   verify-fail discuss-milestone M015: existsSync false for
+//     .../milestones/M015/M015-CONTEXT.md
+// This test guards the project-root legacy lookup, not just paths.ts.
+
+test("resolveProjectMilestonePath ignores META-only dir: flat-phase wins (#852 follow-up to #858)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-meta-bypass-")));
+  try {
+    const gsd = join(root, ".gsd");
+
+    // Flat-phase layout: phases/15-m015/ with real CONTEXT content.
+    const phaseDir = join(gsd, "phases", "15-m015");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "15-CONTEXT.md"), "# M015 context\n");
+
+    // Pollution: git-service.ts:450 created milestones/M015/ for META only.
+    // This is the dir that previously flipped the early-return to legacy.
+    const metaDir = join(gsd, "milestones", "M015");
+    mkdirSync(metaDir, { recursive: true });
+    writeFileSync(join(metaDir, "M015-META.json"), '{"branch":"milestone/M015"}');
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("discuss-milestone", "M015", root);
+
+    // MUST resolve to the flat-phase path, NOT the legacy META-only path.
+    assert.equal(
+      resolved,
+      join(phaseDir, "15-CONTEXT.md"),
+      "META-only milestones/M015/ must not produce the legacy path; flat-phase wins",
+    );
+    // Explicitly assert the bug does NOT reproduce — the legacy path is wrong.
+    assert.notEqual(
+      resolved,
+      join(metaDir, "M015-CONTEXT.md"),
+      "must NOT resolve to the legacy milestones/M015/M015-CONTEXT.md path",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolveProjectMilestonePath ignores META-only dir even when phases/ has no matching dir yet", () => {
+  // The worktree/early-run edge case: phases/ doesn't exist yet (or doesn't have
+  // 15-m015/), but milestones/M015/ exists with only META. The resolver must
+  // return null (file genuinely not found yet) rather than the wrong legacy
+  // path — so the caller reports a clear "missing" instead of looping on a
+  // path that will never exist.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-meta-no-phase-")));
+  try {
+    const metaDir = join(root, ".gsd", "milestones", "M015");
+    mkdirSync(metaDir, { recursive: true });
+    writeFileSync(join(metaDir, "M015-META.json"), '{"branch":"milestone/M015"}');
+    // Note: no phases/ dir at all.
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("discuss-milestone", "M015", root);
+    // Must not produce the legacy path; null or a non-legacy path is correct.
+    assert.ok(
+      resolved === null || !resolved.includes(join("milestones", "M015")),
+      `META-only dir with no phases/ must not resolve to legacy; got: ${resolved}`,
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Despite #858 being merged, the loop persists:

```
verify-fail discuss-milestone M015: existsSync false for
  .../milestones/M015/M015-CONTEXT.md
```

`15-CONTEXT.md` exists at `phases/15-m015/` (the correct flat-phase path), but verification still resolves to the legacy `milestones/M015/M015-CONTEXT.md`.

## Why #858 didn't fix it

**I patched the wrong functions.** #858 fixed `legacyMilestonesHasSubdirs`, `resolvePhaseDir`, and `resolveMilestonePath` in `paths.ts`. But `resolveMilestoneArtifactPath` (`auto-artifact-paths.ts:35`) has an **early-return legacy check** via `resolveProjectMilestonePath` that runs *before* any of those patched functions:

```ts
// auto-artifact-paths.ts:35 — the line that was never fixed
const legacyDir = resolveProjectedMilestonePath(base, mid) ?? resolveProjectMilestonePath(base, mid);
if (legacyDir) return join(legacyDir, `${mid}-${suffix}.md`);  // ← returns legacy, bypasses flat-phase
```

`resolveProjectMilestonePath` calls `resolveDir(gsdRoot(base)/milestones, mid)`, finds the `milestones/M015/` dir that `git-service.ts` created for `M015-META.json`, and returns it — so the early-return builds the legacy filename `M015-CONTEXT.md` **before** the flat-phase fallback ever runs. Every function I fixed in #858 sits below this early-return and never executes.

## Fix

Apply the same `dirIsContentBearingLegacyMilestone` guard (now exported from `paths.ts`) at `resolveProjectMilestonePath` — the actual function on the failure path:

```ts
function resolveProjectMilestonePath(base, mid) {
  const milestonesDir = join(gsdRoot(base), "milestones");
  const dir = resolveDir(milestonesDir, mid);
  if (!dir) return null;
  if (!dirIsContentBearingLegacyMilestone(join(milestonesDir, dir))) return null;  // ← new
  return join(milestonesDir, dir);
}
```

Guarding at the source means every consumer (file lookup, path lookup, slice path) ignores metadata-only dirs — not just the three functions #858 patched.

## Testing

2 new tests reproducing the exact production failure:
- **flat-phase project + META-only `milestones/M015/` + `phases/15-m015/15-CONTEXT.md`** → asserts `resolveExpectedArtifactPath("discuss-milestone", "M015", root)` returns the flat-phase path, explicitly asserts it does NOT return the legacy path
- **META-only `milestones/M015/` with no `phases/` dir** → asserts the resolver returns null (genuinely not found) rather than the wrong legacy path

All 64 path/worktree/verification tests pass, TypeScript clean.

Follow-up to #858, which fixed the right concept (content-bearing guard) at the wrong layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow artifact verification and path resolution where wrong paths caused production retry loops; change is narrow and covered by targeted regression tests.
> 
> **Overview**
> Fixes a **finalize-retry loop** where `discuss-milestone` verification looked for `milestones/M015/M015-CONTEXT.md` even though the real file lived under `phases/15-m015/15-CONTEXT.md`.
> 
> `resolveMilestoneArtifactPath` still **early-returned** a legacy path when `resolveProjectMilestonePath` found `milestones/<MID>/` created only for `*-META.json` (git integration metadata). That bypassed the #858 guards in `paths.ts`. **`resolveProjectMilestonePath` now uses the same `dirIsContentBearingLegacyMilestone` check** (exported from `paths.ts`), so metadata-only dirs are ignored and resolution can fall through to flat-phase paths.
> 
> Two tests lock in the project-root lookup: flat-phase + META-only dir resolves to `phases/…`, and META-only with no `phases/` does not produce a bogus legacy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e43be1207ff12ed96d9537ff1ef3528620d453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->