### PR TITLE
fix(issue): [Bug]: file-lock onLocked:"skip" callers burn ~250ms of Atomics.wait retries before skipping

### DIFF
--- a/src/resources/extensions/gsd/file-lock.ts
+++ b/src/resources/extensions/gsd/file-lock.ts
@@ -56,9 +56,9 @@ export function withFileLockSync<T>(
 ): T {
   if (!existsSync(filePath)) return fn();
 
-  const retries = opts.retries ?? DEFAULT_RETRIES;
   const stale = opts.stale ?? DEFAULT_STALE_MS;
   const onLocked: OnLocked = opts.onLocked ?? "fail";
+  const retries = onLocked === "skip" ? 0 : (opts.retries ?? DEFAULT_RETRIES);
 
   try {
     const release = acquireLockSyncWithRetry(filePath, retries, stale);

--- a/src/resources/extensions/gsd/tests/file-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/file-lock.test.ts
@@ -114,6 +114,49 @@ test("withFileLockSync: onLocked=\"skip\" runs callback unlocked on ELOCKED", ()
   }
 });
 
+test("withFileLockSync: onLocked=\"skip\" does not sleep through retries before fallback", () => {
+  if (!hasProperLockfile() || process.platform === "win32") {
+    return;
+  }
+
+  const lockfile = require("proper-lockfile");
+  const dir = mkdtempSync(join(tmpdir(), "gsd-file-lock-test-"));
+  const filePath = join(dir, "locked.jsonl");
+  writeFileSync(filePath, "{}\n", "utf-8");
+
+  const release = lockfile.lockSync(filePath, { retries: 0, stale: 10000 });
+  const waitDescriptor = Object.getOwnPropertyDescriptor(Atomics, "wait");
+  assert.ok(waitDescriptor, "Atomics.wait descriptor should exist");
+  let sleepCalls = 0;
+
+  Object.defineProperty(Atomics, "wait", {
+    ...waitDescriptor,
+    value: () => {
+      sleepCalls++;
+      throw new Error("skip fallback must not wait before running callback");
+    },
+  });
+
+  try {
+    let called = 0;
+    const result = withFileLockSync(
+      filePath,
+      () => {
+        called++;
+        return "fallback-ok";
+      },
+      { onLocked: "skip" },
+    );
+    assert.equal(result, "fallback-ok");
+    assert.equal(called, 1, "callback should run when onLocked is skip");
+    assert.equal(sleepCalls, 0, "skip path must not block on retry sleeps");
+  } finally {
+    Object.defineProperty(Atomics, "wait", waitDescriptor);
+    release();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("withFileLock: throws ELOCKED by default (no silent fallback)", async () => {
   if (!hasProperLockfile() || process.platform === "win32") {
     return;


### PR DESCRIPTION
## Summary
- Fixed sync file-lock skip contention to avoid retry sleeps and verified with diff check plus a focused stub harness.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #883
- [#883 [Bug]: file-lock onLocked:"skip" callers burn ~250ms of Atomics.wait retries before skipping](https://github.com/open-gsd/gsd-pi/issues/883)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/883-bug-file-lock-onlocked-skip-callers-burn-1782520520`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to contention handling for an existing skip path; default fail behavior and async `withFileLock` are unchanged.
> 
> **Overview**
> **`withFileLockSync`** now sets **`retries` to 0** when **`onLocked: "skip"`**, so a contended lock no longer runs the default sync retry loop ( **`Atomics.wait`** sleeps) before invoking the unlocked fallback.
> 
> A new test stubs **`Atomics.wait`** to assert the skip path does not sleep when **`onLocked: "skip"`** is used without an explicit **`retries: 0`**—matching callers like journal appends that only pass **`onLocked: "skip"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcdd17e529d9ed36c7dbf7fa05567ceb69c7d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->