### PR TITLE
fix(issue): [Bug]: discuss-milestone CONTEXT-DRAFT resume seed is appended after the preamble cap, growing the prompt 1:1 with the draft

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1691,7 +1691,13 @@ export async function buildDiscussMilestonePrompt(
   const draftContent = draftPath ? await loadFile(draftPath) : null;
 
   if (includeDraftSeed && draftContent) {
-    return `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${draftContent}`;
+    const draftRelPath = relMilestoneFile(base, mid, "CONTEXT-DRAFT");
+    const draftSeed = `### Prior Discussion Draft\nSource: \`${draftRelPath}\`\n\n${draftContent.trim()}`;
+    const cappedDraftSeed = capPreamble(draftSeed);
+    const truncationNote = cappedDraftSeed !== draftSeed
+      ? `\n\n_(Draft seed truncated; read the full draft at \`${draftRelPath}\` if needed.)`
+      : "";
+    return `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${cappedDraftSeed}${truncationNote}`;
   }
 
   return promptWithContextMode;

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1695,7 +1695,7 @@ export async function buildDiscussMilestonePrompt(
     const draftSeed = `### Prior Discussion Draft\nSource: \`${draftRelPath}\`\n\n${draftContent.trim()}`;
     const cappedDraftSeed = capPreamble(draftSeed);
     const truncationNote = cappedDraftSeed !== draftSeed
-      ? `\n\n_(Draft seed truncated; read the full draft at \`${draftRelPath}\` if needed.)`
+      ? `\n\n_(Draft seed truncated; read the full draft at \`${draftRelPath}\` if needed.)_`
       : "";
     return `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${cappedDraftSeed}${truncationNote}`;
   }

--- a/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
@@ -86,3 +86,45 @@ test("guided milestone prompt builder preloads milestone planning context", asyn
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("guided milestone prompt builder caps prior draft seed before interpolation", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-guided-milestone-draft-cap-"));
+  const previousGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = join(base, ".gsd-home");
+
+  try {
+    const currentDir = join(base, ".gsd", "milestones", "M001");
+    mkdirSync(currentDir, { recursive: true });
+
+    const draftPath = join(currentDir, "M001-CONTEXT-DRAFT.md");
+    writeFileSync(draftPath, "# Draft\n\nSMALL-DRAFT-SIGNAL", "utf-8");
+    const smallPrompt = await buildDiscussMilestonePrompt("M001", "Draft Resume", base, "true", {
+      includeContextMode: false,
+    });
+
+    writeFileSync(
+      draftPath,
+      ["# Draft", "", "SMALL-DRAFT-SIGNAL", "", "A".repeat(200_000), "", "OVERSIZED-DRAFT-TAIL-SIGNAL"].join("\n"),
+      "utf-8",
+    );
+    const largePrompt = await buildDiscussMilestonePrompt("M001", "Draft Resume", base, "true", {
+      includeContextMode: false,
+    });
+
+    const addedChars = largePrompt.length - smallPrompt.length;
+
+    assert.match(largePrompt, /## Prior Discussion \(Draft Seed\)/);
+    assert.match(largePrompt, /### Prior Discussion Draft/);
+    assert.match(largePrompt, /SMALL-DRAFT-SIGNAL/);
+    assert.doesNotMatch(largePrompt, /OVERSIZED-DRAFT-TAIL-SIGNAL/);
+    assert.match(
+      largePrompt,
+      /Draft seed truncated; read the full draft at `\.gsd\/milestones\/M001\/M001-CONTEXT-DRAFT\.md` if needed\./,
+    );
+    assert.ok(addedChars < 25_000, `large draft should add bounded seed chars, added ${addedChars}`);
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Capped discuss-milestone draft seed interpolation and verified the truncation primitive plus bounded 200k seed behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #965
- [#965 [Bug]: discuss-milestone CONTEXT-DRAFT resume seed is appended after the preamble cap, growing the prompt 1:1 with the draft](https://github.com/open-gsd/gsd-pi/issues/965)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/965-bug-discuss-milestone-context-draft-resu-1782570703`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt assembly only for discuss-milestone draft resume; uses existing capPreamble with a new test—no auth, data, or execution path changes.
> 
> **Overview**
> Fixes **discuss-milestone** prompts growing roughly 1:1 with large `CONTEXT-DRAFT` files because the resume seed was appended **after** the inlined preamble was already capped.
> 
> When a draft is included, the seed is now built as a structured block (source path + trimmed body), run through **`capPreamble`**, and the capped block is what gets interpolated. If truncation happens, the prompt adds a short note pointing the agent at the full draft on disk.
> 
> A regression test asserts that a ~200k-character draft does not add unbounded characters to the final prompt and that content past the cap is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927f58dbc0af5acfa8a8f74e85234519ab8904ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->