### PR TITLE
fix(issue): [Bug]: /gsd context token analysis serializes full tool-call arguments (including large content) with no redaction

### DIFF
--- a/src/resources/extensions/gsd/commands-context.ts
+++ b/src/resources/extensions/gsd/commands-context.ts
@@ -11,6 +11,7 @@ import { formatPercent, formatTokenCount } from "./metrics.js";
 import { countTokensSync, type TokenProvider } from "./token-counter.js";
 import { writeContextChartHtml } from "./context-chart-html.js";
 import { openInBrowser } from "./export.js";
+import { truncateWithEllipsis } from "../shared/format-utils.js";
 
 export interface ContextSectionBreakdown {
   label: string;
@@ -34,6 +35,7 @@ export interface ContextBreakdownReport {
   subagentSpawns: number;
 }
 
+const REDACTED_TOOL_ARGUMENT_KEYS = new Set(["content", "oldText", "newText"]);
 
 function resolveProvider(provider: string | undefined): TokenProvider {
   const normalized = (provider ?? "unknown").toLowerCase();
@@ -206,6 +208,21 @@ export function parseSystemPromptSections(systemPrompt: string, provider: TokenP
   return sections;
 }
 
+function redactToolCallArguments(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactToolCallArguments);
+  if (!value || typeof value !== "object") return value;
+
+  const safe: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (REDACTED_TOOL_ARGUMENT_KEYS.has(key)) {
+      safe[key] = typeof child === "string" ? truncateWithEllipsis(child, 101) : "[redacted]";
+    } else {
+      safe[key] = redactToolCallArguments(child);
+    }
+  }
+  return safe;
+}
+
 function messageToText(message: SessionMessageEntry["message"]): string {
   const role = message.role;
 
@@ -220,7 +237,7 @@ function messageToText(message: SessionMessageEntry["message"]): string {
         if (typed.type === "thinking" && typed.thinking) parts.push(typed.thinking);
         if (typed.type === "toolCall") {
           parts.push(typed.name ?? "tool");
-          parts.push(JSON.stringify(typed.arguments ?? {}));
+          parts.push(JSON.stringify(redactToolCallArguments(typed.arguments ?? {})));
         }
       }
     }

--- a/src/resources/extensions/gsd/tests/commands-context.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-context.test.ts
@@ -101,6 +101,32 @@ test("analyzeSessionContext buckets injections, tool results, and loaded skills"
   assert.equal(result.subagentSpawns, 1);
 });
 
+test("analyzeSessionContext bounds large assistant tool-call arguments", () => {
+  const result = analyzeSessionContext(sessionEntries({
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: "tc-save",
+        name: "gsd_summary_save",
+        arguments: {
+          path: ".gsd/milestones/M001/M001-SUMMARY.md",
+          artifact_type: "SUMMARY",
+          content: "x".repeat(20_000),
+        },
+      },
+    ],
+    timestamp: TS,
+  }), PROVIDER);
+
+  const assistant = result.conversationSections.find((section) => section.label === "Assistant responses");
+  assert.ok(assistant);
+  assert.ok(
+    assistant.tokens < 200,
+    `assistant tool-call arguments should be redacted before token counting, got ${assistant.tokens} tokens`,
+  );
+});
+
 test("formatContextReport lists skills and subagents", () => {
   const report = buildContextBreakdown({
     modelLabel: "claude-code/claude-sonnet-4-6",


### PR DESCRIPTION
## Summary
- Redacted large `/gsd context` tool-call body arguments before token counting and verified the focused context tests plus syntax checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #970
- [#970 [Bug]: /gsd context token analysis serializes full tool-call arguments (including large content) with no redaction](https://github.com/open-gsd/gsd-pi/issues/970)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/970-bug-gsd-context-token-analysis-serialize-1782566733`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to context breakdown serialization only; no runtime tool execution or auth paths affected.
> 
> **Overview**
> Fixes `/gsd context` so assistant **tool-call arguments** no longer inflate token estimates by serializing full file bodies.
> 
> Before counting tokens, `messageToText` now runs tool arguments through **`redactToolCallArguments`**, which truncates string values for `content`, `oldText`, and `newText` (via shared `truncateWithEllipsis`) and replaces other shapes with `[redacted]`. Other argument keys are left intact and nested objects are handled recursively.
> 
> A focused test asserts that a 20k-character `content` field on a save tool call keeps the **Assistant responses** bucket under a small token budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72d792da15b60449a0d603af83f1025a03a1925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->