### PR TITLE
fix(issue): [Bug]: First-prompt `before_agent_start` runs a serial, un-gated chain of synchronous DB-open, backfills, projections, and scans

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -114,7 +114,17 @@ async function runSessionStartupMaintenanceOnce(
   basePath: string,
   ctx: ExtensionContext,
 ): Promise<boolean> {
-  if (contextMaintenanceCompletedForBasePath.has(basePath)) return false;
+  if (contextMaintenanceCompletedForBasePath.has(basePath)) {
+    // Backfills are session-once, but memory queries and other DB-backed
+    // prompt assembly still need an active adapter on every turn.
+    try {
+      const { ensureDbOpen } = await import("./dynamic-tools.js");
+      await ensureDbOpen(basePath);
+    } catch (e) {
+      logWarning("bootstrap", `project DB open failed: ${(e as Error).message}`);
+    }
+    return false;
+  }
 
   let inFlight = contextMaintenanceInFlightByBasePath.get(basePath);
   const isInitiator = !inFlight;
@@ -293,6 +303,9 @@ export async function buildBeforeAgentStartResult(
   }
 
   const shouldScheduleDeferredMaintenance = await runSessionStartupMaintenanceOnce(basePath, ctx);
+  if (shouldScheduleDeferredMaintenance) {
+    scheduleDeferredContextMaintenance(basePath);
+  }
 
   const { block: knowledgeBlock, globalSizeKb } = loadKnowledgeBlock(gsdHome(), basePath);
   if (globalSizeKb > 4) {
@@ -372,9 +385,6 @@ export async function buildBeforeAgentStartResult(
   });
 
   const contextMessage = buildContextMessage({ memoryBlock, injection, forensicsInjection });
-  if (shouldScheduleDeferredMaintenance) {
-    scheduleDeferredContextMaintenance(basePath);
-  }
 
   return {
     systemPrompt: fullSystem,

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -126,8 +126,10 @@ async function runSessionStartupMaintenanceOnce(
     return false;
   }
 
-  let inFlight = contextMaintenanceInFlightByBasePath.get(basePath);
-  const isInitiator = !inFlight;
+  const existing = contextMaintenanceInFlightByBasePath.get(basePath);
+  const isInitiator = !existing;
+  // Use a definite Promise<boolean> so `await inFlight` has a known return type.
+  let inFlight: Promise<boolean>;
   if (isInitiator) {
     inFlight = performSessionStartupMaintenance(basePath, ctx);
     contextMaintenanceInFlightByBasePath.set(basePath, inFlight);
@@ -136,6 +138,8 @@ async function runSessionStartupMaintenanceOnce(
         contextMaintenanceInFlightByBasePath.delete(basePath);
       }
     });
+  } else {
+    inFlight = existing;
   }
 
   const result = await inFlight;

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -170,8 +170,10 @@ async function performSessionStartupMaintenance(
     runKnowledgeMemoryBackfill(basePath, ctx),
   ]);
 
-  scheduleDeferredContextMaintenance(basePath);
+  // Mark session complete before scheduling deferred work so any concurrent
+  // caller that observes the completed state does not re-enter maintenance.
   contextMaintenanceCompletedForBasePath.add(basePath);
+  scheduleDeferredContextMaintenance(basePath);
   return true;
 }
 

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -28,6 +28,9 @@ const DEFAULT_CODEBASE_MAX_CHARS = 8_000;
 const MIN_CONTEXT_MESSAGE_MAX_CHARS = 1_000;
 const MIN_KNOWLEDGE_MAX_CHARS = 1_000;
 
+const contextMaintenanceStartedForBasePath = new Set<string>();
+const deferredContextMaintenanceByBasePath = new Map<string, Promise<void>>();
+
 /**
  * Bundled skill triggers — resolved dynamically at runtime instead of
  * hardcoding absolute paths in the system prompt template. Only skills
@@ -106,6 +109,119 @@ function warnDeprecatedAgentInstructions(): void {
   }
 }
 
+async function runSessionStartupMaintenanceOnce(
+  basePath: string,
+  ctx: ExtensionContext,
+): Promise<boolean> {
+  if (contextMaintenanceStartedForBasePath.has(basePath)) return false;
+  contextMaintenanceStartedForBasePath.add(basePath);
+
+  // DB-backed memory backfills run below. On a cold session the database file
+  // may exist without an active in-process adapter, so open the canonical
+  // project DB before those best-effort operations inspect it.
+  try {
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    await ensureDbOpen(basePath);
+  } catch (e) {
+    logWarning("bootstrap", `project DB open failed before memory projection: ${(e as Error).message}`);
+  }
+
+  // These backfills are independent idempotent migrations. Keep them on the
+  // startup path because their rows can affect the MEMORY block for this turn,
+  // but do not make their import/IO latencies add serially.
+  await Promise.allSettled([
+    runDecisionsMemoryBackfill(ctx),
+    runKnowledgeMemoryBackfill(basePath, ctx),
+  ]);
+
+  return true;
+}
+
+async function runDecisionsMemoryBackfill(ctx: ExtensionContext): Promise<void> {
+  // ADR-013 step 5: opportunistic decisions->memories backfill. Idempotent
+  // and best-effort — first run absorbs the existing decisions table into
+  // the memory store; repeated turns skip this session-once maintenance.
+  try {
+    const { backfillDecisionsToMemories } = await import("../memory-backfill.js");
+    const written = backfillDecisionsToMemories();
+    if (written > 0) {
+      ctx.ui.notify(`GSD: backfilled ${written} decision${written === 1 ? "" : "s"} into the memory store.`, "info");
+    }
+  } catch (e) {
+    logWarning("bootstrap", `decisions backfill failed: ${(e as Error).message}`);
+  }
+}
+
+async function runKnowledgeMemoryBackfill(
+  basePath: string,
+  ctx: ExtensionContext,
+): Promise<void> {
+  // ADR-013 Stage 2b: KNOWLEDGE.md Patterns + Lessons backfill. Idempotent
+  // and best-effort — first run migrates rows into memories; repeated turns
+  // skip this session-once maintenance.
+  try {
+    const { backfillKnowledgeToMemories } = await import("../knowledge-backfill.js");
+    const writtenK = backfillKnowledgeToMemories(basePath);
+    if (writtenK > 0) {
+      ctx.ui.notify(`GSD: backfilled ${writtenK} KNOWLEDGE.md row${writtenK === 1 ? "" : "s"} into the memory store.`, "info");
+    }
+  } catch (e) {
+    logWarning("bootstrap", `KNOWLEDGE.md backfill failed: ${(e as Error).message}`);
+  }
+}
+
+function scheduleDeferredContextMaintenance(basePath: string): void {
+  if (deferredContextMaintenanceByBasePath.has(basePath)) return;
+
+  const task = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      void runDeferredContextMaintenance(basePath).finally(resolve);
+    }, 0);
+  });
+
+  deferredContextMaintenanceByBasePath.set(basePath, task);
+  void task.finally(() => {
+    if (deferredContextMaintenanceByBasePath.get(basePath) === task) {
+      deferredContextMaintenanceByBasePath.delete(basePath);
+    }
+  });
+}
+
+async function runDeferredContextMaintenance(basePath: string): Promise<void> {
+  // Projection rendering and consolidation-gap reporting do not contribute to
+  // the returned system prompt. Run them after startup context is assembled so
+  // their DB/file scans do not block the first response.
+  await Promise.allSettled([
+    renderKnowledgeProjectionDeferred(basePath),
+    reportConsolidationGapsDeferred(basePath),
+  ]);
+}
+
+async function renderKnowledgeProjectionDeferred(basePath: string): Promise<void> {
+  try {
+    const { renderKnowledgeProjection } = await import("../knowledge-projection.js");
+    renderKnowledgeProjection(basePath);
+  } catch (e) {
+    logWarning("bootstrap", `KNOWLEDGE.md projection render failed: ${(e as Error).message}`);
+  }
+}
+
+async function reportConsolidationGapsDeferred(basePath: string): Promise<void> {
+  try {
+    const { reportConsolidationGaps } = await import("../memory-consolidation-scanner.js");
+    reportConsolidationGaps(basePath);
+  } catch (e) {
+    logWarning("bootstrap", `memory consolidation scan failed: ${(e as Error).message}`);
+  }
+}
+
+export async function _flushDeferredContextMaintenanceForTest(basePath?: string): Promise<void> {
+  const tasks = basePath
+    ? [deferredContextMaintenanceByBasePath.get(basePath)].filter((task): task is Promise<void> => Boolean(task))
+    : [...deferredContextMaintenanceByBasePath.values()];
+  await Promise.allSettled(tasks);
+}
+
 export async function buildBeforeAgentStartResult(
   event: { prompt: string; systemPrompt: string },
   ctx: ExtensionContext,
@@ -153,58 +269,7 @@ export async function buildBeforeAgentStartResult(
     }
   }
 
-  // DB-backed memory backfills and projections run below. On a cold session
-  // the database file may exist without an active in-process adapter, so open
-  // the canonical project DB before those best-effort operations inspect it.
-  try {
-    const { ensureDbOpen } = await import("./dynamic-tools.js");
-    await ensureDbOpen(basePath);
-  } catch (e) {
-    logWarning("bootstrap", `project DB open failed before memory projection: ${(e as Error).message}`);
-  }
-
-  // ADR-013 step 5: opportunistic decisions->memories backfill. Idempotent
-  // and best-effort — first run absorbs the existing decisions table into
-  // the memory store; subsequent runs are a single sentinel SELECT.
-  try {
-    const { backfillDecisionsToMemories } = await import("../memory-backfill.js");
-    const written = backfillDecisionsToMemories();
-    if (written > 0) {
-      ctx.ui.notify(`GSD: backfilled ${written} decision${written === 1 ? "" : "s"} into the memory store.`, "info");
-    }
-  } catch (e) {
-    logWarning("bootstrap", `decisions backfill failed: ${(e as Error).message}`);
-  }
-
-  // ADR-013 Stage 2b: KNOWLEDGE.md Patterns + Lessons backfill, then
-  // re-render the hybrid projection (manual Rules + projected Patterns +
-  // projected Lessons). Both are idempotent and best-effort — failures here
-  // can't block agent startup.
-  try {
-    const { backfillKnowledgeToMemories } = await import("../knowledge-backfill.js");
-    const writtenK = backfillKnowledgeToMemories(basePath);
-    if (writtenK > 0) {
-      ctx.ui.notify(`GSD: backfilled ${writtenK} KNOWLEDGE.md row${writtenK === 1 ? "" : "s"} into the memory store.`, "info");
-    }
-  } catch (e) {
-    logWarning("bootstrap", `KNOWLEDGE.md backfill failed: ${(e as Error).message}`);
-  }
-  try {
-    const { renderKnowledgeProjection } = await import("../knowledge-projection.js");
-    renderKnowledgeProjection(basePath);
-  } catch (e) {
-    logWarning("bootstrap", `KNOWLEDGE.md projection render failed: ${(e as Error).message}`);
-  }
-
-  // ADR-013 step 6 preflight: warn when decisions / KNOWLEDGE.md rows are not
-  // yet in the memories table. Read-only; never throws. Runs after the two
-  // backfills above so the gap report reflects post-backfill state.
-  try {
-    const { reportConsolidationGaps } = await import("../memory-consolidation-scanner.js");
-    reportConsolidationGaps(basePath);
-  } catch (e) {
-    logWarning("bootstrap", `memory consolidation scan failed: ${(e as Error).message}`);
-  }
+  const shouldScheduleDeferredMaintenance = await runSessionStartupMaintenanceOnce(basePath, ctx);
 
   const { block: knowledgeBlock, globalSizeKb } = loadKnowledgeBlock(gsdHome(), basePath);
   if (globalSizeKb > 4) {
@@ -284,6 +349,9 @@ export async function buildBeforeAgentStartResult(
   });
 
   const contextMessage = buildContextMessage({ memoryBlock, injection, forensicsInjection });
+  if (shouldScheduleDeferredMaintenance) {
+    scheduleDeferredContextMaintenance(basePath);
+  }
 
   return {
     systemPrompt: fullSystem,

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -28,7 +28,8 @@ const DEFAULT_CODEBASE_MAX_CHARS = 8_000;
 const MIN_CONTEXT_MESSAGE_MAX_CHARS = 1_000;
 const MIN_KNOWLEDGE_MAX_CHARS = 1_000;
 
-const contextMaintenanceStartedForBasePath = new Set<string>();
+const contextMaintenanceCompletedForBasePath = new Set<string>();
+const contextMaintenanceInFlightByBasePath = new Map<string, Promise<boolean>>();
 const deferredContextMaintenanceByBasePath = new Map<string, Promise<void>>();
 
 /**
@@ -113,18 +114,39 @@ async function runSessionStartupMaintenanceOnce(
   basePath: string,
   ctx: ExtensionContext,
 ): Promise<boolean> {
-  if (contextMaintenanceStartedForBasePath.has(basePath)) return false;
-  contextMaintenanceStartedForBasePath.add(basePath);
+  if (contextMaintenanceCompletedForBasePath.has(basePath)) return false;
 
+  let inFlight = contextMaintenanceInFlightByBasePath.get(basePath);
+  const isInitiator = !inFlight;
+  if (isInitiator) {
+    inFlight = performSessionStartupMaintenance(basePath, ctx);
+    contextMaintenanceInFlightByBasePath.set(basePath, inFlight);
+    void inFlight.finally(() => {
+      if (contextMaintenanceInFlightByBasePath.get(basePath) === inFlight) {
+        contextMaintenanceInFlightByBasePath.delete(basePath);
+      }
+    });
+  }
+
+  const result = await inFlight;
+  return isInitiator ? result : false;
+}
+
+async function performSessionStartupMaintenance(
+  basePath: string,
+  ctx: ExtensionContext,
+): Promise<boolean> {
   // DB-backed memory backfills run below. On a cold session the database file
   // may exist without an active in-process adapter, so open the canonical
   // project DB before those best-effort operations inspect it.
+  let dbOpen = false;
   try {
     const { ensureDbOpen } = await import("./dynamic-tools.js");
-    await ensureDbOpen(basePath);
+    dbOpen = await ensureDbOpen(basePath);
   } catch (e) {
     logWarning("bootstrap", `project DB open failed before memory projection: ${(e as Error).message}`);
   }
+  if (!dbOpen) return false;
 
   // These backfills are independent idempotent migrations. Keep them on the
   // startup path because their rows can affect the MEMORY block for this turn,
@@ -134,6 +156,7 @@ async function runSessionStartupMaintenanceOnce(
     runKnowledgeMemoryBackfill(basePath, ctx),
   ]);
 
+  contextMaintenanceCompletedForBasePath.add(basePath);
   return true;
 }
 

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -170,6 +170,7 @@ async function performSessionStartupMaintenance(
     runKnowledgeMemoryBackfill(basePath, ctx),
   ]);
 
+  scheduleDeferredContextMaintenance(basePath);
   contextMaintenanceCompletedForBasePath.add(basePath);
   return true;
 }
@@ -306,10 +307,7 @@ export async function buildBeforeAgentStartResult(
     }
   }
 
-  const shouldScheduleDeferredMaintenance = await runSessionStartupMaintenanceOnce(basePath, ctx);
-  if (shouldScheduleDeferredMaintenance) {
-    scheduleDeferredContextMaintenance(basePath);
-  }
+  await runSessionStartupMaintenanceOnce(basePath, ctx);
 
   const { block: knowledgeBlock, globalSizeKb } = loadKnowledgeBlock(gsdHome(), basePath);
   if (globalSizeKb > 4) {

--- a/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
@@ -192,6 +192,139 @@ test("#896 startup maintenance skips repeated sentinel work in one session", asy
   assert.equal(secondPass.count, 0, "second startup in same session should not re-run KNOWLEDGE.md sentinel backfill");
 });
 
+test("#896 later turns reopen the project DB after startup maintenance is complete", async (t) => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-startup-maintenance-reopen-")));
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  execFileSync("git", ["init", "-q"], { cwd: base, stdio: "ignore" });
+  process.chdir(base);
+  process.env.GSD_HOME = join(base, ".gsd-home");
+
+  t.after(async () => {
+    await _flushDeferredContextMaintenanceForTest(base);
+    if (isDbAvailable()) closeDatabase();
+    invalidateStateCache();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  closeDatabase();
+  assert.equal(isDbAvailable(), false);
+
+  const ctx = {
+    projectRoot: base,
+    ui: { notify: () => undefined },
+  } as unknown as ExtensionContext;
+
+  await buildBeforeAgentStartResult(
+    { prompt: "Inspect project knowledge", systemPrompt: "base system prompt" },
+    ctx,
+  );
+  await _flushDeferredContextMaintenanceForTest(base);
+
+  const memoryId = createMemory({
+    category: "gotcha",
+    content: "Later before_agent_start turns reopen the project DB.",
+    scope: "project",
+    confidence: 0.95,
+  });
+  assert.ok(memoryId);
+
+  closeDatabase();
+  assert.equal(isDbAvailable(), false);
+
+  const result = await buildBeforeAgentStartResult(
+    { prompt: "Inspect project knowledge again", systemPrompt: "base system prompt" },
+    ctx,
+  );
+
+  assert.equal(isDbAvailable(), true, "completed startup maintenance should still reopen the DB per turn");
+  assert.match(
+    result?.message?.content ?? "",
+    /Later before_agent_start turns reopen the project DB\./,
+    "DB-backed memory context should still be available on later turns",
+  );
+});
+
+test("#896 deferred maintenance is queued before later prompt assembly can throw", async (t) => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-startup-maintenance-deferred-")));
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const gsdDir = join(base, ".gsd");
+  const knowledgePath = join(gsdDir, "KNOWLEDGE.md");
+  const gsdHomeDir = join(base, ".gsd-home");
+  mkdirSync(gsdDir, { recursive: true });
+  mkdirSync(join(gsdHomeDir, "agent"), { recursive: true });
+  execFileSync("git", ["init", "-q"], { cwd: base, stdio: "ignore" });
+  process.chdir(base);
+  process.env.GSD_HOME = gsdHomeDir;
+
+  t.after(async () => {
+    await _flushDeferredContextMaintenanceForTest(base);
+    if (isDbAvailable()) closeDatabase();
+    invalidateStateCache();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  writeFileSync(
+    join(gsdHomeDir, "agent", "KNOWLEDGE.md"),
+    ["# Global Knowledge", "", "Large global knowledge warning. ".repeat(220)].join("\n"),
+    "utf-8",
+  );
+
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  const memoryId = createMemory({
+    category: "pattern",
+    content: "Deferred maintenance survives prompt assembly failures",
+    scope: "project",
+    confidence: 0.9,
+    structuredFields: {
+      sourceKnowledgeId: "P001",
+      sourceKnowledgeTable: "patterns",
+      pattern: "Deferred maintenance survives prompt assembly failures",
+      where: "bootstrap",
+      notes: "regression coverage",
+    },
+  });
+  assert.ok(memoryId);
+  closeDatabase();
+  assert.equal(isDbAvailable(), false);
+
+  const ctx = {
+    projectRoot: base,
+    ui: {
+      notify: (message: string) => {
+        if (message.includes("KNOWLEDGE.md is")) {
+          throw new Error("notification failure after startup maintenance");
+        }
+      },
+    },
+  } as unknown as ExtensionContext;
+
+  await assert.rejects(
+    () => buildBeforeAgentStartResult(
+      { prompt: "Inspect project knowledge", systemPrompt: "base system prompt" },
+      ctx,
+    ),
+    /notification failure after startup maintenance/,
+  );
+
+  await _flushDeferredContextMaintenanceForTest(base);
+  assert.equal(existsSync(knowledgePath), true, "deferred projection should still run after prompt assembly throws");
+  assert.match(
+    readFileSync(knowledgePath, "utf-8"),
+    /\| P001 \| Deferred maintenance survives prompt assembly failures \| bootstrap \| regression coverage \|/,
+  );
+});
+
 test("#830 knowledge command opens the project DB before capturing patterns", async (t) => {
   const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-knowledge-command-")));
   const gsdDir = join(base, ".gsd");

--- a/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,7 +15,7 @@ import { execFileSync } from "node:child_process";
 
 import type { ExtensionCommandContext, ExtensionContext } from "@gsd/pi-coding-agent";
 
-import { buildBeforeAgentStartResult } from "../bootstrap/system-context.ts";
+import { buildBeforeAgentStartResult, _flushDeferredContextMaintenanceForTest } from "../bootstrap/system-context.ts";
 import { handleKnowledge } from "../commands-handlers.ts";
 import { withCommandCwd } from "../commands/context.ts";
 import {
@@ -37,7 +38,8 @@ test("#830 startup opens the project DB before projecting KNOWLEDGE.md", async (
   process.chdir(base);
   process.env.GSD_HOME = join(base, ".gsd-home");
 
-  t.after(() => {
+  t.after(async () => {
+    await _flushDeferredContextMaintenanceForTest(base);
     if (isDbAvailable()) closeDatabase();
     invalidateStateCache();
     process.chdir(originalCwd);
@@ -75,11 +77,119 @@ test("#830 startup opens the project DB before projecting KNOWLEDGE.md", async (
   );
 
   assert.equal(isDbAvailable(), true, "startup should open the project DB");
-  assert.equal(existsSync(knowledgePath), true, "startup should write KNOWLEDGE.md");
+  assert.equal(existsSync(knowledgePath), false, "startup should defer KNOWLEDGE.md projection off the prompt path");
+  await _flushDeferredContextMaintenanceForTest(base);
+  assert.equal(existsSync(knowledgePath), true, "deferred maintenance should write KNOWLEDGE.md");
   assert.match(
     readFileSync(knowledgePath, "utf-8"),
     /\| P001 \| Cold-start projections open the canonical DB first \| bootstrap \| regression coverage \|/,
   );
+});
+
+test("#896 startup maintenance skips repeated sentinel work in one session", async (t) => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-startup-maintenance-once-")));
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const gsdDir = join(base, ".gsd");
+  const knowledgePath = join(gsdDir, "KNOWLEDGE.md");
+  mkdirSync(gsdDir, { recursive: true });
+  execFileSync("git", ["init", "-q"], { cwd: base, stdio: "ignore" });
+  process.chdir(base);
+  process.env.GSD_HOME = join(base, ".gsd-home");
+
+  t.after(async () => {
+    await _flushDeferredContextMaintenanceForTest(base);
+    if (isDbAvailable()) closeDatabase();
+    invalidateStateCache();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  writeFileSync(
+    knowledgePath,
+    [
+      "# Project Knowledge",
+      "",
+      "## Rules",
+      "",
+      "| # | Scope | Rule | Why | Added |",
+      "|---|-------|------|-----|-------|",
+      "",
+      "## Patterns",
+      "",
+      "| # | Pattern | Where | Notes |",
+      "|---|---------|-------|-------|",
+      "| P001 | Run startup maintenance once | bootstrap | first pass |",
+      "",
+      "## Lessons Learned",
+      "",
+      "| # | What Happened | Root Cause | Fix | Scope |",
+      "|---|--------------|------------|-----|-------|",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  closeDatabase();
+  assert.equal(isDbAvailable(), false);
+
+  const ctx = {
+    projectRoot: base,
+    ui: { notify: () => undefined },
+  } as unknown as ExtensionContext;
+
+  await buildBeforeAgentStartResult(
+    { prompt: "Inspect project knowledge", systemPrompt: "base system prompt" },
+    ctx,
+  );
+  await _flushDeferredContextMaintenanceForTest(base);
+
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  const firstPass = adapter
+    .prepare("SELECT COUNT(*) AS count FROM memories WHERE structured_fields LIKE '%\"sourceKnowledgeId\":\"P001\"%'")
+    .get() as { count: number };
+  assert.equal(firstPass.count, 1, "first startup should backfill existing KNOWLEDGE.md row");
+
+  writeFileSync(
+    knowledgePath,
+    [
+      "# Project Knowledge",
+      "",
+      "## Rules",
+      "",
+      "| # | Scope | Rule | Why | Added |",
+      "|---|-------|------|-----|-------|",
+      "",
+      "## Patterns",
+      "",
+      "| # | Pattern | Where | Notes |",
+      "|---|---------|-------|-------|",
+      "| P001 | Run startup maintenance once | bootstrap | first pass |",
+      "| P002 | Do not re-run startup sentinels | bootstrap | second pass |",
+      "",
+      "## Lessons Learned",
+      "",
+      "| # | What Happened | Root Cause | Fix | Scope |",
+      "|---|--------------|------------|-----|-------|",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  await buildBeforeAgentStartResult(
+    { prompt: "Inspect project knowledge again", systemPrompt: "base system prompt" },
+    ctx,
+  );
+  await _flushDeferredContextMaintenanceForTest(base);
+
+  const secondPass = adapter
+    .prepare("SELECT COUNT(*) AS count FROM memories WHERE structured_fields LIKE '%\"sourceKnowledgeId\":\"P002\"%'")
+    .get() as { count: number };
+  assert.equal(secondPass.count, 0, "second startup in same session should not re-run KNOWLEDGE.md sentinel backfill");
 });
 
 test("#830 knowledge command opens the project DB before capturing patterns", async (t) => {


### PR DESCRIPTION
## Summary
- Fixed before_agent_start startup maintenance gating, parallelization, and deferral with syntax/diff verification; runtime tests were blocked by missing dependencies and restricted registry access.

## Bugs Addressed
- [x] **Maintenance sentinels run on every turn**
- [x] **Independent context maintenance runs serially**
- [x] **Non-context maintenance blocks first response**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #896
- [#896 [Bug]: First-prompt `before_agent_start` runs a serial, un-gated chain of synchronous DB-open, backfills, projections, and scans](https://github.com/open-gsd/gsd-pi/issues/896)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/896-bug-first-prompt-before-agent-start-runs-1782518008`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-turn bootstrap timing and when KNOWLEDGE.md is written relative to prompt assembly; behavior is idempotent with new regression tests but touches core session startup and memory migration.
> 
> **Overview**
> **`before_agent_start`** no longer runs the full DB-open, memory backfill, KNOWLEDGE projection, and consolidation scan chain on every turn or serially on the first prompt path.
> 
> Startup maintenance is **session-once per project root**: decisions and KNOWLEDGE→memories backfills still run on the first pass (in **parallel**), with in-flight coalescing if multiple hooks race. **KNOWLEDGE.md projection** and **consolidation-gap reporting** move to **deferred** work (`setTimeout(0)`) so they do not block the first agent response. Later turns in the same session skip backfill sentinels but still **reopen the project DB** so the memory block can load.
> 
> Tests assert deferred projection, one-shot backfill, per-turn DB reopen, and deferred work surviving failures after maintenance is scheduled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c28955fd534dbf337498a26de28e87f63aff67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->