### PR TITLE
fix(issue): [Bug]: gsd_slice_complete re-renders every completed-task summary in the milestone within a single slice completion, freezing the tool result

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -203,6 +203,10 @@ console.log('\n=== complete-slice: handler happy path ===');
   insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Second Slice', risk: 'low', depends: ['S01'], demo: 'advanced stuff', sequence: 2 });
   insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
   insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 2' });
+  insertTask({ id: 'T99', sliceId: 'S02', milestoneId: 'M001', status: 'complete', title: 'Sibling Task' });
+  const siblingSummaryPath = path.join(path.dirname(roadmapPath), 'T99-SUMMARY.md');
+  const siblingSummaryBefore = '# Existing sibling task summary\n\nDo not rewrite this file.\n';
+  fs.writeFileSync(siblingSummaryPath, siblingSummaryBefore);
 
   const params = makeValidSliceParams();
   const result = await handleCompleteSlice(params, basePath);
@@ -267,6 +271,13 @@ console.log('\n=== complete-slice: handler happy path ===');
     // (e) Verify slice status is complete in DB
     assertEq(sliceAfter!.status, 'complete', 'slice status should be complete in DB');
     assertTrue(sliceAfter!.completed_at !== null, 'completed_at should be set in DB');
+
+    // (f) Verify unrelated completed task summaries are not re-rendered during slice completion
+    assertEq(
+      fs.readFileSync(siblingSummaryPath, 'utf-8'),
+      siblingSummaryBefore,
+      'complete-slice should not re-render sibling completed task summaries',
+    );
   }
 
   cleanupDir(basePath);

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -540,6 +540,11 @@ export async function handleCompleteSlice(
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
   try {
+    await renderRoadmapFromDb(artifactBasePath, params.milestoneId);
+  } catch (projErr) {
+    logWarning("tool", `complete-slice milestone roadmap projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
+  }
+  try {
     renderTopLevelRoadmapFromDb(artifactBasePath);
   } catch (projErr) {
     logWarning("tool", `complete-slice roadmap projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -541,10 +541,18 @@ export async function handleCompleteSlice(
   // the event log entry (critical for worktree reconciliation).
   try {
     renderTopLevelRoadmapFromDb(artifactBasePath);
+  } catch (projErr) {
+    logWarning("tool", `complete-slice roadmap projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
+  }
+  try {
     renderTopLevelQueueFromDb(artifactBasePath);
+  } catch (projErr) {
+    logWarning("tool", `complete-slice queue projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
+  }
+  try {
     await renderStateProjection(artifactBasePath);
   } catch (projErr) {
-    logWarning("tool", `complete-slice projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
+    logWarning("tool", `complete-slice state projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
   }
   try {
     writeManifest(artifactBasePath);

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -539,6 +539,18 @@ export async function handleCompleteSlice(
   // ── Post-mutation hook: projections, manifest, event log ───────────────
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
+  //
+  // If the primary summary/UAT/roadmap write block failed (projectionStale),
+  // retry the milestone-level roadmap here so ROADMAP.md is not left stale
+  // after a committed slice completion. This restores the recovery that the
+  // removed flushWorkflowProjections/renderAllProjections provided.
+  if (projectionStale) {
+    try {
+      await renderRoadmapFromDb(artifactBasePath, params.milestoneId);
+    } catch (projErr) {
+      logWarning("tool", `complete-slice milestone roadmap retry warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
+    }
+  }
   try {
     await renderRoadmapFromDb(artifactBasePath, params.milestoneId);
   } catch (projErr) {

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -30,7 +30,7 @@ import { classifyUatContent, escalatesArtifactUatToBrowser } from "../uat-policy
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapFromDb, roadmapRenderMarksSliceDone } from "../markdown-renderer.js";
 import { isStaleWrite } from "../auto/turn-epoch.js";
-import { flushWorkflowProjections } from "../projection-flush.js";
+import { renderStateProjection, renderTopLevelQueueFromDb, renderTopLevelRoadmapFromDb } from "../workflow-projections.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
@@ -540,7 +540,9 @@ export async function handleCompleteSlice(
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
   try {
-    await flushWorkflowProjections(artifactBasePath, { milestoneId: params.milestoneId });
+    renderTopLevelRoadmapFromDb(artifactBasePath);
+    renderTopLevelQueueFromDb(artifactBasePath);
+    await renderStateProjection(artifactBasePath);
   } catch (projErr) {
     logWarning("tool", `complete-slice projection warning for ${params.milestoneId}/${params.sliceId}: ${(projErr as Error).message}`);
   }


### PR DESCRIPTION
## Summary
- Scoped complete-slice projection refresh to roadmap, queue, and state only, with a regression check for untouched sibling task summaries.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #947
- [#947 [Bug]: gsd_slice_complete re-renders every completed-task summary in the milestone within a single slice completion, freezing the tool result](https://github.com/open-gsd/gsd-pi/issues/947)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/947-bug-gsd-slice-complete-re-renders-every--1782565535`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which artifacts are refreshed after slice completion; roadmap/queue/state stay updated but milestone-wide task summary re-projection is skipped, which could matter if something relied on that side effect.
> 
> **Overview**
> **Fixes slice completion hanging** when a milestone has many completed tasks by stopping the post-mutation hook from re-rendering every completed-task `SUMMARY.md` in that milestone.
> 
> `handleCompleteSlice` no longer calls `flushWorkflowProjections` / `renderAllProjections`. It now refreshes only **milestone roadmap**, **top-level roadmap**, **queue**, and **STATE** projections, each in its own try/catch with clearer warning messages.
> 
> A regression test seeds a completed sibling task’s `T99-SUMMARY.md` and asserts its bytes are unchanged after completing another slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5970882b2128a13f57fc12d98e1f13f0e9c499d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->