### PR TITLE
fix(issue): [Bug]: guided discuss units advertise the interview-lane exec trio their contracts hard-block on live /gsd discuss turns

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  CONTEXT_MODE_GUIDANCE_BY_UNIT,
   composeContractedUnitContext,
   composeContextModeInstructions,
   composeInlinedContext,
@@ -158,11 +159,45 @@ const laneLabelByMode: Record<string, string> = {
   triage: "triage",
 };
 
-const unitSpecificContextModeGuidanceUnits = new Set([
-  "run-uat",
-  "replan-slice",
-  "reassess-roadmap",
-]);
+const contextModeGuidanceOverrideExpectedTools: Record<string, readonly string[]> = {
+  "discuss-milestone": [
+    "ask_user_questions",
+    "gsd_summary_save",
+    "gsd_decision_save",
+    "gsd_requirement_save",
+    "gsd_requirement_update",
+    "gsd_plan_milestone",
+    "gsd_milestone_generate_id",
+  ],
+  "discuss-project": [
+    "ask_user_questions",
+    "gsd_summary_save",
+    "gsd_decision_save",
+    "gsd_requirement_save",
+  ],
+  "discuss-requirements": [
+    "ask_user_questions",
+    "gsd_requirement_save",
+    "gsd_summary_save",
+  ],
+  "discuss-slice": [
+    "ask_user_questions",
+    "gsd_summary_save",
+    "gsd_decision_save",
+  ],
+  "replan-slice": [
+    "gsd_replan_slice",
+    "gsd_decision_save",
+  ],
+  "reassess-roadmap": [
+    "gsd_milestone_status",
+    "gsd_reassess_roadmap",
+  ],
+  "run-uat": [
+    "gsd_uat_exec",
+    "gsd_resume",
+  ],
+};
 
 test("Context Mode composer: every known eligible unit renders its configured lane and required tools", () => {
   for (const unitType of KNOWN_UNIT_TYPES) {
@@ -176,25 +211,65 @@ test("Context Mode composer: every known eligible unit renders its configured la
     assert.ok(out.startsWith("## Context Mode"), `${unitType} should render standalone Context Mode heading`);
     assert.match(out, new RegExp(`Lane: \\*\\*${laneLabelByMode[manifest.contextMode]} lane\\*\\*\\.`, "i"));
     const forbidden = getUnitToolSurfaceContract(unitType)?.forbiddenGsdTools ?? {};
-    if (unitSpecificContextModeGuidanceUnits.has(unitType)) {
-      // Unit-specific guidance replaces the lane default, so it must not
-      // advertise the exec tools that narrow contracts do not allow.
+    const overrideExpectedTools = contextModeGuidanceOverrideExpectedTools[unitType];
+    if ("gsd_exec" in forbidden || overrideExpectedTools) {
+      // Unit overrides are the contract-specific exception to lane defaults.
+      // Steering to the lane default here can produce unavailable-tool loops.
       assert.doesNotMatch(out, /`gsd_exec`/, `${unitType} guidance must not steer to gsd_exec`);
       assert.doesNotMatch(out, /`gsd_exec_search`/, `${unitType} guidance must not steer to gsd_exec_search`);
-      continue;
-    }
-    if ("gsd_exec" in forbidden) {
-      // Units that forbid gsd_exec (run-uat) have it stripped from their
-      // Claude Code dispatch surface; guidance steering to it produces
-      // "No such tool available" loops in the dispatched agent.
-      assert.doesNotMatch(out, /`gsd_exec`/, `${unitType} forbids gsd_exec; guidance must not steer to it`);
-      assert.doesNotMatch(out, /`gsd_exec_search`/, `${unitType} guidance must not steer to gsd_exec_search`);
-      assert.match(out, /`gsd_uat_exec`/, `${unitType} guidance should steer to gsd_uat_exec instead`);
+      for (const toolName of overrideExpectedTools ?? []) {
+        assert.match(out, new RegExp(`\`${toolName}\``), `${unitType} guidance should mention ${toolName}`);
+      }
     } else {
       assert.match(out, /`gsd_exec`/, `${unitType} should mention gsd_exec`);
       assert.match(out, /`gsd_exec_search`/, `${unitType} should mention gsd_exec_search`);
     }
-    assert.match(out, /`gsd_resume`/, `${unitType} should mention gsd_resume`);
+    if (!overrideExpectedTools || overrideExpectedTools.includes("gsd_resume")) {
+      assert.match(out, /`gsd_resume`/, `${unitType} should mention gsd_resume`);
+    } else {
+      assert.doesNotMatch(out, /`gsd_resume`/, `${unitType} guidance must not steer to gsd_resume`);
+    }
+  }
+});
+
+test("Context Mode composer: discuss interview overrides stay within unit contracts", () => {
+  const discussUnits = [
+    "discuss-milestone",
+    "discuss-project",
+    "discuss-requirements",
+    "discuss-slice",
+  ];
+
+  for (const unitType of discussUnits) {
+    const guidance = CONTEXT_MODE_GUIDANCE_BY_UNIT[unitType];
+    assert.ok(guidance, `${unitType} should have a Context Mode override`);
+    assert.doesNotMatch(guidance, /`gsd_exec`/, `${unitType} guidance must not mention gsd_exec`);
+    assert.doesNotMatch(guidance, /`gsd_exec_search`/, `${unitType} guidance must not mention gsd_exec_search`);
+    assert.doesNotMatch(guidance, /`gsd_resume`/, `${unitType} guidance must not mention gsd_resume`);
+
+    const expectedTools = contextModeGuidanceOverrideExpectedTools[unitType] ?? [];
+    assert.ok(expectedTools.length > 0, `${unitType} should declare expected override tools`);
+    const contract = getUnitToolSurfaceContract(unitType);
+    assert.ok(contract, `${unitType} should have a tool contract`);
+    const contractTools = new Set([
+      ...contract.allowedGsdTools,
+      ...contract.requiredWorkflowTools,
+    ]);
+
+    for (const toolName of expectedTools) {
+      assert.match(guidance, new RegExp(`\`${toolName}\``), `${unitType} guidance should mention ${toolName}`);
+      assert.ok(contractTools.has(toolName as UnitGsdToolName), `${unitType} contract should allow ${toolName}`);
+      const scope = shouldBlockAutoUnitToolCall(unitType, toolName);
+      assert.equal(scope.block, false, `${unitType} should not hard-block ${toolName}: ${scope.reason ?? ""}`);
+    }
+
+    const out = composeContextModeInstructions(unitType, { enabled: true, renderMode: "standalone" });
+    if (out) {
+      assert.match(out, /interview lane/i);
+      assert.doesNotMatch(out, /`gsd_exec`/);
+      assert.doesNotMatch(out, /`gsd_exec_search`/);
+      assert.doesNotMatch(out, /`gsd_resume`/);
+    }
   }
 });
 

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -135,9 +135,18 @@ const CONTEXT_MODE_GUIDANCE_BY_LANE: Record<Exclude<ContextModePolicy, "none">, 
     "Use `gsd_resume` for prior context, `gsd_exec_search` for saved evidence, and `gsd_exec` for noisy doc validation commands.",
 };
 
-// Per-unit overrides win over the lane default for units whose tool contracts
-// are narrower than the shared lane guidance.
-const CONTEXT_MODE_GUIDANCE_BY_UNIT: Record<string, string> = {
+// Per-unit overrides win over the lane default. Some units intentionally run
+// with narrower tool contracts than their shared Context Mode lane, so their
+// guidance must name only tools the unit can actually call.
+export const CONTEXT_MODE_GUIDANCE_BY_UNIT: Readonly<Record<string, string>> = {
+  "discuss-milestone":
+    "Use `ask_user_questions` to continue the milestone interview, then persist outcomes with `gsd_summary_save`, `gsd_decision_save`, `gsd_requirement_save`, `gsd_requirement_update`, `gsd_plan_milestone`, or `gsd_milestone_generate_id` as appropriate.",
+  "discuss-slice":
+    "Use `ask_user_questions` to continue the slice interview, then persist outcomes with `gsd_summary_save` or `gsd_decision_save` as appropriate.",
+  "discuss-project":
+    "Use `ask_user_questions` to continue the project interview, then persist outcomes with `gsd_summary_save`, `gsd_decision_save`, or `gsd_requirement_save` as appropriate.",
+  "discuss-requirements":
+    "Use `ask_user_questions` to continue the requirements interview, then persist outcomes with `gsd_requirement_save` or `gsd_summary_save` as appropriate.",
   "replan-slice":
     "Use `gsd_replan_slice` to persist the revised slice plan, and `gsd_decision_save` for planning decisions that need durable rationale.",
   "reassess-roadmap":


### PR DESCRIPTION
## Summary
- Fixed discuss Context Mode guidance overrides and added focused contract-alignment tests; verification was limited by unavailable npm registry dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #961
- [#961 [Bug]: guided discuss units advertise the interview-lane exec trio their contracts hard-block on live /gsd discuss turns](https://github.com/open-gsd/gsd-pi/issues/961)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/961-bug-guided-discuss-units-advertise-the-i-1782565534`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only guidance and test coverage; no runtime dispatch or auth changes.
> 
> **Overview**
> **Guided discuss units** (`discuss-milestone`, `discuss-project`, `discuss-requirements`, `discuss-slice`) still use the **interview** Context Mode lane, but their prompts no longer inherit the lane default that steers agents toward `gsd_exec`, `gsd_exec_search`, and `gsd_resume`—tools their planning contracts do not expose.
> 
> `CONTEXT_MODE_GUIDANCE_BY_UNIT` now includes overrides that point at **interview + persist** tools (`ask_user_questions`, `gsd_summary_save`, `gsd_decision_save`, `gsd_requirement_*`, etc., per unit). The map is **exported** so tests can assert the raw guidance strings. `run-uat` keeps its existing UAT-specific override.
> 
> Tests were broadened: eligible units with overrides must not mention the exec trio; `gsd_resume` is only required when the override lists it; a dedicated test checks discuss overrides against tool contracts and auto-tool scope blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304f0b3da50a925fed505d5ca59ae9eb505f74d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->