### PR TITLE
fix(issue): [Bug] complete-slice unit stuck-loop: closer LLM hits HARD BLOCK on gsd_milestone_status

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -82,8 +82,9 @@ test("refine-slice requires canonical slice planning tool", () => {
   assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("refine-slice"), ["gsd_plan_slice"]);
 });
 
-test("complete-slice requires closeout and execution handoff tools", () => {
+test("complete-slice requires status, closeout, and execution handoff tools", () => {
   const expected = [
+    "gsd_milestone_status",
     "gsd_exec",
     "gsd_capture_thought",
     "gsd_slice_complete",

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -431,7 +431,10 @@ test('auto-unit scope: execute-task blocks slice and milestone lifecycle aliases
   assert.match(reopen.reason!, /gsd_milestone_reopen/);
 });
 
-test('auto-unit scope: complete-slice blocks milestone validation and native Workflow', () => {
+test('auto-unit scope: complete-slice allows milestone status but blocks milestone validation and native Workflow', () => {
+  const status = shouldBlockPlanningUnit('gsd_milestone_status', '', BASE, 'complete-slice', ALL);
+  assert.strictEqual(status.block, false);
+
   const closeSlice = shouldBlockPlanningUnit('gsd_slice_complete', '', BASE, 'complete-slice', ALL);
   assert.strictEqual(closeSlice.block, false);
 

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -242,6 +242,7 @@ export const UNIT_REGISTRY = {
     phaseChain: ["completion"],
     toolContract: {
       allowedGsdTools: [
+        "gsd_milestone_status",
         "gsd_exec",
         "gsd_slice_complete",
         "gsd_task_reopen",
@@ -253,6 +254,7 @@ export const UNIT_REGISTRY = {
         "subagent",
       ],
       requiredWorkflowTools: [
+        "gsd_milestone_status",
         "gsd_exec",
         "gsd_capture_thought",
         "gsd_slice_complete",


### PR DESCRIPTION
## Summary
- Allowed complete-slice to use gsd_milestone_status and added focused contract assertions; source checks passed while dependency-based tests were blocked by missing packages.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #871
- [#871 [Bug] complete-slice unit stuck-loop: closer LLM hits HARD BLOCK on gsd_milestone_status](https://github.com/open-gsd/gsd-pi/issues/871)

## User
- @AReid987

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/871-bug-complete-slice-unit-stuck-loop-close-1782524095`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow tool-contract change for one unit type with matching test updates; no auth, data, or broad execution-path changes.
> 
> **Overview**
> Fixes **complete-slice** stuck loops where the closer model called **`gsd_milestone_status`** and hit a **HARD BLOCK** because that tool was missing from the unit’s scoped contract.
> 
> The **`complete-slice`** entry in **`unit-registry.ts`** now includes **`gsd_milestone_status`** in both **`allowedGsdTools`** and **`requiredWorkflowTools`**, alongside the existing closeout and handoff tools. Tests were updated so workflow MCP contract checks expect status in the required set, and write-gate / auto-unit scope tests assert **`gsd_milestone_status`** is **not** blocked for **`complete-slice`** while milestone validation and native **`Workflow`** remain blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e9b76af25e2e03b2c0bde966028719ae6f551b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->