### PR TITLE
fix(gsd): tighten artifact and tool loop guards

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -537,14 +537,21 @@ export function verifyExpectedArtifact(
   // discuss-milestone unit with CONTEXT at phases/NN-slug/ in the project root
   // but not in the worktree resolves to null → "resolveExpectedArtifactPath
   // returned null" → finalize-retry loop (#852).
-  if (artifactBase !== base) {
+  //
+  // #870: the fallback must fire whenever the artifact is missing at
+  // `artifactBase`, NOT only when `artifactBase !== base`. When the real call
+  // site passes the worktree path as `base` (auto-post-unit.ts:1726 uses
+  // `s.currentUnit.workspaceRoot ?? s.basePath`), resolveCanonicalMilestoneRoot
+  // round-trips the worktree path back to itself, so `artifactBase === base`
+  // while still being a worktree path that lacks the projected artifact. The
+  // old `if (artifactBase !== base)` guard skipped the fallback in exactly that
+  // case, stranding CONTEXT at the project root and producing a stuck-loop.
+  if (!absPath || !existsSync(absPath)) {
     const projectRoot = resolve(resolveWorktreeProjectRoot(artifactBase));
     if (projectRoot && projectRoot !== artifactBase) {
-      if (!absPath || !existsSync(absPath)) {
-        const projectPath = resolveExpectedArtifactPath(unitType, unitId, projectRoot);
-        if (projectPath && existsSync(projectPath)) {
-          absPath = projectPath;
-        }
+      const projectPath = resolveExpectedArtifactPath(unitType, unitId, projectRoot);
+      if (projectPath && existsSync(projectPath)) {
+        absPath = projectPath;
       }
     }
   }

--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -55,8 +55,8 @@ const REPEATABLE_TOOLS = new Set([
   "bash",
   "grep",
   "glob",
-  "web_search",
-  "web_fetch",
+  "search-the-web",
+  "fetch_page",
   "todo_write",
   "notebook_edit",
 ]);

--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -10,6 +10,13 @@
  * and blocks when the same signature appears more than MAX_CONSECUTIVE
  * times in a row. Resets on each agent turn (session_start, agent_end)
  * and when a different tool call breaks the streak.
+ *
+ * A second, independent check (#783 Brief C) tracks per-tool-name call
+ * counts within a turn regardless of args. This catches improvisation
+ * loops where the model attempts the same missing workflow tool through
+ * varied surfaces (bash → `node -e` → CLI), each with a different
+ * signature, so the identical-args streak never trips. Whichever guard
+ * trips first blocks.
  */
 
 import { createHash } from "node:crypto";
@@ -20,10 +27,47 @@ const MAX_CONSECUTIVE_IDENTICAL_CALLS = 4;
 const STRICT_LOOP_TOOLS = new Set(["ask_user_questions"]);
 const MAX_CONSECUTIVE_STRICT = 1;
 
+/**
+ * Per-turn cap on calls to the SAME tool name, regardless of args (#783).
+ *
+ * General-purpose execution tools are routinely called many times per turn
+ * (touching multiple files, running several commands), so they get a higher
+ * ceiling. Everything else — workflow one-shot tools (e.g. gsd_complete_milestone)
+ * and any non-allowlisted tool — gets the default cap. The default is generous
+ * enough to absorb legitimate retries but catches the reported improvisation
+ * loop (~51 calls) well before a cost spike.
+ */
+const PER_TOOL_DEFAULT_CAP = 6;
+const PER_TOOL_REPEATABLE_CAP = 15;
+
+/**
+ * Inherently-repeatable tools: called many times per turn in normal work
+ * (reading/writing several files, running several commands, searching). These
+ * get PER_TOOL_REPEATABLE_CAP rather than the default. Keep this list
+ * conservative — a tool here can be invoked up to PER_TOOL_REPEATABLE_CAP times
+ * per turn before the guard blocks.
+ */
+const REPEATABLE_TOOLS = new Set([
+  "read",
+  "write",
+  "edit",
+  "multi_edit",
+  "bash",
+  "grep",
+  "glob",
+  "web_search",
+  "web_fetch",
+  "todo_write",
+  "notebook_edit",
+]);
+
 let consecutiveCount = 0;
 let lastSignature = "";
 let lastToolName = "";
 let enabled = true;
+
+/** Per-tool-name call counts within the current turn (#783 Brief C). */
+const perToolCounts = new Map<string, number>();
 
 /** Hash tool name + args into a compact signature for comparison. */
 function hashToolCall(toolName: string, args: Record<string, unknown>): string {
@@ -46,6 +90,12 @@ function hashToolCall(toolName: string, args: Record<string, unknown>): string {
  *
  * Returns `{ block: false }` for allowed calls.
  * Returns `{ block: true, reason }` when the loop threshold is exceeded.
+ *
+ * Two independent guards run; whichever trips first blocks:
+ *  1. Identical-signature streak (MAX_CONSECUTIVE_IDENTICAL_CALLS, strict for
+ *     ask_user_questions).
+ *  2. Per-tool-name cap (PER_TOOL_DEFAULT_CAP / PER_TOOL_REPEATABLE_CAP),
+ *     independent of args — catches improvisation loops (#783).
  */
 export function checkToolCallLoop(
   toolName: string,
@@ -63,6 +113,7 @@ export function checkToolCallLoop(
     lastToolName = toolName;
   }
 
+  // ── Guard 1: identical-signature streak ──
   const threshold = STRICT_LOOP_TOOLS.has(toolName)
     ? MAX_CONSECUTIVE_STRICT
     : MAX_CONSECUTIVE_IDENTICAL_CALLS;
@@ -71,10 +122,30 @@ export function checkToolCallLoop(
     return {
       block: true,
       reason:
-        `Tool loop detected: ${toolName} called ${consecutiveCount} times ` +
+        `Tool loop detected (identical args): ${toolName} called ${consecutiveCount} times ` +
         `with identical arguments. Blocking to prevent infinite loop. ` +
         `Try a different approach or modify your arguments.`,
       count: consecutiveCount,
+    };
+  }
+
+  // ── Guard 2: per-tool-name cap, independent of args (#783 Brief C) ──
+  // Catches improvisation loops where the same tool is invoked many times with
+  // varied args (e.g. retrying a missing workflow tool via bash/node -e/CLI).
+  const perToolCount = (perToolCounts.get(toolName) ?? 0) + 1;
+  perToolCounts.set(toolName, perToolCount);
+  const perToolCap = REPEATABLE_TOOLS.has(toolName)
+    ? PER_TOOL_REPEATABLE_CAP
+    : PER_TOOL_DEFAULT_CAP;
+
+  if (perToolCount > perToolCap) {
+    return {
+      block: true,
+      reason:
+        `Tool loop detected (repeated tool): ${toolName} called ${perToolCount} times ` +
+        `this turn (cap ${perToolCap}). Blocking to prevent infinite loop. ` +
+        `The tool may be unavailable or failing repeatedly — try a different approach.`,
+      count: perToolCount,
     };
   }
 
@@ -87,6 +158,7 @@ export function resetToolCallLoopGuard(): void {
   lastSignature = "";
   lastToolName = "";
   enabled = true;
+  perToolCounts.clear();
 }
 
 /** Disable the guard (e.g. during shutdown). */
@@ -95,9 +167,18 @@ export function disableToolCallLoopGuard(): void {
   consecutiveCount = 0;
   lastSignature = "";
   lastToolName = "";
+  perToolCounts.clear();
 }
 
 /** Get current consecutive count for diagnostics. */
 export function getToolCallLoopCount(): number {
   return consecutiveCount;
+}
+
+/**
+ * Get the per-tool-name call count for the current turn (#783 Brief C).
+ * Returns 0 for tools not yet called. Diagnostic only.
+ */
+export function getToolCallCountForTool(toolName: string): number {
+  return perToolCounts.get(toolName) ?? 0;
 }

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -10,6 +10,7 @@ import {
   resetToolCallLoopGuard,
   disableToolCallLoopGuard,
   getToolCallLoopCount,
+  getToolCallCountForTool,
 } from '../bootstrap/tool-call-loop-guard.ts';
 
 
@@ -174,6 +175,73 @@ console.log('\n── Loop guard: nested key order is normalized ──');
   checkToolCallLoop('tool', { outer: { b: 2, a: 1 } });
   const result = checkToolCallLoop('tool', { outer: { a: 1, b: 2 } });
   assert.deepStrictEqual(getToolCallLoopCount(), 2, 'Same nested args in different key order should match');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Per-tool-name cap (#783 Brief C) — catches improvisation loops with varied args
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: per-tool cap blocks varied-args improvisation (#783) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  // A one-shot workflow tool called with DIFFERENT args each time (the reported
+  // improvisation pattern). The identical-signature streak alone would reset
+  // every call; the per-tool cap must catch it.
+  for (let i = 1; i <= 6; i++) {
+    const result = checkToolCallLoop('gsd_complete_milestone', { milestone: `M${i}` });
+    assert.ok(result.block === false, `one-shot call ${i} (varied args) should be allowed`);
+    assert.deepStrictEqual(getToolCallCountForTool('gsd_complete_milestone'), i, `per-tool count should be ${i}`);
+  }
+  // 7th call (cap 6 + 1) must be blocked by the per-tool guard.
+  const blocked = checkToolCallLoop('gsd_complete_milestone', { milestone: 'M7' });
+  assert.ok(blocked.block === true, '7th one-shot call (varied args) should be blocked by per-tool cap');
+  assert.ok(blocked.reason!.includes('repeated tool'), 'reason should identify the per-tool guard');
+  assert.ok(blocked.reason!.includes('gsd_complete_milestone'), 'reason should name the tool');
+  assert.ok(blocked.reason!.includes('7'), 'reason should mention the count');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Repeatable tools get the higher cap
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: repeatable tools get the higher cap (#783) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  // bash is repeatable: varied commands are legitimate up to the higher cap.
+  for (let i = 1; i <= 15; i++) {
+    const result = checkToolCallLoop('bash', { command: `echo ${i}` });
+    assert.ok(result.block === false, `bash call ${i} (varied args) should be allowed`);
+  }
+  // 16th call (cap 15 + 1) is blocked by the per-tool guard — this is the
+  // improvisation-through-bash case from the forensics (~51 calls).
+  const blocked = checkToolCallLoop('bash', { command: 'echo 16' });
+  assert.ok(blocked.block === true, '16th bash call (varied args) should be blocked by per-tool cap');
+  assert.ok(blocked.reason!.includes('cap 15'), 'reason should mention the repeatable cap');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Per-tool counts are independent per tool and reset together
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: per-tool counts are independent and reset together (#783) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  // Two different tools tracked separately.
+  for (let i = 0; i < 3; i++) checkToolCallLoop('read', { path: `f${i}` });
+  for (let i = 0; i < 3; i++) checkToolCallLoop('write', { path: `g${i}` });
+  assert.deepStrictEqual(getToolCallCountForTool('read'), 3, 'read tracked separately');
+  assert.deepStrictEqual(getToolCallCountForTool('write'), 3, 'write tracked separately');
+  assert.deepStrictEqual(getToolCallCountForTool('edit'), 0, 'uncalled tool reports 0');
+
+  resetToolCallLoopGuard();
+  assert.deepStrictEqual(getToolCallCountForTool('read'), 0, 'per-tool counts cleared on reset');
+  assert.deepStrictEqual(getToolCallCountForTool('write'), 0, 'per-tool counts cleared on reset');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
+++ b/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
@@ -292,3 +292,69 @@ test("#852: discuss-milestone fails when CONTEXT is in neither worktree nor proj
     rmSync(projectRoot, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// #870: discuss-milestone verify-fail when the unit runs IN the worktree.
+//
+// The #852 tests above all pass `projectRoot` as the base. But the real call
+// site (auto-post-unit.ts:1726) passes `s.currentUnit.workspaceRoot ?? s.basePath`
+// — i.e. the WORKTREE path when the unit executed in a worktree. In the
+// canonical layout (`<root>/.gsd-worktrees/<MID>/`) resolveCanonicalMilestoneRoot
+// round-trips the worktree path back to itself, so `artifactBase === base` and
+// the worktree→project-root fallback (guarded by `artifactBase !== base`) is
+// skipped. CONTEXT is written to the project root, not projected into the
+// worktree, so verification finds nothing → "existsSync false" → re-dispatch
+// 3× → stuck-loop stop. These tests pin the real call site.
+// ---------------------------------------------------------------------------
+
+test("#870: discuss-milestone falls back to project root when base IS the canonical-layout worktree", () => {
+  closeDatabase();
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-canonical-wt-"));
+  try {
+    // CONTEXT lives ONLY at the project root (flat-phase layout).
+    const phaseDir = join(projectRoot, ".gsd", "phases", "15-m015");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "15-CONTEXT.md"), "# M015 context\n");
+
+    // Canonical-layout worktree: <root>/.gsd-worktrees/<MID>/. Registered
+    // with git (.git file) so resolveCanonicalMilestoneRoot treats it as the
+    // canonical milestone root — but it has NO phases/ projection.
+    const wtRoot = join(projectRoot, ".gsd-worktrees", "M015");
+    mkdirSync(join(wtRoot, ".gsd", "milestones", "M015"), { recursive: true });
+    writeFileSync(join(wtRoot, ".gsd", "milestones", "M015", "M015-META.json"), '{"branch":"milestone/M015"}');
+    writeFileSync(join(wtRoot, ".git"), "gitdir: /fake/path");
+
+    // Real call site: base = worktree path (workspaceRoot).
+    assert.equal(
+      verifyExpectedArtifact("discuss-milestone", "M015", wtRoot),
+      true,
+      "must fall back to project root when base is the canonical-layout worktree",
+    );
+  } finally {
+    closeDatabase();
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("#870: discuss-milestone also falls back when base is the legacy-layout worktree", () => {
+  closeDatabase();
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-legacy-wt-"));
+  try {
+    const phaseDir = join(projectRoot, ".gsd", "phases", "15-m015");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "15-CONTEXT.md"), "# M015 context\n");
+
+    const wtRoot = join(projectRoot, ".gsd", "worktrees", "M015");
+    mkdirSync(join(wtRoot, ".gsd", "milestones", "M015"), { recursive: true });
+    writeFileSync(join(wtRoot, ".git"), "gitdir: /fake/path");
+
+    assert.equal(
+      verifyExpectedArtifact("discuss-milestone", "M015", wtRoot),
+      true,
+      "must fall back to project root when base is the legacy-layout worktree",
+    );
+  } finally {
+    closeDatabase();
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why

Tightens two recovery/guard paths that can otherwise leave GSD loops stuck or expensive:

- `discuss-milestone` artifact verification can miss project-root CONTEXT artifacts when execution happens inside a worktree.
- Tool-call loop protection only counted identical signatures, so varied-args retries could keep invoking the same workflow tool repeatedly.

## How

- Falls back to the project root whenever the expected artifact is missing at the current artifact base.
- Adds a per-turn per-tool-name cap alongside the existing identical-signature guard, with a higher cap for repeatable file/shell/search tools.
- Adds regression tests for canonical and legacy worktree artifact fallback plus varied-args tool-loop blocking.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts`
- Sabotage checks: raised per-tool cap and restored the old artifact fallback guard; both targeted tests failed as expected.
- `bash scripts/ci-fast-gates.sh` partially passed through fast scans/script-policy gates, then blocked in `postinstall` during a nested pnpm boundary install.
- `./node_modules/.bin/tsc --noEmit --project tsconfig.extensions.json && node scripts/compile-tests.mjs && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.js dist-test/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.js`

## Change Type

- [x] fix — Bug fix
- [x] test — Adding or updating tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode completion verification and native-engine tool blocking; wrong caps or fallback logic could block legitimate agents or advance units incorrectly, but scope is narrow and well-tested.
> 
> **Overview**
> Fixes two stuck-loop paths in GSD auto-mode recovery and agent tool hooks.
> 
> **Artifact verification (#870):** `verifyExpectedArtifact` now falls back from the worktree/milestone base to the **project root whenever the expected file is missing**, not only when `artifactBase !== base`. That matches the real verification base (`workspaceRoot` from `auto-post-unit`), where canonical worktrees round-trip to themselves and CONTEXT can live only at the project root—avoiding false verify-fail and finalize-retry loops for `discuss-milestone`.
> 
> **Tool loop guard (#783):** Keeps the identical-args streak guard and adds a **per-turn per-tool-name cap** (default 6, 15 for allowlisted read/write/bash-style tools). Varied-arg retries against the same workflow tool are blocked before long improvisation loops; reset/disable clears the new counters. Adds `getToolCallCountForTool` for diagnostics.
> 
> Regression tests cover canonical/legacy worktree bases and per-tool caps for one-shot vs repeatable tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a82b1c74bf6fcd144bc94214046324c2313a691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->