### PR TITLE
fix(issue): [Bug]: metrics.json is fully read, de-duplicated, and rewritten on every unit completion (O(history))

### DIFF
--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -846,6 +846,12 @@ function defaultLedger(): MetricsLedger {
   return { version: 1, projectStartedAt: Date.now(), units: [] };
 }
 
+export const METRICS_LEDGER_KEEP_UNITS = 1500;
+
+function keepNewestUnits(units: UnitMetrics[], keepCount = METRICS_LEDGER_KEEP_UNITS): UnitMetrics[] {
+  return units.length > keepCount ? units.slice(-keepCount) : units;
+}
+
 /**
  * Prune the metrics ledger to at most `keepCount` most-recent unit entries.
  *
@@ -862,11 +868,11 @@ export function pruneMetricsLedger(base: string, keepCount: number): number {
   const disk = loadLedgerFromDisk(base);
   if (!disk || disk.units.length <= keepCount) return 0;
   const removed = disk.units.length - keepCount;
-  disk.units = disk.units.slice(-keepCount);
+  disk.units = keepNewestUnits(disk.units, keepCount);
   saveJsonFile(metricsPath(base), disk);
   // Keep the in-memory ledger in sync if it is loaded for this session.
   if (ledger) {
-    ledger.units = ledger.units.slice(-keepCount);
+    ledger.units = keepNewestUnits(ledger.units, keepCount);
   }
   // Invalidate all scoped ledger cache entries. Prune is rare; clearing the
   // entire map is simpler than tracking which entry belongs to `base`. Without
@@ -1024,12 +1030,13 @@ function saveLedger(base: string, data: MetricsLedger): void {
       // Read current on-disk state and merge with worker's in-memory units.
       // Worker units take precedence on conflict (by finishedAt in deduplicateUnits).
       const onDisk = loadJsonFileOrNull(path, isMetricsLedger);
-      if (onDisk && onDisk.units.length > 0) {
-        const merged = deduplicateUnits([...onDisk.units, ...data.units]);
-        saveJsonFile(path, { ...data, units: merged });
-      } else {
-        saveJsonFile(path, data);
-      }
+      const dataUnits = keepNewestUnits(data.units);
+      const merged =
+        onDisk && onDisk.units.length > 0
+          ? deduplicateUnits([...keepNewestUnits(onDisk.units), ...dataUnits])
+          : dataUnits;
+      data.units = keepNewestUnits(merged);
+      saveJsonFile(path, data);
     } finally {
       releaseLock(lockPath);
     }
@@ -1040,6 +1047,7 @@ function saveLedger(base: string, data: MetricsLedger): void {
     // to a torn write caused by two writers simultaneously executing the
     // read-merge-write sequence without mutual exclusion.
     logWarning("fs", "saveLedger: lock not acquired — falling back to direct write (no merge)");
+    data.units = keepNewestUnits(data.units);
     saveJsonFile(path, data);
   }
 }

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -1033,7 +1033,9 @@ function saveLedger(base: string, data: MetricsLedger): void {
       const dataUnits = keepNewestUnits(data.units);
       const merged =
         onDisk && onDisk.units.length > 0
-          ? deduplicateUnits([...keepNewestUnits(onDisk.units), ...dataUnits])
+          ? deduplicateUnits([...keepNewestUnits(onDisk.units), ...dataUnits]).sort(
+              (a, b) => a.finishedAt - b.finishedAt
+            )
           : dataUnits;
       merged.sort((a, b) => a.finishedAt - b.finishedAt || a.startedAt - b.startedAt);
       data.units = keepNewestUnits(merged);

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -848,16 +848,20 @@ function defaultLedger(): MetricsLedger {
 
 export const METRICS_LEDGER_KEEP_UNITS = 1500;
 
+function compareUnitsByTime(a: UnitMetrics, b: UnitMetrics): number {
+  return a.finishedAt - b.finishedAt || a.startedAt - b.startedAt;
+}
+
 function keepNewestUnits(units: UnitMetrics[], keepCount = METRICS_LEDGER_KEEP_UNITS): UnitMetrics[] {
-  return units.length > keepCount ? units.slice(-keepCount) : units;
+  return units.length > keepCount ? [...units].sort(compareUnitsByTime).slice(-keepCount) : units;
 }
 
 /**
  * Prune the metrics ledger to at most `keepCount` most-recent unit entries.
  *
  * Called by the doctor when the ledger exceeds the bloat threshold.
- * Keeps the newest entries (highest index = most recent) and discards
- * the oldest from the head of the array. Preserves `projectStartedAt`.
+ * Keeps the newest entries by unit timestamps and discards the oldest.
+ * Preserves `projectStartedAt`.
  *
  * Updates both the on-disk file and the in-memory ledger if it is loaded,
  * so the current session sees the pruned state immediately.
@@ -1033,11 +1037,9 @@ function saveLedger(base: string, data: MetricsLedger): void {
       const dataUnits = keepNewestUnits(data.units);
       const merged =
         onDisk && onDisk.units.length > 0
-          ? deduplicateUnits([...keepNewestUnits(onDisk.units), ...dataUnits]).sort(
-              (a, b) => a.finishedAt - b.finishedAt
-            )
+          ? deduplicateUnits([...keepNewestUnits(onDisk.units), ...dataUnits])
           : dataUnits;
-      merged.sort((a, b) => a.finishedAt - b.finishedAt || a.startedAt - b.startedAt);
+      merged.sort(compareUnitsByTime);
       data.units = keepNewestUnits(merged);
       saveJsonFile(path, data);
     } finally {

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -1035,6 +1035,7 @@ function saveLedger(base: string, data: MetricsLedger): void {
         onDisk && onDisk.units.length > 0
           ? deduplicateUnits([...keepNewestUnits(onDisk.units), ...dataUnits])
           : dataUnits;
+      merged.sort((a, b) => a.finishedAt - b.finishedAt || a.startedAt - b.startedAt);
       data.units = keepNewestUnits(merged);
       saveJsonFile(path, data);
     } finally {

--- a/src/resources/extensions/gsd/tests/metrics-ledger-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics-ledger-cap.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  getLedger,
+  initMetrics,
+  METRICS_LEDGER_KEEP_UNITS,
+  resetMetrics,
+  snapshotUnitMetrics,
+  type MetricsLedger,
+  type UnitMetrics,
+} from "../metrics.js";
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-metrics-cap-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return dir;
+}
+
+function metricsPath(base: string): string {
+  return join(base, ".gsd", "metrics.json");
+}
+
+function assistantCtx(): any {
+  return {
+    sessionManager: {
+      getEntries: () => [
+        {
+          type: "message",
+          id: "entry-0",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Done" }],
+            usage: {
+              input: 100,
+              output: 50,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 150,
+              cost: 0.01,
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+function makeUnit(index: number, id = `M001/S01/T${String(index).padStart(4, "0")}`): UnitMetrics {
+  const startedAt = 1_700_000_000_000 + index * 1000;
+  return {
+    type: "execute-task",
+    id,
+    model: "test-model",
+    startedAt,
+    finishedAt: startedAt + 500,
+    tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
+    cost: 0.001,
+    toolCalls: 1,
+    assistantMessages: 1,
+    userMessages: 1,
+    apiRequests: 1,
+  };
+}
+
+function writeLedger(base: string, units: UnitMetrics[]): void {
+  const ledger: MetricsLedger = {
+    version: 1,
+    projectStartedAt: 1_700_000_000_000,
+    units,
+  };
+  writeFileSync(metricsPath(base), JSON.stringify(ledger, null, 2) + "\n", "utf-8");
+}
+
+function readLedger(base: string): MetricsLedger {
+  return JSON.parse(readFileSync(metricsPath(base), "utf-8")) as MetricsLedger;
+}
+
+describe("metrics ledger steady-state cap", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = makeProjectDir();
+    resetMetrics();
+  });
+
+  afterEach(() => {
+    resetMetrics();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("snapshot saves keep metrics.json and in-memory ledger bounded while preserving peer writes", () => {
+    const historicalUnits = Array.from(
+      { length: METRICS_LEDGER_KEEP_UNITS + 25 },
+      (_, index) => makeUnit(index),
+    );
+    writeLedger(projectDir, historicalUnits);
+
+    initMetrics(projectDir);
+
+    const peerUnit = makeUnit(historicalUnits.length, "M998/S01/T01");
+    writeLedger(projectDir, [...historicalUnits, peerUnit]);
+
+    const newStartedAt = peerUnit.startedAt + 1000;
+    const unit = snapshotUnitMetrics(
+      assistantCtx(),
+      "execute-task",
+      "M999/S01/T01",
+      newStartedAt,
+      "test-model",
+    );
+
+    assert.ok(unit, "snapshot should record the new unit");
+
+    const diskLedger = readLedger(projectDir);
+    assert.equal(diskLedger.units.length, METRICS_LEDGER_KEEP_UNITS);
+    assert.ok(
+      diskLedger.units.some((u) => u.id === peerUnit.id),
+      "peer unit written after init must survive the save merge",
+    );
+    assert.ok(
+      diskLedger.units.some((u) => u.id === "M999/S01/T01"),
+      "new unit must be persisted",
+    );
+    assert.equal(
+      diskLedger.units.some((u) => u.id === historicalUnits[0]!.id),
+      false,
+      "oldest history must be pruned from disk",
+    );
+
+    const memoryLedger = getLedger();
+    assert.equal(memoryLedger?.units.length, METRICS_LEDGER_KEEP_UNITS);
+    assert.equal(
+      memoryLedger?.units.some((u) => u.id === historicalUnits[0]!.id),
+      false,
+      "oldest history must be pruned from memory so the next save stays bounded",
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/metrics-ledger-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics-ledger-cap.test.ts
@@ -100,6 +100,55 @@ describe("metrics ledger steady-state cap", () => {
     rmSync(projectDir, { recursive: true, force: true });
   });
 
+  test("final cap preserves newest units by finishedAt when memory lags peer writes", () => {
+    // Scenario: memory loaded units 0..KEEP-1; a peer then advanced disk to
+    // units PEER_OFFSET..PEER_OFFSET+KEEP-1, adding PEER_OFFSET newer entries
+    // the worker has never seen.  The final keepNewestUnits call must rank by
+    // finishedAt, not by insertion order (disk-first), so old memory-only units
+    // do not crowd out newer on-disk peer units.
+    const KEEP = METRICS_LEDGER_KEEP_UNITS;
+    const PEER_OFFSET = 500;
+
+    // Load memory with units 0..KEEP-1.
+    const memUnits = Array.from({ length: KEEP }, (_, i) => makeUnit(i));
+    writeLedger(projectDir, memUnits);
+    initMetrics(projectDir);
+
+    // Peer advances disk to units PEER_OFFSET..PEER_OFFSET+KEEP-1.
+    const diskUnits = Array.from({ length: KEEP }, (_, i) => makeUnit(i + PEER_OFFSET));
+    writeLedger(projectDir, diskUnits);
+
+    // Trigger saveLedger.
+    const unit = snapshotUnitMetrics(
+      assistantCtx(),
+      "execute-task",
+      "M_STALE_MEM/S01/T01",
+      makeUnit(PEER_OFFSET + KEEP).startedAt,
+      "test-model",
+    );
+    assert.ok(unit, "snapshot must succeed");
+
+    const disk = readLedger(projectDir);
+    assert.equal(disk.units.length, KEEP, "disk must be capped at KEEP units");
+
+    // A disk unit that sits in the range evicted by insertion-order cap
+    // (positions 0..PEER_OFFSET-1 of the merged array) but must be kept
+    // by finishedAt-ordered cap because it is newer than memory-only units.
+    const diskUnitInEvictedRange = makeUnit(PEER_OFFSET + 1); // unit 501, newer than any memory-only unit
+    assert.ok(
+      disk.units.some((u) => u.id === diskUnitInEvictedRange.id),
+      `unit ${diskUnitInEvictedRange.id} (on-disk, newer than memory-only units) must not be displaced by stale memory tail`,
+    );
+
+    // The oldest surviving memory-only unit must be evicted.
+    const oldestMemOnlyUnit = makeUnit(1); // unit 1, older than all disk units (disk starts at 500)
+    assert.equal(
+      disk.units.some((u) => u.id === oldestMemOnlyUnit.id),
+      false,
+      `unit ${oldestMemOnlyUnit.id} (memory-only, older than all disk units) must be pruned`,
+    );
+  });
+
   test("snapshot saves keep metrics.json and in-memory ledger bounded while preserving peer writes", () => {
     const historicalUnits = Array.from(
       { length: METRICS_LEDGER_KEEP_UNITS + 25 },

--- a/src/resources/extensions/gsd/tests/metrics-ledger-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics-ledger-cap.test.ts
@@ -149,6 +149,46 @@ describe("metrics ledger steady-state cap", () => {
     );
   });
 
+  test("pre-merge cap preserves newest on-disk units even when disk order is stale", () => {
+    const KEEP = METRICS_LEDGER_KEEP_UNITS;
+
+    // Load memory with older local units.
+    const memUnits = Array.from(
+      { length: KEEP },
+      (_, i) => makeUnit(i, `M_MEM/S01/T${String(i).padStart(4, "0")}`),
+    );
+    writeLedger(projectDir, memUnits);
+    initMetrics(projectDir);
+
+    // Disk has more than KEEP entries, but its newest peer entries are at the
+    // head. A tail-slice pre-cap would discard these before the merge.
+    const newestPeerUnits = Array.from(
+      { length: 10 },
+      (_, i) => makeUnit(KEEP + i, `M_PEER/S01/T${String(i).padStart(4, "0")}`),
+    );
+    const olderPeerUnits = Array.from(
+      { length: KEEP },
+      (_, i) => makeUnit(i, `M_PEER_OLD/S01/T${String(i).padStart(4, "0")}`),
+    );
+    writeLedger(projectDir, [...newestPeerUnits, ...olderPeerUnits]);
+
+    const unit = snapshotUnitMetrics(
+      assistantCtx(),
+      "execute-task",
+      "M_STALE_DISK/S01/T01",
+      makeUnit(KEEP + newestPeerUnits.length).startedAt,
+      "test-model",
+    );
+    assert.ok(unit, "snapshot must succeed");
+
+    const disk = readLedger(projectDir);
+    assert.equal(disk.units.length, KEEP, "disk must be capped at KEEP units");
+    assert.ok(
+      disk.units.some((u) => u.id === newestPeerUnits[0]!.id),
+      "newer on-disk head unit must survive the pre-merge cap",
+    );
+  });
+
   test("snapshot saves keep metrics.json and in-memory ledger bounded while preserving peer writes", () => {
     const historicalUnits = Array.from(
       { length: METRICS_LEDGER_KEEP_UNITS + 25 },


### PR DESCRIPTION
## Summary
- Capped metrics ledger saves to the newest 1500 units, added regression coverage, and verified with syntax checks plus a merge/cap simulation.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #907
- [#907 [Bug]: metrics.json is fully read, de-duplicated, and rewritten on every unit completion (O(history))](https://github.com/open-gsd/gsd-pi/issues/907)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/907-bug-metrics-json-is-fully-read-de-duplic-1782524105`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk metrics merge and retention semantics; incorrect capping could drop newer peer entries, though regression tests target those races.
> 
> **Overview**
> Bounds **metrics.json** steady-state size by capping the ledger to the **1500 newest unit entries** on every save, addressing unbounded read/merge/rewrite work as history grows (#907).
> 
> Retention no longer uses a simple array tail slice: **`keepNewestUnits`** ranks by **`finishedAt`** (then **`startedAt`**) so **`pruneMetricsLedger`** and **`saveLedger`** keep the right rows when disk order is wrong or in-memory state lags peer workers. The locked merge path pre-caps on-disk and in-memory units before dedupe, sorts the merged set, then writes a capped ledger; the lock-timeout fallback also caps before a direct write.
> 
> Adds **`metrics-ledger-cap.test.ts`** for stale memory vs peer disk, stale on-disk ordering, and bounded disk/memory after snapshots with concurrent peer writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ffcb9d134b122e7269677b17079b9059d6128cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->