### PR TITLE
fix(issue): [Bug]: Per-commit `git rm --cached` cleanup loop re-runs on every unit dispatch (17 git spawns each time)

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -378,6 +378,8 @@ export const RUNTIME_EXCLUSION_PATHS: readonly string[] = [
   ".gsd/DISCUSSION-MANIFEST.json",
 ];
 
+const runtimeFilesCleanedUpRepos = new Set<string>();
+
 // ─── Integration Branch Metadata ───────────────────────────────────────────
 
 /**
@@ -755,7 +757,8 @@ export class GitServiceImpl {
     // and the worktree is torn down. This prevents a mid-execution behavioral
     // discontinuity where the first half of a milestone has .gsd/ artifacts
     // committed but the second half doesn't (#1326).
-    if (!this._runtimeFilesCleanedUp) {
+    const cleanupRepoKey = resolve(this.basePath);
+    if (!runtimeFilesCleanedUpRepos.has(cleanupRepoKey)) {
       let cleaned = false;
       for (const exclusion of RUNTIME_EXCLUSION_PATHS) {
         const removed = nativeRmCached(this.basePath, [exclusion]);
@@ -764,7 +767,7 @@ export class GitServiceImpl {
       if (cleaned) {
         nativeCommit(this.basePath, "chore: untrack .gsd/ runtime files from git index", { allowEmpty: false });
       }
-      this._runtimeFilesCleanedUp = true;
+      runtimeFilesCleanedUpRepos.add(cleanupRepoKey);
     }
 
     // Stage everything using pathspec exclusions so excluded paths are never
@@ -892,9 +895,6 @@ export class GitServiceImpl {
       return false;
     }
   }
-
-  /** Tracks whether runtime file cleanup has run this session. */
-  private _runtimeFilesCleanedUp = false;
 
   /**
    * Stage files (smart staging) and commit.

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -3,7 +3,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, readFileSync, chmodSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, delimiter } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync, execSync } from "node:child_process";
 
@@ -23,6 +23,7 @@ import {
   type PreMergeCheckResult,
   type TaskCommitContext,
 } from "../../git-service.ts";
+import { GIT_NO_PROMPT_ENV } from "../../git-constants.ts";
 import { nativeAddAllWithExclusions, nativeHasChanges, _resetHasChangesCache } from "../../native-git-bridge.ts";
 function run(command: string, cwd: string): string {
   return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
@@ -405,6 +406,49 @@ describe('git-service', async () => {
     }).trim();
   }
 
+  function findGitExecutable(): string {
+    const command = process.platform === "win32" ? "where git" : "command -v git";
+    const output = execSync(command, { encoding: "utf-8" });
+    const found = output.split(/\r?\n/).map(line => line.trim()).find(Boolean);
+    assert.ok(found, "git executable is available");
+    return found;
+  }
+
+  function installGitRmCachedCounterShim(shimDir: string): void {
+    const shimScript = join(shimDir, "git-shim.cjs");
+    writeFileSync(shimScript, `
+const { appendFileSync } = require("node:fs");
+const { spawnSync } = require("node:child_process");
+
+const args = process.argv.slice(2);
+if (args[0] === "rm" && args[1] === "--cached") {
+  appendFileSync(process.env.GSD_GIT_SHIM_LOG, args.join("\\0") + "\\n");
+}
+
+const result = spawnSync(process.env.GSD_REAL_GIT || "git", args, {
+  stdio: "inherit",
+  env: process.env,
+});
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 0);
+`.trimStart(), "utf-8");
+
+    const posixShim = join(shimDir, "git");
+    const quotedScript = `'${shimScript.replace(/'/g, "'\\''")}'`;
+    writeFileSync(posixShim, `#!/bin/sh\nexec node ${quotedScript} "$@"\n`, "utf-8");
+    chmodSync(posixShim, 0o755);
+
+    writeFileSync(join(shimDir, "git.cmd"), "@echo off\r\nnode \"%~dp0git-shim.cjs\" %*\r\n", "utf-8");
+  }
+
+  function countRmCachedInvocations(logFile: string): number {
+    if (!existsSync(logFile)) return 0;
+    return readFileSync(logFile, "utf-8").split(/\r?\n/).filter(Boolean).length;
+  }
+
   // ─── GitServiceImpl: smart staging ─────────────────────────────────────
 
   test('GitServiceImpl: smart staging', () => {
@@ -445,6 +489,80 @@ describe('git-service', async () => {
     assert.ok(statusOut.includes(".gsd/STATE.md"), "STATE.md still untracked after commit");
 
     rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('GitServiceImpl: runtime cleanup runs once per repo across service instances', () => {
+    const repo = initTempRepo();
+    const shimDir = mkdtempSync(join(tmpdir(), "gsd-git-rm-shim-"));
+    const logFile = join(shimDir, "git-rm-cached.log");
+    const originalPath = process.env.PATH;
+    const originalRealGit = process.env.GSD_REAL_GIT;
+    const originalShimLog = process.env.GSD_GIT_SHIM_LOG;
+    const originalSafePath = GIT_NO_PROMPT_ENV.PATH;
+    const originalSafeRealGit = GIT_NO_PROMPT_ENV.GSD_REAL_GIT;
+    const originalSafeShimLog = GIT_NO_PROMPT_ENV.GSD_GIT_SHIM_LOG;
+
+    try {
+      installGitRmCachedCounterShim(shimDir);
+      const realGit = findGitExecutable();
+      process.env.GSD_REAL_GIT = realGit;
+      process.env.GSD_GIT_SHIM_LOG = logFile;
+      process.env.PATH = `${shimDir}${delimiter}${originalPath ?? ""}`;
+      GIT_NO_PROMPT_ENV.GSD_REAL_GIT = realGit;
+      GIT_NO_PROMPT_ENV.GSD_GIT_SHIM_LOG = logFile;
+      GIT_NO_PROMPT_ENV.PATH = process.env.PATH;
+
+      createFile(repo, "src/first.ts", "first");
+      const first = new GitServiceImpl(repo).commit({ message: "test: first cleanup pass" });
+      assert.deepStrictEqual(first, "test: first cleanup pass", "first commit succeeds");
+      assert.deepStrictEqual(
+        countRmCachedInvocations(logFile),
+        RUNTIME_EXCLUSION_PATHS.length,
+        "first service instance checks each runtime exclusion once",
+      );
+
+      createFile(repo, "src/second.ts", "second");
+      const second = new GitServiceImpl(repo).commit({ message: "test: second cleanup pass" });
+      assert.deepStrictEqual(second, "test: second cleanup pass", "second commit succeeds");
+      assert.deepStrictEqual(
+        countRmCachedInvocations(logFile),
+        RUNTIME_EXCLUSION_PATHS.length,
+        "fresh service instance for the same repo does not rerun runtime cleanup",
+      );
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      if (originalRealGit === undefined) {
+        delete process.env.GSD_REAL_GIT;
+      } else {
+        process.env.GSD_REAL_GIT = originalRealGit;
+      }
+      if (originalShimLog === undefined) {
+        delete process.env.GSD_GIT_SHIM_LOG;
+      } else {
+        process.env.GSD_GIT_SHIM_LOG = originalShimLog;
+      }
+      if (originalSafePath === undefined) {
+        delete GIT_NO_PROMPT_ENV.PATH;
+      } else {
+        GIT_NO_PROMPT_ENV.PATH = originalSafePath;
+      }
+      if (originalSafeRealGit === undefined) {
+        delete GIT_NO_PROMPT_ENV.GSD_REAL_GIT;
+      } else {
+        GIT_NO_PROMPT_ENV.GSD_REAL_GIT = originalSafeRealGit;
+      }
+      if (originalSafeShimLog === undefined) {
+        delete GIT_NO_PROMPT_ENV.GSD_GIT_SHIM_LOG;
+      } else {
+        GIT_NO_PROMPT_ENV.GSD_GIT_SHIM_LOG = originalSafeShimLog;
+      }
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(shimDir, { recursive: true, force: true });
+    }
   });
 
   test('GitServiceImpl: task autoCommit skips keyFiles inside submodules', () => {


### PR DESCRIPTION
## Summary
- Fixed runtime cleanup to run once per repo per session and verified syntax plus diff checks; full test was blocked by offline dependency install failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #893
- [#893 [Bug]: Per-commit `git rm --cached` cleanup loop re-runs on every unit dispatch (17 git spawns each time)](https://github.com/open-gsd/gsd-pi/issues/893)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/893-bug-per-commit-git-rm-cached-cleanup-loo-1782565918`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Staging behavior is unchanged except skipping redundant cleanup; risk is low and limited to git index maintenance during commits.
> 
> **Overview**
> **Fixes repeated `git rm --cached` work on every unit dispatch** by tracking cleanup at the **repository** level instead of on each `GitServiceImpl` instance.
> 
> `smartStage()` still performs the one-time untrack pass over `RUNTIME_EXCLUSION_PATHS` when legacy `.gsd/` runtime files are in the index, but a module-level `Set` keyed by `resolve(basePath)` ensures that pass runs **once per repo per process**, even when dispatch creates a fresh service instance each commit.
> 
> An integration test uses a `git` shim on `PATH` to assert the first commit issues one `rm --cached` per exclusion path and a second instance against the same repo does not repeat the cleanup loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02911a9d3a811a66616c2807b980a5f91eb9186d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->