### PR TITLE
fix(issue): [Bug]: replan-slice and reassess-roadmap inherit the planning-lane exec trio their narrow contracts hard-block

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -158,6 +158,12 @@ const laneLabelByMode: Record<string, string> = {
   triage: "triage",
 };
 
+const unitSpecificContextModeGuidanceUnits = new Set([
+  "run-uat",
+  "replan-slice",
+  "reassess-roadmap",
+]);
+
 test("Context Mode composer: every known eligible unit renders its configured lane and required tools", () => {
   for (const unitType of KNOWN_UNIT_TYPES) {
     const manifest = UNIT_MANIFESTS[unitType];
@@ -170,6 +176,13 @@ test("Context Mode composer: every known eligible unit renders its configured la
     assert.ok(out.startsWith("## Context Mode"), `${unitType} should render standalone Context Mode heading`);
     assert.match(out, new RegExp(`Lane: \\*\\*${laneLabelByMode[manifest.contextMode]} lane\\*\\*\\.`, "i"));
     const forbidden = getUnitToolSurfaceContract(unitType)?.forbiddenGsdTools ?? {};
+    if (unitSpecificContextModeGuidanceUnits.has(unitType)) {
+      // Unit-specific guidance replaces the lane default, so it must not
+      // advertise the exec tools that narrow contracts do not allow.
+      assert.doesNotMatch(out, /`gsd_exec`/, `${unitType} guidance must not steer to gsd_exec`);
+      assert.doesNotMatch(out, /`gsd_exec_search`/, `${unitType} guidance must not steer to gsd_exec_search`);
+      continue;
+    }
     if ("gsd_exec" in forbidden) {
       // Units that forbid gsd_exec (run-uat) have it stripped from their
       // Claude Code dispatch surface; guidance steering to it produces
@@ -193,6 +206,33 @@ test("Context Mode composer: run-uat guidance steers to gsd_uat_exec in both ren
   const standalone = composeContextModeInstructions("run-uat", { enabled: true, renderMode: "standalone" });
   assert.match(standalone, /`gsd_uat_exec`/);
   assert.doesNotMatch(standalone, /`gsd_exec`/);
+});
+
+test("Context Mode composer: narrow planning guidance steers only to contracted tools", () => {
+  const cases = [
+    {
+      unitType: "replan-slice",
+      expectedTools: ["gsd_replan_slice", "gsd_decision_save"],
+    },
+    {
+      unitType: "reassess-roadmap",
+      expectedTools: ["gsd_milestone_status", "gsd_reassess_roadmap"],
+    },
+  ];
+  const disallowedTools = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
+
+  for (const { unitType, expectedTools } of cases) {
+    for (const renderMode of ["nested", "standalone"] as const) {
+      const out = composeContextModeInstructions(unitType, { enabled: true, renderMode });
+      assert.match(out, /planning lane/i, `${unitType} should still render planning lane guidance`);
+      for (const toolName of expectedTools) {
+        assert.ok(out.includes(`\`${toolName}\``), `${unitType} guidance should mention ${toolName}`);
+      }
+      for (const toolName of disallowedTools) {
+        assert.ok(!out.includes(`\`${toolName}\``), `${unitType} guidance must not mention ${toolName}`);
+      }
+    }
+  }
 });
 
 test("Context Mode composer: slice planning and research guidance tools pass unit contracts", () => {

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -135,12 +135,13 @@ const CONTEXT_MODE_GUIDANCE_BY_LANE: Record<Exclude<ContextModePolicy, "none">, 
     "Use `gsd_resume` for prior context, `gsd_exec_search` for saved evidence, and `gsd_exec` for noisy doc validation commands.",
 };
 
-// Per-unit overrides win over the lane default. run-uat's tool contract
-// forbids `gsd_exec`/`gsd_exec_search` (acceptance evidence must flow through
-// `gsd_uat_exec`) and Claude Code dispatch strips the tools entirely, so the
-// shared verification-lane guidance would steer the agent into calling an
-// unavailable tool.
+// Per-unit overrides win over the lane default for units whose tool contracts
+// are narrower than the shared lane guidance.
 const CONTEXT_MODE_GUIDANCE_BY_UNIT: Record<string, string> = {
+  "replan-slice":
+    "Use `gsd_replan_slice` to persist the revised slice plan, and `gsd_decision_save` for planning decisions that need durable rationale.",
+  "reassess-roadmap":
+    "Use `gsd_milestone_status` to inspect current milestone state, then `gsd_reassess_roadmap` to persist the roadmap reassessment.",
   "run-uat":
     "Use `gsd_uat_exec` for acceptance checks so evidence is typed as UAT-owned, and `gsd_resume` after compaction or resume.",
 };


### PR DESCRIPTION
## Summary
- Fixed Context Mode guidance for replan-slice and reassess-roadmap and verified the changed prompt strings with a focused static assertion.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #958
- [#958 [Bug]: replan-slice and reassess-roadmap inherit the planning-lane exec trio their narrow contracts hard-block](https://github.com/open-gsd/gsd-pi/issues/958)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/958-bug-replan-slice-and-reassess-roadmap-in-1782565552`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-string and test-only changes in the GSD unit context composer; no runtime dispatch or auth paths.
> 
> **Overview**
> **Context Mode** for **`replan-slice`** and **`reassess-roadmap`** no longer repeats the shared planning-lane **`gsd_exec` / `gsd_exec_search` / `gsd_resume`** trio. Those units get per-unit guidance that matches their allowed tools: **`gsd_replan_slice`** and **`gsd_decision_save`** for replan-slice; **`gsd_milestone_status`** and **`gsd_reassess_roadmap`** for reassess-roadmap.
> 
> Tests treat **`run-uat`**, **`replan-slice`**, and **`reassess-roadmap`** as units whose lane default is fully replaced, and add coverage that nested and standalone prompts mention only the contracted tools and omit the exec trio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94386f7ec5f0722516df8259636031720403cb35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->