### PR TITLE
fix(issue): [Bug]: the always-on gsd-health widget runs a synchronous recursive readdirSync project-state scan on every 60s refresh

### DIFF
--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -30,10 +30,10 @@ const PROJECT_STATE_CACHE_TTL_MS = REFRESH_INTERVAL_MS;
 
 const projectStateCache = new Map<string, { state: HealthWidgetProjectState; computedAt: number }>();
 
-export function getCachedProjectState(basePath: string): HealthWidgetProjectState {
+export function getCachedProjectState(basePath: string, force?: boolean): HealthWidgetProjectState {
   const now = Date.now();
   const cached = projectStateCache.get(basePath);
-  if (cached && now - cached.computedAt <= PROJECT_STATE_CACHE_TTL_MS) {
+  if (!force && cached && now - cached.computedAt <= PROJECT_STATE_CACHE_TTL_MS) {
     return cached.state;
   }
 
@@ -84,7 +84,7 @@ async function loadLastCommitInfoAsync(basePath: string): Promise<{ epoch: numbe
 
 function loadHealthWidgetData(
   basePath: string,
-  options?: { includeChecks?: boolean },
+  options?: { includeChecks?: boolean; forceProjectState?: boolean },
 ): HealthWidgetData {
   // `includeChecks` gates the expensive subprocess-backed checks (provider +
   // environment doctor: `lsof`, `docker`, `node --version`, ...). The initial
@@ -99,7 +99,7 @@ function loadHealthWidgetData(
   let lastCommitEpoch: number | null = null;
   let lastCommitMessage: string | null = null;
 
-  const projectState = getCachedProjectState(basePath);
+  const projectState = getCachedProjectState(basePath, options?.forceProjectState);
 
   try {
     const prefs = loadEffectiveGSDPreferences();
@@ -195,7 +195,7 @@ export function initHealthWidget(ctx: ExtensionContext): void {
   // block first paint by ~0.9s (lsof/docker probes, otherwise run again
   // immediately by the factory below). The factory's async refresh fills in
   // real health once the screen is up.
-  const initialData = loadHealthWidgetData(basePath, { includeChecks: false });
+  const initialData = loadHealthWidgetData(basePath, { includeChecks: false, forceProjectState: true });
   ctx.ui.setWidget("gsd-health", buildHealthLines(initialData), { placement: "belowEditor" });
 
   // Factory-based widget for TUI mode — replaces the string-array above

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -185,6 +185,10 @@ export function initHealthWidget(ctx: ExtensionContext): void {
 
   const basePath = projectRoot();
 
+  // Re-init must reflect filesystem changes immediately; the TTL cache is for
+  // interval refreshes, not this one-off synchronous paint.
+  projectStateCache.delete(basePath);
+
   // String-array fallback — used in RPC mode (factory is a no-op there).
   // Skip the expensive provider/environment doctor checks here: this runs
   // synchronously on the interactive-startup path, where running them would

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -16,14 +16,31 @@ import {
   buildHealthLines,
   detectHealthWidgetProjectState,
   type HealthWidgetData,
+  type HealthWidgetProjectState,
 } from "./health-widget-core.js";
 
 export const HEALTH_WIDGET_ACTIVE_HINTS =
   "  /gsd auto to run  ·  /gsd status to inspect  ·  /gsd report for snapshots  ·  /gsd notifications for history  ·  /gsd help";
 
 const LAST_COMMIT_LOOKUP_TIMEOUT_MS = 3_000;
+const REFRESH_INTERVAL_MS = 60_000;
+const PROJECT_STATE_CACHE_TTL_MS = REFRESH_INTERVAL_MS;
 
 // ── Data loader ────────────────────────────────────────────────────────────────
+
+const projectStateCache = new Map<string, { state: HealthWidgetProjectState; computedAt: number }>();
+
+export function getCachedProjectState(basePath: string): HealthWidgetProjectState {
+  const now = Date.now();
+  const cached = projectStateCache.get(basePath);
+  if (cached && now - cached.computedAt <= PROJECT_STATE_CACHE_TTL_MS) {
+    return cached.state;
+  }
+
+  const state = detectHealthWidgetProjectState(basePath);
+  projectStateCache.set(basePath, { state, computedAt: now });
+  return state;
+}
 
 function runHealthWidgetGit(basePath: string, args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
@@ -82,7 +99,7 @@ function loadHealthWidgetData(
   let lastCommitEpoch: number | null = null;
   let lastCommitMessage: string | null = null;
 
-  const projectState = detectHealthWidgetProjectState(basePath);
+  const projectState = getCachedProjectState(basePath);
 
   try {
     const prefs = loadEffectiveGSDPreferences();
@@ -158,8 +175,6 @@ async function loadHealthWidgetDataAsync(basePath: string): Promise<HealthWidget
 }
 
 // ── Widget init ────────────────────────────────────────────────────────────────
-
-const REFRESH_INTERVAL_MS = 60_000;
 
 /**
  * Initialize the always-on gsd-health widget (belowEditor).

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -172,6 +172,39 @@ test("getCachedProjectState: force=true bypasses TTL and returns fresh state wit
   assert.equal(getCachedProjectState(dir), "active");
 });
 
+test("initHealthWidget: re-init paints fresh project state within cache TTL", (t) => {
+  const dir = makeTempDir("reinit-state");
+  t.after(() => { cleanup(dir); });
+
+  let now = 3_000_000;
+  const dateNow = t.mock.method(Date, "now", () => now);
+  t.after(() => { dateNow.mock.restore(); });
+
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  t.after(() => { process.chdir(originalCwd); });
+
+  const initialLineSets: string[][] = [];
+  const ctx = {
+    hasUI: true,
+    ui: {
+      setWidget: (_key: string, value: unknown) => {
+        if (Array.isArray(value)) initialLineSets.push(value as string[]);
+      },
+    },
+  } as any;
+
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  initHealthWidget(ctx);
+  assert.equal(initialLineSets.at(-1)?.[0], "  GSD  Project Initialized");
+
+  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  now += 1_000;
+
+  initHealthWidget(ctx);
+  assert.match(initialLineSets.at(-1)?.[0] ?? "", /System OK/);
+});
+
 test("buildHealthLines: none state shows single onboarding line pointing at /gsd", (t) => {
   const lines = buildHealthLines(activeData({ projectState: "none" }));
   assert.equal(lines.length, 1, "renders exactly one line");

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -146,6 +146,32 @@ test("getCachedProjectState: reuses project state until the refresh TTL expires"
   assert.equal(getCachedProjectState(dir), "active");
 });
 
+test("getCachedProjectState: force=true bypasses TTL and returns fresh state within TTL window", (t) => {
+  const dir = makeTempDir("forced-state");
+  t.after(() => { cleanup(dir); });
+
+  let now = 2_000_000;
+  const dateNow = t.mock.method(Date, "now", () => now);
+  t.after(() => { dateNow.mock.restore(); });
+
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  // Prime the cache with "initialized".
+  assert.equal(getCachedProjectState(dir), "initialized");
+
+  // Disk changes within the TTL window.
+  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  now += 1_000; // well within 60s TTL
+
+  // Normal call still returns stale cached value.
+  assert.equal(getCachedProjectState(dir), "initialized");
+
+  // force=true bypasses TTL and returns the fresh disk state.
+  assert.equal(getCachedProjectState(dir, true), "active");
+
+  // Subsequent non-forced call also reflects the freshened cache.
+  assert.equal(getCachedProjectState(dir), "active");
+});
+
 test("buildHealthLines: none state shows single onboarding line pointing at /gsd", (t) => {
   const lines = buildHealthLines(activeData({ projectState: "none" }));
   assert.equal(lines.length, 1, "renders exactly one line");

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -14,7 +14,7 @@ import {
   formatRelativeTime,
   type HealthWidgetData,
 } from "../health-widget-core.ts";
-import { HEALTH_WIDGET_ACTIVE_HINTS, initHealthWidget } from "../health-widget.ts";
+import { HEALTH_WIDGET_ACTIVE_HINTS, getCachedProjectState, initHealthWidget } from "../health-widget.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
 
@@ -123,6 +123,27 @@ test("detectHealthWidgetProjectState: milestone without metrics returns active",
 
   mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
   assert.equal(detectHealthWidgetProjectState(dir), "active");
+});
+
+test("getCachedProjectState: reuses project state until the refresh TTL expires", (t) => {
+  const dir = makeTempDir("cached-state");
+  t.after(() => { cleanup(dir); });
+
+  let now = 1_000_000;
+  const dateNow = t.mock.method(Date, "now", () => now);
+  t.after(() => { dateNow.mock.restore(); });
+
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  assert.equal(getCachedProjectState(dir), "initialized");
+
+  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  assert.equal(getCachedProjectState(dir), "initialized");
+
+  now += 60_000;
+  assert.equal(getCachedProjectState(dir), "initialized");
+
+  now += 1;
+  assert.equal(getCachedProjectState(dir), "active");
 });
 
 test("buildHealthLines: none state shows single onboarding line pointing at /gsd", (t) => {


### PR DESCRIPTION
## Summary
- Added a 60s health-widget project-state cache with TTL regression coverage; parser checks and diff check passed, while full test execution was blocked by unavailable npm dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1010
- [#1010 [Bug]: the always-on gsd-health widget runs a synchronous recursive readdirSync project-state scan on every 60s refresh](https://github.com/open-gsd/gsd-pi/issues/1010)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1010-bug-the-always-on-gsd-health-widget-runs-1782588423`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized widget performance fix with explicit cache bypass on init; display may lag disk changes by up to 60s between refreshes.
> 
> **Overview**
> Stops the always-on **gsd-health** widget from running the synchronous filesystem project-state scan on every 60s refresh by caching results for one refresh interval.
> 
> **`getCachedProjectState`** wraps **`detectHealthWidgetProjectState`** with a per-`basePath` TTL (aligned to **`REFRESH_INTERVAL_MS`**). Interval/async refreshes reuse the cache; **`initHealthWidget`** clears the entry for the current root and uses **`forceProjectState: true`** on first paint so re-init still shows up-to-date state without waiting for TTL expiry.
> 
> Tests cover TTL reuse, **`force`** bypass, and re-init painting fresh state within the cache window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846565dc00a6b2f2af74757b0a7c8c69b1945e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->