### PR TITLE
fix(issue): [Bug]: gate-evaluate prompt advertises the verification exec trio its narrow contract hard-blocks

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -142,8 +142,9 @@ test("Context Mode composer: nested output is compact single sentence", () => {
   assert.ok(!out.startsWith("## Context Mode"));
   assert.match(out, /^Context Mode \(verification lane\): /);
   assert.strictEqual(out.split(/\n/).length, 1);
-  assert.match(out, /tester/);
-  assert.match(out, /`subagent`/);
+  // Nested guidance is embedded into tester subagent prompts — it must instruct the tester
+  // to run verification and call gsd_save_gate_result, NOT to dispatch further subagents.
+  assert.doesNotMatch(out, /`subagent`/, "tester prompts must not be told to dispatch subagents");
   assert.match(out, /`gsd_save_gate_result`/);
   assert.doesNotMatch(out, /`gsd_exec`/);
   assert.doesNotMatch(out, /`gsd_exec_search`/);

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -142,9 +142,12 @@ test("Context Mode composer: nested output is compact single sentence", () => {
   assert.ok(!out.startsWith("## Context Mode"));
   assert.match(out, /^Context Mode \(verification lane\): /);
   assert.strictEqual(out.split(/\n/).length, 1);
-  assert.match(out, /`gsd_exec`/);
-  assert.match(out, /`gsd_exec_search`/);
-  assert.match(out, /`gsd_resume`/);
+  assert.match(out, /tester/);
+  assert.match(out, /`subagent`/);
+  assert.match(out, /`gsd_save_gate_result`/);
+  assert.doesNotMatch(out, /`gsd_exec`/);
+  assert.doesNotMatch(out, /`gsd_exec_search`/);
+  assert.doesNotMatch(out, /`gsd_resume`/);
   assert.ok(out.length < 240, `nested guidance should stay compact, got ${out.length} chars`);
 });
 
@@ -196,6 +199,10 @@ const contextModeGuidanceOverrideExpectedTools: Record<string, readonly string[]
   "run-uat": [
     "gsd_uat_exec",
     "gsd_resume",
+  ],
+  "gate-evaluate": [
+    "subagent",
+    "gsd_save_gate_result",
   ],
 };
 

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -157,6 +157,16 @@ export const CONTEXT_MODE_GUIDANCE_BY_UNIT: Readonly<Record<string, string>> = {
     "Use `subagent` to dispatch tester agents, then persist each gate with `gsd_save_gate_result`; rely on testers for verification evidence.",
 };
 
+// Per-unit guidance for the nested render mode (renderMode: "nested"), used when this
+// unit's Context Mode line is embedded into a subagent prompt — e.g. the tester prompts
+// dispatched by gate-evaluate. Must instruct the subagent on what IT should do, not
+// re-state the parent coordinator's dispatch instructions. Falls back to
+// CONTEXT_MODE_GUIDANCE_BY_UNIT then the lane default when no nested entry exists.
+export const CONTEXT_MODE_NESTED_GUIDANCE_BY_UNIT: Readonly<Record<string, string>> = {
+  "gate-evaluate":
+    "Run verification checks to answer the gate question, then persist the verdict with `gsd_save_gate_result`.",
+};
+
 /**
  * Render the Context Mode instruction lane for a unit type. Unknown unit
  * types, disabled config, and explicit `contextMode: "none"` all omit the
@@ -172,7 +182,9 @@ export function composeContextModeInstructions(
 
   const lane = CONTEXT_MODE_LANE_LABELS[manifest.contextMode];
   const guidance =
-    CONTEXT_MODE_GUIDANCE_BY_UNIT[unitType] ?? CONTEXT_MODE_GUIDANCE_BY_LANE[manifest.contextMode];
+    (opts.renderMode === "nested" ? CONTEXT_MODE_NESTED_GUIDANCE_BY_UNIT[unitType] : undefined)
+    ?? CONTEXT_MODE_GUIDANCE_BY_UNIT[unitType]
+    ?? CONTEXT_MODE_GUIDANCE_BY_LANE[manifest.contextMode];
   if (opts.renderMode === "nested") {
     return `Context Mode (${lane} lane): ${guidance}`;
   }

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -153,6 +153,8 @@ export const CONTEXT_MODE_GUIDANCE_BY_UNIT: Readonly<Record<string, string>> = {
     "Use `gsd_milestone_status` to inspect current milestone state, then `gsd_reassess_roadmap` to persist the roadmap reassessment.",
   "run-uat":
     "Use `gsd_uat_exec` for acceptance checks so evidence is typed as UAT-owned, and `gsd_resume` after compaction or resume.",
+  "gate-evaluate":
+    "Use `subagent` to dispatch tester agents, then persist each gate with `gsd_save_gate_result`; rely on testers for verification evidence.",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Added a gate-evaluate Context Mode override and focused tests; diff/source checks passed, while the focused unit test was blocked by missing dependencies and DNS-disabled install.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #950
- [#950 [Bug]: gate-evaluate prompt advertises the verification exec trio its narrow contract hard-blocks](https://github.com/open-gsd/gsd-pi/issues/950)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/950-bug-gate-evaluate-prompt-advertises-the--1782570751`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only alignment with existing tool-surface contracts; no runtime dispatch or authorization changes.
> 
> **Overview**
> **gate-evaluate** still uses the **verification** Context Mode lane, but its guidance no longer inherits the lane default that names `gsd_exec`, `gsd_exec_search`, and `gsd_resume`—tools its narrow contract blocks.
> 
> A per-unit override in `CONTEXT_MODE_GUIDANCE_BY_UNIT` tells the unit to dispatch **tester** agents via `subagent`, persist gates with `gsd_save_gate_result`, and rely on testers for evidence. Tests cover nested compact output and the shared “eligible unit” override expectations for `gate-evaluate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311bd189ee37bfcdf66ad46642a4f9cfe5f38a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->