### PR TITLE
fix(issue): [Bug]: Claude Code strict-phase prompt advertises ask_user_questions when the phase allowedTools omit it

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -101,6 +101,7 @@ export type {
 interface PromptToolContextOptions {
 	workflowMcpServerName?: string | null;
 	browserMcpServerName?: string | null;
+	questionToolAvailable?: boolean;
 }
 
 /** `SimpleStreamOptions` extended with an optional extension UI context for elicitation dialogs. */
@@ -480,8 +481,10 @@ export function buildPromptFromContext(context: Context, toolContext: PromptTool
 		? "- GSD workflow tools (gsd_exec, gsd_slice_complete, gsd_task_complete, gsd_plan_slice, gsd_save_gate_result, etc.) " +
 			`are MCP tools — call them as mcp__${toolContext.workflowMcpServerName}__<tool_name> ` +
 			`(e.g. mcp__${toolContext.workflowMcpServerName}__gsd_exec, mcp__${toolContext.workflowMcpServerName}__gsd_save_gate_result)\n` +
-			`- Structured user input: call mcp__${toolContext.workflowMcpServerName}__ask_user_questions. ` +
-			"Do not call bare ask_user_questions. Do not call native AskUserQuestion.\n"
+			(toolContext.questionToolAvailable !== false
+				? `- Structured user input: call mcp__${toolContext.workflowMcpServerName}__ask_user_questions. ` +
+					"Do not call bare ask_user_questions. Do not call native AskUserQuestion.\n"
+				: "")
 		: "- GSD workflow MCP tools are unavailable in this Claude Code run.\n";
 	const toolSearchLine = toolContext.workflowMcpServerName
 		? "- ToolSearch is available only for Claude Code deferred workflow MCP hydration. " +
@@ -2257,6 +2260,10 @@ async function pumpSdkMessages(
 		const prompt = buildPromptFromContext(context, {
 			workflowMcpServerName,
 			browserMcpServerName: browserMcpServerNameFromAllowedTools(sdkOpts.allowedTools),
+			questionToolAvailable: workflowMcpServerName && gsdPhase
+				? Array.isArray(sdkOpts.allowedTools)
+					&& sdkOpts.allowedTools.includes(`mcp__${workflowMcpServerName}__ask_user_questions`)
+				: undefined,
 		});
 		const queryPrompt = buildSdkQueryPrompt(context, prompt);
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -2001,6 +2001,76 @@ describe("stream-adapter — session persistence (#2859)", () => {
 });
 
 describe("stream-adapter — workflow MCP readiness", () => {
+	test("strict phase prompt omits workflow MCP question guidance when allowedTools omit it", async () => {
+		const cwd = realpathSync(mkdtempSync(join(tmpdir(), "claude-sdk-strict-question-prompt-")));
+		const restore = setWorkflowMcpEnv({
+			GSD_WORKFLOW_MCP_COMMAND: process.execPath,
+			GSD_WORKFLOW_MCP_NAME: "gsd-workflow",
+			GSD_WORKFLOW_MCP_ARGS: JSON.stringify(["-e", ""]),
+			GSD_WORKFLOW_MCP_CWD: cwd,
+		});
+		let capturedPrompt: unknown;
+		let capturedAllowedTools: string[] | undefined;
+		clearGuidedUnitContext();
+		_setAutoActiveForTest(true);
+		autoSession.currentUnit = { type: "plan-slice", id: "M001/S001", startedAt: 0, workspaceRoot: cwd } as never;
+		try {
+			const stream = streamViaClaudeCode(
+				{ id: "claude-sonnet-4-6" } as any,
+				{
+					systemPrompt: "UNIT: Plan Slice",
+					messages: [{ role: "user", content: "Plan the next slice." } as Message],
+				},
+				{
+					cwd,
+					_skipWorkflowMcpPreflightForTest: true,
+					async *_sdkQueryForTest(args: {
+						prompt: string | AsyncIterable<unknown>;
+						options?: Record<string, unknown>;
+					}) {
+						capturedPrompt = args.prompt;
+						capturedAllowedTools = args.options?.allowedTools as string[] | undefined;
+						yield {
+							type: "result",
+							subtype: "success",
+							uuid: "result-1",
+							session_id: "session-1",
+							duration_ms: 1,
+							duration_api_ms: 1,
+							is_error: false,
+							num_turns: 1,
+							result: "planned",
+							stop_reason: "end_turn",
+							total_cost_usd: 0,
+							usage: {
+								input_tokens: 0,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						};
+					},
+				} as any,
+			);
+
+			await stream.result();
+
+			assert.equal(typeof capturedPrompt, "string");
+			const prompt = capturedPrompt as string;
+			assert.ok(capturedAllowedTools?.includes("mcp__gsd-workflow__gsd_plan_slice"));
+			assert.ok(!capturedAllowedTools?.includes("mcp__gsd-workflow__ask_user_questions"));
+			assert.ok(!prompt.includes("mcp__gsd-workflow__ask_user_questions"));
+			assert.ok(!prompt.includes("Do not call bare ask_user_questions"));
+			assert.ok(prompt.includes("ToolSearch is available only for Claude Code deferred workflow MCP hydration"));
+		} finally {
+			autoSession.currentUnit = null;
+			_setAutoActiveForTest(false);
+			restore();
+			rmSync(cwd, { recursive: true, force: true });
+			clearMcpConfigCache();
+		}
+	});
+
 	test("resolves the workflow MCP preflight config from SDK mcpServers", () => {
 		const workflowConfig = { command: "node", args: ["workflow-server.js"] };
 		const browserConfig = { command: "gsd-browser" };


### PR DESCRIPTION
## Summary
- Gated Claude Code ask_user_questions prompt guidance on strict-phase allowedTools and added a regression test; git diff --check passed while test execution was blocked by missing deps/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #962
- [#962 [Bug]: Claude Code strict-phase prompt advertises ask_user_questions when the phase allowedTools omit it](https://github.com/open-gsd/gsd-pi/issues/962)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/962-bug-claude-code-strict-phase-prompt-adve-1782582684`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only alignment with existing SDK tool allowlists plus a focused test; no auth, data, or tool-surface policy changes beyond what strict phases already enforce.
> 
> **Overview**
> Fixes a mismatch where **strict GSD phase** Claude Code runs told the model to use `mcp__…__ask_user_questions` even when that tool was **not** in `allowedTools` (e.g. plan-slice), which could push the model toward unavailable tools.
> 
> The adapter now passes **`questionToolAvailable`** into prompt construction: for phased runs it is true only when `allowedTools` includes the workflow MCP `ask_user_questions` entry. The **structured user input** line in `<tool_context>` is omitted when that flag is false; non-phase behavior is unchanged (still defaults to showing guidance).
> 
> A **regression test** asserts plan-slice strict mode keeps phase workflow tools in `allowedTools` but drops question-related prompt text while other ToolSearch guidance remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257e6fc26164b7e8e3cc59bab47d479e164d8bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->