### PR TITLE
fix(issue): [Bug]: auto-retry re-streams the entire turn from scratch on a `terminated` stream error with no no-progress guard, turning one interrupted generation into 3 full re-streams

### DIFF
--- a/packages/gsd-agent-core/src/agent-session.test.ts
+++ b/packages/gsd-agent-core/src/agent-session.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { parseSkillBlock } from "./agent-session.ts";
 import { AgentSessionExtensionsModule } from "./session/agent-session-extensions.ts";
+import { AgentSessionPromptModule } from "./session/agent-session-prompt.ts";
 
 describe("parseSkillBlock", () => {
   test("parses a valid skill block with trailing user message", () => {
@@ -81,6 +82,52 @@ describe("AgentSessionExtensionsModule", () => {
   });
 });
 
+describe("AgentSessionPromptModule", () => {
+  test("keeps no-progress terminal fingerprint across other retryable errors", async () => {
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "do the work" }],
+      timestamp: 1,
+    };
+    const events: Array<{ type: string }> = [];
+    const host = {
+      _retryAttempt: 0,
+      _retryAbortController: undefined,
+      settingsManager: {
+        getRetrySettings: () => ({
+          enabled: true,
+          maxRetries: 5,
+          baseDelayMs: 0,
+        }),
+      },
+      emit: (event: { type: string }) => {
+        events.push(event);
+      },
+      agent: {
+        state: {
+          messages: [] as any[],
+        },
+      },
+    };
+    const mod = new AgentSessionPromptModule(host as any);
+
+    const firstTerminalFailure = makeAssistantError("terminated before any output");
+    host.agent.state.messages = [userMessage, firstTerminalFailure];
+    assert.equal(await mod.prepareRetry(firstTerminalFailure as any), true);
+
+    const unrelatedRetryableFailure = makeAssistantError("overloaded_error: provider is busy");
+    host.agent.state.messages = [userMessage, unrelatedRetryableFailure];
+    assert.equal(await mod.prepareRetry(unrelatedRetryableFailure as any), true);
+
+    const repeatedTerminalFailure = makeAssistantError("terminated before any output");
+    host.agent.state.messages = [userMessage, repeatedTerminalFailure];
+    assert.equal(mod.canPrepareRetry(repeatedTerminalFailure as any), false);
+    assert.equal(await mod.prepareRetry(repeatedTerminalFailure as any), false);
+    assert.equal(host._retryAttempt, 2);
+    assert.equal(events.filter((event) => event.type === "auto_retry_start").length, 2);
+  });
+});
+
 function makeSkill(name: string) {
   return {
     name,
@@ -90,5 +137,31 @@ function makeSkill(name: string) {
     sourceInfo: { kind: "test" },
     source: "test",
     disableModelInvocation: false,
+  };
+}
+
+function makeAssistantError(errorMessage: string) {
+  return {
+    role: "assistant",
+    content: [],
+    api: "test",
+    provider: "test",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "error",
+    errorMessage,
+    timestamp: 1,
   };
 }

--- a/packages/gsd-agent-core/src/agent-session.ts
+++ b/packages/gsd-agent-core/src/agent-session.ts
@@ -318,6 +318,10 @@ export class AgentSession implements AgentSessionHost {
 		return this._prompt.isRetryableError(message);
 	}
 
+	canPrepareRetry(message: AssistantMessage): boolean {
+		return this._prompt.canPrepareRetry(message);
+	}
+
 	runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
 		return this._prompt.runAgentPrompt(messages);
 	}

--- a/packages/gsd-agent-core/src/session/agent-session-events.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-events.ts
@@ -114,7 +114,7 @@ export class AgentSessionEventsModule {
 		for (let i = event.messages.length - 1; i >= 0; i--) {
 			const message = event.messages[i];
 			if (message.role === "assistant") {
-				return this.host.isRetryableError(message as AssistantMessage);
+				return this.host.canPrepareRetry(message as AssistantMessage);
 			}
 		}
 		return false;

--- a/packages/gsd-agent-core/src/session/agent-session-host.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-host.ts
@@ -126,6 +126,7 @@ export interface AgentSessionHost {
 	disconnectFromAgent(): void;
 	reconnectToAgent(): void;
 	isRetryableError(message: AssistantMessage): boolean;
+	canPrepareRetry(message: AssistantMessage): boolean;
 	runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void>;
 	handlePostAgentRun(): Promise<boolean>;
 	flushPendingBashMessages(): void;

--- a/packages/gsd-agent-core/src/session/agent-session-prompt.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-prompt.ts
@@ -557,7 +557,9 @@ export class AgentSessionPromptModule {
 			this.host._retryAbortController = undefined;
 		}
 
-		this.lastNoProgressTerminalRetry = retryFingerprint;
+		if (retryFingerprint !== undefined) {
+			this.lastNoProgressTerminalRetry = retryFingerprint;
+		}
 		return true;
 	}
 

--- a/packages/gsd-agent-core/src/session/agent-session-prompt.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-prompt.ts
@@ -10,7 +10,15 @@ import { sleep } from "@gsd/pi-coding-agent/utils/sleep.js";
 import type { PromptOptions } from "./agent-session-types.js";
 import type { AgentSessionHost } from "./agent-session-host.js";
 
+type NoProgressTerminalRetryFingerprint = {
+	errorKind: "terminated" | "timeout";
+	contextMessageCount: number;
+	lastContextMessage: AgentMessage | undefined;
+};
+
 export class AgentSessionPromptModule {
+	private lastNoProgressTerminalRetry: NoProgressTerminalRetryFingerprint | undefined;
+
 	constructor(readonly host: AgentSessionHost) {}
 
 	async runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
@@ -41,7 +49,7 @@ export class AgentSessionPromptModule {
 			return false;
 		}
 
-		if (this.isRetryableError(msg) && (await this.prepareRetry(msg))) {
+		if (this.canPrepareRetry(msg) && (await this.prepareRetry(msg))) {
 			return true;
 		}
 
@@ -488,12 +496,24 @@ export class AgentSessionPromptModule {
 		);
 	}
 
-	async prepareRetry(message: AssistantMessage): Promise<boolean> {
+	canPrepareRetry(message: AssistantMessage): boolean {
 		const settings = this.host.settingsManager.getRetrySettings();
-		if (!settings.enabled) {
+		if (!settings.enabled || this.host._retryAttempt >= settings.maxRetries) {
+			return false;
+		}
+		if (!this.isRetryableError(message)) {
+			return false;
+		}
+		return !this.isRepeatedNoProgressTerminalRetry(message);
+	}
+
+	async prepareRetry(message: AssistantMessage): Promise<boolean> {
+		if (!this.canPrepareRetry(message)) {
 			return false;
 		}
 
+		const settings = this.host.settingsManager.getRetrySettings();
+		const retryFingerprint = this.getNoProgressTerminalRetryFingerprint(message);
 		this.host._retryAttempt++;
 
 		if (this.host._retryAttempt > settings.maxRetries) {
@@ -537,7 +557,54 @@ export class AgentSessionPromptModule {
 			this.host._retryAbortController = undefined;
 		}
 
+		this.lastNoProgressTerminalRetry = retryFingerprint;
 		return true;
+	}
+
+	private isRepeatedNoProgressTerminalRetry(message: AssistantMessage): boolean {
+		if (this.host._retryAttempt === 0) {
+			return false;
+		}
+		const previous = this.lastNoProgressTerminalRetry;
+		const current = this.getNoProgressTerminalRetryFingerprint(message);
+		return (
+			previous !== undefined &&
+			current !== undefined &&
+			previous.errorKind === current.errorKind &&
+			previous.contextMessageCount === current.contextMessageCount &&
+			previous.lastContextMessage === current.lastContextMessage
+		);
+	}
+
+	private getNoProgressTerminalRetryFingerprint(
+		message: AssistantMessage,
+	): NoProgressTerminalRetryFingerprint | undefined {
+		const errorKind = this.getNoProgressTerminalRetryErrorKind(message.errorMessage);
+		if (!errorKind) {
+			return undefined;
+		}
+
+		const messages = this.host.agent.state.messages;
+		const hasTrailingAssistant = messages.length > 0 && messages[messages.length - 1].role === "assistant";
+		const contextMessageCount = messages.length - (hasTrailingAssistant ? 1 : 0);
+		return {
+			errorKind,
+			contextMessageCount,
+			lastContextMessage: messages[contextMessageCount - 1],
+		};
+	}
+
+	private getNoProgressTerminalRetryErrorKind(errorMessage: string | undefined): "terminated" | "timeout" | undefined {
+		if (!errorMessage) {
+			return undefined;
+		}
+		if (/terminated/i.test(errorMessage)) {
+			return "terminated";
+		}
+		if (/timed? out|timeout/i.test(errorMessage)) {
+			return "timeout";
+		}
+		return undefined;
 	}
 
 	abortRetry(): void {

--- a/packages/gsd-agent-core/src/session/agent-session-prompt.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-prompt.ts
@@ -557,6 +557,10 @@ export class AgentSessionPromptModule {
 			this.host._retryAbortController = undefined;
 		}
 
+		// Only record a fingerprint when the current failure is a terminal kind (terminated/timeout).
+		// Unconditionally assigning retryFingerprint would clear the stored fingerprint for other
+		// retryable errors (e.g. overloaded_error), allowing a later identical terminated/timeout
+		// failure to bypass the no-progress guard.
 		if (retryFingerprint !== undefined) {
 			this.lastNoProgressTerminalRetry = retryFingerprint;
 		}

--- a/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -73,6 +73,29 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.faux.state.callCount).toBe(3);
 	});
 
+	it("bounds repeated no-progress terminated retries", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		const retryEvents: string[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") retryEvents.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") retryEvents.push(`end:${event.success}`);
+		});
+
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "terminated" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "terminated" }),
+			fauxAssistantMessage("unexpected retry"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(retryEvents).toEqual(["start:1", "end:false"]);
+		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, false]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.isRetrying).toBe(false);
+	});
+
 	it("exhausts max retries and emits a failure event", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } } });
 		harnesses.push(harness);

--- a/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -96,6 +96,31 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.session.isRetrying).toBe(false);
 	});
 
+	it("bounds no-progress terminated retry even when interleaved with another retryable error", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		const retryEvents: string[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") retryEvents.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") retryEvents.push(`end:${event.success}`);
+		});
+
+		// terminated → overloaded_error (clears fingerprint in the bug) → terminated again
+		// The second terminated has the same context, so the no-progress guard must still fire.
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "terminated" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "terminated" }),
+			fauxAssistantMessage("unexpected retry"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(retryEvents).toEqual(["start:1", "start:2", "end:false"]);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.session.isRetrying).toBe(false);
+	});
+
 	it("exhausts max retries and emits a failure event", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } } });
 		harnesses.push(harness);


### PR DESCRIPTION
## Summary
- Added a bounded no-progress guard for repeated terminated/timeout retries with a regression test; whitespace verification passed, but dependency-backed tests were blocked by unavailable npm registry access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1028
- [#1028 [Bug]: auto-retry re-streams the entire turn from scratch on a `terminated` stream error with no no-progress guard, turning one interrupted generation into 3 full re-streams](https://github.com/open-gsd/gsd-pi/issues/1028)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1028-bug-auto-retry-re-streams-the-entire-tur-1782625637`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core auto-retry and agent loop continuation behavior for stream termination errors; mistakes could block legitimate retries or allow extra re-streams, though behavior is covered by new tests.
> 
> **Overview**
> Stops auto-retry from repeatedly re-streaming the same turn when **`terminated`** or **timeout** errors happen again with **unchanged** conversation context (same message count and last context message).
> 
> `AgentSessionPromptModule` adds a **no-progress terminal fingerprint** and **`canPrepareRetry`**, which gates both post-run retries and **`agent_end`**’s **`willRetry`**. A second matching terminal failure after an earlier retry is refused even if **`maxRetries`** would allow more attempts. The fingerprint is updated **only** on terminal failures so an interleaved retryable error (e.g. **`overloaded_error`**) does not clear the guard.
> 
> **`AgentSession`** exposes **`canPrepareRetry`** on the host surface. Regression tests cover back-to-back **`terminated`** failures and **terminated → overloaded → terminated** sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125c834eb83b8e62b38687c46ddca05657545187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->