### PR TITLE
fix(issue): [Bug]: The always-on health widget refresh ends with synchronous git-log spawns, freezing the TUI on slow repos

### DIFF
--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -2,11 +2,13 @@
 // File Purpose: Always-on ambient health signal rendered below the editor.
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
+import { execFile } from "node:child_process";
 import type { GSDState } from "./types.js";
 import { runProviderChecks, summariseProviderIssues } from "./doctor-providers.js";
 import { runEnvironmentChecks, runEnvironmentChecksAsync } from "./doctor-environment.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { nativeIsRepo, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeCommitSubject } from "./native-git-bridge.js";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { loadLedgerFromDisk, getProjectTotals } from "./metrics.js";
 import { describeNextUnit, estimateTimeRemaining, updateSliceProgressCache } from "./auto-dashboard.js";
 import { projectRoot } from "./commands/context.js";
@@ -20,11 +22,13 @@ import {
 export const HEALTH_WIDGET_ACTIVE_HINTS =
   "  /gsd auto to run  ·  /gsd status to inspect  ·  /gsd report for snapshots  ·  /gsd notifications for history  ·  /gsd help";
 
+const LAST_COMMIT_LOOKUP_TIMEOUT_MS = 3_000;
+
 // ── Data loader ────────────────────────────────────────────────────────────────
 
 // Last-commit lookup is subprocess-backed (native-git-bridge → git spawns),
 // so it is treated like the other expensive checks: skipped on first paint,
-// run only by the background refresh.
+// and never used by the async widget refresh path.
 function loadLastCommitInfo(basePath: string): { epoch: number | null; message: string | null } {
   try {
     if (nativeIsRepo(basePath)) {
@@ -36,6 +40,46 @@ function loadLastCommitInfo(basePath: string): { epoch: number | null; message: 
     }
   } catch { /* non-fatal */ }
   return { epoch: null, message: null };
+}
+
+function runHealthWidgetGit(basePath: string, args: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = execFile(
+      "git",
+      args,
+      {
+        cwd: basePath,
+        timeout: LAST_COMMIT_LOOKUP_TIMEOUT_MS,
+        encoding: "utf-8",
+        env: GIT_NO_PROMPT_ENV,
+      },
+      (err, stdout) => resolve(err ? null : String(stdout).trimEnd()),
+    );
+    child.on("error", () => resolve(null));
+  });
+}
+
+async function loadLastCommitInfoAsync(basePath: string): Promise<{ epoch: number | null; message: string | null }> {
+  try {
+    if ((await runHealthWidgetGit(basePath, ["rev-parse", "--git-dir"])) === null) {
+      return { epoch: null, message: null };
+    }
+
+    const branch = await runHealthWidgetGit(basePath, ["branch", "--show-current"]);
+    const ref = branch || "HEAD";
+    const raw = await runHealthWidgetGit(basePath, ["log", "-1", "--format=%ct%x00%s", ref]);
+    if (!raw) return { epoch: null, message: null };
+
+    const separator = raw.indexOf("\0");
+    const epochText = separator >= 0 ? raw.slice(0, separator) : raw;
+    const epoch = parseInt(epochText.trim(), 10) || 0;
+    if (epoch <= 0) return { epoch: null, message: null };
+
+    const message = separator >= 0 ? raw.slice(separator + 1).trim() : "";
+    return { epoch, message: message || null };
+  } catch {
+    return { epoch: null, message: null };
+  }
 }
 
 function loadHealthWidgetData(
@@ -104,10 +148,8 @@ function loadHealthWidgetData(
 }
 
 // Non-blocking variant used by the widget's background refresh: the cheap fields
-// come from the synchronous snapshot, then provider + environment checks are
-// layered in off the event-loop critical path (env checks run concurrently via
-// runEnvironmentChecksAsync). Keeps the always-on widget from stalling the UI on
-// its initial enrichment or its 60s refresh.
+// come from the synchronous snapshot, then provider, environment, and last-commit
+// checks are layered in off the event-loop critical path.
 async function loadHealthWidgetDataAsync(basePath: string): Promise<HealthWidgetData> {
   const data = loadHealthWidgetData(basePath, { includeChecks: false });
   let providerIssue = data.providerIssue;
@@ -126,7 +168,7 @@ async function loadHealthWidgetDataAsync(basePath: string): Promise<HealthWidget
     }
   } catch { /* non-fatal */ }
 
-  const commit = loadLastCommitInfo(basePath);
+  const commit = await loadLastCommitInfoAsync(basePath);
 
   return {
     ...data,

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -207,6 +207,7 @@ test("health widget async refresh does not block timers while git log is slow", 
   } as any);
 
   assert.ok(factory, "health widget factory is registered");
+  const resolvedFactory = factory;
 
   heartbeat = setInterval(() => {
     const now = performance.now();
@@ -214,7 +215,7 @@ test("health widget async refresh does not block timers while git log is slow", 
     lastTick = now;
   }, 25);
 
-  widget = factory(
+  widget = resolvedFactory(
     { requestRender: () => { resolveRefresh?.(); } },
     { fg: (_style: string, text: string) => text },
   );

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -3,8 +3,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   buildHealthLines,
@@ -12,8 +14,9 @@ import {
   formatRelativeTime,
   type HealthWidgetData,
 } from "../health-widget-core.ts";
-import { HEALTH_WIDGET_ACTIVE_HINTS } from "../health-widget.ts";
+import { HEALTH_WIDGET_ACTIVE_HINTS, initHealthWidget } from "../health-widget.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
 
 function makeTempDir(prefix: string): string {
   const dir = join(
@@ -31,6 +34,58 @@ function cleanup(dir: string): void {
     // best-effort
   }
 }
+
+function runGit(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function makeTempRepo(prefix: string): string {
+  const dir = makeTempDir(prefix);
+  runGit(dir, "init");
+  runGit(dir, "config", "user.email", "test@test.com");
+  runGit(dir, "config", "user.name", "Test");
+  writeFileSync(join(dir, "README.md"), "# test\n", "utf-8");
+  runGit(dir, "add", "README.md");
+  runGit(dir, "commit", "-m", "initial commit");
+  return dir;
+}
+
+function installSlowGitLogShim(binDir: string): void {
+  writeFileSync(
+    join(binDir, "git"),
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "log" ]; then sleep 1; fi',
+      'PATH="$GSD_REAL_PATH"',
+      "export PATH",
+      'exec git "$@"',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  chmodSync(join(binDir, "git"), 0o755);
+
+  writeFileSync(
+    join(binDir, "git.cmd"),
+    [
+      "@echo off",
+      'if "%1"=="log" powershell -NoProfile -Command "Start-Sleep -Seconds 1"',
+      'set "PATH=%GSD_REAL_PATH%"',
+      "git %*",
+      "",
+    ].join("\r\n"),
+    "utf-8",
+  );
+}
+
+type HealthWidgetFactory = (
+  tui: { requestRender(): void },
+  theme: { fg(style: string, text: string): string },
+) => { dispose(): void };
 
 function activeData(overrides: Partial<HealthWidgetData> = {}): HealthWidgetData {
   return {
@@ -99,6 +154,82 @@ test("health widget active hints include visualization and notifications", () =>
   assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd report for snapshots/);
   assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd notifications for history/);
   assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd help/);
+});
+
+test("health widget async refresh does not block timers while git log is slow", async (t) => {
+  const dir = makeTempRepo("slow-git-log");
+  const binDir = makeTempDir("slow-git-log-bin");
+  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  installSlowGitLogShim(binDir);
+
+  const originalCwd = process.cwd();
+  const originalProcessPath = process.env.PATH;
+  const originalEnvPath = GIT_NO_PROMPT_ENV.PATH;
+  const originalEnvRealPath = GIT_NO_PROMPT_ENV.GSD_REAL_PATH;
+  const shimmedPath = `${binDir}${delimiter}${originalProcessPath ?? ""}`;
+
+  process.chdir(dir);
+  process.env.PATH = shimmedPath;
+  GIT_NO_PROMPT_ENV.PATH = shimmedPath;
+  GIT_NO_PROMPT_ENV.GSD_REAL_PATH = originalProcessPath ?? "";
+
+  let factory: HealthWidgetFactory | null = null;
+  let resolveRefresh: (() => void) | undefined;
+  const refreshed = new Promise<void>((resolve) => { resolveRefresh = resolve; });
+  const gaps: number[] = [];
+  let lastTick = performance.now();
+  let heartbeat: NodeJS.Timeout | undefined;
+  let refreshTimeout: NodeJS.Timeout | undefined;
+  let widget: { dispose(): void } | undefined;
+
+  t.after(() => {
+    if (widget) widget.dispose();
+    if (heartbeat) clearInterval(heartbeat);
+    if (refreshTimeout) clearTimeout(refreshTimeout);
+    process.chdir(originalCwd);
+    if (originalProcessPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalProcessPath;
+    if (originalEnvPath === undefined) delete GIT_NO_PROMPT_ENV.PATH;
+    else GIT_NO_PROMPT_ENV.PATH = originalEnvPath;
+    if (originalEnvRealPath === undefined) delete GIT_NO_PROMPT_ENV.GSD_REAL_PATH;
+    else GIT_NO_PROMPT_ENV.GSD_REAL_PATH = originalEnvRealPath;
+    cleanup(binDir);
+    cleanup(dir);
+  });
+
+  initHealthWidget({
+    hasUI: true,
+    ui: {
+      setWidget: (_key: string, value: unknown) => {
+        if (typeof value === "function") factory = value as HealthWidgetFactory;
+      },
+    },
+  } as any);
+
+  assert.ok(factory, "health widget factory is registered");
+
+  heartbeat = setInterval(() => {
+    const now = performance.now();
+    gaps.push(now - lastTick);
+    lastTick = now;
+  }, 25);
+
+  widget = factory(
+    { requestRender: () => { resolveRefresh?.(); } },
+    { fg: (_style: string, text: string) => text },
+  );
+
+  await Promise.race([
+    refreshed,
+    new Promise<never>((_, reject) => {
+      refreshTimeout = setTimeout(() => reject(new Error("health widget refresh did not complete")), 4_000);
+    }),
+  ]);
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+
+  assert.ok(gaps.length > 0, "heartbeat ran while refresh was in flight");
+  const maxGap = Math.max(...gaps);
+  assert.ok(maxGap < 750, `slow git log must not starve timers; max gap was ${Math.round(maxGap)}ms`);
 });
 
 test("buildHealthLines: active state with budget ceiling shows percent summary", (t) => {

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -207,7 +207,6 @@ test("health widget async refresh does not block timers while git log is slow", 
   } as any);
 
   assert.ok(factory, "health widget factory is registered");
-  const resolvedFactory = factory;
 
   heartbeat = setInterval(() => {
     const now = performance.now();
@@ -215,7 +214,9 @@ test("health widget async refresh does not block timers while git log is slow", 
     lastTick = now;
   }, 25);
 
-  widget = resolvedFactory(
+  // assert.ok above guards at runtime; double-cast is needed because TypeScript
+  // cannot track the factory assignment through the `as any` closure call.
+  widget = (factory as unknown as HealthWidgetFactory)(
     { requestRender: () => { resolveRefresh?.(); } },
     { fg: (_style: string, text: string) => text },
   );


### PR DESCRIPTION
## Summary
- Fixed the health widget async refresh to use non-blocking git commit lookups and added a slow-git-log timer starvation regression, with syntax and whitespace checks passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #964
- [#964 [Bug]: The always-on health widget refresh ends with synchronous git-log spawns, freezing the TUI on slow repos](https://github.com/open-gsd/gsd-pi/issues/964)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/964-bug-the-always-on-health-widget-refresh--1782570726`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to health widget enrichment and git subprocess wiring; sync paths and display logic are largely unchanged aside from the async refresh path.
> 
> **Overview**
> Fixes TUI freezes during the always-on health widget’s **background refresh** by moving last-commit lookup off the synchronous `native-git-bridge` path and onto **async `git` subprocess calls** with a 3s timeout and `GIT_NO_PROMPT_ENV`.
> 
> `loadHealthWidgetDataAsync` now awaits `loadLastCommitInfoAsync` (repo check, current branch, single `git log` for epoch + subject) instead of blocking on sync spawns at the end of refresh. The sync `loadLastCommitInfo` path is unchanged for loads that use `includeChecks: true`; first paint still skips expensive work via `includeChecks: false`.
> 
> Adds a regression test that shims a slow `git log`, runs `initHealthWidget`, and asserts timer heartbeats stay under ~750ms while refresh completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096f232a9428ebb199dadeba2ff8fadf6463ed96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->