### PR TITLE
fix(issue): [Bug] DB migration to .gsd-backups/migrate-<ts>/ propagates only S##-PLAN.md (often a BLOCKER placeholder), orphaning S##-CONTEXT/RESEARCH/CONTINUE — strands the slice behind require_slice_discussion + repeated CONTEXT-DRAFT save failures

### DIFF
--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -351,6 +351,15 @@ export function getMilestoneScopedArtifacts(milestoneId: string): ArtifactRow[] 
   return rows.map(rowToArtifact);
 }
 
+/** Slice-level artifacts (CONTEXT, RESEARCH, CONTINUE, etc.) from the artifacts table. */
+export function getSliceScopedArtifacts(milestoneId: string, sliceId: string): ArtifactRow[] {
+  if (!getDbOrNull()!) return [];
+  const rows = getDbOrNull()!.prepare(
+    "SELECT * FROM artifacts WHERE milestone_id = :mid AND slice_id = :sid AND task_id IS NULL ORDER BY path",
+  ).all({ ":mid": milestoneId, ":sid": sliceId });
+  return rows.map(rowToArtifact);
+}
+
 /** Fast milestone status check — avoids deserializing JSON planning fields. */
 export function getActiveMilestoneIdFromDb(): IdStatusSummary | null {
   if (!getDbOrNull()!) return null;

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -17,6 +17,7 @@ import {
   getAllMilestones,
   getMilestone,
   getMilestoneScopedArtifacts,
+  getSliceScopedArtifacts,
   getMilestoneSlices,
   getSliceTasks,
   getTask,
@@ -684,6 +685,44 @@ export async function renderMilestoneArtifactsFromDb(
   return wrote;
 }
 
+/**
+ * Slice-scoped artifacts (CONTEXT, RESEARCH, CONTINUE, etc.) must survive
+ * layout migration. PLAN is normally regenerated from task rows, but a real
+ * imported PLAN can still be replayed as a fallback; known recovery stubs are
+ * treated as missing.
+ */
+export async function renderSliceArtifactsFromDb(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+): Promise<boolean> {
+  const artifacts = getSliceScopedArtifacts(milestoneId, sliceId);
+  if (artifacts.length === 0) return false;
+
+  let wrote = false;
+  for (const artifact of artifacts) {
+    const artifactType = artifact.artifact_type.toUpperCase();
+    if (!artifact.full_content.trim()) continue;
+    if (artifactType === "PLAN" && isAutoRecoveryPlaceholderPlan(artifact.full_content)) continue;
+
+    const absPath = join(basePath, relSliceFile(basePath, milestoneId, sliceId, artifactType));
+    mkdirSync(dirname(absPath), { recursive: true });
+    const artifactPath = toArtifactPath(absPath, basePath);
+    await writeAndStore(absPath, artifactPath, artifact.full_content, {
+      artifact_type: artifactType,
+      milestone_id: milestoneId,
+      slice_id: sliceId,
+    }, basePath);
+    wrote = true;
+  }
+
+  return wrote;
+}
+
+function isAutoRecoveryPlaceholderPlan(content: string): boolean {
+  return /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content) && /auto-mode recovery failed/i.test(content);
+}
+
 // ─── Plan Checkbox Rendering ──────────────────────────────────────────────
 
 /**
@@ -861,6 +900,18 @@ export async function renderAllFromDb(basePath: string): Promise<RenderAllResult
     // Iterate slices
     const slices = getMilestoneSlices(milestone.id);
     for (const slice of slices) {
+      // Preserve slice-scoped artifacts imported from disk, including real PLAN
+      // fallback content when task rows cannot regenerate it.
+      try {
+        const ok = await renderSliceArtifactsFromDb(basePath, milestone.id, slice.id);
+        if (ok) result.rendered++;
+        else result.skipped++;
+      } catch (err) {
+        result.errors.push(
+          `slice artifacts ${milestone.id}/${slice.id}: ${(err as Error).message}`,
+        );
+      }
+
       // Render plan checkboxes
       try {
         const ok = await renderPlanCheckboxes(basePath, milestone.id, slice.id);

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -330,7 +330,7 @@ function importRequirements(gsdDir: string): number {
 
 /** Artifact suffixes to look for at each hierarchy level */
 const MILESTONE_SUFFIXES = ['ROADMAP', 'CONTEXT', 'RESEARCH', 'ASSESSMENT', 'SUMMARY', 'VALIDATION'];
-const SLICE_SUFFIXES = ['PLAN', 'SUMMARY', 'RESEARCH', 'CONTEXT', 'ASSESSMENT', 'UAT'];
+const SLICE_SUFFIXES = ['PLAN', 'SUMMARY', 'RESEARCH', 'CONTEXT', 'CONTEXT-DRAFT', 'ASSESSMENT', 'UAT', 'CONTINUE'];
 const TASK_SUFFIXES = ['PLAN', 'SUMMARY', 'CONTINUE', 'CONTEXT', 'RESEARCH'];
 
 /**
@@ -428,7 +428,7 @@ function importHierarchyArtifacts(gsdDir: string): number {
       .sort();
 
     for (const planFile of planFiles) {
-      const planMatch = planFile.match(/^\d+-(\d+)-(\w+)\.md$/i);
+      const planMatch = planFile.match(/^\d+-(\d+)-([A-Z0-9-]+)\.md$/i);
       if (!planMatch) continue;
       const planNum = parseInt(planMatch[1]!, 10);
       const sliceId = `S${String(planNum).padStart(2, '0')}`;

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Tests the one-time migration from nested to flat-phase layout.
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -11,20 +11,26 @@ import { migrateToFlatPhase, needsFlatPhaseMigration } from "../flat-phase-migra
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
 
 const tmpDirs: string[] = [];
-function makeTmp(): string {
+function makeTmp(options: { withTask?: boolean } = {}): string {
   const base = mkdtempSync(join(tmpdir(), `gsd-mig-${randomUUID()}`));
   // Create legacy nested structure
-  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01"), { recursive: true });
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(
+    options.withTask === false ? join(sliceDir, "tasks") : join(sliceDir, "tasks", "T01"),
+    { recursive: true },
+  );
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Foundation", status: "active" });
   insertSlice({
     milestoneId: "M001", id: "S01", title: "Set up tooling", status: "pending",
     risk: "low", depends: [], demo: "build runs", sequence: 1,
   });
-  insertTask({
-    milestoneId: "M001", sliceId: "S01", id: "T01", title: "Init repo",
-    status: "pending", sequence: 1,
-  });
+  if (options.withTask !== false) {
+    insertTask({
+      milestoneId: "M001", sliceId: "S01", id: "T01", title: "Init repo",
+      status: "pending", sequence: 1,
+    });
+  }
   tmpDirs.push(base);
   return base;
 }
@@ -80,4 +86,29 @@ test("migrateToFlatPhase is idempotent (second run is a no-op)", async () => {
   await migrateToFlatPhase(base);
   const backups = readdirSync(join(base, ".gsd-backups")).filter(d => d.startsWith("migrate-"));
   assert.equal(backups.length, 1, "should only have one backup");
+});
+
+test("migrateToFlatPhase preserves slice sidecar artifacts and skips recovery placeholder PLAN", async () => {
+  const base = makeTmp({ withTask: false });
+  const legacySliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  writeFileSync(join(legacySliceDir, "S01-CONTEXT.md"), "# Final Slice Context\n\nPrior discussion.", "utf-8");
+  writeFileSync(join(legacySliceDir, "S01-RESEARCH.md"), "# Slice Research\n\nPrior research.", "utf-8");
+  writeFileSync(join(legacySliceDir, "S01-CONTINUE.md"), "# Continue\n\nCompacted marker.", "utf-8");
+  writeFileSync(
+    join(legacySliceDir, "S01-PLAN.md"),
+    "# BLOCKER - auto-mode recovery failed\n\nUnit `plan-slice` failed to produce this artifact.",
+    "utf-8",
+  );
+
+  await migrateToFlatPhase(base);
+
+  const phaseDir = join(base, ".gsd", "phases", "01-foundation");
+  assert.equal(readFileSync(join(phaseDir, "01-01-CONTEXT.md"), "utf-8"), "# Final Slice Context\n\nPrior discussion.");
+  assert.equal(readFileSync(join(phaseDir, "01-01-RESEARCH.md"), "utf-8"), "# Slice Research\n\nPrior research.");
+  assert.equal(readFileSync(join(phaseDir, "01-01-CONTINUE.md"), "utf-8"), "# Continue\n\nCompacted marker.");
+  assert.equal(
+    existsSync(join(phaseDir, "01-01-PLAN.md")),
+    false,
+    "recovery placeholder PLAN should not be promoted when no DB tasks can render a real plan",
+  );
 });


### PR DESCRIPTION
## Summary
- Preserved slice sidecar artifacts across migration, skipped recovery placeholder plans, and verified changed files with syntax and diff checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #877
- [#877 [Bug] DB migration to .gsd-backups/migrate-<ts>/ propagates only S##-PLAN.md (often a BLOCKER placeholder), orphaning S##-CONTEXT/RESEARCH/CONTINUE — strands the slice behind require_slice_discussion + repeated CONTEXT-DRAFT save failures](https://github.com/open-gsd/gsd-pi/issues/877)

## User
- @astark-uni

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/877-bug-db-migration-to-gsd-backups-migrate--1782523915`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes migration and markdown projection paths that affect workflow state on disk; incorrect behavior could still strand slices, but scope is localized to GSD artifact import/render.
> 
> **Overview**
> Fixes flat-phase migration dropping slice **CONTEXT**, **RESEARCH**, **CONTINUE**, and related sidecars while often promoting a useless **BLOCKER** recovery **PLAN** stub—behavior that could strand slices behind discussion gates.
> 
> Adds **`getSliceScopedArtifacts`** and **`renderSliceArtifactsFromDb`** so DB-backed slice artifacts are written into the flat-phase layout during full re-projection; auto-recovery placeholder plans are detected and **not** replayed when task rows cannot regenerate a real plan.
> 
> **Import** now recognizes **CONTEXT-DRAFT** and **CONTINUE** slice files and parses flat-phase `NN-MM-SUFFIX` names with hyphenated suffixes. **`renderAllFromDb`** runs slice artifact projection before plan regeneration. A migration test asserts sidecars survive and placeholder **PLAN** files are omitted when there are no tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8a9d3f16ff63948104360ffd299fbba6affdf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->