### PR TITLE
fix(issue): [Bug]: in sessions that never used /gsd quick, each assistant turn_end re-spawns `git branch --show-current` because cleanupQuickBranch has no negative-result cache

### DIFF
--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -10,8 +10,8 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { isAbsolute, join, relative } from "node:path";
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { QUICK_BRANCH_RE } from "./branch-patterns.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
@@ -31,7 +31,7 @@ interface QuickReturnState {
 }
 
 let pendingQuickReturn: QuickReturnState | null = null;
-const pendingQuickReturnMisses = new Set<string>();
+const pendingQuickReturnMisses = new Map<string, string>();
 
 // ─── Quick Task Helpers ───────────────────────────────────────────────────────
 
@@ -190,6 +190,28 @@ export function buildQuickCommitInstruction(basePath: string, root: string): str
   ].join("\n");
 }
 
+function readHeadBranchName(basePath: string): string | null {
+  try {
+    const gitPath = join(basePath, ".git");
+    if (!existsSync(gitPath)) return null;
+
+    let headPath: string;
+    if (lstatSync(gitPath).isDirectory()) {
+      headPath = join(gitPath, "HEAD");
+    } else {
+      const gitFile = readFileSync(gitPath, "utf-8").trim();
+      if (!gitFile.startsWith("gitdir: ")) return null;
+      headPath = join(resolve(basePath, gitFile.slice("gitdir: ".length)), "HEAD");
+    }
+
+    const head = readFileSync(headPath, "utf-8").trim();
+    if (!head.startsWith("ref: refs/heads/")) return null;
+    return head.slice("ref: refs/heads/".length);
+  } catch {
+    return null;
+  }
+}
+
 function quickReturnStatePath(basePath: string): string {
   return join(gsdRoot(basePath), "runtime", "quick-return.json");
 }
@@ -206,7 +228,11 @@ function readPendingReturn(basePath: string): QuickReturnState | null {
     return pendingQuickReturn;
   }
   if (pendingQuickReturnMisses.has(basePath)) {
-    return null;
+    const statePath = quickReturnStatePath(basePath);
+    if (!existsSync(statePath) && readHeadBranchName(basePath) === pendingQuickReturnMisses.get(basePath)) {
+      return null;
+    }
+    pendingQuickReturnMisses.delete(basePath);
   }
 
   try {
@@ -235,7 +261,10 @@ function readPendingReturn(basePath: string): QuickReturnState | null {
     return inferred;
   }
 
-  pendingQuickReturnMisses.add(basePath);
+  const branchAtMiss = readHeadBranchName(basePath);
+  if (branchAtMiss) {
+    pendingQuickReturnMisses.set(basePath, branchAtMiss);
+  }
   return null;
 }
 
@@ -243,7 +272,10 @@ function clearPendingReturn(basePath: string): void {
   if (pendingQuickReturn?.basePath === basePath) {
     pendingQuickReturn = null;
   }
-  pendingQuickReturnMisses.add(basePath);
+  const branchAtMiss = readHeadBranchName(basePath);
+  if (branchAtMiss) {
+    pendingQuickReturnMisses.set(basePath, branchAtMiss);
+  }
   rmSync(quickReturnStatePath(basePath), { force: true });
 }
 

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -31,6 +31,7 @@ interface QuickReturnState {
 }
 
 let pendingQuickReturn: QuickReturnState | null = null;
+const pendingQuickReturnMisses = new Set<string>();
 
 // ─── Quick Task Helpers ───────────────────────────────────────────────────────
 
@@ -195,6 +196,7 @@ function quickReturnStatePath(basePath: string): string {
 
 function persistPendingReturn(state: QuickReturnState): void {
   pendingQuickReturn = state;
+  pendingQuickReturnMisses.delete(state.basePath);
   mkdirSync(join(gsdRoot(state.basePath), "runtime"), { recursive: true });
   writeFileSync(quickReturnStatePath(state.basePath), JSON.stringify(state) + "\n", "utf-8");
 }
@@ -202,6 +204,9 @@ function persistPendingReturn(state: QuickReturnState): void {
 function readPendingReturn(basePath: string): QuickReturnState | null {
   if (pendingQuickReturn && pendingQuickReturn.basePath === basePath) {
     return pendingQuickReturn;
+  }
+  if (pendingQuickReturnMisses.has(basePath)) {
+    return null;
   }
 
   try {
@@ -216,6 +221,7 @@ function readPendingReturn(basePath: string): QuickReturnState | null {
       && typeof parsed.description === "string"
     ) {
       pendingQuickReturn = parsed as QuickReturnState;
+      pendingQuickReturnMisses.delete(basePath);
       return pendingQuickReturn;
     }
   } catch {
@@ -225,9 +231,11 @@ function readPendingReturn(basePath: string): QuickReturnState | null {
   const inferred = inferQuickReturnFromBranch(basePath);
   if (inferred) {
     pendingQuickReturn = inferred;
+    pendingQuickReturnMisses.delete(basePath);
     return inferred;
   }
 
+  pendingQuickReturnMisses.add(basePath);
   return null;
 }
 
@@ -235,6 +243,7 @@ function clearPendingReturn(basePath: string): void {
   if (pendingQuickReturn?.basePath === basePath) {
     pendingQuickReturn = null;
   }
+  pendingQuickReturnMisses.add(basePath);
   rmSync(quickReturnStatePath(basePath), { force: true });
 }
 

--- a/src/resources/extensions/gsd/tests/integration/quick-branch-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/quick-branch-lifecycle.test.ts
@@ -251,6 +251,43 @@ test('cleanupQuickBranch: infers return state from current gsd/quick branch', as
 });
 
   // ═══════════════════════════════════════════════════════════════════════
+  // cleanupQuickBranch: stale miss invalidated after mid-session branch switch
+  // ═══════════════════════════════════════════════════════════════════════
+test('cleanupQuickBranch: clears stale miss when branch switches to gsd/quick mid-session', async () => {
+    const repo = createTestRepo();
+    const origCwd = process.cwd();
+    try {
+      // Create a quick branch with real product work (so inference finds a diff)
+      run("git checkout -b gsd/quick/3-stale-miss", repo);
+      writeFileSync(join(repo, "stale.txt"), "stale miss test\n");
+      run("git add stale.txt", repo);
+      run('git commit -m "test: stale miss"', repo);
+      // Return to main so the first cleanupQuickBranch call records a miss
+      run("git checkout main", repo);
+
+      process.chdir(repo);
+      const { cleanupQuickBranch } = await import("../../quick.ts");
+
+      // First call: on main with no disk state → miss recorded (keyed to "main")
+      const result1 = cleanupQuickBranch();
+      assert.ok(!result1, "first call (on main) returns false — miss recorded");
+
+      // Simulate mid-session external branch switch to the stranded quick branch
+      run("git checkout gsd/quick/3-stale-miss", repo);
+
+      // Second call: branch changed from the recorded miss, so cache is invalidated
+      // and inferQuickReturnFromBranch runs — cleanup must succeed
+      const result2 = cleanupQuickBranch();
+      assert.ok(result2, "second call returns true after mid-session switch to quick branch");
+      assert.deepStrictEqual(getCurrentBranch(repo), "main",
+        "cleanup merged back to main after stale-miss invalidation");
+    } finally {
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
+});
+
+  // ═══════════════════════════════════════════════════════════════════════
   // End-to-end: quick branch does NOT contaminate integration branch
   // ═══════════════════════════════════════════════════════════════════════
 test('E2E: quick branch does not contaminate integration branch', () => {

--- a/src/resources/extensions/gsd/tests/integration/quick-branch-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/quick-branch-lifecycle.test.ts
@@ -16,6 +16,7 @@ import { execSync } from "node:child_process";
 
 import { captureIntegrationBranch, getCurrentBranch } from "../../worktree.ts";
 import { readIntegrationBranch, QUICK_BRANCH_RE } from "../../git-service.ts";
+import { disableDebug, enableDebug, getDebugCounters } from "../../debug-logger.ts";
 
 function run(command: string, cwd: string): string {
   return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
@@ -205,16 +206,25 @@ test('cleanupQuickBranch: recovers from disk state (cross-session)', async () =>
 test('cleanupQuickBranch: no-op without pending state', async () => {
     const repo = createTestRepo();
     const origCwd = process.cwd();
-    process.chdir(repo);
+    try {
+      process.chdir(repo);
+      enableDebug(repo);
 
-    const { cleanupQuickBranch } = await import("../../quick.ts");
-    const result = cleanupQuickBranch();
+      const { cleanupQuickBranch } = await import("../../quick.ts");
+      const result = cleanupQuickBranch();
+      const firstGitInvocations = getDebugCounters().gitInvocations;
+      const secondResult = cleanupQuickBranch();
 
-    assert.ok(!result, "returns false when no pending state");
-    assert.deepStrictEqual(getCurrentBranch(repo), "main", "stays on main");
-
-    process.chdir(origCwd);
-    rmSync(repo, { recursive: true, force: true });
+      assert.ok(!result, "returns false when no pending state");
+      assert.ok(!secondResult, "still returns false when no pending state");
+      assert.deepStrictEqual(getDebugCounters().gitInvocations, firstGitInvocations,
+        "cached no-state cleanup does not re-run git branch inference");
+      assert.deepStrictEqual(getCurrentBranch(repo), "main", "stays on main");
+    } finally {
+      disableDebug();
+      process.chdir(origCwd);
+      rmSync(repo, { recursive: true, force: true });
+    }
 });
 
 test('cleanupQuickBranch: infers return state from current gsd/quick branch', async () => {


### PR DESCRIPTION
## Summary
- Cached missing quick-return state and verified the focused lifecycle regression plus diff whitespace check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1011
- [#1011 [Bug]: in sessions that never used /gsd quick, each assistant turn_end re-spawns `git branch --show-current` because cleanupQuickBranch has no negative-result cache](https://github.com/open-gsd/gsd-pi/issues/1011)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1011-bug-in-sessions-that-never-used-gsd-quic-1782588421`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized quick-mode state lookup optimization with invalidation on branch or persisted state changes; behavior for real quick tasks unchanged aside from fewer redundant git calls.
> 
> **Overview**
> Fixes repeated **`git branch --show-current`** (and related inference) on every assistant **`turn_end`** when a session never used `/gsd quick`. **`cleanupQuickBranch`** already no-ops without pending state, but **`readPendingReturn`** still fell through to **`inferQuickReturnFromBranch`** each time.
> 
> Adds a per-repo **negative cache** (`pendingQuickReturnMisses`) keyed by **`basePath`**, storing the branch name at the miss. Subsequent lookups skip disk and git inference while HEAD is unchanged and there is still no **`quick-return.json`**. **`readHeadBranchName`** reads **`refs/heads/*`** from **`.git/HEAD`** (including **gitdir** worktrees) to invalidate the cache when the user checks out another branch or when state is persisted again.
> 
> Clears the miss entry when pending return is found or persisted; after **`clearPendingReturn`**, records a miss so post-cleanup paths stay cheap. Integration test asserts two back-to-back **`cleanupQuickBranch`** calls do not increase debug **git** invocation counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92206bf46a8a5da922ca13a3a13cb0e0a47116d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->