### PR TITLE
fix(issue): [Bug]: Planning/research unit prompts advertise GSD tools their contracts hard-block

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -26,6 +26,7 @@ import type {
 } from "../unit-context-manifest.ts";
 import { KNOWN_UNIT_TYPES, UNIT_MANIFESTS } from "../unit-context-manifest.ts";
 import { getUnitToolSurfaceContract } from "../unit-tool-contracts.ts";
+import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.ts";
 import {
   buildExecuteTaskPrompt,
   buildGateEvaluatePrompt,
@@ -191,6 +192,26 @@ test("Context Mode composer: run-uat guidance steers to gsd_uat_exec in both ren
   const standalone = composeContextModeInstructions("run-uat", { enabled: true, renderMode: "standalone" });
   assert.match(standalone, /`gsd_uat_exec`/);
   assert.doesNotMatch(standalone, /`gsd_exec`/);
+});
+
+test("Context Mode composer: slice planning and research guidance tools pass unit contracts", () => {
+  const affectedUnits = ["research-slice", "plan-slice", "refine-slice"];
+  const contextModeTools = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
+  const readOnlyOrientationTools = ["gsd_milestone_status", ...contextModeTools];
+
+  for (const unitType of affectedUnits) {
+    const out = composeContextModeInstructions(unitType, { enabled: true, renderMode: "standalone" });
+    const allowed = new Set(getUnitToolSurfaceContract(unitType)?.allowedGsdTools ?? []);
+
+    for (const toolName of contextModeTools) {
+      assert.ok(out.includes(`\`${toolName}\``), `${unitType} guidance should mention ${toolName}`);
+    }
+    for (const toolName of readOnlyOrientationTools) {
+      assert.ok(allowed.has(toolName), `${unitType} contract should allow ${toolName}`);
+      const scope = shouldBlockAutoUnitToolCall(unitType, toolName);
+      assert.equal(scope.block, false, `${unitType} should not hard-block ${toolName}: ${scope.reason ?? ""}`);
+    }
+  }
 });
 
 test("Context Mode composer: workflow-preferences and research-decision render no Context Mode block", () => {

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -27,6 +27,7 @@ import type {
 import { KNOWN_UNIT_TYPES, UNIT_MANIFESTS } from "../unit-context-manifest.ts";
 import { getUnitToolSurfaceContract } from "../unit-tool-contracts.ts";
 import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.ts";
+import type { UnitGsdToolName } from "../unit-registry.ts";
 import {
   buildExecuteTaskPrompt,
   buildGateEvaluatePrompt,
@@ -196,8 +197,8 @@ test("Context Mode composer: run-uat guidance steers to gsd_uat_exec in both ren
 
 test("Context Mode composer: slice planning and research guidance tools pass unit contracts", () => {
   const affectedUnits = ["research-slice", "plan-slice", "refine-slice"];
-  const contextModeTools = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
-  const readOnlyOrientationTools = ["gsd_milestone_status", ...contextModeTools];
+  const contextModeTools: UnitGsdToolName[] = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
+  const readOnlyOrientationTools: UnitGsdToolName[] = ["gsd_milestone_status", ...contextModeTools];
 
   for (const unitType of affectedUnits) {
     const out = composeContextModeInstructions(unitType, { enabled: true, renderMode: "standalone" });

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -183,7 +183,14 @@ export const UNIT_REGISTRY = {
     scopeClass: "standard",
     phaseChain: ["research"],
     toolContract: {
-      allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+      allowedGsdTools: [
+        "gsd_milestone_status",
+        "gsd_summary_save",
+        "gsd_decision_save",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
+      ],
       requiredWorkflowTools: ["gsd_summary_save"],
     },
   },
@@ -192,7 +199,15 @@ export const UNIT_REGISTRY = {
     scopeClass: "standard",
     phaseChain: ["planning"],
     toolContract: {
-      allowedGsdTools: ["gsd_plan_slice", "gsd_reassess_roadmap", "gsd_decision_save"],
+      allowedGsdTools: [
+        "gsd_milestone_status",
+        "gsd_plan_slice",
+        "gsd_reassess_roadmap",
+        "gsd_decision_save",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
+      ],
       requiredWorkflowTools: ["gsd_plan_slice", "gsd_reassess_roadmap"],
     },
   },
@@ -201,7 +216,14 @@ export const UNIT_REGISTRY = {
     scopeClass: "standard",
     phaseChain: ["planning"],
     toolContract: {
-      allowedGsdTools: ["gsd_plan_slice", "gsd_decision_save"],
+      allowedGsdTools: [
+        "gsd_milestone_status",
+        "gsd_plan_slice",
+        "gsd_decision_save",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
+      ],
       requiredWorkflowTools: ["gsd_plan_slice"],
     },
   },


### PR DESCRIPTION
## Summary
- Allowed Context Mode orientation tools for affected slice planning/research unit contracts and added a regression check; syntax/static verification passed, but full focused test execution was blocked by missing dependencies and network DNS failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #866
- [#866 [Bug]: Planning/research unit prompts advertise GSD tools their contracts hard-block](https://github.com/open-gsd/gsd-pi/issues/866)

## User
- @astark-uni

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/866-bug-planning-research-unit-prompts-adver-1782422954`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only allowlist updates plus a unit-context composer test; no auth, data, or execution-path logic changes beyond letting advertised tools match prompts.
> 
> **Overview**
> Fixes a mismatch where **research-slice**, **plan-slice**, and **refine-slice** Context Mode prompts steered agents toward orientation/exec tools that their unit tool contracts did not allow (and could be hard-blocked).
> 
> **`unit-registry.ts`** expands `allowedGsdTools` for those three units to include `gsd_milestone_status`, `gsd_exec`, `gsd_exec_search`, and `gsd_resume` (on top of their existing planning/research workflow tools). **`replan-slice`** is unchanged.
> 
> A regression test in **`unit-context-composer.test.ts`** checks that Context Mode text mentions the exec/orientation tools, the unit surface contract allows them, and `shouldBlockAutoUnitToolCall` does not block those calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d94f2b7ee8fb7ded0c21e4d214bd7930a44e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->