### PR TITLE
fix(issue): [Bug]: manual /gsd discuss terminal provider stream error returns before stopReason handling, so the failed turn is never surfaced

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -1,6 +1,8 @@
 // gsd-pi + src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts - Handles provider and agent-end recovery for GSD auto-mode.
 
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import type { AgentEndEvent, ErrorContext } from "../auto/types.js";
 import { logWarning } from "../workflow-logger.js";
@@ -11,7 +13,7 @@ import {
   maybeHandleEmptyIntentTurn,
   resetEmptyTurnCounter,
 } from "../guided-flow.js";
-import { clearPathCache } from "../paths.js";
+import { clearPathCache, gsdRoot } from "../paths.js";
 import {
   getAutoDashboardData,
   getAutoModeStartModel,
@@ -34,7 +36,7 @@ import { resolveModelId } from "../auto-model-selection.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
 import { scheduleFallbackContinuation } from "./fallback-continuation.js";
-import { clearGuidedUnitContext } from "../guided-unit-context.js";
+import { clearGuidedUnitContext, getGuidedUnitContext, type GuidedUnitContext } from "../guided-unit-context.js";
 import { resumeAutoAfterProviderDelay } from "./provider-error-resume.js";
 import {
   classifyError,
@@ -388,6 +390,104 @@ export function suppressTerminalDeletedWorktreeMessageEnd(event: MessageEndLike)
   return true;
 }
 
+function modelLabel(ctx: ExtensionContext): string {
+  const provider = ctx.model?.provider;
+  const id = ctx.model?.id;
+  return provider && id ? `${provider}/${id}` : "unknown model";
+}
+
+function isFatalManualGuidedTerminalFailure(lastMsg: unknown): boolean {
+  if (!isObjectRecord(lastMsg) || !("stopReason" in lastMsg)) return false;
+  if (lastMsg.stopReason === "error") return true;
+  if (lastMsg.stopReason !== "aborted") return false;
+
+  const content = "content" in lastMsg ? lastMsg.content : undefined;
+  const hasErrorMessage = "errorMessage" in lastMsg && !!lastMsg.errorMessage;
+  return hasErrorMessage || !_hasEmptyAgentEndContent(content);
+}
+
+function terminalFailureDetail(lastMsg: unknown): string {
+  if (!isObjectRecord(lastMsg)) return "Provider turn ended with an unknown terminal error.";
+  const rawErrorMsg = ("errorMessage" in lastMsg && lastMsg.errorMessage) ? String(lastMsg.errorMessage) : "";
+  const content = "content" in lastMsg ? lastMsg.content : undefined;
+  const displayMsg = resolveAgentEndErrorDisplay(rawErrorMsg, content).replace(/\s+/g, " ").trim();
+  if (displayMsg) return displayMsg.length > 300 ? `${displayMsg.slice(0, 300)}...` : displayMsg;
+  return lastMsg.stopReason === "aborted"
+    ? "Provider turn aborted with error context."
+    : "Provider stream ended with stopReason=error.";
+}
+
+function nextManualActivitySequence(activityDir: string): string {
+  let maxSeq = 0;
+  try {
+    for (const file of readdirSync(activityDir)) {
+      const match = /^(\d+)-/.exec(file);
+      if (match) maxSeq = Math.max(maxSeq, Number.parseInt(match[1]!, 10));
+    }
+  } catch {
+    return "001";
+  }
+  return String(maxSeq + 1).padStart(3, "0");
+}
+
+function writeManualGuidedTerminalErrorActivity(
+  basePath: string,
+  unitType: string,
+  model: string,
+  detail: string,
+  stopReason: unknown,
+): void {
+  const activityDir = join(gsdRoot(basePath), "activity");
+  mkdirSync(activityDir, { recursive: true });
+  const seq = nextManualActivitySequence(activityDir);
+  const safeUnitType = unitType.replace(/[^a-z0-9_.-]+/gi, "-");
+  const markerPath = join(activityDir, `${seq}-${safeUnitType}-manual-terminal-provider-error.jsonl`);
+  const message = `Manual guided ${unitType} turn ended with provider ${String(stopReason)} on ${model}: ${detail}`;
+  writeFileSync(
+    markerPath,
+    JSON.stringify({
+      type: "message",
+      message: {
+        role: "toolResult",
+        toolCallId: "manual-guided-terminal-provider-error",
+        toolName: "provider",
+        isError: true,
+        content: [{ type: "text", text: message }],
+      },
+    }) + "\n",
+    "utf-8",
+  );
+}
+
+function observeManualDiscussTerminalError(
+  ctx: ExtensionContext,
+  lastMsg: unknown,
+  guidedUnit: GuidedUnitContext | null,
+): void {
+  if (!guidedUnit?.unitType.startsWith("discuss-")) return;
+  if (!isFatalManualGuidedTerminalFailure(lastMsg)) return;
+
+  const model = modelLabel(ctx);
+  const detail = terminalFailureDetail(lastMsg);
+  ctx.ui.notify(
+    `Manual /gsd discuss ${guidedUnit.unitType} ended with a provider error on ${model}: ${detail}`,
+    "warning",
+  );
+
+  try {
+    writeManualGuidedTerminalErrorActivity(
+      guidedUnit.basePath,
+      guidedUnit.unitType,
+      model,
+      detail,
+      isObjectRecord(lastMsg) ? lastMsg.stopReason : "unknown",
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logWarning("bootstrap", `Failed to write manual guided terminal-error activity marker: ${message}`);
+  }
+}
+
 async function pauseTransientWithBackoff(
   cls: ErrorClass,
   pi: ExtensionAPI,
@@ -437,7 +537,9 @@ export async function handleAgentEnd(
   // rejected" loop even though the files are on disk.
   clearPathCache();
   const basePath = resolveAgentEndBasePath();
-  clearGuidedUnitContext(basePath);
+  const lastMsg = event.messages[event.messages.length - 1];
+  const guidedUnit = basePath ? getGuidedUnitContext(basePath) ?? getGuidedUnitContext() : getGuidedUnitContext();
+  clearGuidedUnitContext(guidedUnit?.basePath ?? basePath);
 
   try {
     if (await checkDeepProjectSetupAfterTurn(event, ctx, basePath)) {
@@ -466,13 +568,15 @@ export async function handleAgentEnd(
   // discussions (where isAutoActive may be false) still get recovered.
   if (maybeHandleEmptyIntentTurn(event, isAutoActive(), basePath)) return;
 
-  if (!isAutoActive()) return;
+  if (!isAutoActive()) {
+    observeManualDiscussTerminalError(ctx, lastMsg, guidedUnit);
+    return;
+  }
 
   if (shouldIgnoreAgentEndForActiveUnit(event)) {
     return;
   }
 
-  const lastMsg = event.messages[event.messages.length - 1];
   if (isSessionSwitchInFlight()) {
     _handleSessionSwitchAgentEnd(lastMsg, resolveAgentEndCancelled);
     return;

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -398,7 +398,11 @@ function modelLabel(ctx: ExtensionContext): string {
 
 function isFatalManualGuidedTerminalFailure(lastMsg: unknown): boolean {
   if (!isObjectRecord(lastMsg) || !("stopReason" in lastMsg)) return false;
-  if (lastMsg.stopReason === "error") return true;
+  if (lastMsg.stopReason === "error") {
+    const rawErrorMsg = ("errorMessage" in lastMsg && lastMsg.errorMessage) ? String(lastMsg.errorMessage) : "";
+    if (isUserInitiatedAbortMessage(rawErrorMsg)) return false;
+    return true;
+  }
   if (lastMsg.stopReason !== "aborted") return false;
 
   const content = "content" in lastMsg ? lastMsg.content : undefined;

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -729,6 +729,60 @@ test("manual guided discuss provider error records warning and activity marker (
   }
 });
 
+test("manual guided discuss user-cancel is not treated as a provider error (#944)", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-manual-discuss-cancel-"));
+  const guidedBase = join(base, "slice-work");
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    autoSession.reset();
+    mkdirSync(join(base, ".git"), { recursive: true });
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    mkdirSync(guidedBase, { recursive: true });
+    process.chdir(base);
+    initNotificationStore(base);
+
+    setGuidedUnitContext(guidedBase, "discuss-slice");
+
+    const ctx = {
+      model: { provider: "anthropic", id: "claude-opus-4" },
+      modelRegistry: { getAvailable: () => [] },
+      ui: {
+        notify(message: string, level?: "info" | "warning" | "error" | "success") {
+          notifications.push({ message, level });
+        },
+      },
+    } as any;
+    installNotifyInterceptor(ctx);
+
+    const pi = { sendMessage: () => {} } as any;
+
+    await handleAgentEnd(pi, {
+      messages: [{
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Request aborted by user",
+        content: [],
+      }],
+    } as any, ctx);
+
+    assert.deepEqual(notifications, [], "user-cancel stopReason=error must not emit a provider-error warning");
+    assert.equal(getGuidedUnitContext(guidedBase), null, "context must be cleared even for user-cancel");
+
+    // No activity directory should have been created
+    let activityExists = false;
+    try { readdirSync(join(base, ".gsd", "activity")); activityExists = true; } catch { /* expected */ }
+    assert.equal(activityExists, false, "user-cancel must not write an activity error marker");
+  } finally {
+    clearGuidedUnitContext();
+    _resetNotificationStore();
+    autoSession.reset();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 // ── resumeAutoAfterProviderDelay ────────────────────────────────────────────
 
 test("resumeAutoAfterProviderDelay restarts paused auto-mode from the recorded base path", async () => {

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -655,7 +655,6 @@ test("does not suppress deleted-worktree provider errors outside terminal comple
 test("manual guided discuss provider error records warning and activity marker (#944)", async () => {
   const originalCwd = process.cwd();
   const base = mkdtempSync(join(tmpdir(), "gsd-manual-discuss-error-"));
-  const guidedBase = join(base, "slice-work");
   const notifications: Array<{ message: string; level?: string }> = [];
   const sendMessageCalls: unknown[][] = [];
 
@@ -663,11 +662,14 @@ test("manual guided discuss provider error records warning and activity marker (
     autoSession.reset();
     mkdirSync(join(base, ".git"), { recursive: true });
     mkdirSync(join(base, ".gsd"), { recursive: true });
-    mkdirSync(guidedBase, { recursive: true });
     process.chdir(base);
     initNotificationStore(base);
 
-    setGuidedUnitContext(guidedBase, "discuss-slice");
+    // Use base as the guided context path so gsdRoot(base) hits the fast path
+    // (.gsd exists at base directly) and doesn't need git to walk up from a
+    // subdirectory — the empty .git folder is not a real repo and git resolution
+    // from a child directory would return the wrong .gsd path.
+    setGuidedUnitContext(base, "discuss-slice");
 
     const ctx = {
       model: { provider: "openai-codex", id: "gpt-5.1-codex" },
@@ -696,7 +698,7 @@ test("manual guided discuss provider error records warning and activity marker (
     } as any, ctx);
 
     assert.deepEqual(sendMessageCalls, [], "manual discuss terminal errors must not auto-retry or redispatch");
-    assert.equal(getGuidedUnitContext(guidedBase), null, "guided unit context must still be cleared after the turn");
+    assert.equal(getGuidedUnitContext(base), null, "guided unit context must still be cleared after the turn");
     assert.equal(notifications.length, 1);
     assert.equal(notifications[0]?.level, "warning");
     assert.match(notifications[0]?.message ?? "", /Manual \/gsd discuss discuss-slice ended with a provider error/);

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -7,7 +7,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { classifyError, isTransient, isTransientNetworkError } from "../error-classifier.ts";
@@ -26,6 +26,10 @@ import { _buildCancelledUnitStopReason } from "../auto/phase-helpers.ts";
 import { _classifyZeroToolProviderMessageForTest } from "../auto/unit-phase.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { getNextFallbackModel } from "../preferences.ts";
+import { clearGuidedUnitContext, getGuidedUnitContext, setGuidedUnitContext } from "../guided-unit-context.ts";
+import { initNotificationStore, readNotifications, _resetNotificationStore } from "../notification-store.ts";
+import { installNotifyInterceptor } from "../bootstrap/notify-interceptor.ts";
+import { extractTrace } from "../session-forensics.ts";
 // Zero-import module — imported by path rather than through the package
 // barrel to avoid pulling the full AgentSession / @gsd/pi-ai dep graph into
 // this unit test (see #4837).
@@ -646,6 +650,83 @@ test("does not suppress deleted-worktree provider errors outside terminal comple
 
   assert.equal(suppressTerminalDeletedWorktreeMessageEnd(event), false);
   assert.equal(event.message.stopReason, "error");
+});
+
+test("manual guided discuss provider error records warning and activity marker (#944)", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-manual-discuss-error-"));
+  const guidedBase = join(base, "slice-work");
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const sendMessageCalls: unknown[][] = [];
+
+  try {
+    autoSession.reset();
+    mkdirSync(join(base, ".git"), { recursive: true });
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    mkdirSync(guidedBase, { recursive: true });
+    process.chdir(base);
+    initNotificationStore(base);
+
+    setGuidedUnitContext(guidedBase, "discuss-slice");
+
+    const ctx = {
+      model: { provider: "openai-codex", id: "gpt-5.1-codex" },
+      modelRegistry: { getAvailable: () => [] },
+      ui: {
+        notify(message: string, level?: "info" | "warning" | "error" | "success") {
+          notifications.push({ message, level });
+        },
+      },
+    } as any;
+    installNotifyInterceptor(ctx);
+
+    const pi = {
+      sendMessage: (...args: unknown[]) => {
+        sendMessageCalls.push(args);
+      },
+    } as any;
+
+    await handleAgentEnd(pi, {
+      messages: [{
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "",
+        content: [{ type: "text", text: "stream idle timeout while saving summary" }],
+      }],
+    } as any, ctx);
+
+    assert.deepEqual(sendMessageCalls, [], "manual discuss terminal errors must not auto-retry or redispatch");
+    assert.equal(getGuidedUnitContext(guidedBase), null, "guided unit context must still be cleared after the turn");
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0]?.level, "warning");
+    assert.match(notifications[0]?.message ?? "", /Manual \/gsd discuss discuss-slice ended with a provider error/);
+    assert.match(notifications[0]?.message ?? "", /openai-codex\/gpt-5\.1-codex/);
+    assert.match(notifications[0]?.message ?? "", /stream idle timeout/);
+
+    const persisted = readNotifications(base);
+    assert.equal(persisted.length, 1, "wrapped notify should persist exactly one warning notification");
+    assert.equal(persisted[0]?.severity, "warning");
+    assert.equal(persisted[0]?.source, "notify");
+
+    const activityDir = join(base, ".gsd", "activity");
+    const files = readdirSync(activityDir).filter((file) => file.endsWith(".jsonl"));
+    assert.equal(files.length, 1, "manual guided provider error should write one activity marker");
+    const entries = readFileSync(join(activityDir, files[0]!), "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 1);
+    assert.match(trace.errors[0] ?? "", /discuss-slice/);
+    assert.match(trace.errors[0] ?? "", /openai-codex\/gpt-5\.1-codex/);
+    assert.match(trace.errors[0] ?? "", /stream idle timeout/);
+  } finally {
+    clearGuidedUnitContext();
+    _resetNotificationStore();
+    autoSession.reset();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 // ── resumeAutoAfterProviderDelay ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixed manual guided discuss terminal provider errors to emit one warning and a forensics-visible activity marker, with parser and diff checks passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #944
- [#944 [Bug]: manual /gsd discuss terminal provider stream error returns before stopReason handling, so the failed turn is never surfaced](https://github.com/open-gsd/gsd-pi/issues/944)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/944-bug-manual-gsd-discuss-terminal-provider-1782564204`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the non-auto early-return path for manual discuss flows; auto-mode provider recovery is unchanged aside from reordering guided-context capture/clear.
> 
> **Overview**
> Fixes **#944**: manual `/gsd discuss` turns that ended with a provider stream error (`stopReason` **error** or a fatal **aborted**) were dropped because `handleAgentEnd` returned early when auto-mode was inactive, before any stop-reason handling ran.
> 
> **`handleAgentEnd`** now captures guided-unit context and the last message before clearing context, then on the non-auto path calls **`observeManualDiscussTerminalError`**. For `discuss-*` units with a fatal terminal failure, that emits one **warning** (model + detail from `errorMessage` or assistant text) and writes a sequenced **`.gsd/activity/*-manual-terminal-provider-error.jsonl`** marker for session forensics—without auto-retry or redispatch.
> 
> Adds an integration test asserting no `sendMessage`, context still clears, persisted notifications, and traceable activity output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6034149f2dbb579a1d8124f959bccbf4a7469a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->