### PR TITLE
fix(bootstrap): assertCriticalGsdWorkflowToolsRegistered tolerates pre-bind runtime

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -141,10 +141,30 @@ export function installEpipeGuard(): void {
   }
 }
 
+/**
+ * Assert that critical GSD workflow tools were registered.
+ *
+ * During extension loading, getAllTools() is a throwing stub
+ * ("Extension runtime not initialized") that only becomes real after
+ * runner.bindCore(). Calling it here used to throw, propagating to index.ts's
+ * catch and firing "Extension setup partially failed" — which, under Claude
+ * Code CLI, left the model's tool surface incomplete and trapped units in a
+ * finalize-retry loop. Tolerate the pre-bind throw and defer the real check to
+ * the first before_agent_start (where applyMinimalGsdToolSurface already
+ * re-reads the registered surface post-bind).
+ */
 function assertCriticalGsdWorkflowToolsRegistered(pi: ExtensionAPI): void {
   if (typeof pi.getAllTools !== "function") return;
 
-  const registered = new Set(pi.getAllTools().map((tool) => tool.name));
+  let registered: Set<string>;
+  try {
+    registered = new Set(pi.getAllTools().map((tool) => tool.name));
+  } catch {
+    // Pre-bind runtime: getAllTools() is not yet wired. The critical-tools
+    // invariant is re-checked post-bind during the first before_agent_start.
+    return;
+  }
+
   const missing = CRITICAL_GSD_WORKFLOW_TOOL_NAMES.filter((toolName) => !registered.has(toolName));
   if (missing.length === 0) return;
 

--- a/src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts
@@ -195,4 +195,57 @@ describe("registerGsdExtension defensive registration", () => {
     assert.ok(!registeredTools.includes("gsd_plan_slice"));
     drainLogs();
   });
+
+  // ── #852 follow-up: assertCriticalGsdWorkflowToolsRegistered tolerates pre-bind ──
+  //
+  // During extension loading, getAllTools() is a throwing stub
+  // ("Extension runtime not initialized"). The assertion used to call it
+  // synchronously and throw, propagating to index.ts's catch and firing
+  // "Extension setup partially failed" — leaving the tool surface incomplete
+  // under Claude Code CLI. It must tolerate the pre-bind throw.
+
+  test("registerGsdExtension does not throw when getAllTools is the pre-bind stub", () => {
+    const registeredTools: string[] = [];
+    const pi = {
+      registerCommand: () => {},
+      registerTool: (tool: { name: string }) => { registeredTools.push(tool.name); },
+      registerHook: () => {},
+      registerShortcut: () => {},
+      events: { on: () => {}, off: () => {}, emit: () => {} },
+      // Simulate the pre-bind throwing stub (loader.ts:182).
+      getAllTools: () => {
+        throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
+      },
+    };
+
+    // Must not throw — the old code let this propagate as "Extension setup partially failed".
+    assert.doesNotThrow(() => registerGsdExtension(pi as any));
+    // Critical tools should still have been registered (registerTool is valid during load).
+    assert.ok(registeredTools.includes("gsd_plan_milestone"));
+    assert.ok(registeredTools.includes("gsd_plan_slice"));
+    drainLogs();
+  });
+
+  test("registerGsdExtension still throws when getAllTools works and critical tools are missing (post-bind)", () => {
+    // The assertion must still fire when getAllTools returns a real value but
+    // a critical tool is missing — just not during the pre-bind window.
+    const registeredTools: string[] = [];
+    const pi = {
+      registerCommand: () => {},
+      registerTool: (tool: { name: string }) => {
+        if (tool.name === "gsd_plan_slice") throw new Error("simulated failure");
+        registeredTools.push(tool.name);
+      },
+      registerHook: () => {},
+      registerShortcut: () => {},
+      events: { on: () => {}, off: () => {}, emit: () => {} },
+      getAllTools: () => registeredTools.map((name) => ({ name })),
+    };
+
+    assert.throws(
+      () => registerGsdExtension(pi as any),
+      /Critical GSD workflow tool registration failed/,
+    );
+    drainLogs();
+  });
 });


### PR DESCRIPTION
## Problem

Every session still logs:

```
Extension setup partially failed — /gsd commands are available but shortcuts/tools may be missing: Extension runtime not initialized. Action methods cannot be called during extension loading.
```

despite #857 being merged (which wrapped the `tool-search-shim`'s `getActiveTools`/`setActiveTools` calls).

## Root cause

`registerGsdExtension`'s **last line** calls `assertCriticalGsdWorkflowToolsRegistered(pi)`, which calls `pi.getAllTools()`. During extension loading, `getAllTools()` is a **throwing stub** (`loader.ts:182`):

```ts
getAllTools: notInitialized,  // → throws "Extension runtime not initialized"
```

The `typeof pi.getAllTools !== "function"` guard at line 145 passes (the stub IS a function), so line 147 calls it → **throws** → propagates to `index.ts:30`'s catch → "Extension setup partially failed".

#857 wrapped the `tool-search-shim`'s `getActiveTools`/`setActiveTools` (lines 193-200), but this is a **separate `getAllTools()` call** in a different function (`assertCriticalGsdWorkflowToolsRegistered`) that was never wrapped.

## Fix

Wrap the `getAllTools()` call in `try/catch`. During loading it throws → return early (the tools aren't all registered yet anyway). Post-bind it returns a real value → the assertion runs normally. The assertion's purpose (catch missing critical tools) is preserved post-bind — the first `before_agent_start` already re-reads the registered surface via `applyMinimalGsdToolSurface`.

```ts
let registered: Set<string>;
try {
  registered = new Set(pi.getAllTools().map((tool) => tool.name));
} catch {
  // Pre-bind runtime: getAllTools() is not yet wired.
  return;
}
```

## Testing

2 new tests:
- **does not throw when `getAllTools` is the pre-bind stub** — the core regression (simulates `loader.ts:182`)
- **still throws when `getAllTools` works and critical tools are missing (post-bind)** — proves the assertion isn't disabled, just deferred

All 9 bootstrap-isolation tests pass, TypeScript clean.

Follow-up to #857 (which fixed the shim's action-method calls but missed this one).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bootstrap timing fix with tests; defers validation to existing post-bind path without weakening the missing-tool failure mode.
> 
> **Overview**
> Stops **false "Extension setup partially failed"** during GSD extension load when `pi.getAllTools()` is still the pre-bind throwing stub (`Extension runtime not initialized`).
> 
> `assertCriticalGsdWorkflowToolsRegistered` now **wraps `getAllTools()` in try/catch** and returns early on that error instead of letting it bubble to `index.ts`. The **post-bind** check for missing critical workflow tools is unchanged when `getAllTools()` succeeds.
> 
> Adds bootstrap isolation tests: **no throw** with the pre-bind stub, and **still throws** when tools are actually missing after bind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866937d7f3b3fc89a2fffc36ead58cc0be8d6446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->