### PR TITLE
fix(issue): [Bug]: /gsd forensics re-queries every slice and task to compute six summary counts when three aggregate queries suffice

### DIFF
--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -28,6 +28,7 @@ import {
 import { rowToGate } from "../db-gate-rows.js";
 import { rowToArtifact, rowToMilestone, type ArtifactRow, type MilestoneRow } from "../db-milestone-artifact-rows.js";
 import { rowToSlice, rowToTask, type SliceRow, type TaskRow } from "../db-task-slice-rows.js";
+import { TERMINAL_STATUS_SQL } from "./sql-constants.js";
 
 
 function parseStringArrayColumn(raw: unknown): string[] {
@@ -47,6 +48,59 @@ function parseStringArrayColumn(raw: unknown): string[] {
 
 function normalizeRepoPath(file: string): string {
   return file.trim().replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
+
+export interface HierarchyCompletionCounts {
+  milestones: number;
+  milestonesTotal: number;
+  slices: number;
+  slicesTotal: number;
+  tasks: number;
+  tasksTotal: number;
+}
+
+function numberColumn(row: Record<string, unknown> | undefined, column: string): number {
+  const value = row?.[column];
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function getCompletionCount(table: "milestones" | "slices" | "tasks"): { completed: number; total: number } {
+  const row = getDbOrNull()!.prepare(
+    `SELECT
+       COUNT(*) AS total,
+       COALESCE(SUM(CASE WHEN status IN (${TERMINAL_STATUS_SQL}) THEN 1 ELSE 0 END), 0) AS completed
+     FROM ${table}`,
+  ).get();
+
+  return {
+    completed: numberColumn(row, "completed"),
+    total: numberColumn(row, "total"),
+  };
+}
+
+export function getHierarchyCompletionCounts(): HierarchyCompletionCounts {
+  if (!getDbOrNull()!) {
+    return { milestones: 0, milestonesTotal: 0, slices: 0, slicesTotal: 0, tasks: 0, tasksTotal: 0 };
+  }
+
+  const milestones = getCompletionCount("milestones");
+  const slices = getCompletionCount("slices");
+  const tasks = getCompletionCount("tasks");
+
+  return {
+    milestones: milestones.completed,
+    milestonesTotal: milestones.total,
+    slices: slices.completed,
+    slicesTotal: slices.total,
+    tasks: tasks.completed,
+    tasksTotal: tasks.total,
+  };
 }
 
 export function getDecisionById(id: string): Decision | null {

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -28,8 +28,7 @@ import { deriveState } from "./state.js";
 import { isAutoActive } from "./auto.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
-import { isDbAvailable, getAllMilestones, getMilestoneSlices, getSliceTasks } from "./gsd-db.js";
-import { isClosedStatus } from "./status-guards.js";
+import { isDbAvailable, getHierarchyCompletionCounts } from "./gsd-db.js";
 import { formatDuration } from "../shared/format-utils.js";
 import { getAutoWorktreePath } from "./auto-worktree.js";
 import { clearGSDPreferencesCache, loadEffectiveGSDPreferences, loadGlobalGSDPreferences, getGlobalGSDPreferencesPath } from "./preferences.js";
@@ -759,37 +758,7 @@ function loadCompletedKeys(basePath: string): string[] {
 function getDbCompletionCounts(): DbCompletionCounts | null {
   if (!isDbAvailable()) return null;
 
-  const milestones = getAllMilestones();
-  let completedMilestones = 0;
-  let totalSlices = 0;
-  let completedSlices = 0;
-  let totalTasks = 0;
-  let completedTasks = 0;
-
-  for (const m of milestones) {
-    if (isClosedStatus(m.status)) completedMilestones++;
-
-    const slices = getMilestoneSlices(m.id);
-    for (const s of slices) {
-      totalSlices++;
-      if (isClosedStatus(s.status)) completedSlices++;
-
-      const tasks = getSliceTasks(m.id, s.id);
-      for (const t of tasks) {
-        totalTasks++;
-        if (isClosedStatus(t.status)) completedTasks++;
-      }
-    }
-  }
-
-  return {
-    milestones: completedMilestones,
-    milestonesTotal: milestones.length,
-    slices: completedSlices,
-    slicesTotal: totalSlices,
-    tasks: completedTasks,
-    tasksTotal: totalTasks,
-  };
+  return getHierarchyCompletionCounts();
 }
 
 // ─── Anomaly Detectors ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/doctor-forensics-db-open-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-forensics-db-open-regression.test.ts
@@ -1,10 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { closeDatabase } from "../gsd-db.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  getHierarchyCompletionCounts,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
 import { buildForensicReport } from "../forensics.ts";
 import { handleDoctor } from "../commands-handlers.ts";
 import { withCommandCwd } from "../commands/context.ts";
@@ -21,6 +29,66 @@ test("#5194 forensics opens DB before computing completion counts", async (t) =>
   assert.equal(report.dbCompletionCounts?.milestonesTotal, 0);
   assert.equal(report.dbCompletionCounts?.slicesTotal, 0);
   assert.equal(report.dbCompletionCounts?.tasksTotal, 0);
+});
+
+test("#968 completion counts use fixed aggregate queries and canonical closed statuses", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-forensics-counts-"));
+  const dbPath = join(base, "gsd.db");
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(dbPath);
+
+  insertMilestone({ id: "M001", status: "complete" });
+  insertMilestone({ id: "M002", status: "active" });
+  insertMilestone({ id: "M003", status: "closed" });
+
+  insertSlice({ milestoneId: "M001", id: "S01", status: "done" });
+  insertSlice({ milestoneId: "M001", id: "S02", status: "pending" });
+  insertSlice({ milestoneId: "M002", id: "S01", status: "skipped" });
+  insertSlice({ milestoneId: "M003", id: "S01", status: "active" });
+
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", status: "complete" });
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T02", status: "done" });
+  insertTask({ milestoneId: "M001", sliceId: "S02", id: "T01", status: "skipped" });
+  insertTask({ milestoneId: "M002", sliceId: "S01", id: "T01", status: "closed" });
+  insertTask({ milestoneId: "M002", sliceId: "S01", id: "T02", status: "pending" });
+  insertTask({ milestoneId: "M003", sliceId: "S01", id: "T01", status: "active" });
+
+  const adapter = _getAdapter()!;
+  const originalPrepare = adapter.prepare.bind(adapter);
+  const preparedSql: string[] = [];
+  adapter.prepare = (sql) => {
+    preparedSql.push(sql);
+    return originalPrepare(sql);
+  };
+
+  assert.deepEqual(getHierarchyCompletionCounts(), {
+    milestones: 2,
+    milestonesTotal: 3,
+    slices: 2,
+    slicesTotal: 4,
+    tasks: 4,
+    tasksTotal: 6,
+  });
+
+  assert.equal(preparedSql.length, 3);
+  assert.ok(preparedSql.every((sql) => /COUNT\(\*\)/i.test(sql)));
+  assert.doesNotMatch(preparedSql.join("\n"), /SELECT\s+\*/i);
+});
+
+test("#968 forensics completion counts do not re-query slices and tasks", () => {
+  const source = readFileSync(join(process.cwd(), "src/resources/extensions/gsd/forensics.ts"), "utf-8");
+  const start = source.indexOf("function getDbCompletionCounts()");
+  const end = source.indexOf("// ─── Anomaly Detectors", start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const body = source.slice(start, end);
+
+  assert.match(body, /getHierarchyCompletionCounts\(\)/);
+  assert.doesNotMatch(body, /getAllMilestones|getMilestoneSlices|getSliceTasks/);
 });
 
 test("#5194 doctor command does not emit false db_unavailable when gsd.db exists", async (t) => {


### PR DESCRIPTION
## Summary
- Replaced /gsd forensics completion counting with fixed aggregate DB counts and verified with syntax/static checks; full tests were blocked by missing dependencies and network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #968
- [#968 [Bug]: /gsd forensics re-queries every slice and task to compute six summary counts when three aggregate queries suffice](https://github.com/open-gsd/gsd-pi/issues/968)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/968-bug-gsd-forensics-re-queries-every-slice-1782570689`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only query path used only for forensics reporting; behavior is tightened with tests and shared terminal-status SQL.
> 
> **Overview**
> **`/gsd forensics` no longer walks the full milestone → slice → task hierarchy** to produce six completion numbers. It now calls **`getHierarchyCompletionCounts()`**, which runs **three `COUNT(*)` aggregate queries** on `milestones`, `slices`, and `tasks`.
> 
> Completed rows are counted with **`TERMINAL_STATUS_SQL`** (same closed-status set as `isClosedStatus()`), so forensics summary totals stay aligned with the rest of GSD without loading every row.
> 
> Regression tests assert exactly three aggregate prepares (no `SELECT *`) and that `getDbCompletionCounts` in `forensics.ts` no longer references `getAllMilestones`, `getMilestoneSlices`, or `getSliceTasks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6488dfb20d675d0bd94930889716a80b76a828dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->