### PR TITLE
fix(issue): [Bug]: A cancelled secure_env_collect parks until the 10-minute elicitation timeout because the handler never passes the abort signal

### DIFF
--- a/packages/mcp-server/src/secure-env-collect.test.ts
+++ b/packages/mcp-server/src/secure-env-collect.test.ts
@@ -232,6 +232,48 @@ describe("secure_env_collect — handler behaviour", () => {
     }
   });
 
+  it("returns promptly when the client aborts while elicitation is pending", async () => {
+    const controller = new AbortController();
+    let resolveElicitStarted!: () => void;
+    const elicitStarted = new Promise<void>((resolve) => {
+      resolveElicitStarted = resolve;
+    });
+    const never = new Promise<ElicitResponse>(() => {});
+
+    const resultPromise = secureEnvCollectHandler(
+      {
+        projectDir: tmp,
+        keys: [{ key: "ABORTED_KEY" }],
+        destination: "dotenv",
+      },
+      () => {
+        resolveElicitStarted();
+        return never;
+      },
+      controller.signal,
+    );
+
+    await elicitStarted;
+    controller.abort();
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await Promise.race([
+        resultPromise,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("secure_env_collect did not observe client abort")),
+            250,
+          );
+        }),
+      ]);
+
+      assert.match(textOf(result), /secure_env_collect cancelled by client/);
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+
   it("auto-detects destination from project files when not specified", async () => {
     // No vercel/convex signals — falls back to dotenv.
     const { fn } = fakeElicit({

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -906,6 +906,7 @@ type ToolContent =
 export async function secureEnvCollectHandler(
   args: Record<string, unknown>,
   elicitInput: ElicitInputFn,
+  signal?: AbortSignal,
 ): Promise<ToolContent> {
   const { projectDir, keys, destination, envFilePath, environment } = args as {
     projectDir: string;
@@ -963,6 +964,8 @@ export async function secureEnvCollectHandler(
         },
       }),
       'secure_env_collect',
+      undefined,
+      signal,
     );
 
     if (elicitation.action !== 'accept' || !elicitation.content) {
@@ -1276,9 +1279,11 @@ export async function createMcpServer(
       envFilePath: z.string().optional().describe('Path to .env file (dotenv only). Defaults to .env in projectDir.'),
       environment: z.enum(['development', 'preview', 'production']).optional().describe('Target environment (vercel/convex only)'),
     },
-    async (args: Record<string, unknown>) =>
-      secureEnvCollectHandler(args, (params) =>
-        server.server.elicitInput(params as ElicitRequestFormParams),
+    async (args: Record<string, unknown>, extra?: McpToolExtra) =>
+      secureEnvCollectHandler(
+        args,
+        (params) => server.server.elicitInput(params as ElicitRequestFormParams),
+        extra?.signal,
       ),
   );
 


### PR DESCRIPTION
## Summary
- Wired secure_env_collect abort signals through the handler and added a pending-elicitation cancellation regression test; dependency-free checks passed while compiled tests were blocked by offline dependency install.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #963
- [#963 [Bug]: A cancelled secure_env_collect parks until the 10-minute elicitation timeout because the handler never passes the abort signal](https://github.com/open-gsd/gsd-pi/issues/963)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/963-bug-a-cancelled-secure-env-collect-parks-1782565039`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow wiring change to interactive env collection cancellation; existing elicitation and write paths are unchanged aside from honoring abort.
> 
> **Overview**
> **Fixes client cancellation of `secure_env_collect` hanging until the 10-minute elicitation timeout** by threading the MCP `tools/call` **AbortSignal** into the handler and through `withElicitTimeout` while the env-var form is pending.
> 
> The tool registration now passes `extra?.signal` from `McpToolExtra` into `secureEnvCollectHandler`, matching patterns used elsewhere (e.g. `gsd_execute`). A regression test asserts the handler finishes within ~250ms after abort and returns a **cancelled by client** message instead of waiting on a never-resolving elicitation promise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1265aa7d660285818ea05e09e13c11966a74af85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->