### PR TITLE
fix(issue): [Bug]: Workflow MCP repo-root discovery walks the directory tree ~4× per launch-config build and is uncached

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -283,6 +283,35 @@ test("detectWorkflowMcpLaunchConfig resolves the bundled server from GSD_BIN_PAT
   assert.match(launch?.env?.GSD_WORKFLOW_WRITE_GATE_MODULE ?? "", /write-gate\.(js|ts)$/);
 });
 
+test("detectWorkflowMcpLaunchConfig memoizes repo root discovery for the same deep GSD_BIN_PATH", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-root-cache-"));
+  const worktreeRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-root-cache-wt-"));
+  const cliPath = join(repoRoot, "packages", "mcp-server", "dist", "cli.js");
+  const devCliPath = join(repoRoot, ".gsd", "worktrees", "M001", "S01", "deep", "bin", "gsd");
+
+  mkdirSync(join(repoRoot, "packages", "mcp-server", "dist"), { recursive: true });
+  mkdirSync(join(repoRoot, ".gsd", "worktrees", "M001", "S01", "deep", "bin"), { recursive: true });
+  writeFileSync(cliPath, "#!/usr/bin/env node\n", "utf-8");
+  writeFileSync(devCliPath, "#!/usr/bin/env node\n", "utf-8");
+
+  try {
+    const firstLaunch = detectWorkflowMcpLaunchConfig(worktreeRoot, {
+      GSD_BIN_PATH: devCliPath,
+    });
+    assert.equal(firstLaunch?.args?.[0], cliPath);
+
+    rmSync(cliPath, { force: true });
+
+    const secondLaunch = detectWorkflowMcpLaunchConfig(worktreeRoot, {
+      GSD_BIN_PATH: devCliPath,
+    });
+    assert.equal(secondLaunch?.args?.[0], cliPath);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
 test("detectWorkflowMcpLaunchConfig resolves the bundled server from a symlinked GSD_BIN_PATH", () => {
   const repoRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-symlink-root-"));
   const binDir = mkdtempSync(join(tmpdir(), "gsd-workflow-symlink-bin-"));

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -85,6 +85,8 @@ function lookupCommand(command: string, platform: NodeJS.Platform = process.plat
   }
 }
 
+const gsdPiRepoRootCache = new Map<string, string | null>();
+
 function findGsdPiRepoRoot(startPath: string): string | null {
   let current: string;
   try {
@@ -93,15 +95,24 @@ function findGsdPiRepoRoot(startPath: string): string | null {
     current = resolve(startPath);
   }
 
+  const cacheKey = current;
+  if (gsdPiRepoRootCache.has(cacheKey)) {
+    return gsdPiRepoRootCache.get(cacheKey) ?? null;
+  }
+
   while (true) {
     const distCli = resolve(current, "packages", "mcp-server", "dist", "cli.js");
-    if (existsSync(distCli)) return current;
+    if (existsSync(distCli)) {
+      gsdPiRepoRootCache.set(cacheKey, current);
+      return current;
+    }
 
     const parent = dirname(current);
     if (parent === current) break;
     current = parent;
   }
 
+  gsdPiRepoRootCache.set(cacheKey, null);
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Memoized workflow MCP repo-root discovery per resolved start path and added a focused regression test; syntax and diff checks pass, while runtime tests were blocked by missing dependencies and restricted npm access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #898
- [#898 [Bug]: Workflow MCP repo-root discovery walks the directory tree ~4× per launch-config build and is uncached](https://github.com/open-gsd/gsd-pi/issues/898)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/898-bug-workflow-mcp-repo-root-discovery-wal-1782523039`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped performance/cache change in MCP path discovery; behavior is unchanged except avoiding repeat walks, with a small theoretical staleness risk if repo layout changes in the same process.
> 
> **Overview**
> **Workflow MCP launch config** no longer repeats full ancestor walks for the same resolved start path when discovering the gsd-pi repo root.
> 
> `findGsdPiRepoRoot` now uses an in-process `Map` keyed by the realpath-resolved start path, returning cached repo roots (or cached misses) on repeat calls. That cuts redundant filesystem walks when `detectWorkflowMcpLaunchConfig` and bundled-path helpers hit the same anchors (e.g. deep `GSD_BIN_PATH` under `.gsd/worktrees`).
> 
> A regression test asserts that a second `detectWorkflowMcpLaunchConfig` with the same deep `GSD_BIN_PATH` still resolves the original bundled `cli.js` path even after that file is removed on disk—proving the cache is used instead of re-walking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8ef675ea171786c1506eb35b278ef9bc5a28e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->