### PR TITLE
fix(issue): [Bug]: MCP config files re-read and re-parsed from disk 3–5× per Claude Code dispatch

### DIFF
--- a/src/resources/extensions/gsd/mcp-filter.ts
+++ b/src/resources/extensions/gsd/mcp-filter.ts
@@ -84,7 +84,7 @@ export function discoverMcpServers(projectDir: string): DiscoveredMcpServer[] {
   const settingsPath = resolve(resolvedProjectDir, ".claude", "settings.json");
   const localSettingsPath = resolve(resolvedProjectDir, ".claude", "settings.local.json");
   const signatures = [
-    getJsonFileSignature(mcpJsonPath),
+    getJsonFileSignature(mcpJsonPath, true),
     getJsonFileSignature(settingsPath, true),
     getJsonFileSignature(localSettingsPath, true),
   ];

--- a/src/resources/extensions/gsd/mcp-filter.ts
+++ b/src/resources/extensions/gsd/mcp-filter.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
@@ -21,12 +21,50 @@ interface DiscoveredMcpServer {
   config: unknown;
 }
 
+interface JsonFileSignature {
+  exists: boolean;
+  mtimeMs?: number;
+  size?: number;
+}
+
+interface ProjectMcpDiscoveryCacheEntry {
+  signatures: JsonFileSignature[];
+  servers: DiscoveredMcpServer[];
+}
+
+const projectMcpDiscoveryCache = new Map<string, ProjectMcpDiscoveryCacheEntry>();
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function readJsonFile(path: string, ignoreParseErrors = false): unknown | undefined {
-  if (!existsSync(path)) return undefined;
+function getJsonFileSignature(path: string, ignoreAccessErrors = false): JsonFileSignature {
+  try {
+    const stats = statSync(path);
+    return { exists: true, mtimeMs: stats.mtimeMs, size: stats.size };
+  } catch (err) {
+    const code = isRecord(err) ? err.code : undefined;
+    if (code === "ENOENT" || code === "ENOTDIR" || ignoreAccessErrors) return { exists: false };
+    throw err;
+  }
+}
+
+function jsonFileSignaturesEqual(a: JsonFileSignature[], b: JsonFileSignature[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((signature, index) => {
+    const other = b[index];
+    return signature.exists === other.exists
+      && signature.mtimeMs === other.mtimeMs
+      && signature.size === other.size;
+  });
+}
+
+function readJsonFile(
+  path: string,
+  ignoreParseErrors = false,
+  signature = getJsonFileSignature(path, ignoreParseErrors),
+): unknown | undefined {
+  if (!signature.exists) return undefined;
   try {
     return JSON.parse(readFileSync(path, "utf-8")) as unknown;
   } catch (err) {
@@ -41,13 +79,23 @@ function collectServerEntries(servers: unknown): DiscoveredMcpServer[] {
 }
 
 export function discoverMcpServers(projectDir: string): DiscoveredMcpServer[] {
-  const mcpJsonPath = resolve(projectDir, ".mcp.json");
-  const settingsPath = resolve(projectDir, ".claude", "settings.json");
-  const localSettingsPath = resolve(projectDir, ".claude", "settings.local.json");
+  const resolvedProjectDir = resolve(projectDir);
+  const mcpJsonPath = resolve(resolvedProjectDir, ".mcp.json");
+  const settingsPath = resolve(resolvedProjectDir, ".claude", "settings.json");
+  const localSettingsPath = resolve(resolvedProjectDir, ".claude", "settings.local.json");
+  const signatures = [
+    getJsonFileSignature(mcpJsonPath),
+    getJsonFileSignature(settingsPath, true),
+    getJsonFileSignature(localSettingsPath, true),
+  ];
+  const cached = projectMcpDiscoveryCache.get(resolvedProjectDir);
+  if (cached && jsonFileSignaturesEqual(cached.signatures, signatures)) {
+    return [...cached.servers];
+  }
 
-  const mcpJson = readJsonFile(mcpJsonPath) as McpJsonFile | undefined;
-  const settings = readJsonFile(settingsPath, true) as ClaudeSettingsFile | undefined;
-  const localSettings = readJsonFile(localSettingsPath, true) as ClaudeSettingsFile | undefined;
+  const mcpJson = readJsonFile(mcpJsonPath, false, signatures[0]) as McpJsonFile | undefined;
+  const settings = readJsonFile(settingsPath, true, signatures[1]) as ClaudeSettingsFile | undefined;
+  const localSettings = readJsonFile(localSettingsPath, true, signatures[2]) as ClaudeSettingsFile | undefined;
 
   const seen = new Set<string>();
   const discovered: DiscoveredMcpServer[] = [];
@@ -61,7 +109,8 @@ export function discoverMcpServers(projectDir: string): DiscoveredMcpServer[] {
     seen.add(entry.name);
     discovered.push(entry);
   }
-  return discovered;
+  projectMcpDiscoveryCache.set(resolvedProjectDir, { signatures, servers: discovered });
+  return [...discovered];
 }
 
 function isWorkflowMcpServerConfig(config: unknown): boolean {

--- a/src/resources/extensions/gsd/tests/mcp-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-filter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import fs, { mkdtempSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -106,6 +107,78 @@ describe("discoverMcpServerNames", () => {
       }),
     );
     assert.equal(discoverBrowserMcpServerName(dir), "browser-uat");
+  });
+
+  it("invalidates cached project MCP config when .mcp.json changes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mcp-filter-cache-test-"));
+    const configPath = join(dir, ".mcp.json");
+    writeFileSync(configPath, JSON.stringify({ mcpServers: { "server-a": {} } }));
+    assert.deepEqual(discoverMcpServerNames(dir), ["server-a"]);
+
+    writeFileSync(configPath, JSON.stringify({ mcpServers: { "server-b": {} } }));
+    const later = new Date(Date.now() + 5_000);
+    utimesSync(configPath, later, later);
+
+    assert.deepEqual(discoverMcpServerNames(dir), ["server-b"]);
+  });
+
+  it("reuses parsed project MCP config across discovery helpers", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mcp-filter-cache-test-"));
+    const claudeDir = join(dir, ".claude");
+    const mcpJsonPath = join(dir, ".mcp.json");
+    const settingsPath = join(claudeDir, "settings.json");
+    const localSettingsPath = join(claudeDir, "settings.local.json");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      mcpJsonPath,
+      JSON.stringify({
+        mcpServers: {
+          "custom-workflow": {
+            command: "node",
+            args: ["custom-cli.js"],
+            env: { GSD_WORKFLOW_PROJECT_ROOT: dir },
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ mcpServers: { "browser-uat": { command: "gsd-browser", args: ["mcp"] } } }),
+    );
+    writeFileSync(
+      localSettingsPath,
+      JSON.stringify({ mcpServers: { "local-server": { command: "npx", args: ["local"] } } }),
+    );
+
+    const trackedPaths = new Set([mcpJsonPath, settingsPath, localSettingsPath]);
+    const readCounts = new Map<string, number>();
+    const originalReadFileSync = fs.readFileSync;
+    fs.readFileSync = ((...args: Parameters<typeof fs.readFileSync>) => {
+      const path = args[0];
+      if (typeof path === "string" && trackedPaths.has(path)) {
+        readCounts.set(path, (readCounts.get(path) ?? 0) + 1);
+      }
+      return originalReadFileSync(...args);
+    }) as typeof fs.readFileSync;
+    syncBuiltinESMExports();
+
+    try {
+      const mcpFilter = await import(`../mcp-filter.ts?cache-test=${Date.now()}`);
+      const discovered = mcpFilter.discoverMcpServerNames(dir);
+      const workflowName = mcpFilter.discoverWorkflowMcpServerName(dir);
+      const browserName = mcpFilter.discoverBrowserMcpServerName(dir);
+
+      assert.deepEqual(discovered.sort(), ["browser-uat", "custom-workflow", "local-server"]);
+      assert.equal(workflowName, "custom-workflow");
+      assert.equal(browserName, "browser-uat");
+      assert.deepEqual(
+        [mcpJsonPath, settingsPath, localSettingsPath].map((path) => readCounts.get(path) ?? 0),
+        [1, 1, 1],
+      );
+    } finally {
+      fs.readFileSync = originalReadFileSync;
+      syncBuiltinESMExports();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Added mtime-aware MCP discovery caching and focused tests; verified with mcp-filter tests via native strip-types resolver and git diff --check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #897
- [#897 [Bug]: MCP config files re-read and re-parsed from disk 3–5× per Claude Code dispatch](https://github.com/open-gsd/gsd-pi/issues/897)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/897-bug-mcp-config-files-re-read-and-re-pars-1782526519`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance fix in MCP discovery with signature-based invalidation; behavior should match prior parsing except fewer disk reads.
> 
> **Overview**
> **Caches per-project MCP server discovery** so `.mcp.json` and `.claude` settings are not read and parsed multiple times on each Claude Code dispatch when several helpers run in the same flow.
> 
> `discoverMcpServers` now **stat-checks** those JSON paths (existence, mtime, size), returns a **cached** server list when signatures match, and **refreshes** after edits. `readJsonFile` uses the same signature so missing optional settings files are handled without extra `existsSync` calls.
> 
> **Tests** cover cache invalidation when `.mcp.json` changes and that name/workflow/browser discovery helpers share one read per config file per project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36af79dbec71511c0649fd16475885a5c035362a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->