### PR TITLE
fix(issue): [Bug]: the per-delta message_update hook does synchronous readFileSync of the write-gate snapshot when the assistant streams a consent question

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -13,7 +13,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
 import { buildMilestoneFileName, canonicalPhaseDirName, clearPathCache, milestonesDir, legacyMilestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { applyAskUserQuestionsGateResult, clearDiscussionFlowState, formatPendingAskUserQuestionsGateMessage, formatTimedOutAskUserQuestionsGateMessage, hostWriteGateAdapter, isApprovalGateVerifiedInSnapshot, isDepthConfirmationAnswer, isMilestoneDepthVerified, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeBash, shouldBlockWorktreeWrite, isGateQuestionId, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
+import { applyAskUserQuestionsGateResult, clearDiscussionFlowState, currentWriteGateSnapshot, formatPendingAskUserQuestionsGateMessage, formatTimedOutAskUserQuestionsGateMessage, hostWriteGateAdapter, isApprovalGateVerifiedInSnapshot, isDepthConfirmationAnswer, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeBash, shouldBlockWorktreeWrite, isGateQuestionId, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId, type WriteGateSnapshot } from "./write-gate.js";
 import { canonicalToolName } from "../engine-hook-contract.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
@@ -583,6 +583,10 @@ function deferApprovalGate(gateId: string, basePath: string): void {
   // workflow MCP child already verified this gate, deferring would block
   // tools for a gate that can never legitimately arm.
   const snapshot = hostWriteGateAdapter.readState(basePath);
+  deferApprovalGateFromSnapshot(gateId, basePath, snapshot);
+}
+
+function deferApprovalGateFromSnapshot(gateId: string, basePath: string, snapshot: WriteGateSnapshot): void {
   if (isApprovalGateVerifiedInSnapshot(snapshot, gateId)) return;
   const milestoneId = extractDepthVerificationMilestoneId(gateId);
   if (milestoneId && isMilestoneDepthVerifiedInSnapshot(snapshot, milestoneId)) return;
@@ -1233,13 +1237,15 @@ export function registerHooks(
 
     const gateId = approvalGateIdForUnit(unitType, unitId);
     if (gateId) {
+      const basePath = contextBasePath(ctx);
+      const gateSnapshot = currentWriteGateSnapshot(basePath);
       // Skip the gate if this milestone is already depth-verified — the approval
       // pattern matched again on post-verification text (a false-positive re-trigger).
       // Without this guard, the second firing blocks gsd_plan_milestone in the same
       // turn and leaves CONTEXT.md on disk with no DB row (#discuss-milestone-no-db).
       const gateMilestoneId = extractDepthVerificationMilestoneId(gateId);
-      if (gateMilestoneId && isMilestoneDepthVerified(gateMilestoneId, contextBasePath(ctx))) return;
-      deferApprovalGate(gateId, contextBasePath(ctx));
+      if (gateMilestoneId && isMilestoneDepthVerifiedInSnapshot(gateSnapshot, gateMilestoneId)) return;
+      deferApprovalGateFromSnapshot(gateId, basePath, gateSnapshot);
     }
 
     approvalQuestionAbortInFlight = true;

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -180,7 +180,7 @@ function ensureWriteGateSnapshotDirectory(basePath: string): void {
   mkdirSync(join(gsdPath, "runtime"), { recursive: true });
 }
 
-function currentWriteGateSnapshot(basePath: string = process.cwd()): WriteGateSnapshot {
+export function currentWriteGateSnapshot(basePath: string = process.cwd()): WriteGateSnapshot {
   const state = getWriteGateState(basePath);
   return {
     verifiedDepthMilestones: [...state.verifiedDepthMilestones].sort(),

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -970,6 +970,93 @@ test("register-hooks agent_end does not re-arm deferred gate after workflow MCP 
   });
 });
 
+test("register-hooks message_update uses in-memory write-gate snapshot instead of disk reconcile", async (t) => {
+  const dir = makeTempDir("message-update-memory-snapshot");
+  const originalCwd = process.cwd();
+  const originalEnv = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+  process.chdir(dir);
+  process.env.GSD_PERSIST_WRITE_GATE_STATE = "1";
+  resetWriteGateState(dir);
+  clearPendingAutoStart(dir);
+
+  const gateId = "depth_verification_M012_confirm";
+  const statePath = join(dir, ".gsd", "runtime", "write-gate-state.json");
+
+  t.after(() => {
+    try {
+      resetWriteGateState(dir);
+      clearPendingAutoStart(dir);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+      } else {
+        process.env.GSD_PERSIST_WRITE_GATE_STATE = originalEnv;
+      }
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  const notices: Array<{ text: string; level: string }> = [];
+  const ctx = {
+    cwd: dir,
+    ui: { notify: (text: string, level: string) => notices.push({ text, level }) },
+  } as any;
+
+  registerHooks(pi, []);
+  setPendingAutoStart(dir, {
+    basePath: dir,
+    milestoneId: "M012",
+    ctx,
+    pi: { sendMessage: () => undefined } as any,
+  });
+
+  mkdirSync(join(dir, ".gsd", "runtime"), { recursive: true });
+  writeFileSync(statePath, JSON.stringify({
+    verifiedDepthMilestones: ["M012"],
+    verifiedApprovalGates: [gateId],
+    activeQueuePhase: false,
+    pendingGateId: null,
+  }, null, 2), "utf-8");
+
+  const approvalMessage = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Here is the milestone plan.\n\nDid I capture the project correctly?" },
+    ],
+  };
+
+  for (const handler of handlers.get("message_update") ?? []) {
+    await handler({ message: approvalMessage }, ctx);
+  }
+
+  assert.equal(
+    notices.some((n) => /discuss-milestone M012 is waiting for your approval - pausing/.test(n.text)),
+    true,
+    "streaming hook must not suppress the pause from a disk-only verification",
+  );
+  assert.equal(
+    shouldBlockContextArtifactSave("CONTEXT", "M012", null, dir).block,
+    true,
+    "streaming hook must not reconcile disk-only verification into the in-memory snapshot",
+  );
+
+  for (const handler of handlers.get("agent_end") ?? []) {
+    await handler({ messages: [] }, ctx);
+  }
+
+  assert.equal(getPendingGate(dir), null, "agent_end still reconciles disk and suppresses durable re-arm");
+});
+
 // ── External-engine post-hoc gate replay (write-gate two-process sync) ──────
 // On claude-code-cli, pi ingests the SDK turn's tool blocks after the workflow
 // MCP child already executed them. The depth gate can therefore arrive at


### PR DESCRIPTION
## Summary
- Updated the streamed approval hook to use in-memory write-gate snapshots and verified syntax/static checks, with the focused test runner blocked by missing deps and network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1012
- [#1012 [Bug]: the per-delta message_update hook does synchronous readFileSync of the write-gate snapshot when the assistant streams a consent question](https://github.com/open-gsd/gsd-pi/issues/1012)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1012-bug-the-per-delta-message-update-hook-do-1782588400`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches discuss-milestone approval gating and write-gate timing; wrong snapshot choice could skip pauses or block tools, but behavior is covered by a focused regression test and `agent_end` still reconciles disk.
> 
> **Overview**
> Fixes **#1012** by stopping the streamed `message_update` approval path from doing a synchronous disk reconcile on every assistant delta when consent text streams in.
> 
> The hook now reads **`currentWriteGateSnapshot`** (in-memory only) and uses **`isMilestoneDepthVerifiedInSnapshot`** / **`deferApprovalGateFromSnapshot`** instead of **`isMilestoneDepthVerified`** (which pulled from disk via the host adapter). **`currentWriteGateSnapshot`** is exported from `write-gate.ts`; other defer paths still use disk-backed **`deferApprovalGate`** where appropriate.
> 
> **`agent_end`** continues to reconcile persisted write-gate state, so MCP-child verifications on disk are not lost after the turn. A regression test covers disk-only verification during streaming: pause still arms, in-memory state is not upgraded from disk mid-stream, and **`agent_end`** suppresses durable re-arm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3811f5cbdd3fcd05a2bd5889e3bd7801c9968ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->