### PR TITLE
fix(issue): [Bug]: `initResources()` fast-path performs ~2,500+ synchronous recursive directory walks before the early return, even when the content hash matches

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -714,9 +714,9 @@ function pruneRemovedBundledExtensions(
  * - gsd-browser skill → ~/.gsd/agent/skills/gsd-browser/ from @opengsd/gsd-browser
  * - GSD-WORKFLOW.md → ~/.gsd/agent/GSD-WORKFLOW.md (fallback for env var miss)
  *
- * Skips the full copy only when the managed-resources.json version, content
- * fingerprint, and package-owned gsd-browser skill all match the current
- * install, avoiding ~128ms of synchronous cpSync on steady-state startup.
+ * Skips the full copy when the managed-resources.json version and content
+ * fingerprint match the current install, avoiding ~128ms of synchronous cpSync
+ * on steady-state startup.
  * After `npm update -g @opengsd/gsd-pi`, versions will differ and the copy
  * runs once to land the new resources.
  *
@@ -755,24 +755,7 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
   if (manifest && isCurrentPackageManifest(manifest) && manifest.gsdVersion === currentVersion) {
     // Version matches — check content fingerprint for same-version staleness.
     const currentHash = getCurrentResourceFingerprint()
-    const hasStaleExtensionFiles = hasStaleCompiledExtensionSiblings(extensionsDir, bundledExtensionsDir)
-    const hasMissingSharedFiles = hasMissingBundledResourceFiles(
-      join(agentDir, 'shared'),
-      join(resourcesDir, 'shared'),
-    )
-    const hasMissingSkillFiles = hasMissingBundledResourceFiles(
-      skillsDir,
-      join(resourcesDir, 'skills'),
-    )
-    const hasStaleGsdBrowserSkill = hasStaleGsdBrowserPackageSkill(skillsDir)
-    if (
-      manifest.contentHash &&
-      manifest.contentHash === currentHash &&
-      !hasStaleExtensionFiles &&
-      !hasMissingSharedFiles &&
-      !hasMissingSkillFiles &&
-      !hasStaleGsdBrowserSkill
-    ) {
+    if (manifest.contentHash && manifest.contentHash === currentHash) {
       return
     }
   }

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -295,7 +295,7 @@ test("initResources syncs the gsd-browser skill from the installed gsd-browser p
   }
 });
 
-test("initResources refreshes a stale managed gsd-browser package skill", async (t) => {
+test("initResources refreshes a stale managed gsd-browser package skill during resource refresh", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-browser-skill-stale-"));
   const fakeAgentDir = join(tmp, ".gsd", "agent");
   const restoreHomeEnv = overrideHomeEnv(tmp);
@@ -307,7 +307,6 @@ test("initResources refreshes a stale managed gsd-browser package skill", async 
 
   const {
     collectGsdBrowserPackageSkillReferences,
-    computeResourceFingerprint,
     hasStaleGsdBrowserPackageSkill,
     initResources,
   } = await import("../resource-loader.ts");
@@ -333,7 +332,7 @@ test("initResources refreshes a stale managed gsd-browser package skill", async 
     JSON.stringify({
       gsdVersion: currentPackageVersion(),
       packageName: "@opengsd/gsd-pi",
-      contentHash: computeResourceFingerprint(),
+      contentHash: "force-refresh",
     }),
   );
 
@@ -348,13 +347,13 @@ test("initResources refreshes a stale managed gsd-browser package skill", async 
   assert.equal(
     readFileSync(join(fakeAgentDir, "skills", "gsd-browser", "SKILL.md"), "utf-8"),
     packageSkill,
-    "current managed-resource manifests must not skip stale package-owned gsd-browser skills",
+    "resource refresh must update stale package-owned gsd-browser skills",
   );
   if (missingSupportRef) {
     assert.equal(
       existsSync(join(fakeAgentDir, "skills", "gsd-browser", missingSupportRef)),
       false,
-      "current managed-resource manifests must prune stale placeholder support files not shipped by @opengsd/gsd-browser",
+      "resource refresh must prune stale placeholder support files not shipped by @opengsd/gsd-browser",
     );
   }
 });
@@ -544,7 +543,37 @@ test("initResources syncs top-level shared resources used by extension imports",
   );
 });
 
-test("initResources resyncs when current manifest is missing top-level shared resources", async (t) => {
+test("initResources steady-state hash match returns before recursive drift checks", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-fast-path-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const skillsDir = join(tmp, "skills");
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir, skillsDir);
+
+  const manifest = JSON.parse(readFileSync(join(fakeAgentDir, "managed-resources.json"), "utf-8"));
+  assert.equal(typeof manifest.contentHash, "string", "test setup should have a current content hash");
+
+  const sharedDir = join(fakeAgentDir, "shared");
+  rmSync(sharedDir, { recursive: true, force: true });
+  writeFileSync(sharedDir, "not a directory");
+
+  assert.doesNotThrow(
+    () => initResources(fakeAgentDir, skillsDir),
+    "matching manifest hash should return before walking installed resource trees",
+  );
+  assert.equal(
+    readFileSync(sharedDir, "utf-8"),
+    "not a directory",
+    "matching manifest hash should skip the refresh path",
+  );
+});
+
+test("initResources restores missing top-level shared resources during resource refresh", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-shared-stale-"));
   const fakeAgentDir = join(tmp, ".gsd", "agent");
 
@@ -553,7 +582,6 @@ test("initResources resyncs when current manifest is missing top-level shared re
   });
 
   const {
-    computeResourceFingerprint,
     hasMissingBundledResourceFiles,
     initResources,
   } = await import("../resource-loader.ts");
@@ -570,7 +598,7 @@ test("initResources resyncs when current manifest is missing top-level shared re
         ? process.env.GSD_VERSION
         : packageVersion,
       packageName: "@opengsd/gsd-pi",
-      contentHash: computeResourceFingerprint(),
+      contentHash: "force-refresh",
     }),
   );
 
@@ -588,11 +616,11 @@ test("initResources resyncs when current manifest is missing top-level shared re
   assert.equal(
     hasSyncedResourceFile(join(fakeAgentDir, "shared"), "package-manager-detection"),
     true,
-    "current managed-resource manifests must not skip missing top-level shared files",
+    "resource refresh must restore missing top-level shared files",
   );
 });
 
-test("initResources resyncs when current manifest is missing bundled skills", async (t) => {
+test("initResources restores missing bundled skills during resource refresh", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-skill-stale-"));
   const fakeAgentDir = join(tmp, ".gsd", "agent");
   const restoreHome = overrideHomeEnv(tmp);
@@ -603,7 +631,6 @@ test("initResources resyncs when current manifest is missing bundled skills", as
   });
 
   const {
-    computeResourceFingerprint,
     hasMissingBundledResourceFiles,
     initResources,
   } = await import("../resource-loader.ts");
@@ -620,7 +647,7 @@ test("initResources resyncs when current manifest is missing bundled skills", as
         ? process.env.GSD_VERSION
         : packageVersion,
       packageName: "@opengsd/gsd-pi",
-      contentHash: computeResourceFingerprint(),
+      contentHash: "force-refresh",
     }),
   );
 
@@ -638,7 +665,7 @@ test("initResources resyncs when current manifest is missing bundled skills", as
   assert.equal(
     existsSync(join(fakeAgentDir, "skills", "tdd", "SKILL.md")),
     true,
-    "current managed-resource manifests must not skip missing bundled skills",
+    "resource refresh must restore missing bundled skills",
   );
 });
 


### PR DESCRIPTION
## Summary
- Optimized the initResources hash-match fast path and verified diff/syntax checks, with runtime tests blocked by missing dependencies and registry DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #908
- [#908 [Bug]: `initResources()` fast-path performs ~2,500+ synchronous recursive directory walks before the early return, even when the content hash matches](https://github.com/open-gsd/gsd-pi/issues/908)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/908-bug-initresources-fast-path-performs-2-5-1782518478`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Steady-state launches no longer auto-resync when on-disk managed files drift but the manifest hash still matches; repairs wait until the fingerprint or version changes.
> 
> **Overview**
> **Fixes slow steady-state startup** when `managed-resources.json` already matches the installed package version and bundled **content fingerprint**.
> 
> `initResources()` no longer runs recursive “drift” scans (`hasStaleCompiledExtensionSiblings`, missing shared/skills trees, stale `gsd-browser` skill) **before** the early return on a matching hash. It returns as soon as version, package name, and `contentHash` align, so normal launches avoid thousands of synchronous directory walks while still skipping the full `cpSync` refresh.
> 
> Tests now assert that a matching hash **does not** repair local corruption (e.g. replacing `shared/` with a file), and drift scenarios are covered by forcing a resource refresh via a bogus `contentHash` instead of expecting detection on the fast path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 414363f16fb569dd3606dd31ab1a63f2c1a22d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->