### PR TITLE
fix(issue): [Bug]: Worktree-log reconcile can freeze the entire Node event loop for up to 5s on sync-lock contention

### DIFF
--- a/src/resources/extensions/gsd/sync-lock.ts
+++ b/src/resources/extensions/gsd/sync-lock.ts
@@ -1,25 +1,16 @@
 // GSD Extension — Advisory Sync Lock
 // Prevents concurrent worktree syncs from colliding via a simple file lock.
 // Stale locks (mtime > 60s, owner PID confirmed dead) are overridden. Lock
-// acquisition waits up to 5 seconds then skips non-fatally.
+// acquisition skips non-fatally when a live lock is already held.
 
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, statSync, unlinkSync, writeSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 const STALE_THRESHOLD_MS = 60_000; // 60 seconds
-const DEFAULT_TIMEOUT_MS = 5_000;  // 5 seconds
-const SPIN_INTERVAL_MS = 100;      // 100ms polling interval
-
-// SharedArrayBuffer for synchronous sleep via Atomics.wait
-const SLEEP_BUFFER = new SharedArrayBuffer(4);
-const SLEEP_VIEW = new Int32Array(SLEEP_BUFFER);
+const DEFAULT_TIMEOUT_MS = 0;      // fail fast; sync waits block the JS event loop
 
 function lockFilePath(basePath: string): string {
   return join(basePath, ".gsd", "sync.lock");
-}
-
-function sleepSync(ms: number): void {
-  Atomics.wait(SLEEP_VIEW, 0, 0, ms);
 }
 
 /** True if the given PID is alive in the current process namespace. */
@@ -64,7 +55,7 @@ function tryCreateLockFile(lp: string, payload: string): boolean {
 
 /**
  * Acquire an advisory sync lock for the given basePath.
- * Returns { acquired: true } on success, { acquired: false } after timeout.
+ * Returns { acquired: true } on success, { acquired: false } when a live lock is held.
  *
  * Replaces a non-atomic `existsSync` + `atomicWriteSync` (write-temp+rename,
  * which is not exclusive-create) sequence that allowed two callers to both
@@ -75,13 +66,16 @@ function tryCreateLockFile(lp: string, payload: string): boolean {
  * before stealing — prevents a slow event-loop pause (>60s under heavy I/O)
  * from making a legitimately-held lock appear stale and get stolen.
  * (Issue #4980 M-concurrency-3)
+ *
+ * Contended live locks fail fast. A synchronous wait here would freeze timers,
+ * I/O, and UI work on Node's single JS thread. The timeout argument remains
+ * accepted for compatibility but is intentionally not used for sync waiting.
  */
 export function acquireSyncLock(
   basePath: string,
-  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  _timeoutMs: number = DEFAULT_TIMEOUT_MS,
 ): { acquired: boolean } {
   const lp = lockFilePath(basePath);
-  const deadline = Date.now() + timeoutMs;
   const lockData = JSON.stringify(
     { pid: process.pid, acquired_at: new Date().toISOString() },
     null,
@@ -98,7 +92,7 @@ export function acquireSyncLock(
       /* unexpected — fall through to retry */
     }
 
-    // File exists. Decide whether to steal (stale + owner dead) or wait.
+    // File exists. Decide whether to steal (stale + owner dead) or skip.
     let canSteal = false;
     try {
       const stat = statSync(lp);
@@ -129,11 +123,8 @@ export function acquireSyncLock(
       continue;
     }
 
-    // Lock is held and not stale (or owner is alive) — wait or give up.
-    if (Date.now() >= deadline) {
-      return { acquired: false };
-    }
-    sleepSync(SPIN_INTERVAL_MS);
+    // Lock is held and not stale (or owner is alive) — skip non-fatally.
+    return { acquired: false };
   }
 }
 

--- a/src/resources/extensions/gsd/tests/sync-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/sync-lock.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { performance } from 'node:perf_hooks';
 import { acquireSyncLock, releaseSyncLock } from '../sync-lock.ts';
 
 function tempDir(): string {
@@ -148,6 +149,28 @@ test('sync-lock: EPERM from live owner PID prevents stale lock stealing', () => 
     assert.strictEqual(content.pid, fakePid, 'lock file should not be overwritten');
   } finally {
     process.kill = originalKill;
+    cleanupDir(base);
+  }
+});
+
+test('sync-lock: contended fresh lock fails fast without honoring long sync timeout', () => {
+  const base = tempDir();
+  fs.mkdirSync(path.join(base, '.gsd'), { recursive: true });
+  const lockPath = path.join(base, '.gsd', 'sync.lock');
+
+  try {
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 99999, acquired_at: new Date().toISOString() }));
+
+    const startedAt = performance.now();
+    const result = acquireSyncLock(base, 1_000);
+    const elapsedMs = performance.now() - startedAt;
+
+    assert.strictEqual(result.acquired, false, 'fresh lock should not be stolen');
+    assert.ok(
+      elapsedMs < 250,
+      `contended sync lock should fail fast instead of blocking for timeout; elapsed=${elapsedMs.toFixed(1)}ms`,
+    );
+  } finally {
     cleanupDir(base);
   }
 });


### PR DESCRIPTION
## Summary
- Fixed sync-lock contention to fail fast without blocking the Node event loop and verified it with the focused sync-lock test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #881
- [#881 [Bug]: Worktree-log reconcile can freeze the entire Node event loop for up to 5s on sync-lock contention](https://github.com/open-gsd/gsd-pi/issues/881)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/881-bug-worktree-log-reconcile-can-freeze-th-1782519918`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized concurrency fix in advisory lock acquisition with added regression test; callers already handle `acquired: false` non-fatally.
> 
> **Overview**
> **`acquireSyncLock`** no longer spins for up to 5s when another process holds a live lock. It immediately returns `{ acquired: false }` so worktree sync does not block Node’s single thread (timers, I/O, UI).
> 
> The synchronous **`Atomics.wait`** polling loop and related timeout/spin constants are removed; default timeout is **0** and the `timeoutMs` parameter is kept only for API compatibility. **Stale-lock** steal-and-retry behavior is unchanged.
> 
> A unit test asserts that a contended fresh lock fails in under ~250ms even when a 1s timeout is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36c955de43c71e749f6ef1820cd9c1e7e3db0d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->