### PR TITLE
fix(issue): [Bug]: Preferences serializer writes `post_unit_hooks[].on_block` as literal `[object Object]`, breaking every reload of the gate config

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1732,7 +1732,7 @@ export function serializePreferencesToFrontmatter(prefs: Record<string, unknown>
             } else if (typeof firstVal === "object" && firstVal !== null) {
               lines.push(`${prefix}  - ${firstKey}:`);
               for (const [k, v] of Object.entries(firstVal as Record<string, unknown>)) {
-                serializeValue(k, v, indent + 2);
+                serializeValue(k, v, indent + 3);
               }
             } else {
               lines.push(`${prefix}  - ${firstKey}: ${yamlSafeString(firstVal)}`);

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1724,17 +1724,22 @@ export function serializePreferencesToFrontmatter(prefs: Record<string, unknown>
           const entries = Object.entries(item as Record<string, unknown>);
           if (entries.length > 0) {
             const [firstKey, firstVal] = entries[0];
-            lines.push(`${prefix}  - ${firstKey}: ${yamlSafeString(firstVal)}`);
+            if (Array.isArray(firstVal)) {
+              lines.push(`${prefix}  - ${firstKey}:`);
+              for (const arrItem of firstVal) {
+                lines.push(`${prefix}      - ${yamlSafeString(arrItem)}`);
+              }
+            } else if (typeof firstVal === "object" && firstVal !== null) {
+              lines.push(`${prefix}  - ${firstKey}:`);
+              for (const [k, v] of Object.entries(firstVal as Record<string, unknown>)) {
+                serializeValue(k, v, indent + 2);
+              }
+            } else {
+              lines.push(`${prefix}  - ${firstKey}: ${yamlSafeString(firstVal)}`);
+            }
             for (let i = 1; i < entries.length; i++) {
               const [k, v] = entries[i];
-              if (Array.isArray(v)) {
-                lines.push(`${prefix}    ${k}:`);
-                for (const arrItem of v) {
-                  lines.push(`${prefix}      - ${yamlSafeString(arrItem)}`);
-                }
-              } else {
-                lines.push(`${prefix}    ${k}: ${yamlSafeString(v)}`);
-              }
+              serializeValue(k, v, indent + 2);
             }
           }
         } else {

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -135,7 +135,8 @@ test("prefs serializer correctly indents nested object when it is the first arra
   // on_block is the FIRST property — exercises the first-key-is-object branch
   const frontmatter = serializePreferencesToFrontmatter({
     post_unit_hooks: [{
-      on_block: { action: "pause" },
+      on_block: { action: "pause" }, // first property — exercises the first-key-is-object branch
+      name: "gate",                  // name comes after so on_block stays first
     }],
   });
 

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -131,6 +131,28 @@ test("prefs serializer preserves nested hook on_block objects", () => {
   assert.deepEqual(preferences.post_unit_hooks?.[0]?.on_block, { action: "pause" });
 });
 
+test("prefs serializer correctly indents nested object when it is the first array-item property", () => {
+  // on_block is the FIRST property — exercises the first-key-is-object branch
+  const frontmatter = serializePreferencesToFrontmatter({
+    post_unit_hooks: [{
+      on_block: { action: "pause" },
+    }],
+  });
+
+  assert.doesNotMatch(frontmatter, /\[object Object\]/);
+  // Children of on_block must be indented deeper than on_block itself (not siblings)
+  assert.ok(
+    frontmatter.includes("  - on_block:\n      action: pause\n"),
+    `Expected on_block children indented as nested YAML, got:\n${frontmatter}`,
+  );
+  // Sanity: parse + validate round-trip
+  const parsed = parsePreferencesMarkdown(`---\n${frontmatter}---\n`);
+  assert.notEqual(parsed, null);
+  const { errors, preferences } = validatePreferences(parsed!);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(preferences.post_unit_hooks?.[0]?.on_block, { action: "pause" });
+});
+
 test("prefs wizard save path preserves every known preference key", async () => {
   const missingSamples = [...KNOWN_PREFERENCE_KEYS].filter((key) => !(key in PREF_SAMPLE_VALUES));
   assert.deepEqual(missingSamples, [], "test fixture must cover every known preference key");

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -136,7 +136,9 @@ test("prefs serializer correctly indents nested object when it is the first arra
   const frontmatter = serializePreferencesToFrontmatter({
     post_unit_hooks: [{
       on_block: { action: "pause" }, // first property — exercises the first-key-is-object branch
-      name: "gate",                  // name comes after so on_block stays first
+      name: "gate",                  // required fields come after so on_block stays first
+      after: ["execute-task"],
+      prompt: "review output",
     }],
   });
 

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -6,7 +6,12 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { buildCategorySummaries, handlePrefsWizard } from "../commands-prefs-wizard.ts";
+import {
+  buildCategorySummaries,
+  handlePrefsWizard,
+  serializePreferencesToFrontmatter,
+} from "../commands-prefs-wizard.ts";
+import { parsePreferencesMarkdown, validatePreferences } from "../preferences.ts";
 import { KNOWN_PREFERENCE_KEYS } from "../preferences-types.ts";
 
 const PREF_SAMPLE_VALUES: Record<string, unknown> = {
@@ -102,6 +107,29 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
     },
   },
 };
+
+test("prefs serializer preserves nested hook on_block objects", () => {
+  const frontmatter = serializePreferencesToFrontmatter({
+    post_unit_hooks: [{
+      name: "plan-review",
+      after: ["execute-task"],
+      prompt: "write PLAN-REVIEW.md",
+      artifact: "PLAN-REVIEW.md",
+      criticality: "blocking",
+      on_block: { action: "pause" },
+    }],
+  });
+
+  assert.doesNotMatch(frontmatter, /\[object Object\]/);
+  assert.ok(frontmatter.includes("    on_block:\n      action: pause\n"));
+
+  const parsed = parsePreferencesMarkdown(`---\n${frontmatter}---\n`);
+  assert.notEqual(parsed, null);
+
+  const { errors, preferences } = validatePreferences(parsed!);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(preferences.post_unit_hooks?.[0]?.on_block, { action: "pause" });
+});
 
 test("prefs wizard save path preserves every known preference key", async () => {
   const missingSamples = [...KNOWN_PREFERENCE_KEYS].filter((key) => !(key in PREF_SAMPLE_VALUES));


### PR DESCRIPTION
## Summary
- Fixed nested hook on_block preference serialization and added regression coverage; whitespace and isolated serializer checks passed, while the focused test runner was blocked by missing dependencies/DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #943
- [#943 [Bug]: Preferences serializer writes `post_unit_hooks[].on_block` as literal `[object Object]`, breaking every reload of the gate config](https://github.com/open-gsd/gsd-pi/issues/943)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/943-bug-preferences-serializer-writes-post-u-1782565959`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to preferences serialization plus tests; no auth or runtime gate logic changes.
> 
> **Overview**
> Fixes preferences frontmatter serialization so nested objects inside list items (e.g. **`post_unit_hooks[].on_block`**) emit proper YAML instead of the literal **`[object Object]`**, which broke gate config on every reload after save.
> 
> **`serializeValue`** in `commands-prefs-wizard.ts` now treats the first field of each array-of-object entry like later fields: nested arrays and objects recurse through **`serializeValue`**, and scalar fields still use **`yamlSafeString`**.
> 
> Adds a regression test that round-trips **`on_block: { action: pause }`** through **`serializePreferencesToFrontmatter`**, **`parsePreferencesMarkdown`**, and **`validatePreferences`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c8e6f85da296e88b769df3b81d14db1722c6a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->