### PR TITLE
fix(issue): [Bug]: Workspace store emits a new state object per streaming token, re-rendering every consumer (no emit coalescing)

### DIFF
--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -1662,6 +1662,9 @@ export class GSDWorkspaceStore {
   private commandTimeoutTimer: ReturnType<typeof setTimeout> | null = null
   private lastBootRefreshAt = 0
   private visibilityHandler: (() => void) | null = null
+  private emitScheduled = false
+  private emitFrame: number | null = null
+  private emitTimer: ReturnType<typeof setTimeout> | null = null
 
   subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener)
@@ -1691,6 +1694,7 @@ export class GSDWorkspaceStore {
   dispose = (): void => {
     this.disposed = true
     this.started = false
+    this.cancelScheduledEmit()
     this.stopOnboardingPoller()
     this.closeEventStream()
     this.clearCommandTimeout()
@@ -4632,10 +4636,43 @@ export class GSDWorkspaceStore {
     }
   }
 
+  private scheduleEmit(): void {
+    if (this.emitScheduled || this.listeners.size === 0) return
+    this.emitScheduled = true
+
+    if (typeof requestAnimationFrame === "function") {
+      this.emitFrame = requestAnimationFrame(this.flushEmit)
+      return
+    }
+
+    this.emitTimer = setTimeout(this.flushEmit, 0)
+  }
+
+  private flushEmit = (): void => {
+    this.emitScheduled = false
+    this.emitFrame = null
+    this.emitTimer = null
+    if (this.disposed) return
+    this.emit()
+  }
+
+  private cancelScheduledEmit(): void {
+    if (!this.emitScheduled) return
+    if (this.emitFrame !== null && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(this.emitFrame)
+    }
+    if (this.emitTimer !== null) {
+      clearTimeout(this.emitTimer)
+    }
+    this.emitScheduled = false
+    this.emitFrame = null
+    this.emitTimer = null
+  }
+
   private patchState(patch: Partial<WorkspaceStoreState>): void {
     this.state = { ...this.state, ...patch }
     this.syncOnboardingPoller()
-    this.emit()
+    this.scheduleEmit()
   }
 
   private syncOnboardingPoller(): void {


### PR DESCRIPTION
## Summary
- Coalesced workspace store emissions per frame and verified with the focused web test suite plus diff checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #879
- [#879 [Bug]: Workspace store emits a new state object per streaming token, re-rendering every consumer (no emit coalescing)](https://github.com/open-gsd/gsd-pi/issues/879)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/879-bug-workspace-store-emits-a-new-state-ob-1782565895`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized store notification timing change; final state per frame is unchanged and scheduled work is cleared on dispose.
> 
> **Overview**
> Fixes excessive React re-renders during assistant streaming by **batching** `GSDWorkspaceStore` subscriber notifications instead of firing on every `patchState` call.
> 
> `patchState` now calls **`scheduleEmit()`**, which schedules at most one flush per frame via `requestAnimationFrame` (with `setTimeout(0)` when rAF is unavailable). Intermediate updates in the same frame collapse into a single `emit()` so `useSyncExternalStore` consumers see one snapshot change per paint. **`dispose()`** calls **`cancelScheduledEmit()`** so a torn-down store does not notify listeners after unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69222535e77a1c9a3cf02790fe67104145fea129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->