### PR TITLE
fix(auto-artifact-paths): layout-aware filename for ALL dir branches

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -32,12 +32,16 @@ function resolveMilestoneArtifactPath(
 ): string | null {
   const existing = resolveProjectedMilestoneFile(base, mid, suffix) ?? resolveProjectMilestoneFile(base, mid, suffix);
   if (existing) return existing;
-  // Try legacy projected (worktree) path, then legacy project-root path.
-  const legacyDir = resolveProjectedMilestonePath(base, mid) ?? resolveProjectMilestonePath(base, mid);
-  if (legacyDir) return join(legacyDir, `${mid}-${suffix}.md`);
-  // Flat-phase fallback: use resolveMilestonePath which handles phases/ and milestones/.
-  const dir = resolveMilestonePath(base, mid);
+  // Try projected (worktree) path, then project-root path. Both can return
+  // either a legacy (milestones/<MID>/) or flat-phase (phases/NN-slug/) dir.
+  const dir = resolveProjectedMilestonePath(base, mid) ?? resolveProjectMilestonePath(base, mid) ?? resolveMilestonePath(base, mid);
   if (dir) {
+    // The filename depends on the LAYOUT of the resolved directory, not on
+    // which resolver found it. A flat-phase dir (phases/NN-slug/) uses the
+    // phase-number prefix (15-CONTEXT.md); a legacy dir (milestones/<MID>/)
+    // uses the milestone-id prefix (M015-CONTEXT.md). Building the wrong
+    // filename for the resolved dir produces existsSync-false paths that trap
+    // the unit in a finalize-retry loop (#852).
     const legacyBase = legacyMilestonesDir(base);
     const isLegacy = dir.startsWith(legacyBase + "/") || dir.startsWith(legacyBase + "\\");
     const phaseNum = milestoneIdToPhaseNum(mid);
@@ -47,6 +51,20 @@ function resolveMilestoneArtifactPath(
     return join(dir, filename);
   }
   return null;
+}
+
+/**
+ * Build the layout-aware filename for a milestone artifact suffix.
+ * Exported so other callers (e.g. verification diagnostics) use the same
+ * naming policy: flat-phase dirs use the phase-number prefix (15-CONTEXT.md),
+ * legacy dirs use the milestone-id prefix (M015-CONTEXT.md).
+ */
+export function buildMilestoneArtifactFilename(mid: string, suffix: string, dir: string, legacyBase: string): string {
+  const isLegacy = dir.startsWith(legacyBase + "/") || dir.startsWith(legacyBase + "\\");
+  const phaseNum = milestoneIdToPhaseNum(mid);
+  return isLegacy
+    ? `${mid}-${suffix}.md`
+    : `${String(phaseNum).padStart(2, "0")}-${suffix}.md`;
 }
 
 function resolveSliceArtifactPath(

--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -43,7 +43,10 @@ function resolveMilestoneArtifactPath(
     // filename for the resolved dir produces existsSync-false paths that trap
     // the unit in a finalize-retry loop (#852).
     const legacyBase = legacyMilestonesDir(base);
-    const isLegacy = dir.startsWith(legacyBase + "/") || dir.startsWith(legacyBase + "\\");
+    const projectLegacyBase = join(gsdRoot(base), "milestones");
+    const isLegacy =
+      dir.startsWith(legacyBase + "/") || dir.startsWith(legacyBase + "\\")
+      || dir.startsWith(projectLegacyBase + "/") || dir.startsWith(projectLegacyBase + "\\");
     const phaseNum = milestoneIdToPhaseNum(mid);
     const filename = isLegacy
       ? `${mid}-${suffix}.md`

--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -13,7 +13,6 @@ import {
   resolveMilestonePath,
   resolveMilestoneFile,
   resolveSliceFile,
-  legacyMilestonesDir,
   relMilestoneFile,
   relSliceFile,
   buildTaskFileName,
@@ -23,7 +22,7 @@ import {
 } from "./paths.js";
 import { milestoneIdToPhaseNum } from "./layout-policy.js";
 import { parseUnitId } from "./unit-id.js";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 function resolveMilestoneArtifactPath(
   base: string,
@@ -42,11 +41,17 @@ function resolveMilestoneArtifactPath(
     // uses the milestone-id prefix (M015-CONTEXT.md). Building the wrong
     // filename for the resolved dir produces existsSync-false paths that trap
     // the unit in a finalize-retry loop (#852).
-    const legacyBase = legacyMilestonesDir(base);
-    const projectLegacyBase = join(gsdRoot(base), "milestones");
-    const isLegacy =
-      dir.startsWith(legacyBase + "/") || dir.startsWith(legacyBase + "\\")
-      || dir.startsWith(projectLegacyBase + "/") || dir.startsWith(projectLegacyBase + "\\");
+    //
+    // Layout is determined structurally from the resolved directory's parent
+    // segment name, NOT by comparing against a root-anchored legacyMilestonesDir
+    // base path. On a canonical worktree (<project>/.gsd-worktrees/M001/),
+    // legacyMilestonesDir uses gsdProjectionRoot (the worktree .gsd) while
+    // resolveProjectMilestonePath uses gsdRoot (the project .gsd) — two
+    // different roots. A dir returned by resolveProjectMilestonePath would
+    // fail the startsWith check against the worktree root and incorrectly
+    // produce a flat-phase filename for a legacy directory (#bugbot c5ee8eba).
+    const parentDir = dirname(dir);
+    const isLegacy = parentDir.endsWith("/milestones") || parentDir.endsWith("\\milestones");
     const phaseNum = milestoneIdToPhaseNum(mid);
     const filename = isLegacy
       ? `${mid}-${suffix}.md`
@@ -61,9 +66,15 @@ function resolveMilestoneArtifactPath(
  * Exported so other callers (e.g. verification diagnostics) use the same
  * naming policy: flat-phase dirs use the phase-number prefix (15-CONTEXT.md),
  * legacy dirs use the milestone-id prefix (M015-CONTEXT.md).
+ *
+ * Layout is determined structurally: dirs whose immediate parent is named
+ * "milestones" are legacy; all others are flat-phase. This avoids the
+ * root-path ambiguity between gsdProjectionRoot (worktree .gsd) and gsdRoot
+ * (project .gsd) that caused wrong filenames on canonical worktrees.
  */
-export function buildMilestoneArtifactFilename(mid: string, suffix: string, dir: string, legacyBase: string): string {
-  const isLegacy = dir.startsWith(legacyBase + "/") || dir.startsWith(legacyBase + "\\");
+export function buildMilestoneArtifactFilename(mid: string, suffix: string, dir: string): string {
+  const parentDir = dirname(dir);
+  const isLegacy = parentDir.endsWith("/milestones") || parentDir.endsWith("\\milestones");
   const phaseNum = milestoneIdToPhaseNum(mid);
   return isLegacy
     ? `${mid}-${suffix}.md`

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -246,3 +246,67 @@ test("resolveProjectMilestonePath ignores META-only dir even when phases/ has no
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// ── #852: flat-phase dir must get flat-phase filename, not legacy ─────────────
+//
+// The most insidious variant: resolveProjectedMilestonePath found the correct
+// flat-phase directory (phases/15-m015/), but the old code at line 37 built
+// the LEGACY filename (M015-CONTEXT.md) unconditionally — producing
+// existsSync-false for phases/15-m015/M015-CONTEXT.md. The file is named
+// 15-CONTEXT.md. This test guards the layout-aware filename for ALL branches.
+
+test("flat-phase worktree dir resolves to 15-CONTEXT.md not M015-CONTEXT.md (#852)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-filename-layout-")));
+  try {
+    const gsd = join(root, ".gsd");
+    // Flat-phase layout: phases/15-m015/ with the correctly-named file.
+    const phaseDir = join(gsd, "phases", "15-m015");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "15-CONTEXT.md"), "# M015 context\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("discuss-milestone", "M015", root);
+
+    // MUST use the flat-phase filename, not the legacy one.
+    assert.equal(
+      resolved,
+      join(phaseDir, "15-CONTEXT.md"),
+      "flat-phase dir must use 15-CONTEXT.md (phase-number prefix)",
+    );
+    assert.notEqual(
+      resolved,
+      join(phaseDir, "M015-CONTEXT.md"),
+      "must NOT use M015-CONTEXT.md (legacy milestone-id prefix) for a flat-phase dir",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("flat-phase project-root dir resolves to 15-ROADMAP.md not M015-ROADMAP.md (#852)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-filename-roadmap-")));
+  try {
+    const gsd = join(root, ".gsd");
+    const phaseDir = join(gsd, "phases", "16-m016");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "16-ROADMAP.md"), "# M016 roadmap\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("plan-milestone", "M016", root);
+    assert.equal(
+      resolved,
+      join(phaseDir, "16-ROADMAP.md"),
+      "flat-phase dir must use 16-ROADMAP.md (phase-number prefix)",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -310,3 +310,52 @@ test("flat-phase project-root dir resolves to 15-ROADMAP.md not M015-ROADMAP.md 
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// ── Bugbot c5ee8eba: canonical worktree + project-root legacy dir ─────────────
+//
+// On a canonical worktree (<project>/.gsd-worktrees/M001/):
+//   - legacyMilestonesDir(base) uses gsdProjectionRoot → <project>/.gsd-worktrees/M001/.gsd/milestones
+//   - resolveProjectMilestonePath(base) uses gsdRoot → <project>/.gsd/milestones/M001/
+//
+// These are different paths. When there is no flat-phase dir in the worktree
+// but a legacy milestones/<MID>/ dir exists at the project root, the old code
+// compared the project-root dir against the worktree legacyBase — a mismatch
+// — so isLegacy was false and the flat-phase filename "01-ROADMAP.md" was
+// built instead of "M001-ROADMAP.md". The file-not-found loop follows.
+
+test("canonical worktree + project-root legacy dir produces legacy filename (#bugbot c5ee8eba)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-canonical-wt-legacy-")));
+  try {
+    // Project-root legacy milestone dir with some content (not just META).
+    const projectLegacyDir = join(root, ".gsd", "milestones", "M001");
+    mkdirSync(projectLegacyDir, { recursive: true });
+    // Write CONTEXT but NOT ROADMAP — forces the dir-resolution cold path for ROADMAP.
+    writeFileSync(join(projectLegacyDir, "M001-CONTEXT.md"), "# M001 context\n");
+
+    // Canonical worktree: <project>/.gsd-worktrees/M001/.gsd/ (no phases dir).
+    const wtRoot = join(root, ".gsd-worktrees", "M001");
+    mkdirSync(join(wtRoot, ".gsd"), { recursive: true });
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("plan-milestone", "M001", wtRoot);
+
+    // Must use the legacy milestone-id prefix (M001-ROADMAP.md), not the
+    // flat-phase phase-number prefix (01-ROADMAP.md).
+    assert.equal(
+      resolved,
+      join(projectLegacyDir, "M001-ROADMAP.md"),
+      "canonical worktree + project-root legacy dir must use M001-ROADMAP.md",
+    );
+    assert.notEqual(
+      resolved,
+      join(projectLegacyDir, "01-ROADMAP.md"),
+      "must NOT produce flat-phase filename 01-ROADMAP.md for a legacy milestones/ dir",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

The `finalize-retry` loop persists with a new path mismatch — the directory is correct (flat-phase) but the filename is legacy:

```
verify-fail discuss-milestone M015: existsSync false for
  .../.gsd-worktrees/M015/.gsd/phases/15-m015/M015-CONTEXT.md
```

Note: `phases/15-m015/` is the **correct flat-phase directory**, but `M015-CONTEXT.md` is the **legacy filename** (should be `15-CONTEXT.md`).

## Root cause

`resolveMilestoneArtifactPath` had two branches that resolved a directory then built a filename:

```ts
// Branch 1 (line 36-37): the BUG — blindly uses legacy filename
const legacyDir = resolveProjectedMilestonePath(base, mid) ?? resolveProjectMilestonePath(base, mid);
if (legacyDir) return join(legacyDir, `${mid}-${suffix}.md`);  // ← ALWAYS M015- prefix

// Branch 2 (line 38-47): layout-aware — correct
const dir = resolveMilestonePath(base, mid);
if (dir) {
  const isLegacy = dir.startsWith(legacyBase + "/");
  const filename = isLegacy ? `${mid}-${suffix}.md` : `${phaseNum}-${suffix}.md`;  // ← checks layout
}
```

`resolveProjectedMilestonePath` (the **worktree** resolver) correctly found `phases/15-m015/` (a flat-phase dir). But Branch 1 blindly built the legacy filename `M015-CONTEXT.md` without checking the layout → `existsSync false for phases/15-m015/M015-CONTEXT.md`.

This is the 4th distinct filename/path bug in this function. The prior fixes (#858, #863) addressed the *directory* resolution; this one addresses the *filename* built for a correctly-resolved directory.

## Fix

Unify both branches into a single directory resolution chain with ONE layout-aware filename builder:

```ts
const dir = resolveProjectedMilestonePath(base, mid)
  ?? resolveProjectMilestonePath(base, mid)
  ?? resolveMilestonePath(base, mid);
if (dir) {
  const isLegacy = dir.startsWith(legacyBase + "/");
  const filename = isLegacy ? `${mid}-${suffix}.md` : `${phaseNum}-${suffix}.md`;
  return join(dir, filename);
}
```

The filename now **always** matches the layout of the resolved directory, regardless of which resolver found it.

## Testing

2 new tests:
- **flat-phase worktree dir** → resolves to `15-CONTEXT.md` (not `M015-CONTEXT.md`)
- **flat-phase project-root dir** → resolves to `16-ROADMAP.md` (not `M016-ROADMAP.md`)

All 31 artifact-path/verify/flat-phase tests pass, TypeScript clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auto-mode artifact verification paths; wrong naming would still break workflow finalization, but change is narrowly scoped with targeted regression tests.
> 
> **Overview**
> Fixes **finalize-retry loops** where artifact verification looked in the right flat-phase folder (`phases/15-m015/`) but used a **legacy filename** (`M015-CONTEXT.md` instead of `15-CONTEXT.md`), so `existsSync` always failed.
> 
> **`resolveMilestoneArtifactPath`** now resolves the directory through a single chain (`resolveProjectedMilestonePath` → `resolveProjectMilestonePath` → `resolveMilestonePath`) and **always** picks the filename from the directory layout (legacy `M015-*` vs flat-phase `15-*`). Legacy detection also treats project-root `.gsd/milestones/` like worktree legacy bases.
> 
> Exports **`buildMilestoneArtifactFilename`** so verification/diagnostics can share the same naming rule. Adds two regression tests for flat-phase CONTEXT and ROADMAP paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf92f25e3a60e94598bdff0dbfbd6c2834d9db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->