### PR TITLE
fix(issue): [Bug]: An aborted gsd_exec keeps its child process alive until the timeout cap (up to 10 minutes)

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -133,7 +133,7 @@ function makeMockServer() {
     name: string;
     description: string;
     params: Record<string, unknown>;
-    handler: (args: Record<string, unknown>) => Promise<unknown>;
+    handler: (args: Record<string, unknown>, extra?: { signal?: AbortSignal }) => Promise<unknown>;
   }> = [];
   return {
     tools,
@@ -141,7 +141,7 @@ function makeMockServer() {
       name: string,
       description: string,
       params: Record<string, unknown>,
-      handler: (args: Record<string, unknown>) => Promise<unknown>,
+      handler: (args: Record<string, unknown>, extra?: { signal?: AbortSignal }) => Promise<unknown>,
     ) {
       tools.push({ name, description, params, handler });
     },
@@ -511,6 +511,45 @@ describe("workflow MCP tools", () => {
       assert.equal(record.isError, false);
       assert.equal(record.structuredContent.runtime, "bash");
       assert.match(record.content[0].text as string, /mcp-command-alias-defaults-to-bash/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_exec honors MCP abort signal before the sandbox timeout", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_exec");
+      assert.ok(tool, "exec tool should be registered");
+
+      const controller = new AbortController();
+      controller.abort();
+      const timeoutMs = 5_000;
+
+      const result = await tool!.handler(
+        {
+          projectDir: base,
+          runtime: "node",
+          script: "setTimeout(() => {}, 30_000);",
+          timeout_ms: timeoutMs,
+        },
+        { signal: controller.signal },
+      );
+
+      const record = result as any;
+      assert.equal(record.isError, true);
+      assert.equal(record.structuredContent.operation, "gsd_exec");
+      assert.equal(record.structuredContent.aborted, true);
+      assert.equal(record.structuredContent.timed_out, false);
+      assert.ok(
+        record.structuredContent.duration_ms < timeoutMs,
+        `expected abort before ${timeoutMs}ms timeout, got ${record.structuredContent.duration_ms}ms`,
+      );
+      assert.match(record.content[0].text as string, /exit=aborted/);
+      const meta = JSON.parse(readFileSync(record.structuredContent.meta_path, "utf-8"));
+      assert.equal(meta.aborted, true);
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -840,7 +840,7 @@ interface McpToolServer {
     name: string,
     description: string,
     params: Record<string, unknown>,
-    handler: (args: Record<string, unknown>) => Promise<unknown>,
+    handler: (args: Record<string, unknown>, extra?: { signal?: AbortSignal }) => Promise<unknown>,
   ): unknown;
 }
 
@@ -2000,9 +2000,9 @@ const resumeSchema = z.object(resumeParams);
 function wrapServerWithErrorHandler(realServer: McpToolServer): McpToolServer {
   return {
     tool(name, description, params, handler) {
-      return realServer.tool(name, description, params, async (args) => {
+      return realServer.tool(name, description, params, async (args, extra) => {
         try {
-          return await handler(args);
+          return await handler(args, extra);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           return {
@@ -2636,7 +2636,7 @@ export function registerWorkflowTools(
     "gsd_uat_exec",
     "Run one UAT-scoped bash/node/python check with milestone/slice/check metadata. Evidence persists under .gsd/exec with kind=uat_exec.",
     uatExecParams,
-    async (args: Record<string, unknown>) => {
+    async (args: Record<string, unknown>, extra?: { signal?: AbortSignal }) => {
       const { projectDir, ...params } = parseWorkflowArgs(uatExecSchema, args);
       await enforceWorkflowWriteGate("gsd_uat_exec", projectDir);
       const { executeUatExec } = await importLocalModule<any>(
@@ -2647,6 +2647,7 @@ export function registerWorkflowTools(
           executeUatExec(params, {
             baseDir: projectDir,
             preferences: await loadProjectPreferences(projectDir),
+            signal: extra?.signal,
           }),
         ),
       );
@@ -2657,7 +2658,7 @@ export function registerWorkflowTools(
     "gsd_exec",
     "Run a short bash/node/python script in the project directory. Capped stdout/stderr and metadata persist under .gsd/exec; only a digest returns to MCP.",
     execParams,
-    async (args: Record<string, unknown>) => {
+    async (args: Record<string, unknown>, extra?: { signal?: AbortSignal }) => {
       const { projectDir, ...params } = parseWorkflowArgs(execSchema, args);
       await enforceWorkflowWriteGate("gsd_exec", projectDir);
       const { executeGsdExec } = await importLocalModule<any>(
@@ -2668,6 +2669,7 @@ export function registerWorkflowTools(
           executeGsdExec(params, {
             baseDir: projectDir,
             preferences: await loadProjectPreferences(projectDir),
+            signal: extra?.signal,
           }),
         ),
       );

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -72,6 +72,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
       return executeUatExec(params as Parameters<typeof executeUatExec>[0], {
         baseDir,
         preferences: await loadContextModePreferences(baseDir),
+        signal: _signal,
       });
     },
   });
@@ -119,6 +120,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
       return executeGsdExec(params as Parameters<typeof executeGsdExec>[0], {
         baseDir,
         preferences: await loadContextModePreferences(baseDir),
+        signal: _signal,
       });
     },
   });

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -48,6 +48,8 @@ export interface ExecSandboxOptions {
   now?: () => Date;
   /** Optional override for id generation (tests). */
   generateId?: () => string;
+  /** Optional request cancellation signal. Aborting kills the child process tree. */
+  signal?: AbortSignal;
   /**
    * Grace period (ms) between SIGTERM and SIGKILL on timeout.
    * Defaults to SIGKILL_GRACE_MS. Exposed as a test seam.
@@ -67,6 +69,8 @@ export interface ExecSandboxResult {
   exit_code: number | null;
   signal: NodeJS.Signals | null;
   timed_out: boolean;
+  /** True when an external AbortSignal terminated the child process tree. */
+  aborted?: boolean;
   /**
    * True when the result came from the hard-deadline force-resolve (a non-closing
    * D-state child that never emitted 'close') rather than an observed process exit.
@@ -260,11 +264,23 @@ export function runExecSandbox(
     const effectiveForceResolveDelay = opts.force_resolve_delay_ms ?? (effectiveGraceMs + HARD_DEADLINE_MS);
 
     let timedOut = false;
+    let aborted = false;
     let settled = false;
+    let killInitiated = false;
+    let timer: NodeJS.Timeout | undefined;
     let forceResolveTimer: NodeJS.Timeout | undefined;
+    let abortListener: (() => void) | undefined;
 
-    const timer = setTimeout(() => {
-      timedOut = true;
+    const removeAbortListener = () => {
+      if (opts.signal && abortListener) {
+        opts.signal.removeEventListener("abort", abortListener);
+        abortListener = undefined;
+      }
+    };
+
+    const initiateKill = () => {
+      if (killInitiated) return;
+      killInitiated = true;
       // killProcessTree handles both platforms and kills the whole tree: on Unix
       // it signals the process group (SIGTERM -> grace -> SIGKILL); on Windows it
       // force-kills the tree via taskkill /F /T. Using child.kill("SIGTERM") here
@@ -281,14 +297,14 @@ export function runExecSandbox(
         finalize(null, "SIGKILL", true);
       }, effectiveForceResolveDelay);
       forceResolveTimer.unref?.();
-    }, timeoutMs);
-    timer.unref?.();
+    };
 
     const finalize = (exitCode: number | null, signal: NodeJS.Signals | null, forceResolved = false) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       clearTimeout(forceResolveTimer);
+      removeAbortListener();
       const duration = Date.now() - started;
       const stdoutBuf = Buffer.concat(stdoutChunks);
       const stderrBuf = Buffer.concat(stderrChunks);
@@ -301,11 +317,13 @@ export function runExecSandbox(
       const digest =
         digestBody.length > 0
           ? digestBody
-          : timedOut
-            ? "[no stdout — timed out]"
-            : stderrBuf.length > 0
-              ? `[no stdout — tail of stderr]\n${tail(stderrBuf, opts.digest_chars)}`
-              : "[no output]";
+          : aborted
+            ? "[no stdout — aborted]"
+            : timedOut
+              ? "[no stdout — timed out]"
+              : stderrBuf.length > 0
+                ? `[no stdout — tail of stderr]\n${tail(stderrBuf, opts.digest_chars)}`
+                : "[no output]";
 
       const result: ExecSandboxResult = {
         id,
@@ -313,6 +331,7 @@ export function runExecSandbox(
         exit_code: exitCode,
         signal,
         timed_out: timedOut,
+        aborted,
         force_resolved: forceResolved,
         duration_ms: duration,
         stdout_bytes: stdoutBytes,
@@ -327,6 +346,25 @@ export function runExecSandbox(
       writeMeta(metaPath, result, request, now);
       resolveP(result);
     };
+
+    timer = setTimeout(() => {
+      timedOut = true;
+      initiateKill();
+    }, timeoutMs);
+    timer.unref?.();
+
+    if (opts.signal) {
+      abortListener = () => {
+        if (settled || timedOut) return;
+        aborted = true;
+        initiateKill();
+      };
+      if (opts.signal.aborted) {
+        abortListener();
+      } else {
+        opts.signal.addEventListener("abort", abortListener, { once: true });
+      }
+    }
 
     child.on("error", (err) => {
       const message = err instanceof Error ? err.message : String(err);
@@ -364,6 +402,7 @@ function writeMeta(
     exit_code: result.exit_code,
     signal: result.signal,
     timed_out: result.timed_out,
+    aborted: result.aborted === true,
     force_resolved: result.force_resolved,
     duration_ms: result.duration_ms,
     stdout_bytes: result.stdout_bytes,

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -357,6 +357,7 @@ export function runExecSandbox(
       abortListener = () => {
         if (settled || timedOut) return;
         aborted = true;
+        clearTimeout(timer);
         initiateKill();
       };
       if (opts.signal.aborted) {

--- a/src/resources/extensions/gsd/tests/exec-graceful-kill.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-graceful-kill.test.ts
@@ -97,6 +97,7 @@ test(
     );
     const meta = JSON.parse(readFileSync(result.meta_path, 'utf-8'));
     assert.equal(meta.aborted, true, 'meta.json must persist the aborted marker');
+    assert.equal(meta.timed_out, false, 'meta.json must not report timed_out when abort caused the kill');
   },
 );
 

--- a/src/resources/extensions/gsd/tests/exec-graceful-kill.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-graceful-kill.test.ts
@@ -63,6 +63,43 @@ function wallClockGuard<T>(promise: Promise<T>, ms: number): Promise<T> {
   ]);
 }
 
+test(
+  'runExecSandbox: aborted signal terminates promptly without waiting for timeout',
+  { timeout: 10_000 },
+  async (t) => {
+    const base = freshBase();
+    t.after(() => cleanup(base));
+
+    const controller = new AbortController();
+    controller.abort();
+    const TIMEOUT_MS = 10_000;
+
+    const start = Date.now();
+    const result = await wallClockGuard(
+      runExecSandbox(
+        { runtime: 'node', script: 'setTimeout(() => {}, 30_000);', timeout_ms: TIMEOUT_MS },
+        baseOpts(base, {
+          signal: controller.signal,
+          kill_grace_ms: 500,
+          force_resolve_delay_ms: 2_000,
+        }),
+      ),
+      5_000,
+    );
+    const elapsed = Date.now() - start;
+
+    assert.equal(result.aborted, true, 'aborted signal must be recorded on the sandbox result');
+    assert.equal(result.timed_out, false, 'client abort must not be reported as a sandbox timeout');
+    assert.ok(elapsed < TIMEOUT_MS, `expected abort before ${TIMEOUT_MS}ms timeout, took ${elapsed}ms`);
+    assert.ok(
+      result.duration_ms < TIMEOUT_MS,
+      `expected result duration before timeout, got ${result.duration_ms}ms`,
+    );
+    const meta = JSON.parse(readFileSync(result.meta_path, 'utf-8'));
+    assert.equal(meta.aborted, true, 'meta.json must persist the aborted marker');
+  },
+);
+
 // Clean up a detached child (and its process group) that a large kill_grace_ms
 // intentionally leaves alive past the force-resolve deadline.
 function cleanupByPidFile(pidFile: string): void {

--- a/src/resources/extensions/gsd/tests/exec-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-tool.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { registerExecTools } from "../bootstrap/exec-tools.ts";
 import { executeGsdExec, executeUatExec } from "../tools/exec-tool.ts";
-import type { ExecSandboxRequest, ExecSandboxResult } from "../exec-sandbox.ts";
+import type { ExecSandboxOptions, ExecSandboxRequest, ExecSandboxResult } from "../exec-sandbox.ts";
 
 function makeExecResult(request: ExecSandboxRequest): ExecSandboxResult {
   return {
@@ -12,6 +12,7 @@ function makeExecResult(request: ExecSandboxRequest): ExecSandboxResult {
     exit_code: 0,
     signal: null,
     timed_out: false,
+    aborted: false,
     force_resolved: false,
     duration_ms: 1,
     stdout_bytes: 12,
@@ -50,6 +51,49 @@ test("executeUatExec accepts evidence-mode aliases for intent", async () => {
   assert.equal(result.details?.operation, "gsd_uat_exec");
   assert.equal(result.details?.intent, "uat-artifact-check");
   assert.equal(requests[0]?.metadata?.intent, "uat-artifact-check");
+});
+
+test("executeGsdExec passes AbortSignal into sandbox options", async () => {
+  const controller = new AbortController();
+  let capturedSignal: AbortSignal | undefined;
+
+  const result = await executeGsdExec(
+    { runtime: "bash", script: "sleep 60" },
+    {
+      baseDir: "/tmp/gsd-exec-abort-signal-test",
+      preferences: null,
+      signal: controller.signal,
+      run: async (request, opts: ExecSandboxOptions) => {
+        capturedSignal = opts.signal;
+        return makeExecResult(request);
+      },
+    },
+  );
+
+  assert.equal(result.isError, false);
+  assert.equal(capturedSignal, controller.signal);
+});
+
+test("gsd_exec surfaces aborted child termination distinctly from a clean exit", async () => {
+  const result = await executeGsdExec(
+    { runtime: "bash", script: "trap 'exit 0' TERM; sleep 60" },
+    {
+      baseDir: "/tmp/gsd-exec-aborted-test",
+      preferences: null,
+      run: async (request) => ({
+        ...makeExecResult(request),
+        aborted: true,
+        exit_code: 0,
+        signal: null,
+        digest: "[no stdout — aborted]",
+      }),
+    },
+  );
+
+  assert.equal(result.isError, true, "an aborted run must be an error even if the child exits 0");
+  assert.equal(result.details?.aborted, true, "details must expose aborted");
+  const text = result.content.map((c) => c.text ?? "").join("\n");
+  assert.match(text, /exit=aborted/, "summary must distinguish an aborted result");
 });
 
 test("gsd_exec surfaces a force-resolved (D-state) kill distinctly from a clean exit", async () => {

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -31,6 +31,7 @@ export interface ExecToolDeps {
   env?: NodeJS.ProcessEnv;
   now?: () => Date;
   generateId?: () => string;
+  signal?: AbortSignal;
 }
 
 export type UatExecIntent =
@@ -74,7 +75,7 @@ const UAT_EXEC_INTENT_ALIASES: Record<string, UatExecIntent> = {
 export function buildExecOptions(
   baseDir: string,
   cfg: ContextModeConfig | undefined,
-  extras?: Pick<ExecSandboxOptions, "env" | "now" | "generateId">,
+  extras?: Pick<ExecSandboxOptions, "env" | "now" | "generateId" | "signal">,
 ): ExecSandboxOptions {
   const allowlist = Array.isArray(cfg?.exec_env_allowlist) ? cfg!.exec_env_allowlist! : EXEC_DEFAULTS.envAllowlist;
   const stdoutCap = clampNumber(
@@ -209,7 +210,7 @@ export async function executeGsdExec(
   const opts = buildExecOptions(
     deps.baseDir,
     deps.preferences?.context_mode,
-    { env: deps.env, now: deps.now, generateId: deps.generateId },
+    { env: deps.env, now: deps.now, generateId: deps.generateId, signal: deps.signal },
   );
   const run = deps.run ?? runExecSandbox;
 
@@ -308,6 +309,7 @@ function formatResult(result: ExecSandboxResult): ToolExecutionResult {
       exit_code: result.exit_code,
       signal: result.signal,
       timed_out: result.timed_out,
+      aborted: result.aborted === true,
       force_resolved: result.force_resolved,
       duration_ms: result.duration_ms,
       stdout_bytes: result.stdout_bytes,
@@ -318,13 +320,15 @@ function formatResult(result: ExecSandboxResult): ToolExecutionResult {
       stderr_path: result.stderr_path,
       meta_path: result.meta_path,
     },
-    isError: result.timed_out || result.signal !== null || result.exit_code !== 0,
+    isError: result.aborted === true || result.timed_out || result.signal !== null || result.exit_code !== 0,
   };
 }
 
 function formatExit(result: ExecSandboxResult): string {
   // force_resolved means a non-closing (D-state) child was force-resolved past its
   // hard deadline rather than observed exiting; distinguish it from a clean timeout.
+  if (result.aborted && result.force_resolved) return "aborted(force-killed)";
+  if (result.aborted) return "aborted";
   if (result.force_resolved) return "timeout(force-killed)";
   if (result.timed_out) return "timeout";
   if (result.signal) return `signal:${result.signal}`;


### PR DESCRIPTION
## Summary
- Added abort-signal propagation and sandbox abort cleanup for gsd_exec/gsd_uat_exec with focused regression tests and static verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #952
- [#952 [Bug]: An aborted gsd_exec keeps its child process alive until the timeout cap (up to 10 minutes)](https://github.com/open-gsd/gsd-pi/issues/952)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/952-bug-an-aborted-gsd-exec-keeps-its-child--1782570745`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess lifecycle and kill/timeout coordination in the exec sandbox; behavior change is scoped to cancellation but incorrect abort vs timeout handling could affect long-running MCP exec calls.
> 
> **Overview**
> Fixes **#952**: when an MCP client cancels a tool call, **`gsd_exec` and `gsd_uat_exec` no longer leave subprocesses running until the sandbox timeout** (up to minutes).
> 
> **Abort propagation** runs from MCP workflow handlers (optional `extra.signal`) through Pi `exec-tools`, `executeGsdExec` / `executeUatExec`, and into **`runExecSandbox`**, which listens on `AbortSignal`, clears the timeout timer, kills the process tree, and records **`aborted`** separately from **`timed_out`**.
> 
> **Tool results** treat aborted runs as errors (`exit=aborted`), expose `aborted` in structured details and **`.gsd/exec` meta.json**, and use an aborted-specific digest when stdout is empty. Regression tests cover the sandbox, exec tool, and MCP `gsd_exec` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9691426afaa2346d0093087e29392ad1b543631d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->