### PR TITLE
fix(gitignore): append granular GSD_RUNTIME_PATTERNS when .gsd/ is tracked

### DIFF
--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -221,10 +221,14 @@ export function ensureGitignore(
   );
 
   // Determine which patterns to apply. If .gsd/ has tracked files,
-  // exclude the ".gsd" pattern to prevent deleting tracked state.
+  // exclude the ".gsd" pattern to prevent deleting tracked state, but
+  // substitute the granular GSD_RUNTIME_PATTERNS so transient artifacts
+  // (STATE.md, runtime/, gsd.db, event-log.jsonl, …) still get ignored.
+  // Without this fallback, the pre-completion commit gate sees those
+  // runtime paths as untracked and blocks milestone close-out forever.
   const gsdIsTracked = hasGitTrackedGsdFiles(basePath);
-  const patternsToApply = gsdIsTracked
-    ? BASELINE_PATTERNS.filter((p) => p !== ".gsd")
+  const patternsToApply: readonly string[] = gsdIsTracked
+    ? Array.from(new Set([...BASELINE_PATTERNS.filter((p) => p !== ".gsd"), ...GSD_RUNTIME_PATTERNS]))
     : BASELINE_PATTERNS;
 
   // Find patterns not yet present

--- a/src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
@@ -113,6 +113,61 @@ test("ensureGitignore does NOT add .gsd when .gsd/ has tracked files (#1364)", (
   }
 });
 
+test("ensureGitignore adds granular runtime patterns when .gsd/ has tracked files", (t) => {
+  // Regression: pre-completion close-out gate (auto-dispatch.ts) blocks when
+  // RUNTIME_EXCLUSION_PATHS artifacts appear as untracked. They are excluded
+  // from smartStage by design, so the auto-commit can never absorb them; the
+  // umbrella .gsd ignore pattern would normally cover them, but it is stripped
+  // when .gsd/ has tracked files. Without a granular fallback, runtime paths
+  // surface as `??` in `git status` and trip the close-out gate forever.
+  const dir = makeTempRepo();
+  try {
+    // Set up .gsd/ with tracked files (mirrors the close-out smoke scenario).
+    mkdirSync(join(dir, ".gsd", "milestones"), { recursive: true });
+    writeFileSync(join(dir, ".gsd", "PROJECT.md"), "# Test Project\n");
+    git(dir, "add", ".gsd/");
+    git(dir, "commit", "-m", "track gsd state");
+
+    ensureGitignore(dir);
+
+    const gitignore = readFileSync(join(dir, ".gitignore"), "utf-8");
+    const lines = new Set(gitignore.split("\n").map((l) => l.trim()));
+
+    // The umbrella pattern must still be omitted (preserves #1364).
+    assert.ok(!lines.has(".gsd"), `.gsd should not appear when tracked; got:\n${gitignore}`);
+
+    // The runtime artifacts that break the close-out gate must be ignored.
+    for (const pattern of [
+      ".gsd/STATE.md",
+      ".gsd/runtime/",
+      ".gsd/activity/",
+      ".gsd/audit/",
+      ".gsd/journal/",
+      ".gsd/gsd.db*",
+      ".gsd/event-log.jsonl",
+      ".gsd/metrics.json",
+      ".gsd/state-manifest.json",
+    ]) {
+      assert.ok(
+        lines.has(pattern),
+        `Expected ${pattern} in .gitignore so close-out gate sees a clean tree; got:\n${gitignore}`,
+      );
+    }
+
+    // BASELINE and GSD_RUNTIME both contain .gsd-worktrees/ — must not duplicate.
+    const worktreeOccurrences = gitignore
+      .split("\n")
+      .filter((l) => l.trim() === ".gsd-worktrees/").length;
+    assert.equal(
+      worktreeOccurrences,
+      1,
+      `.gsd-worktrees/ should appear exactly once; got ${worktreeOccurrences} in:\n${gitignore}`,
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
 test("ensureGitignore adds .gsd when .gsd/ has NO tracked files", (t) => {
   const dir = makeTempRepo();
   try {


### PR DESCRIPTION
## Summary
- `ensureGitignore` correctly strips the `.gsd` umbrella when `.gsd/` has
  tracked files (#1364) but doesn't substitute the granular runtime
  patterns. Result: runtime artifacts (STATE.md, runtime/, gsd.db, …) are
  untracked AND ungitignored, so the pre-completion commit gate in
  `commitPendingMilestoneCloseoutChanges` (`auto-dispatch.ts:266`) blocks
  milestone close-out forever with "uncommitted changes remain after the
  pre-completion commit."
- Fix: in the `gsdIsTracked` branch, append `GSD_RUNTIME_PATTERNS` (the
  in-file canonical runtime list at `gitignore.ts:27`) and dedup.
  Preserves #1364's invariant.

## Test plan
- [x] New regression test in
  `src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts`
  asserts the 9 runtime patterns land in `.gitignore` for tracked-`.gsd/`
  projects; pins `.gsd-worktrees/` to exactly one occurrence.
- [x] RED proven on `main` (1 fail / 10 pass on the changed file);
  GREEN after fix.
- [x] Sibling suites — `gitignore-bg-shell-runtime`,
  `migrate-external-worktree`, `stash-queued-context-files`,
  `gitignore-tracked-gsd`, `start-auto-detached`, `git-service`
  integration — 108/108 pass.

Fixes #928