### PR TITLE
fix(issue): [Bug]: Opening or scrolling the dashboard overlay runs the synchronous environment-doctor subprocess suite, freezing the TUI

### DIFF
--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -29,7 +29,7 @@ import { getWorkerBatches, hasActiveWorkers, type WorkerEntry } from "../subagen
 import { formatDuration, padRight, joinColumns, centerLine, fitColumns, STATUS_GLYPH, STATUS_COLOR } from "../shared/mod.js";
 import { estimateTimeRemaining } from "./auto-dashboard.js";
 import { computeProgressScore, formatProgressLine } from "./progress-score.js";
-import { runEnvironmentChecks, type EnvironmentCheckResult } from "./doctor-environment.js";
+import { runEnvironmentChecksAsync, type EnvironmentCheckResult } from "./doctor-environment.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { renderDialogFrame, renderKeyHints } from "./tui/render-kit.js";
 
@@ -71,6 +71,9 @@ export class GSDDashboardOverlay {
   private loading = true;
   private loadedDashboardIdentity?: string;
   private refreshInFlight: Promise<void> | null = null;
+  private envRefreshInFlight: Promise<void> | null = null;
+  private cachedEnvBasePath?: string;
+  private cachedEnvIssues: EnvironmentCheckResult[] = [];
   private disposed = false;
   private resizeHandler: (() => void) | null = null;
   private cachedMetrics: {
@@ -181,10 +184,37 @@ export class GSDDashboardOverlay {
       this.loading = false;
     }
 
+    this.scheduleEnvironmentRefresh(this.dashData.basePath || process.cwd());
+
     if (identityChanged) {
       this.invalidate();
     }
     this.tui.requestRender();
+  }
+
+  private scheduleEnvironmentRefresh(basePath: string): void {
+    if (this.cachedEnvBasePath !== basePath) {
+      this.cachedEnvBasePath = basePath;
+      this.cachedEnvIssues = [];
+      this.invalidate();
+    }
+    if (this.envRefreshInFlight || this.disposed) return;
+    this.envRefreshInFlight = this.refreshEnvironmentHealth(basePath)
+      .finally(() => {
+        this.envRefreshInFlight = null;
+      });
+  }
+
+  private async refreshEnvironmentHealth(basePath: string): Promise<void> {
+    try {
+      const envResults = await runEnvironmentChecksAsync(basePath);
+      if (this.disposed || this.cachedEnvBasePath !== basePath) return;
+      this.cachedEnvIssues = envResults.filter(r => r.status !== "ok");
+      this.invalidate();
+      this.tui.requestRender();
+    } catch {
+      // Non-fatal — keep last known environment issues
+    }
   }
 
   private async loadData(): Promise<boolean> {
@@ -629,8 +659,7 @@ export class GSDDashboardOverlay {
     }
 
     // Environment health section (#1221) — only show issues
-    const envResults = runEnvironmentChecks(this.dashData.basePath || process.cwd());
-    const envIssues = envResults.filter(r => r.status !== "ok");
+    const envIssues = this.cachedEnvIssues;
     if (envIssues.length > 0) {
       lines.push(blank());
       lines.push(hr());

--- a/src/resources/extensions/gsd/tests/dashboard-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/dashboard-overlay.test.ts
@@ -4,9 +4,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
+import { performance } from "node:perf_hooks";
 
 import { GSDDashboardOverlay } from "../dashboard-overlay.ts";
 import type { UnitMetrics } from "../metrics.ts";
@@ -82,6 +83,58 @@ test("GSDDashboardOverlay non-identity refresh avoids reparsing preferences", as
   await assert.doesNotReject(
     () => (overlay as any).refreshDashboard(false),
     "unchanged overlay identity should not call getAutoDashboardData or read preferences",
+  );
+});
+
+test("GSDDashboardOverlay render and scroll do not run environment doctor subprocesses", (t) => {
+  const basePath = join(
+    tmpdir(),
+    `gsd-dashboard-overlay-env-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  const shimDir = join(
+    tmpdir(),
+    `gsd-dashboard-overlay-shim-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(basePath, { recursive: true });
+  mkdirSync(shimDir, { recursive: true });
+  writeFileSync(join(basePath, "package.json"), JSON.stringify({ engines: { node: ">=22.0.0" } }));
+
+  const posixNodeShim = join(shimDir, "node");
+  writeFileSync(posixNodeShim, "#!/bin/sh\nsleep 1\nexit 1\n");
+  chmodSync(posixNodeShim, 0o755);
+  writeFileSync(join(shimDir, "node.cmd"), "@echo off\r\nping -n 2 127.0.0.1 > nul\r\nexit /b 1\r\n");
+
+  const originalPath = process.env.PATH;
+  const overlay = new GSDDashboardOverlay({ requestRender() {} }, fakeTheme as any, () => {});
+  overlay.dispose();
+
+  t.after(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    rmSync(basePath, { recursive: true, force: true });
+    rmSync(shimDir, { recursive: true, force: true });
+  });
+
+  (overlay as any).loading = false;
+  (overlay as any).milestoneData = null;
+  (overlay as any).dashData = {
+    ...(overlay as any).dashData,
+    basePath,
+  };
+
+  process.env.PATH = `${shimDir}${delimiter}${originalPath ?? ""}`;
+  const start = performance.now();
+  overlay.render(100);
+  overlay.handleInput("j");
+  overlay.render(100);
+  const elapsed = performance.now() - start;
+
+  assert.ok(
+    elapsed < 500,
+    `rendering and scrolling should not wait for environment subprocesses, took ${Math.round(elapsed)}ms`,
   );
 });
 


### PR DESCRIPTION
## Summary
- Fixed the dashboard overlay to render cached async environment health results and added a focused render/scroll regression test; dependency-free checks passed but test execution was blocked by missing offline packages.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #953
- [#953 [Bug]: Opening or scrolling the dashboard overlay runs the synchronous environment-doctor subprocess suite, freezing the TUI](https://github.com/open-gsd/gsd-pi/issues/953)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/953-bug-opening-or-scrolling-the-dashboard-o-1782565796`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to dashboard overlay rendering; uses existing async doctor API and preserves prior Environment UI behavior with deferred updates.
> 
> **Overview**
> **Fixes TUI freezes** when opening or scrolling the GSD dashboard overlay by removing synchronous environment-doctor subprocess work from the render path.
> 
> The overlay now **schedules** `runEnvironmentChecksAsync` during dashboard refresh, stores non-OK results in `cachedEnvIssues`, and the **Environment** section reads that cache during `buildContentLines` instead of calling `runEnvironmentChecks` on every paint. Base-path changes clear the cache and trigger a new background refresh; in-flight work is deduped and errors are non-fatal.
> 
> A regression test prepends a slow `node` shim to `PATH` and asserts `render` + scroll (`j`) complete in under 500ms without waiting on those subprocesses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b27aa5e14f759670c6b880d779c164a217a7dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->