### PR TITLE
fix(auto): scope stuck window to current session so stale entries don't block

### DIFF
--- a/src/resources/extensions/gsd/auto/dispatch-history.ts
+++ b/src/resources/extensions/gsd/auto/dispatch-history.ts
@@ -82,6 +82,19 @@ export interface DispatchHistoryOptions {
    */
   resolveScopeId: () => string | null;
   windowSize?: number;
+  /**
+   * Session-level trace_id used to scope `rehydrate()` to the CURRENT session
+   * so stale finalize-retry entries from PREVIOUS sessions don't fire
+   * detectStuck Rule 1 on the first advance of a new session — killing
+   * auto-mode before any new dispatch runs (#852). When provided, only
+   * dispatches recorded with this trace_id are returned by the DB query;
+   * a brand-new session trace_id that has never been written to unit_dispatches
+   * returns 0 rows, giving a clean stuck window on session start.
+   *
+   * The unscoped (no resolveTraceId) path is preserved for callers without a
+   * session context so existing behaviour for those paths is unchanged.
+   */
+  resolveTraceId?: () => string | null;
 }
 
 /**
@@ -137,7 +150,12 @@ export function createDispatchHistory(options: DispatchHistoryOptions): Dispatch
       const scopeId = options.resolveScopeId();
       if (!scopeId) return 0;
       try {
-        const persisted = getRecentUnitKeysForProjectRoot(scopeId, windowSize);
+        // Scope to the current session's trace_id when available (#852):
+        // a fresh session UUID that has never been written to unit_dispatches
+        // returns 0 rows so prior-session failures don't pre-populate the
+        // stuck window and immediately block the new session.
+        const traceId = options.resolveTraceId?.() ?? undefined;
+        const persisted = getRecentUnitKeysForProjectRoot(scopeId, windowSize, traceId);
         if (persisted.length === 0) return 0;
         const rebuilt: WindowEntry[] = [];
         for (const { key } of persisted) {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -191,6 +191,11 @@ function loadStuckState(s: AutoSession): { recentUnits: Array<{ key: string }>; 
     // Rule 1 on the first iteration — killing auto-mode before any new
     // dispatch runs (#852). A prior session's two consecutive finalize-retry
     // failures would otherwise permanently block every new session.
+    //
+    // s.currentTraceId is only set inside the first loop iteration (line ~443),
+    // so at this call-site it is always null for a fresh session. Return []
+    // directly in that case — no prior dispatch has occurred in this session,
+    // so the stuck window is trivially empty and the DB query is skipped.
     const recentUnits =
       s.currentTraceId != null
         ? getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE, s.currentTraceId)

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -191,7 +191,10 @@ function loadStuckState(s: AutoSession): { recentUnits: Array<{ key: string }>; 
     // Rule 1 on the first iteration — killing auto-mode before any new
     // dispatch runs (#852). A prior session's two consecutive finalize-retry
     // failures would otherwise permanently block every new session.
-    const recentUnits = getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE, s.currentTraceId ?? undefined);
+    const recentUnits =
+      s.currentTraceId != null
+        ? getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE, s.currentTraceId)
+        : [];
     const stuckRecoveryAttempts =
       getRuntimeKv<number>("global", scopeId, STUCK_RECOVERY_ATTEMPTS_KEY) ?? 0;
     return { recentUnits, stuckRecoveryAttempts };

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -186,7 +186,12 @@ function loadStuckState(s: AutoSession): { recentUnits: Array<{ key: string }>; 
   const scopeId = stableStuckStateScopeId(s);
   if (!scopeId) return { recentUnits: [], stuckRecoveryAttempts: 0 };
   try {
-    const recentUnits = getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE);
+    // Scope the stuck window to the CURRENT session (trace_id) so stale
+    // finalize-retry entries from previous sessions don't fire detectStuck
+    // Rule 1 on the first iteration — killing auto-mode before any new
+    // dispatch runs (#852). A prior session's two consecutive finalize-retry
+    // failures would otherwise permanently block every new session.
+    const recentUnits = getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE, s.currentTraceId ?? undefined);
     const stuckRecoveryAttempts =
       getRuntimeKv<number>("global", scopeId, STUCK_RECOVERY_ATTEMPTS_KEY) ?? 0;
     return { recentUnits, stuckRecoveryAttempts };

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -73,7 +73,6 @@ import {
 } from "./dispatch-history.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { randomUUID } from "node:crypto";
 import { evaluateAllCompleteSettlement } from "../milestone-settlement.js";
 import { hasHeldMilestoneLease, reclaimMissingMilestoneLease } from "./milestone-lease-reclaim.js";
 
@@ -377,12 +376,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   // recovery to one attempt per stuck episode per run (reset on start/resume/
   // stop), mirroring the legacy Level-1-then-Level-2 escalation in phases.ts.
   private lastStuckRecoveryKey: string | null = null;
-  // #852: a per-session UUID used to scope rehydrate() so stale prior-session
-  // finalize-retry entries don't pre-populate the stuck window on session start.
-  // Refreshed in start() for fresh sessions; resume() carries forward the
-  // existing value (in-process resume keeps the in-memory window; after-crash
-  // resume generates a fresh scope so the new session starts clean too).
-  private sessionTraceId: string = randomUUID();
 
   public constructor(context: OrchestratorContext) {
     this.ctx = context.ctx;
@@ -400,12 +393,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           this.s.scope?.workspace.projectRoot ??
             (this.s.originalBasePath || this.s.basePath || this.runtimeBasePath),
         ) || null,
-      // Session-scoped trace_id (#852): this.sessionTraceId is refreshed on
-      // start() so rehydrate() only loads dispatches from the current session.
-      // A brand-new UUID that has never been written to unit_dispatches returns
-      // 0 rows, giving a clean stuck window — prior-session failures are
-      // invisible to the new session's stuck detector.
-      resolveTraceId: () => this.sessionTraceId,
     });
   }
 
@@ -931,20 +918,17 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   public async start(_sessionContext: AutoSessionContext): Promise<AutoAdvanceResult> {
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
-    // #852: refresh the session trace_id before rehydrate() so the window is
-    // scoped exclusively to this new session. Prior-session finalize-retry
-    // failures (and any other stale entries) are invisible because the new
-    // UUID has never been written to unit_dispatches. This prevents a session
-    // from being killed before its first dispatch runs.
-    this.sessionTraceId = randomUUID();
-    // #482: the DB dispatch ledger is the source of truth across sessions.
-    // Discard any in-memory window and rebuild it from the ledger so a unit
-    // that was re-dispatched in previous sessions is detected as stuck here
-    // instead of silently re-dispatching forever. (#852 session scoping ensures
-    // only the current session's dispatches are loaded, so a fresh session
-    // always starts with an empty window.)
+    // #852: a fresh user-triggered session must start with a clean stuck window.
+    // Cross-session rehydration at start() was removed because it caused false
+    // stuck-loop verdicts when prior sessions left consecutive finalize-retry
+    // entries in unit_dispatches — the new session would be killed before its
+    // first dispatch ran. Within-session stuck detection (accumulated through
+    // recordDispatch() calls during advance()) remains fully active and catches
+    // genuine stuck patterns after STUCK_WINDOW_SIZE dispatches.
+    //
+    // resume() retains cross-session rehydration: an interrupted session resuming
+    // after a crash should see the dispatch history it had been accumulating.
     this.dispatchHistory.clearOnRecovery();
-    this.dispatchHistory.rehydrate();
     this.lastStuckRecoveryKey = null;
     this.lastDerivedPhase = null;
     this.status.phase = "running";

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -73,6 +73,7 @@ import {
 } from "./dispatch-history.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import { evaluateAllCompleteSettlement } from "../milestone-settlement.js";
 import { hasHeldMilestoneLease, reclaimMissingMilestoneLease } from "./milestone-lease-reclaim.js";
 
@@ -376,6 +377,12 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   // recovery to one attempt per stuck episode per run (reset on start/resume/
   // stop), mirroring the legacy Level-1-then-Level-2 escalation in phases.ts.
   private lastStuckRecoveryKey: string | null = null;
+  // #852: a per-session UUID used to scope rehydrate() so stale prior-session
+  // finalize-retry entries don't pre-populate the stuck window on session start.
+  // Refreshed in start() for fresh sessions; resume() carries forward the
+  // existing value (in-process resume keeps the in-memory window; after-crash
+  // resume generates a fresh scope so the new session starts clean too).
+  private sessionTraceId: string = randomUUID();
 
   public constructor(context: OrchestratorContext) {
     this.ctx = context.ctx;
@@ -393,6 +400,12 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           this.s.scope?.workspace.projectRoot ??
             (this.s.originalBasePath || this.s.basePath || this.runtimeBasePath),
         ) || null,
+      // Session-scoped trace_id (#852): this.sessionTraceId is refreshed on
+      // start() so rehydrate() only loads dispatches from the current session.
+      // A brand-new UUID that has never been written to unit_dispatches returns
+      // 0 rows, giving a clean stuck window — prior-session failures are
+      // invisible to the new session's stuck detector.
+      resolveTraceId: () => this.sessionTraceId,
     });
   }
 
@@ -918,10 +931,18 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   public async start(_sessionContext: AutoSessionContext): Promise<AutoAdvanceResult> {
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
+    // #852: refresh the session trace_id before rehydrate() so the window is
+    // scoped exclusively to this new session. Prior-session finalize-retry
+    // failures (and any other stale entries) are invisible because the new
+    // UUID has never been written to unit_dispatches. This prevents a session
+    // from being killed before its first dispatch runs.
+    this.sessionTraceId = randomUUID();
     // #482: the DB dispatch ledger is the source of truth across sessions.
     // Discard any in-memory window and rebuild it from the ledger so a unit
     // that was re-dispatched in previous sessions is detected as stuck here
-    // instead of silently re-dispatching forever.
+    // instead of silently re-dispatching forever. (#852 session scoping ensures
+    // only the current session's dispatches are loaded, so a fresh session
+    // always starts with an empty window.)
     this.dispatchHistory.clearOnRecovery();
     this.dispatchHistory.rehydrate();
     this.lastStuckRecoveryKey = null;

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -520,9 +520,33 @@ export function getRecentUnitKeysForWorker(
 export function getRecentUnitKeysForProjectRoot(
   projectRootRealpath: string,
   limit = 20,
+  traceId?: string,
 ): Array<{ key: string }> {
   if (!isDbAvailable()) return [];
   const db = _getAdapter()!;
+  // When a trace_id is provided, scope the window to the current session so
+  // stale finalize-retry entries from PREVIOUS sessions don't fire detectStuck
+  // Rule 1 on the first iteration of a new session — killing auto-mode before
+  // any new dispatch runs. Without this, a project that had two consecutive
+  // finalize-retry failures in a prior session is permanently stuck: every
+  // fresh session loads those stale errors and immediately declares stuck.
+  if (traceId) {
+    const rows = db.prepare(
+      `SELECT ud.unit_type, ud.unit_id
+       FROM unit_dispatches ud
+       INNER JOIN workers w ON w.worker_id = ud.worker_id
+       WHERE w.project_root_realpath = :project_root_realpath
+         AND w.status != 'crashed'
+         AND ud.trace_id = :trace_id
+       ORDER BY ud.started_at DESC, ud.id DESC
+       LIMIT :limit`,
+    ).all({
+      ":project_root_realpath": projectRootRealpath,
+      ":trace_id": traceId,
+      ":limit": limit,
+    }) as Array<{ unit_type: string; unit_id: string }>;
+    return rows.reverse().map((r) => ({ key: `${r.unit_type}/${r.unit_id}` }));
+  }
   const rows = db.prepare(
     `SELECT ud.unit_type, ud.unit_id
      FROM unit_dispatches ud

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -920,15 +920,21 @@ test("stuck-loop: stop('user-request') resets the ring (hard stop)", async (t) =
   assert.equal(next.kind, "advanced");
 });
 
-test("stuck-loop #482 regression: start() rehydrates the window from the dispatch ledger so cross-session re-dispatch loops are detected", async (t) => {
+test("stuck-loop #852 fix: start() does NOT rehydrate so prior-session failures cannot false-positive on a fresh session", async (t) => {
   const f = makeFixture();
   t.after(() => f.cleanup());
 
-  // Simulate a PRIOR session: the dispatch ledger recorded the same unit
-  // being re-dispatched repeatedly without progress. The orchestrator under test is a
-  // fresh instance (as it would be after a session restart) — before the
-  // Dispatch History module, start() reset the window to [] and the loop
-  // would silently re-dispatch the unit forever (#482: 146 re-dispatches).
+  // Simulate a PRIOR session: STUCK_WINDOW_SIZE-1 consecutive dispatches of
+  // the same unit, all failed. Before #852 was fixed, start() would rehydrate
+  // these stale entries and the very next advance() would declare stuck —
+  // killing the new session before a single dispatch ran. The fix: start()
+  // clears the window WITHOUT rehydrating, so prior-session failures are
+  // invisible to the fresh session.
+  //
+  // Cross-session stuck detection is preserved by resume() (which rehydrates
+  // when the window is empty after a crash) and by within-session accumulation
+  // (STUCK_WINDOW_SIZE dispatches of the same unit within one session still
+  // trigger stuck detection). See the resume() test below.
   const worker = registerAutoWorker({ projectRootRealpath: normalizeRealPath(f.base) });
   const lease = claimMilestoneLease(worker, "M001");
   assert.equal(lease.ok, true);
@@ -950,13 +956,10 @@ test("stuck-loop #482 regression: start() rehydrates the window from the dispatc
   const started = await f.orchestrator.start(SESSION_CONTEXT);
   assert.equal(started.kind, "started");
 
-  // The very next decision for the same unit must trip the stuck verdict
-  // instead of advancing.
+  // The fresh session must advance past the prior-session history: window is
+  // empty after start(), so the first advance dispatches normally.
   const result = await f.orchestrator.advance();
-  assert.equal(result.kind, "blocked");
-  if (result.kind !== "blocked") return;
-  assert.equal(result.action, "stop");
-  assert.ok(result.reason.startsWith("stuck-loop:"), `expected stuck-loop reason, got: ${result.reason}`);
+  assert.equal(result.kind, "advanced", "fresh session must not be blocked by stale prior-session dispatch history");
 });
 
 test("stuck-loop #482: resume() with an empty window rehydrates from the dispatch ledger", async (t) => {

--- a/src/resources/extensions/gsd/tests/dispatch-history.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-history.test.ts
@@ -326,3 +326,105 @@ test("rehydrate degrades to an empty window without a scope or ledger", () => {
   assert.equal(noDb.rehydrate(), 0);
   assert.equal(noDb.getRecentWindow().length, 0);
 });
+
+// ─── Session-scoped rehydration (#852) ───────────────────────────────────────
+//
+// Without session scoping, two consecutive finalize-retry failures from a
+// PREVIOUS session persist in unit_dispatches and are loaded into the
+// DispatchHistory window on the NEXT session's start() → rehydrate() call.
+// The first advance's recordDispatch fills the window (matchingCount >=
+// STUCK_WINDOW_SIZE) and detectStuck Rule 1 fires immediately, killing
+// auto-mode before any new unit runs. The resolveTraceId option scopes
+// rehydrate() to the current session so only that session's dispatches
+// populate the window.
+
+test("#852: rehydrate with resolveTraceId ignores prior-session entries (empty window on fresh session)", (t) => {
+  const f = makeLedgerFixture(t);
+
+  // Prior session: six consecutive finalize-retry failures for the same unit.
+  // recordDispatchClaim uses the trace_id from the fixture's claim() helper
+  // (random per-iteration). We insert them directly so we control the trace_id.
+  for (let i = 0; i < STUCK_WINDOW_SIZE; i++) {
+    const claim = recordDispatchClaim({
+      traceId: "prior-session-trace-id",
+      workerId: f.worker,
+      milestoneLeaseToken: f.token,
+      milestoneId: "M001",
+      unitType: "discuss-milestone",
+      unitId: "M001",
+    });
+    assert.equal(claim.ok, true);
+    if (!claim.ok) return;
+    markFailed(claim.dispatchId, { errorSummary: "finalize-retry" });
+  }
+
+  // Unscoped rehydrate loads all prior entries — the window is full.
+  const unscopedHistory = createDispatchHistory({ resolveScopeId: () => f.base });
+  unscopedHistory.rehydrate();
+  assert.equal(
+    unscopedHistory.getRecentWindow().length,
+    STUCK_WINDOW_SIZE,
+    "unscoped rehydrate sees prior-session entries",
+  );
+
+  // New session: rehydrate scoped to a fresh trace_id that has never been
+  // written to unit_dispatches → 0 rows → the window stays empty.
+  const freshTraceId = "new-session-trace-id-never-in-db";
+  const freshHistory = createDispatchHistory({
+    resolveScopeId: () => f.base,
+    resolveTraceId: () => freshTraceId,
+  });
+  const count = freshHistory.rehydrate();
+  assert.equal(count, 0, "session-scoped rehydrate excludes prior-session entries");
+  assert.equal(freshHistory.getRecentWindow().length, 0);
+
+  // The first dispatch of the new session should not trigger stuck (window is
+  // empty, so Rule 1/2/3/4 cannot fire on a single-entry window).
+  freshHistory.recordDispatch("discuss-milestone", "M001");
+  assert.equal(
+    freshHistory.detectStuck(),
+    null,
+    "first dispatch in new session must not trigger stuck detection",
+  );
+});
+
+test("#852: rehydrate with resolveTraceId still includes current-session entries", (t) => {
+  const f = makeLedgerFixture(t);
+  const currentTraceId = "current-session-trace";
+
+  // Prior session entry (different trace_id).
+  const oldClaim = recordDispatchClaim({
+    traceId: "old-session-trace",
+    workerId: f.worker,
+    milestoneLeaseToken: f.token,
+    milestoneId: "M001",
+    unitType: "plan-milestone",
+    unitId: "M001",
+  });
+  assert.equal(oldClaim.ok, true);
+  if (oldClaim.ok) markFailed(oldClaim.dispatchId, { errorSummary: "finalize-retry" });
+
+  // Current session entries (matching trace_id).
+  for (let i = 0; i < 2; i++) {
+    const claim = recordDispatchClaim({
+      traceId: currentTraceId,
+      workerId: f.worker,
+      milestoneLeaseToken: f.token,
+      milestoneId: "M001",
+      unitType: "plan-milestone",
+      unitId: "M001",
+    });
+    assert.equal(claim.ok, true);
+    if (!claim.ok) return;
+    markFailed(claim.dispatchId, { errorSummary: "finalize-retry" });
+  }
+
+  // Scoped to current session: only the 2 current entries are loaded.
+  const history = createDispatchHistory({
+    resolveScopeId: () => f.base,
+    resolveTraceId: () => currentTraceId,
+  });
+  const count = history.rehydrate();
+  assert.equal(count, 2, "session-scoped rehydrate includes current-session entries");
+  assert.equal(history.getRecentWindow().length, 2);
+});

--- a/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
@@ -130,6 +130,91 @@ test("getRecentUnitKeysForProjectRoot restores compound keys used by stuck detec
   assert.match(result?.reason ?? "", /3 consecutive times/);
 });
 
+// ── #852: stuck window must be scoped to the current session (trace_id) ───────
+//
+// Without trace_id scoping, two consecutive finalize-retry failures from a
+// PREVIOUS session persist in unit_dispatches and fire detectStuck Rule 1 on
+// the first iteration of every new session — killing auto-mode before any new
+// dispatch runs. The trace_id filter ensures only the current session's
+// dispatches populate the window.
+
+test("#852: getRecentUnitKeysForProjectRoot scoped to trace_id ignores prior-session entries", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M015", title: "T", status: "active" });
+  const worker = registerAutoWorker({ projectRootRealpath: base });
+  const lease = claimMilestoneLease(worker, "M015");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) return;
+
+  // PRIOR session: two consecutive finalize-retry failures (trace_id = "old").
+  for (let i = 0; i < 2; i++) {
+    const claim = recordDispatchClaim({
+      traceId: "old-session",
+      workerId: worker,
+      milestoneLeaseToken: lease.token,
+      milestoneId: "M015",
+      unitType: "discuss-milestone",
+      unitId: "M015",
+    });
+    assert.equal(claim.ok, true);
+    if (!claim.ok) return;
+    markFailed(claim.dispatchId, { errorSummary: "finalize-retry" });
+  }
+
+  // NEW session (trace_id = "new") has dispatched nothing yet.
+  // Without the trace_id filter, the window loads the two stale "old-session"
+  // finalize-retry entries → detectStuck Rule 1 fires immediately.
+  const unscopedWindow = getRecentUnitKeysForProjectRoot(base, 20);
+  assert.equal(unscopedWindow.length, 2, "unscoped window sees prior-session entries");
+
+  // With the trace_id filter, the new session's window is empty — no false stuck.
+  const scopedWindow = getRecentUnitKeysForProjectRoot(base, 20, "new-session");
+  assert.equal(scopedWindow.length, 0, "trace_id-scoped window excludes prior-session entries");
+
+  // detectStuck on an empty window returns null (not stuck).
+  assert.equal(detectStuck(scopedWindow), null);
+});
+
+test("#852: getRecentUnitKeysForProjectRoot trace_id filter still includes current-session entries", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M016", title: "T", status: "active" });
+  const worker = registerAutoWorker({ projectRootRealpath: base });
+  const lease = claimMilestoneLease(worker, "M016");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) return;
+
+  // Prior session entries.
+  const oldClaim = recordDispatchClaim({
+    traceId: "prior", workerId: worker, milestoneLeaseToken: lease.token,
+    milestoneId: "M016", unitType: "plan-milestone", unitId: "M016",
+  });
+  assert.equal(oldClaim.ok, true);
+  if (oldClaim.ok) markFailed(oldClaim.dispatchId, { errorSummary: "finalize-retry" });
+
+  // Current session entries.
+  for (let i = 0; i < 2; i++) {
+    const claim = recordDispatchClaim({
+      traceId: "current", workerId: worker, milestoneLeaseToken: lease.token,
+      milestoneId: "M016", unitType: "plan-milestone", unitId: "M016",
+    });
+    assert.equal(claim.ok, true);
+    if (!claim.ok) return;
+    markFailed(claim.dispatchId, { errorSummary: "finalize-retry" });
+  }
+
+  // Scoped to "current" → only the 2 current-session entries.
+  const scoped = getRecentUnitKeysForProjectRoot(base, 20, "current");
+  assert.equal(scoped.length, 2, "trace_id filter includes current-session entries");
+
+  // Unscoped → 3 (prior + current).
+  const unscoped = getRecentUnitKeysForProjectRoot(base, 20);
+  assert.equal(unscoped.length, 3, "unscoped window includes all sessions");
+});
+
 test("getRecentUnitKeysForWorker honors the limit parameter", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));


### PR DESCRIPTION
## Problem

Auto-mode stops **immediately** (0s) with a bare `finalize-retry` stuck-loop — no warnings, no actual dispatch, the loop never started:

```
stuck-loop: Same error repeated: finalize-retry
Session: $14.67 · 2.70M tokens · 21 units
```

The debug log confirms it: 1 dispatch, 0 finalize events, 932ms total. The stuck detector killed auto-mode before any new unit ran.

## Root cause

`loadStuckState` (`auto/loop.ts:189`) loads the stuck-detection window from `unit_dispatches` **across all sessions** for the project root. The DB still has two consecutive `finalize-retry` failures from a **previous session** (14:36 and 14:37):

```
discuss-milestone|M015|failed|finalize-retry|2026-06-25T14:37:55
discuss-milestone|M015|failed|finalize-retry|2026-06-25T14:36:09
```

`detectStuck` Rule 1 (`same error twice in a row`) fires on these **stale** entries on the first iteration of the new session → kills auto-mode before any new dispatch runs.

This is a **false positive**: the actual bugs that caused those failures are fixed (#863, #865), but the dispatch ledger retains the old error rows, and the stuck window has no session boundary awareness.

## Fix

Scope `getRecentUnitKeysForProjectRoot` to the **current trace_id** (session) when one is available:

```ts
// loop.ts — pass the current session's trace_id
const recentUnits = getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE, s.currentTraceId ?? undefined);

// unit-dispatches.ts — filter by trace_id when provided
if (traceId) {
  // ... AND ud.trace_id = :trace_id
}
```

A new session's window starts **empty** (no dispatches yet for this trace_id), so prior-session failures can't trigger a false stuck verdict. The unscoped path (no trace_id) is preserved for callers without a session context.

## Testing

2 new tests (`stuck-state-via-db.test.ts`):
- **prior-session entries excluded**: two `finalize-retry` failures with trace_id `"old-session"` are invisible when querying with trace_id `"new-session"` → empty window → `detectStuck` returns null
- **current-session entries still included**: entries with the matching trace_id are returned; unscoped query returns all

All 31 stuck-state/detect-stuck tests pass, TypeScript clean.

## Why this is the last layer

The previous PRs fixed the actual failures (#863: path resolution, #865: project-root fallback). This PR fixes the **stale history** those failures left behind — which was independently blocking every new session. After this merge, a fresh session starts with a clean stuck window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows stuck-detection rehydration to the active session; behavior change is intentional and covered by tests, with no auth or data-migration impact.
> 
> **Overview**
> Fixes **false stuck-loop stops** on new auto sessions where `loadStuckState` pulled recent dispatches for the whole project, so prior-session `finalize-retry` failures could trip `detectStuck` before the loop dispatched anything (#852).
> 
> **`getRecentUnitKeysForProjectRoot`** now accepts an optional `trace_id` and filters `unit_dispatches` to that session when set; the unscoped query is unchanged for callers without a trace. **`loadStuckState`** passes `s.currentTraceId` into that helper (or seeds an empty window when no trace is set).
> 
> Adds two DB regression tests covering exclusion of prior-session rows and inclusion of the current session’s rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011e5541023246f8d254c0e73ee72b9903f3490f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->