### PR TITLE
fix(issue): [Bug]: interactive chat rebuilds all earlier text-run segments per render frame during a single streamed assistant turn, defeating the Markdown parse cache and hitching the TUI

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -11,6 +11,7 @@ import {
 	priorAssistantTextFromSession,
 	textInvitesUserReply,
 } from "./chat-controller.js";
+import { AssistantMessageComponent } from "../components/assistant-message.js";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
 
 function createStreamingHost(chatContainer: Container): any {
@@ -357,6 +358,78 @@ test("handleAgentEvent: hidden thinking-only updates do not render transcript ca
 	await handleAgentEvent(host, { type: "message_end", message } as any);
 
 	assert.equal(stripAnsi(chatContainer.render(100).join("\n")).trim(), "");
+});
+
+test("handleAgentEvent: message_update does not rebuild unchanged earlier text-run segments", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const host = createStreamingHost(chatContainer);
+	host.hideThinkingBlock = false;
+	const updateCalls = new WeakMap<AssistantMessageComponent, number>();
+	const originalUpdateContent = AssistantMessageComponent.prototype.updateContent;
+	AssistantMessageComponent.prototype.updateContent = function (
+		this: AssistantMessageComponent,
+		...args: Parameters<AssistantMessageComponent["updateContent"]>
+	): ReturnType<AssistantMessageComponent["updateContent"]> {
+		updateCalls.set(this, (updateCalls.get(this) ?? 0) + 1);
+		return originalUpdateContent.apply(this, args);
+	};
+	const makeMessage = (content: any[]): any => ({
+		id: "a-stream",
+		role: "assistant",
+		provider: "claude-code",
+		model: "claude-opus-4-8",
+		timestamp: 1,
+		stopReason: "stop",
+		content,
+	});
+	const first = makeMessage([
+		{ type: "thinking", thinking: "I am considering the answer." },
+		{ type: "text", text: "First visible text." },
+	]);
+	const second = makeMessage([
+		{ type: "thinking", thinking: "I am considering the answer." },
+		{ type: "text", text: "First visible text. More streamed text." },
+	]);
+
+	try {
+		await handleAgentEvent(host, { type: "message_start", message: makeMessage([]) } as any);
+		await handleAgentEvent(host, {
+			type: "message_update",
+			message: first,
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 1,
+				delta: "First visible text.",
+				partial: first,
+			},
+		} as any);
+
+		const [thinkingSegment, textSegment] = chatContainer.children as AssistantMessageComponent[];
+		assert.equal(updateCalls.get(thinkingSegment), 1);
+		assert.equal(updateCalls.get(textSegment), 1);
+
+		await handleAgentEvent(host, {
+			type: "message_update",
+			message: second,
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 1,
+				delta: " More streamed text.",
+				partial: second,
+			},
+		} as any);
+
+		assert.equal(
+			updateCalls.get(thinkingSegment),
+			1,
+			"unchanged earlier text-run segment must not rebuild on later deltas",
+		);
+		assert.equal(updateCalls.get(textSegment), 2);
+	} finally {
+		AssistantMessageComponent.prototype.updateContent = originalUpdateContent;
+		await handleAgentEvent(host, { type: "message_end", message: second } as any);
+	}
 });
 
 test("handleAgentEvent: agent_start clears stale adaptive blocking error", async () => {

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -255,7 +255,7 @@ function isSubTurnTextReplacement(
 		if (seg.kind !== "text-run") continue;
 		const oldText = (seg.cachedText ?? "").trim();
 		if (!oldText) continue;
-		const newText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex).trim();
+		const newText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex, seg.contentType).trim();
 		if (!newText || newText === oldText) continue;
 		// Streaming growth extends prior text; a new sub-turn replaces it wholesale.
 		if (!newText.startsWith(oldText) && !oldText.startsWith(newText)) return seg.startIndex;
@@ -263,12 +263,24 @@ function isSubTurnTextReplacement(
 	return null;
 }
 
-function getTextFromContentBlocks(blocks: Array<any>, startIndex: number, endIndex: number): string {
+function getTextFromContentBlocks(
+	blocks: Array<any>,
+	startIndex: number,
+	endIndex: number,
+	contentType: "text" | "thinking" = "text",
+): string {
 	const parts: string[] = [];
 	for (let i = startIndex; i <= endIndex && i < blocks.length; i++) {
 		const block = blocks[i];
-		if (block?.type === "text" && typeof block.text === "string" && block.text.trim()) {
+		if (contentType === "text" && block?.type === "text" && typeof block.text === "string" && block.text.trim()) {
 			parts.push(block.text.trim());
+		} else if (
+			contentType === "thinking"
+			&& block?.type === "thinking"
+			&& typeof block.thinking === "string"
+			&& block.thinking.trim()
+		) {
+			parts.push(block.thinking.trim());
 		}
 	}
 	return parts.join("\n\n");
@@ -1032,8 +1044,9 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 								(s) => s.kind === "text-run" && s.startIndex === seg.startIndex && s.contentType === seg.contentType,
 							);
 							if (!existing) {
-								const segmentText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex);
+								const segmentText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex, seg.contentType);
 								if (
+									seg.contentType === "text" &&
 									shouldSuppressRedundantHandoffText(
 										host.session.messages,
 										segmentText,
@@ -1051,6 +1064,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 									{ startIndex: seg.startIndex, endIndex: seg.endIndex },
 								);
 								host.chatContainer.addChild(comp);
+								comp.updateContent(host.streamingMessage);
 								markFirstVisibleAssistantOutput(host, seg.contentType, {
 									contentIndex: seg.startIndex,
 								});
@@ -1080,8 +1094,11 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 								seg.endIndex = d.endIndex;
 								seg.component.setRange({ startIndex: seg.startIndex, endIndex: seg.endIndex });
 							}
-							seg.cachedText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex);
-							seg.component.updateContent(host.streamingMessage);
+							const newText = getTextFromContentBlocks(blocks, seg.startIndex, seg.endIndex, seg.contentType);
+							if (newText !== seg.cachedText) {
+								seg.cachedText = newText;
+								seg.component.updateContent(host.streamingMessage);
+							}
 						}
 					}
 
@@ -1275,13 +1292,16 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 								{ startIndex: seg.startIndex, endIndex: seg.endIndex },
 							);
 							comp.updateContent(host.streamingMessage);
-							const segmentText = getTextFromContentBlocks(finalBlocks, seg.startIndex, seg.endIndex);
-							if (shouldSuppressRedundantHandoffText(
-								host.session.messages,
-								segmentText,
-								orphanedSegments,
-								renderedSegments,
-							)) {
+							const segmentText = getTextFromContentBlocks(finalBlocks, seg.startIndex, seg.endIndex, seg.contentType);
+							if (
+								seg.contentType === "text" &&
+								shouldSuppressRedundantHandoffText(
+									host.session.messages,
+									segmentText,
+									orphanedSegments,
+									renderedSegments,
+								)
+							) {
 								continue;
 							}
 							host.chatContainer.addChild(comp);


### PR DESCRIPTION
## Summary
- Gated streaming segment rebuilds on actual text/thinking changes and added a regression test; dependency-free checks passed while the focused test was blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1008
- [#1008 [Bug]: interactive chat rebuilds all earlier text-run segments per render frame during a single streamed assistant turn, defeating the Markdown parse cache and hitching the TUI](https://github.com/open-gsd/gsd-pi/issues/1008)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1008-bug-interactive-chat-rebuilds-all-earlie-1782588445`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted interactive chat rendering optimization with behavior preserved via existing tests plus a new streaming regression test.
> 
> **Overview**
> Fixes interactive TUI hitching during a single streamed assistant turn by **not** calling `updateContent` on every text/thinking segment on each `message_update`—only when that segment’s extracted content actually changes.
> 
> `getTextFromContentBlocks` now respects segment **`contentType`** (`text` vs `thinking`), so thinking runs compare thinking blocks and sub-turn replacement detection stays correct. Redundant handoff suppression is limited to **text** segments. New segments still get an initial `updateContent` after attach.
> 
> Adds a regression test that counts `AssistantMessageComponent.updateContent` calls and asserts an unchanged thinking segment is not rebuilt when later text deltas arrive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9fffdb4c9b74737e794b0f4d847e846c182d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->