### PR TITLE
fix(issue): [Bug]: Cant do anything: Error: spawn ENAMETOOLONG

### DIFF
--- a/src/resources/extensions/google-cli/stream-adapter.ts
+++ b/src/resources/extensions/google-cli/stream-adapter.ts
@@ -20,7 +20,13 @@ const ZERO_USAGE = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-type GoogleCliProviderId = "google-gemini-cli" | "google-antigravity";
+export type GoogleCliProviderId = "google-gemini-cli" | "google-antigravity";
+
+export interface GoogleCliRunPlan {
+	command: string;
+	args: string[];
+	stdin?: string;
+}
 
 interface CliRunResult {
 	stdout: string;
@@ -120,15 +126,15 @@ function commandForProvider(provider: GoogleCliProviderId): string {
 	return provider === "google-gemini-cli" ? "gemini" : "agy";
 }
 
-function argsForProvider(provider: GoogleCliProviderId, model: Model<Api>, prompt: string): string[] {
+function argsForProvider(provider: GoogleCliProviderId, modelId: string, prompt?: string): string[] {
 	if (provider === "google-gemini-cli") {
-		const args = ["-p", prompt, "--output-format", "json"];
-		if (model.id !== "default") args.unshift("-m", model.id);
+		const args = prompt === undefined ? ["--output-format", "json"] : ["-p", prompt, "--output-format", "json"];
+		if (modelId !== "default") args.unshift("-m", modelId);
 		return args;
 	}
 
-	const args = ["-p", prompt];
-	if (model.id !== "default") args.unshift("-m", model.id);
+	const args = prompt === undefined ? [] : ["-p", prompt];
+	if (modelId !== "default") args.unshift("-m", modelId);
 	return args;
 }
 
@@ -136,20 +142,33 @@ export function buildGoogleCliSpawnInvocation(
 	command: string,
 	args: string[],
 	platform: NodeJS.Platform = process.platform,
-): { command: string; args: string[] } {
+): Omit<GoogleCliRunPlan, "stdin"> {
 	if (platform === "win32") {
 		return { command: "cmd", args: ["/c", command, ...args] };
 	}
 	return { command, args };
 }
 
-function runCli(command: string, args: string[], options?: SimpleStreamOptions): Promise<CliRunResult> {
+export function buildGoogleCliRunPlan(
+	provider: GoogleCliProviderId,
+	modelId: string,
+	prompt: string,
+	platform: NodeJS.Platform = process.platform,
+): GoogleCliRunPlan {
+	const pipePrompt = platform === "win32";
+	const args = argsForProvider(provider, modelId, pipePrompt ? undefined : prompt);
+	return {
+		...buildGoogleCliSpawnInvocation(commandForProvider(provider), args, platform),
+		...(pipePrompt ? { stdin: prompt } : {}),
+	};
+}
+
+function runCli(plan: GoogleCliRunPlan, options?: SimpleStreamOptions): Promise<CliRunResult> {
 	return new Promise((resolve, reject) => {
-		const invocation = buildGoogleCliSpawnInvocation(command, args);
-		const child = spawn(invocation.command, invocation.args, {
+		const child = spawn(plan.command, plan.args, {
 			cwd: options?.cwd || process.cwd(),
 			env: process.env,
-			stdio: ["ignore", "pipe", "pipe"],
+			stdio: [plan.stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
 		});
 
 		let stdout = "";
@@ -173,6 +192,11 @@ function runCli(command: string, args: string[], options?: SimpleStreamOptions):
 			return;
 		}
 		options?.signal?.addEventListener("abort", onAbort);
+
+		if (plan.stdin !== undefined) {
+			child.stdin?.on("error", () => {});
+			child.stdin?.end(plan.stdin);
+		}
 
 		child.stdout.setEncoding("utf8");
 		child.stderr.setEncoding("utf8");
@@ -243,9 +267,7 @@ export function streamViaGoogleCli(
 	queueMicrotask(async () => {
 		try {
 			const prompt = buildGoogleCliPrompt(context);
-			const command = commandForProvider(provider);
-			const args = argsForProvider(provider, model, prompt);
-			const result = await runCli(command, args, options);
+			const result = await runCli(buildGoogleCliRunPlan(provider, model.id, prompt), options);
 
 			if (result.code !== 0) {
 				const detail = (result.stderr || result.stdout || `CLI exited with code ${result.code}`).trim();

--- a/src/resources/extensions/google-cli/stream-adapter.ts
+++ b/src/resources/extensions/google-cli/stream-adapter.ts
@@ -198,12 +198,12 @@ function runCli(plan: GoogleCliRunPlan, options?: SimpleStreamOptions): Promise<
 			child.stdin?.end(plan.stdin);
 		}
 
-		child.stdout.setEncoding("utf8");
-		child.stderr.setEncoding("utf8");
-		child.stdout.on("data", (chunk) => {
+		child.stdout!.setEncoding("utf8");
+		child.stderr!.setEncoding("utf8");
+		child.stdout!.on("data", (chunk) => {
 			stdout += chunk;
 		});
-		child.stderr.on("data", (chunk) => {
+		child.stderr!.on("data", (chunk) => {
 			stderr += chunk;
 		});
 

--- a/src/tests/windows-portability.test.ts
+++ b/src/tests/windows-portability.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { encodeCwd } from "../resources/extensions/subagent/isolation.ts";
-import { buildGoogleCliSpawnInvocation } from "../resources/extensions/google-cli/stream-adapter.ts";
+import { buildGoogleCliRunPlan, buildGoogleCliSpawnInvocation } from "../resources/extensions/google-cli/stream-adapter.ts";
 import { buildGsdClientSpawnPlan } from "../../vscode-extension/src/gsd-client-spawn.ts";
 
 test("encodeCwd produces a filesystem-safe token for Windows paths", () => {
@@ -22,13 +22,25 @@ test("VS Code RPC launch plan uses shell mode for Windows command shims", () => 
 });
 
 test("Google CLI spawn plan uses cmd.exe on Windows command shims", () => {
-	const plan = buildGoogleCliSpawnInvocation("gemini", ["-p", "hello"], "win32");
+	const plan = buildGoogleCliSpawnInvocation("gemini", ["--output-format", "json"], "win32");
 	assert.equal(plan.command, "cmd");
-	assert.deepEqual(plan.args, ["/c", "gemini", "-p", "hello"]);
+	assert.deepEqual(plan.args, ["/c", "gemini", "--output-format", "json"]);
 });
 
 test("Google CLI spawn plan keeps direct execution on non-Windows platforms", () => {
 	const plan = buildGoogleCliSpawnInvocation("agy", ["-p", "hello"], "linux");
 	assert.equal(plan.command, "agy");
 	assert.deepEqual(plan.args, ["-p", "hello"]);
+});
+
+test("Google CLI run plan pipes prompt on Windows to avoid command-line length limits", () => {
+	const prompt = "hello ".repeat(10_000);
+	const plan = buildGoogleCliRunPlan("google-gemini-cli", "gemini-2.5-pro", prompt, "win32");
+	const antigravityPlan = buildGoogleCliRunPlan("google-antigravity", "default", prompt, "win32");
+
+	assert.equal(plan.command, "cmd");
+	assert.deepEqual(plan.args, ["/c", "gemini", "-m", "gemini-2.5-pro", "--output-format", "json"]);
+	assert.equal(plan.stdin, prompt);
+	assert.ok(!plan.args.some((arg) => arg.includes(prompt)));
+	assert.deepEqual(antigravityPlan, { command: "cmd", args: ["/c", "agy"], stdin: prompt });
 });

--- a/src/tests/windows-portability.test.ts
+++ b/src/tests/windows-portability.test.ts
@@ -44,3 +44,18 @@ test("Google CLI run plan pipes prompt on Windows to avoid command-line length l
 	assert.ok(!plan.args.some((arg) => arg.includes(prompt)));
 	assert.deepEqual(antigravityPlan, { command: "cmd", args: ["/c", "agy"], stdin: prompt });
 });
+
+test("Google CLI run plan passes prompt as -p arg on non-Windows platforms", () => {
+	const prompt = "hello ".repeat(10_000);
+	const plan = buildGoogleCliRunPlan("google-gemini-cli", "gemini-2.5-pro", prompt, "linux");
+	const antigravityPlan = buildGoogleCliRunPlan("google-antigravity", "default", prompt, "linux");
+
+	assert.equal(plan.command, "gemini");
+	assert.ok(plan.args.includes("-p"));
+	assert.ok(plan.args.includes(prompt));
+	assert.equal(plan.stdin, undefined);
+	assert.equal(antigravityPlan.command, "agy");
+	assert.ok(antigravityPlan.args.includes("-p"));
+	assert.ok(antigravityPlan.args.includes(prompt));
+	assert.equal(antigravityPlan.stdin, undefined);
+});


### PR DESCRIPTION
## Summary
- Fixed Windows Google CLI prompt spawning by piping prompts over stdin and verified the run-plan logic plus diff cleanliness.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1005
- [#1005 [Bug]: Cant do anything: Error: spawn ENAMETOOLONG](https://github.com/open-gsd/gsd-pi/issues/1005)

## User
- @aloxuhik

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1005-bug-cant-do-anything-error-spawn-enameto-1782580877`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Windows Google CLI subprocess spawning; Linux/macOS still use `-p` args, with new tests for the Windows run plan.
> 
> **Overview**
> Fixes **`spawn ENAMETOOLONG`** on Windows when the Google CLI bridge builds a very long prompt (full conversation context) and passes it as a `-p` argument through `cmd.exe`.
> 
> On **win32**, prompts are now sent via **stdin** instead of the command line: `buildGoogleCliRunPlan` omits `-p` from args and sets `stdin` on the run plan; `runCli` pipes that data when spawning. Non-Windows behavior is unchanged (still uses `-p` in args).
> 
> The spawn path is refactored around a **`GoogleCliRunPlan`** (`command`, `args`, optional `stdin`), with `argsForProvider` taking `modelId` and an optional prompt. **`windows-portability.test.ts`** adds coverage for large prompts on Windows for both `google-gemini-cli` and `google-antigravity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f74876c149c82324c07c76ab396fb8c5b534fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->