### PR TITLE
fix(issue): [Bug]: Dashboard overlay re-parses preferences markdown every 2s while open via uncached loadEffectiveGSDPreferences

### DIFF
--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -23,6 +23,7 @@ import {
   type UnitMetrics,
 } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { countPendingCaptures } from "./captures.js";
 import { getActiveWorktreeName } from "./worktree-session-state.js";
 import { getWorkerBatches, hasActiveWorkers, type WorkerEntry } from "../subagent/worker-registry.js";
 import { formatDuration, padRight, joinColumns, centerLine, fitColumns, STATUS_GLYPH, STATUS_COLOR } from "../shared/mod.js";
@@ -130,6 +131,14 @@ export class GSDDashboardOverlay {
   }
 
   private refreshVolatileDashboardData(snapshot = getAutoRuntimeSnapshot()): void {
+    let pendingCaptureCount = this.dashData.pendingCaptureCount;
+    try {
+      if (snapshot.basePath) {
+        pendingCaptureCount = countPendingCaptures(snapshot.basePath);
+      }
+    } catch {
+      // Non-fatal — keep last known value
+    }
     this.dashData = {
       ...this.dashData,
       active: snapshot.active,
@@ -146,6 +155,7 @@ export class GSDDashboardOverlay {
         ? (this.dashData.startTime > 0 ? Date.now() - this.dashData.startTime : 0)
         : 0,
       toolSurface: snapshot.toolSurface,
+      pendingCaptureCount,
     };
   }
 

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -15,6 +15,7 @@ import { isDbAvailable, getMilestoneSlices, getSliceTasks } from "./gsd-db.js";
 import { resolveMilestoneFile, resolveSliceFile } from "./paths.js";
 import { getAutoDashboardData } from "./auto.js";
 import type { AutoDashboardData } from "./auto-dashboard.js";
+import { getAutoRuntimeSnapshot } from "./auto-runtime-state.js";
 import {
   getLedger, getProjectTotals, aggregateByPhase, aggregateBySlice,
   aggregateByModel, aggregateCacheHitRate, formatCost, formatTokenCount, formatCostProjection,
@@ -113,7 +114,9 @@ export class GSDDashboardOverlay {
       });
   }
 
-  private computeDashboardIdentity(dashData: AutoDashboardData): string {
+  private computeDashboardIdentity(
+    dashData: Pick<AutoDashboardData, "active" | "paused" | "currentUnit" | "basePath">,
+  ): string {
     const base = dashData.basePath || process.cwd();
     const currentUnit = dashData.currentUnit
       ? `${dashData.currentUnit.type}:${dashData.currentUnit.id}:${dashData.currentUnit.startedAt}`
@@ -126,18 +129,42 @@ export class GSDDashboardOverlay {
     ].join("|");
   }
 
+  private refreshVolatileDashboardData(snapshot = getAutoRuntimeSnapshot()): void {
+    this.dashData = {
+      ...this.dashData,
+      active: snapshot.active,
+      paused: snapshot.paused,
+      currentUnit: snapshot.currentUnit
+        ? {
+            type: snapshot.currentUnit.type,
+            id: snapshot.currentUnit.id,
+            startedAt: snapshot.currentUnit.startedAt,
+          }
+        : null,
+      basePath: snapshot.basePath,
+      elapsed: snapshot.active || snapshot.paused
+        ? (this.dashData.startTime > 0 ? Date.now() - this.dashData.startTime : 0)
+        : 0,
+      toolSurface: snapshot.toolSurface,
+    };
+  }
+
   private async refreshDashboard(initial = false): Promise<void> {
     if (this.disposed) return;
-    this.dashData = getAutoDashboardData();
-    const nextIdentity = this.computeDashboardIdentity(this.dashData);
+    const runtimeSnapshot = getAutoRuntimeSnapshot();
+    const nextIdentity = this.computeDashboardIdentity(runtimeSnapshot);
 
     const identityChanged = initial || nextIdentity !== this.loadedDashboardIdentity;
     if (identityChanged) {
+      this.dashData = getAutoDashboardData();
+      const loadedIdentity = this.computeDashboardIdentity(this.dashData);
       const loaded = await this.loadData();
       if (this.disposed) return;
       if (loaded) {
-        this.loadedDashboardIdentity = nextIdentity;
+        this.loadedDashboardIdentity = loadedIdentity;
       }
+    } else {
+      this.refreshVolatileDashboardData(runtimeSnapshot);
     }
 
     if (initial) {

--- a/src/resources/extensions/gsd/tests/dashboard-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/dashboard-overlay.test.ts
@@ -4,10 +4,14 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import { GSDDashboardOverlay } from "../dashboard-overlay.ts";
 import type { UnitMetrics } from "../metrics.ts";
 import { assertFullOuterBorder } from "./tui-border-assertions.ts";
+import { autoSession, getAutoRuntimeSnapshot } from "../auto-runtime-state.ts";
 
 const fakeTheme = {
   fg: (_color: string, text: string) => text,
@@ -46,6 +50,39 @@ test("GSDDashboardOverlay reuses metrics aggregations until the unit count chang
   assert.notEqual(increasedCountMetrics, firstMetrics, "changed unit count should recompute metrics");
   assert.equal(increasedCountMetrics.totals.units, 2);
   assert.equal(increasedCountMetrics.totals.cost, 1.25);
+});
+
+test("GSDDashboardOverlay non-identity refresh avoids reparsing preferences", async (t) => {
+  const basePath = join(
+    tmpdir(),
+    `gsd-dashboard-overlay-refresh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.basePath = basePath;
+  autoSession.autoStartTime = Date.now() - 1000;
+  autoSession.setCurrentUnit({
+    type: "execute-task",
+    id: "M001/S001/T001",
+    startedAt: Date.now() - 500,
+  });
+
+  const overlay = new GSDDashboardOverlay({ requestRender() {} }, fakeTheme as any, () => {});
+  t.after(() => {
+    overlay.dispose();
+    autoSession.reset();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  (overlay as any).loadedDashboardIdentity = (overlay as any).computeDashboardIdentity(getAutoRuntimeSnapshot());
+  mkdirSync(join(basePath, ".gsd", "PREFERENCES.md"));
+
+  await assert.doesNotReject(
+    () => (overlay as any).refreshDashboard(false),
+    "unchanged overlay identity should not call getAutoDashboardData or read preferences",
+  );
 });
 
 function makeUnit(id: string, cost: number): UnitMetrics {


### PR DESCRIPTION
## Summary
- Avoided dashboard overlay preference reparsing on unchanged refresh ticks and verified syntax/diff checks; targeted test was blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #911
- [#911 [Bug]: Dashboard overlay re-parses preferences markdown every 2s while open via uncached loadEffectiveGSDPreferences](https://github.com/open-gsd/gsd-pi/issues/911)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/911-bug-dashboard-overlay-re-parses-preferen-1782523726`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized dashboard refresh optimization with no changes to auth, persistence, or auto-mode orchestration logic.
> 
> **Overview**
> Fixes the dashboard overlay **re-parsing preferences on every ~2s refresh** while auto-mode identity (base path, active/paused, current unit) is unchanged.
> 
> **`refreshDashboard`** now compares **`getAutoRuntimeSnapshot()`** to the cached identity. On a match it only runs **`refreshVolatileDashboardData`**, merging live fields (status, current unit, elapsed, tool surface, pending capture count) without calling **`getAutoDashboardData()`** or reloading milestone DB state. Full reload (**`getAutoDashboardData`**, **`loadData`**) runs only on the initial open or when identity changes.
> 
> A test asserts that a non-identity **`refreshDashboard`** completes cleanly even when **`PREFERENCES.md`** is present on disk (the path that previously triggered repeated preference reads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56402f5b29c49de6e69dd91caa7e4723e4162975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->