### PR TITLE
fix(issue): [Bug]: Working-tree status is read twice per commit (`git status --porcelain` then `git status --short`)

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -921,16 +921,19 @@ export class GitServiceImpl {
    *
    * Returns the commit message on success, or null if nothing to commit.
    * @param extraExclusions Additional paths to exclude from staging (e.g. [".gsd/"] for pre-switch commits).
+   * @param knownDirty Fresh caller-provided dirty status; when omitted, autoCommit probes the tree.
    */
   autoCommit(
     unitType: string,
     unitId: string,
     extraExclusions: readonly string[] = [],
     taskContext?: TaskCommitContext,
+    knownDirty?: boolean,
   ): string | null {
     // Quick check: is there anything dirty at all?
     // Native path uses libgit2 (single syscall), fallback spawns git.
-    if (!nativeHasChanges(this.basePath)) return null;
+    if (knownDirty === false) return null;
+    if (knownDirty !== true && !nativeHasChanges(this.basePath)) return null;
 
     const scoped = taskContext
       ? this.scopedStageTaskFiles(taskContext, extraExclusions)
@@ -1282,6 +1285,7 @@ function runPerRepositoryCommitAction(args: {
   unitId: string;
   taskContext?: TaskCommitContext;
   targetRepositories?: string[];
+  dirtyRepositories?: Record<string, boolean>;
 }): {
   commitMessages: Record<string, string>;
   commitErrors: Record<string, string>;
@@ -1313,6 +1317,7 @@ function runPerRepositoryCommitAction(args: {
           args.unitId,
           [],
           args.taskContext,
+          args.dirtyRepositories?.[repo.id],
         ) ?? "";
       if (message) {
         commitMessages[repo.id] = message;
@@ -1360,7 +1365,7 @@ export function runTurnGitAction(args: {
       };
     }
 
-    const repoCommitResult = runPerRepositoryCommitAction(args);
+    const repoCommitResult = runPerRepositoryCommitAction({ ...args, dirtyRepositories });
     if (Object.keys(repoCommitResult.commitErrors).length > 0) {
       return {
         action: args.action,

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -3,10 +3,20 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
 import { handleTurnGitActionError, runTurnGitAction } from "../git-service.ts";
 
 function run(cmd: string, cwd: string): string {
@@ -135,6 +145,67 @@ test("uok gitops turn action commit creates commit with unit trailer", () => {
     assert.ok(body.includes("GSD-Unit: M001/S01/T02"));
   } finally {
     rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("uok gitops turn action commit reuses the collected dirty status", () => {
+  const repo = makeRepo();
+  const wrapperDir = mkdtempSync(join(tmpdir(), "gsd-uok-git-wrapper-"));
+  const logPath = join(wrapperDir, "git.log");
+  const wrapperPath = join(wrapperDir, "git");
+  const realGit = execSync("command -v git", { encoding: "utf-8" }).trim();
+  const gitEnv = GIT_NO_PROMPT_ENV as NodeJS.ProcessEnv;
+  const previousPath = gitEnv.PATH;
+  const previousRealGit = gitEnv.GSD_TEST_REAL_GIT;
+  const previousLogPath = gitEnv.GSD_TEST_GIT_LOG;
+
+  writeFileSync(wrapperPath, [
+    "#!/bin/sh",
+    "printf '%s\\n' \"$*\" >> \"$GSD_TEST_GIT_LOG\"",
+    "exec \"$GSD_TEST_REAL_GIT\" \"$@\"",
+    "",
+  ].join("\n"), "utf-8");
+  chmodSync(wrapperPath, 0o755);
+
+  try {
+    gitEnv.PATH = `${wrapperDir}:${previousPath ?? ""}`;
+    gitEnv.GSD_TEST_REAL_GIT = realGit;
+    gitEnv.GSD_TEST_GIT_LOG = logPath;
+
+    writeFileSync(join(repo, "feature.ts"), "export const x = 1;\n", "utf-8");
+    const result = runTurnGitAction({
+      basePath: repo,
+      action: "commit",
+      unitType: "execute-task",
+      unitId: "M001/S01/T-status",
+    });
+
+    assert.equal(result.status, "ok");
+    const invocations = readFileSync(logPath, "utf-8").trim().split("\n");
+    assert.equal(
+      invocations.filter((line) => line === "status --porcelain").length,
+      1,
+      "turn status is collected once",
+    );
+    assert.equal(
+      invocations.includes("status --short"),
+      false,
+      "autoCommit should not re-read working-tree status when turn status is known",
+    );
+  } finally {
+    gitEnv.PATH = previousPath;
+    if (previousRealGit === undefined) {
+      delete gitEnv.GSD_TEST_REAL_GIT;
+    } else {
+      gitEnv.GSD_TEST_REAL_GIT = previousRealGit;
+    }
+    if (previousLogPath === undefined) {
+      delete gitEnv.GSD_TEST_GIT_LOG;
+    } else {
+      gitEnv.GSD_TEST_GIT_LOG = previousLogPath;
+    }
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(wrapperDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Threaded turn dirty status into autoCommit and added a regression test; git diff --check passed, while runtime tests were blocked by missing deps/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #904
- [#904 [Bug]: Working-tree status is read twice per commit (`git status --porcelain` then `git status --short`)](https://github.com/open-gsd/gsd-pi/issues/904)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/904-bug-working-tree-status-is-read-twice-pe-1782525079`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized git-service change with backward-compatible optional parameter and a targeted regression test; no auth or data-path changes.
> 
> **Overview**
> Turn **commit** actions already collect per-repo dirtiness once via `git status --porcelain` in `collectRepositoryDirtyStatus`. This change **threads that map into** `runPerRepositoryCommitAction` and **`autoCommit`’s new `knownDirty` argument**, so a repo marked dirty skips the extra `nativeHasChanges` probe (fallback path uses `git status --short`).
> 
> When `knownDirty` is **`false`**, `autoCommit` returns immediately without re-reading the tree; when **`undefined`**, behavior stays the same as before for callers that do not pass turn status.
> 
> A **regression test** wraps `git` and asserts a commit turn invokes `status --porcelain` only once and never `status --short`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270474530b6cfe8bd4a37e16fa06ab45d1dea66c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->