### PR TITLE
fix(issue): [Bug]: complete-slice verification prompt advertises gsd_exec_search/gsd_resume that its own tool contract hard-blocks

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -236,7 +236,7 @@ test("Context Mode composer: narrow planning guidance steers only to contracted 
 });
 
 test("Context Mode composer: slice planning and research guidance tools pass unit contracts", () => {
-  const affectedUnits = ["research-milestone", "research-slice", "plan-slice", "refine-slice"];
+  const affectedUnits = ["research-milestone", "research-slice", "plan-slice", "refine-slice", "complete-slice"];
   const contextModeTools: UnitGsdToolName[] = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
   const readOnlyOrientationTools: UnitGsdToolName[] = ["gsd_milestone_status", ...contextModeTools];
 

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -250,6 +250,8 @@ export const UNIT_REGISTRY = {
       allowedGsdTools: [
         "gsd_milestone_status",
         "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
         "gsd_slice_complete",
         "gsd_task_reopen",
         "gsd_replan_slice",


### PR DESCRIPTION
## Summary
- Added complete-slice allow-list entries for gsd_exec_search and gsd_resume, extended regression coverage, and verified with static sanity plus diff checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #948
- [#948 [Bug]: complete-slice verification prompt advertises gsd_exec_search/gsd_resume that its own tool contract hard-blocks](https://github.com/open-gsd/gsd-pi/issues/948)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/948-bug-complete-slice-verification-prompt-a-1782565534`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry allow-list and test-only changes for one unit type; no auth, data, or broad execution-path refactors.
> 
> **Overview**
> **Aligns `complete-slice` tool allow-list with Context Mode guidance** so agents are not told to use tools the dispatch surface rejects.
> 
> The `complete-slice` entry in `unit-registry.ts` now includes **`gsd_exec_search`** and **`gsd_resume`** alongside the existing **`gsd_exec`** verification tools. Regression coverage in `unit-context-composer.test.ts` adds **`complete-slice`** to the slice guidance contract test, asserting those tools appear in composed instructions, are allowed by the unit contract, and are not hard-blocked by auto-unit scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30e13b7850c9122b409b8ab0da1fafe8ed54d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->