### PR TITLE
fix(issue): [Bug]: `gsd-browser --version` is spawned synchronously on every interactive startup, before the 24h update-cache check

### DIFF
--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -387,6 +387,56 @@ test('checkForUpdates uses cache and skips fetch when checked recently', async (
   assert.equal(reportedLatest, '10.0.0')
 })
 
+test('checkForUpdates shows cached update banner even without explicit currentVersion (gsd-pi)', async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-update-'))
+  const cachePath = join(tmp, '.update-check')
+  const originalVersion = process.env.GSD_VERSION
+  t.after(() => {
+    if (originalVersion === undefined) {
+      delete process.env.GSD_VERSION
+    } else {
+      process.env.GSD_VERSION = originalVersion
+    }
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  process.env.GSD_VERSION = '1.0.0'
+  writeUpdateCache({ lastCheck: Date.now(), latestVersion: '2.0.0' }, cachePath)
+
+  let reportedCurrent = ''
+  let reportedLatest = ''
+
+  // Intentionally omit currentVersion — simulates the cli.ts call: checkForUpdates().catch(...)
+  await checkForUpdates({
+    cachePath,
+    checkIntervalMs: 60 * 60 * 1000,
+    onUpdate: (current, latest) => {
+      reportedCurrent = current
+      reportedLatest = latest
+    },
+  })
+
+  assert.equal(reportedCurrent, '1.0.0', 'should resolve current version from GSD_VERSION env var')
+  assert.equal(reportedLatest, '2.0.0', 'should report the cached latest version')
+})
+
+test('checkForGsdBrowserUpdates does not show banner from cache when currentVersion is absent (no spawn)', async (t) => {
+  const { cachePath, spawnCountPath } = installCountingGsdBrowserShim(t)
+  writeUpdateCache({ lastCheck: Date.now(), latestVersion: '9.9.9' }, cachePath, GSD_BROWSER_PACKAGE_NAME)
+
+  let bannerFired = false
+
+  await checkForGsdBrowserUpdates({
+    cachePath,
+    checkIntervalMs: 60 * 60 * 1000,
+    fetchTimeoutMs: 1,
+    onUpdate: () => { bannerFired = true },
+  })
+
+  assert.equal(readFileSync(spawnCountPath, 'utf-8'), '0', 'PATH binary must not be spawned in the fresh-cache fast-path')
+  assert.equal(bannerFired, false, 'banner must not fire when gsd-browser currentVersion is absent — PATH spawn is deferred')
+})
+
 test('checkForUpdates ignores fresh legacy gsd-pi cache and fetches scoped package version', async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), 'gsd-update-'))
   const cachePath = join(tmp, '.update-check')

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -1,7 +1,7 @@
-import test from 'node:test'
+import test, { type TestContext } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createServer } from 'node:http'
 
@@ -116,6 +116,56 @@ function startMockRegistry(responseBody: object, statusCode = 200): Promise<{ ur
       })
     })
   })
+}
+
+function installCountingGsdBrowserShim(t: TestContext): { cachePath: string; spawnCountPath: string } {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-browser-update-'))
+  const binDir = join(tmp, 'bin')
+  const cachePath = join(tmp, '.update-check-gsd-browser')
+  const spawnCountPath = join(tmp, 'spawn-count')
+  const originalPath = process.env.PATH
+  const originalPathVersion = process.env.GSD_BROWSER_PATH_VERSION
+  const originalSpawnCount = process.env.GSD_BROWSER_SPAWN_COUNT
+
+  t.after(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = originalPath
+    }
+    if (originalPathVersion === undefined) {
+      delete process.env.GSD_BROWSER_PATH_VERSION
+    } else {
+      process.env.GSD_BROWSER_PATH_VERSION = originalPathVersion
+    }
+    if (originalSpawnCount === undefined) {
+      delete process.env.GSD_BROWSER_SPAWN_COUNT
+    } else {
+      process.env.GSD_BROWSER_SPAWN_COUNT = originalSpawnCount
+    }
+    rmSync(tmp, { recursive: true, force: true })
+  });
+
+  mkdirSync(binDir)
+  writeFileSync(spawnCountPath, '0')
+  const shim = join(binDir, 'gsd-browser')
+  writeFileSync(shim, [
+    '#!/usr/bin/env node',
+    "const { readFileSync, writeFileSync } = require('node:fs');",
+    'const countPath = process.env.GSD_BROWSER_SPAWN_COUNT;',
+    "const count = Number(readFileSync(countPath, 'utf8')) || 0;",
+    "writeFileSync(countPath, String(count + 1));",
+    "console.log('gsd-browser 9.9.9');",
+    '',
+  ].join('\n'))
+  chmodSync(shim, 0o755)
+  writeFileSync(join(binDir, 'gsd-browser.cmd'), '@echo off\r\nnode "%~dp0gsd-browser" %*\r\n')
+
+  process.env.PATH = `${binDir}${delimiter}${originalPath ?? ''}`
+  process.env.GSD_BROWSER_SPAWN_COUNT = spawnCountPath
+  delete process.env.GSD_BROWSER_PATH_VERSION
+
+  return { cachePath, spawnCountPath }
 }
 
 test('checkForUpdates calls onUpdate when newer version is available', async (t) => {
@@ -274,6 +324,39 @@ test('checkForGsdBrowserUpdates treats a newer PATH browser as the current versi
 
   assert.equal(called, false, 'startup banner must not fire when PATH already has latest gsd-browser')
   assert.equal(readUpdateCache(cachePath, GSD_BROWSER_PACKAGE_NAME)?.latestVersion, '0.2.2')
+})
+
+test('checkForGsdBrowserUpdates does not spawn PATH browser when browser cache is fresh', async (t) => {
+  const { cachePath, spawnCountPath } = installCountingGsdBrowserShim(t)
+  writeUpdateCache({ lastCheck: Date.now(), latestVersion: '9.9.9' }, cachePath, GSD_BROWSER_PACKAGE_NAME)
+
+  await checkForGsdBrowserUpdates({
+    cachePath,
+    checkIntervalMs: 60 * 60 * 1000,
+    fetchTimeoutMs: 1,
+    onUpdate: () => {
+      throw new Error('fresh browser cache should short-circuit before notification')
+    },
+  })
+
+  assert.equal(readFileSync(spawnCountPath, 'utf-8'), '0')
+})
+
+test('checkForGsdBrowserUpdates defers PATH browser spawn when browser cache is stale', async (t) => {
+  const { cachePath, spawnCountPath } = installCountingGsdBrowserShim(t)
+
+  const pendingCheck = checkForGsdBrowserUpdates({
+    cachePath,
+    registryUrl: 'http://127.0.0.1:9',
+    fetchTimeoutMs: 1,
+    onUpdate: () => {
+      throw new Error('network failure should prevent notification')
+    },
+  })
+
+  assert.equal(readFileSync(spawnCountPath, 'utf-8'), '0')
+  await pendingCheck
+  assert.equal(readFileSync(spawnCountPath, 'utf-8'), '1')
 })
 
 test('checkForUpdates uses cache and skips fetch when checked recently', async (t) => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -240,9 +240,6 @@ function defaultRegistryUrl(packageName: string): string {
  */
 export async function checkForUpdates(options: UpdateCheckOptions = {}): Promise<void> {
   const packageName = options.packageName || GSD_PI_PACKAGE_NAME
-  const currentVersion = options.currentVersion || defaultCurrentVersion(packageName)
-  if (!currentVersion) return
-
   const cachePath = options.cachePath || defaultCachePath(packageName)
   const registryUrl = options.registryUrl || defaultRegistryUrl(packageName)
   const checkIntervalMs = options.checkIntervalMs ?? CHECK_INTERVAL_MS
@@ -252,11 +249,19 @@ export async function checkForUpdates(options: UpdateCheckOptions = {}): Promise
   // Check cache — skip network if checked recently
   const cache = readUpdateCache(cachePath, packageName)
   if (cache && Date.now() - cache.lastCheck < checkIntervalMs) {
-    if (compareSemver(cache.latestVersion, currentVersion) > 0) {
+    const currentVersion = options.currentVersion
+    if (currentVersion && compareSemver(cache.latestVersion, currentVersion) > 0) {
       onUpdate(currentVersion, cache.latestVersion, packageName)
     }
     return
   }
+
+  // For gsd-browser, resolving the default version may spawn the PATH binary.
+  // Yield first so startup callers that do not await this check stay non-blocking.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+  const currentVersion = options.currentVersion || defaultCurrentVersion(packageName)
+  if (!currentVersion) return
 
   try {
     const latestVersion = await fetchLatestVersionFromRegistry(registryUrl, fetchTimeoutMs)

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -249,7 +249,15 @@ export async function checkForUpdates(options: UpdateCheckOptions = {}): Promise
   // Check cache — skip network if checked recently
   const cache = readUpdateCache(cachePath, packageName)
   if (cache && Date.now() - cache.lastCheck < checkIntervalMs) {
-    const currentVersion = options.currentVersion
+    // Resolve current version via cheap means (env var / installed package.json)
+    // even when the caller did not pass options.currentVersion, so that a cached
+    // "update available" result still produces a banner on subsequent startups
+    // within the 24h window.  For gsd-browser, skip this fallback to avoid a
+    // synchronous PATH binary spawn in the fast-path; the PATH version is only
+    // resolved when the cache is stale and the check runs asynchronously.
+    const currentVersion =
+      options.currentVersion ??
+      (packageName !== GSD_BROWSER_PACKAGE_NAME ? defaultCurrentVersion(packageName) : null)
     if (currentVersion && compareSemver(cache.latestVersion, currentVersion) > 0) {
       onUpdate(currentVersion, cache.latestVersion, packageName)
     }


### PR DESCRIPTION
## Summary
- Fixed browser update checks to honor the cache before spawning gsd-browser and verified the focused no-spawn regressions.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #910
- [#910 [Bug]: `gsd-browser --version` is spawned synchronously on every interactive startup, before the 24h update-cache check](https://github.com/open-gsd/gsd-pi/issues/910)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/910-bug-gsd-browser-version-is-spawned-synch-1782524086`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only update-check ordering and a microtask yield; behavior change is limited to when PATH version resolution runs, with focused regression tests.
> 
> **Overview**
> **Fixes interactive startup spawning `gsd-browser --version` on every launch** by reordering `checkForUpdates` so the 24h cache is evaluated before resolving the default current version (which runs the PATH binary for `@opengsd/gsd-browser`).
> 
> When the cache is still fresh, the check can notify using only an explicit `currentVersion` and **returns without** calling `defaultCurrentVersion` or hitting the network. When the cache is stale, resolution and registry fetch happen only after a **`setTimeout(0)` yield**, so callers like `cli.ts` that fire `checkForGsdBrowserUpdates().catch(() => {})` without awaiting do not block the TUI on the synchronous spawn.
> 
> Adds **`installCountingGsdBrowserShim`** integration tests: fresh browser cache keeps spawn count at 0; stale cache defers spawn until after the first tick of the async check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e34d6acfc13aa67bb30df8b5a2774914967024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->