### PR TITLE
fix(issue): [Bug]: notification-store `_withLock` busy-spins the event loop during lock contention

### DIFF
--- a/src/resources/extensions/gsd/notification-store.ts
+++ b/src/resources/extensions/gsd/notification-store.ts
@@ -310,40 +310,29 @@ function _atomicWrite(basePath: string, content: string): void {
 /**
  * Acquire an exclusive lockfile for rewrite operations.
  * Uses O_CREAT|O_EXCL for atomic creation — if the file exists, another
- * process holds the lock. Retries briefly, then proceeds anyway (best-effort)
- * to avoid deadlocking the UI on a stale lock.
+ * process holds the lock. Clears stale locks, then proceeds anyway
+ * (best-effort) to avoid blocking the UI.
  */
 function _withLock<T>(basePath: string, fn: () => T): T {
   const lockPath = join(basePath, ".gsd", LOCKFILE);
   let fd: number | null = null;
-  const maxAttempts = 5;
-  const retryMs = 20;
 
-  for (let i = 0; i < maxAttempts; i++) {
-    try {
-      mkdirSync(join(basePath, ".gsd"), { recursive: true });
-      fd = openSync(lockPath, "wx");
-      break;
-    } catch (err: any) {
-      if (err?.code === "EEXIST") {
-        // Check if lock is stale (older than 5s)
-        try {
-          const stat = readFileSync(lockPath, "utf-8");
-          const lockTime = parseInt(stat, 10);
-          if (Date.now() - lockTime > 5000) {
-            try { unlinkSync(lockPath); } catch { /* race ok */ }
-            continue;
-          }
-        } catch { /* can't read lock, retry */ }
-
-        // Wait and retry
-        const start = Date.now();
-        while (Date.now() - start < retryMs) { /* spin */ }
-        continue;
-      }
-      // Other error — proceed without lock
-      break;
+  try {
+    mkdirSync(join(basePath, ".gsd"), { recursive: true });
+    fd = openSync(lockPath, "wx");
+  } catch (err: any) {
+    if (err?.code === "EEXIST") {
+      // Check if lock is stale (older than 5s)
+      try {
+        const stat = readFileSync(lockPath, "utf-8");
+        const lockTime = parseInt(stat, 10);
+        if (Date.now() - lockTime > 5000) {
+          try { unlinkSync(lockPath); } catch { /* race ok */ }
+          try { fd = openSync(lockPath, "wx"); } catch { /* race ok */ }
+        }
+      } catch { /* proceed without lock */ }
     }
+    // Any lock acquisition error leaves fd null; proceed without lock.
   }
 
   // Best-effort: mutation runs regardless of lock status (idempotent overwrites).

--- a/src/resources/extensions/gsd/tests/notification-store.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-store.test.ts
@@ -306,6 +306,29 @@ describe("notification-store", () => {
     rmSync(lockPath, { force: true });
   });
 
+  test("markAllRead does not busy-spin when a foreign lock is held", (t) => {
+    initNotificationStore(tmp);
+    appendNotification("msg1", "info");
+
+    const lockPath = join(tmp, ".gsd", "notifications.lock");
+    writeFileSync(lockPath, "1000", "utf-8");
+
+    let now = 1001;
+    let calls = 0;
+    t.mock.method(Date, "now", () => {
+      calls++;
+      return now++;
+    });
+
+    markAllRead();
+
+    assert.ok(calls <= 2, `expected no retry spin, got ${calls} Date.now calls`);
+    assert.ok(existsSync(lockPath), "foreign lock file should not be deleted");
+    assert.equal(getUnreadCount(), 0, "best-effort mutation should still run");
+
+    rmSync(lockPath, { force: true });
+  });
+
   test("structured meta persists kind and scope on the entry", () => {
     initNotificationStore(tmp);
     appendNotification("Auto-mode blocked — validation gate", "warning", "notify", { kind: "auto-stop", scope: "M005" });


### PR DESCRIPTION
## Summary
- Removed the notification-store lock busy-spin and verified the contended path no longer retries while preserving best-effort mutation behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #884
- [#884 [Bug]: notification-store `_withLock` busy-spins the event loop during lock contention](https://github.com/open-gsd/gsd-pi/issues/884)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/884-bug-notification-store-withlock-busy-spi-1782519318`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to extension lock acquisition with existing best-effort semantics preserved and new test coverage.
> 
> **Overview**
> **`_withLock`** in the notification store no longer retries lock acquisition with a tight busy-spin when another process holds `notifications.lock`. It makes one exclusive-create attempt, optionally clears a **stale** lock (>5s) and tries once more, then runs the rewrite callback anyway without blocking the UI.
> 
> Behavior for **best-effort** mutations (`markAllRead`, `clearNotifications`, rotation) is unchanged: work still proceeds when the lock cannot be taken, and foreign locks are not removed. A regression test asserts that `markAllRead` under a fresh foreign lock does not hammer `Date.now` via retry spinning while still marking notifications read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eba1670e39cf132369e8528b68d07fa18d4c7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->