### PR TITLE
fix(issue): [Bug]: /gsd forensics reports "Errors: 0" for tool calls that started but never returned a result

### DIFF
--- a/src/resources/extensions/gsd/session-forensics.ts
+++ b/src/resources/extensions/gsd/session-forensics.ts
@@ -223,11 +223,14 @@ export function extractTrace(entries: unknown[]): ExecutionTrace {
 
   // Flush any pending tool calls that never got results (crash mid-tool)
   for (const [, pending] of pendingTools) {
+    const missingResultError = `Tool call ${pending.name} started but no toolResult was recorded`;
     toolCalls.push({
       name: pending.name,
       input: redactInput(pending.name, pending.input),
-      isError: false,
+      result: "missing tool result (stream/tool-call abort before execution)",
+      isError: true,
     });
+    errors.push(missingResultError);
   }
 
   return {

--- a/src/resources/extensions/gsd/session-forensics.ts
+++ b/src/resources/extensions/gsd/session-forensics.ts
@@ -231,6 +231,13 @@ export function extractTrace(entries: unknown[]): ExecutionTrace {
       isError: true,
     });
     errors.push(missingResultError);
+
+    // Mark the matching commandsRun entry as failed so it is consistent with
+    // the isError: true on the tool call above (bash/bg_shell only).
+    if (pending.name === "bash" || pending.name === "bg_shell") {
+      const lastCmd = findLast(commandsRun, c => c.command === String(pending.input.command));
+      if (lastCmd) lastCmd.failed = true;
+    }
   }
 
   return {

--- a/src/resources/extensions/gsd/tests/forensics-error-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-error-filter.test.ts
@@ -119,3 +119,33 @@ describe("extractTrace error filtering (#2539)", () => {
     assert.equal(trace.errors.length, 1, "lint error with output should be counted");
   });
 });
+
+describe("extractTrace pending tool calls (#945)", () => {
+  test("tool call without a toolResult is counted as an error", () => {
+    const entries = [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "toolu_missing",
+              name: "gsd_summary_save",
+              arguments: { content: "unfinished summary" },
+            },
+          ],
+        },
+      },
+    ];
+
+    const trace = extractTrace(entries);
+
+    assert.equal(trace.toolCalls.length, 1);
+    assert.equal(trace.toolCalls[0]?.name, "gsd_summary_save");
+    assert.equal(trace.toolCalls[0]?.isError, true);
+    assert.equal(trace.toolCalls[0]?.result, "missing tool result (stream/tool-call abort before execution)");
+    assert.equal(trace.errors.length, 1);
+    assert.equal(trace.errors[0], "Tool call gsd_summary_save started but no toolResult was recorded");
+  });
+});

--- a/src/resources/extensions/gsd/tests/forensics-error-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-error-filter.test.ts
@@ -148,4 +148,62 @@ describe("extractTrace pending tool calls (#945)", () => {
     assert.equal(trace.errors.length, 1);
     assert.equal(trace.errors[0], "Tool call gsd_summary_save started but no toolResult was recorded");
   });
+
+  test("pending bash call with no toolResult marks commandsRun entry as failed", () => {
+    // A bash tool call that was initiated but never got a toolResult (stream abort).
+    const entries = [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "toolu_bash_missing",
+              name: "bash",
+              arguments: { command: "npm run build" },
+            },
+          ],
+        },
+      },
+    ];
+
+    const trace = extractTrace(entries);
+
+    // The tool call should be recorded as an error.
+    assert.equal(trace.toolCalls.length, 1);
+    assert.equal(trace.toolCalls[0]?.name, "bash");
+    assert.equal(trace.toolCalls[0]?.isError, true);
+
+    // The commandsRun entry must be consistent: failed: true, not failed: false.
+    assert.equal(trace.commandsRun.length, 1);
+    assert.equal(trace.commandsRun[0]?.command, "npm run build");
+    assert.equal(trace.commandsRun[0]?.failed, true,
+      "commandsRun entry should be failed when its bash call never returned a result");
+  });
+
+  test("pending bg_shell call with no toolResult marks commandsRun entry as failed", () => {
+    const entries = [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "toolu_bg_missing",
+              name: "bg_shell",
+              arguments: { command: "sleep 30" },
+            },
+          ],
+        },
+      },
+    ];
+
+    const trace = extractTrace(entries);
+
+    assert.equal(trace.commandsRun.length, 1);
+    assert.equal(trace.commandsRun[0]?.failed, true,
+      "bg_shell commandsRun entry should be failed when no toolResult was recorded");
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed pending session-forensics tool calls to report one error and verified with the focused regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #945
- [#945 [Bug]: /gsd forensics reports "Errors: 0" for tool calls that started but never returned a result](https://github.com/open-gsd/gsd-pi/issues/945)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/945-bug-gsd-forensics-reports-errors-0-for-t-1782566601`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to trace extraction and error accounting for incomplete tool pairs, with a focused unit test and no auth or data-path impact.
> 
> **Overview**
> Fixes **`/gsd` forensics** reporting **Errors: 0** when a session JSONL contains assistant **tool calls that never received a matching `toolResult`** (e.g. crash or stream abort mid-tool).
> 
> In `extractTrace`, the end-of-pass flush for leftover `pendingTools` now treats each orphan as a failed call: **`isError: true`**, a placeholder **result** string, and an entry in **`trace.errors`** (`Tool call <name> started but no toolResult was recorded`). That flows into diagnostics like `formatTraceSummary` / activity log summaries that print the error count.
> 
> Adds a regression test for a lone `gsd_summary_save` tool call with no result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1306a2e44d5da826b699fa008ba062554d422bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->