### PR TITLE
fix(issue): [Bug]: getWorktreeHealth re-detects the constant main branch per worktree (~4 spawns each), so health scans cost N×~9 git spawns

### DIFF
--- a/src/resources/extensions/gsd/git-constants.ts
+++ b/src/resources/extensions/gsd/git-constants.ts
@@ -32,7 +32,7 @@ function buildSafeParentEnv(): NodeJS.ProcessEnv {
 }
 
 /** Env overlay that suppresses interactive git credential prompts and git-svn noise. */
-export const GIT_NO_PROMPT_ENV = {
+export const GIT_NO_PROMPT_ENV: NodeJS.ProcessEnv = {
   ...buildSafeParentEnv(),
   GIT_TERMINAL_PROMPT: "0",
   GIT_ASKPASS: "",

--- a/src/resources/extensions/gsd/tests/worktree-health.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health.test.ts
@@ -5,13 +5,14 @@
  * that getWorktreeHealth and formatWorktreeStatusLine return correct results.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
-import { getWorktreeHealth, formatWorktreeStatusLine } from "../worktree-health.ts";
+import { getAllWorktreeHealth, getWorktreeHealth, formatWorktreeStatusLine } from "../worktree-health.ts";
 import { listWorktrees } from "../worktree-manager.ts";
+import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -171,6 +172,45 @@ describe('worktree-health', async () => {
       const line = formatWorktreeStatusLine(health);
       // Should show last commit age since it's not merged and not stale
       assert.ok(line.includes("last commit"), "shows last commit age for active worktree");
+    }
+
+    // ─── Test: batch health detects main branch once ───────────────────
+    console.log("\n=== worktree health: batch main branch detection ===");
+    {
+      const dir = createBaseRepo();
+      cleanups.push(dir);
+
+      mkdirSync(join(dir, ".gsd", "worktrees"), { recursive: true });
+      run("git worktree add -b worktree/batch-a .gsd/worktrees/batch-a", dir);
+      run("git worktree add -b worktree/batch-b .gsd/worktrees/batch-b", dir);
+
+      const bin = mkdtempSync(join(tmpdir(), "wt-health-git-shim-"));
+      cleanups.push(bin);
+      const logPath = join(bin, "git.log");
+      const realGit = execSync("command -v git", { encoding: "utf-8" }).trim();
+      const shim = join(bin, "git");
+      writeFileSync(shim, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\nexec ${JSON.stringify(realGit)} "$@"\n`, "utf-8");
+      chmodSync(shim, 0o755);
+
+      const originalPath = process.env.PATH ?? "";
+      const originalGitEnvPath = GIT_NO_PROMPT_ENV.PATH;
+      try {
+        process.env.PATH = `${bin}${delimiter}${originalPath}`;
+        GIT_NO_PROMPT_ENV.PATH = process.env.PATH;
+
+        const health = getAllWorktreeHealth(dir);
+        assert.equal(health.length, 2, "both worktrees have health entries");
+      } finally {
+        process.env.PATH = originalPath;
+        GIT_NO_PROMPT_ENV.PATH = originalGitEnvPath;
+      }
+
+      const invocations = readFileSync(logPath, "utf-8")
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+      const mainBranchDetections = invocations.filter(line => line === "symbolic-ref refs/remotes/origin/HEAD");
+      assert.equal(mainBranchDetections.length, 1, "batch health detects main branch once");
     }
 
   } finally {

--- a/src/resources/extensions/gsd/worktree-health.ts
+++ b/src/resources/extensions/gsd/worktree-health.ts
@@ -54,14 +54,14 @@ const DEFAULT_STALE_DAYS = 14;
  * @param basePath — the main project root (not the worktree path)
  * @param wt — worktree info from listWorktrees()
  * @param staleDays — days without commits to consider stale (default: 14)
+ * @param mainBranch — pre-detected main branch for batched health checks
  */
 export function getWorktreeHealth(
   basePath: string,
   wt: WorktreeInfo,
   staleDays = DEFAULT_STALE_DAYS,
+  mainBranch = nativeDetectMainBranch(basePath),
 ): WorktreeHealthStatus {
-  const mainBranch = nativeDetectMainBranch(basePath);
-
   // Merge status: is the worktree branch fully contained in main?
   let mergedIntoMain = false;
   try {
@@ -131,7 +131,10 @@ export function getAllWorktreeHealth(
   staleDays = DEFAULT_STALE_DAYS,
 ): WorktreeHealthStatus[] {
   const worktrees = listWorktrees(basePath);
-  return worktrees.map(wt => getWorktreeHealth(basePath, wt, staleDays));
+  if (worktrees.length === 0) return [];
+
+  const mainBranch = nativeDetectMainBranch(basePath);
+  return worktrees.map(wt => getWorktreeHealth(basePath, wt, staleDays, mainBranch));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Hoisted batched worktree main-branch detection to one call, added regression coverage, and verified syntax/whitespace while full test execution was blocked by missing dependencies and sandboxed registry DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #902
- [#902 [Bug]: getWorktreeHealth re-detects the constant main branch per worktree (~4 spawns each), so health scans cost N×~9 git spawns](https://github.com/open-gsd/gsd-pi/issues/902)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/902-bug-getworktreehealth-re-detects-the-con-1782525798`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change with backward-compatible `getWorktreeHealth` defaults; behavior unchanged aside from fewer git invocations on batch paths.
> 
> **Overview**
> **Batch worktree health** no longer runs main-branch detection for every worktree. `getAllWorktreeHealth` calls `nativeDetectMainBranch` once and passes that branch into each `getWorktreeHealth` call, cutting redundant git spawns during `/worktree list` and doctor-style scans.
> 
> `getWorktreeHealth` gains an optional `mainBranch` argument (default still detects when used alone). An early return when there are no worktrees avoids unnecessary git work.
> 
> A regression test uses a **PATH git shim** to assert `symbolic-ref refs/remotes/origin/HEAD` runs exactly once when health is computed for two worktrees via `getAllWorktreeHealth`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68404478b8c3ab157a4fa7d1f22e161181bb0b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->