### PR TITLE
fix(issue): [Bug]: Post-execution cross-task signature check re-reads and re-parses every prior task's files on each task completion (O(N²))

### DIFF
--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -16,7 +16,7 @@
  *   - No AST parsers — uses regex heuristics
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve, dirname, join, extname } from "node:path";
 import type { TaskRow } from "./db-task-slice-rows.js";
 
@@ -364,6 +364,14 @@ interface FunctionSignature {
   lineNum: number;
 }
 
+interface CachedFunctionSignatures {
+  mtimeMs: number;
+  signatures: FunctionSignature[];
+}
+
+let signatureCacheScope: string | null = null;
+const signatureCache = new Map<string, CachedFunctionSignatures>();
+
 /**
  * Extract function signatures from TypeScript/JavaScript source code.
  */
@@ -404,6 +412,35 @@ function extractFunctionSignatures(
   return signatures;
 }
 
+function signatureCacheFor(taskRow: TaskRow, basePath: string): Map<string, CachedFunctionSignatures> {
+  const scope = `${resolve(basePath)}\0${taskRow.milestone_id}\0${taskRow.slice_id}`;
+
+  if (signatureCacheScope !== scope) {
+    signatureCacheScope = scope;
+    signatureCache.clear();
+  }
+
+  return signatureCache;
+}
+
+function getCachedFunctionSignatures(
+  cache: Map<string, CachedFunctionSignatures>,
+  absolutePath: string,
+  fileName: string
+): FunctionSignature[] {
+  const mtimeMs = statSync(absolutePath).mtimeMs;
+  const cached = cache.get(absolutePath);
+
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return cached.signatures.map((sig) => ({ ...sig, file: fileName }));
+  }
+
+  const source = readFileSync(absolutePath, "utf-8");
+  const signatures = extractFunctionSignatures(source, fileName);
+  cache.set(absolutePath, { mtimeMs, signatures });
+  return signatures;
+}
+
 /**
  * Normalize parameter list for comparison.
  */
@@ -437,6 +474,7 @@ export function checkCrossTaskSignatures(
 
   // Build map of functions from prior tasks' key_files
   const priorSignatures = new Map<string, FunctionSignature[]>();
+  const cache = signatureCacheFor(taskRow, basePath);
 
   for (const task of priorTasks) {
     for (const file of task.key_files) {
@@ -447,8 +485,7 @@ export function checkCrossTaskSignatures(
       if (!existsSync(absolutePath)) continue;
 
       try {
-        const source = readFileSync(absolutePath, "utf-8");
-        const sigs = extractFunctionSignatures(source, file);
+        const sigs = getCachedFunctionSignatures(cache, absolutePath, file);
         for (const sig of sigs) {
           const existing = priorSignatures.get(sig.name) || [];
           existing.push(sig);

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -366,6 +366,7 @@ interface FunctionSignature {
 
 interface CachedFunctionSignatures {
   mtimeMs: number;
+  size: number;
   signatures: FunctionSignature[];
 }
 
@@ -428,16 +429,18 @@ function getCachedFunctionSignatures(
   absolutePath: string,
   fileName: string
 ): FunctionSignature[] {
-  const mtimeMs = statSync(absolutePath).mtimeMs;
+  const stat = statSync(absolutePath);
+  const mtimeMs = stat.mtimeMs;
+  const size = stat.size;
   const cached = cache.get(absolutePath);
 
-  if (cached && cached.mtimeMs === mtimeMs) {
+  if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
     return cached.signatures.map((sig) => ({ ...sig, file: fileName }));
   }
 
   const source = readFileSync(absolutePath, "utf-8");
   const signatures = extractFunctionSignatures(source, fileName);
-  cache.set(absolutePath, { mtimeMs, signatures });
+  cache.set(absolutePath, { mtimeMs, size, signatures });
   return signatures;
 }
 

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -10,7 +10,8 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import fs, { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { join } from "node:path";
 
 import {
@@ -766,6 +767,52 @@ describe("checkCrossTaskSignatures", () => {
       assert.equal(results.length, 1);
       assert.ok(results[0].message.includes("parse"));
     } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("caches prior task signature reads across calls for the same slice", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "post-exec-cache-"));
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+
+    const priorPath = join(tempDir, "src", "utils.ts");
+    writeFileSync(
+      priorPath,
+      "export function process(data: string): boolean { return true; }"
+    );
+    writeFileSync(
+      join(tempDir, "src", "api.ts"),
+      "export function process(data: string): boolean { return false; }"
+    );
+
+    const originalReadFileSync = fs.readFileSync;
+    let priorReads = 0;
+
+    fs.readFileSync = ((...args: unknown[]) => {
+      const path = args[0];
+      if (path === priorPath) priorReads++;
+      return originalReadFileSync(...(args as Parameters<typeof fs.readFileSync>));
+    }) as typeof fs.readFileSync;
+    syncBuiltinESMExports();
+
+    try {
+      const priorTask = createTask({
+        id: "T01",
+        slice_id: "S01",
+        key_files: ["src/utils.ts"],
+      });
+      const currentTask = createTask({
+        id: "T02",
+        slice_id: "S01",
+        key_files: ["src/api.ts"],
+      });
+
+      assert.deepEqual(checkCrossTaskSignatures(currentTask, [priorTask], tempDir), []);
+      assert.deepEqual(checkCrossTaskSignatures(currentTask, [priorTask], tempDir), []);
+      assert.equal(priorReads, 1);
+    } finally {
+      fs.readFileSync = originalReadFileSync;
+      syncBuiltinESMExports();
       rmSync(tempDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- Added an mtime-aware prior signature cache and verified it with focused post-execution tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #906
- [#906 [Bug]: Post-execution cross-task signature check re-reads and re-parses every prior task's files on each task completion (O(N²))](https://github.com/open-gsd/gsd-pi/issues/906)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/906-bug-post-execution-cross-task-signature--1782523520`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change to post-execution validation; cache is scoped per slice and invalidated on file mtime, with no change to check outcomes when files are unchanged.
> 
> **Overview**
> Fixes **O(N²)** work in post-execution **cross-task signature** checks by caching parsed signatures for prior tasks’ `key_files` instead of re-reading and re-parsing them on every task completion.
> 
> `checkCrossTaskSignatures` now routes prior-file work through a **slice-scoped** in-memory cache (`basePath` + `milestone_id` + `slice_id`). Entries are keyed by absolute path and refreshed when **`mtimeMs`** changes via `statSync`, so unchanged files skip `readFileSync` and regex extraction on repeat calls.
> 
> A unit test asserts that two consecutive checks for the same slice only **read** a shared prior file once (via a patched `readFileSync`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4e50a8bf576d241fbec6cb897e93f39aec15b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->