### PR TITLE
fix(issue): [Bug]: timeout/idle recovery advances a plan-slice unit when a stale PLAN.md merely exists, without verifying the DB has any tasks

### DIFF
--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -14,6 +14,7 @@ import {
 import {
   resolveExpectedArtifactPath,
   diagnoseExpectedArtifact,
+  verifyExpectedArtifact,
   writeBlockerPlaceholder,
 } from "./auto-recovery.js";
 import { existsSync } from "node:fs";
@@ -194,10 +195,10 @@ export async function recoverTimedOutUnit(
     return "recovered";
   }
 
-  // Check if the artifact already exists on disk — agent may have written it
+  // Check if the artifact is already valid on disk — agent may have written it
   // without signaling completion.
   const artifactPath = resolveExpectedArtifactPath(unitType, unitId, basePath);
-  if (artifactPath && existsSync(artifactPath)) {
+  if (artifactPath && existsSync(artifactPath) && verifyExpectedArtifact(unitType, unitId, basePath)) {
     writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnitStartedAt, {
       phase: "finalized",
       recoveryAttempts: recoveryAttempts + 1,

--- a/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
@@ -48,6 +48,16 @@ function makeRecordingPi() {
   } as any;
 }
 
+function makeRecordingCtx() {
+  const notifications: Array<{ message: string; level: string }> = [];
+  return {
+    notifications,
+    ui: {
+      notify: (message: string, level: string) => { notifications.push({ message, level }); },
+    },
+  } as any;
+}
+
 // ═══ #1855: empty RecoveryContext (basePath undefined) crashes ════════════════
 
 {
@@ -105,6 +115,52 @@ function makeRecordingPi() {
     const runtime = JSON.parse(readFileSync(join(base, ".gsd", "runtime", "units", "execute-task-M001-S01-T01.json"), "utf-8"));
     assert.equal(runtime.phase, "finalized", "db-complete task should be finalized");
     assert.equal(runtime.recovery.dbComplete, true, "runtime recovery should record DB completion");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+// ═══ plan-slice timeout recovery verifies stale PLAN before advancing ═══════
+
+{
+  console.log("\n=== plan-slice timeout recovery rejects stale placeholder PLAN ===");
+  const base = mkdtempSync(join(tmpdir(), "gsd-timeout-stale-plan-"));
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+    writeFileSync(
+      join(sliceDir, "S01-PLAN.md"),
+      "# S01: Slice\n\n## Tasks\n\nPlanning was interrupted before task rows were persisted.\n",
+      "utf-8",
+    );
+
+    const ctx = makeRecordingCtx();
+    const pi = makeRecordingPi();
+    const result = await recoverTimedOutUnit(ctx, pi, "plan-slice", "M001/S01", "idle", {
+      basePath: base,
+      verbose: false,
+      currentUnitStartedAt: Date.now(),
+      unitRecoveryCount: new Map(),
+    });
+
+    assert.equal(result, "recovered", "invalid existing plan should enter steering recovery");
+    assert.equal(pi.messages.length, 1, "invalid existing plan should trigger steering instead of advancing");
+    assert.ok(
+      ctx.notifications.some((entry: { message: string }) => entry.message.includes("steering plan-slice M001/S01")),
+      "recovery notification should describe steering, not artifact advance",
+    );
+    assert.ok(
+      !ctx.notifications.some((entry: { message: string }) => entry.message.includes("artifact already exists on disk. Advancing.")),
+      "stale placeholder plan should not use the advance-on-existence path",
+    );
+    const runtime = JSON.parse(readFileSync(join(base, ".gsd", "runtime", "units", "plan-slice-M001-S01.json"), "utf-8"));
+    assert.equal(runtime.phase, "recovered", "stale placeholder plan must not be finalized");
+    assert.equal(runtime.recoveryAttempts, 1, "steering recovery attempt should be recorded");
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fixed timeout recovery to verify existing artifacts before advancing and added a stale plan-slice regression, with syntax/diff checks passing and runtime tests blocked by unavailable dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1029
- [#1029 [Bug]: timeout/idle recovery advances a plan-slice unit when a stale PLAN.md merely exists, without verifying the DB has any tasks](https://github.com/open-gsd/gsd-pi/issues/1029)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1029-bug-timeout-idle-recovery-advances-a-pla-1782626116`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode timeout/idle recovery advancement logic for all unit types that use the artifact-exists shortcut; incorrect verification could block valid recoveries or still mis-advance edge cases.
> 
> **Overview**
> **Idle/timeout recovery** no longer treats “artifact file exists” as done for generic units. It now calls **`verifyExpectedArtifact`** (same checks as post-unit closeout) before finalizing and advancing the pipeline.
> 
> For **`plan-slice`**, that means a stale or interrupted **`PLAN.md`** on disk is not enough—recovery must see **DB-backed task rows** (or other verification rules). Otherwise recovery **steers** the agent instead of notifying “artifact already exists on disk. Advancing.”
> 
> Adds a regression test with a placeholder plan and **no tasks** in the DB: expects steering, no advance-on-existence path, and runtime phase **`recovered`** (not **`finalized`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182d28f4224a7b259ea76bad18dd960b16243729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->