### PR TITLE
fix(issue): [Bug]: an in-flight tool card arms a 70ms full-render timer even when it renders as a static collapsed strip, driving ~14 full-tree TUI renders/sec for the whole duration of a long tool call

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -71,68 +71,78 @@ function renderToolCollapsed(
 }
 
 describe("ToolExecutionComponent", () => {
-	test("running-rail animates at a constant cadence while in-flight, and not at all when the setting is off", (t) => {
-		// The running tool card animates its rail by re-rendering the transcript on a
-		// fixed-cadence timer while in-flight (isInFlight === !result). The cadence is
-		// constant (matched to the rail's per-cell step) and keeps going for as long as
-		// the tool runs — a 30-minute tool stays visibly alive, never frozen. When the
-		// `terminal.toolRailAnimation` setting is off the timer is never armed, so a
-		// long-running tool costs zero idle CPU.
+	test("running timer uses rail cadence only for expanded cards", (t) => {
+		// Expanded running tool cards animate their rail at the rail frame cadence.
+		// Collapsed strips are static except for the elapsed-seconds label, so they
+		// must not drive full-tree renders every 70ms.
 		mock.timers.enable({ apis: ["setInterval", "Date"] });
 		t.after(() => {
 			setRailAnimationEnabled(true); // module-global — restore default for other tests
 			mock.timers.reset();
 		});
 
-		// --- animation ON (default) ---
 		setRailAnimationEnabled(true);
-		let renderRequests = 0;
-		const onCard = new ToolExecutionComponent(
-			"bash",
-			{ command: "sleep 99999" },
+
+		// Collapsed non-bash tools render as a static compact strip. The elapsed
+		// label changes only once per second, so the timer uses that cadence.
+		let collapsedRenderRequests = 0;
+		const collapsedCard = new ToolExecutionComponent(
+			"gsd_plan_slice",
+			{ prompt: "large context" },
 			{},
 			undefined,
-			{ requestRender() { renderRequests++; } } as any,
+			{ requestRender() { collapsedRenderRequests++; } } as any,
 		);
-		onCard.render(120); // arms the rail timer
-		assert.equal(renderRequests, 0, "render itself does not request a render");
-
-		// Each 70ms tick re-renders once — constant cadence, one cell of movement per frame.
+		collapsedCard.render(120);
 		mock.timers.tick(70);
 		mock.timers.tick(70);
-		assert.ok(renderRequests >= 2, `rail should animate while in-flight, got ${renderRequests}`);
+		assert.equal(collapsedRenderRequests, 0, "compact strip does not use the 70ms rail cadence");
+		mock.timers.tick(860);
+		assert.equal(collapsedRenderRequests, 1, "compact strip refreshes at elapsed-seconds cadence");
 
-		// It keeps animating indefinitely while in-flight — no cap, no freeze. 200 ticks
-		// (~14s) each request a render at the constant rate.
-		const before = renderRequests;
+		// Expanded cards keep the fast rail cadence while in-flight.
+		let expandedRenderRequests = 0;
+		const expandedCard = new ToolExecutionComponent(
+			"gsd_plan_slice",
+			{ prompt: "large context" },
+			{},
+			undefined,
+			{ requestRender() { expandedRenderRequests++; } } as any,
+		);
+		expandedCard.setExpanded(true);
+		mock.timers.tick(70);
+		mock.timers.tick(70);
+		assert.ok(expandedRenderRequests >= 2, `rail should animate while expanded, got ${expandedRenderRequests}`);
+
+		// It keeps animating indefinitely while in-flight — no cap, no freeze.
+		const before = expandedRenderRequests;
 		for (let i = 0; i < 200; i++) mock.timers.tick(70);
+		const animatedTicks = expandedRenderRequests - before;
 		assert.ok(
-			renderRequests - before >= 180,
-			`rail must keep animating at a constant rate (no cap), got ${renderRequests - before} over 200 ticks`,
+			animatedTicks >= 180,
+			`rail must keep animating at a constant rate (no cap), got ${animatedTicks} over 200 ticks`,
 		);
 
 		// Stops once the result arrives.
-		onCard.updateResult({ content: [{ type: "text", text: "done" }], isError: false });
-		const afterResult = renderRequests;
+		expandedCard.updateResult({ content: [{ type: "text", text: "done" }], isError: false });
+		const afterResult = expandedRenderRequests;
 		mock.timers.tick(70);
 		mock.timers.tick(70);
-		assert.equal(renderRequests, afterResult, "rail stops once the tool has a result");
+		assert.equal(expandedRenderRequests, afterResult, "rail stops once the tool has a result");
 
-		// --- animation OFF: the timer is never armed ---
+		// Animation OFF: the timer is never armed.
 		setRailAnimationEnabled(false);
 		let offRenders = 0;
 		const offCard = new ToolExecutionComponent(
-			"bash",
-			{ command: "sleep 99999" },
+			"gsd_plan_slice",
+			{ prompt: "large context" },
 			{},
 			undefined,
 			{ requestRender() { offRenders++; } } as any,
 		);
 		offCard.render(120);
-		mock.timers.tick(70);
-		mock.timers.tick(70);
-		mock.timers.tick(70);
-		assert.equal(offRenders, 0, "no rail animation when the setting is off (zero idle CPU)");
+		mock.timers.tick(1000);
+		assert.equal(offRenders, 0, "no running timer when the setting is off (zero idle CPU)");
 	});
 
 	test("reuses shared tool-argument normalization for pending invocation matching", () => {

--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -47,16 +47,19 @@ const BASH_PREVIEW_LINES = 5;
 // During partial write tool-call streaming, re-highlight the first N lines fully
 // to keep multiline tokenization mostly correct without re-highlighting the full file.
 const WRITE_PARTIAL_FULL_HIGHLIGHT_LINES = 50;
-// The in-flight tool card animates its rail by re-rendering the transcript on a
-// fixed-cadence timer. The cadence is matched to the rail's own step
+// Expanded in-flight tool cards animate their rail by re-rendering the transcript
+// on a fixed-cadence timer. The cadence is matched to the rail's own step
 // (RUNNING_RAIL_FRAME_MS in transcript-design): one re-render == one cell of head
-// movement, so the motion is smooth and no frame is wasted. Animation is gated by
-// the `terminal.toolRailAnimation` user setting (isRailAnimationEnabled): when it
-// is off, the timer is never armed and the rail renders statically, so even a tool
+// movement, so the motion is smooth and no frame is wasted. Collapsed strips have
+// no animated rail; their only self-changing field is the elapsed whole-second
+// counter, so they refresh on a slower cadence. Both timers are gated by the
+// `terminal.toolRailAnimation` user setting (isRailAnimationEnabled): when it is
+// off, the timer is never armed and the rail renders statically, so even a tool
 // that runs for 30 minutes costs zero idle CPU. (A genuinely hung tool is finalized
 // at the source by agent-loop's raceToolExecutionAgainstAbort, which gives the card
 // a result and lets the timer stop on its own.)
 const RUNNING_RAIL_RENDER_INTERVAL_MS = 70;
+const RUNNING_COMPACT_RENDER_INTERVAL_MS = 1000;
 
 /**
  * Replace tabs with spaces for consistent rendering
@@ -388,6 +391,7 @@ export class ToolExecutionComponent extends Container {
 	private hideComponent = false;
 	private toolRenderState: Record<string, unknown> = {};
 	private runningRailTimer: ReturnType<typeof setInterval> | undefined;
+	private runningRailTimerIntervalMs: number | undefined;
 
 	private createRenderContext(): ToolRenderContext {
 		return {
@@ -481,21 +485,32 @@ export class ToolExecutionComponent extends Container {
 		this.result = undefined;
 	}
 
-	private syncRunningRailTimer(): void {
+	private getRunningRenderIntervalMs(): number | undefined {
 		if (!this.isInFlight() || this.hideComponent || !isRailAnimationEnabled()) {
+			return undefined;
+		}
+		return this.showExpandedBody() ? RUNNING_RAIL_RENDER_INTERVAL_MS : RUNNING_COMPACT_RENDER_INTERVAL_MS;
+	}
+
+	private syncRunningRailTimer(): void {
+		const intervalMs = this.getRunningRenderIntervalMs();
+		if (intervalMs === undefined) {
 			this.stopRunningRailTimer();
 			return;
 		}
-		if (this.runningRailTimer) return;
+		if (this.runningRailTimer && this.runningRailTimerIntervalMs === intervalMs) return;
 
+		this.stopRunningRailTimer();
+		this.runningRailTimerIntervalMs = intervalMs;
 		this.runningRailTimer = setInterval(() => {
-			// Stop once the tool finishes, is hidden, or the animation setting is off.
-			if (!this.isInFlight() || this.hideComponent || !isRailAnimationEnabled()) {
-				this.stopRunningRailTimer();
+			// Stop or re-arm if the tool finishes, is hidden, the animation setting is
+			// toggled, or the card switches between compact and expanded rendering.
+			if (this.getRunningRenderIntervalMs() !== intervalMs) {
+				this.syncRunningRailTimer();
 				return;
 			}
 			this.ui.requestRender();
-		}, RUNNING_RAIL_RENDER_INTERVAL_MS);
+		}, intervalMs);
 		this.runningRailTimer.unref?.();
 	}
 
@@ -513,6 +528,7 @@ export class ToolExecutionComponent extends Container {
 		if (!this.runningRailTimer) return;
 		clearInterval(this.runningRailTimer);
 		this.runningRailTimer = undefined;
+		this.runningRailTimerIntervalMs = undefined;
 	}
 
 	updateArgs(args: any): void {


### PR DESCRIPTION
## Summary
- Fixed the in-flight tool timer cadence so collapsed strips avoid 70ms renders, added regression coverage, and ran parse/diff checks while package tests were blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1030
- [#1030 [Bug]: an in-flight tool card arms a 70ms full-render timer even when it renders as a static collapsed strip, driving ~14 full-tree TUI renders/sec for the whole duration of a long tool call](https://github.com/open-gsd/gsd-pi/issues/1030)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1030-bug-an-in-flight-tool-card-arms-a-70ms-f-1782625276`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI performance fix with targeted timer logic and regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **in-flight tool cards** that rendered as a **collapsed compact strip** but still armed the **70ms** running timer, forcing ~14 full TUI tree redraws per second for the whole tool run.
> 
> `ToolExecutionComponent` now picks the timer interval from layout: **70ms** when `showExpandedBody()` (animated rail), **1000ms** when compact (only the elapsed **seconds** label changes). The interval is tracked so **expand/collapse** or setting toggles **re-arm** the timer instead of keeping the wrong cadence. **`terminal.toolRailAnimation` off** still means no timer.
> 
> Tests were updated to assert collapsed `gsd_plan_slice` strips skip 70ms ticks and refresh about once per second, while expanded cards keep the rail cadence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3da0d543f93bf3564844d96fbd03036ddf4816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->