### PR TITLE
fix(issue): [Bug]: Reorder Milestones does not effect /gsd

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -187,6 +187,7 @@ sequence                INTEGER DEFAULT 0                  ← V23
 ```
 - Index: `idx_milestones_status` (status)
 - Status values: `active`, `closed`, `queued`
+- `sequence` is the canonical DB ordering used to choose the next open milestone. `.gsd/QUEUE-ORDER.json` is the durable operator reorder contract for `/gsd rethink` and `/gsd phase`; when present, state derivation mirrors that file into `milestones.sequence` before dispatch.
 
 ---
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -31,6 +31,8 @@ vscode-extension/         VS Code extension — chat participant (@gsd), sidebar
 
 GSD stores runtime workflow state in the project-root SQLite database. Auto mode derives phases, completion status, requirements, decisions, summaries, and hierarchy from that database, then renders markdown projections in `.gsd/` for human review, prompt context, and git-friendly history. No in-memory state survives across sessions. This enables crash recovery, multi-terminal steering, and session resumption while avoiding silent markdown re-imports during normal runtime.
 
+Milestone queue position has one explicit file contract: `.gsd/QUEUE-ORDER.json`. `/gsd rethink` and `/gsd phase` use it as a durable reorder record, and state derivation mirrors that order into `milestones.sequence` before selecting the active milestone. Other generated `.gsd` artifacts remain projections unless an explicit import or recovery command reads them.
+
 ### Two-File Loader Pattern
 
 `loader.ts` sets all environment variables with zero SDK imports, then dynamically imports `cli.ts` which does static SDK imports. This ensures `PI_PACKAGE_DIR` is set before any SDK code evaluates.
@@ -157,7 +159,7 @@ Model routing (complexity classification, budget pressure, routing history, capa
 | `visualizer-data.ts` | Data loading for visualizer tabs, including active memory-store rows |
 | `visualizer-views.ts` | Tab renderers (progress, timeline, deps, metrics, health, agent, changes, knowledge, memories, captures, export) |
 | `metrics.ts` | Token and cost tracking ledger |
-| `state.ts` | DB-authoritative state derivation with explicit legacy markdown fallback for tests/recovery |
+| `state.ts` | DB-authoritative state derivation with explicit legacy markdown fallback for tests/recovery, plus QUEUE-ORDER.json replay into milestone sequence |
 | `session-lock.ts` | OS-level exclusive session locking (proper-lockfile) |
 | `crash-recovery.ts` | Lock file management for crash detection and recovery |
 | `guidance.ts` | Single catalog mapping typed findings (recovery kinds, milestone blockers, doctor issue codes, crash unit classes) to user-facing remediation prose |
@@ -169,7 +171,7 @@ Model routing (complexity classification, budget pressure, routing history, capa
 | `roadmap-slices.ts` | Roadmap parser with prose fallback for LLM-generated variants |
 | `memory-extractor.ts` | Extract reusable knowledge from session transcripts |
 | `memory-store.ts` | Persistent memory store for cross-session knowledge |
-| `queue-order.ts` | Milestone queue ordering |
+| `queue-order.ts` | Durable milestone queue ordering contract and DB sequence mirroring |
 | `context-masker.ts` | Context masking for model routing optimization |
 | `phase-anchor.ts` | Phase anchoring for dispatch pipeline |
 | `slice-parallel-orchestrator.ts` | Slice-level parallelism with dependency-aware dispatch |

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -56,6 +56,8 @@ See also:
    auto.ts loop ──► back to auto-dispatch.ts
 ```
 
+`QUEUE-ORDER.json` is the exception to the usual generated-artifact projection rule. `/gsd rethink` and related phase-management flows write it as the durable milestone reorder contract, and state derivation mirrors it into `milestones.sequence` before dispatch so stale DB sequence can be repaired without importing arbitrary markdown projections.
+
 ---
 
 ## 2. Prompt → DB Read/Write Reference
@@ -122,7 +124,7 @@ Each row = one prompt file. Columns show which DB tables it touches and how.
 | Prompt | DB Reads | DB Writes | Disk Artifact Written |
 |--------|----------|-----------|----------------------|
 | `replan-slice` | slices, tasks | slices, tasks, replan_history, quality_gates | S##-PLAN.md, S##-REPLAN.md |
-| `rethink` | milestones, slices, artifacts | slices (UPDATE status=skipped), milestones (UPDATE sequence) | QUEUE-ORDER.json, PARKED.md |
+| `rethink` | milestones, slices, artifacts | slices (UPDATE status=skipped), milestones (UPDATE sequence; repaired from QUEUE-ORDER.json during state derivation) | QUEUE-ORDER.json, PARKED.md |
 | `rewrite-docs` | decisions, requirements, artifacts | decisions, requirements, artifacts | DECISIONS.md, REQUIREMENTS.md, task/slice plans |
 | `doctor-heal` | slices, tasks, artifacts | artifacts (repair CONTEXT/SUMMARY/UAT) | repairs existing artifacts |
 | `review-migration` | milestones, slices, tasks, artifacts, decisions, requirements | — (read-only audit) | — |

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -247,7 +247,7 @@ complete-milestone
 | Prompt | Purpose | Key Tools Called |
 |--------|---------|-----------------|
 | `replan-slice.md` | Replan after blocker discovered mid-slice. Preserves completed tasks. | `gsd_replan_slice` |
-| `rethink.md` | Reorder, park, unpark, skip, or discard milestones. | `gsd_skip_slice`, writes `QUEUE-ORDER.json` |
+| `rethink.md` | Reorder, park, unpark, skip, or discard milestones. | `gsd_skip_slice`, writes `QUEUE-ORDER.json` as the durable reorder contract; state derivation mirrors it into DB sequence |
 | `worktree-merge.md` | Merge a worktree branch into a target branch from the main tree. | git merge (main tree CWD) |
 | `reassess-roadmap.md` | *(see Completion Flow above)* | — |
 | `rewrite-docs.md` | Apply OVERRIDES.md changes across all planning docs. | — |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -42,6 +42,8 @@ The SQLite database is the runtime source of truth for milestones, slices, tasks
 
 Markdown files in `.gsd/` are rendered projections for review, prompts, and git-friendly history. `.gsd/DECISIONS.md` is projected from architecture memories, and the Patterns/Lessons sections of `.gsd/KNOWLEDGE.md` are projected from memory rows; editing those projections does not override the database unless a command imports or saves the change through GSD. The Rules section of `KNOWLEDGE.md` remains manually authored and is preserved separately.
 
+`.gsd/QUEUE-ORDER.json` is the special durable reorder contract for milestone queue order. Commands such as `/gsd rethink` and `/gsd phase` write it when an operator reorders milestones; when the runtime database is open, GSD mirrors that order into `milestones.sequence`. State derivation also replays an existing `QUEUE-ORDER.json` into the database before choosing the active milestone, which repairs stale DB sequence for prompt-driven reorder flows without making arbitrary markdown projections runtime authority.
+
 In worktree mode, the project-root database remains authoritative runtime state, while artifact/projection writes render under the active worktree-local `.gsd/`. Those worktree markdown projections are not treated as runtime state fallbacks. If the database is unavailable, runtime state derivation refuses to silently rebuild from markdown. Use explicit recovery/import commands, or run `/gsd migrate` when markdown is the intended source.
 
 ### Single-Host Runtime Constraint

--- a/src/resources/extensions/gsd/queue-order.ts
+++ b/src/resources/extensions/gsd/queue-order.ts
@@ -64,8 +64,9 @@ export function loadQueueOrder(basePath: string): string[] | null {
 }
 
 /**
- * Save a custom queue order. The DB sequence is canonical when a DB
- * connection is open; QUEUE-ORDER.json remains a compatibility projection.
+ * Save a custom queue order. When the DB connection is open, mirror the order
+ * into milestone sequence; QUEUE-ORDER.json remains the durable file contract
+ * for prompt-driven flows such as /gsd rethink.
  */
 export function saveQueueOrder(basePath: string, order: string[]): void {
   if (isDbAvailable()) {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -67,6 +67,7 @@ import {
   getRequirementCounts,
   getLatestAssessmentByScope,
   getPendingGateCountForTurn,
+  setMilestoneQueueOrder,
 } from './gsd-db.js';
 import { openExistingWorkflowDatabase, wasWorkflowDatabaseOpenAttempted } from './db-workspace.js';
 import { formatCompletePhaseNextAction, countUnmappedActiveRequirements } from './requirements-backlog.js';
@@ -269,9 +270,21 @@ export function invalidateStateCache(): void {
   _stateCache = null;
 }
 
+function syncQueueOrderProjectionToDb(basePath: string): void {
+  const queueOrder = loadQueueOrder(basePath);
+  if (!queueOrder) return;
+
+  const currentIds = getAllMilestones().map((m) => m.id);
+  const desiredIds = sortByQueueOrder(currentIds, queueOrder);
+  if (currentIds.length === desiredIds.length && currentIds.every((id, i) => id === desiredIds[i])) return;
+
+  setMilestoneQueueOrder(queueOrder);
+}
+
 function ensureExistingWorkflowDbOpen(basePath: string): boolean {
-  if (isDbAvailable()) return true;
-  return openExistingWorkflowDatabase(basePath).ok;
+  const opened = isDbAvailable() || openExistingWorkflowDatabase(basePath).ok;
+  if (opened) syncQueueOrderProjectionToDb(basePath);
+  return opened;
 }
 
 function buildDbUnavailableState(): GSDState {
@@ -319,6 +332,7 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
 
   // DB-first: query milestones table for the first non-complete, non-parked milestone
   if (isDbAvailable()) {
+    syncQueueOrderProjectionToDb(basePath);
     const allMilestones = getAllMilestones();
     if (allMilestones.length > 0) {
       for (const m of allMilestones) {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -278,7 +278,7 @@ function syncQueueOrderProjectionToDb(basePath: string): void {
   const desiredIds = sortByQueueOrder(currentIds, queueOrder);
   if (currentIds.length === desiredIds.length && currentIds.every((id, i) => id === desiredIds[i])) return;
 
-  setMilestoneQueueOrder(queueOrder);
+  setMilestoneQueueOrder(desiredIds);
 }
 
 function ensureExistingWorkflowDbOpen(basePath: string): boolean {

--- a/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
@@ -58,7 +58,7 @@ function activeRequirement(id: string): Requirement {
   };
 }
 
-test("DB authority: PROJECT.md and QUEUE-ORDER projections do not choose runtime milestone", async (t) => {
+test("DB authority: PROJECT.md projection does not create runtime milestones from QUEUE-ORDER", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
 

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -20,6 +20,7 @@ import {
   insertRequirement,
   insertSlice,
   insertTask,
+  getAllMilestones,
   setMilestoneQueueOrder,
   transaction,
   updateTaskStatus,
@@ -445,11 +446,10 @@ describe('derive-state-helpers', () => {
     }
   });
 
-  // ─── Queue order: DB sequence is authoritative ─────────────────────
-  test('deriveStateFromDb ignores QUEUE-ORDER.json and uses DB sequence', async () => {
+  // ─── Queue order: explicit file order repairs stale DB sequence ─────
+  test('deriveStateFromDb syncs QUEUE-ORDER.json into DB sequence', async () => {
     const base = createFixtureBase();
     try {
-      // QUEUE-ORDER.json is a projection and should not drive DB derivation.
       const queueOrder = JSON.stringify({ order: ['M003', 'M001', 'M002'], updatedAt: new Date().toISOString() });
       writeFileSync(join(base, '.gsd', 'QUEUE-ORDER.json'), queueOrder);
       writeFile(base, 'milestones/M001/M001-CONTEXT.md', '# M001\n\nContext.');
@@ -466,8 +466,9 @@ describe('derive-state-helpers', () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      assert.equal(state.activeMilestone?.id, 'M002', 'queue-order: DB sequence chooses M002');
-      assert.equal(state.registry[0]?.id, 'M002', 'queue-order: registry[0] follows DB sequence');
+      assert.equal(state.activeMilestone?.id, 'M003', 'queue-order: QUEUE-ORDER.json chooses M003');
+      assert.equal(state.registry[0]?.id, 'M003', 'queue-order: registry[0] follows QUEUE-ORDER.json');
+      assert.deepEqual(getAllMilestones().map(m => m.id), ['M003', 'M001', 'M002'], 'queue-order: DB sequence is repaired');
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -475,6 +475,49 @@ describe('derive-state-helpers', () => {
     }
   });
 
+  // ─── Queue order: milestone absent from file gets explicit sequence (idempotency) ─
+  test('deriveStateFromDb sync is idempotent when a milestone is omitted from QUEUE-ORDER.json', async () => {
+    const base = createFixtureBase();
+    try {
+      // QUEUE-ORDER.json lists only M002 and M001; M003 is absent.
+      const queueOrder = JSON.stringify({ order: ['M002', 'M001'], updatedAt: new Date().toISOString() });
+      writeFileSync(join(base, '.gsd', 'QUEUE-ORDER.json'), queueOrder);
+      writeFile(base, 'milestones/M001/M001-CONTEXT.md', '# M001\n\nContext.');
+      writeFile(base, 'milestones/M002/M002-CONTEXT.md', '# M002\n\nContext.');
+      writeFile(base, 'milestones/M003/M003-CONTEXT.md', '# M003\n\nContext.');
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'First', status: 'active' });
+      insertMilestone({ id: 'M002', title: 'Second', status: 'active' });
+      insertMilestone({ id: 'M003', title: 'Third', status: 'active' });
+      // DB starts with natural order M001→M002→M003 (stale vs the file's M002→M001).
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      // After sync, M002 leads (per file), M003 is appended at the end.
+      assert.equal(state.activeMilestone?.id, 'M002', 'omitted-milestone: QUEUE-ORDER.json chooses M002 as active');
+      assert.deepEqual(
+        getAllMilestones().map(m => m.id),
+        ['M002', 'M001', 'M003'],
+        'omitted-milestone: DB sequence is M002, M001, M003 with M003 appended',
+      );
+
+      // Second derive must not re-write the DB (idempotency guard holds).
+      invalidateStateCache();
+      const state2 = await deriveStateFromDb(base);
+      assert.equal(state2.activeMilestone?.id, 'M002', 'omitted-milestone: second derive still picks M002');
+      assert.deepEqual(
+        getAllMilestones().map(m => m.id),
+        ['M002', 'M001', 'M003'],
+        'omitted-milestone: DB sequence unchanged on second call',
+      );
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
   test('setMilestoneQueueOrder can be composed inside a transaction', async () => {
     const base = createFixtureBase();
     try {


### PR DESCRIPTION
## Summary
- Synced queue-order files into DB-backed milestone state and verified syntax/diff checks; focused tests were blocked by missing dependencies and network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #874
- [#874 [Bug]: Reorder Milestones does not effect /gsd](https://github.com/open-gsd/gsd-pi/issues/874)

## User
- @VladimirCores

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/874-bug-reorder-milestones-does-not-effect-g-1782483673`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which milestone auto mode treats as active by rewriting `milestones.sequence` from disk; scope is limited to an existing operator-controlled file and guarded by an idempotent compare-before-write.
> 
> **Overview**
> Fixes milestone reordering not affecting `/gsd` auto dispatch when the DB still had an old `milestones.sequence`.
> 
> **Runtime behavior:** On DB open and before active-milestone selection, `deriveState` / `getActiveMilestoneId` call **`syncQueueOrderProjectionToDb`**, which loads `.gsd/QUEUE-ORDER.json`, sorts known milestone IDs with `sortByQueueOrder`, and updates the DB via `setMilestoneQueueOrder` only when order differs (idempotent). **`saveQueueOrder`** still mirrors writes into the DB when connected; docs now treat the JSON file as the **durable reorder contract** for `/gsd rethink` and `/gsd phase`, not a disposable projection.
> 
> **Docs:** Architecture, auto-mode, db-map, and prompt maps describe this exception to “markdown is projection-only” without making arbitrary `.gsd` files runtime authority.
> 
> **Tests:** Queue-order tests expect the file to drive active milestone and repaired DB sequence; DB-authority regression clarifies that `QUEUE-ORDER` does not invent milestones from `PROJECT.md` alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1216d1d578d84a5d9973b5eabe69805ffb1ad22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->