### PR TITLE
fix(issue): [Bug]: Unmerged-milestone command preflight SHA-256-hashes every dirty project file before checking whether any is relevant

### DIFF
--- a/src/resources/extensions/gsd/tests/unmerged-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/unmerged-milestone-guard.test.ts
@@ -127,6 +127,31 @@ test("formatUnmergedMilestoneBlockMessage includes files, branch, and dirty over
   }
 });
 
+test("findUnmergedCompletedMilestones reports dirty overlap without content fingerprints", async () => {
+  const base = makeTempRepo("gsd-unmerged-guard-");
+  try {
+    const relPath = "build/output.bin";
+    const absPath = join(base, relPath);
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, "main artifact\n");
+    git(base, "add", relPath);
+    git(base, "commit", "-m", "test: track build output fixture");
+
+    seedMilestone(base, "M012");
+    commitBranchFile(base, "milestone/M012", relPath, "milestone artifact\n");
+    writeFileSync(absPath, "dirty root artifact\n");
+
+    const [blocker] = await findUnmergedCompletedMilestones(base);
+    assert.ok(blocker);
+    assert.deepEqual(blocker.files, [relPath]);
+    assert.deepEqual(blocker.dirtyOverlap, [{ path: relPath, status: "M" }]);
+    assert.equal(Object.hasOwn(blocker.dirtyOverlap[0], "fingerprint"), false);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("isUnmergedMilestoneAllowedCommand permits inspection and explicit recovery commands", () => {
   assert.equal(isUnmergedMilestoneAllowedCommand(""), false);
   assert.equal(isUnmergedMilestoneAllowedCommand("auto"), false);

--- a/src/resources/extensions/gsd/unmerged-milestone-guard.ts
+++ b/src/resources/extensions/gsd/unmerged-milestone-guard.ts
@@ -1,6 +1,8 @@
 // Project/App: gsd-pi
 // File Purpose: Block new workflow entry when completed milestone branches are still unmerged.
 
+import { execFileSync } from "node:child_process";
+
 import {
   nativeBranchExists,
   nativeDetectMainBranch,
@@ -12,16 +14,22 @@ import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 import { getAllMilestones } from "./gsd-db.js";
 import { resolveMilestoneIntegrationBranch } from "./git-service.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
-import { captureRootDirtySnapshot, type RootDirtyEntry } from "./root-write-leak-guard.js";
 import { isClosedStatus } from "./status-guards.js";
+
+export interface UnmergedMilestoneDirtyEntry {
+  path: string;
+  status: string;
+}
 
 export interface UnmergedMilestoneBlocker {
   milestoneId: string;
   branch: string;
   integrationBranch: string;
   files: string[];
-  dirtyOverlap: RootDirtyEntry[];
+  dirtyOverlap: UnmergedMilestoneDirtyEntry[];
 }
+
+type UnmergedMilestoneDirtySnapshot = Map<string, UnmergedMilestoneDirtyEntry>;
 
 const BLOCKED_COMMANDS = new Set([
   "auto",
@@ -65,6 +73,32 @@ const UNMERGED_SAFE_PARALLEL_SUBCOMMANDS = new Set([
 
 function isRuntimePath(path: string): boolean {
   return path === ".gsd" || path.startsWith(".gsd/");
+}
+
+function captureDirtyPathStatusSnapshot(rootPath: string): UnmergedMilestoneDirtySnapshot {
+  const snapshot: UnmergedMilestoneDirtySnapshot = new Map();
+  let status = "";
+  try {
+    status = execFileSync("git", ["status", "--porcelain", "--untracked-files=all"], {
+      cwd: rootPath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+  } catch {
+    return snapshot;
+  }
+
+  for (const line of status.split("\n")) {
+    if (!line.trim()) continue;
+    const code = line.slice(0, 2);
+    const path = line.slice(3).replace(/^"|"$/g, "");
+    if (!path || isRuntimePath(path)) continue;
+    snapshot.set(path, {
+      path,
+      status: code.trim() || code,
+    });
+  }
+  return snapshot;
 }
 
 function formatCommandLabel(attemptedCommand: string): string {
@@ -132,7 +166,7 @@ export async function findUnmergedCompletedMilestones(base: string): Promise<Unm
   await ensureDbOpen(base);
 
   const blockers: UnmergedMilestoneBlocker[] = [];
-  const dirtyByPath = captureRootDirtySnapshot(base);
+  let dirtyByPath: UnmergedMilestoneDirtySnapshot | null = null;
 
   for (const milestone of getAllMilestones()) {
     if (!isClosedStatus(milestone.status)) continue;
@@ -158,14 +192,16 @@ export async function findUnmergedCompletedMilestones(base: string): Promise<Unm
     const uniqueFiles = [...new Set(files)].sort();
     if (uniqueFiles.length === 0) continue;
 
+    if (!dirtyByPath) dirtyByPath = captureDirtyPathStatusSnapshot(base);
+    const dirtySnapshot = dirtyByPath;
     blockers.push({
       milestoneId: milestone.id,
       branch,
       integrationBranch,
       files: uniqueFiles,
       dirtyOverlap: uniqueFiles
-        .map((path) => dirtyByPath.get(path))
-        .filter((entry): entry is RootDirtyEntry => Boolean(entry)),
+        .map((path) => dirtySnapshot.get(path))
+        .filter((entry): entry is UnmergedMilestoneDirtyEntry => Boolean(entry)),
     });
   }
 


### PR DESCRIPTION
## Summary
- Fixed the unmerged milestone guard to use lazy path/status dirty snapshots without content hashing and verified syntax, whitespace, and root-write fingerprint behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #954
- [#954 [Bug]: Unmerged-milestone command preflight SHA-256-hashes every dirty project file before checking whether any is relevant](https://github.com/open-gsd/gsd-pi/issues/954)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/954-bug-unmerged-milestone-command-preflight-1782565808`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized preflight performance/behavior change in the unmerged-milestone guard; overlap reporting drops fingerprints but block messaging still uses path and status.
> 
> **Overview**
> Fixes unmerged-milestone command preflight that previously pulled in **root-write leak** dirty snapshots and **SHA-256-hashed every dirty project file**, even when only path/status overlap with an unmerged branch mattered.
> 
> **`findUnmergedCompletedMilestones`** now uses a local **`captureDirtyPathStatusSnapshot`** (`git status --porcelain`) that records only **path and status**, with **`.gsd` paths still excluded**. Dirty state is captured **lazily**—only after a milestone is classified as blocked with non-empty product diffs—so clean repos skip the work entirely. **`dirtyOverlap`** is typed as **`UnmergedMilestoneDirtyEntry`** (no `fingerprint`).
> 
> A regression test confirms overlapping dirty files are reported **without** a `fingerprint` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0daf11f16fbd4b9cf86e024c9ee69f38a7be8fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->