### PR TITLE
fix(issue): [Bug]: /api/visualizer forks a fresh Node subprocess on every poll with no caching (2/4/8 spawns/min)

### DIFF
--- a/src/tests/visualizer-service.test.ts
+++ b/src/tests/visualizer-service.test.ts
@@ -172,3 +172,69 @@ test("collectVisualizerData shares in-flight work and reuses a recent project re
   pendingExecs.shift()?.(null, JSON.stringify(createVisualizerPayload("refreshed")), "")
   assert.deepEqual(await refreshed, createVisualizerPayload("refreshed"))
 })
+
+test("collectVisualizerData expires a stuck in-flight subprocess and ignores its late result", async (t) => {
+  const mutableChildProcess = childProcess as typeof childProcess & {
+    execFile: typeof childProcess.execFile
+  }
+  const mutableFs = fs as typeof fs & {
+    existsSync: typeof fs.existsSync
+  }
+  const originalExecFile = mutableChildProcess.execFile
+  const originalExistsSync = mutableFs.existsSync
+  const originalDateNow = Date.now
+  const originalPackageRoot = process.env.GSD_WEB_PACKAGE_ROOT
+
+  type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+  const pendingExecs: ExecCallback[] = []
+  let execCount = 0
+  let now = 1_000
+
+  mutableChildProcess.execFile = ((...args: unknown[]) => {
+    execCount += 1
+    pendingExecs.push(args[3] as ExecCallback)
+    return {} as ReturnType<typeof childProcess.execFile>
+  }) as typeof childProcess.execFile
+  mutableFs.existsSync = (() => true) as typeof fs.existsSync
+  Date.now = () => now
+  process.env.GSD_WEB_PACKAGE_ROOT = join(tmpdir(), "gsd-pi-visualizer-cache-test-stuck")
+  syncBuiltinESMExports()
+
+  t.after(() => {
+    mutableChildProcess.execFile = originalExecFile
+    mutableFs.existsSync = originalExistsSync
+    Date.now = originalDateNow
+    if (originalPackageRoot === undefined) {
+      delete process.env.GSD_WEB_PACKAGE_ROOT
+    } else {
+      process.env.GSD_WEB_PACKAGE_ROOT = originalPackageRoot
+    }
+    syncBuiltinESMExports()
+  })
+
+  const visualizerService = await import("../web/visualizer-service.ts")
+  visualizerService.resetVisualizerDataCacheForTests()
+
+  const stuck = visualizerService.collectVisualizerData("/project-stuck")
+  const shared = visualizerService.collectVisualizerData("/project-stuck")
+  assert.equal(execCount, 1, "requests share the subprocess before the in-flight entry expires")
+
+  now = 31_001
+  const refreshed = visualizerService.collectVisualizerData("/project-stuck")
+  assert.equal(execCount, 2, "stuck in-flight entries expire and spawn a fresh subprocess")
+
+  pendingExecs[1]?.(null, JSON.stringify(createVisualizerPayload("fresh")), "")
+  assert.deepEqual(await refreshed, createVisualizerPayload("fresh"))
+
+  pendingExecs[0]?.(null, JSON.stringify(createVisualizerPayload("stale")), "")
+  assert.deepEqual(await Promise.all([stuck, shared]), [
+    createVisualizerPayload("stale"),
+    createVisualizerPayload("stale"),
+  ])
+
+  assert.deepEqual(
+    await visualizerService.collectVisualizerData("/project-stuck"),
+    createVisualizerPayload("fresh"),
+    "a late result from an expired in-flight subprocess must not replace the current cache entry",
+  )
+})

--- a/src/tests/visualizer-service.test.ts
+++ b/src/tests/visualizer-service.test.ts
@@ -40,6 +40,66 @@ function createVisualizerPayload(phase: string): SerializedVisualizerData {
   }
 }
 
+test("collectVisualizerData clears the cache entry when the subprocess errors, allowing retries", async (t) => {
+  const mutableChildProcess = childProcess as typeof childProcess & {
+    execFile: typeof childProcess.execFile
+  }
+  const mutableFs = fs as typeof fs & {
+    existsSync: typeof fs.existsSync
+  }
+  const originalExecFile = mutableChildProcess.execFile
+  const originalExistsSync = mutableFs.existsSync
+  const originalPackageRoot = process.env.GSD_WEB_PACKAGE_ROOT
+
+  type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+  const pendingExecs: ExecCallback[] = []
+  let execCount = 0
+
+  mutableChildProcess.execFile = ((...args: unknown[]) => {
+    execCount += 1
+    pendingExecs.push(args[3] as ExecCallback)
+    return {} as ReturnType<typeof childProcess.execFile>
+  }) as typeof childProcess.execFile
+  mutableFs.existsSync = (() => true) as typeof fs.existsSync
+  process.env.GSD_WEB_PACKAGE_ROOT = join(tmpdir(), "gsd-pi-visualizer-cache-test-error")
+  syncBuiltinESMExports()
+
+  t.after(() => {
+    mutableChildProcess.execFile = originalExecFile
+    mutableFs.existsSync = originalExistsSync
+    if (originalPackageRoot === undefined) {
+      delete process.env.GSD_WEB_PACKAGE_ROOT
+    } else {
+      process.env.GSD_WEB_PACKAGE_ROOT = originalPackageRoot
+    }
+    syncBuiltinESMExports()
+  })
+
+  const visualizerService = await import("../web/visualizer-service.ts")
+  visualizerService.resetVisualizerDataCacheForTests()
+
+  // Start two concurrent requests — they share the same in-flight promise.
+  const first = visualizerService.collectVisualizerData("/project-err")
+  const second = visualizerService.collectVisualizerData("/project-err")
+  assert.equal(execCount, 1, "concurrent requests share one subprocess")
+
+  // Simulate a subprocess timeout / error (what execFile calls back with when its
+  // `timeout` option fires and the child is killed).
+  const timedOutError = Object.assign(new Error("spawnSync node ETIMEDOUT"), { killed: true, signal: "SIGTERM" })
+  pendingExecs.shift()?.(timedOutError, "", "")
+
+  // Both callers should receive a rejection.
+  await assert.rejects(first, /subprocess failed/)
+  // `second` holds the same promise reference, also rejected.
+  await assert.rejects(second, /subprocess failed/)
+
+  // After the error the cache entry must be cleared so a retry spawns a fresh subprocess.
+  const retry = visualizerService.collectVisualizerData("/project-err")
+  assert.equal(execCount, 2, "retry after timeout spawns a new subprocess")
+  pendingExecs.shift()?.(null, JSON.stringify(createVisualizerPayload("retry")), "")
+  assert.deepEqual(await retry, createVisualizerPayload("retry"))
+})
+
 test("collectVisualizerData shares in-flight work and reuses a recent project result", async (t) => {
   const mutableChildProcess = childProcess as typeof childProcess & {
     execFile: typeof childProcess.execFile

--- a/src/tests/visualizer-service.test.ts
+++ b/src/tests/visualizer-service.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict"
+import { createRequire, syncBuiltinESMExports } from "node:module"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import test from "node:test"
+
+import type { SerializedVisualizerData } from "../web/visualizer-service.ts"
+
+const require = createRequire(import.meta.url)
+const childProcess = require("node:child_process") as typeof import("node:child_process")
+const fs = require("node:fs") as typeof import("node:fs")
+
+function createVisualizerPayload(phase: string): SerializedVisualizerData {
+  return {
+    milestones: [],
+    phase,
+    totals: null,
+    byPhase: [],
+    bySlice: [],
+    byModel: [],
+    byTier: [],
+    tierSavingsLine: "",
+    units: [],
+    criticalPath: {
+      milestonePath: [],
+      slicePath: [],
+      milestoneSlack: {},
+      sliceSlack: {},
+    },
+    remainingSliceCount: 0,
+    agentActivity: null,
+    changelog: null,
+    sliceVerifications: [],
+    knowledge: null,
+    memories: null,
+    captures: null,
+    health: null,
+    discussion: [],
+    stats: null,
+  }
+}
+
+test("collectVisualizerData shares in-flight work and reuses a recent project result", async (t) => {
+  const mutableChildProcess = childProcess as typeof childProcess & {
+    execFile: typeof childProcess.execFile
+  }
+  const mutableFs = fs as typeof fs & {
+    existsSync: typeof fs.existsSync
+  }
+  const originalExecFile = mutableChildProcess.execFile
+  const originalExistsSync = mutableFs.existsSync
+  const originalDateNow = Date.now
+  const originalPackageRoot = process.env.GSD_WEB_PACKAGE_ROOT
+
+  type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+  const pendingExecs: ExecCallback[] = []
+  let execCount = 0
+  let now = 1_000
+
+  mutableChildProcess.execFile = ((...args: unknown[]) => {
+    execCount += 1
+    pendingExecs.push(args[3] as ExecCallback)
+    return {} as ReturnType<typeof childProcess.execFile>
+  }) as typeof childProcess.execFile
+  mutableFs.existsSync = (() => true) as typeof fs.existsSync
+  Date.now = () => now
+  process.env.GSD_WEB_PACKAGE_ROOT = join(tmpdir(), "gsd-pi-visualizer-cache-test")
+  syncBuiltinESMExports()
+
+  t.after(() => {
+    mutableChildProcess.execFile = originalExecFile
+    mutableFs.existsSync = originalExistsSync
+    Date.now = originalDateNow
+    if (originalPackageRoot === undefined) {
+      delete process.env.GSD_WEB_PACKAGE_ROOT
+    } else {
+      process.env.GSD_WEB_PACKAGE_ROOT = originalPackageRoot
+    }
+    syncBuiltinESMExports()
+  })
+
+  const visualizerService = await import("../web/visualizer-service.ts")
+  visualizerService.resetVisualizerDataCacheForTests()
+
+  const first = visualizerService.collectVisualizerData("/project-a")
+  const second = visualizerService.collectVisualizerData("/project-a")
+
+  assert.equal(execCount, 1, "concurrent requests for one project share the subprocess")
+  pendingExecs.shift()?.(null, JSON.stringify(createVisualizerPayload("first")), "")
+
+  assert.deepEqual(await Promise.all([first, second]), [
+    createVisualizerPayload("first"),
+    createVisualizerPayload("first"),
+  ])
+
+  now = 5_000
+  assert.deepEqual(
+    await visualizerService.collectVisualizerData("/project-a"),
+    createVisualizerPayload("first"),
+    "requests inside the TTL reuse the cached payload",
+  )
+  assert.equal(execCount, 1)
+
+  const otherProject = visualizerService.collectVisualizerData("/project-b")
+  assert.equal(execCount, 2, "cache entries are keyed by project cwd")
+  pendingExecs.shift()?.(null, JSON.stringify(createVisualizerPayload("second")), "")
+  assert.deepEqual(await otherProject, createVisualizerPayload("second"))
+
+  now = 11_001
+  const refreshed = visualizerService.collectVisualizerData("/project-a")
+  assert.equal(execCount, 3, "expired cache entries refresh with a new subprocess")
+  pendingExecs.shift()?.(null, JSON.stringify(createVisualizerPayload("refreshed")), "")
+  assert.deepEqual(await refreshed, createVisualizerPayload("refreshed"))
+})

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -10,6 +10,7 @@ import { resolveSubprocessModule, buildSubprocessPrefixArgs } from "./ts-subproc
 
 const VISUALIZER_MAX_BUFFER = 2 * 1024 * 1024
 const VISUALIZER_CACHE_TTL_MS = 10_000
+const VISUALIZER_TIMEOUT_MS = 30_000
 const VISUALIZER_MODULE_ENV = "GSD_VISUALIZER_MODULE"
 
 /**
@@ -154,6 +155,7 @@ async function loadVisualizerData(config: VisualizerRuntimeConfig): Promise<Seri
           GSD_VISUALIZER_BASE: projectCwd,
         },
         maxBuffer: VISUALIZER_MAX_BUFFER,
+        timeout: VISUALIZER_TIMEOUT_MS,
         windowsHide: true,
       },
       (error, stdout, stderr) => {

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -73,7 +73,7 @@ export async function collectVisualizerData(projectCwdOverride?: string): Promis
   const cached = visualizerDataCache.get(cacheKey)
   const now = Date.now()
 
-  if (cached?.promise) {
+  if (cached?.promise && cached.expiresAt >= now) {
     return cached.promise
   }
   if (cached?.data && cached.expiresAt >= now) {
@@ -81,14 +81,19 @@ export async function collectVisualizerData(projectCwdOverride?: string): Promis
   }
 
   const promise = loadVisualizerData(config)
-  visualizerDataCache.set(cacheKey, { promise, expiresAt: 0 })
+  visualizerDataCache.set(cacheKey, {
+    promise,
+    expiresAt: now + VISUALIZER_TIMEOUT_MS,
+  })
 
   try {
     const data = await promise
-    visualizerDataCache.set(cacheKey, {
-      data,
-      expiresAt: Date.now() + VISUALIZER_CACHE_TTL_MS,
-    })
+    if (visualizerDataCache.get(cacheKey)?.promise === promise) {
+      visualizerDataCache.set(cacheKey, {
+        data,
+        expiresAt: Date.now() + VISUALIZER_CACHE_TTL_MS,
+      })
+    }
     return data
   } catch (error) {
     if (visualizerDataCache.get(cacheKey)?.promise === promise) {

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -6,9 +6,10 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag, resolveSubprocessModule, buildSubprocessPrefixArgs } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule, buildSubprocessPrefixArgs } from "./ts-subprocess-flags.ts"
 
 const VISUALIZER_MAX_BUFFER = 2 * 1024 * 1024
+const VISUALIZER_CACHE_TTL_MS = 10_000
 const VISUALIZER_MODULE_ENV = "GSD_VISUALIZER_MODULE"
 
 /**
@@ -46,6 +47,15 @@ export interface SerializedVisualizerData {
   stats: unknown
 }
 
+type VisualizerRuntimeConfig = ReturnType<typeof resolveBridgeRuntimeConfig>
+type VisualizerCacheEntry = {
+  promise?: Promise<SerializedVisualizerData>
+  data?: SerializedVisualizerData
+  expiresAt: number
+}
+
+const visualizerDataCache = new Map<string, VisualizerCacheEntry>()
+
 function resolveTsLoaderPath(packageRoot: string): string {
   return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
 }
@@ -58,6 +68,41 @@ function resolveTsLoaderPath(packageRoot: string): string {
  */
 export async function collectVisualizerData(projectCwdOverride?: string): Promise<SerializedVisualizerData> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
+  const cacheKey = config.projectCwd
+  const cached = visualizerDataCache.get(cacheKey)
+  const now = Date.now()
+
+  if (cached?.promise) {
+    return cached.promise
+  }
+  if (cached?.data && cached.expiresAt >= now) {
+    return cached.data
+  }
+
+  const promise = loadVisualizerData(config)
+  visualizerDataCache.set(cacheKey, { promise, expiresAt: 0 })
+
+  try {
+    const data = await promise
+    visualizerDataCache.set(cacheKey, {
+      data,
+      expiresAt: Date.now() + VISUALIZER_CACHE_TTL_MS,
+    })
+    return data
+  } catch (error) {
+    if (visualizerDataCache.get(cacheKey)?.promise === promise) {
+      visualizerDataCache.delete(cacheKey)
+    }
+    throw error
+  }
+}
+
+/** @internal — test-only: reset the in-process visualizer data cache. */
+export function resetVisualizerDataCacheForTests(): void {
+  visualizerDataCache.clear()
+}
+
+async function loadVisualizerData(config: VisualizerRuntimeConfig): Promise<SerializedVisualizerData> {
   const { packageRoot, projectCwd } = config
 
   const resolveTsLoader = resolveTsLoaderPath(packageRoot)


### PR DESCRIPTION
## Summary
- Added per-project visualizer data caching with focused regression coverage; syntax and whitespace checks pass, while runtime tests were blocked by unavailable dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #895
- [#895 [Bug]: /api/visualizer forks a fresh Node subprocess on every poll with no caching (2/4/8 spawns/min)](https://github.com/open-gsd/gsd-pi/issues/895)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/895-bug-api-visualizer-forks-a-fresh-node-su-1782565942`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path behavior for the visualizer API (caching, timeouts, and race handling); mistakes could serve stale data or leave polls stuck, but scope is limited to subprocess collection—not auth or persistence.
> 
> **Overview**
> Stops `/api/visualizer` from spawning a new Node subprocess on every poll by adding an **in-process, per-project cache** in `collectVisualizerData`.
> 
> Concurrent requests for the same project cwd **share one in-flight promise**; successful responses are reused for **10s** (`VISUALIZER_CACHE_TTL_MS`). The child `execFile` call now has a **30s timeout**, and failed runs **drop the cache entry** so the next request can retry. If an in-flight load outlives that window, a new subprocess can start and **late completions from the old run must not overwrite** the newer cached result. Subprocess loading is moved into `loadVisualizerData`, with `resetVisualizerDataCacheForTests` for isolation.
> 
> Adds **`visualizer-service.test.ts`** with mocked `execFile`/`Date.now` coverage for sharing, TTL, per-project keys, errors, stuck in-flight expiry, and stale-result rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9971979877ea010ac6badf27ab190fc125f4de44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->