### PR TITLE
fix(issue): [Bug]: the always-on gsd-health widget's 60s "async" refresh runs synchronous PATH existsSync sweep + models.json JSON.parse on the main thread

### DIFF
--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -12,6 +12,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { access, readFile } from "node:fs/promises";
 import { delimiter, join } from "node:path";
 import { AuthStorage } from "@gsd/pi-coding-agent";
 import { getEnvApiKey } from "@gsd/pi-ai";
@@ -166,15 +167,11 @@ const CLI_AUTH_PATH_CHECK_PROVIDERS = new Set([
   "google-antigravity",
 ]);
 
-/**
- * Check if a CLI provider's binary exists anywhere in PATH.
- * Fast filesystem scan — no subprocess, no network, sub-1ms.
- */
-function isCliBinaryInPath(providerId: string): boolean {
-  const binaries = CLI_BINARY_MAP[providerId];
-  if (!binaries) return false;
+let asyncCliBinaryPathCache: Map<string, boolean> | null = null;
 
-  const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+function cliExecutableNames(providerId: string): string[] {
+  const binaries = CLI_BINARY_MAP[providerId];
+  if (!binaries) return [];
 
   // On Windows, command shims are commonly installed as .cmd/.exe/.bat/.com.
   // Scan PATHEXT candidates in addition to the bare binary name.
@@ -196,7 +193,49 @@ function isCliBinaryInPath(providerId: string): boolean {
     }
   }
 
+  return executableNames;
+}
+
+/**
+ * Check if a CLI provider's binary exists anywhere in PATH.
+ * Fast filesystem scan — no subprocess, no network, sub-1ms.
+ */
+function isCliBinaryInPath(providerId: string): boolean {
+  const cached = asyncCliBinaryPathCache?.get(providerId);
+  if (cached !== undefined) return cached;
+
+  const executableNames = cliExecutableNames(providerId);
+  if (executableNames.length === 0) return false;
+
+  const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+
   return pathDirs.some(dir => executableNames.some(name => existsSync(join(dir, name))));
+}
+
+async function isCliBinaryInPathAsync(providerId: string): Promise<boolean> {
+  const executableNames = cliExecutableNames(providerId);
+  if (executableNames.length === 0) return false;
+
+  const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  const candidates = pathDirs.flatMap(dir => executableNames.map(name => join(dir, name)));
+  if (candidates.length === 0) return false;
+
+  try {
+    await Promise.any(candidates.map(candidate => access(candidate)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function loadCliBinaryPathCache(): Promise<Map<string, boolean>> {
+  const entries = await Promise.all(
+    Object.keys(CLI_BINARY_MAP).map(async providerId => [
+      providerId,
+      await isCliBinaryInPathAsync(providerId),
+    ] as const),
+  );
+  return new Map(entries);
 }
 
 function modelsJsonPaths(): string[] {
@@ -208,7 +247,13 @@ function modelsJsonPaths(): string[] {
   ];
 }
 
+let asyncModelsJsonApiKeyCache: Set<string> | null = null;
+
 function hasModelsJsonApiKey(providerId: string): boolean {
+  if (asyncModelsJsonApiKeyCache) {
+    return asyncModelsJsonApiKeyCache.has(providerId);
+  }
+
   for (const path of modelsJsonPaths()) {
     if (!existsSync(path)) continue;
     try {
@@ -226,7 +271,27 @@ function hasModelsJsonApiKey(providerId: string): boolean {
   return false;
 }
 
-function resolveKey(providerId: string): KeyLookup {
+async function loadModelsJsonApiKeyCache(): Promise<Set<string>> {
+  const providersWithKeys = new Set<string>();
+  for (const path of modelsJsonPaths()) {
+    try {
+      const parsed = JSON.parse(await readFile(path, "utf-8")) as {
+        providers?: Record<string, { apiKey?: unknown }>;
+      };
+      for (const [providerId, provider] of Object.entries(parsed.providers ?? {})) {
+        const apiKey = provider.apiKey;
+        if (typeof apiKey === "string" && apiKey.trim().length > 0) {
+          providersWithKeys.add(providerId);
+        }
+      }
+    } catch {
+      // Missing or malformed models.json should not break dashboard health checks.
+    }
+  }
+  return providersWithKeys;
+}
+
+function resolveKeyFromAuthOrEnv(providerId: string): KeyLookup | null {
   const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
 
   if (providerId === "anthropic-vertex" && process.env.ANTHROPIC_VERTEX_PROJECT_ID) {
@@ -275,6 +340,13 @@ function resolveKey(providerId: string): KeyLookup {
   if (info?.envVar && process.env[info.envVar]) {
     return { found: true, source: "env", backedOff: false };
   }
+
+  return null;
+}
+
+function resolveKey(providerId: string): KeyLookup {
+  const direct = resolveKeyFromAuthOrEnv(providerId);
+  if (direct) return direct;
 
   if (hasModelsJsonApiKey(providerId)) {
     return { found: true, source: "models.json", backedOff: false };
@@ -493,6 +565,28 @@ export function runProviderChecks(): ProviderCheckResult[] {
   results.push(...checkOptionalProviders());
 
   return results;
+}
+
+/**
+ * Non-blocking equivalent of `runProviderChecks` for the health-widget
+ * background refresh. PATH checks and custom models.json discovery use async
+ * filesystem APIs so periodic widget refreshes do not stall the input loop.
+ */
+export async function runProviderChecksAsync(): Promise<ProviderCheckResult[]> {
+  const [cliCache, modelsJsonCache] = await Promise.all([
+    loadCliBinaryPathCache(),
+    loadModelsJsonApiKeyCache(),
+  ]);
+  const previousCliCache = asyncCliBinaryPathCache;
+  const previousModelsJsonCache = asyncModelsJsonApiKeyCache;
+  asyncCliBinaryPathCache = cliCache;
+  asyncModelsJsonApiKeyCache = modelsJsonCache;
+  try {
+    return runProviderChecks();
+  } finally {
+    asyncCliBinaryPathCache = previousCliCache;
+    asyncModelsJsonApiKeyCache = previousModelsJsonCache;
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -4,7 +4,7 @@
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { execFile } from "node:child_process";
 import type { GSDState } from "./types.js";
-import { runProviderChecks, summariseProviderIssues } from "./doctor-providers.js";
+import { runProviderChecks, runProviderChecksAsync, summariseProviderIssues } from "./doctor-providers.js";
 import { runEnvironmentChecks, runEnvironmentChecksAsync } from "./doctor-environment.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { nativeIsRepo, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeCommitSubject } from "./native-git-bridge.js";
@@ -157,7 +157,7 @@ async function loadHealthWidgetDataAsync(basePath: string): Promise<HealthWidget
   let environmentWarningCount = 0;
 
   try {
-    providerIssue = summariseProviderIssues(runProviderChecks());
+    providerIssue = summariseProviderIssues(await runProviderChecksAsync());
   } catch { /* non-fatal */ }
 
   try {

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 
 import {
   runProviderChecks,
+  runProviderChecksAsync,
   formatProviderReport,
   summariseProviderIssues,
   type ProviderCheckResult,
@@ -47,6 +48,26 @@ function withEnv(vars: Record<string, string | undefined>, fn: () => void): void
   }
 }
 
+async function withEnvAsync(vars: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(vars)) {
+    saved[k] = process.env[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
 function withCwd(nextCwd: string, fn: () => void): void {
   const saved = process.cwd();
   process.chdir(nextCwd);
@@ -55,6 +76,22 @@ function withCwd(nextCwd: string, fn: () => void): void {
   } finally {
     process.chdir(saved);
   }
+}
+
+async function withCwdAsync(nextCwd: string, fn: () => Promise<void>): Promise<void> {
+  const saved = process.cwd();
+  process.chdir(nextCwd);
+  try {
+    await fn();
+  } finally {
+    process.chdir(saved);
+  }
+}
+
+function normalizeProviderResults(results: ProviderCheckResult[]): string[] {
+  return results
+    .map(r => `${r.name}|${r.label}|${r.category}|${r.status}|${r.message}|${r.detail ?? ""}|${r.required}`)
+    .sort();
 }
 
 const PRESENT_TEST_VALUE = "configured";
@@ -375,6 +412,76 @@ test("runProviderChecks detects custom provider keys from models.json", () => {
 
   rmSync(repo, { recursive: true, force: true });
   rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test("runProviderChecksAsync matches sync for models.json keys and PATH CLI checks", async () => {
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-async-home-")));
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-async-repo-")));
+  const agentDir = join(tmpHome, ".gsd", "agent");
+  const binDir = join(tmpHome, "bin");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+
+  writeFileSync(
+    join(repo, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "models:",
+      "  execution:",
+      "    model: custom-model",
+      "    provider: custom-provider",
+      "  validation:",
+      "    model: gemini-2.5-pro",
+      "    provider: google-gemini-cli",
+      "---",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(agentDir, "models.json"), JSON.stringify({
+    providers: {
+      "custom-provider": {
+        api: "openai-completions",
+        apiKey: "x",
+        baseUrl: "https://example.invalid/v1",
+        models: [{ id: "custom-model", name: "Custom Model" }],
+      },
+    },
+  }));
+
+  const fakeGemini = join(binDir, "gemini");
+  writeFileSync(fakeGemini, "#!/bin/sh\necho mock\n");
+  chmodSync(fakeGemini, 0o755);
+
+  try {
+    await withEnvAsync({
+      HOME: tmpHome,
+      CUSTOM_PROVIDER_API_KEY: undefined,
+      GEMINI_API_KEY: undefined,
+      GOOGLE_API_KEY: undefined,
+      PATH: binDir,
+    }, async () => {
+      await withCwdAsync(repo, async () => {
+        const syncResults = runProviderChecks();
+        const asyncResults = await runProviderChecksAsync();
+
+        assert.deepEqual(normalizeProviderResults(asyncResults), normalizeProviderResults(syncResults));
+        assert.equal(
+          asyncResults.find(r => r.name === "custom-provider")?.status,
+          "ok",
+          "models.json apiKey should satisfy custom provider auth",
+        );
+        assert.equal(
+          asyncResults.find(r => r.name === "google-gemini-cli")?.status,
+          "ok",
+          "gemini CLI binary should satisfy explicit CLI provider",
+        );
+      });
+    });
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
 });
 
 test("runProviderChecks reports missing custom provider key without models.json apiKey", () => {


### PR DESCRIPTION
## Summary
- Fixed the health widget provider refresh to use async PATH/models.json preloads and verified syntax/diff checks, with focused tests blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1009
- [#1009 [Bug]: the always-on gsd-health widget's 60s "async" refresh runs synchronous PATH existsSync sweep + models.json JSON.parse on the main thread](https://github.com/open-gsd/gsd-pi/issues/1009)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1009-bug-the-always-on-gsd-health-widget-s-60-1782588429`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to health-widget refresh and doctor provider checks; sync `runProviderChecks` behavior is unchanged except when temporary async caches are injected.
> 
> **Overview**
> Fixes the **gsd-health** widget’s periodic refresh blocking the input loop by moving expensive provider discovery off synchronous filesystem work.
> 
> Adds **`runProviderChecksAsync`**, which preloads CLI-on-**PATH** probes (`fs.promises.access`) and **`models.json`** API-key discovery (`readFile`) in parallel, then runs the existing **`runProviderChecks`** logic behind short-lived module caches so results stay aligned with the sync path. **`loadHealthWidgetDataAsync`** now awaits that async entry point instead of calling **`runProviderChecks`** directly during the 60s background refresh.
> 
> A regression test asserts async and sync provider check output match for custom **`models.json`** keys and a fake **`gemini`** CLI on **PATH**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44db9c9e71ec96462e64bccc39e0906421851021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->