### PR TITLE
fix(issue): [Bug]: A single timed-out workflow MCP operation releases the serial mutation queue while it keeps running, so the retry races the zombie write

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
 import { z } from "zod";
 
 import { symlinkSync, realpathSync } from "node:fs";
@@ -37,6 +38,7 @@ import {
   validateProjectDir,
   _parseWorkflowArgsForTest,
   _summarySaveSchemaForTest,
+  _runSerializedWorkflowOperationForTest,
   _sliceCompleteSchemaForTest,
 } from "./workflow-tools.ts";
 
@@ -208,6 +210,68 @@ describe("warmWorkflowToolBridges", () => {
         delete process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
       } else {
         process.env.GSD_WORKFLOW_EXECUTORS_MODULE = prevModule;
+      }
+    }
+  });
+});
+
+describe("runSerializedWorkflowOperation", () => {
+  it("keeps the queue held until a timed-out operation settles", async () => {
+    const previousTimeout = process.env.GSD_MCP_WORKFLOW_TIMEOUT_MS;
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let second: Promise<string> | undefined;
+
+    try {
+      process.env.GSD_MCP_WORKFLOW_TIMEOUT_MS = "20";
+
+      const first = _runSerializedWorkflowOperationForTest(async () => {
+        events.push("first-start");
+        await firstCanFinish;
+        events.push("first-finish");
+        return "first";
+      });
+
+      await assert.rejects(first, /Workflow operation exceeded 20ms deadline/);
+      events.push("first-timeout-returned");
+
+      let secondSettled = false;
+      second = _runSerializedWorkflowOperationForTest(async () => {
+        events.push("second-start");
+        return "second";
+      }).then((value) => {
+        secondSettled = true;
+        events.push("second-finish");
+        return value;
+      });
+
+      await delay(30);
+      assert.equal(
+        secondSettled,
+        false,
+        "retry should remain queued while the timed-out operation is still running",
+      );
+      assert.deepEqual(events, ["first-start", "first-timeout-returned"]);
+
+      releaseFirst?.();
+      assert.equal(await second, "second");
+      assert.deepEqual(events, [
+        "first-start",
+        "first-timeout-returned",
+        "first-finish",
+        "second-start",
+        "second-finish",
+      ]);
+    } finally {
+      releaseFirst?.();
+      if (second) await second.catch(() => undefined);
+      if (previousTimeout === undefined) {
+        delete process.env.GSD_MCP_WORKFLOW_TIMEOUT_MS;
+      } else {
+        process.env.GSD_MCP_WORKFLOW_TIMEOUT_MS = previousTimeout;
       }
     }
   });

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -908,18 +908,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 async function runSerializedWorkflowOperation<T>(fn: () => Promise<T>): Promise<T> {
   // The shared DB adapter and workflow log base path are process-global, so
   // workflow MCP mutations must not overlap within a single server process.
-  // A per-operation deadline prevents a single stuck call from wedging every
-  // subsequent write for the lifetime of the process.
+  // A per-operation deadline prevents a single stuck call from wedging its
+  // caller for the lifetime of the process.
   //
-  // Known limitation: on timeout we surface an error and release the queue,
-  // but Promise.race cannot cancel the underlying `fn()` — it may continue
-  // running in the background and overlap with the next admitted operation.
-  // Proper cancellation requires threading an AbortSignal through every
-  // workflow executor (`workflow-tool-executors.ts` and friends), which is
-  // a larger change. The current trade-off: risk a theoretical overlap after
-  // a 5-minute wall-clock timeout vs permanently wedging the server. The
-  // overlap window is bounded by how long the zombie `fn()` keeps running;
-  // in practice DB writes complete quickly even when the caller gave up.
+  // Promise.race cannot cancel the underlying `fn()`. On timeout, surface an
+  // error to the caller but keep the queue held until `fn()` actually settles
+  // so a retry cannot overlap with the still-running operation. True
+  // cancellation remains a larger deferred design: it requires threading an
+  // AbortSignal through every workflow executor (`workflow-tool-executors.ts`
+  // and friends).
   const prior = workflowExecutionQueue;
   let release!: () => void;
   workflowExecutionQueue = new Promise<void>((resolve) => {
@@ -928,24 +925,36 @@ async function runSerializedWorkflowOperation<T>(fn: () => Promise<T>): Promise<
 
   await prior;
   const timeoutMs = getWorkflowOpTimeoutMs();
+  const operationPromise = Promise.resolve().then(fn);
+  let timedOut = false;
   try {
     if (timeoutMs === 0) {
-      return await fn();
+      return await operationPromise;
     }
     let timer: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
+        timedOut = true;
         reject(new Error(`Workflow operation exceeded ${timeoutMs}ms deadline (GSD_MCP_WORKFLOW_TIMEOUT_MS)`));
       }, timeoutMs);
     });
     try {
-      return await Promise.race([fn(), timeoutPromise]);
+      return await Promise.race([operationPromise, timeoutPromise]);
     } finally {
       if (timer) clearTimeout(timer);
     }
   } finally {
-    release();
+    if (timedOut) {
+      void operationPromise.then(release, release);
+    } else {
+      release();
+    }
   }
+}
+
+/** @internal — exported for testing only */
+export function _runSerializedWorkflowOperationForTest<T>(fn: () => Promise<T>): Promise<T> {
+  return runSerializedWorkflowOperation(fn);
 }
 
 async function runSerializedWorkflowDbOperation<T>(


### PR DESCRIPTION
## Summary
- Fixed workflow MCP timeout queue release behavior and verified the drain logic with a focused harness plus diff checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #951
- [#951 [Bug]: A single timed-out workflow MCP operation releases the serial mutation queue while it keeps running, so the retry races the zombie write](https://github.com/open-gsd/gsd-pi/issues/951)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/951-bug-a-single-timed-out-workflow-mcp-oper-1782565813`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialization timing for all workflow MCP mutations on timeout paths; behavior is narrower and tested, but affects concurrent access to the process-global DB adapter.
> 
> **Overview**
> Fixes a race where a workflow MCP call that hit `GSD_MCP_WORKFLOW_TIMEOUT_MS` returned an error and **released the serial mutation queue** while the underlying executor was still running, so an immediate retry could overlap with the “zombie” write.
> 
> `runSerializedWorkflowOperation` in `workflow-tools.ts` now races the caller against the deadline as before, but on timeout it **defers `release()` until the operation promise settles** (success or failure). Callers still get the timeout error; the next queued mutation cannot start until the stuck work finishes. Comments note that true cancellation via `AbortSignal` through executors remains future work.
> 
> Adds `_runSerializedWorkflowOperationForTest` and a focused test that proves a second operation stays queued after the first times out until the first operation completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ed97f7d754a3c84baf928066ec6c2b87f993b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->