### PR TITLE
fix(issue): [Bug]: `git ls-files` is spawned synchronously on every `before_agent_start`, before the freshness TTL short-circuit

### DIFF
--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -472,20 +472,17 @@ export function ensureCodebaseMapFresh(
   const force = ensureOptions?.force === true;
   const now = Date.now();
 
-  // Enumerate files and compute fingerprint before the TTL check so that
-  // file changes are always detected, even within the TTL window.
-  const existing = readCodebaseMap(basePath);
-  const listed = enumerateFiles(basePath, resolved.excludes, resolved.maxFiles);
-  const fingerprint = computeCodebaseFingerprint(listed.files, resolved, listed.truncated);
-
-  // TTL short-circuit: only bypass regeneration when the fingerprint matches,
-  // confirming that no tracked files changed since the last check.
+  // TTL short-circuit: avoid spawning git on the per-turn freshness path.
   if (!force && ttlMs > 0) {
     const cached = freshnessCache.get(cacheKey);
-    if (cached && now - cached.checkedAt < ttlMs && cached.result.fingerprint === fingerprint) {
+    if (cached && now - cached.checkedAt < ttlMs) {
       return cached.result;
     }
   }
+
+  const existing = readCodebaseMap(basePath);
+  const listed = enumerateFiles(basePath, resolved.excludes, resolved.maxFiles);
+  const fingerprint = computeCodebaseFingerprint(listed.files, resolved, listed.truncated);
 
   const cacheAndReturn = (result: EnsureCodebaseMapResult): EnsureCodebaseMapResult => {
     freshnessCache.set(cacheKey, { checkedAt: now, result });

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -697,23 +697,27 @@ test("ensureCodebaseMapFresh: does not rewrite expired metadata when fingerprint
   }
 });
 
-test("ensureCodebaseMapFresh: detects file changes within the TTL window", () => {
+test("ensureCodebaseMapFresh: uses TTL cache before enumerating files", () => {
   const base = makeTmpRepo();
   try {
     addFile(base, "src/main.ts");
-    // Generate initial map with a long TTL so the cache is still active.
     const initial = ensureCodebaseMapFresh(base, undefined, { ttlMs: 60_000 });
     assert.equal(initial.status, "generated");
 
-    // Add a new tracked file while the TTL is still active.
-    addFile(base, "src/new.ts");
+    const emptyBin = join(base, "empty-bin");
+    mkdirSync(emptyBin);
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = emptyBin;
 
-    // Must detect the change even though the TTL has not expired.
-    const refreshed = ensureCodebaseMapFresh(base, undefined, { ttlMs: 60_000 });
-    assert.equal(refreshed.status, "updated");
-    assert.equal(refreshed.reason, "files-changed");
-    const written = readCodebaseMap(base);
-    assert.ok(written?.includes("`src/new.ts`"));
+      const cached = ensureCodebaseMapFresh(base, undefined, { ttlMs: 60_000 });
+      assert.equal(cached.status, "generated");
+      assert.equal(cached.fingerprint, initial.fingerprint);
+      assert.equal(cached.fileCount, 1);
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    }
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Fixed the CODEBASE freshness TTL path to return cached results before spawning git and verified with the focused codebase-generator test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #888
- [#888 [Bug]: `git ls-files` is spawned synchronously on every `before_agent_start`, before the freshness TTL short-circuit](https://github.com/open-gsd/gsd-pi/issues/888)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/888-bug-git-ls-files-is-spawned-synchronousl-1782522318`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Performance fix trades mid-TTL staleness for avoiding git on every agent turn; CODEBASE.md can lag briefly after file changes unless TTL expires or force refresh runs.
> 
> **Overview**
> **Moves the freshness TTL check ahead of file enumeration** in `ensureCodebaseMapFresh`, so repeated calls on paths like `before_agent_start` can return the in-memory cache **without** synchronously spawning `git ls-files`.
> 
> Previously, enumeration and fingerprinting ran before TTL, so git still ran every turn; TTL only skipped regeneration when the fingerprint matched. **Within the TTL window, results are now served from cache on time alone**, so tracked-file changes may not refresh `CODEBASE.md` until the TTL expires (or `force` is used).
> 
> The test suite replaces the “detect changes within TTL” case with one that **empties `PATH`** on the second call to prove a cache hit does not invoke git.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa62eb447108f1851634a0883ac3c0dfe1962ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->