### PR TITLE
fix(gsd): flat-phase validation-path readers use layout-aware helpers (#876)

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -15,7 +15,7 @@
 
 import type { ExtensionContext, ExtensionAPI } from "@gsd/pi-coding-agent";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { gsdProjectionRoot, resolveSliceFile, resolveSlicePath } from "./paths.js";
+import { gsdProjectionRoot, relMilestoneFile, resolveSliceFile, resolveSlicePath } from "./paths.js";
 import { resolveMilestoneValidationVerdict } from "./milestone-validation-verdict.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { parseUnitId } from "./unit-id.js";
@@ -262,12 +262,10 @@ async function runValidateMilestonePostCheck(
   };
 
   const validationBasePath = resolveCanonicalMilestoneRoot(s.basePath, mid);
-  const validationFile = join(
-    gsdProjectionRoot(validationBasePath),
-    "milestones",
-    mid,
-    `${mid}-VALIDATION.md`,
-  );
+  // Layout-aware: matches the writer at tools/validate-milestone.ts:167.
+  // Flat-phase resolves to phases/NN-slug/NN-VALIDATION.md; legacy resolves
+  // to milestones/MID/MID-VALIDATION.md. See open-gsd/gsd-pi#876.
+  const validationFile = join(validationBasePath, relMilestoneFile(validationBasePath, mid, "VALIDATION"));
   const validationContent = await loadFile(validationFile);
   if (validationContent !== null && validationContent.trim() === "") {
     if (await reassessmentInvalidatedValidation()) {

--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -4,9 +4,8 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { loadFile } from "./files.js";
-import { gsdProjectionRoot, resolveMilestoneFile } from "./paths.js";
+import { resolveMilestoneFile } from "./paths.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
-import { join } from "node:path";
 import { deriveState } from "./state.js";
 import { executeValidateMilestone } from "./tools/workflow-tool-executors.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
@@ -125,22 +124,24 @@ async function loadExistingValidation(
   basePath: string,
   milestoneId: string,
 ): Promise<ExistingValidation | null> {
+  // Layout-aware lookup against the canonical milestone root first (handles the
+  // worktree case via resolveCanonicalMilestoneRoot), then against the raw
+  // basePath if they differ. See open-gsd/gsd-pi#876.
   const canonicalBase = resolveCanonicalMilestoneRoot(basePath, milestoneId);
-  const canonicalValidationPath = join(
-    gsdProjectionRoot(canonicalBase),
-    "milestones",
-    milestoneId,
-    `${milestoneId}-VALIDATION.md`,
-  );
-  const canonicalContent = await loadFile(canonicalValidationPath);
-  if (canonicalContent) {
-    return { content: canonicalContent, source: canonicalValidationPath };
+  const canonicalValidationPath = resolveMilestoneFile(canonicalBase, milestoneId, "VALIDATION");
+  if (canonicalValidationPath) {
+    const canonicalContent = await loadFile(canonicalValidationPath);
+    if (canonicalContent) {
+      return { content: canonicalContent, source: canonicalValidationPath };
+    }
   }
 
-  const validationPath = resolveMilestoneFile(basePath, milestoneId, "VALIDATION");
-  if (validationPath && validationPath !== canonicalValidationPath) {
-    const content = await loadFile(validationPath);
-    if (content) return { content, source: validationPath };
+  if (basePath !== canonicalBase) {
+    const validationPath = resolveMilestoneFile(basePath, milestoneId, "VALIDATION");
+    if (validationPath && validationPath !== canonicalValidationPath) {
+      const content = await loadFile(validationPath);
+      if (content) return { content, source: validationPath };
+    }
   }
 
   await ensureDbOpen(basePath);

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -804,7 +804,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
         code: "all_slices_done_missing_milestone_validation",
         scope: "milestone",
         unitId: milestoneId,
-        message: `All slices are done but ${milestoneId}-VALIDATION.md is missing \u2014 milestone is in validating-milestone phase`,
+        message: `All slices are done but the milestone VALIDATION.md is missing \u2014 milestone is in validating-milestone phase`,
         file: relMilestoneFile(basePath, milestoneId, "VALIDATION"),
         fixable: false,
       });

--- a/src/resources/extensions/gsd/milestone-validation-verdict.ts
+++ b/src/resources/extensions/gsd/milestone-validation-verdict.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
 import { loadFile } from "./files.js";
 import { getLatestAssessmentByScope, isDbAvailable } from "./gsd-db.js";
-import { gsdProjectionRoot } from "./paths.js";
+import { relMilestoneFile } from "./paths.js";
 import {
   extractVerdict,
   isValidMilestoneVerdict,
@@ -68,13 +68,11 @@ export async function resolveMilestoneValidationVerdict(
     if (projectVerdict) return projectVerdict;
   }
 
-  // Last resort: direct canonical projection path even when resolveDir helpers
-  // have not materialized the milestone directory yet.
-  const directPath = join(
-    gsdProjectionRoot(canonicalBase),
-    "milestones",
-    milestoneId,
-    `${milestoneId}-VALIDATION.md`,
-  );
+  // Last resort: layout-aware fallback path when resolveDir helpers
+  // haven't materialized the milestone directory yet. relMilestoneFile()
+  // builds the canonical NN-VALIDATION.md path for flat-phase and the
+  // legacy MID-VALIDATION.md path for projects that haven't migrated.
+  // See open-gsd/gsd-pi#876.
+  const directPath = join(canonicalBase, relMilestoneFile(canonicalBase, milestoneId, "VALIDATION"));
   return verdictFromValidationPath(directPath);
 }

--- a/src/resources/extensions/gsd/tests/flat-phase-validation-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-validation-integration.test.ts
@@ -1,0 +1,120 @@
+// Project/App: gsd-pi
+// File Purpose: End-to-end integration test for the upstream issue #876
+// fix — exercises the actual verdict-resolution code paths against a real
+// on-disk flat-phase project fixture, with no LLM or smoke required.
+//
+// Counterpart to flat-phase-validation-path.test.ts (which tests the
+// path helpers in isolation). This file tests the integrated readers
+// that auto-verification, commands-verdict, and milestone-validation-verdict
+// rely on.
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadFile } from "../files.ts";
+import { resolveMilestoneValidationVerdict } from "../milestone-validation-verdict.ts";
+import { relMilestoneFile } from "../paths.ts";
+
+function makeFlatPhaseFixtureWithPassVerdict(): {
+  basePath: string;
+  cleanup: () => void;
+} {
+  const basePath = mkdtempSync(join(tmpdir(), "flat-phase-validation-int-"));
+  const phaseDir = join(basePath, ".gsd", "phases", "01-foo");
+  mkdirSync(phaseDir, { recursive: true });
+  const validationPath = join(phaseDir, "01-VALIDATION.md");
+  writeFileSync(
+    validationPath,
+    [
+      "---",
+      "verdict: pass",
+      "---",
+      "",
+      "# M001 Validation",
+      "",
+      "All slices verified, all acceptance criteria met.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  return {
+    basePath,
+    cleanup: () => rmSync(basePath, { recursive: true, force: true }),
+  };
+}
+
+test("flat-phase integration: auto-verification reader path loads the on-disk VALIDATION.md (#876)", async () => {
+  // Simulates the exact path construction at auto-verification.ts:264-266
+  // after the Task 2 fix: join(basePath, relMilestoneFile(basePath, mid, "VALIDATION")).
+  // This is the load-bearing reader that was permanently null-returning on
+  // flat-phase projects before the fix.
+  const { basePath, cleanup } = makeFlatPhaseFixtureWithPassVerdict();
+  try {
+    const validationFile = join(
+      basePath,
+      relMilestoneFile(basePath, "M001", "VALIDATION"),
+    );
+    const content = await loadFile(validationFile);
+    assert.ok(
+      content && content.includes("verdict: pass"),
+      "auto-verification reader path must load the flat-phase VALIDATION.md content; received: " +
+        JSON.stringify(content),
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("flat-phase integration: resolveMilestoneValidationVerdict returns 'pass' from disk (#876)", async () => {
+  // Exercises the full verdict-resolution waterfall in
+  // resolveMilestoneValidationVerdict: DB check first (returns undefined
+  // when no DB is open), then canonical/project-root file lookups, then
+  // the last-resort path Task 4 patched. With the fix, at least one of
+  // these branches finds the flat-phase VALIDATION.md and returns "pass".
+  // Pre-fix, the last-resort branch hardcoded milestones/MID/MID-VALIDATION.md
+  // and would miss the flat-phase file.
+  const { basePath, cleanup } = makeFlatPhaseFixtureWithPassVerdict();
+  try {
+    const verdict = await resolveMilestoneValidationVerdict(basePath, "M001");
+    assert.equal(
+      verdict,
+      "pass",
+      "resolveMilestoneValidationVerdict must read the verdict from the flat-phase VALIDATION.md on disk",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("flat-phase integration: pre-fix legacy hardcoded path would have missed this fixture", async () => {
+  // Documents what the bug looked like: the legacy hardcoded reader path
+  // (milestones/MID/MID-VALIDATION.md) does NOT exist in a flat-phase
+  // fixture, so loadFile on it returns null. This is the failure the fix
+  // closes.
+  const { basePath, cleanup } = makeFlatPhaseFixtureWithPassVerdict();
+  try {
+    const legacyHardcoded = join(
+      basePath,
+      ".gsd",
+      "milestones",
+      "M001",
+      "M001-VALIDATION.md",
+    );
+    assert.equal(
+      existsSync(legacyHardcoded),
+      false,
+      "fixture invariant: legacy path must not exist on flat-phase",
+    );
+    const content = await loadFile(legacyHardcoded);
+    assert.equal(
+      content,
+      null,
+      "loadFile on the pre-fix legacy hardcoded path must return null on a flat-phase fixture — this is the bug shape",
+    );
+  } finally {
+    cleanup();
+  }
+});

--- a/src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts
@@ -1,0 +1,74 @@
+// Project/App: gsd-pi
+// File Purpose: Regression test for upstream issue #876 — flat-phase
+// validation-path readers must use layout-aware helpers, not hardcoded
+// legacy paths.
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { relMilestoneFile, resolveMilestoneFile } from "../paths.ts";
+
+function makeFlatPhaseFixture(): { basePath: string; cleanup: () => void } {
+  const basePath = mkdtempSync(join(tmpdir(), "flat-phase-validation-"));
+  const phaseDir = join(basePath, ".gsd", "phases", "01-foo");
+  mkdirSync(phaseDir, { recursive: true });
+  const validationPath = join(phaseDir, "01-VALIDATION.md");
+  writeFileSync(
+    validationPath,
+    [
+      "---",
+      "verdict: pass",
+      "---",
+      "",
+      "# M001 Validation",
+      "",
+      "All slices verified.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  return { basePath, cleanup: () => rmSync(basePath, { recursive: true, force: true }) };
+}
+
+test("flat-phase: relMilestoneFile resolves to the layout-aware path", () => {
+  const { basePath, cleanup } = makeFlatPhaseFixture();
+  try {
+    const rel = relMilestoneFile(basePath, "M001", "VALIDATION");
+    assert.equal(rel, ".gsd/phases/01-foo/01-VALIDATION.md");
+    const abs = join(basePath, rel);
+    assert.equal(existsSync(abs), true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("flat-phase: resolveMilestoneFile finds the on-disk file", () => {
+  const { basePath, cleanup } = makeFlatPhaseFixture();
+  try {
+    const abs = resolveMilestoneFile(basePath, "M001", "VALIDATION");
+    assert.ok(abs, "resolveMilestoneFile must return a path for the flat-phase fixture");
+    assert.equal(abs!.endsWith("/.gsd/phases/01-foo/01-VALIDATION.md"), true);
+    assert.equal(existsSync(abs!), true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("flat-phase: the legacy hardcoded path does NOT resolve (regression for #876)", () => {
+  const { basePath, cleanup } = makeFlatPhaseFixture();
+  try {
+    // This is the path that auto-verification.ts:264-270 used to construct.
+    // It must NOT exist on a flat-phase project — that's the whole bug.
+    const legacyHardcoded = join(basePath, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+    assert.equal(
+      existsSync(legacyHardcoded),
+      false,
+      "legacy hardcoded path must not exist in flat-phase fixture — if it does, the test fixture is wrong",
+    );
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Closes #876.

## Problem

PR #811's flat-phase rename was incomplete: the writer at `tools/validate-milestone.ts:167` correctly emits `phases/NN-slug/NN-VALIDATION.md` via the layout-aware `relMilestoneFile()` helper, but 4 call sites still hardcoded the legacy `milestones/MID/MID-VALIDATION.md` path. Every milestone built via auto-mode on a flat-phase-default project (the default since PR #811) hit the load-bearing `existsSync` at `auto-verification.ts:264-270` returning null, and the milestone was permanently stuck in `verdict: needs-attention` despite holding a valid VALIDATION.md on disk.

## Fix

Routes the 4 readers through the same `relMilestoneFile()` / `resolveMilestoneFile()` helpers the writer already uses:

| File | Change |
| --- | --- |
| `auto-verification.ts:264-270` | **Load-bearing.** Inline path construction now matches the writer pattern at `tools/validate-milestone.ts:167`. |
| `commands-verdict.ts:124-138` | `loadExistingValidation` uses `resolveMilestoneFile` directly instead of a hardcoded canonical-try + helper fallback. |
| `milestone-validation-verdict.ts:73-79` | Last-resort `directPath` is layout-aware. |
| `doctor.ts:807` | User-facing diagnostic message no longer names the legacy-prefix filename. |

## Out of scope (deliberate)

- \`worktree-state-projection.ts:84,92\` — its caller (line 287-288) also hardcodes the legacy \`milestones/MID\` segment, so fixing only the filename layer here would create an asymmetric flat-filename-in-legacy-dir bug. The whole module is gated behind the legacy path layer; on flat-phase projects \`existsSync(legacy-path) === false\` short-circuits before the filename pattern matters. Addressing this requires a wider refactor of the worktree projection module to be layout-aware — file as a follow-up if reviewers want it.
- \`migrate/writer.ts:510\` — legacy → flat-phase migration source writer; legacy naming intentional there.

## Tests

Two new test files in \`src/resources/extensions/gsd/tests/\`:

1. \`flat-phase-validation-path.test.ts\` — helper-level regression witness. 3 tests verify \`relMilestoneFile\` and \`resolveMilestoneFile\` against a flat-phase fixture and document the bug shape (the legacy hardcoded path does not exist on flat-phase).
2. \`flat-phase-validation-integration.test.ts\` — end-to-end integration test. 3 tests exercise the reader code paths against a real on-disk flat-phase fixture (no LLM, no DB).

Targeted suite: **21/21 pass** across \`auto-verification.test.ts\`, \`commands-verdict.test.ts\`, and the two new files.

Broader extension test pack: only the documented pre-existing failures (better-sqlite3 + lazy-pi-tui-import 3-pack) — unchanged from main.

\`pnpm run typecheck:extensions\` — clean. \`pnpm run build:core\` — exit 0.

### A note on regression coverage

A red-green cycle (revert all 4 fix files to \`main\`, re-run the targeted suite) revealed that the new tests are witness/documentation style — they pass against both fix and pre-fix code because layout-aware upstream helpers in \`auto-artifact-paths.ts\` (\`resolveExpectedArtifactPath\` → \`resolveMilestoneArtifactPath\`) absorb the bug shape before reaching Task 4's last-resort branch in \`resolveMilestoneValidationVerdict\`. The genuinely load-bearing fix is \`auto-verification.ts:264-270\`, whose inline path construction doesn't route through those upstream helpers.

A stricter regression test that proves each call-site fix is independently load-bearing would require either a full LLM-driven auto-mode smoke or extracting the inline path construction into a small testable function. I went with the smoke (see below) rather than expanding the patch scope; reviewers can decide whether to push for the refactor as a follow-up.

## End-to-end smoke

I ran a head-to-head smoke against a fresh 1-slice spec (\"Tiny Echo CLI\") using \`gsd headless new-milestone --context SPEC.md --auto\` (\`claude-code/claude-opus-4-7\` planning + \`claude-code/claude-sonnet-4-6\` execution).

| Signal | Smoke 4 (pre-fix, prior session) | This PR's smoke (post-fix) |
| --- | --- | --- |
| VALIDATION.md path | \`phases/01-foo/01-VALIDATION.md\` written + workaround copy at \`M001-VALIDATION.md\` | Single \`phases/01-tiny-echo-cli/01-VALIDATION.md\`, no workaround |
| \`/gsd verdict pass\` manual override | **Yes**, needed to advance past the bug | **No** — 0 occurrences in log |
| \`verdict=needs-attention\` | **Yes** — milestone stuck in \`phase: blocked\` | **No** — 0 occurrences |
| \`[recovery] verify-fail validate-milestone existsSync false\` | **Yes** — the failure mode | **No** — 0 occurrences |
| Phase reached after validation gate | \`blocked\` | \`completing-milestone\` (advanced past the bug) |
| Wall-clock | 1h 56m | 9.7 min |

Verdict file written autonomously by the validator with byte-exact UAT evidence:

\`\`\`yaml
---
verdict: pass
remediation_round: 0
---
# Milestone Validation: M001
## Success Criteria Checklist
- [x] \`tiny-echo.sh\` exists at the project root — Evidence: \`gsd_uat_exec:983...\` ...
- [x] \`tiny-echo.sh\` has the executable bit set (\`+x\`) — Evidence: \`gsd_uat_exec:364...\` (\`test -x\` exit=0) ...
- [x] \`bash tiny-echo.sh foo\` outputs exactly \`hello: foo\n\` — Evidence: xxd hex \`6865 6c6c 6f3a 2066 6f6f 0a\` byte-exact ...
- [x] \`bash tiny-echo.sh\` outputs exactly \`hello: world\n\` — Evidence: xxd hex \`6865 6c6c 6f3a 2077 6f72 6c64 0a\` byte-exact ...
\`\`\`

The autonomous validator successfully wrote a real verdict to the flat-phase path, and the auto-mode reader correctly found it — the exact path the integration tests modeled. The bug is closed.

## A separate finding the smoke surfaced (out of scope here)

The smoke paused at the next gate after validation with a different blocker — \`completing-milestone\` phase, pre-completion-commit guard refusing to close because runtime artifacts (\`.gsd/STATE.md\`, \`.gsd/activity/\`, \`.gsd/audit/\`, \`.gsd/event-log.jsonl\`, \`.gsd/gsd.db\`, \`.gsd/journal/\`, \`.gsd/metrics.json\`, \`.gsd/runtime/\`, \`.gsd/state-manifest.json\`) were written by the validation + close-out phases AFTER the auto-commit that precedes the gate. Same family as the SUMMARY-side close-out, unrelated to #876. I'll file separately if useful.

## Environment

- Built from \`open-gsd/gsd-pi:main @ 1d522472\` (local; equivalent to upstream at the time of merging PR #811's wave).
- Node v22.22.0.
- Smoke dir preserved locally for evidence at \`/tmp/planf3-gsd-resmoke-876/\`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785097905&installation_id=134682257&pr_number=878&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F878&signature=22437f6d614eda8389780638ac4a9bc503035ad7432d1744dda73f1a5179e50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->