### PR TITLE
fix(issue): [Bug]: Desktop notification delivery runs synchronous execFileSync (which + terminal-notifier/osascript) on the event loop

### DIFF
--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -1,7 +1,9 @@
 // GSD Extension — Desktop Notification Helper
 // Cross-platform desktop notifications for auto-mode events.
 
-import { execFileSync } from "node:child_process";
+import childProcess from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { delimiter, resolve } from "node:path";
 import type { NotificationPreferences } from "./types.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { sendRemoteNotification as _sendRemoteNotification } from "../remote-questions/notify.js";
@@ -24,6 +26,8 @@ interface BellStream {
   isTTY?: boolean;
   write(chunk: string): unknown;
 }
+
+const executablePathCache = new Map<string, string | null>();
 
 /**
  * Send a native desktop notification. Non-blocking, non-fatal.
@@ -73,11 +77,24 @@ export function sendDesktopNotification(
     try {
       const command = buildDesktopNotificationCommand(process.platform, title, message, level);
       if (!command) return;
-      execFileSync(command.file, command.args, { timeout: 3000, stdio: "ignore" });
+      launchDesktopNotification(command);
     } catch {
       // Non-fatal — desktop notifications are best-effort
     }
   }).catch(() => {});
+}
+
+export function launchDesktopNotification(command: NotificationCommand): void {
+  try {
+    const child = childProcess.spawn(command.file, command.args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Non-fatal — desktop notifications are best-effort
+  }
 }
 
 export function shouldSendDesktopNotification(
@@ -194,11 +211,25 @@ function escapeAppleScript(s: string): string {
  * Non-fatal — returns null on any error.
  */
 function findExecutable(name: string): string | null {
-  try {
-    return execFileSync("which", [name], { timeout: 2000, stdio: ["ignore", "pipe", "ignore"] }).toString().trim() || null;
-  } catch {
-    return null;
+  if (executablePathCache.has(name)) return executablePathCache.get(name) ?? null;
+
+  let resolved: string | null = null;
+  const path = process.env.PATH;
+  if (path) {
+    for (const dir of path.split(delimiter)) {
+      const candidate = resolve(dir || ".", name);
+      try {
+        accessSync(candidate, constants.X_OK);
+        resolved = candidate;
+        break;
+      } catch {
+        // keep searching PATH
+      }
+    }
   }
+
+  executablePathCache.set(name, resolved);
+  return resolved;
 }
 
 function resolveBellStream(): BellStream | null {

--- a/src/resources/extensions/gsd/tests/notifications.test.ts
+++ b/src/resources/extensions/gsd/tests/notifications.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +13,7 @@ import {
   buildDesktopNotificationCommand,
   shouldSendDesktopNotification,
   formatNotificationTitle,
+  launchDesktopNotification,
   playNotificationBell,
   shouldPlayNotificationBell,
 } from "../notifications.js";
@@ -125,6 +128,36 @@ test("stopAuto plays local bell for auto-mode stop notifications", async () => {
     process.chdir(previousCwd);
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("launchDesktopNotification starts notifier as detached fire-and-forget process", (t) => {
+  const child = {
+    on(_event: string, _listener: (error: Error) => void) {
+      return child;
+    },
+    unref() {
+      return child;
+    },
+  };
+  const onMock = t.mock.method(child, "on");
+  const unrefMock = t.mock.method(child, "unref");
+  const spawnMock = t.mock.method(
+    childProcess,
+    "spawn",
+    () => child as unknown as ChildProcess,
+  );
+
+  launchDesktopNotification({ file: "notify-send", args: ["Title", "Message"] });
+
+  assert.equal(spawnMock.mock.callCount(), 1);
+  assert.deepEqual(spawnMock.mock.calls[0].arguments, [
+    "notify-send",
+    ["Title", "Message"],
+    { detached: true, stdio: "ignore" },
+  ]);
+  assert.equal(onMock.mock.callCount(), 1);
+  assert.equal(onMock.mock.calls[0].arguments[0], "error");
+  assert.equal(unrefMock.mock.callCount(), 1);
 });
 
 test("buildDesktopNotificationCommand falls back to osascript on macOS when terminal-notifier is absent", () => {


### PR DESCRIPTION
## Summary
- Fixed desktop notifications to use detached spawn with cached PATH lookup; lightweight checks passed while full tests were blocked by missing dependencies/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #885
- [#885 [Bug]: Desktop notification delivery runs synchronous execFileSync (which + terminal-notifier/osascript) on the event loop](https://github.com/open-gsd/gsd-pi/issues/885)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/885-bug-desktop-notification-delivery-runs-s-1782520764`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort notification path only; behavior is intended to match prior delivery with lower blocking risk, and changes are covered by a focused spawn test.
> 
> **Overview**
> Fixes desktop notification delivery blocking the Node event loop during auto-mode events (e.g. budget, milestones, errors).
> 
> **Notification launch** no longer uses synchronous `execFileSync` for `terminal-notifier`, `osascript`, or `notify-send`. A new **`launchDesktopNotification`** helper **`spawn`s** the notifier with **`detached: true`**, **`stdio: "ignore"`**, and **`unref()`**, so the parent does not wait on the child. Errors on the child are swallowed so delivery stays best-effort.
> 
> **PATH resolution** for tools like `terminal-notifier` no longer shells out to `which`. **`findExecutable`** walks **`process.env.PATH`**, checks execute permission with **`accessSync`**, and **caches** results to avoid repeated lookups.
> 
> Adds a unit test that **`launchDesktopNotification`** uses **`spawn`** with the expected detached options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27cefdd6abfb500650d0fbb3ed42bc3456ca9b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->