### PR TITLE
fix(issue): [Bug]: gsd_complete_task re-renders every completed-task summary in the milestone within a single task completion, freezing the tool result

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -381,6 +381,39 @@ console.log('\n=== complete-task: handler happy path ===');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// complete-task: Handler does not re-render completed sibling summaries
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: handler leaves completed sibling summaries untouched ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath, planPath } = createTempProject();
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'high', depends: [], demo: 'basic functionality works', sequence: 1 });
+  insertTask({ id: 'T00', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Already complete task', oneLiner: 'Previously completed' });
+  insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', status: 'pending', title: 'Second task' });
+
+  const siblingSummaryPath = path.join(path.dirname(planPath), 'T00-SUMMARY.md');
+  const siblingSummaryContent = 'existing sibling summary marker\n';
+  fs.writeFileSync(siblingSummaryPath, siblingSummaryContent);
+
+  const result = await handleCompleteTask(makeValidParams(), basePath);
+
+  assertTrue(!('error' in result), 'handler should succeed without error');
+  assertEq(
+    fs.readFileSync(siblingSummaryPath, 'utf-8'),
+    siblingSummaryContent,
+    'complete-task should not re-render summaries for already-completed sibling tasks',
+  );
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // complete-task: hard-blocker escalation with mid-execution escalation disabled
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -35,9 +35,13 @@ import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, taskUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
-import { renderPlanCheckboxes } from "../markdown-renderer.js";
-import { renderSummaryContent } from "../workflow-projections.js";
-import { flushWorkflowProjections } from "../projection-flush.js";
+import { renderPlanCheckboxes, renderRoadmapFromDb } from "../markdown-renderer.js";
+import {
+  renderStateProjection,
+  renderSummaryContent,
+  renderTopLevelQueueFromDb,
+  renderTopLevelRoadmapFromDb,
+} from "../workflow-projections.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
@@ -101,6 +105,29 @@ function taskSummaryPath(
   );
 }
 
+async function renderCompleteTaskProjections(basePath: string, milestoneId: string): Promise<void> {
+  try {
+    await renderRoadmapFromDb(basePath, milestoneId);
+  } catch (err) {
+    logWarning("projection", `renderRoadmapFromDb failed for ${milestoneId}: ${(err as Error).message}`);
+  }
+  try {
+    renderTopLevelRoadmapFromDb(basePath);
+  } catch (err) {
+    logWarning("projection", `renderTopLevelRoadmapFromDb failed: ${(err as Error).message}`);
+  }
+  try {
+    renderTopLevelQueueFromDb(basePath);
+  } catch (err) {
+    logWarning("projection", `renderTopLevelQueueFromDb failed: ${(err as Error).message}`);
+  }
+  try {
+    await renderStateProjection(basePath);
+  } catch (err) {
+    logWarning("projection", `renderStateProjection failed: ${(err as Error).message}`);
+  }
+}
+
 async function repairMissingTaskSummaryProjection(
   artifactBasePath: string,
   taskRow: TaskRow,
@@ -131,7 +158,7 @@ async function repairMissingTaskSummaryProjection(
   clearParseCache();
 
   try {
-    await flushWorkflowProjections(artifactBasePath, { milestoneId: taskRow.milestone_id });
+    await renderCompleteTaskProjections(artifactBasePath, taskRow.milestone_id);
   } catch (projErr) {
     logWarning("tool", `complete-task repair projection warning: ${(projErr as Error).message}`);
   }
@@ -569,7 +596,7 @@ export async function handleCompleteTask(
   // Separate try/catch per step so a projection failure doesn't prevent
   // the event log entry (critical for worktree reconciliation).
   try {
-    await flushWorkflowProjections(artifactBasePath, { milestoneId: params.milestoneId });
+    await renderCompleteTaskProjections(artifactBasePath, params.milestoneId);
   } catch (projErr) {
     logWarning("tool", `complete-task projection warning: ${(projErr as Error).message}`);
   }


### PR DESCRIPTION
## Summary
- Scoped complete-task projection rendering to avoid sibling summary rewrites and added a regression test; syntax checks passed, focused test was blocked by missing dependencies and network DNS failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #946
- [#946 [Bug]: gsd_complete_task re-renders every completed-task summary in the milestone within a single task completion, freezing the tool result](https://github.com/open-gsd/gsd-pi/issues/946)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/946-bug-gsd-complete-task-re-renders-every-c-1782565540`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which workflow artifacts are refreshed on every task completion; behavior is narrower than before but still on a hot path for agents.
> 
> **Overview**
> **`gsd_complete_task` no longer runs the full milestone projection flush** after completing a task, which was re-writing every completed task’s `*-SUMMARY.md` in the milestone and could freeze or stall the tool response.
> 
> Post-completion and missing-summary repair paths now call **`renderCompleteTaskProjections`**, which refreshes only milestone roadmap, top-level roadmap/queue, and state projections—while the current task’s summary and plan checkboxes are still written directly as before.
> 
> A regression test asserts that completing one task **does not change** an on-disk summary file for an already-complete sibling task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9527b09e7d095403496de0d652bb258a35237ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->