### PR TITLE
fix(gsd): treat .gsd-backups/ as runtime and stop safety false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need help choosing settings? Use the [GSD Pi web configurator](https://pi.opengs
 gsd
 ```
 
-Run the setup flow, choose your preferred model provider, and open a project directory. GSD stores project planning and runtime state in `.gsd/`.
+Run the setup flow, choose your preferred model provider, and open a project directory. GSD stores project planning and runtime state in `.gsd/`, with gitignored sibling runtime directories such as `.gsd-backups/` for migration snapshots. Stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the flat-phase `.gsd/phases/` migration is complete.
 
 For a full first-run walkthrough, see [Getting Started With gsd-pi](./docs/user-docs/getting-started.md).
 

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -208,6 +208,8 @@ Start from a clean worktree when possible. GSD can create task worktrees for iso
 
 GSD stores project state in `.gsd/`. Depending on your workflow, some generated markdown files may be useful to commit and review, while runtime/cache files should stay local.
 
+Local runtime/cache paths include `.gsd/gsd.db*`, `.gsd/runtime/`, `.gsd-worktrees/`, and `.gsd-backups/`. GSD manages `.gitignore` for these paths by default. `.gsd-backups/` stores migration snapshots, and stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.
+
 When in doubt:
 
 ```bash

--- a/docs/user-docs/migration.md
+++ b/docs/user-docs/migration.md
@@ -21,6 +21,7 @@ The migration tool:
 - Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
 - Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
 - Backs up any existing `.gsd/` to `.gsd-backups/migrate-YYYYMMDD-HHMMSS/`, deletes the old `.gsd/`, and restores the backup if migration fails
+- Keeps `.gsd-backups/` as local runtime data: GSD adds it to baseline `.gitignore` and runtime exclusions, and stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration
 - Writes the imported hierarchy into the GSD database, then renders markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`

--- a/docs/user-docs/parallel-orchestration.md
+++ b/docs/user-docs/parallel-orchestration.md
@@ -282,7 +282,7 @@ The coordinator runs stale detection during status refresh and either marks the 
 └── ...
 ```
 
-`.gsd/gsd.db*`, `.gsd/parallel/`, `.gsd/worktrees/`, and `.gsd-worktrees/` are all local runtime artifacts and should remain gitignored.
+`.gsd/gsd.db*`, `.gsd/parallel/`, `.gsd/worktrees/`, `.gsd-worktrees/`, and `.gsd-backups/` are all local runtime artifacts and should remain gitignored. `.gsd-backups/` stores migration snapshots; stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.
 
 ## Troubleshooting
 

--- a/docs/user-docs/working-in-teams.md
+++ b/docs/user-docs/working-in-teams.md
@@ -34,6 +34,7 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 .gsd/runtime/
 .gsd/worktrees/
 .gsd-worktrees/
+.gsd-backups/
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
 ```
@@ -46,7 +47,7 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 - `.gsd/milestones/` — roadmaps, plans, summaries, research
 
 **What stays local** (gitignored):
-- Database files, metrics, state projections, runtime records, worktrees, activity logs
+- Database files, metrics, state projections, runtime records, worktrees, activity logs, and migration backups under `.gsd-backups/`. Stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the flat-phase `.gsd/phases/` migration is complete.
 
 ### 3. Commit the Preferences
 

--- a/gitbook/core-concepts/project-structure.md
+++ b/gitbook/core-concepts/project-structure.md
@@ -67,6 +67,8 @@ The `.gsd/` directory looks like this:
             T01-SUMMARY.md — what the task accomplished
 ```
 
+GSD may also create sibling runtime directories next to `.gsd/`. `.gsd-worktrees/` holds isolated milestone checkouts, and `.gsd-backups/` holds migration snapshots such as `.gsd-backups/migrate-*`. These sibling directories are local-only and gitignored; stale `migrate-*` backup snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.
+
 ### Key Files
 
 | File | Purpose |

--- a/gitbook/features/teams.md
+++ b/gitbook/features/teams.md
@@ -40,6 +40,7 @@ Share planning artifacts while keeping runtime files local:
 .gsd/activity/
 .gsd/runtime/
 .gsd/worktrees/
+.gsd-backups/
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
 ```
@@ -52,7 +53,7 @@ Share planning artifacts while keeping runtime files local:
 - `.gsd/milestones/` — roadmaps, plans, summaries, research
 
 **What stays local** (gitignored):
-- Database files, lock files, metrics, state projections, activity logs, worktrees
+- Database files, lock files, metrics, state projections, activity logs, worktrees, and migration backups under `.gsd-backups/`. Stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the flat-phase `.gsd/phases/` migration is complete.
 
 ## Commit the Config
 

--- a/gitbook/getting-started/first-project.md
+++ b/gitbook/getting-started/first-project.md
@@ -122,6 +122,8 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
             T01-SUMMARY.md
 ```
 
+GSD may also create sibling runtime directories next to `.gsd/`: `.gsd-worktrees/` for isolated milestone checkouts and `.gsd-backups/` for migration snapshots. Keep those directories local and gitignored; stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.
+
 `KNOWLEDGE.md` has a split source of truth. Rules stay in the file and are visible immediately. Patterns and lessons added through `/gsd knowledge` are persisted to the `memories` table, then rendered into `KNOWLEDGE.md` the next time a GSD session starts, so they will not appear in the file immediately.
 
 Existing pattern and lesson rows are backfilled into `memories` during that startup path. The Patterns and Lessons sections in `KNOWLEDGE.md` are generated projections, so manual edits to those generated sections may be overwritten on regeneration.

--- a/gitbook/reference/migration.md
+++ b/gitbook/reference/migration.md
@@ -21,6 +21,7 @@ The migration tool:
 - Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
 - Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
 - Backs up any existing `.gsd/` to `.gsd-backups/migrate-YYYYMMDD-HHMMSS/`, deletes the old `.gsd/`, and restores the backup if migration fails
+- Keeps `.gsd-backups/` as local runtime data: GSD adds it to baseline `.gitignore` and runtime exclusions, and stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration
 - Writes the imported hierarchy into the GSD database, then renders markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -904,6 +904,15 @@ export function registerHooks(
               "flat-phase migration deferred: legacy .gsd/milestones/ layout detected but the workflow database could not be opened — will retry on next session",
             );
           }
+        } else {
+          const { pruneStaleFlatPhaseBackups } = await import("../flat-phase-migration.js");
+          const pruned = pruneStaleFlatPhaseBackups(basePath);
+          if (pruned > 0) {
+            safetyLogWarning(
+              "bootstrap",
+              `pruned ${pruned} stale flat-phase migration backup(s) from .gsd-backups/ (retention exceeded)`,
+            );
+          }
         }
       }
     } catch (err) {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -904,16 +904,16 @@ export function registerHooks(
               "flat-phase migration deferred: legacy .gsd/milestones/ layout detected but the workflow database could not be opened — will retry on next session",
             );
           }
-        } else {
-          const { pruneStaleFlatPhaseBackups } = await import("../flat-phase-migration.js");
-          const pruned = pruneStaleFlatPhaseBackups(basePath);
-          if (pruned > 0) {
-            safetyLogWarning(
-              "bootstrap",
-              `pruned ${pruned} stale flat-phase migration backup(s) from .gsd-backups/ (retention exceeded)`,
-            );
-          }
         }
+      }
+      const projectRoot = resolveWorktreeProjectRoot(basePath);
+      const { pruneStaleFlatPhaseBackups } = await import("../flat-phase-migration.js");
+      const pruned = pruneStaleFlatPhaseBackups(projectRoot);
+      if (pruned > 0) {
+        safetyLogWarning(
+          "bootstrap",
+          `pruned ${pruned} stale flat-phase migration backup(s) from .gsd-backups/ (retention exceeded)`,
+        );
       }
     } catch (err) {
       safetyLogWarning("bootstrap", `flat-phase migration: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -408,6 +408,9 @@ export async function checkRuntimeHealth(
       if (!existingLines.has(".gsd-worktrees/") && !existingLines.has(".gsd-worktrees")) {
         missing.push(".gsd-worktrees/");
       }
+      if (!existingLines.has(".gsd-backups/") && !existingLines.has(".gsd-backups")) {
+        missing.push(".gsd-backups/");
+      }
       if (!hasBlanketIgnore) {
         missing.push(...criticalPatterns.filter(p => !existingLines.has(p)));
       }

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -70,6 +70,50 @@ export function needsFlatPhaseMigration(basePath: string): boolean {
   return hasLegacyMilestoneSubdirs(legacyMigratingPath(basePath));
 }
 
+/** Retention window before flat-phase migration backups are auto-pruned. */
+export const FLAT_PHASE_BACKUP_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Remove stale flat-phase migration backups after the retention window.
+ * Only runs when migration is complete (.gsd/phases/ exists, legacy layout gone).
+ * Returns the number of migrate-* directories removed.
+ */
+export function pruneStaleFlatPhaseBackups(basePath: string): number {
+  if (needsFlatPhaseMigration(basePath)) return 0;
+
+  const phasesPath = join(basePath, ".gsd", LAYOUT_SEGMENTS.level1);
+  if (!existsSync(phasesPath)) return 0;
+
+  const backupRoot = join(basePath, ".gsd-backups");
+  if (!existsSync(backupRoot)) return 0;
+
+  const now = Date.now();
+  let removed = 0;
+  for (const entry of readdirSync(backupRoot)) {
+    if (!entry.startsWith("migrate-")) continue;
+    const dirPath = join(backupRoot, entry);
+    try {
+      const st = statSync(dirPath);
+      if (!st.isDirectory()) continue;
+      if (now - st.mtimeMs < FLAT_PHASE_BACKUP_RETENTION_MS) continue;
+      rmSync(dirPath, { recursive: true, force: true });
+      removed++;
+    } catch {
+      // Non-fatal: leave backup for manual recovery.
+    }
+  }
+
+  try {
+    if (readdirSync(backupRoot).length === 0) {
+      rmSync(backupRoot, { recursive: true, force: true });
+    }
+  } catch {
+    // Non-fatal.
+  }
+
+  return removed;
+}
+
 /**
  * Migrate from legacy nested .gsd/milestones/ to flat-phase .gsd/phases/.
  *

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -360,6 +360,7 @@ export interface PreMergeCheckResult {
  */
 export const RUNTIME_EXCLUSION_PATHS: readonly string[] = [
   ".gsd-worktrees/",
+  ".gsd-backups/**",
   ".gsd/activity/",
   ".gsd/audit/",
   ".gsd/forensics/",

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -51,6 +51,8 @@ const BASELINE_PATTERNS = [
   ".gsd",
   // Worktree container sibling — NOT covered by the ".gsd" pattern above.
   ".gsd-worktrees/",
+  // Flat-phase migration snapshots — NOT covered by the ".gsd" pattern above.
+  ".gsd-backups/",
   ".gsd-id",
   ".mcp.json",
   ".bg-shell/",

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -26,6 +26,7 @@ import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
  */
 const GSD_RUNTIME_PATTERNS = [
   ".gsd-worktrees/",
+  ".gsd-backups/",
   ".gsd/activity/",
   ".gsd/audit/",
   ".gsd/forensics/",

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -76,8 +76,14 @@ export function validateFileChanges(
   const actualFiles = getChangedFilesFromLastCommit(basePath);
   if (!actualFiles) return null;
 
-  // Filter out .gsd/ internal files — only validate project source files
-  const projectFiles = actualFiles.filter(f => !f.startsWith(".gsd/") && !f.startsWith(".gsd\\"));
+  // Filter out GSD-internal paths — only validate project source files.
+  const projectFiles = actualFiles.filter(
+    (f) =>
+      !f.startsWith(".gsd/") &&
+      !f.startsWith(".gsd\\") &&
+      !f.startsWith(".gsd-backups/") &&
+      !f.startsWith(".gsd-backups\\"),
+  );
 
   // Normalize expected paths (strip leading ./ or /)
   const normalizedExpected = new Set(

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -116,6 +116,46 @@ test("effectiveFileChangeAllowlist keeps .gitignore auditable when management is
   assert.deepEqual(effectiveFileChangeAllowlist(["docs/**"], false), ["docs/**"]);
 });
 
+test("validateFileChanges excludes .gsd-backups/ migration snapshots from unexpected-change warnings", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const backupFile = join(
+    base,
+    ".gsd-backups",
+    "migrate-1782703701330",
+    "M010",
+    "slices",
+    "S01",
+    "S01-ASSESSMENT.md",
+  );
+  mkdirSync(join(base, "src"), { recursive: true });
+  mkdirSync(join(backupFile, ".."), { recursive: true });
+
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "src", "app.ts"), "initial\n");
+  writeFileSync(backupFile, "legacy assessment\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "initial");
+
+  writeFileSync(join(base, "src", "app.ts"), "updated\n");
+  writeFileSync(backupFile, "legacy assessment touched\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "task commit");
+
+  const audit = validateFileChanges(base, ["src/app.ts"], []);
+  assert.ok(audit, "audit should be produced");
+  assert.deepEqual(audit!.unexpectedFiles, [], ".gsd-backups/ must not trigger warnings");
+  assert.equal(
+    audit!.violations.filter(v => v.severity === "warning").length,
+    0,
+    "no warnings when only source and migration backup files changed",
+  );
+});
+
 test("GSD-managed .gitignore edit swept into a task commit is not flagged", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -2,12 +2,16 @@
 // File Purpose: Tests the one-time migration from nested to flat-phase layout.
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { migrateToFlatPhase, needsFlatPhaseMigration } from "../flat-phase-migration.ts";
+import {
+  migrateToFlatPhase,
+  needsFlatPhaseMigration,
+  pruneStaleFlatPhaseBackups,
+} from "../flat-phase-migration.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
 
 const tmpDirs: string[] = [];
@@ -111,4 +115,35 @@ test("migrateToFlatPhase preserves slice sidecar artifacts and skips recovery pl
     false,
     "recovery placeholder PLAN should not be promoted when no DB tasks can render a real plan",
   );
+});
+
+test("pruneStaleFlatPhaseBackups removes migrate-* dirs older than retention window", async () => {
+  const base = makeTmp();
+  await migrateToFlatPhase(base);
+
+  const backupRoot = join(base, ".gsd-backups");
+  assert.ok(existsSync(backupRoot), "backup should exist immediately after migration");
+
+  const staleDir = join(backupRoot, "migrate-stale");
+  mkdirSync(staleDir, { recursive: true });
+  writeFileSync(join(staleDir, "marker.txt"), "old backup\n", "utf-8");
+  const staleDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+  utimesSync(staleDir, staleDate, staleDate);
+
+  const removed = pruneStaleFlatPhaseBackups(base);
+  assert.equal(removed, 1, "stale migrate-* dir should be pruned");
+  assert.equal(existsSync(staleDir), false, "stale backup dir should be gone");
+  assert.ok(existsSync(backupRoot), "fresh migration backup should remain");
+});
+
+test("pruneStaleFlatPhaseBackups is a no-op while flat-phase migration is still needed", () => {
+  const base = makeTmp();
+  const backupRoot = join(base, ".gsd-backups", "migrate-stale");
+  mkdirSync(backupRoot, { recursive: true });
+  writeFileSync(join(backupRoot, "marker.txt"), "old backup\n", "utf-8");
+  const staleDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+  utimesSync(backupRoot, staleDate, staleDate);
+
+  assert.equal(pruneStaleFlatPhaseBackups(base), 0, "must not prune while migration is pending");
+  assert.ok(existsSync(backupRoot), "backup must remain until migration completes");
 });

--- a/src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts
@@ -40,6 +40,10 @@ describe('ensureGitignore writes .bg-shell/ baseline (#4902)', () => {
         lines.has('.bg-shell/'),
         `.gitignore should include .bg-shell/. Got:\n${ignore}`,
       );
+      assert.ok(
+        lines.has('.gsd-backups/'),
+        `.gitignore should include .gsd-backups/. Got:\n${ignore}`,
+      );
     } finally {
       cleanup(dir);
     }

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -294,12 +294,13 @@ describe('git-service', async () => {
 
   assert.deepStrictEqual(
     RUNTIME_EXCLUSION_PATHS.length,
-    17,
-    "exactly 17 runtime exclusion paths"
+    18,
+    "exactly 18 runtime exclusion paths"
   );
 
   const expectedPaths = [
     ".gsd-worktrees/",
+    ".gsd-backups/**",
     ".gsd/activity/",
     ".gsd/audit/",
     ".gsd/forensics/",

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1624,11 +1624,13 @@ process.exit(result.status ?? 0);
     // Create and track runtime files (simulates pre-.gitignore state)
     mkdirSync(join(repo, ".gsd", "activity"), { recursive: true });
     mkdirSync(join(repo, ".gsd", "runtime"), { recursive: true });
+    mkdirSync(join(repo, ".gsd-backups", "migrate-old"), { recursive: true });
     writeFileSync(join(repo, ".gsd", "completed-units.json"), '["u1"]');
     writeFileSync(join(repo, ".gsd", "metrics.json"), '{}');
     writeFileSync(join(repo, ".gsd", "STATE.md"), "# State");
     writeFileSync(join(repo, ".gsd", "activity", "log.jsonl"), "{}");
     writeFileSync(join(repo, ".gsd", "runtime", "data.json"), "{}");
+    writeFileSync(join(repo, ".gsd-backups", "migrate-old", "marker.txt"), "backup");
     writeFileSync(join(repo, "src.ts"), "code");
     runGit(repo, ["add", "-A"]);
     runGit(repo, ["commit", "-m", "init"]);
@@ -1637,6 +1639,8 @@ process.exit(result.status ?? 0);
     const trackedBefore = run("git ls-files .gsd/", repo);
     assert.ok(trackedBefore.includes("completed-units.json"), "untrack: precondition — completed-units tracked");
     assert.ok(trackedBefore.includes("metrics.json"), "untrack: precondition — metrics tracked");
+    const backupTrackedBefore = run("git ls-files .gsd-backups/", repo);
+    assert.ok(backupTrackedBefore.includes("marker.txt"), "untrack: precondition — migration backup tracked");
 
     // Run untrackRuntimeFiles
     untrackRuntimeFiles(repo);
@@ -1644,6 +1648,8 @@ process.exit(result.status ?? 0);
     // Runtime files should be removed from the index
     const trackedAfter = run("git ls-files .gsd/", repo);
     assert.deepStrictEqual(trackedAfter, "", "untrack: all runtime files removed from index");
+    const backupTrackedAfter = run("git ls-files .gsd-backups/", repo);
+    assert.deepStrictEqual(backupTrackedAfter, "", "untrack: migration backups removed from index");
 
     // Non-runtime files remain tracked
     const srcTracked = run("git ls-files src.ts", repo);
@@ -1654,6 +1660,8 @@ process.exit(result.status ?? 0);
       "untrack: completed-units.json still on disk");
     assert.ok(existsSync(join(repo, ".gsd", "metrics.json")),
       "untrack: metrics.json still on disk");
+    assert.ok(existsSync(join(repo, ".gsd-backups", "migrate-old", "marker.txt")),
+      "untrack: migration backup still on disk");
 
     // Idempotent — running again doesn't error
     untrackRuntimeFiles(repo);


### PR DESCRIPTION
## Summary
- Add `.gsd-backups/` to gitignore baseline, auto-commit staging exclusions, and doctor gitignore checks so flat-phase migration snapshots are treated like other GSD runtime paths.
- Skip `.gsd-backups/` in the post-unit file-change safety validator to stop thousands of false "unexpected file change" warnings when backup files ride into task commits.
- Auto-prune `migrate-*` backup directories older than 30 days on startup once flat-phase migration is complete.

## Test plan
- [x] `node --import tsx --test src/resources/extensions/gsd/tests/file-change-validator.test.ts`
- [x] `node --import tsx --test src/resources/extensions/gsd/tests/flat-phase-migration.test.ts`
- [x] `node --import tsx --test src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts`
- [x] `node --import tsx --test src/resources/extensions/gsd/tests/integration/git-service.test.ts`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->