### PR TITLE
fix(issue): [Bug]: Auto-loop re-runs the full `advance()` pipeline with no backoff on a persistent "skip", pinning a core until the 500-iteration runaway cap

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1143,9 +1143,6 @@ export async function autoLoop(
         });
       }
 
-      consecutiveOrchestrationSkips = 0;
-      lastOrchestrationSkipKey = null;
-
       await enforceMinRequestInterval(s, prefs);
 
       // Phase B: claim a unit_dispatches row before invoking the unit. The

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -175,6 +175,7 @@ function resolveCompletionStopFromOutcome(
 // tolerates — same behavior as a fresh session.
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
 const MAX_CONSECUTIVE_ALREADY_ACTIVE_SKIPS = 3;
+const MAX_CONSECUTIVE_ORCHESTRATION_SKIPS = 3;
 const ORCHESTRATION_MISSING_REASON =
   "Auto Orchestration Module is not wired; cannot dispatch built-in GSD Unit.";
 
@@ -419,6 +420,8 @@ export async function autoLoop(
   let consecutiveErrors = 0;
   let consecutiveCooldowns = 0;
   let consecutiveAlreadyActiveSkips = 0;
+  let consecutiveOrchestrationSkips = 0;
+  let lastOrchestrationSkipKey: string | null = null;
   const recentErrorMessages: string[] = [];
 
   while (s.active) {
@@ -938,11 +941,43 @@ export async function autoLoop(
 
           if (orchestrationResult.kind === "skipped") {
             s.pendingOrchestrationDispatch = null;
+            const skipState = orchestrationResult.stateSnapshot;
+            const skipKey = [
+              orchestrationResult.reason,
+              skipState?.phase,
+              skipState?.activeMilestone?.id,
+              skipState?.activeSlice?.id,
+              skipState?.activeTask?.id,
+            ].join("|");
+            consecutiveOrchestrationSkips = skipKey === lastOrchestrationSkipKey
+              ? consecutiveOrchestrationSkips + 1
+              : 1;
+            lastOrchestrationSkipKey = skipKey;
+            if (consecutiveOrchestrationSkips >= MAX_CONSECUTIVE_ORCHESTRATION_SKIPS) {
+              const msg = `Orchestration skipped ${consecutiveOrchestrationSkips} consecutive attempts without progress. Pausing auto-mode for manual recovery.`;
+              ctx.ui.notify(msg, "error");
+              await deps.pauseAuto(ctx, pi, {
+                message: msg,
+                category: "unknown",
+              }, {
+                expectedCurrentUnit: null,
+              });
+              finishTurn("paused", "manual-attention", orchestrationResult.reason ?? "orchestration-skipped");
+              finishIncompleteIteration({
+                status: "paused",
+                reason: orchestrationResult.reason ?? "orchestration-skipped",
+                failureClass: "manual-attention",
+              });
+              break;
+            }
             emitIterationEnd({ skipped: true });
             completeIteration();
             finishTurn("skipped");
             continue;
           }
+
+          consecutiveOrchestrationSkips = 0;
+          lastOrchestrationSkipKey = null;
 
           if (orchestrationResult.kind === "paused") {
             s.pendingOrchestrationDispatch = null;
@@ -1107,6 +1142,9 @@ export async function autoLoop(
           sidecarKind: sidecarItem.kind,
         });
       }
+
+      consecutiveOrchestrationSkips = 0;
+      lastOrchestrationSkipKey = null;
 
       await enforceMinRequestInterval(s, prefs);
 

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -941,37 +941,43 @@ export async function autoLoop(
 
           if (orchestrationResult.kind === "skipped") {
             s.pendingOrchestrationDispatch = null;
-            const isIdempotentSkip = orchestrationResult.reason === "idempotent advance: unit already active";
-            if (!isIdempotentSkip) {
-              const skipState = orchestrationResult.stateSnapshot;
-              const skipKey = [
-                orchestrationResult.reason,
-                skipState?.phase,
-                skipState?.activeMilestone?.id,
-                skipState?.activeSlice?.id,
-                skipState?.activeTask?.id,
-              ].join("|");
-              consecutiveOrchestrationSkips = skipKey === lastOrchestrationSkipKey
-                ? consecutiveOrchestrationSkips + 1
-                : 1;
-              lastOrchestrationSkipKey = skipKey;
-              if (consecutiveOrchestrationSkips >= MAX_CONSECUTIVE_ORCHESTRATION_SKIPS) {
-                const msg = `Orchestration skipped ${consecutiveOrchestrationSkips} consecutive attempts without progress. Pausing auto-mode for manual recovery.`;
-                ctx.ui.notify(msg, "error");
-                await deps.pauseAuto(ctx, pi, {
-                  message: msg,
-                  category: "unknown",
-                }, {
-                  expectedCurrentUnit: null,
-                });
-                finishTurn("paused", "manual-attention", orchestrationResult.reason ?? "orchestration-skipped");
-                finishIncompleteIteration({
-                  status: "paused",
-                  reason: orchestrationResult.reason ?? "orchestration-skipped",
-                  failureClass: "manual-attention",
-                });
-                break;
-              }
+            // Idempotent re-poll skips are benign (an active unit is still running).
+            // The orchestrator's own stuck-window detection handles the truly-stuck case.
+            // Do not count these toward the consecutive-skip streak.
+            if (orchestrationResult.reason === "idempotent advance: unit already active") {
+              emitIterationEnd({ skipped: true });
+              completeIteration();
+              finishTurn("skipped");
+              continue;
+            }
+            const skipState = orchestrationResult.stateSnapshot;
+            const skipKey = [
+              orchestrationResult.reason,
+              skipState?.phase,
+              skipState?.activeMilestone?.id,
+              skipState?.activeSlice?.id,
+              skipState?.activeTask?.id,
+            ].join("|");
+            consecutiveOrchestrationSkips = skipKey === lastOrchestrationSkipKey
+              ? consecutiveOrchestrationSkips + 1
+              : 1;
+            lastOrchestrationSkipKey = skipKey;
+            if (consecutiveOrchestrationSkips >= MAX_CONSECUTIVE_ORCHESTRATION_SKIPS) {
+              const msg = `Orchestration skipped ${consecutiveOrchestrationSkips} consecutive attempts without progress. Pausing auto-mode for manual recovery.`;
+              ctx.ui.notify(msg, "error");
+              await deps.pauseAuto(ctx, pi, {
+                message: msg,
+                category: "unknown",
+              }, {
+                expectedCurrentUnit: null,
+              });
+              finishTurn("paused", "manual-attention", orchestrationResult.reason ?? "orchestration-skipped");
+              finishIncompleteIteration({
+                status: "paused",
+                reason: orchestrationResult.reason ?? "orchestration-skipped",
+                failureClass: "manual-attention",
+              });
+              break;
             }
             emitIterationEnd({ skipped: true });
             completeIteration();

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -941,34 +941,37 @@ export async function autoLoop(
 
           if (orchestrationResult.kind === "skipped") {
             s.pendingOrchestrationDispatch = null;
-            const skipState = orchestrationResult.stateSnapshot;
-            const skipKey = [
-              orchestrationResult.reason,
-              skipState?.phase,
-              skipState?.activeMilestone?.id,
-              skipState?.activeSlice?.id,
-              skipState?.activeTask?.id,
-            ].join("|");
-            consecutiveOrchestrationSkips = skipKey === lastOrchestrationSkipKey
-              ? consecutiveOrchestrationSkips + 1
-              : 1;
-            lastOrchestrationSkipKey = skipKey;
-            if (consecutiveOrchestrationSkips >= MAX_CONSECUTIVE_ORCHESTRATION_SKIPS) {
-              const msg = `Orchestration skipped ${consecutiveOrchestrationSkips} consecutive attempts without progress. Pausing auto-mode for manual recovery.`;
-              ctx.ui.notify(msg, "error");
-              await deps.pauseAuto(ctx, pi, {
-                message: msg,
-                category: "unknown",
-              }, {
-                expectedCurrentUnit: null,
-              });
-              finishTurn("paused", "manual-attention", orchestrationResult.reason ?? "orchestration-skipped");
-              finishIncompleteIteration({
-                status: "paused",
-                reason: orchestrationResult.reason ?? "orchestration-skipped",
-                failureClass: "manual-attention",
-              });
-              break;
+            const isIdempotentSkip = orchestrationResult.reason === "idempotent advance: unit already active";
+            if (!isIdempotentSkip) {
+              const skipState = orchestrationResult.stateSnapshot;
+              const skipKey = [
+                orchestrationResult.reason,
+                skipState?.phase,
+                skipState?.activeMilestone?.id,
+                skipState?.activeSlice?.id,
+                skipState?.activeTask?.id,
+              ].join("|");
+              consecutiveOrchestrationSkips = skipKey === lastOrchestrationSkipKey
+                ? consecutiveOrchestrationSkips + 1
+                : 1;
+              lastOrchestrationSkipKey = skipKey;
+              if (consecutiveOrchestrationSkips >= MAX_CONSECUTIVE_ORCHESTRATION_SKIPS) {
+                const msg = `Orchestration skipped ${consecutiveOrchestrationSkips} consecutive attempts without progress. Pausing auto-mode for manual recovery.`;
+                ctx.ui.notify(msg, "error");
+                await deps.pauseAuto(ctx, pi, {
+                  message: msg,
+                  category: "unknown",
+                }, {
+                  expectedCurrentUnit: null,
+                });
+                finishTurn("paused", "manual-attention", orchestrationResult.reason ?? "orchestration-skipped");
+                finishIncompleteIteration({
+                  status: "paused",
+                  reason: orchestrationResult.reason ?? "orchestration-skipped",
+                  failureClass: "manual-attention",
+                });
+                break;
+              }
             }
             emitIterationEnd({ skipped: true });
             completeIteration();

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3381,6 +3381,87 @@ test("autoLoop pauses after repeated orchestration skips", async () => {
   assert.equal(deps.callLog.includes("stopAuto"), false, "persistent orchestration skips should not hit the max-iteration stop");
 });
 
+test("autoLoop does not pause on repeated idempotent advance skips", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  let advanceCalls = 0;
+  const s = makeLoopSession({
+    currentMilestoneId: "M001",
+    orchestration: {
+      start: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      advance: async () => {
+        advanceCalls++;
+        if (advanceCalls >= 5) s.active = false;
+        return { kind: "skipped" as const, reason: "idempotent advance: unit already active" };
+      },
+      completeActiveUnit: async () => {},
+      retryActiveUnit: async () => {},
+      resume: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      stop: async (reason: string) => ({ kind: "stopped" as const, reason }),
+      getStatus: () => ({ phase: "running" as const, transitionCount: 1 }),
+    } satisfies AutoOrchestrationModule,
+  });
+
+  const deps = makeMockDeps();
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.ok(advanceCalls >= 5, "loop should complete multiple idempotent skips before deactivating");
+  assert.equal(deps.callLog.includes("pauseAuto"), false, "idempotent advance skips must not trigger the consecutive-skip pause");
+  assert.equal(deps.callLog.includes("stopAuto"), false, "idempotent advance skips must not reach the max-iteration stop");
+});
+
+test("autoLoop skip streak survives sidecar iteration without resetting", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  let advanceCalls = 0;
+  const s = makeLoopSession({ currentMilestoneId: "M001" });
+  s.orchestration = {
+    start: async () => ({ kind: "stopped" as const, reason: "unused" }),
+    advance: async () => {
+      advanceCalls++;
+      if (advanceCalls === 2) {
+        // Inject a sidecar so the *next* iteration takes the sidecar path rather than
+        // calling orchestration.advance() — which must NOT reset the skip streak.
+        s.sidecarQueue.push({
+          kind: "hook" as const,
+          unitType: "run-uat",
+          unitId: "M001/S01/T01/review",
+          prompt: "review",
+        });
+      }
+      return { kind: "skipped" as const, reason: "gate-marker-drift" };
+    },
+    completeActiveUnit: async () => {},
+    retryActiveUnit: async () => {},
+    resume: async () => ({ kind: "stopped" as const, reason: "unused" }),
+    stop: async (reason: string) => ({ kind: "stopped" as const, reason }),
+    getStatus: () => ({ phase: "running" as const, transitionCount: advanceCalls }),
+  } satisfies AutoOrchestrationModule;
+
+  const deps = makeMockDeps();
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  // Wait for the sidecar unit to call newSession (pi.calls grows)
+  await waitForMicrotasks(() => pi.calls.length >= 1, "sidecar unit to start");
+  resolveAgentEnd(makeEvent()); // resolve the sidecar unit
+
+  await loopPromise;
+
+  // Skip 1 (call 1) + sidecar iteration (no advance) + skip 3 (call 3, matches key) → pause.
+  // The old reset at the dispatch boundary would have zeroed the counter during the sidecar,
+  // requiring 3 more skips (calls 3,4,5) before pausing. With the fix, 3 total → call 3.
+  assert.equal(advanceCalls, 3, "skip streak must survive the sidecar iteration: pause on the 3rd total skip");
+  assert.ok(deps.callLog.includes("pauseAuto"), "persistent skips must still pause after an interleaved sidecar");
+  assert.equal(deps.callLog.includes("stopAuto"), false, "must not hit the max-iteration stop");
+});
+
 test("autoLoop drains sidecar queue after postUnitPostVerification enqueues items", async (t) => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3358,6 +3358,29 @@ test("autoLoop handles dispatch skip action by continuing", async (t) => {
   );
 });
 
+test("autoLoop pauses after repeated orchestration skips", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return { action: "skip" as const, reason: "gate-marker-drift" as const };
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  const dispatchCalls = deps.callLog.filter((c) => c === "resolveDispatch");
+  assert.equal(dispatchCalls.length, 3, "persistent orchestration skips should pause before the runaway cap");
+  assert.equal(deps.callLog.includes("pauseAuto"), true, "persistent orchestration skips should pause auto-mode");
+  assert.equal(deps.callLog.includes("stopAuto"), false, "persistent orchestration skips should not hit the max-iteration stop");
+});
+
 test("autoLoop drains sidecar queue after postUnitPostVerification enqueues items", async (t) => {
   _resetPendingResolve();
 


### PR DESCRIPTION
## Summary
- Added a repeated orchestration-skip pause guard and regression test; syntax/diff checks passed, while the focused test was blocked by missing dependencies under restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #901
- [#901 [Bug]: Auto-loop re-runs the full `advance()` pipeline with no backoff on a persistent "skip", pinning a core until the 500-iteration runaway cap](https://github.com/open-gsd/gsd-pi/issues/901)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/901-bug-auto-loop-re-runs-the-full-advance-p-1782525445`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core auto-loop exit behavior when orchestration repeatedly skips; mis-tuned thresholds or skip-key logic could pause auto-mode earlier than intended, but scope is narrow and mirrors an existing dispatch-claim guard.
> 
> **Overview**
> Fixes a **CPU spin** when `orchestration.advance()` keeps returning **skipped** (non-idempotent reasons): the loop previously retried immediately with no backoff until the **500-iteration** safety stop.
> 
> Auto-loop now tracks **consecutive orchestration skips** with a stable key (skip reason plus workflow snapshot fields), **ignores** the idempotent `"idempotent advance: unit already active"` case, and after **3** identical skips in a row **pauses** auto-mode with an error notification instead of continuing. Counters reset when orchestration makes progress.
> 
> Adds a regression test asserting pause after three persistent skips and that **`stopAuto`** is not used for this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c168ad77c3a20df53ae3b39df9bb38c967aed44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->