### PR TITLE
fix(issue): [Bug]: /gsd queue and /gsd rethink existing-milestones context inlines full active/pending CONTEXT, CONTEXT-DRAFT, and ROADMAP with no size cap

### DIFF
--- a/src/resources/extensions/gsd/guided-flow-queue.ts
+++ b/src/resources/extensions/gsd/guided-flow-queue.ts
@@ -20,6 +20,7 @@ import { invalidateAllCaches } from "./cache.js";
 import {
   gsdRoot, resolveMilestoneFile, resolveSliceFile,
   resolveGsdRootFile, relGsdRootFile, relSliceFile,
+  relMilestoneFile,
 } from "./paths.js";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { atomicWriteSync } from "./atomic-write.js";
@@ -28,6 +29,10 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { loadQueueOrder, sortByQueueOrder, saveQueueOrder } from "./queue-order.js";
 import { findMilestoneIds, nextMilestoneId } from "./milestone-ids.js";
 import { isFutureMilestoneStatus } from "./status-guards.js";
+
+const QUEUE_ARTIFACT_EXCERPT_MAX_CHARS = 20_000;
+const QUEUE_EXISTING_MILESTONES_CONTEXT_MAX_CHARS = 120_000;
+const QUEUE_CONTEXT_SECTION_SEPARATOR = "\n\n---\n\n";
 
 // ─── Queue Entry Point ──────────────────────────────────────────────────────
 
@@ -280,7 +285,9 @@ export async function buildExistingMilestonesContext(
     if (contextFile) {
       const content = await loadFile(contextFile);
       if (content) {
-        parts.push(`\n**Context:**\n${content.trim()}`);
+        parts.push(
+          `\n**Context:**\n${summarizeArtifactForQueue(content, relMilestoneFile(basePath, mid, "CONTEXT"))}`,
+        );
       }
     } else {
       // No full CONTEXT.md — check for CONTEXT-DRAFT.md (draft seed from prior discussion)
@@ -288,7 +295,9 @@ export async function buildExistingMilestonesContext(
       if (draftFile) {
         const draftContent = await loadFile(draftFile);
         if (draftContent) {
-          parts.push(`\n**Draft context available:**\n${draftContent.trim()}`);
+          parts.push(
+            `\n**Draft context available:**\n${summarizeArtifactForQueue(draftContent, relMilestoneFile(basePath, mid, "CONTEXT-DRAFT"))}`,
+          );
         }
       }
     }
@@ -300,7 +309,9 @@ export async function buildExistingMilestonesContext(
       if (roadmapFile) {
         const content = await loadFile(roadmapFile);
         if (content) {
-          parts.push(`\n**Roadmap:**\n${content.trim()}`);
+          parts.push(
+            `\n**Roadmap:**\n${summarizeArtifactForQueue(content, relMilestoneFile(basePath, mid, "ROADMAP"))}`,
+          );
         }
       }
     }
@@ -317,7 +328,74 @@ export async function buildExistingMilestonesContext(
     }
   }
 
-  return sections.join("\n\n---\n\n");
+  return capExistingMilestonesContext(sections);
+}
+
+function summarizeArtifactForQueue(
+  content: string,
+  sourcePath: string,
+  cap = QUEUE_ARTIFACT_EXCERPT_MAX_CHARS,
+): string {
+  const trimmed = content.trim();
+  if (trimmed.length <= cap) {
+    return `Source: \`${sourcePath}\`\n\n${trimmed}`;
+  }
+
+  const excerpt = trimmed.slice(0, cap).trimEnd();
+  const omittedChars = trimmed.length - excerpt.length;
+  return [
+    `Source: \`${sourcePath}\``,
+    "",
+    excerpt,
+    "",
+    `[Truncated ${omittedChars} chars. Read \`${sourcePath}\` for full content.]`,
+  ].join("\n");
+}
+
+function capExistingMilestonesContext(
+  sections: string[],
+  cap = QUEUE_EXISTING_MILESTONES_CONTEXT_MAX_CHARS,
+): string {
+  const fullContext = sections.join(QUEUE_CONTEXT_SECTION_SEPARATOR);
+  if (fullContext.length <= cap) return fullContext;
+
+  const notice = `[Existing milestones context truncated to ${cap} chars. Read source paths in this prompt or the corresponding .gsd artifacts for full details.]`;
+  const compactSections = sections.map(compactSectionForQueueBudget);
+  const selected: string[] = [];
+
+  for (let i = 0; i < sections.length; i++) {
+    const withFullSection = [
+      ...selected,
+      sections[i],
+      ...compactSections.slice(i + 1),
+      notice,
+    ].join(QUEUE_CONTEXT_SECTION_SEPARATOR);
+
+    selected.push(withFullSection.length <= cap ? sections[i] : compactSections[i]);
+  }
+
+  const capped = [...selected, notice].join(QUEUE_CONTEXT_SECTION_SEPARATOR);
+  if (capped.length <= cap) return capped;
+
+  return `${capped.slice(0, Math.max(0, cap - notice.length - 2)).trimEnd()}\n\n${notice}`;
+}
+
+function compactSectionForQueueBudget(section: string): string {
+  const lines = section.split("\n");
+  const compact: string[] = [];
+
+  if (lines[0]) compact.push(lines[0]);
+
+  const statusLine = lines.find(line => line.startsWith("**Status:**"));
+  if (statusLine) compact.push(statusLine);
+
+  const sourceLines = lines.filter(line => line.startsWith("Source: `"));
+  if (sourceLines.length > 0) {
+    compact.push("", "**Sources:**", ...sourceLines);
+    compact.push("", "[Artifact excerpts omitted due to total queue/rethink context budget.]");
+  }
+
+  return compact.join("\n");
 }
 
 // ─── Internal Helpers ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/integration/queue-active-milestone-context-budget.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/queue-active-milestone-context-budget.test.ts
@@ -1,0 +1,93 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildExistingMilestonesContext } from "../../guided-flow-queue.ts";
+import type { GSDState, MilestoneRegistryEntry } from "../../types.ts";
+
+const LARGE_BODY = "A".repeat(150_000);
+const LARGE_DRAFT = "D".repeat(150_000);
+const LARGE_ROADMAP = "R".repeat(150_000);
+
+function makeState(registry: MilestoneRegistryEntry[]): GSDState {
+  return {
+    activeMilestone: registry.find(m => m.status === "active") ?? null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry,
+  };
+}
+
+function writeMilestoneArtifact(base: string, mid: string, suffix: string, content: string): void {
+  mkdirSync(join(base, ".gsd", "milestones", mid), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", mid, `${mid}-${suffix}.md`), content);
+}
+
+describe("queue active/pending milestone context budget", () => {
+  test("summarizes active and pending artifacts with source paths and bounded excerpts", async () => {
+    const tmpBase = mkdtempSync(join(tmpdir(), "gsd-queue-active-budget-"));
+    try {
+      writeMilestoneArtifact(tmpBase, "M001", "CONTEXT", `# Active context\n\n${LARGE_BODY}\nEND_ACTIVE_CONTEXT`);
+      writeMilestoneArtifact(tmpBase, "M001", "ROADMAP", `# Active roadmap\n\n${LARGE_ROADMAP}\nEND_ACTIVE_ROADMAP`);
+      writeMilestoneArtifact(tmpBase, "M002", "CONTEXT-DRAFT", `# Pending draft\n\n${LARGE_DRAFT}\nEND_PENDING_DRAFT`);
+      writeMilestoneArtifact(tmpBase, "M002", "ROADMAP", `# Pending roadmap\n\n${LARGE_ROADMAP}\nEND_PENDING_ROADMAP`);
+
+      const registry: MilestoneRegistryEntry[] = [
+        { id: "M001", title: "Active milestone", status: "active" },
+        { id: "M002", title: "Pending milestone", status: "pending" },
+      ];
+
+      const context = await buildExistingMilestonesContext(tmpBase, ["M001", "M002"], makeState(registry));
+
+      assert.match(context, /Source: `.gsd\/milestones\/M001\/M001-CONTEXT.md`/);
+      assert.match(context, /Source: `.gsd\/milestones\/M001\/M001-ROADMAP.md`/);
+      assert.match(context, /Source: `.gsd\/milestones\/M002\/M002-CONTEXT-DRAFT.md`/);
+      assert.match(context, /Source: `.gsd\/milestones\/M002\/M002-ROADMAP.md`/);
+      assert.match(context, /Read `.gsd\/milestones\/M001\/M001-CONTEXT.md` for full content/);
+      assert.equal(context.includes("END_ACTIVE_CONTEXT"), false);
+      assert.equal(context.includes("END_ACTIVE_ROADMAP"), false);
+      assert.equal(context.includes("END_PENDING_DRAFT"), false);
+      assert.equal(context.includes("END_PENDING_ROADMAP"), false);
+    } finally {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  test("caps the total existing milestones context", async () => {
+    const tmpBase = mkdtempSync(join(tmpdir(), "gsd-queue-total-budget-"));
+    try {
+      const registry: MilestoneRegistryEntry[] = [];
+      const milestoneIds: string[] = [];
+      for (let i = 1; i <= 5; i++) {
+        const mid = `M${String(i).padStart(3, "0")}`;
+        milestoneIds.push(mid);
+        registry.push({ id: mid, title: `Pending milestone ${i}`, status: "pending" });
+        writeMilestoneArtifact(tmpBase, mid, "CONTEXT", `# ${mid} context\n\n${LARGE_BODY}\nEND_${mid}_CONTEXT`);
+        writeMilestoneArtifact(tmpBase, mid, "ROADMAP", `# ${mid} roadmap\n\n${LARGE_ROADMAP}\nEND_${mid}_ROADMAP`);
+      }
+
+      const context = await buildExistingMilestonesContext(tmpBase, milestoneIds, makeState(registry));
+
+      assert.ok(
+        context.length <= 120_000,
+        `expected total context to stay within budget, got ${context.length} chars`,
+      );
+      assert.match(context, /Existing milestones context truncated/);
+      for (let i = 1; i <= 5; i++) {
+        const mid = `M${String(i).padStart(3, "0")}`;
+        assert.match(context, new RegExp(`### ${mid}: Pending milestone ${i}`));
+        assert.match(context, new RegExp(`Source: \`.gsd/milestones/${mid}/${mid}-CONTEXT.md\``));
+        assert.match(context, new RegExp(`Source: \`.gsd/milestones/${mid}/${mid}-ROADMAP.md\``));
+      }
+      assert.equal(context.includes("END_M005_ROADMAP"), false);
+    } finally {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Bounded queue/rethink milestone artifact context with source-linked excerpts, total cap handling, and focused regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #967
- [#967 [Bug]: /gsd queue and /gsd rethink existing-milestones context inlines full active/pending CONTEXT, CONTEXT-DRAFT, and ROADMAP with no size cap](https://github.com/open-gsd/gsd-pi/issues/967)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/967-bug-gsd-queue-and-gsd-rethink-existing-m-1782570695`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-shaping only in queue/rethink flows; no auth, persistence, or execution-path changes beyond smaller LLM context.
> 
> **Overview**
> **`/gsd queue` and `/gsd rethink`** no longer inline full **CONTEXT**, **CONTEXT-DRAFT**, and **ROADMAP** bodies into the existing-milestones prompt. `buildExistingMilestonesContext` now wraps each artifact with a **source path**, a **20k-character excerpt**, and a pointer to read the file for the rest.
> 
> When the combined block still exceeds **120k characters**, the builder **progressively compacts** milestone sections (headers, status, source list) and appends a truncation notice so prompt size stays bounded.
> 
> Integration tests cover large active/pending artifacts and multi-milestone total budget behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54da325de5d9a6be02297fe0b46b8f1ce43e8ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->