### PR TITLE
fix(issue): [Bug]: milestone closeout false-blocks on "missing UAT PASS verdict" when ASSESSMENT is orphaned by a path migration (#1022)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -30,6 +30,7 @@ import {
   setSliceSketchFlag,
   transaction,
   getAssessment,
+  getSliceRunUatAssessment,
 } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
@@ -320,6 +321,19 @@ export async function readUatGateVerdict(
     if (legacyUatVerdict) {
       return { verdict: legacyUatVerdict, uatType };
     }
+  }
+
+  // ADR-017 DB fallback: when the ASSESSMENT markdown is missing or orphaned
+  // from its canonical path (e.g. after a milestone artifact-layout migration
+  // moves slice artifacts from `phases/…` to `milestones/…`), consult the
+  // authoritative assessments table by (mid, slice) identity instead of path.
+  // `gsd_uat_result_save` always writes this row, so it is the source of truth.
+  const runUatAssessment = getSliceRunUatAssessment(mid, sliceId);
+  if (runUatAssessment?.status) {
+    return {
+      verdict: runUatAssessment.status,
+      uatType: uatType ?? extractUatType(runUatAssessment.fullContent),
+    };
   }
 
   return null;

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -544,6 +544,31 @@ export function getAssessment(path: string): Record<string, unknown> | null {
   return row ?? null;
 }
 
+/**
+ * Look up a slice's `run-uat` assessment by (milestoneId, sliceId) identity,
+ * independent of the artifact `path`. Used as a DB fallback by the UAT
+ * closeout gate when a path migration orphans the ASSESSMENT markdown from its
+ * canonical expected path (ADR-017: DB-authoritative UAT sign-off).
+ *
+ * `status` holds the normalized verdict (`pass`/`fail`/…) written by
+ * `executeUatResultSave`; `fullContent` carries the ASSESSMENT body so callers
+ * can derive `uatType` without re-reading a file that may not exist.
+ */
+export function getSliceRunUatAssessment(
+  milestoneId: string,
+  sliceId: string,
+): { status: string; fullContent: string } | null {
+  if (!getDbOrNull()!) return null;
+  const row = getDbOrNull()!.prepare(
+    `SELECT status, full_content AS fullContent FROM assessments
+      WHERE milestone_id = :mid AND slice_id = :sid AND scope = 'run-uat'
+      ORDER BY created_at DESC, ROWID DESC
+      LIMIT 1`,
+  ).get({ ":mid": milestoneId, ":sid": sliceId });
+  if (!row) return null;
+  return { status: String(row["status"] ?? ""), fullContent: String(row["fullContent"] ?? "") };
+}
+
 export function getLatestAssessmentByScope(
   milestoneId: string,
   scope: string,

--- a/src/resources/extensions/gsd/tests/read-uat-gate-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/read-uat-gate-verdict.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Behavioural regression test for the milestone-closeout UAT gate —
+ * `readUatGateVerdict`.
+ *
+ * The gate (ADR-017: DB-authoritative UAT sign-off) reads a slice's UAT
+ * verdict from its ASSESSMENT artifact via the *canonical* expected path
+ * (`resolveSliceFile` + a path-keyed `getAssessment`). When a milestone
+ * artifact-layout migration orphans the ASSESSMENT markdown from that canonical
+ * path (e.g. `phases/…` → `milestones/…`), the gate used to return `null` and
+ * block milestone closure with "missing UAT PASS verdict" — even though the
+ * verdict was correctly recorded in the `assessments` table by
+ * `gsd_uat_result_save`.
+ *
+ * The DB fallback added to `readUatGateVerdict` consults the authoritative
+ * `assessments` table by (milestoneId, sliceId, scope='run-uat') identity,
+ * independent of path. These tests pin that behaviour.
+ */
+
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertAssessment,
+} from '../gsd-db.ts';
+import { readUatGateVerdict } from '../auto-dispatch.ts';
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-uat-gate-'));
+  return path.join(dir, 'test.db');
+}
+
+function cleanupDb(dbPath: string): void {
+  closeDatabase();
+  try { fs.rmSync(path.dirname(dbPath), { recursive: true, force: true }); } catch { /* */ }
+}
+
+const MID = 'M001';
+const SLICE = 'S01';
+
+/** Canonical on-disk ASSESSMENT path produced by `resolveSliceFile`. */
+function canonicalAssessmentPath(basePath: string): string {
+  return path.join(basePath, '.gsd', 'milestones', MID, 'slices', SLICE, `${SLICE}-ASSESSMENT.md`);
+}
+
+/** An ASSESSMENT body that declares a runtime-executable UAT type and a PASS verdict. */
+const RUNTIME_PASS_BODY = [
+  '---',
+  'verdict: pass',
+  '---',
+  '',
+  '# S01 UAT Assessment',
+  '',
+  '## UAT Type',
+  '- UAT mode: runtime-executable',
+  '',
+  '## Result',
+  'All checks passed.',
+].join('\n');
+
+describe('readUatGateVerdict — DB fallback for orphaned ASSESSMENT', () => {
+  let dbPath: string;
+  let basePath: string;
+
+  beforeEach(() => {
+    dbPath = tempDbPath();
+    openDatabase(dbPath);
+    basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-uat-gate-proj-'));
+    insertMilestone({ id: MID });
+    insertSlice({ id: SLICE, milestoneId: MID });
+  });
+
+  afterEach(() => {
+    cleanupDb(dbPath);
+    try { fs.rmSync(basePath, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  test('returns pass when the ASSESSMENT is keyed by a legacy/orphaned path (the bug)', async () => {
+    // Reproduces milestone 15: `gsd_uat_result_save` wrote S01's assessment row
+    // under a now-migrated path; the canonical file never existed on disk and
+    // the `assessments.path` is not what `resolveSliceFile` computes.
+    insertAssessment({
+      // Deliberately non-canonical — a legacy `phases/…` path.
+      path: `.gsd/phases/01-some-feature/01-01-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'run-uat',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.ok(result, 'expected the DB fallback to resolve a verdict, got null');
+    assert.equal(result!.verdict, 'pass');
+  });
+
+  test('the DB fallback derives uatType from the assessment body when no file exists', async () => {
+    insertAssessment({
+      path: `.gsd/phases/01-some-feature/01-01-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'run-uat',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.ok(result);
+    assert.equal(result!.verdict, 'pass');
+    assert.equal(result!.uatType, 'runtime-executable');
+  });
+
+  test('canonical ASSESSMENT file on disk still resolves (regression guard)', async () => {
+    // When the file is present at the canonical path, the existing path-keyed
+    // lookup must resolve it without needing the fallback.
+    const file = canonicalAssessmentPath(basePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, RUNTIME_PASS_BODY);
+    // Also seed the path-keyed assessments row, mirroring a normal save.
+    insertAssessment({
+      path: `.gsd/milestones/${MID}/slices/${SLICE}/${SLICE}-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'run-uat',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.ok(result);
+    assert.equal(result!.verdict, 'pass');
+    assert.equal(result!.uatType, 'runtime-executable');
+  });
+
+  test('a roadmap-scoped assessment does NOT satisfy the UAT gate', async () => {
+    // `reassess-roadmap` writes roadmap-scoped assessments to the same
+    // S##-ASSESSMENT path; those must never be treated as a UAT verdict. The
+    // legacy-path fallback queries scope='run-uat', so a roadmap-only row is
+    // invisible and the gate returns null.
+    insertAssessment({
+      path: `.gsd/milestones/${MID}/slices/${SLICE}/${SLICE}-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'roadmap',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.equal(result, null, 'roadmap-scoped assessments must not satisfy the UAT gate');
+  });
+
+  test('returns null when no assessment and no file exist (fallback does not hallucinate)', async () => {
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+    assert.equal(result, null);
+  });
+
+  test('surfaces a recorded non-pass verdict via the DB fallback', async () => {
+    // A failing verdict stored under a legacy path must surface (not be masked
+    // as "missing") so the gate's non-PASS branch can act on it.
+    insertAssessment({
+      path: `.gsd/phases/01-some-feature/01-01-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'fail',
+      scope: 'run-uat',
+      fullContent: RUNTIME_PASS_BODY.replace('verdict: pass', 'verdict: fail'),
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.ok(result);
+    assert.equal(result!.verdict, 'fail');
+  });
+});


### PR DESCRIPTION
## Linked issue

Closes #1022

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds a DB-authoritative fallback to the milestone-closeout UAT gate so it reads a slice's verdict by `(milestoneId, sliceId)` identity, not just by canonical ASSESSMENT path.
**Why:** A milestone artifact-layout migration can orphan a slice's ASSESSMENT markdown from its canonical path, making the gate report a "missing UAT PASS verdict" that is actually present in three DB tables.
**How:** New `getSliceRunUatAssessment(mid, slice)` helper consults `assessments` where `scope='run-uat'`, wired into `readUatGateVerdict` as a fallback before `return null`.

## What

Three files:

- **`src/resources/extensions/gsd/db/queries.ts`** — new `getSliceRunUatAssessment(milestoneId, sliceId)` helper. Looks up a slice's `run-uat` assessment by identity (`milestone_id`, `slice_id`, `scope='run-uat'`), ordered `created_at DESC, ROWID DESC`, returning `{ status, fullContent }`. The `status` column holds the normalized verdict written by `executeUatResultSave`; `fullContent` lets callers derive `uatType` without re-reading a file that may not exist.
- **`src/resources/extensions/gsd/auto-dispatch.ts`** — wired the fallback into `readUatGateVerdict`, just before the final `return null`. It is a **pure fallback**: it only changes behavior when the canonical file read, the path-keyed `getAssessment`, and the legacy UAT-file extraction all miss. Added `getSliceRunUatAssessment` to the existing `gsd-db.js` import block (it is re-exported through that barrel via `export * from "./db/queries.js"`).
- **`src/resources/extensions/gsd/tests/read-uat-gate-verdict.test.ts`** — new test file. `readUatGateVerdict` previously had **zero** direct test coverage, which is a contributing factor to this regression. 6 tests: the legacy-path bug repro, `uatType` derivation, the canonical-file regression guard, roadmap-scope exclusion, the null case, and non-pass surfacing.

## Why

Milestone 15 in `bbb-aaa` was stuck on closeout with `missing UAT PASS verdict for S01`, but S01 had genuinely passed UAT — the verdict was correctly recorded in `assessments`, `quality_gates`, `gate_runs`, and on disk (`uat/15/S01/attempt-1.json`, 4/4 checks PASS). Milestone 15's slice layout migrated from `phases/01-drag-and-drop-task-reorder/…` to the canonical `milestones/15/slices/…`. S01's UAT result was saved *before* the migration, so its `assessments` row is keyed by the legacy path (which no longer exists on disk); S02 was saved *after* and lands correctly. The gate's canonical-path lookup missed S01's row and returned `null`, hard-stopping closeout.

Any milestone that undergoes an artifact-layout migration after a slice's UAT result was recorded becomes permanently uncloseable via `/gsd auto`, with a misleading "missing verdict" message.

## How

The gate (`readUatGateVerdict`) already follows ADR-017 ("DB-authoritative UAT sign-off") in spirit — closed slices come from the DB, never the ROADMAP projection. But it read the *verdict* via the canonical ASSESSMENT path, which is a path-keyed, filesystem-adjacent lookup. This PR makes the DB the true source of truth: when the path-keyed lookups miss, consult the `assessments` table by identity. `gsd_uat_result_save` always writes this row, so it is authoritative.

The fallback scopes to `scope='run-uat'`, so `reassess-roadmap`'s roadmap-scoped assessments (written to the same `S##-ASSESSMENT` path) are never mistaken for UAT — preserving existing semantics (covered by a test).

**Alternatives considered:**
- *Reconcile the orphaned artifact* (write the canonical file + artifacts row) — fixes only this one DB; the next migration silently re-breaks. Doesn't fix the gate.
- *Re-run UAT for S01* — overwrites a valid verdict with a redundant Playwright run; doesn't address root cause.
- *Fall back to `quality_gates`/`gate_runs`* — equivalent effect, but `assessments` holds both the normalized verdict *and* the content needed to derive `uatType` in one query. Cleaner than stitching two tables.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

The change is a pure fallback; it only changes behavior when existing lookups already miss (i.e. the orphaned-artifact case). Slices with a readable canonical ASSESSMENT (the normal case) are unaffected.

## Test plan

- [x] New/updated tests included — `tests/read-uat-gate-verdict.test.ts` (6 tests, all pass)
- [x] CI passes — typecheck:extensions clean
- [x] Manual testing — verified against the live `bbb-aaa` DB: the fallback's exact SQL returns `status='pass'` for S01 (the previously-blocked slice)

Local results:
- `pnpm run typecheck:extensions` — clean
- New suite — 6/6 pass
- Neighbor suites (no regressions): `complete-slice-verification-gate` + `integration/run-uat` → 44/44; `milestone-closeout` + `guidance` + `run-uat-replay-cap` → 29/29

## Out of scope (follow-up)

The **reconciler** that performed the `phases/…` → `milestones/…` migration dropped S01's ASSESSMENT (it moved SUMMARYs but orphaned the ASSESSMENT) — the actual root cause of the orphan. This PR makes the gate resilient to it; fixing the reconciler is tracked separately in #1022.

## AI disclosure

- [x] This PR includes AI-assisted code — authored by ZCode (GLM-5.2). Verified with typecheck + the new and neighbor test suites, and confirmed against the live reproduction DB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure fallback on an existing closeout gate; behavior is unchanged when canonical files or path-keyed rows resolve, with tests covering scope filtering and regression paths.
> 
> **Overview**
> Fixes milestone closeout falsely reporting **missing UAT PASS** when a slice’s UAT was saved before an artifact layout migration left the ASSESSMENT row keyed on a legacy path and the canonical markdown is absent.
> 
> **`readUatGateVerdict`** still prefers on-disk ASSESSMENT/UAT and path-keyed `getAssessment`; if those miss, it now calls **`getSliceRunUatAssessment`**, which loads the latest `assessments` row for `(milestone_id, slice_id, scope='run-uat')` and returns `status` plus `fullContent` (for `uatType`). Roadmap-scoped assessments stay excluded via the `run-uat` filter.
> 
> Adds **`read-uat-gate-verdict.test.ts`** (six cases: legacy-path pass/fail, `uatType` from body, canonical-file regression, roadmap exclusion, null when nothing exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2399b75920dc6861bff8d37719eaaa213dac236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->