### PR TITLE
fix(issue): [Bug]: empty errorMessage with a stream-failure signature in content classifies as `unknown` and pauses auto-mode instead of retrying

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -555,9 +555,9 @@ export async function handleAgentEnd(
       });
       return;
     }
-    // #3588: When errorMessage is uninformative, extract the real error from
-    // the assistant message text content for display purposes only.
-    // Classification still uses rawErrorMsg to avoid false positives from prose.
+    // #3588/#956: When errorMessage is uninformative, extract the real error
+    // from assistant text. Prefer rawErrorMsg for classification to avoid
+    // prose false-positives, but use display text when rawErrorMsg is empty.
     const displayMsg = resolveAgentEndErrorDisplay(
       rawErrorMsg,
       "content" in lastMsg ? lastMsg.content : undefined,
@@ -576,8 +576,8 @@ export async function handleAgentEnd(
     const errorDetail = displayMsg ? `: ${displayMsg}` : "";
     const explicitRetryAfterMs = ("retryAfterMs" in lastMsg && typeof lastMsg.retryAfterMs === "number") ? lastMsg.retryAfterMs : undefined;
 
-    // ── 1. Classify using rawErrorMsg to avoid prose false-positives ────
-    const cls = classifyError(rawErrorMsg, explicitRetryAfterMs);
+    // ── 1. Classify, preserving non-empty errorMessage precedence ──────
+    const cls = classifyError(rawErrorMsg || displayMsg, explicitRetryAfterMs);
 
     // ── 1a. Unsupported-model: provider rejected this model for the current
     //        account/plan at request time (#4513).  Persist a block so the

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -118,6 +118,10 @@ export function shouldDeferTransientErrorToCoreRetry(
   rawErrorMsg: string,
 ): boolean {
   if (!isTransient(cls) || cls.kind === "rate-limit") return false;
+  // Empty rawErrorMsg means the SDK terminated the session without providing an
+  // error string — core is done, not mid-retry.  GSD must schedule its own
+  // retry rather than silently deferring to a core that has already exited.
+  if (!rawErrorMsg) return false;
   return !/retry failed after \d+ attempts:/i.test(rawErrorMsg);
 }
 

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -116,13 +116,14 @@ export function isUserInitiatedAbortMessage(message: string | undefined | null):
 export function shouldDeferTransientErrorToCoreRetry(
   cls: ErrorClass,
   rawErrorMsg: string,
+  deferCheckMsg: string = rawErrorMsg,
 ): boolean {
   if (!isTransient(cls) || cls.kind === "rate-limit") return false;
   // Empty rawErrorMsg means the SDK terminated the session without providing an
   // error string — core is done, not mid-retry.  GSD must schedule its own
   // retry rather than silently deferring to a core that has already exited.
   if (!rawErrorMsg) return false;
-  return !/retry failed after \d+ attempts:/i.test(rawErrorMsg);
+  return !/retry failed after \d+ attempts:/i.test(deferCheckMsg);
 }
 
 type ProviderModelFallbackParams = {
@@ -659,7 +660,7 @@ export async function handleAgentEnd(
     // Core retries transient failures in-session after this handler.
     // Keep that behavior for non-rate-limit classes to avoid pause/retry races,
     // but let rate-limit continue into model fallback logic below (#4373).
-    if (shouldDeferTransientErrorToCoreRetry(cls, rawErrorMsg)) {
+    if (shouldDeferTransientErrorToCoreRetry(cls, rawErrorMsg, rawErrorMsg || displayMsg)) {
       return;
     }
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -495,7 +495,13 @@ test("agent_end retries when empty errorMessage has stream failure in content (#
   const timers: Array<{ fn: () => void; delay: number }> = [];
 
   resetTransientRetryState();
+  autoSession.reset();
+  // handleAgentEnd returns at the isAutoActive() guard unless auto-mode is
+  // active. Set the minimum fields needed to reach the stopReason === "error"
+  // branch without requiring a real DB or worktree.
   autoSession.active = true;
+  autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+
   globalThis.setTimeout = ((fn: () => void, delay?: number) => {
     timers.push({ fn, delay: delay ?? 0 });
     return 0 as unknown as ReturnType<typeof setTimeout>;

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -488,6 +488,56 @@ test("pauseAutoForProviderError falls back to indefinite pause when not rate lim
   ]);
 });
 
+test("agent_end retries when empty errorMessage has stream failure in content (#956)", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const sendMessageCalls: unknown[][] = [];
+  const timers: Array<{ fn: () => void; delay: number }> = [];
+
+  resetTransientRetryState();
+  globalThis.setTimeout = ((fn: () => void, delay?: number) => {
+    timers.push({ fn, delay: delay ?? 0 });
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    await handleAgentEnd({
+      sendMessage: (...args: unknown[]) => {
+        sendMessageCalls.push(args);
+      },
+    } as any, {
+      messages: [{
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "",
+        content: [{ type: "text", text: "API Error: stream idle timeout - partial response received" }],
+      }],
+    } as any, {
+      model: { provider: "openai-codex", id: "gpt-5.5" },
+      ui: {
+        notify(message: string, level?: "info" | "warning" | "error" | "success") {
+          notifications.push({ message, level });
+        },
+      },
+    } as any);
+
+    assert.equal(timers.length, 1, "empty errorMessage stream failures should use the network retry path");
+    assert.equal(timers[0].delay, 3_000);
+    assert.deepEqual(notifications[0], {
+      message: "Network error on gpt-5.5: API Error: stream idle timeout - partial response received. Retry 1/2 in 3s...",
+      level: "warning",
+    });
+
+    timers[0].fn();
+    assert.equal(sendMessageCalls.length, 1);
+    assert.deepEqual(sendMessageCalls[0][1], { triggerTurn: true });
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    resetTransientRetryState();
+    autoSession.reset();
+  }
+});
+
 test("rate-limit agent_end walks past unavailable fallback models before pausing (#716 follow-up)", async () => {
   const originalCwd = process.cwd();
   const originalSetTimeout = globalThis.setTimeout;

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -495,6 +495,7 @@ test("agent_end retries when empty errorMessage has stream failure in content (#
   const timers: Array<{ fn: () => void; delay: number }> = [];
 
   resetTransientRetryState();
+  autoSession.active = true;
   globalThis.setTimeout = ((fn: () => void, delay?: number) => {
     timers.push({ fn, delay: delay ?? 0 });
     return 0 as unknown as ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary
- Fixed empty-errorMessage stream failure classification and added a regression test; syntax and diff checks passed while full focused test execution was blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #956
- [#956 [Bug]: empty errorMessage with a stream-failure signature in content classifies as `unknown` and pauses auto-mode instead of retrying](https://github.com/open-gsd/gsd-pi/issues/956)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/956-bug-empty-errormessage-with-a-stream-fai-1782565534`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to agent_end error classification and defer-to-core logic in GSD auto-mode recovery, with a focused regression test.
> 
> **Overview**
> Fixes **auto-mode pausing on transient stream failures** when the SDK leaves `errorMessage` empty but puts the real error (e.g. stream idle timeout) in assistant text (#956).
> 
> **`handleAgentEnd`** now classifies with `rawErrorMsg || displayMsg` so empty `errorMessage` still picks up content from `resolveAgentEndErrorDisplay`. **`shouldDeferTransientErrorToCoreRetry`** gains a `deferCheckMsg` argument and returns **false** when `rawErrorMsg` is empty so GSD does not defer to core retry after the session has already ended without an error string.
> 
> Adds a regression test asserting the **network retry** path (3s backoff, `triggerTurn` continuation) for empty `errorMessage` + stream timeout in content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04047379367cb5073c98fd776b09d8ee3a0f7005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->