### PR TITLE
fix(issue): [Bug]: milestone validate+complete closeout contracts omit the verification-lane exec trio their prompts advertise

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -310,8 +310,16 @@ test("Context Mode composer: narrow planning guidance steers only to contracted 
   }
 });
 
-test("Context Mode composer: slice planning and research guidance tools pass unit contracts", () => {
-  const affectedUnits = ["research-milestone", "research-slice", "plan-slice", "refine-slice", "complete-slice"];
+test("Context Mode composer: lane guidance tools pass unit contracts", () => {
+  const affectedUnits = [
+    "research-milestone",
+    "research-slice",
+    "plan-slice",
+    "refine-slice",
+    "complete-slice",
+    "validate-milestone",
+    "complete-milestone",
+  ];
   const contextModeTools: UnitGsdToolName[] = ["gsd_exec", "gsd_exec_search", "gsd_resume"];
   const readOnlyOrientationTools: UnitGsdToolName[] = ["gsd_milestone_status", ...contextModeTools];
 

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -160,7 +160,15 @@ export const UNIT_REGISTRY = {
     scopeClass: "section-close",
     phaseChain: ["validation", "planning"],
     toolContract: {
-      allowedGsdTools: ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
+      allowedGsdTools: [
+        "gsd_milestone_status",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
+        "gsd_validate_milestone",
+        "gsd_reassess_roadmap",
+        "subagent",
+      ],
       requiredWorkflowTools: ["gsd_milestone_status", "gsd_validate_milestone", "gsd_reassess_roadmap"],
     },
   },
@@ -171,6 +179,9 @@ export const UNIT_REGISTRY = {
     toolContract: {
       allowedGsdTools: [
         "gsd_milestone_status",
+        "gsd_exec",
+        "gsd_exec_search",
+        "gsd_resume",
         "gsd_requirement_update",
         "gsd_summary_save",
         "gsd_complete_milestone",


### PR DESCRIPTION
## Summary
- Allowed the Context Mode verification exec trio for milestone validate/complete contracts and verified the diff plus static contract probe.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #949
- [#949 [Bug]: milestone validate+complete closeout contracts omit the verification-lane exec trio their prompts advertise](https://github.com/open-gsd/gsd-pi/issues/949)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/949-bug-milestone-validate-complete-closeout-1782570763`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow contract expansion to tools already advertised in prompts; no auth or data-path changes, only fixes tool-scope mismatches during milestone closeout.
> 
> **Overview**
> Aligns **milestone validate** and **complete** unit tool contracts with their **verification-lane** Context Mode guidance so agents can call `gsd_exec`, `gsd_exec_search`, and `gsd_resume` during closeout instead of hitting scope blocks while prompts still steer to those tools.
> 
> Registry `allowedGsdTools` for `validate-milestone` and `complete-milestone` now include the exec trio alongside existing milestone workflow tools. The Context Mode composer test is broadened (and renamed) to assert that lane-advertised tools are allowed and not hard-blocked for those units, matching other planning/research/closeout lanes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9f806596a6d04eeb86e69f99cc3d31bb5da8526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->