### PR TITLE
fix(issue): C:/Program Files/Git/gsd auto reports roadmap-divergence after DB-backed recovery even though milestone status and roadmap artifact are consistent

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -201,7 +201,7 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
   let currentSlice: RoadmapSliceEntry | null = null;
 
   for (const line of checkboxItems) {
-    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/);
+    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.-]+):\s+(.+?)\*\*\s*(.*)/);
     if (cbMatch) {
       if (currentSlice) slices.push(currentSlice);
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -60,6 +60,7 @@ function milestoneHasDivergence(
 
   const dbSlices = getMilestoneSlices(milestoneId);
   const dbSliceMap = new Map(dbSlices.map((s) => [s.id, s]));
+  const dbSliceOrder = new Map(dbSlices.map((s, index) => [s.id, index]));
   const readySliceIds = getSlicesReadyForDivergenceCheck(milestoneId, dbSlices);
   if (dbSlices.length > 0 && readySliceIds.size === 0) {
     return false;
@@ -69,11 +70,10 @@ function milestoneHasDivergence(
   for (let i = 0; i < roadmap.slices.length; i++) {
     const roadmapSlice = roadmap.slices[i]!;
     roadmapSliceIds.add(roadmapSlice.id);
-    const expectedSequence = i + 1;
     const dbSlice = dbSliceMap.get(roadmapSlice.id);
     if (!dbSlice) return true; // Roadmap has a slice the DB doesn't.
     if (!readySliceIds.has(dbSlice.id)) continue;
-    if (dbSlice.sequence !== expectedSequence) return true;
+    if (dbSliceOrder.get(dbSlice.id) !== i) return true;
     if (!arraysEqual(dbSlice.depends, roadmapSlice.depends)) return true;
     if (isClosedStatus(dbSlice.status) !== roadmapSlice.done) return true;
   }

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1022,6 +1022,71 @@ test("ADR-017 (#391): roadmap-divergence skips slices before task planning compl
   assert.deepEqual(getSlice("M001", "S02")?.depends, [], "DB remains unchanged");
 });
 
+test("ADR-017 (#870): roadmap-divergence accepts recovered S00 blocker sequence", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-s00-"));
+  const milestoneId = "M002-a1rwmq";
+  const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
+  const roadmapPath = join(milestoneDir, `${milestoneId}-ROADMAP.md`);
+  mkdirSync(milestoneDir, { recursive: true });
+  const originalRoadmap = [
+    "# M002-a1rwmq: Support Command Policy Hardening",
+    "",
+    "**Vision:** Recover DB-backed planning state.",
+    "",
+    "## Slices",
+    "",
+    "- [x] **S00-blocker: Blocker placeholder - planning failed** `risk:medium` `depends:[]`",
+    "  > After this: ",
+    "",
+    "- [ ] **S01: Source of truth contract** `risk:medium` `depends:[]`",
+    "  > After this: S01 tasks are planned.",
+    "",
+    "- [ ] **S02: Policy implementation** `risk:medium` `depends:[]`",
+    "  > After this: ",
+    "",
+    "- [ ] **S03: Verification coverage** `risk:medium` `depends:[]`",
+    "  > After this: ",
+    "",
+    "- [ ] **S04: Documentation handoff** `risk:medium` `depends:[]`",
+    "  > After this: ",
+    "",
+  ].join("\n");
+  writeFileSync(roadmapPath, originalRoadmap);
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({
+    id: milestoneId,
+    title: "Support Command Policy Hardening",
+    status: "active",
+    planning: { vision: "Recover DB-backed planning state." },
+  });
+  insertSlice({ id: "S00-blocker", milestoneId, title: "Blocker placeholder - planning failed", status: "complete", risk: "medium", depends: [], demo: "", sequence: 0 });
+  insertSlice({ id: "S01", milestoneId, title: "Source of truth contract", status: "pending", risk: "medium", depends: [], demo: "S01 tasks are planned.", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId, title: "Policy implementation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+  insertSlice({ id: "S03", milestoneId, title: "Verification coverage", status: "pending", risk: "medium", depends: [], demo: "", sequence: 3 });
+  insertSlice({ id: "S04", milestoneId, title: "Documentation handoff", status: "pending", risk: "medium", depends: [], demo: "", sequence: 4 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId, title: "Map current support command policy inputs", status: "pending" });
+  insertTask({ id: "T02", sliceId: "S01", milestoneId, title: "Define shared policy surface shape", status: "pending" });
+  insertTask({ id: "T03", sliceId: "S01", milestoneId, title: "Lock source of truth contract coverage", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: milestoneId, title: "Support Command Policy Hardening" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "roadmap-divergence"),
+    false,
+    "matching recovered DB/ROADMAP state must not report persistent roadmap-divergence",
+  );
+  assert.equal(readFileSync(roadmapPath, "utf-8"), originalRoadmap);
+});
+
 test("ADR-017 (#5705): roadmap-divergence re-renders projection without syncing depends into DB", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-"));
   const milestoneDir = join(base, ".gsd", "phases", "01-test");


### PR DESCRIPTION
## Summary
- Fixed false roadmap-divergence for recovered S00 blocker state and verified formatting plus parser behavior; full test run was blocked by missing offline dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #870
- [#870 C:/Program Files/Git/gsd auto reports roadmap-divergence after DB-backed recovery even though milestone status and roadmap artifact are consistent](https://github.com/open-gsd/gsd-pi/issues/870)

## User
- @mik888em

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/870-c-program-files-git-gsd-auto-reports-roa-1782523835`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted parser and drift-comparison tweaks with a focused regression test; no auth, persistence, or broad API changes.
> 
> **Overview**
> Fixes **false `roadmap-divergence`** when the DB and `ROADMAP.md` already agree after DB-backed recovery (e.g. milestone with **`S00-blocker`**).
> 
> **Roadmap parsing** now accepts **hyphenated slice IDs** in checkbox lines (`[\w.-]+` instead of `[\w.]+`), so entries like `S00-blocker` are parsed instead of being skipped or misread.
> 
> **Divergence detection** no longer compares roadmap position to **`sequence === index + 1`**. It compares each slice’s **index in the DB milestone slice list** to its **index in the parsed roadmap**, which matches recovered layouts where `S00-blocker` uses **`sequence: 0`** but still appears first in the artifact.
> 
> Adds an **ADR-017 (#870)** reconciliation test that asserts matching recovered DB/ROADMAP state does not trigger repair or rewrite the roadmap file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7c930a11f1eaf7c53474000543ac1e4966e166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->