### PR TITLE
fix(issue): [Bug]: Per-turn before_agent_start re-runs memory/knowledge backfills + N+1 LIKE-scan consolidation scanner every turn (no session-once guard)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -28,9 +28,10 @@ const DEFAULT_CODEBASE_MAX_CHARS = 8_000;
 const MIN_CONTEXT_MESSAGE_MAX_CHARS = 1_000;
 const MIN_KNOWLEDGE_MAX_CHARS = 1_000;
 
-const contextMaintenanceCompletedForBasePath = new Set<string>();
-const contextMaintenanceInFlightByBasePath = new Map<string, Promise<boolean>>();
-const deferredContextMaintenanceByBasePath = new Map<string, Promise<void>>();
+const CONTEXT_MAINTENANCE_KEY_SEPARATOR = "\0";
+const contextMaintenanceCompletedForSession = new Set<string>();
+const contextMaintenanceInFlightBySession = new Map<string, Promise<boolean>>();
+const deferredContextMaintenanceBySession = new Map<string, Promise<void>>();
 
 /**
  * Bundled skill triggers — resolved dynamically at runtime instead of
@@ -114,7 +115,8 @@ async function runSessionStartupMaintenanceOnce(
   basePath: string,
   ctx: ExtensionContext,
 ): Promise<boolean> {
-  if (contextMaintenanceCompletedForBasePath.has(basePath)) {
+  const maintenanceKey = getContextMaintenanceKey(basePath, ctx);
+  if (contextMaintenanceCompletedForSession.has(maintenanceKey)) {
     // Backfills are session-once, but memory queries and other DB-backed
     // prompt assembly still need an active adapter on every turn.
     try {
@@ -126,16 +128,16 @@ async function runSessionStartupMaintenanceOnce(
     return false;
   }
 
-  const existing = contextMaintenanceInFlightByBasePath.get(basePath);
+  const existing = contextMaintenanceInFlightBySession.get(maintenanceKey);
   const isInitiator = !existing;
   // Use a definite Promise<boolean> so `await inFlight` has a known return type.
   let inFlight: Promise<boolean>;
   if (isInitiator) {
-    inFlight = performSessionStartupMaintenance(basePath, ctx);
-    contextMaintenanceInFlightByBasePath.set(basePath, inFlight);
+    inFlight = performSessionStartupMaintenance(basePath, ctx, maintenanceKey);
+    contextMaintenanceInFlightBySession.set(maintenanceKey, inFlight);
     void inFlight.finally(() => {
-      if (contextMaintenanceInFlightByBasePath.get(basePath) === inFlight) {
-        contextMaintenanceInFlightByBasePath.delete(basePath);
+      if (contextMaintenanceInFlightBySession.get(maintenanceKey) === inFlight) {
+        contextMaintenanceInFlightBySession.delete(maintenanceKey);
       }
     });
   } else {
@@ -149,6 +151,7 @@ async function runSessionStartupMaintenanceOnce(
 async function performSessionStartupMaintenance(
   basePath: string,
   ctx: ExtensionContext,
+  maintenanceKey: string,
 ): Promise<boolean> {
   // DB-backed memory backfills run below. On a cold session the database file
   // may exist without an active in-process adapter, so open the canonical
@@ -172,9 +175,38 @@ async function performSessionStartupMaintenance(
 
   // Mark session complete before scheduling deferred work so any concurrent
   // caller that observes the completed state does not re-enter maintenance.
-  contextMaintenanceCompletedForBasePath.add(basePath);
-  scheduleDeferredContextMaintenance(basePath);
+  contextMaintenanceCompletedForSession.add(maintenanceKey);
+  scheduleDeferredContextMaintenance(basePath, maintenanceKey);
   return true;
+}
+
+function getContextMaintenanceKey(basePath: string, ctx: ExtensionContext): string {
+  return `${basePath}${CONTEXT_MAINTENANCE_KEY_SEPARATOR}${getContextSessionPart(ctx)}`;
+}
+
+function getContextSessionPart(ctx: ExtensionContext): string {
+  const sessionManager = (ctx as {
+    sessionManager?: {
+      getSessionId?: () => string | undefined;
+      getSessionFile?: () => string | undefined;
+    };
+  }).sessionManager;
+
+  try {
+    const sessionId = sessionManager?.getSessionId?.();
+    if (typeof sessionId === "string" && sessionId.length > 0) return `id:${sessionId}`;
+  } catch {
+    // Fall through to session file / process fallback.
+  }
+
+  try {
+    const sessionFile = sessionManager?.getSessionFile?.();
+    if (typeof sessionFile === "string" && sessionFile.length > 0) return `file:${sessionFile}`;
+  } catch {
+    // Fall through to process fallback.
+  }
+
+  return "process";
 }
 
 async function runDecisionsMemoryBackfill(ctx: ExtensionContext): Promise<void> {
@@ -210,8 +242,8 @@ async function runKnowledgeMemoryBackfill(
   }
 }
 
-function scheduleDeferredContextMaintenance(basePath: string): void {
-  if (deferredContextMaintenanceByBasePath.has(basePath)) return;
+function scheduleDeferredContextMaintenance(basePath: string, maintenanceKey: string): void {
+  if (deferredContextMaintenanceBySession.has(maintenanceKey)) return;
 
   const task = new Promise<void>((resolve) => {
     setTimeout(() => {
@@ -219,10 +251,10 @@ function scheduleDeferredContextMaintenance(basePath: string): void {
     }, 0);
   });
 
-  deferredContextMaintenanceByBasePath.set(basePath, task);
+  deferredContextMaintenanceBySession.set(maintenanceKey, task);
   void task.finally(() => {
-    if (deferredContextMaintenanceByBasePath.get(basePath) === task) {
-      deferredContextMaintenanceByBasePath.delete(basePath);
+    if (deferredContextMaintenanceBySession.get(maintenanceKey) === task) {
+      deferredContextMaintenanceBySession.delete(maintenanceKey);
     }
   });
 }
@@ -257,8 +289,10 @@ async function reportConsolidationGapsDeferred(basePath: string): Promise<void> 
 
 export async function _flushDeferredContextMaintenanceForTest(basePath?: string): Promise<void> {
   const tasks = basePath
-    ? [deferredContextMaintenanceByBasePath.get(basePath)].filter((task): task is Promise<void> => Boolean(task))
-    : [...deferredContextMaintenanceByBasePath.values()];
+    ? [...deferredContextMaintenanceBySession.entries()]
+        .filter(([key]) => key.startsWith(`${basePath}${CONTEXT_MAINTENANCE_KEY_SEPARATOR}`))
+        .map(([, task]) => task)
+    : [...deferredContextMaintenanceBySession.values()];
   await Promise.allSettled(tasks);
 }
 

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -195,15 +195,15 @@ function getContextSessionPart(ctx: ExtensionContext): string {
   try {
     const sessionId = sessionManager?.getSessionId?.();
     if (typeof sessionId === "string" && sessionId.length > 0) return `id:${sessionId}`;
-  } catch {
-    // Fall through to session file / process fallback.
+  } catch (e) {
+    logWarning("bootstrap", `session-id fetch failed: ${(e as Error).message}`);
   }
 
   try {
     const sessionFile = sessionManager?.getSessionFile?.();
     if (typeof sessionFile === "string" && sessionFile.length > 0) return `file:${sessionFile}`;
-  } catch {
-    // Fall through to process fallback.
+  } catch (e) {
+    logWarning("bootstrap", `session-file fetch failed: ${(e as Error).message}`);
   }
 
   return "process";

--- a/src/resources/extensions/gsd/memory-consolidation-scanner.ts
+++ b/src/resources/extensions/gsd/memory-consolidation-scanner.ts
@@ -142,23 +142,53 @@ function getActiveDecisions(): DecisionRow[] {
 }
 
 /**
- * True when a memory row has a `structured_fields` JSON payload containing
- * the given `markerKey: "value"` pair. Matches the LIKE pattern used by
- * `backfillDecisionsToMemories` so the scanner is consistent with the
- * backfill's idempotency check.
+ * Source IDs already present in memory `structured_fields`. Collected with one
+ * pass over the memories table so the scanner does not perform a non-indexable
+ * LIKE probe for every decision and KNOWLEDGE.md row.
  */
-function memoryHasSourceMarker(markerKey: string, value: string): boolean {
-  if (!isDbAvailable()) return false;
+interface MemorySourceMarkers {
+  decisionIds: Set<string>;
+  knowledgeIds: Set<string>;
+}
+
+function emptyMemorySourceMarkers(): MemorySourceMarkers {
+  return { decisionIds: new Set(), knowledgeIds: new Set() };
+}
+
+function getMemorySourceMarkers(): MemorySourceMarkers {
+  const markers = emptyMemorySourceMarkers();
+  if (!isDbAvailable()) return markers;
   const adapter = _getAdapter();
-  if (!adapter) return false;
+  if (!adapter) return markers;
   try {
-    const pattern = `%"${markerKey}":"${value}"%`;
-    const row = adapter
-      .prepare("SELECT 1 FROM memories WHERE structured_fields LIKE :pattern LIMIT 1")
-      .get({ ":pattern": pattern });
-    return row !== undefined;
+    const rows = adapter
+      .prepare("SELECT structured_fields FROM memories WHERE structured_fields IS NOT NULL")
+      .all() as Array<Record<string, unknown>>;
+    for (const row of rows) {
+      collectMemorySourceMarker(markers, row["structured_fields"]);
+    }
   } catch {
-    return false;
+    return markers;
+  }
+  return markers;
+}
+
+function collectMemorySourceMarker(markers: MemorySourceMarkers, raw: unknown): void {
+  if (typeof raw !== "string" || raw.length === 0) return;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
+    const fields = parsed as Record<string, unknown>;
+    const decisionId = fields["sourceDecisionId"];
+    if (typeof decisionId === "string" && decisionId.length > 0) {
+      markers.decisionIds.add(decisionId);
+    }
+    const knowledgeId = fields["sourceKnowledgeId"];
+    if (typeof knowledgeId === "string" && knowledgeId.length > 0) {
+      markers.knowledgeIds.add(knowledgeId);
+    }
+  } catch {
+    return;
   }
 }
 
@@ -174,10 +204,14 @@ const SAMPLE_LIMIT = 5;
 export function scanConsolidationGaps(basePath: string): ConsolidationGapReport {
   // ── Decisions ────────────────────────────────────────────────────────
   const decisions = getActiveDecisions();
+  const knowledgeRows = parseKnowledgeRows(knowledgeMdContent(basePath));
+  const memorySourceMarkers = decisions.length > 0 || knowledgeRows.length > 0
+    ? getMemorySourceMarkers()
+    : emptyMemorySourceMarkers();
   const decisionSamples: DecisionsSurfaceReport["samples"] = [];
   let decisionMigrated = 0;
   for (const decision of decisions) {
-    if (memoryHasSourceMarker("sourceDecisionId", decision.id)) {
+    if (memorySourceMarkers.decisionIds.has(decision.id)) {
       decisionMigrated += 1;
       continue;
     }
@@ -190,16 +224,14 @@ export function scanConsolidationGaps(basePath: string): ConsolidationGapReport 
   }
 
   // ── KNOWLEDGE.md ─────────────────────────────────────────────────────
-  const knowledgeRows = parseKnowledgeRows(knowledgeMdContent(basePath));
   const knowledgeByTable = { rules: 0, patterns: 0, lessons: 0 };
   const knowledgeSamples: KnowledgeSurfaceReport["samples"] = [];
   let knowledgeMigrated = 0;
   for (const row of knowledgeRows) {
     knowledgeByTable[row.table] += 1;
-    // Phase 6 will introduce a `sourceKnowledgeId` marker as part of the
-    // KNOWLEDGE.md backfill. Until that path ships, this check returns
-    // false for every row, which is the honest state of the consolidation.
-    if (memoryHasSourceMarker("sourceKnowledgeId", row.id)) {
+    // KNOWLEDGE.md backfill writes `sourceKnowledgeId`; rows without that
+    // marker are still reported as consolidation gaps.
+    if (memorySourceMarkers.knowledgeIds.has(row.id)) {
       knowledgeMigrated += 1;
       continue;
     }

--- a/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-cold-start.test.ts
@@ -136,8 +136,10 @@ test("#896 startup maintenance skips repeated sentinel work in one session", asy
   closeDatabase();
   assert.equal(isDbAvailable(), false);
 
+  let sessionId = "session-one";
   const ctx = {
     projectRoot: base,
+    sessionManager: { getSessionId: () => sessionId },
     ui: { notify: () => undefined },
   } as unknown as ExtensionContext;
 
@@ -190,6 +192,18 @@ test("#896 startup maintenance skips repeated sentinel work in one session", asy
     .prepare("SELECT COUNT(*) AS count FROM memories WHERE structured_fields LIKE '%\"sourceKnowledgeId\":\"P002\"%'")
     .get() as { count: number };
   assert.equal(secondPass.count, 0, "second startup in same session should not re-run KNOWLEDGE.md sentinel backfill");
+
+  sessionId = "session-two";
+  await buildBeforeAgentStartResult(
+    { prompt: "Inspect project knowledge in a new session", systemPrompt: "base system prompt" },
+    ctx,
+  );
+  await _flushDeferredContextMaintenanceForTest(base);
+
+  const nextSessionPass = adapter
+    .prepare("SELECT COUNT(*) AS count FROM memories WHERE structured_fields LIKE '%\"sourceKnowledgeId\":\"P002\"%'")
+    .get() as { count: number };
+  assert.equal(nextSessionPass.count, 1, "startup maintenance should run once for a later session");
 });
 
 test("#896 later turns reopen the project DB after startup maintenance is complete", async (t) => {

--- a/src/resources/extensions/gsd/tests/memory-consolidation-scanner.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-consolidation-scanner.test.ts
@@ -16,6 +16,7 @@ import {
   openDatabase,
   closeDatabase,
   insertDecision,
+  _getAdapter,
 } from "../gsd-db.ts";
 import { createMemory } from "../memory-store.ts";
 import {
@@ -266,6 +267,83 @@ test("scanConsolidationGaps combines decisions and KNOWLEDGE.md gaps in summary"
     assert.equal(report.totalGaps, 2);
     assert.match(report.summary, /1 of 1 active decisions/);
     assert.match(report.summary, /1 of 1 KNOWLEDGE\.md rows/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("scanConsolidationGaps collects memory source markers with one memories scan", () => {
+  const base = makeTmpBase();
+  try {
+    insertDecision({
+      id: "D001",
+      when_context: "2026-01-01",
+      scope: "M001",
+      decision: "Unmigrated decision",
+      choice: "A",
+      rationale: "x",
+      revisable: "yes",
+      made_by: "agent",
+      superseded_by: null,
+    });
+    insertDecision({
+      id: "D002",
+      when_context: "2026-01-02",
+      scope: "M001",
+      decision: "Migrated decision",
+      choice: "B",
+      rationale: "y",
+      revisable: "yes",
+      made_by: "agent",
+      superseded_by: null,
+    });
+    createMemory({
+      category: "architecture",
+      content: "Migrated decision Chose: B. Rationale: y.",
+      scope: "M001",
+      structuredFields: { sourceDecisionId: "D002" },
+    });
+    createMemory({
+      category: "pattern",
+      content: "Migrated knowledge pattern",
+      scope: "project",
+      structuredFields: { sourceKnowledgeId: "P001" },
+    });
+    writeKnowledgeMd(
+      base,
+      `## Patterns
+
+| # | Pattern | Where | Notes |
+|---|---------|-------|-------|
+| P001 | Migrated knowledge pattern | scanner | covered |
+| P002 | Unmigrated knowledge pattern | scanner | gap |
+`,
+    );
+
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    const originalPrepare = adapter.prepare.bind(adapter);
+    const memorySql: string[] = [];
+    adapter.prepare = (sql: string) => {
+      if (sql.includes("FROM memories")) memorySql.push(sql);
+      return originalPrepare(sql);
+    };
+
+    const report = scanConsolidationGaps(base);
+    assert.equal(report.decisions.migrated, 1);
+    assert.equal(report.decisions.unmigrated, 1);
+    assert.equal(report.knowledge.migrated, 1);
+    assert.equal(report.knowledge.unmigrated, 1);
+    assert.equal(
+      memorySql.filter((sql) => sql.includes("SELECT structured_fields FROM memories")).length,
+      1,
+      "source marker detection should read memories once",
+    );
+    assert.equal(
+      memorySql.some((sql) => sql.includes("LIKE :pattern")),
+      false,
+      "scanner must not reintroduce per-row LIKE marker probes",
+    );
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Fixed session-once startup maintenance and batched consolidation marker scanning, with syntax and diff checks passing while full tests were dependency-blocked.

## Bugs Addressed
- [x] **Maintenance work reruns before every user turn**
- [x] **Consolidation scanner prepares LIKE query per row**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #890
- [#890 [Bug]: Per-turn before_agent_start re-runs memory/knowledge backfills + N+1 LIKE-scan consolidation scanner every turn (no session-once guard)](https://github.com/open-gsd/gsd-pi/issues/890)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/890-bug-per-turn-before-agent-start-re-runs--1782565904`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every-turn `before_agent_start` bootstrap and session identity fallbacks; wrong session keying could skip needed backfills or rerun them, but behavior is covered by regression tests and idempotent migrations.
> 
> **Overview**
> Fixes **per-turn** `before_agent_start` work that was keyed only by project path, so memory/knowledge backfills and deferred maintenance could run on every user turn in the same chat.
> 
> **Session-scoped guards** in `system-context.ts` now use a maintenance key of `basePath` plus session id (or session file, or process fallback). Completed/in-flight/deferred maps are per session; later turns in the same session still call `ensureDbOpen` but skip backfills. A new session on the same repo runs startup maintenance again.
> 
> **Consolidation scanner** in `memory-consolidation-scanner.ts` replaces per-row `structured_fields LIKE` probes with one pass over `memories` that builds sets of `sourceDecisionId` and `sourceKnowledgeId`, so gap detection stays aligned with backfill idempotency without N+1 queries.
> 
> Tests cover same-session skip vs new-session rerun and assert a single memories read with no LIKE marker queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee7ad50ecd5ca4e782f4f110844e7411135006b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->