### PR TITLE
fix(issue): Reconciliation drift persists due to reactive-execute tool contract + worktree merge failure cascade

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-render.ts
@@ -36,6 +36,9 @@ import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
 type StaleRenderDrift = Extract<DriftRecord, { kind: "stale-render" }>;
 
+const VALIDATION_BLOCK_RE =
+  /milestone validation returned needs-(?:attention|remediation)|validation verdict is needs-(?:attention|remediation)/i;
+
 // ─── Core (basePath-only — usable by both drift API and legacy wrapper) ──────
 
 function detectStaleRenderDriftFromBasePath(basePath: string): StaleRenderDrift[] {
@@ -70,6 +73,22 @@ function isRepairableStaleRenderReason(reason: string): boolean {
     (reason.includes("SUMMARY.md missing") && /^T\d+/.test(reason)) ||
     (reason.includes("SUMMARY.md missing") && /^S\d+/.test(reason)) ||
     reason.includes("UAT.md missing")
+  );
+}
+
+function validationBlocker(state: GSDState): string | null {
+  if (state.phase !== "blocked") return null;
+  return state.blockers.find((blocker) => VALIDATION_BLOCK_RE.test(blocker)) ?? null;
+}
+
+function isMilestoneSummaryMissing(record: StaleRenderDrift): boolean {
+  const normPath = record.renderPath.replace(/\\/g, "/");
+  return (
+    record.reason.includes("SUMMARY.md missing") &&
+    (
+      /^M\d+(?:\b|[-_:])/.test(record.reason) ||
+      /(?:^|\/)M\d+(?:-[a-z0-9]+)?-SUMMARY\.md$/i.test(normPath)
+    )
   );
 }
 
@@ -364,9 +383,22 @@ export async function repairStaleRender(
   await repairStaleRenderFromBasePath(record, ctx.basePath);
 }
 
+export function staleRenderBlocker(
+  record: StaleRenderDrift,
+  ctx: DriftContext,
+): string | null {
+  const blocker = validationBlocker(ctx.state);
+  if (!blocker || !isMilestoneSummaryMissing(record)) return null;
+  return [
+    `Stale milestone summary render at ${record.renderPath} is blocked by milestone validation.`,
+    blocker,
+  ].join("\n");
+}
+
 export const staleRenderHandler: DriftHandler<StaleRenderDrift> = {
   kind: "stale-render",
   detect: detectStaleRenderDrift,
+  blocker: staleRenderBlocker,
   repair: repairStaleRender,
 };
 

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -177,6 +177,13 @@ test("auto Unit tool scope allows status/read helpers named by closeout prompts"
   }
 });
 
+test("auto Unit tool scope allows reactive-execute status and diagnostic tools", () => {
+  for (const toolName of ["gsd_milestone_status", "gsd_exec"]) {
+    const result = shouldBlockAutoUnitToolCall("reactive-execute", toolName);
+    assert.equal(result.block, false, `reactive-execute should be able to call ${toolName}`);
+  }
+});
+
 test("auto Unit tool scope blocks stale per-task planner in slice planning phases", () => {
   for (const unitType of ["plan-slice", "refine-slice", "replan-slice"]) {
     const result = shouldBlockAutoUnitToolCall(unitType, "gsd_plan_task");

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -772,6 +772,51 @@ test("#1003: stale-render plan repair switches back from an open wrong DB", asyn
   assert.equal(getSliceTasks("M001", "S01").length, 1, "repair should leave the project DB active");
 });
 
+test("#1034: validation-blocked milestone summary drift returns blocker instead of exhausting repair passes", async () => {
+  const drift: DriftRecord = {
+    kind: "stale-render",
+    renderPath: "/repo/.gsd/milestones/M001/M001-SUMMARY.md",
+    reason: "M001 is complete with summary in DB but SUMMARY.md missing on disk",
+  };
+  let repairCalled = false;
+  const handler: DriftHandler = {
+    kind: "stale-render",
+    detect: () => [drift],
+    blocker: staleRenderHandler.blocker!,
+    repair: () => {
+      repairCalled = true;
+    },
+  };
+
+  const validationBlocker = [
+    "Milestone M001 is blocked because milestone validation returned needs-attention.",
+    "Fix options:",
+    "1. Review the validation details: `/gsd status`",
+  ].join("\n");
+
+  const result = await reconcileBeforeDispatch("/repo", {
+    invalidateStateCache: () => {},
+    deriveState: async () =>
+      makeState({
+        phase: "blocked",
+        blockers: [validationBlocker],
+        nextAction: "Resolve M001 validation attention before proceeding.",
+      }),
+    registry: [handler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(repairCalled, false, "validation-blocked milestone summary drift should not attempt repair");
+  assert.ok(
+    result.blockers.some((blocker) => blocker.includes("milestone validation returned needs-attention")),
+    "validation blocker should be returned to the caller",
+  );
+  assert.ok(
+    result.blockers.some((blocker) => blocker.includes("Stale milestone summary render")),
+    "stale-render blocker should explain why repair did not run",
+  );
+});
+
 test("ADR-017 (#5702): stale-render detector reason strings match repair contract", (t) => {
   t.skip("TODO(flat-phase): stale-render detection temporarily disabled during layout transition"); return;
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-render-reasons-"));

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -773,13 +773,13 @@ test("#1003: stale-render plan repair switches back from an open wrong DB", asyn
 });
 
 test("#1034: validation-blocked milestone summary drift returns blocker instead of exhausting repair passes", async () => {
-  const drift: DriftRecord = {
+  const drift: Extract<DriftRecord, { kind: "stale-render" }> = {
     kind: "stale-render",
     renderPath: "/repo/.gsd/milestones/M001/M001-SUMMARY.md",
     reason: "M001 is complete with summary in DB but SUMMARY.md missing on disk",
   };
   let repairCalled = false;
-  const handler: DriftHandler = {
+  const handler: DriftHandler<Extract<DriftRecord, { kind: "stale-render" }>> = {
     kind: "stale-render",
     detect: () => [drift],
     blocker: staleRenderHandler.blocker!,

--- a/src/resources/extensions/gsd/tests/worktree-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-manager.test.ts
@@ -13,6 +13,7 @@ import {
   diffWorktreeNumstat,
   getWorktreeGSDDiff,
   getWorktreeLog,
+  mergeWorktreeToMain,
   worktreeBranchName,
   worktreePath,
   pruneEphemeralGhostWorktreeDirectories,
@@ -330,6 +331,44 @@ describe("getWorktreeLog", () => {
   test("shows commits", () => {
     const log = getWorktreeLog(base, "feature-x");
     assert.ok(log.includes("add M002"), "log should include the commit message");
+  });
+});
+
+// ─── mergeWorktreeToMain ─────────────────────────────────────────────────────
+
+describe("mergeWorktreeToMain", () => {
+  let base: string;
+  let wtPath: string;
+
+  beforeEach(() => {
+    base = makeBaseRepo();
+    wtPath = worktreePath(base, "M900");
+    mkdirSync(join(base, ".gsd-worktrees"), { recursive: true });
+    run(`git worktree add -b milestone/M900 "${wtPath}"`, base);
+  });
+
+  afterEach(() => { rmSync(base, { recursive: true, force: true }); });
+
+  test("cleans failed milestone squash state and deletes orphan branch", () => {
+    writeFileSync(join(wtPath, "README.md"), "# Milestone change\n", "utf-8");
+    run("git add README.md", wtPath);
+    run('git commit -m "feat: milestone change"', wtPath);
+
+    writeFileSync(join(base, "README.md"), "# Main change\n", "utf-8");
+    run("git add README.md", base);
+    run('git commit -m "feat: main change"', base);
+
+    assert.throws(
+      () => mergeWorktreeToMain(base, "M900", "feat: merge M900", "milestone/M900"),
+      /Merge conflicts detected/,
+    );
+
+    assert.equal(run("git status --porcelain", base), "", "failed squash cleanup should leave main clean");
+    assert.ok(!existsSync(wtPath), "failed milestone worktree should be removed");
+    assert.ok(
+      !run("git branch", base).includes("milestone/M900"),
+      "failed milestone branch should be deleted after worktree removal",
+    );
   });
 });
 

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -345,7 +345,13 @@ export const UNIT_REGISTRY = {
     scopeClass: "execute-task",
     phaseChain: ["execution"],
     toolContract: {
-      allowedGsdTools: ["gsd_task_complete", "gsd_summary_save", "gsd_decision_save"],
+      allowedGsdTools: [
+        "gsd_milestone_status",
+        "gsd_task_complete",
+        "gsd_exec",
+        "gsd_summary_save",
+        "gsd_decision_save",
+      ],
       requiredWorkflowTools: ["gsd_task_complete", "gsd_summary_save"],
     },
   },

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -91,8 +91,9 @@ function deleteBranchIfPresent(basePath: string, branch: string, warningPrefix: 
 function cleanupFailedSquashMergeState(basePath: string): void {
   try {
     nativeMergeAbort(basePath);
-  } catch {
-    // Squash conflicts may not create MERGE_HEAD; continue with reset/marker cleanup.
+  } catch (e) {
+    // Squash conflicts may not create MERGE_HEAD; this is expected.
+    logWarning("worktree", `merge abort skipped: ${(e as Error).message}`);
   }
   try {
     execFileSync("git", ["reset", "--merge"], {

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -19,7 +19,7 @@
  *   4. remove()  — git worktree remove + branch cleanup
  */
 
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, unlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join, resolve, sep } from "node:path";
 import { GSDError, GSD_PARSE_ERROR, GSD_STALE_STATE, GSD_LOCK_HELD, GSD_GIT_ERROR, GSD_MERGE_CONFLICT } from "./errors.js";
@@ -37,6 +37,7 @@ import {
   nativeGetCurrentBranch,
   nativeIsAncestor,
   nativeLogOneline,
+  nativeMergeAbort,
   nativeMergeSquash,
   nativeWorktreeAdd,
   nativeWorktreeList,
@@ -84,6 +85,33 @@ function deleteBranchIfPresent(basePath: string, branch: string, warningPrefix: 
     nativeBranchDelete(basePath, branch, true);
   } catch (e) {
     logWarning("worktree", `${warningPrefix}: ${(e as Error).message}`);
+  }
+}
+
+function cleanupFailedSquashMergeState(basePath: string): void {
+  try {
+    nativeMergeAbort(basePath);
+  } catch {
+    // Squash conflicts may not create MERGE_HEAD; continue with reset/marker cleanup.
+  }
+  try {
+    execFileSync("git", ["reset", "--merge"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+  } catch (e) {
+    logWarning("worktree", `failed squash merge reset failed: ${(e as Error).message}`);
+  }
+
+  const gitDir = resolveGitDir(basePath);
+  for (const marker of ["SQUASH_MSG", "MERGE_MSG", "MERGE_MODE", "MERGE_HEAD", "AUTO_MERGE"]) {
+    try {
+      const markerPath = join(gitDir, marker);
+      if (existsSync(markerPath)) unlinkSync(markerPath);
+    } catch (e) {
+      logWarning("worktree", `failed squash merge marker cleanup failed (${marker}): ${(e as Error).message}`);
+    }
   }
 }
 
@@ -1086,6 +1114,17 @@ export function mergeWorktreeToMain(
 
   const result = nativeMergeSquash(basePath, branch);
   if (!result.success) {
+    const dirtyWorkingTree = result.conflicts.includes("__dirty_working_tree__");
+    if (!dirtyWorkingTree) {
+      cleanupFailedSquashMergeState(basePath);
+    }
+    if (!dirtyWorkingTree && branch.startsWith("milestone/")) {
+      try {
+        removeWorktree(basePath, name, { branch, deleteBranch: true, force: true });
+      } catch (e) {
+        logWarning("worktree", `failed milestone branch cleanup after squash merge failure: ${(e as Error).message}`);
+      }
+    }
     throw new GSDError(GSD_MERGE_CONFLICT, `Merge conflicts detected in: ${result.conflicts.join(", ")}`);
   }
 


### PR DESCRIPTION
## Summary
- Fixed reactive-execute tool scoping, milestone branch cleanup after failed squash merges, and validation-blocked stale-render reconciliation handling with syntax and diff checks passing.

## Bugs Addressed
- [x] **reactive-execute blocks legitimate lifecycle and diagnostic tools**
- [x] **Worktree merge failure teardown leaves orphan milestone branches**
- [x] **stale-render reconciliation loops on validation-blocked milestones**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1034
- [#1034 Reconciliation drift persists due to reactive-execute tool contract + worktree merge failure cascade](https://github.com/open-gsd/gsd-pi/issues/1034)

## User
- @VladimirCores

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1034-reconciliation-drift-persists-due-to-rea-1782653120`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-dispatch reconciliation, auto unit tool scoping, and milestone worktree merge teardown; git cleanup on failed squash could affect recovery if misclassified, but behavior is gated on conflict vs dirty-tree cases.
> 
> **Overview**
> Addresses **#1034** by fixing three reconciliation/drift failure modes that could leave the workflow stuck or git state dirty.
> 
> **Stale-render + validation:** The `stale-render` drift handler now exposes a **`blocker`** when milestone `SUMMARY.md` is missing but workflow state is **blocked** on milestone validation (`needs-attention` / `needs-remediation`). Reconciliation returns that blocker and **skips repair** instead of retrying until repair passes are exhausted.
> 
> **`reactive-execute` tool contract:** `gsd_milestone_status` and `gsd_exec` are added to the unit’s allowed GSD tools so lifecycle status and diagnostics are not blocked during reactive execution.
> 
> **Failed milestone squash merge:** On squash merge failure (excluding a dirty working tree), `mergeWorktreeToMain` **aborts/resets** partial squash state, clears merge markers, and for **`milestone/*`** branches **removes the worktree and deletes the orphan branch** so failed merges do not leave main dirty or stray milestone branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ab8c3e45eec822c5ec9dee9d3a17e764289fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->