### PR TITLE
fix(issue): [Bug]: Parallel monitor overlay spawns sqlite3 synchronously and reads whole worker NDJSON logs on its 5s refresh, blocking the TUI event loop

### DIFF
--- a/src/resources/extensions/gsd/db-workspace.ts
+++ b/src/resources/extensions/gsd/db-workspace.ts
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 
 import type { GsdWorkspace, MilestoneScope } from "./workspace.js";
+import type { DbAdapter } from "./db-adapter.js";
 import {
   backupDatabaseSnapshot,
   checkpointDatabase,
@@ -18,6 +19,7 @@ import {
   openDatabase,
   openDatabaseByScope,
   openDatabaseByWorkspace,
+  openIsolatedDatabase,
   refreshOpenDatabaseFromDisk,
   vacuumDatabase,
   wasDbOpenAttempted,
@@ -111,6 +113,19 @@ export function openExistingWorkflowDatabase(basePath: string): WorkflowDatabase
 
 export function openWorkflowDatabasePath(path: string): boolean {
   return openDatabase(path);
+}
+
+/**
+ * Open an isolated database connection for read-only observation without
+ * displacing the active workflow session's global DB handle. The caller is
+ * responsible for calling `adapter.close()` when done.
+ *
+ * Use this for background observers (e.g. the parallel monitor overlay) that
+ * need to query a database on a 5s tick without interfering with the primary
+ * connection. Returns null if the connection cannot be opened.
+ */
+export function openWorkflowDatabaseIsolated(path: string): DbAdapter | null {
+  return openIsolatedDatabase(path);
 }
 
 export function openWorkflowDatabaseByWorkspace(workspace: GsdWorkspace): boolean {

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -672,6 +672,32 @@ export function closeDatabase(): void {
 }
 
 /**
+ * Open an isolated database connection that does NOT touch the process-wide
+ * `currentDb` singleton. Intended for background observers (e.g. the parallel
+ * monitor overlay) that must read a database without displacing an active
+ * workflow session connection.
+ *
+ * The caller MUST call `adapter.close()` when done. Schema migrations are NOT
+ * run — the database must already exist and be fully migrated by the primary
+ * connection. Returns null if the connection cannot be opened.
+ */
+export function openIsolatedDatabase(path: string): DbAdapter | null {
+  try {
+    const rawDb = providerLoader.openRaw(path);
+    if (!rawDb) return null;
+    const adapter = createDbAdapter(rawDb);
+    // Minimal pragmas for a short-lived read-only observer connection.
+    // WAL mode is already set file-wide by the primary connection; repeating
+    // it here is a no-op on an existing WAL file and safe to issue.
+    adapter.exec("PRAGMA journal_mode=WAL");
+    adapter.exec("PRAGMA busy_timeout = 5000");
+    return adapter;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Re-open the active database connection from disk.
  *
  * Auto-mode can observe artifacts written by a workflow server running in a

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -270,6 +270,66 @@ export function getMilestoneSlices(milestoneId: string): SliceRow[] {
   return rows.map(rowToSlice);
 }
 
+export interface ParallelMonitorSliceProgress {
+  id: string;
+  status: string;
+  total: number;
+  done: number;
+}
+
+export function getParallelMonitorSliceProgress(milestoneId: string): ParallelMonitorSliceProgress[] {
+  const db = getDbOrNull();
+  if (!db) return [];
+  const rows = db.prepare(
+    `SELECT
+       s.id AS id,
+       s.status AS status,
+       COUNT(t.id) AS total,
+       COALESCE(SUM(CASE WHEN t.status='complete' THEN 1 ELSE 0 END), 0) AS done
+     FROM slices s
+     LEFT JOIN tasks t ON s.milestone_id=t.milestone_id AND s.id=t.slice_id
+     WHERE s.milestone_id=:mid
+     GROUP BY s.id
+     ORDER BY s.id`,
+  ).all({ ":mid": milestoneId });
+  return rows.map((row) => ({
+    id: String(row["id"] ?? ""),
+    status: String(row["status"] ?? ""),
+    total: Number(row["total"] ?? 0),
+    done: Number(row["done"] ?? 0),
+  }));
+}
+
+export interface ParallelMonitorCompletion {
+  taskId: string;
+  sliceId: string;
+  oneLiner: string;
+}
+
+export function getParallelMonitorRecentCompletions(
+  milestoneId: string,
+  limit: number = 5,
+): ParallelMonitorCompletion[] {
+  const db = getDbOrNull();
+  if (!db) return [];
+  const numericLimit = Number.isFinite(limit) ? Math.floor(limit) : 5;
+  const safeLimit = Math.max(1, Math.min(50, numericLimit));
+  const rows = db.prepare(
+    `SELECT id, slice_id, one_liner
+     FROM tasks
+     WHERE milestone_id=:mid
+       AND status='complete'
+       AND completed_at IS NOT NULL
+     ORDER BY completed_at DESC
+     LIMIT ${safeLimit}`,
+  ).all({ ":mid": milestoneId });
+  return rows.map((row) => ({
+    taskId: String(row["id"] ?? ""),
+    sliceId: String(row["slice_id"] ?? ""),
+    oneLiner: String(row["one_liner"] ?? ""),
+  }));
+}
+
 /**
  * Load slices for many milestones in a single query. Returns a Map keyed by
  * milestone_id, preserving `ORDER BY sequence, id` within each bucket.

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -3,7 +3,6 @@
 
 import { existsSync, statSync, readFileSync, openSync, readSync, closeSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
 
 import type { Theme } from "@gsd/pi-coding-agent";
 import { matchesKey, Key } from "@gsd/pi-tui";
@@ -11,6 +10,11 @@ import { matchesKey, Key } from "@gsd/pi-tui";
 import { formatDuration } from "../shared/mod.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { resolveGsdPathContract } from "./paths.js";
+import { openWorkflowDatabasePath } from "./db-workspace.js";
+import {
+  getParallelMonitorRecentCompletions,
+  getParallelMonitorSliceProgress,
+} from "./db/queries.js";
 import { worktreePathFor, worktreesDirs } from "./worktree-placement.js";
 import {
   renderBar,
@@ -48,6 +52,13 @@ interface SliceProgress {
   done: number;
 }
 
+interface NdjsonCostCacheEntry {
+  size: number;
+  mtimeMs: number;
+  total: number;
+  pendingLine: string;
+}
+
 interface WorkerView {
   mid: string;
   pid: number;
@@ -66,6 +77,9 @@ interface WorkerView {
   slices: SliceProgress[];
   errors: string[];
 }
+
+const ndjsonCostCache = new Map<string, NdjsonCostCacheEntry>();
+const NDJSON_COST_READ_CHUNK_BYTES = 64 * 1024;
 
 // ─── Data Helpers ─────────────────────────────────────────────────────────
 
@@ -133,38 +147,108 @@ function querySliceProgress(basePath: string, mid: string, workRoot: string = wo
   if (!existsSync(dbPath)) return [];
 
   try {
-    const sql = `SELECT s.id, s.status, COUNT(t.id), SUM(CASE WHEN t.status='complete' THEN 1 ELSE 0 END) FROM slices s LEFT JOIN tasks t ON s.milestone_id=t.milestone_id AND s.id=t.slice_id WHERE s.milestone_id='${mid}' GROUP BY s.id ORDER BY s.id`;
-    const result = spawnSync("sqlite3", [dbPath, sql], { timeout: 3000, encoding: "utf-8" });
-    const out = (result.stdout || "").trim();
-    if (!out || result.status !== 0) return [];
-    return out.split("\n").map((line) => {
-      const [id, status, total, done] = line.split("|");
-      return { id, status, total: parseInt(total, 10), done: parseInt(done || "0", 10) };
-    });
+    if (!openWorkflowDatabasePath(dbPath)) return [];
+    return getParallelMonitorSliceProgress(mid);
   } catch {
     return [];
   }
 }
 
-function extractCostFromNdjson(basePath: string, mid: string): number {
-  const stdoutPath = join(basePath, ".gsd", "parallel", `${mid}.stdout.log`);
-  if (!existsSync(stdoutPath)) return 0;
+function costFromNdjsonLine(line: string): number {
+  if (!line.includes("message_end")) return 0;
   try {
-    const content = readFileSync(stdoutPath, "utf-8");
-    let total = 0;
-    for (const line of content.split("\n")) {
-      if (!line.includes("message_end")) continue;
-      try {
-        const obj = JSON.parse(line);
-        if (obj.type === "message_end") {
-          const cost = obj.message?.usage?.cost?.total;
-          if (typeof cost === "number") total += cost;
-        }
-      } catch { /* skip */ }
-    }
-    return total;
+    const obj = JSON.parse(line);
+    if (obj.type !== "message_end") return 0;
+    const cost = obj.message?.usage?.cost?.total;
+    return typeof cost === "number" ? cost : 0;
   } catch {
     return 0;
+  }
+}
+
+function consumePendingNdjsonLine(line: string): { consumed: boolean; cost: number } {
+  const trimmed = line.trim();
+  if (!trimmed) return { consumed: true, cost: 0 };
+  try {
+    const obj = JSON.parse(trimmed);
+    if (obj.type !== "message_end") return { consumed: true, cost: 0 };
+    const cost = obj.message?.usage?.cost?.total;
+    return { consumed: true, cost: typeof cost === "number" ? cost : 0 };
+  } catch {
+    return { consumed: false, cost: 0 };
+  }
+}
+
+function readNdjsonCostRange(
+  filePath: string,
+  start: number,
+  length: number,
+  initialTotal: number,
+  initialPendingLine: string,
+): { total: number; pendingLine: string } {
+  const fd = openSync(filePath, "r");
+  let total = initialTotal;
+  let pendingLine = initialPendingLine;
+
+  try {
+    let offset = start;
+    let remaining = length;
+    while (remaining > 0) {
+      const readSize = Math.min(remaining, NDJSON_COST_READ_CHUNK_BYTES);
+      const buf = Buffer.alloc(readSize);
+      const bytesRead = readSync(fd, buf, 0, readSize, offset);
+      if (bytesRead <= 0) break;
+
+      offset += bytesRead;
+      remaining -= bytesRead;
+
+      const content = pendingLine + buf.subarray(0, bytesRead).toString("utf-8");
+      const lines = content.split("\n");
+      pendingLine = lines.pop() ?? "";
+      for (const line of lines) total += costFromNdjsonLine(line);
+    }
+  } finally {
+    closeSync(fd);
+  }
+
+  return { total, pendingLine };
+}
+
+function extractCostFromNdjson(basePath: string, mid: string): number {
+  const stdoutPath = join(basePath, ".gsd", "parallel", `${mid}.stdout.log`);
+  if (!existsSync(stdoutPath)) {
+    ndjsonCostCache.delete(stdoutPath);
+    return 0;
+  }
+
+  try {
+    const stat = statSync(stdoutPath);
+    const cached = ndjsonCostCache.get(stdoutPath);
+    if (cached && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) return cached.total;
+
+    const isAppendOnly = cached !== undefined && stat.size > cached.size;
+    const start = isAppendOnly ? cached.size : 0;
+    const initialTotal = isAppendOnly ? cached.total : 0;
+    const initialPendingLine = isAppendOnly ? cached.pendingLine : "";
+    const { total, pendingLine } = readNdjsonCostRange(
+      stdoutPath,
+      start,
+      stat.size - start,
+      initialTotal,
+      initialPendingLine,
+    );
+    const pending = consumePendingNdjsonLine(pendingLine);
+    const nextPendingLine = pending.consumed ? "" : pendingLine;
+    const nextTotal = total + pending.cost;
+    ndjsonCostCache.set(stdoutPath, {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      total: nextTotal,
+      pendingLine: nextPendingLine,
+    });
+    return nextTotal;
+  } catch {
+    return ndjsonCostCache.get(stdoutPath)?.total ?? 0;
   }
 }
 
@@ -173,12 +257,8 @@ function queryRecentCompletions(basePath: string, mid: string): string[] {
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
   try {
-    const sql = `SELECT id, slice_id, one_liner FROM tasks WHERE milestone_id='${mid}' AND status='complete' AND completed_at IS NOT NULL ORDER BY completed_at DESC LIMIT 5`;
-    const result = spawnSync("sqlite3", [dbPath, sql], { timeout: 3000, encoding: "utf-8" });
-    const out = (result.stdout || "").trim();
-    if (!out || result.status !== 0) return [];
-    return out.split("\n").map((line) => {
-      const [taskId, sliceId, oneLiner] = line.split("|");
+    if (!openWorkflowDatabasePath(dbPath)) return [];
+    return getParallelMonitorRecentCompletions(mid).map(({ taskId, sliceId, oneLiner }) => {
       return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
     });
   } catch {

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -10,7 +10,11 @@ import { matchesKey, Key } from "@gsd/pi-tui";
 import { formatDuration } from "../shared/mod.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { resolveGsdPathContract } from "./paths.js";
-import { openWorkflowDatabasePath } from "./db-workspace.js";
+import {
+  closeWorkflowDatabase,
+  getWorkflowDatabasePath,
+  openWorkflowDatabasePath,
+} from "./db-workspace.js";
 import {
   getParallelMonitorRecentCompletions,
   getParallelMonitorSliceProgress,
@@ -55,6 +59,7 @@ interface SliceProgress {
 interface NdjsonCostCacheEntry {
   size: number;
   mtimeMs: number;
+  fileKey: string;
   total: number;
   pendingLine: string;
 }
@@ -82,6 +87,32 @@ const ndjsonCostCache = new Map<string, NdjsonCostCacheEntry>();
 const NDJSON_COST_READ_CHUNK_BYTES = 64 * 1024;
 
 // ─── Data Helpers ─────────────────────────────────────────────────────────
+
+function ndjsonFileKey(stat: ReturnType<typeof statSync>): string {
+  return `${stat.dev}:${stat.ino}`;
+}
+
+function restoreWorkflowDatabasePath(previousPath: string | null): void {
+  if (previousPath) {
+    try {
+      openWorkflowDatabasePath(previousPath);
+    } catch {
+      /* best-effort restore */
+    }
+    return;
+  }
+  closeWorkflowDatabase();
+}
+
+function withWorkflowDatabasePath<T>(dbPath: string, onOpenFailure: T, fn: () => T): T {
+  const previousPath = getWorkflowDatabasePath();
+  try {
+    if (!openWorkflowDatabasePath(dbPath)) return onOpenFailure;
+    return fn();
+  } finally {
+    restoreWorkflowDatabasePath(previousPath);
+  }
+}
 
 function readJsonSafe<T>(filePath: string): T | null {
   try {
@@ -147,8 +178,7 @@ function querySliceProgress(basePath: string, mid: string, workRoot: string = wo
   if (!existsSync(dbPath)) return [];
 
   try {
-    if (!openWorkflowDatabasePath(dbPath)) return [];
-    return getParallelMonitorSliceProgress(mid);
+    return withWorkflowDatabasePath(dbPath, [], () => getParallelMonitorSliceProgress(mid));
   } catch {
     return [];
   }
@@ -226,7 +256,9 @@ function extractCostFromNdjson(basePath: string, mid: string): number {
     const cached = ndjsonCostCache.get(stdoutPath);
     if (cached && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) return cached.total;
 
-    const isAppendOnly = cached !== undefined && stat.size > cached.size;
+    const isAppendOnly = cached !== undefined
+      && stat.size > cached.size
+      && ndjsonFileKey(stat) === cached.fileKey;
     const start = isAppendOnly ? cached.size : 0;
     const initialTotal = isAppendOnly ? cached.total : 0;
     const initialPendingLine = isAppendOnly ? cached.pendingLine : "";
@@ -243,6 +275,7 @@ function extractCostFromNdjson(basePath: string, mid: string): number {
     ndjsonCostCache.set(stdoutPath, {
       size: stat.size,
       mtimeMs: stat.mtimeMs,
+      fileKey: ndjsonFileKey(stat),
       total: nextTotal,
       pendingLine: nextPendingLine,
     });
@@ -257,10 +290,11 @@ function queryRecentCompletions(basePath: string, mid: string): string[] {
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
   try {
-    if (!openWorkflowDatabasePath(dbPath)) return [];
-    return getParallelMonitorRecentCompletions(mid).map(({ taskId, sliceId, oneLiner }) => {
-      return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
-    });
+    return withWorkflowDatabasePath(dbPath, [], () =>
+      getParallelMonitorRecentCompletions(mid).map(({ taskId, sliceId, oneLiner }) => {
+        return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
+      }),
+    );
   } catch {
     return [];
   }
@@ -376,6 +410,7 @@ export class ParallelMonitorOverlay {
   private scrollOffset = 0;
   private disposed = false;
   private resizeHandler: (() => void) | null = null;
+  private savedDbPath: string | null;
 
   constructor(
     tui: { requestRender: () => void },
@@ -387,6 +422,7 @@ export class ParallelMonitorOverlay {
     this.theme = theme;
     this.onClose = onClose;
     this.basePath = basePath || process.cwd();
+    this.savedDbPath = getWorkflowDatabasePath();
 
     this.resizeHandler = () => {
       if (this.disposed) return;
@@ -424,6 +460,9 @@ export class ParallelMonitorOverlay {
       process.stdout.removeListener("resize", this.resizeHandler);
       this.resizeHandler = null;
     }
+    const savedDbPath = this.savedDbPath;
+    this.savedDbPath = null;
+    restoreWorkflowDatabasePath(savedDbPath);
   }
 
   handleInput(data: string): void {

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: Parallel worker monitor overlay with width-safe operations-console rendering.
 
-import { existsSync, statSync, readFileSync, openSync, readSync, closeSync, readdirSync } from "node:fs";
+import { existsSync, statSync, readFileSync, openSync, readSync, closeSync, readdirSync, type Stats } from "node:fs";
 import { join } from "node:path";
 
 import type { Theme } from "@gsd/pi-coding-agent";
@@ -80,7 +80,7 @@ const NDJSON_COST_READ_CHUNK_BYTES = 64 * 1024;
 
 // ─── Data Helpers ─────────────────────────────────────────────────────────
 
-function ndjsonFileKey(stat: ReturnType<typeof statSync>): string {
+function ndjsonFileKey(stat: Stats): string {
   return `${stat.dev}:${stat.ino}`;
 }
 

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -10,15 +10,7 @@ import { matchesKey, Key } from "@gsd/pi-tui";
 import { formatDuration } from "../shared/mod.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { resolveGsdPathContract } from "./paths.js";
-import {
-  closeWorkflowDatabase,
-  getWorkflowDatabasePath,
-  openWorkflowDatabasePath,
-} from "./db-workspace.js";
-import {
-  getParallelMonitorRecentCompletions,
-  getParallelMonitorSliceProgress,
-} from "./db/queries.js";
+import { openWorkflowDatabaseIsolated } from "./db-workspace.js";
 import { worktreePathFor, worktreesDirs } from "./worktree-placement.js";
 import {
   renderBar,
@@ -92,28 +84,6 @@ function ndjsonFileKey(stat: ReturnType<typeof statSync>): string {
   return `${stat.dev}:${stat.ino}`;
 }
 
-function restoreWorkflowDatabasePath(previousPath: string | null): void {
-  if (previousPath) {
-    try {
-      openWorkflowDatabasePath(previousPath);
-    } catch {
-      /* best-effort restore */
-    }
-    return;
-  }
-  closeWorkflowDatabase();
-}
-
-function withWorkflowDatabasePath<T>(dbPath: string, onOpenFailure: T, fn: () => T): T {
-  const previousPath = getWorkflowDatabasePath();
-  try {
-    if (!openWorkflowDatabasePath(dbPath)) return onOpenFailure;
-    return fn();
-  } finally {
-    restoreWorkflowDatabasePath(previousPath);
-  }
-}
-
 function readJsonSafe<T>(filePath: string): T | null {
   try {
     return JSON.parse(readFileSync(filePath, "utf-8")) as T;
@@ -177,10 +147,31 @@ function querySliceProgress(basePath: string, mid: string, workRoot: string = wo
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
 
+  const db = openWorkflowDatabaseIsolated(dbPath);
+  if (!db) return [];
   try {
-    return withWorkflowDatabasePath(dbPath, [], () => getParallelMonitorSliceProgress(mid));
+    const rows = db.prepare(
+      `SELECT
+         s.id AS id,
+         s.status AS status,
+         COUNT(t.id) AS total,
+         COALESCE(SUM(CASE WHEN t.status='complete' THEN 1 ELSE 0 END), 0) AS done
+       FROM slices s
+       LEFT JOIN tasks t ON s.milestone_id=t.milestone_id AND s.id=t.slice_id
+       WHERE s.milestone_id=:mid
+       GROUP BY s.id
+       ORDER BY s.id`,
+    ).all({ ":mid": mid });
+    return rows.map((row) => ({
+      id: String(row["id"] ?? ""),
+      status: String(row["status"] ?? ""),
+      total: Number(row["total"] ?? 0),
+      done: Number(row["done"] ?? 0),
+    }));
   } catch {
     return [];
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
   }
 }
 
@@ -289,14 +280,29 @@ function queryRecentCompletions(basePath: string, mid: string): string[] {
   const workRoot = worktreePathFor(basePath, mid);
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
+
+  const db = openWorkflowDatabaseIsolated(dbPath);
+  if (!db) return [];
   try {
-    return withWorkflowDatabasePath(dbPath, [], () =>
-      getParallelMonitorRecentCompletions(mid).map(({ taskId, sliceId, oneLiner }) => {
-        return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
-      }),
-    );
+    const rows = db.prepare(
+      `SELECT id, slice_id, one_liner
+       FROM tasks
+       WHERE milestone_id=:mid
+         AND status='complete'
+         AND completed_at IS NOT NULL
+       ORDER BY completed_at DESC
+       LIMIT 5`,
+    ).all({ ":mid": mid });
+    return rows.map((row) => {
+      const taskId = String(row["id"] ?? "");
+      const sliceId = String(row["slice_id"] ?? "");
+      const oneLiner = String(row["one_liner"] ?? "");
+      return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
+    });
   } catch {
     return [];
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
   }
 }
 
@@ -410,7 +416,6 @@ export class ParallelMonitorOverlay {
   private scrollOffset = 0;
   private disposed = false;
   private resizeHandler: (() => void) | null = null;
-  private savedDbPath: string | null;
 
   constructor(
     tui: { requestRender: () => void },
@@ -422,7 +427,6 @@ export class ParallelMonitorOverlay {
     this.theme = theme;
     this.onClose = onClose;
     this.basePath = basePath || process.cwd();
-    this.savedDbPath = getWorkflowDatabasePath();
 
     this.resizeHandler = () => {
       if (this.disposed) return;
@@ -460,9 +464,6 @@ export class ParallelMonitorOverlay {
       process.stdout.removeListener("resize", this.resizeHandler);
       this.resizeHandler = null;
     }
-    const savedDbPath = this.savedDbPath;
-    this.savedDbPath = null;
-    restoreWorkflowDatabasePath(savedDbPath);
   }
 
   handleInput(data: string): void {

--- a/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
@@ -3,9 +3,14 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { appendFileSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import { visibleWidth } from "@gsd/pi-tui";
 import { assertFullOuterBorder } from "./tui-border-assertions.ts";
+import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
 
 function assertLinesFit(lines: string[], width: number): void {
   for (const line of lines) {
@@ -17,6 +22,92 @@ function assertLinesFit(lines: string[], width: number): void {
 }
 
 describe("parallel-monitor-overlay", () => {
+  it("reads worker DB progress and appended NDJSON cost without sqlite CLI or full stdout reads", async () => {
+    const base = mkdtempSync(join(tmpdir(), "gsd-parallel-overlay-"));
+    const stdoutPath = join(base, ".gsd", "parallel", "M001.stdout.log");
+    const cjsRequire = createRequire(import.meta.url);
+    const fsBuiltin = cjsRequire("node:fs") as typeof import("node:fs");
+    const childProcessBuiltin = cjsRequire("node:child_process") as typeof import("node:child_process");
+    const originalReadFileSync = fsBuiltin.readFileSync;
+    const originalSpawnSync = childProcessBuiltin.spawnSync;
+
+    try {
+      mkdirSync(join(base, ".gsd", "parallel"), { recursive: true });
+      assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+      insertMilestone({ id: "M001", title: "Monitor Fixture" });
+      insertSlice({ milestoneId: "M001", id: "S01", title: "Build overlay", status: "pending", sequence: 1 });
+      insertTask({
+        milestoneId: "M001",
+        sliceId: "S01",
+        id: "T01",
+        status: "complete",
+        oneLiner: "render progress",
+        sequence: 1,
+      });
+      insertTask({ milestoneId: "M001", sliceId: "S01", id: "T02", status: "pending", sequence: 2 });
+      closeDatabase();
+
+      writeFileSync(
+        join(base, ".gsd", "parallel", "M001.status.json"),
+        JSON.stringify({
+          milestoneId: "M001",
+          pid: process.pid,
+          state: "running",
+          cost: 0,
+          lastHeartbeat: Date.now(),
+          startedAt: Date.now() - 30_000,
+          worktreePath: join(base, ".gsd-worktrees", "M001"),
+        }),
+        "utf-8",
+      );
+      writeFileSync(
+        stdoutPath,
+        JSON.stringify({ type: "message_end", message: { usage: { cost: { total: 1.25 } } } }) + "\n",
+        "utf-8",
+      );
+
+      fsBuiltin.readFileSync = ((filePath: Parameters<typeof originalReadFileSync>[0], ...args: unknown[]) => {
+        if (String(filePath) === stdoutPath) throw new Error("full stdout log reads are disabled in this test");
+        return (originalReadFileSync as (...readArgs: unknown[]) => unknown)(filePath, ...args);
+      }) as typeof fsBuiltin.readFileSync;
+      childProcessBuiltin.spawnSync = ((command: Parameters<typeof originalSpawnSync>[0], ...args: unknown[]) => {
+        if (command === "sqlite3") throw new Error("sqlite3 CLI is disabled in this test");
+        return (originalSpawnSync as (...spawnArgs: unknown[]) => unknown)(command, ...args);
+      }) as typeof childProcessBuiltin.spawnSync;
+
+      const mod = await import("../parallel-monitor-overlay.js");
+      const mockTui = { requestRender: () => {} };
+      const mockTheme = {
+        fg: (_color: string, text: string) => text,
+        bold: (text: string) => text,
+      };
+      const overlay = new mod.ParallelMonitorOverlay(mockTui, mockTheme as any, () => {}, base);
+
+      try {
+        const joined = overlay.render(100).join("\n");
+        assert.match(joined, /S01:1\/2/, "slice progress should come from the in-process DB reader");
+        assert.match(joined, /S01\/T01: render progress/, "recent completions should come from the in-process DB reader");
+        assert.match(joined, /\$1\.25/, "cost should come from bounded NDJSON reads");
+
+        appendFileSync(
+          stdoutPath,
+          JSON.stringify({ type: "message_end", message: { usage: { cost: { total: 2.00 } } } }) + "\n",
+          "utf-8",
+        );
+        (overlay as any).refresh();
+        const refreshed = overlay.render(100).join("\n");
+        assert.match(refreshed, /\$3\.25/, "cost should include only newly appended NDJSON events");
+      } finally {
+        overlay.dispose();
+      }
+    } finally {
+      fsBuiltin.readFileSync = originalReadFileSync;
+      childProcessBuiltin.spawnSync = originalSpawnSync;
+      try { closeDatabase(); } catch { /* already closed */ }
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   it("progressBar generates correct width", async () => {
     // Dynamic import to test the module loads cleanly
     const mod = await import("../parallel-monitor-overlay.js");

--- a/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
@@ -365,6 +365,7 @@ test("DB Workspace Interface owns database open-state and maintenance calls", as
     "openWorkflowDatabase",
     "openWorkflowDatabaseByScope",
     "openWorkflowDatabaseByWorkspace",
+    "openWorkflowDatabaseIsolated",
     "openWorkflowDatabasePath",
     "refreshWorkflowDatabaseFromDisk",
     "resolveProjectRootDbPath",


### PR DESCRIPTION
## Summary
- Fixed parallel monitor refresh blocking by removing sqlite3 spawns, bounding NDJSON cost reads, and adding focused regression coverage; runtime tests were blocked by missing dependencies.

## Bugs Addressed
- [x] **Synchronous sqlite3 calls block the TUI event loop**
- [x] **NDJSON cost extraction rereads full worker logs each tick**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #886
- [#886 [Bug]: Parallel monitor overlay spawns sqlite3 synchronously and reads whole worker NDJSON logs on its 5s refresh, blocking the TUI event loop](https://github.com/open-gsd/gsd-pi/issues/886)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/886-bug-parallel-monitor-overlay-spawns-sqli-1782521725`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Temporary workflow DB path switching during overlay refresh could interact badly with other DB users if restore fails, though changes are scoped to the monitor overlay and restore on dispose.
> 
> **Overview**
> Fixes **parallel monitor** 5s refresh blocking the TUI by replacing synchronous **`sqlite3`** subprocess queries with **in-process** reads through new `getParallelMonitorSliceProgress` and `getParallelMonitorRecentCompletions` helpers, using **`withWorkflowDatabasePath`** to open each worker’s project DB briefly and **restore** the prior workflow DB when the overlay closes.
> 
> **NDJSON worker cost** no longer reloads entire `*.stdout.log` files each tick: a **stat-keyed cache** reads only new bytes when logs grow append-only, with chunked reads and handling for partial trailing lines.
> 
> Adds a regression test that asserts slice progress, recent completions, and incremental cost totals render correctly while **`sqlite3`** and full stdout **`readFileSync`** are forbidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bacbd37153529d4511a7f210c834db0ec05cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->