### PR TITLE
fix(issue): [Bug]: research-milestone contract omits the research-lane exec trio its prompt advertises

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -236,7 +236,7 @@ test("Context Mode composer: narrow planning guidance steers only to contracted 
 });
 
 test("Context Mode composer: slice planning and research guidance tools pass unit contracts", () => {
-  const affectedUnits = ["research-slice", "plan-slice", "refine-slice"];
+  const affectedUnits = ["research-milestone", "research-slice", "plan-slice", "refine-slice"];
   const contextModeTools: UnitGsdToolName[] = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
   const readOnlyOrientationTools: UnitGsdToolName[] = ["gsd_milestone_status", ...contextModeTools];
 
@@ -247,7 +247,10 @@ test("Context Mode composer: slice planning and research guidance tools pass uni
     for (const toolName of contextModeTools) {
       assert.ok(out.includes(`\`${toolName}\``), `${unitType} guidance should mention ${toolName}`);
     }
-    for (const toolName of readOnlyOrientationTools) {
+    const expectedContractTools = unitType === "research-milestone"
+      ? contextModeTools
+      : readOnlyOrientationTools;
+    for (const toolName of expectedContractTools) {
       assert.ok(allowed.has(toolName), `${unitType} contract should allow ${toolName}`);
       const scope = shouldBlockAutoUnitToolCall(unitType, toolName);
       assert.equal(scope.block, false, `${unitType} should not hard-block ${toolName}: ${scope.reason ?? ""}`);

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -98,7 +98,13 @@ export const UNIT_REGISTRY = {
     scopeClass: "standard",
     phaseChain: ["research"],
     toolContract: {
-      allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+      allowedGsdTools: [
+        "gsd_summary_save",
+        "gsd_decision_save",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
+      ],
       requiredWorkflowTools: ["gsd_summary_save"],
     },
   },


### PR DESCRIPTION
## Summary
- Added the research-milestone exec trio to the tool contract, covered it in the Context Mode contract test, and verified with diff checks plus a direct contract probe.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #959
- [#959 [Bug]: research-milestone contract omits the research-lane exec trio its prompt advertises](https://github.com/open-gsd/gsd-pi/issues/959)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/959-bug-research-milestone-contract-omits-th-1782565555`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only allowlist change plus test updates; no auth, data, or execution-path refactors.
> 
> **Overview**
> **Aligns the `research-milestone` unit tool contract with Context Mode prompts** that already steer agents to the research-lane exec trio (`gsd_exec`, `gsd_exec_search`, `gsd_resume`). Those tools are now on `allowedGsdTools` in `UNIT_REGISTRY`, alongside the existing summary/decision saves.
> 
> The Context Mode contract test now covers **`research-milestone`** with the other planning/research units. For that unit only, assertions check the exec trio (not `gsd_milestone_status`), matching its narrower contract while still verifying guidance mentions the tools and auto-dispatch does not hard-block them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e41a2f11961e335a36a5a4006a626386a46734f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->