### PR TITLE
fix(issue): [Bug]: Session-lock recovery uses a CPU busy-wait that pegs a core and blocks the event loop for up to 400ms

### DIFF
--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -698,6 +698,12 @@ export interface RetryOptions {
   delayMs?: number;
 }
 
+const _retrySleepView = new Int32Array(new SharedArrayBuffer(4));
+function sleepSync(ms: number): void {
+  if (!(ms > 0)) return;
+  Atomics.wait(_retrySleepView, 0, 0, ms);
+}
+
 export function readExistingLockDataWithRetry(
   lp: string,
   options?: RetryOptions,
@@ -709,12 +715,7 @@ export function readExistingLockDataWithRetry(
     const data = readExistingLockData(lp);
     if (data !== null) return data;
     if (attempt < maxAttempts) {
-      // Synchronous busy-wait — onCompromised runs in a sync callback context
-      // and the delays are short (200ms default).
-      const start = Date.now();
-      while (Date.now() - start < delayMs) {
-        // busy-wait
-      }
+      sleepSync(delayMs);
     }
   }
   return null;

--- a/src/resources/extensions/gsd/tests/session-lock-transient-read.test.ts
+++ b/src/resources/extensions/gsd/tests/session-lock-transient-read.test.ts
@@ -8,6 +8,7 @@
  *
  * Tests:
  *   - readExistingLockDataWithRetry retries on transient read failure
+ *   - readExistingLockDataWithRetry sleeps between retries without CPU spin
  *   - readExistingLockDataWithRetry returns data when file becomes readable after retries
  *   - readExistingLockDataWithRetry returns null only when ALL retries exhausted
  *   - onCompromised does not declare compromise when lock file is transiently unreadable
@@ -75,6 +76,31 @@ async function main(): Promise<void> {
     }
   }
 
+  // ─── 2b. Retry delay sleeps without CPU spin ──────────────────────────────
+  console.log('\n=== 2b. readExistingLockDataWithRetry sleeps between retry attempts ===');
+  {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-transient-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+    const originalWait = Atomics.wait;
+    const waits: Array<number | undefined> = [];
+
+    try {
+      const lockFile = join(gsdRoot(base), 'auto.lock');
+      Atomics.wait = ((_typedArray: Int32Array, _index: number, _value: number, timeout?: number) => {
+        waits.push(timeout);
+        return 'timed-out';
+      }) as typeof Atomics.wait;
+
+      const result = readExistingLockDataWithRetry(lockFile, { maxAttempts: 3, delayMs: 17 });
+      assertEq(result, null, 'null for missing file after instrumented retries');
+      assertEq(waits.length, 2, 'sleep called only between failed attempts');
+      assertEq(waits, [17, 17], 'sleep preserves delayMs across retries');
+    } finally {
+      Atomics.wait = originalWait;
+      rmSync(base, { recursive: true, force: true });
+    }
+  }
+
   // ─── 3. readExistingLockDataWithRetry recovers after transient rename ──────
   console.log('\n=== 3. readExistingLockDataWithRetry recovers after transient unavailability ===');
   {
@@ -96,8 +122,8 @@ async function main(): Promise<void> {
 
       // Simulate transient unavailability: move file away, spawn a child process
       // to restore it shortly after. The child runs outside our event loop so it
-      // fires even during busy-wait retries. Give the test extra retry budget so
-      // it stays stable under full-suite CPU contention.
+      // fires even during synchronous retry sleeps. Give the test extra retry
+      // budget so it stays stable under full-suite CPU contention.
       renameSync(lockFile, tmpFile);
       spawn('bash', ['-c', `sleep 0.05 && mv "${tmpFile}" "${lockFile}"`], { stdio: 'ignore', detached: true }).unref();
 


### PR DESCRIPTION
## Summary
- Replaced the session-lock retry busy-wait with Atomics.wait sleep, added focused regression coverage, and verified syntax/diff checks while runtime tests were blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #882
- [#882 [Bug]: Session-lock recovery uses a CPU busy-wait that pegs a core and blocks the event loop for up to 400ms](https://github.com/open-gsd/gsd-pi/issues/882)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/882-bug-session-lock-recovery-uses-a-cpu-bus-1782520159`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to retry timing in session-lock recovery; behavior is preserved with lower CPU/event-loop impact during short sync waits.
> 
> **Overview**
> **Session-lock metadata retries** no longer spin the CPU or block the event loop while waiting between read attempts. `readExistingLockDataWithRetry` now calls a small `sleepSync` helper that uses `Atomics.wait` on a `SharedArrayBuffer` instead of a `Date.now()` busy-wait loop (still used from sync paths like `onCompromised`, with the same `delayMs` / attempt behavior).
> 
> **Tests** add regression coverage that retries invoke timed sleep between failures (via a stubbed `Atomics.wait`) and update comments in the transient-recovery scenario to match the new sleep behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae7df65afbd5ab5f068a8d92b61f06c1e107f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->