### PR TITLE
fix(issue): [Bug]: Milestone implementation-evidence check spawns one `git diff-tree` per commit across full history (N+1)

### DIFF
--- a/src/resources/extensions/gsd/milestone-implementation-evidence.ts
+++ b/src/resources/extensions/gsd/milestone-implementation-evidence.ts
@@ -19,6 +19,16 @@ import { resolveTasksDir } from "./paths.js";
 
 /** Large enough for unbounded milestone-history git log scans in big repos. */
 const GIT_LOG_MAX_BUFFER = 16 * 1024 * 1024;
+const LOG_FIELD_SEPARATOR = "\x1f";
+const LOG_RECORD_SEPARATOR = "\x1e";
+
+type CommitRecord = {
+  hash: string;
+  parents: string;
+  committedAt: string;
+  message: string;
+  files: string[];
+};
 
 /**
  * Check whether a milestone produced implementation artifacts (non-`.gsd/`
@@ -198,7 +208,7 @@ function getChangedFilesFromMilestoneTaggedCommits(
   // Primary: path-scoped log against .gsd/milestones/<id>. Fast and unbounded
   // by depth when .gsd/ is tracked in git.
   const scoped = scanGsdTaggedCommits(basePath, milestoneId, [
-    "log", "--format=%H%x1f%B%x1e", "HEAD", "--", `.gsd/milestones/${milestoneId}`,
+    "log", "--full-diff", "--name-only", "--format=%x1e%H%x1f%B%x1f", "HEAD", "--", `.gsd/milestones/${milestoneId}`,
   ]);
   if (!scoped.ok) return scoped;
   if (scoped.matched && classifyImplementationFiles(scoped.files) === "present") return scoped;
@@ -213,7 +223,7 @@ function getChangedFilesFromMilestoneTaggedCommits(
   // reintroducing the rolling-depth failure class removed in #4699 where
   // milestone evidence aged out behind unrelated activity.
   const unscoped = scanGsdTaggedCommits(basePath, milestoneId, [
-    "log", "--format=%H%x1f%B%x1e", "HEAD",
+    "log", "--name-only", "--format=%x1e%H%x1f%B%x1f", "HEAD",
   ]);
   if (!unscoped.ok) return scoped.matched ? scoped : unscoped;
   if (!unscoped.matched) return scoped;
@@ -299,8 +309,7 @@ function backfillChangedFilesFromUntaggedMilestoneCommits(
       if (record.parents.trim().split(/\s+/).filter(Boolean).length > 1) continue;
       if (commitMessageHasGsdTrailer(record.message)) continue;
 
-      const commitFiles = getChangedFilesForCommit(basePath, record.hash);
-      const implementationFiles = commitFiles.map(normalizeRepoPath).filter(isImplementationPath);
+      const implementationFiles = record.files.map(normalizeRepoPath).filter(isImplementationPath);
       if (implementationFiles.length === 0) continue;
       if (!implementationFiles.some((file) => hintSet.has(file))) continue;
 
@@ -323,23 +332,28 @@ function backfillChangedFilesFromUntaggedMilestoneCommits(
   }
 }
 
-function getCommitRecords(basePath: string): Array<{ hash: string; parents: string; committedAt: string; message: string }> {
-  const logOutput = execFileSync("git", ["log", "--format=%H%x1f%P%x1f%cI%x1f%B%x1e", "HEAD"], {
+function getCommitRecords(basePath: string): CommitRecord[] {
+  const logOutput = execFileSync("git", ["log", "--name-only", "--format=%x1e%H%x1f%P%x1f%cI%x1f%B%x1f", "HEAD"], {
     cwd: basePath,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
     maxBuffer: GIT_LOG_MAX_BUFFER,
   });
   return logOutput
-    .split("\x1e")
-    .map((record) => record.trim())
+    .split(LOG_RECORD_SEPARATOR)
     .filter(Boolean)
     .flatMap((record) => {
-      const parts = record.split("\x1f");
-      if (parts.length < 4) return [];
-      const [hash, parents, committedAt, ...messageParts] = parts;
-      return [{ hash: hash.trim(), parents: parents.trim(), committedAt: committedAt.trim(), message: messageParts.join("\x1f") }];
+      const parts = record.split(LOG_FIELD_SEPARATOR);
+      if (parts.length < 5) return [];
+      const [hash, parents, committedAt] = parts;
+      const files = parseNameOnlyFiles(parts.at(-1) ?? "");
+      const message = parts.slice(3, -1).join(LOG_FIELD_SEPARATOR);
+      return [{ hash: hash.trim(), parents: parents.trim(), committedAt: committedAt.trim(), message, files }];
     });
+}
+
+function parseNameOnlyFiles(rawFiles: string): string[] {
+  return rawFiles.split(/\r?\n/).map((file) => file.trim()).filter(Boolean);
 }
 
 function isFullCommitSha(value: string): boolean {
@@ -359,23 +373,23 @@ function scanGsdTaggedCommits(
       maxBuffer: GIT_LOG_MAX_BUFFER,
     });
     const records = logOutput
-      .split("\x1e")
-      .map((record) => record.trim())
+      .split(LOG_RECORD_SEPARATOR)
       .filter(Boolean)
       .flatMap((record) => {
-        const sep = record.indexOf("\x1f");
-        if (sep === -1) return [];
-        const hash = record.slice(0, sep).trim();
-        const message = record.slice(sep + 1);
-        return [{ hash, message }];
+        const parts = record.split(LOG_FIELD_SEPARATOR);
+        if (parts.length < 3) return [];
+        const hash = parts[0].trim();
+        if (!hash) return [];
+        const files = parseNameOnlyFiles(parts.at(-1) ?? "");
+        const message = parts.slice(1, -1).join(LOG_FIELD_SEPARATOR);
+        return [{ message, files }];
       });
 
     const files = new Set<string>();
     let matched = false;
-    for (const { hash, message } of records) {
+    for (const { message, files: commitFiles } of records) {
       if (!commitMessageHasGsdTrailer(message)) continue;
 
-      const commitFiles = getChangedFilesForCommit(basePath, hash);
       if (!commitMatchesMilestone(basePath, message, milestoneId, commitFiles)) continue;
 
       matched = true;

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Tests auto-mode artifact verification and recovery behavior.
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -964,6 +964,45 @@ function makeGitBase(): string {
   return base;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function withLoggedGitCommands<T>(base: string, action: () => T): { result: T; commands: string[] } {
+  const realGit = execFileSync("which", ["git"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim().split(/\r?\n/)[0];
+  if (!realGit) throw new Error("Unable to resolve git executable for invocation logging test");
+  const binDir = join(base, ".git-wrapper-bin");
+  const logFile = join(base, "git-invocations.log");
+  mkdirSync(binDir, { recursive: true });
+  const wrapper = join(binDir, "git");
+  writeFileSync(
+    wrapper,
+    [
+      "#!/usr/bin/env bash",
+      `printf '%s\\n' "$1" >> ${shellQuote(logFile)}`,
+      `exec ${shellQuote(realGit)} "$@"`,
+      "",
+    ].join("\n"),
+  );
+  chmodSync(wrapper, 0o755);
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = originalPath ? `${binDir}:${originalPath}` : binDir;
+  try {
+    const result = action();
+    const commands = existsSync(logFile)
+      ? readFileSync(logFile, "utf-8").split(/\r?\n/).filter(Boolean)
+      : [];
+    return { result, commands };
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+  }
+}
+
 test("hasImplementationArtifacts returns false when only .gsd/ files committed (#1703)", () => {
   const base = makeGitBase();
   try {
@@ -1339,6 +1378,77 @@ test("hasImplementationArtifacts finds implementation commits when .gsd/ is giti
       "present",
       "milestone-tagged commit binding must work when .gsd/ is gitignored",
     );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts scans GSD-tagged history without per-commit diff-tree forks (#892)", { skip: process.platform === "win32" }, () => {
+  const base = makeGitBase();
+  try {
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+      "# Summary",
+    );
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(join(base, "src", `feature-${i}.ts`), `export const feature${i} = true;\n`);
+      execFileSync("git", ["add", "src"], { cwd: base, stdio: "ignore" });
+      execFileSync(
+        "git",
+        ["commit", "-m", `feat: materialize M001 evidence ${i}\n\nGSD-Task: S01/T01`],
+        { cwd: base, stdio: "ignore" },
+      );
+    }
+
+    const { result, commands } = withLoggedGitCommands(base, () => hasImplementationArtifacts(base, "M001"));
+    assert.equal(result, "present", "milestone-tagged commits should still prove implementation evidence");
+    assert.ok(commands.includes("log"), "milestone evidence fallback should scan history with git log");
+    assert.equal(commands.filter((command) => command === "diff-tree").length, 0);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts backfill scans commit records without per-commit diff-tree forks (#892)", { skip: process.platform === "win32" }, () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+      keyFiles: ["src/expected-0.ts", "src/expected-1.ts"],
+      planning: { files: ["src/expected-0.ts", "src/expected-1.ts"] },
+    });
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    for (let i = 0; i < 2; i++) {
+      writeFileSync(join(base, "src", `expected-${i}.ts`), `export const expected${i} = true;\n`);
+      execFileSync("git", ["add", "src"], { cwd: base, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", `feat: untagged implementation ${i}`], { cwd: base, stdio: "ignore" });
+    }
+
+    const { result, commands } = withLoggedGitCommands(base, () => hasImplementationArtifacts(base, "M001"));
+    assert.equal(result, "present", "completed task file hints should still backfill untagged commits");
+    assert.equal(getMilestoneCommitAttributionShas("M001").length, 2);
+    assert.ok(commands.includes("log"), "backfill should scan commit records with git log");
+    assert.equal(commands.filter((command) => command === "diff-tree").length, 0);
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Reduced milestone evidence fallback git forks to single log scans and verified syntax/parser checks; full tests were blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #892
- [#892 [Bug]: Milestone implementation-evidence check spawns one `git diff-tree` per commit across full history (N+1)](https://github.com/open-gsd/gsd-pi/issues/892)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/892-bug-milestone-implementation-evidence-ch-1782565913`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches closeout/recovery git evidence logic on unbounded history scans; behavior should match prior semantics but log format parsing is subtle and attributed-SHA paths still use per-commit diff-tree.
> 
> **Overview**
> Fixes an **N+1 git fork** where milestone implementation-evidence fallback walked full history and ran **`git diff-tree` once per commit** for GSD-tagged scans and untagged backfill.
> 
> **`milestone-implementation-evidence.ts`** now pulls changed paths in the same pass as metadata using **`git log --name-only`** (and **`--full-diff`** on the path-scoped tagged scan), with record parsing via shared separators and a **`CommitRecord`** that carries **`files`**. Tagged-commit matching and backfill read those lists instead of spawning **`diff-tree`** per SHA.
> 
> **Tests** add a PATH-wrapped **`git`** logger and assert GSD-tagged and backfill paths still report **present** while issuing **`log`** only—**zero `diff-tree`** invocations (non-Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b106f2ab1a110596515993025438ee03427551d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->