### PR TITLE
fix(auto-recovery): fall back to project root when worktree lacks the artifact

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -58,7 +58,7 @@ import {
 import { execFileSync } from "node:child_process";
 
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   resolveExpectedArtifactPath,
   diagnoseExpectedArtifact,
@@ -69,6 +69,7 @@ import { validateArtifact } from "./schemas/validate.js";
 import { getProjectResearchStatus } from "./project-research-policy.js";
 import { isGsdWorktreePath } from "./worktree-root.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
 import {
@@ -527,7 +528,26 @@ export function verifyExpectedArtifact(
   }
 
   const artifactBase = resolveArtifactVerificationBase(unitId, base);
-  const absPath = resolveExpectedArtifactPath(unitType, unitId, artifactBase);
+  let absPath = resolveExpectedArtifactPath(unitType, unitId, artifactBase);
+  // Worktree→project-root fallback: a milestone running in a worktree may not
+  // have its CONTEXT/ROADMAP/SUMMARY projected into the worktree yet (the
+  // worktree only has the META dir until planning writes its projections).
+  // When the worktree base yields null or a non-existent path, fall back to the
+  // project root — where the artifact genuinely lives. Without this, a
+  // discuss-milestone unit with CONTEXT at phases/NN-slug/ in the project root
+  // but not in the worktree resolves to null → "resolveExpectedArtifactPath
+  // returned null" → finalize-retry loop (#852).
+  if (artifactBase !== base) {
+    const projectRoot = resolve(resolveWorktreeProjectRoot(artifactBase));
+    if (projectRoot && projectRoot !== artifactBase) {
+      if (!absPath || !existsSync(absPath)) {
+        const projectPath = resolveExpectedArtifactPath(unitType, unitId, projectRoot);
+        if (projectPath && existsSync(projectPath)) {
+          absPath = projectPath;
+        }
+      }
+    }
+  }
   // For unit types with no registered artifact contract (null path), treat the
   // completion state as stale so the key gets evicted (#313).
   if (!absPath) {

--- a/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
+++ b/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
@@ -202,3 +202,93 @@ test("execute-task DB lag branch — summary without checked plan still fails", 
     "pending DB status plus summary is insufficient without a checked task checkbox",
   );
 });
+
+// ── #852 follow-up: worktree→project-root artifact fallback ──────────────────
+//
+// A milestone running in a worktree may not have its CONTEXT projected into the
+// worktree (the worktree only has the META dir until planning writes its
+// projections). When verifyExpectedArtifact can't find the artifact at the
+// worktree base, it must fall back to the project root — where the artifact
+// genuinely lives. Without this, discuss-milestone verification returned false
+// ("resolveExpectedArtifactPath returned null") and trapped the unit in a
+// finalize-retry loop.
+
+test("#852: discuss-milestone falls back to project root when CONTEXT not in worktree", () => {
+  closeDatabase();
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-wt-fallback-proj-"));
+  try {
+    // Flat-phase CONTEXT lives at the project root.
+    const phaseDir = join(projectRoot, ".gsd", "phases", "15-m015");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "15-CONTEXT.md"), "# M015 context\n");
+
+    // Simulate the worktree: exists, registered with git (.git file), but has
+    // NO phases/ dir and no real CONTEXT — only the META dir git-service.ts
+    // created. resolveCanonicalMilestoneRoot redirects here.
+    const wtRoot = join(projectRoot, ".gsd", "worktrees", "M015");
+    const wtGsd = join(wtRoot, ".gsd");
+    mkdirSync(join(wtGsd, "milestones", "M015"), { recursive: true });
+    writeFileSync(join(wtGsd, "milestones", "M015", "M015-META.json"), '{"branch":"milestone/M015"}');
+    writeFileSync(join(wtRoot, ".git"), "gitdir: /fake/path");
+
+    // Verification with the worktree as base must fall back to the project root
+    // and find 15-CONTEXT.md there.
+    assert.equal(
+      verifyExpectedArtifact("discuss-milestone", "M015", projectRoot),
+      true,
+      "must fall back to project root when CONTEXT is not in the worktree",
+    );
+  } finally {
+    closeDatabase();
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("#852: discuss-milestone passes when CONTEXT is in the worktree (no fallback needed)", () => {
+  closeDatabase();
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-wt-present-"));
+  try {
+    // CONTEXT lives in BOTH the project root AND the worktree.
+    const projPhase = join(projectRoot, ".gsd", "phases", "15-m015");
+    mkdirSync(projPhase, { recursive: true });
+    writeFileSync(join(projPhase, "15-CONTEXT.md"), "# project context\n");
+
+    const wtRoot = join(projectRoot, ".gsd", "worktrees", "M015");
+    const wtGsd = join(wtRoot, ".gsd");
+    const wtPhase = join(wtGsd, "phases", "15-m015");
+    mkdirSync(wtPhase, { recursive: true });
+    writeFileSync(join(wtPhase, "15-CONTEXT.md"), "# worktree context\n");
+    writeFileSync(join(wtRoot, ".git"), "gitdir: /fake/path");
+
+    assert.equal(
+      verifyExpectedArtifact("discuss-milestone", "M015", projectRoot),
+      true,
+      "must pass when CONTEXT is in the worktree",
+    );
+  } finally {
+    closeDatabase();
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("#852: discuss-milestone fails when CONTEXT is in neither worktree nor project root", () => {
+  // If the artifact genuinely doesn't exist anywhere, verification must still
+  // fail (fail-closed) — the fallback must not mask a real absence.
+  closeDatabase();
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-wt-absent-"));
+  try {
+    const wtRoot = join(projectRoot, ".gsd", "worktrees", "M015");
+    mkdirSync(join(wtRoot, ".gsd", "milestones", "M015"), { recursive: true });
+    writeFileSync(join(wtRoot, ".git"), "gitdir: /fake/path");
+    // No phases/ anywhere, no CONTEXT anywhere.
+
+    assert.equal(
+      verifyExpectedArtifact("discuss-milestone", "M015", projectRoot),
+      false,
+      "must fail when CONTEXT exists in neither root",
+    );
+  } finally {
+    closeDatabase();
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Despite #858 and #863 being merged (which correctly skip META-only `milestones/` dirs), the `finalize-retry` loop persists with a new error:

```
verify-fail discuss-milestone M015: resolveExpectedArtifactPath returned null
  (no artifact contract registered for this unit type)
```

## Root cause

`verifyExpectedArtifact` resolves the verification base via `resolveArtifactVerificationBase`, which **redirects to the worktree** while one exists. The worktree has a `milestones/M015/` dir (META only — correctly skipped by #863) but **no `phases/` dir** — the CONTEXT hasn't been projected into the worktree yet.

So after #863 correctly skips the META-only dir, there's nothing left in the worktree → `resolveExpectedArtifactPath` returns `null` → verification fails → retry loop.

But the CONTEXT **genuinely exists** at the project root: `phases/15-m015/15-CONTEXT.md` (7945 bytes). The verification just never looked there.

## Fix

When the worktree base yields `null` or a non-existent path, fall back to the **project root** (resolved via `resolveWorktreeProjectRoot`) and re-resolve there:

```ts
if (artifactBase !== base) {
  const projectRoot = resolve(resolveWorktreeProjectRoot(artifactBase));
  if (projectRoot && projectRoot !== artifactBase) {
    if (!absPath || !existsSync(absPath)) {
      const projectPath = resolveExpectedArtifactPath(unitType, unitId, projectRoot);
      if (projectPath && existsSync(projectPath)) {
        absPath = projectPath;
      }
    }
  }
}
```

This mirrors what the forensics module already does for diagnosis (`forensics.ts:901` checks both roots). **Fail-closed**: if the artifact exists in neither root, verification still returns false.

## Why this happens

A milestone running in isolation (worktree mode) writes its artifacts to the project root via the DB-backed projection path, but the worktree checkout only contains the META dir + git-tracked files — the `.gsd/phases/` projection lives in the project root's `.gsd` (which is a symlink to the external state dir). The worktree's `.gsd` is separate and doesn't receive the projection until merge/sync. Verification was assuming the artifact would be in the worktree, but for discuss/plan artifacts that's often not the case.

## Testing

3 new tests:
- **falls back to project root** when CONTEXT is not in the worktree but exists at `phases/15-m015/` in the project root → passes
- **passes when CONTEXT is in the worktree** (no fallback needed) → passes
- **fails when CONTEXT is in neither** → returns false (fail-closed)

All 18 verify-artifact + artifact-paths tests pass, TypeScript clean.

Follow-up to #863 (which fixed the legacy-path resolution; this fixes the missing fallback when the worktree genuinely doesn't have the artifact).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-recovery artifact verification for all unit types that use the worktree base path; behavior is scoped to missing/null worktree paths and remains fail-closed when neither location has the file.
> 
> **Overview**
> Fixes **finalize-retry loops** for `discuss-milestone` (and similar units) when verification runs against a milestone **worktree** that only has META and not yet-projected `phases/` artifacts.
> 
> **`verifyExpectedArtifact`** still resolves paths via the canonical worktree base, but when that yields **null** or a **missing file**, it now **re-resolves** at the **project root** (`resolveWorktreeProjectRoot`) if the artifact exists there. Worktree copies win when present; missing worktree artifacts no longer fail as “no contract” when CONTEXT (etc.) lives only at the project root (#852).
> 
> **Tests** add three `discuss-milestone` scenarios: fallback success, worktree-only success, and fail-closed when absent in both places.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0446bd4c4676e6a10a426380abfe0649de000fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->