### PR TITLE
fix(issue): [Bug]: research-project advertises the research-lane exec trio but should orchestrate scout subagents, not run direct scans

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -74,12 +74,12 @@ Workflow Preferences -> Project Context -> Requirements -> Research Decision -> 
 | `.gsd/PROJECT.md` | `discuss-project` | Project vision, users, anti-goals, constraints, and rough milestone sequence |
 | `.gsd/REQUIREMENTS.md` | `discuss-requirements` | Capability contract using `R###` requirements grouped by Active, Validated, Deferred, and Out of Scope |
 | `.gsd/runtime/research-decision.json` | `research-decision` | Records `research` or `skip`; this unit only asks the question and writes the marker |
-| `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`, only when the decision is `research` | Four parallel project-level research outputs for stack, feature norms, architecture, and pitfalls |
+| `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`, only when the decision is `research` | Four scout-backed project research outputs for stack, feature norms, architecture, and pitfalls |
 | `.gsd/milestones/<MID>/M###-CONTEXT.md` and `M###-ROADMAP.md` | Normal milestone discussion/planning | Milestone-specific context and executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice` |
 
 `REQUIREMENTS.md` is rendered from the requirements stored in the GSD database. Agents should save individual requirements with `gsd_requirement_save`; a final `gsd_summary_save` for `REQUIREMENTS` will fail if no active requirement rows exist instead of treating caller-supplied markdown as canonical.
 
-Project research is informational, not binding. It cross-checks the requirements and surfaces table stakes, risks, and omissions; any new commitment should be added to `.gsd/REQUIREMENTS.md` before planning depends on it.
+Project research is informational, not binding. The `research-project` parent dispatches parallel scout subagents for the four research dimensions; each scout writes one file under `.gsd/research/` (`STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md`). The outputs cross-check the requirements and surface table stakes, risks, and omissions; any new commitment should be added to `.gsd/REQUIREMENTS.md` before planning depends on it.
 
 ## Key Properties
 
@@ -144,11 +144,11 @@ The amount of context inlined is controlled by your [token profile](./token-opti
 
 ### Context Mode
 
-Context Mode is enabled by default for auto-mode runs. Eligible auto-mode units receive manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read a prior compaction snapshot from `.gsd/last-snapshot.md` when one exists.
+Context Mode is enabled by default for auto-mode runs. Eligible auto-mode units receive manifest-driven guidance based on their context lane and any unit-specific override. Most execution-style lanes preserve the conversation window with `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics, `gsd_exec_search` before repeating a prior sandboxed run, and `gsd_resume` after compaction or session resume. Some units name narrower tools instead; for example, `research-project` dispatches parallel scout subagents so each dimension writes one file under `.gsd/research/`.
 
 `contextMode: triage` is used specifically for capture triage turns so they stay focused on classification and routing decisions instead of implementation work.
 
-`gsd_exec` writes capped stdout/stderr and metadata under `.gsd/exec/`; output may be truncated. It then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. In milestone worktree mode, `gsd_exec` also rejects scripts that target the original project root (including traversal patterns such as `cd ../../..`) so execution stays inside the active worktree boundary. To opt out of Context Mode guidance, snapshot injection, `gsd_exec`, `gsd_exec_search`, and `gsd_resume`, set:
+When present in a unit's tool contract, `gsd_exec` writes capped stdout/stderr and metadata under `.gsd/exec/`; output may be truncated. It then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. In milestone worktree mode, `gsd_exec` also rejects scripts that target the original project root (including traversal patterns such as `cd ../../..`) so execution stays inside the active worktree boundary. To opt out of Context Mode guidance, snapshot injection, and context-mode execution tools, set:
 
 ```yaml
 context_mode:

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -308,6 +308,14 @@ test("Context Mode composer: research-project guidance steers to scout orchestra
     assert.doesNotMatch(out, /`gsd_exec_search`/);
     assert.doesNotMatch(out, /`gsd_resume`/);
   }
+
+  const contract = getUnitToolSurfaceContract("research-project");
+  assert.deepEqual(contract?.allowedGsdTools, []);
+  assert.deepEqual(contract?.requiredWorkflowTools, []);
+  for (const toolName of ["gsd_summary_save", "gsd_decision_save"]) {
+    const scope = shouldBlockAutoUnitToolCall("research-project", toolName);
+    assert.equal(scope.block, true, `research-project should not allow ${toolName}`);
+  }
 });
 
 test("Context Mode composer: narrow planning guidance steers only to contracted tools", () => {

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -201,6 +201,9 @@ const contextModeGuidanceOverrideExpectedTools: Record<string, readonly string[]
     "gsd_uat_exec",
     "gsd_resume",
   ],
+  // research-project uses scout subagents that write .gsd/research/ files directly;
+  // the parent dispatches Task calls and verifies file outputs — no GSD save tools.
+  "research-project": [],
   "gate-evaluate": [
     "subagent",
     "gsd_save_gate_result",
@@ -289,6 +292,22 @@ test("Context Mode composer: run-uat guidance steers to gsd_uat_exec in both ren
   const standalone = composeContextModeInstructions("run-uat", { enabled: true, renderMode: "standalone" });
   assert.match(standalone, /`gsd_uat_exec`/);
   assert.doesNotMatch(standalone, /`gsd_exec`/);
+});
+
+test("Context Mode composer: research-project guidance steers to scout orchestration", () => {
+  for (const renderMode of ["nested", "standalone"] as const) {
+    const out = composeContextModeInstructions("research-project", { enabled: true, renderMode });
+    assert.match(out, /research lane/i);
+    assert.match(out, /scout subagents/i);
+    assert.match(out, /\.gsd\/research\//);
+    assert.match(out, /STACK\.md/);
+    assert.match(out, /PITFALLS\.md/);
+    assert.doesNotMatch(out, /`gsd_summary_save`/);
+    assert.doesNotMatch(out, /`gsd_decision_save`/);
+    assert.doesNotMatch(out, /`gsd_exec`/);
+    assert.doesNotMatch(out, /`gsd_exec_search`/);
+    assert.doesNotMatch(out, /`gsd_resume`/);
+  }
 });
 
 test("Context Mode composer: narrow planning guidance steers only to contracted tools", () => {

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -153,6 +153,8 @@ export const CONTEXT_MODE_GUIDANCE_BY_UNIT: Readonly<Record<string, string>> = {
     "Use `gsd_milestone_status` to inspect current milestone state, then `gsd_reassess_roadmap` to persist the roadmap reassessment.",
   "run-uat":
     "Use `gsd_uat_exec` for acceptance checks so evidence is typed as UAT-owned, and `gsd_resume` after compaction or resume.",
+  "research-project":
+    "Dispatch parallel scout subagents for stack, features, architecture, and pitfalls research; each writes one file under `.gsd/research/` (`STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md`).",
   "gate-evaluate":
     "Use `subagent` to dispatch tester agents, then persist each gate with `gsd_save_gate_result`; rely on testers for verification evidence.",
 };

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -426,7 +426,7 @@ export const UNIT_REGISTRY = {
     scopeClass: "standard",
     phaseChain: ["research"],
     toolContract: {
-      allowedGsdTools: ["gsd_summary_save", "gsd_decision_save"],
+      allowedGsdTools: [],
       requiredWorkflowTools: [],
     },
   },

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -421,6 +421,9 @@ export const UNIT_REGISTRY = {
       requiredWorkflowTools: ["ask_user_questions"],
     },
   },
+  // research-project dispatches 4 parallel scout subagents (Task calls); each scout
+  // writes one file under .gsd/research/ directly. The parent coordinator does not
+  // call gsd_summary_save or gsd_decision_save — the scouts own their own output.
   "research-project": {
     kind: "primary",
     scopeClass: "standard",


### PR DESCRIPTION
## Summary
- Fixed research-project Context Mode guidance to steer scout subagent orchestration and verified the diff with static checks while runtime tests were blocked by missing dependencies and restricted npm access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #960
- [#960 [Bug]: research-project advertises the research-lane exec trio but should orchestrate scout subagents, not run direct scans](https://github.com/open-gsd/gsd-pi/issues/960)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/960-bug-research-project-advertises-the-rese-1782570742`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Planning-unit prompt and tool-contract alignment with no auth, data, or execution-path changes; behavior is constrained by new tests and docs.
> 
> **Overview**
> **`research-project`** no longer advertises the generic research-lane **`gsd_exec` / `gsd_exec_search` / `gsd_resume`** trio or **`gsd_summary_save` / `gsd_decision_save`**. Its tool contract is empty, Context Mode guidance tells the parent to **dispatch parallel scout subagents** that write **`.gsd/research/`** (`STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md`), and runtime policy **blocks** the former save tools.
> 
> User docs now describe scout-backed project research and note that Context Mode guidance is **lane- or unit-specific**, with **`gsd_exec`** only when the unit’s contract includes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71334f83262ce96e5b8d9e148d93e3fcf5dbd6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->