### PR TITLE
fix(issue): [Bug]: nativeDetectMainBranch is uncached and re-invoked 5–6 times within a single worktree merge/diff operation

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-manager.test.ts
@@ -10,6 +10,7 @@ import {
   listWorktrees,
   removeWorktree,
   diffWorktreeGSD,
+  diffWorktreeNumstat,
   getWorktreeGSDDiff,
   getWorktreeLog,
   worktreeBranchName,
@@ -288,6 +289,31 @@ describe("diffWorktreeGSD and getWorktreeGSDDiff", () => {
     const fullDiff = getWorktreeGSDDiff(base, "feature-x");
     assert.ok(fullDiff.includes("M002"), "diff should mention M002");
     assert.ok(fullDiff.includes("updated"), "diff should mention the update");
+  });
+});
+
+describe("worktree diff target branch override", () => {
+  let base: string;
+  beforeEach(() => {
+    const repo = makeRepoWithChanges("feature-x");
+    base = repo.base;
+
+    run("git checkout -b integration main", base);
+    writeFileSync(join(base, "TARGET_ONLY.md"), "target branch only\n", "utf-8");
+    run("git add TARGET_ONLY.md", base);
+    run('git commit -m "chore: target branch only"', base);
+    run("git checkout main", base);
+  });
+  afterEach(() => { rmSync(base, { recursive: true, force: true }); });
+
+  test("uses supplied main branch for merge preview helper overrides", () => {
+    const defaultStats = diffWorktreeNumstat(base, "feature-x", undefined, "main");
+    const overrideStats = diffWorktreeNumstat(base, "feature-x", undefined, "integration");
+    const selfLog = getWorktreeLog(base, "feature-x", worktreeBranchName("feature-x"));
+
+    assert.ok(!defaultStats.some(s => s.file === "TARGET_ONLY.md"), "default main stats should not include target-only file");
+    assert.ok(overrideStats.some(s => s.file === "TARGET_ONLY.md"), "override stats should use the supplied target branch");
+    assert.strictEqual(selfLog, "", "override log should use the supplied branch");
   });
 });
 

--- a/src/resources/extensions/gsd/worktree-command.ts
+++ b/src/resources/extensions/gsd/worktree-command.ts
@@ -570,11 +570,11 @@ async function handleMerge(
     }
 
     // Gather merge context — full repo diff, not just .gsd/
-    const diffSummary = diffWorktreeAll(basePath, name);
-    const numstat = diffWorktreeNumstat(basePath, name);
-    const gsdDiff = getWorktreeGSDDiff(basePath, name);
-    const codeDiff = getWorktreeCodeDiff(basePath, name);
-    const commitLog = getWorktreeLog(basePath, name);
+    const diffSummary = diffWorktreeAll(basePath, name, undefined, mainBranch);
+    const numstat = diffWorktreeNumstat(basePath, name, undefined, mainBranch);
+    const gsdDiff = getWorktreeGSDDiff(basePath, name, mainBranch);
+    const codeDiff = getWorktreeCodeDiff(basePath, name, mainBranch);
+    const commitLog = getWorktreeLog(basePath, name, mainBranch);
 
     const totalChanges = diffSummary.added.length + diffSummary.modified.length + diffSummary.removed.length;
     if (totalChanges === 0 && !commitLog.trim()) {
@@ -662,7 +662,7 @@ async function handleMerge(
     }
 
     try {
-      mergeWorktreeToMain(basePath, name, commitMessage);
+      mergeWorktreeToMain(basePath, name, commitMessage, undefined, mainBranch);
       ctx.ui.notify(
         [
           `${CLR.ok("✓")} Merged ${CLR.name(name)} → ${CLR.branch(mainBranch)} ${CLR.muted("(deterministic squash)")}`,

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -964,11 +964,11 @@ function parseDiffNameStatus(entries: { status: string; path: string }[]): Workt
  * Diff the .gsd/ directory between the worktree branch and main branch.
  * Returns a summary of added, modified, and removed GSD artifacts.
  */
-export function diffWorktreeGSD(basePath: string, name: string): WorktreeDiffSummary {
+export function diffWorktreeGSD(basePath: string, name: string, mainBranchOverride?: string): WorktreeDiffSummary {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
 
   const entries = nativeDiffNameStatus(basePath, mainBranch, branch, ".gsd/", true);
 
@@ -981,11 +981,16 @@ export function diffWorktreeGSD(basePath: string, name: string): WorktreeDiffSum
  * on main when the merge is applied. If both branches have identical
  * content, this correctly returns an empty diff.
  */
-export function diffWorktreeAll(basePath: string, name: string, branchOverride?: string): WorktreeDiffSummary {
+export function diffWorktreeAll(
+  basePath: string,
+  name: string,
+  branchOverride?: string,
+  mainBranchOverride?: string,
+): WorktreeDiffSummary {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = branchOverride ?? worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
 
   const entries = nativeDiffNameStatus(basePath, mainBranch, branch);
 
@@ -996,11 +1001,16 @@ export function diffWorktreeAll(basePath: string, name: string, branchOverride?:
  * Get per-file line addition/deletion stats for what will change on main.
  * Uses direct diff (not merge-base) so the preview matches the actual merge outcome.
  */
-export function diffWorktreeNumstat(basePath: string, name: string, branchOverride?: string): FileLineStat[] {
+export function diffWorktreeNumstat(
+  basePath: string,
+  name: string,
+  branchOverride?: string,
+  mainBranchOverride?: string,
+): FileLineStat[] {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = branchOverride ?? worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
 
   const rawStats = nativeDiffNumstat(basePath, mainBranch, branch);
 
@@ -1016,11 +1026,11 @@ export function diffWorktreeNumstat(basePath: string, name: string, branchOverri
  * Get the full diff content for .gsd/ between the worktree branch and main.
  * Returns the raw unified diff for LLM consumption.
  */
-export function getWorktreeGSDDiff(basePath: string, name: string): string {
+export function getWorktreeGSDDiff(basePath: string, name: string, mainBranchOverride?: string): string {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
 
   return nativeDiffContent(basePath, mainBranch, branch, ".gsd/", undefined, true);
 }
@@ -1029,11 +1039,11 @@ export function getWorktreeGSDDiff(basePath: string, name: string): string {
  * Get the full diff content for non-.gsd/ files between the worktree branch and main.
  * Returns the raw unified diff for LLM consumption.
  */
-export function getWorktreeCodeDiff(basePath: string, name: string): string {
+export function getWorktreeCodeDiff(basePath: string, name: string, mainBranchOverride?: string): string {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
 
   return nativeDiffContent(basePath, mainBranch, branch, undefined, ".gsd/", true);
 }
@@ -1041,11 +1051,11 @@ export function getWorktreeCodeDiff(basePath: string, name: string): string {
 /**
  * Get commit log for the worktree branch since it diverged from main.
  */
-export function getWorktreeLog(basePath: string, name: string): string {
+export function getWorktreeLog(basePath: string, name: string, mainBranchOverride?: string): string {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
 
   const entries = nativeLogOneline(basePath, mainBranch, branch);
 
@@ -1057,11 +1067,17 @@ export function getWorktreeLog(basePath: string, name: string): string {
  * Must be called from the main working tree (not the worktree itself).
  * Returns the merge commit message.
  */
-export function mergeWorktreeToMain(basePath: string, name: string, commitMessage: string, branchOverride?: string): string {
+export function mergeWorktreeToMain(
+  basePath: string,
+  name: string,
+  commitMessage: string,
+  branchOverride?: string,
+  mainBranchOverride?: string,
+): string {
   basePath = normalizeBasePathForWorktreeOps(basePath);
 
   const branch = branchOverride ?? worktreeBranchName(name);
-  const mainBranch = nativeDetectMainBranch(basePath);
+  const mainBranch = mainBranchOverride ?? nativeDetectMainBranch(basePath);
   const current = nativeGetCurrentBranch(basePath);
 
   if (current !== mainBranch) {


### PR DESCRIPTION
## Summary
- Reused the resolved main branch across worktree merge preview/merge helpers and verified with the focused worktree-manager test plus diff checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #903
- [#903 [Bug]: nativeDetectMainBranch is uncached and re-invoked 5–6 times within a single worktree merge/diff operation](https://github.com/open-gsd/gsd-pi/issues/903)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/903-bug-nativedetectmainbranch-is-uncached-a-1782518838`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor with backward-compatible optional parameters; merge/git behavior unchanged when override is not passed.
> 
> **Overview**
> **Worktree merge and diff helpers** now accept an optional `mainBranchOverride` so callers can resolve the target branch once instead of each helper calling `nativeDetectMainBranch` again.
> 
> `/worktree merge` already picks `mainBranch` from the optional target argument or `getMainBranch`; that value is passed into `diffWorktreeAll`, `diffWorktreeNumstat`, GSD/code diff getters, `getWorktreeLog`, and `mergeWorktreeToMain`. When the override is omitted, behavior is unchanged (auto-detect as before).
> 
> A focused test confirms numstat and log use the supplied branch (e.g. `integration` vs default `main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5910ab80b0822b24741165539bf18625d4bd0d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->