### PR TITLE
fix(issue): [Bug]: Cant do anything: Error: spawn ENAMETOOLONG

### DIFF
--- a/src/resources/extensions/google-cli/stream-adapter.ts
+++ b/src/resources/extensions/google-cli/stream-adapter.ts
@@ -35,6 +35,71 @@ interface CliRunResult {
 	signal: NodeJS.Signals | null;
 }
 
+const WINDOWS_CHILD_ENV_KEYS = new Set([
+	"ALLUSERSPROFILE",
+	"APPDATA",
+	"COMSPEC",
+	"COMMONPROGRAMFILES",
+	"COMMONPROGRAMFILES(X86)",
+	"FORCE_COLOR",
+	"HOME",
+	"HOMEDRIVE",
+	"HOMEPATH",
+	"LANG",
+	"LC_ALL",
+	"LOCALAPPDATA",
+	"NODE_EXTRA_CA_CERTS",
+	"NO_COLOR",
+	"NO_PROXY",
+	"PATHEXT",
+	"PATH",
+	"PROGRAMDATA",
+	"PROGRAMFILES",
+	"PROGRAMFILES(X86)",
+	"SSL_CERT_FILE",
+	"SYSTEMROOT",
+	"TEMP",
+	"TERM",
+	"TMP",
+	"TMPDIR",
+	"USER",
+	"USERNAME",
+	"USERPROFILE",
+	"WINDIR",
+	"XDG_CACHE_HOME",
+	"XDG_CONFIG_HOME",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+]);
+
+const WINDOWS_CHILD_ENV_PREFIXES = [
+	"AGY_",
+	"ANTIGRAVITY_",
+	"CLOUDSDK_",
+	"GEMINI_",
+	"GOOGLE_",
+];
+
+export function buildGoogleCliChildEnv(
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+	if (platform !== "win32") return env;
+
+	const childEnv: NodeJS.ProcessEnv = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (typeof value !== "string") continue;
+		const upperKey = key.toUpperCase();
+		if (
+			WINDOWS_CHILD_ENV_KEYS.has(upperKey) ||
+			WINDOWS_CHILD_ENV_PREFIXES.some((prefix) => upperKey.startsWith(prefix))
+		) {
+			childEnv[key] = value;
+		}
+	}
+	return childEnv;
+}
+
 function textBlocks(content: (TextContent | { type: string })[]): string {
 	return content
 		.map((block) => block.type === "text" ? (block as TextContent).text : `[${block.type} omitted]`)
@@ -167,7 +232,7 @@ function runCli(plan: GoogleCliRunPlan, options?: SimpleStreamOptions): Promise<
 	return new Promise((resolve, reject) => {
 		const child = spawn(plan.command, plan.args, {
 			cwd: options?.cwd || process.cwd(),
-			env: process.env,
+			env: buildGoogleCliChildEnv(),
 			stdio: [plan.stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
 		});
 

--- a/src/tests/windows-portability.test.ts
+++ b/src/tests/windows-portability.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { encodeCwd } from "../resources/extensions/subagent/isolation.ts";
-import { buildGoogleCliRunPlan, buildGoogleCliSpawnInvocation } from "../resources/extensions/google-cli/stream-adapter.ts";
+import {
+	buildGoogleCliChildEnv,
+	buildGoogleCliRunPlan,
+	buildGoogleCliSpawnInvocation,
+} from "../resources/extensions/google-cli/stream-adapter.ts";
 import { buildGsdClientSpawnPlan } from "../../vscode-extension/src/gsd-client-spawn.ts";
 
 test("encodeCwd produces a filesystem-safe token for Windows paths", () => {
@@ -58,4 +62,42 @@ test("Google CLI run plan passes prompt as -p arg on non-Windows platforms", () 
 	assert.ok(antigravityPlan.args.includes("-p"));
 	assert.ok(antigravityPlan.args.includes(prompt));
 	assert.equal(antigravityPlan.stdin, undefined);
+});
+
+test("Google CLI child env omits large GSD internals on Windows", () => {
+	const hugeInternalValue = "x".repeat(70_000);
+	const env = buildGoogleCliChildEnv({
+		Path: "C:\\Windows\\System32;C:\\Tools",
+		USERPROFILE: "C:\\Users\\Alice",
+		APPDATA: "C:\\Users\\Alice\\AppData\\Roaming",
+		LOCALAPPDATA: "C:\\Users\\Alice\\AppData\\Local",
+		COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+		systemroot: "C:\\Windows",
+		GEMINI_API_KEY: "gemini-key",
+		HTTPS_PROXY: "http://proxy.local:8080",
+		GSD_BUNDLED_EXTENSION_PATHS: hugeInternalValue,
+		GSD_WORKFLOW_EXECUTORS_MODULE: hugeInternalValue,
+		NODE_PATH: hugeInternalValue,
+	}, "win32");
+
+	assert.equal(env.Path, "C:\\Windows\\System32;C:\\Tools");
+	assert.equal(env.USERPROFILE, "C:\\Users\\Alice");
+	assert.equal(env.APPDATA, "C:\\Users\\Alice\\AppData\\Roaming");
+	assert.equal(env.LOCALAPPDATA, "C:\\Users\\Alice\\AppData\\Local");
+	assert.equal(env.COMSPEC, "C:\\Windows\\System32\\cmd.exe");
+	assert.equal(env.systemroot, "C:\\Windows");
+	assert.equal(env.GEMINI_API_KEY, "gemini-key");
+	assert.equal(env.HTTPS_PROXY, "http://proxy.local:8080");
+	assert.equal(env.GSD_BUNDLED_EXTENSION_PATHS, undefined);
+	assert.equal(env.GSD_WORKFLOW_EXECUTORS_MODULE, undefined);
+	assert.equal(env.NODE_PATH, undefined);
+});
+
+test("Google CLI child env is unchanged on non-Windows platforms", () => {
+	const env = {
+		PATH: "/usr/bin",
+		GSD_BUNDLED_EXTENSION_PATHS: "/tmp/extensions",
+	};
+
+	assert.equal(buildGoogleCliChildEnv(env, "linux"), env);
 });


### PR DESCRIPTION
## Summary
- Filtered the Windows Google CLI bridge child environment to avoid spawn ENAMETOOLONG and verified with the focused Windows portability test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1005
- [#1005 [Bug]: Cant do anything: Error: spawn ENAMETOOLONG](https://github.com/open-gsd/gsd-pi/issues/1005)

## User
- @aloxuhik

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1005-bug-cant-do-anything-error-spawn-enameto-1782588456`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Windows spawn fix with allowlisted env vars; non-Windows behavior is unchanged and tests lock in the filtering rules.
> 
> **Overview**
> Fixes **Windows** failures when spawning the Google CLI bridge (`spawn ENAMETOOLONG`) by no longer passing the full parent `process.env` into the child.
> 
> **`buildGoogleCliChildEnv`** builds a reduced environment on `win32`: a fixed allowlist (e.g. `PATH`, profile dirs, proxies, terminal/color vars) plus keys prefixed with `GEMINI_`, `GOOGLE_`, `AGY_`, etc. Large GSD-internal variables (e.g. `GSD_BUNDLED_EXTENSION_PATHS`, `NODE_PATH`) are dropped. **`runCli`** now uses this helper instead of `process.env`. Non-Windows platforms still receive the original env unchanged.
> 
> Windows portability tests cover the filtered env and the Linux passthrough behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66142c44c3fef5d838e832efd23d6d3b2d2b0296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->