### PR TITLE
fix(issue): [Bug]: metrics.json is rewritten with 2-space pretty-printing at unit closeout despite being read only by code

### DIFF
--- a/src/resources/extensions/gsd/json-persistence.ts
+++ b/src/resources/extensions/gsd/json-persistence.ts
@@ -63,6 +63,26 @@ export function saveJsonFile<T>(filePath: string, data: T): void {
 }
 
 /**
+ * Save a JSON file atomically using compact serialization.
+ *
+ * Intended for machine-only ledgers where pretty-printing has no consumer.
+ * Keeps the same write-tmp-rename safety and non-fatal error behavior as
+ * saveJsonFile.
+ */
+export function saveJsonFileCompact<T>(filePath: string, data: T): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    // Use randomized tmp suffix to prevent concurrent-write data loss
+    const tmp = `${filePath}.tmp.${randomBytes(4).toString("hex")}`;
+    writeFileSync(tmp, JSON.stringify(data) + "\n", "utf-8");
+    renameSync(tmp, filePath);
+    // No cleanup needed — renameSync atomically removes tmp on success
+  } catch {
+    // Non-fatal — don't let persistence failures break operation
+  }
+}
+
+/**
  * Write a JSON file atomically (write to .tmp, then rename).
  * Creates parent directories as needed. Non-fatal on error.
  */

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -19,7 +19,7 @@ import { openSync, closeSync, unlinkSync, statSync, writeFileSync } from "node:f
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { gsdRoot } from "./paths.js";
 import { getAndClearSkills } from "./skill-telemetry.js";
-import { loadJsonFile, loadJsonFileOrNull, saveJsonFile } from "./json-persistence.js";
+import { loadJsonFile, loadJsonFileOrNull, saveJsonFileCompact } from "./json-persistence.js";
 import { parseUnitId } from "./unit-id.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./uok/audit.js";
 import { isUnifiedAuditEnabled } from "./uok/audit-toggle.js";
@@ -873,7 +873,7 @@ export function pruneMetricsLedger(base: string, keepCount: number): number {
   if (!disk || disk.units.length <= keepCount) return 0;
   const removed = disk.units.length - keepCount;
   disk.units = keepNewestUnits(disk.units, keepCount);
-  saveJsonFile(metricsPath(base), disk);
+  saveJsonFileCompact(metricsPath(base), disk);
   // Keep the in-memory ledger in sync if it is loaded for this session.
   if (ledger) {
     ledger.units = keepNewestUnits(ledger.units, keepCount);
@@ -1041,7 +1041,7 @@ function saveLedger(base: string, data: MetricsLedger): void {
           : dataUnits;
       merged.sort(compareUnitsByTime);
       data.units = keepNewestUnits(merged);
-      saveJsonFile(path, data);
+      saveJsonFileCompact(path, data);
     } finally {
       releaseLock(lockPath);
     }
@@ -1053,6 +1053,6 @@ function saveLedger(base: string, data: MetricsLedger): void {
     // read-merge-write sequence without mutual exclusion.
     logWarning("fs", "saveLedger: lock not acquired — falling back to direct write (no merge)");
     data.units = keepNewestUnits(data.units);
-    saveJsonFile(path, data);
+    saveJsonFileCompact(path, data);
   }
 }

--- a/src/resources/extensions/gsd/tests/json-persistence-atomic.test.ts
+++ b/src/resources/extensions/gsd/tests/json-persistence-atomic.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 
 import {
   saveJsonFile,
+  saveJsonFileCompact,
   loadJsonFile,
   writeJsonFileAtomic,
 } from "../json-persistence.ts";
@@ -56,6 +57,37 @@ test("saveJsonFile creates file with valid JSON content", () => {
   }
 });
 
+test("saveJsonFile keeps pretty-printed output for human-readable state", () => {
+  const dir = makeTempDir();
+  const filePath = join(dir, "pretty.json");
+
+  try {
+    const data = { foo: "bar", nested: { count: 42 } };
+    saveJsonFile(filePath, data);
+
+    const content = readFileSync(filePath, "utf-8");
+    assert.equal(content, JSON.stringify(data, null, 2) + "\n");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("saveJsonFileCompact writes valid compact JSON content", () => {
+  const dir = makeTempDir();
+  const filePath = join(dir, "compact.json");
+
+  try {
+    const data = { foo: "bar", nested: { count: 42 } };
+    saveJsonFileCompact(filePath, data);
+
+    const content = readFileSync(filePath, "utf-8");
+    assert.equal(content, JSON.stringify(data) + "\n");
+    assert.deepEqual(JSON.parse(content), data);
+  } finally {
+    cleanup(dir);
+  }
+});
+
 test("saveJsonFile does not leave .tmp files on success", () => {
   const dir = makeTempDir();
   const filePath = join(dir, "clean.json");
@@ -64,6 +96,21 @@ test("saveJsonFile does not leave .tmp files on success", () => {
     saveJsonFile(filePath, { test: true });
 
     // No .tmp files should remain
+    const files = readdirSync(dir);
+    const tmpFiles = files.filter(f => f.includes(".tmp"));
+    assert.equal(tmpFiles.length, 0, `Unexpected .tmp files: ${tmpFiles.join(", ")}`);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("saveJsonFileCompact does not leave .tmp files on success", () => {
+  const dir = makeTempDir();
+  const filePath = join(dir, "compact-clean.json");
+
+  try {
+    saveJsonFileCompact(filePath, { test: true });
+
     const files = readdirSync(dir);
     const tmpFiles = files.filter(f => f.includes(".tmp"));
     assert.equal(tmpFiles.length, 0, `Unexpected .tmp files: ${tmpFiles.join(", ")}`);

--- a/src/resources/extensions/gsd/tests/metrics-prune-cache-invalidation.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics-prune-cache-invalidation.test.ts
@@ -112,6 +112,12 @@ describe("pruneMetricsLedger: invalidates scoped ledger cache", () => {
     // 3. Prune to keepCount=2 — should evict 3 old units from disk AND clear scopedLedgers.
     const removed = pruneMetricsLedger(tmpDir, 2);
     assert.equal(removed, 3, "pruneMetricsLedger should report 3 removed units");
+    const prunedRaw = readFileSync(metricsPath(tmpDir), "utf-8");
+    assert.equal(
+      prunedRaw,
+      JSON.stringify(JSON.parse(prunedRaw)) + "\n",
+      "pruneMetricsLedger should persist compact metrics.json",
+    );
 
     // 4. Snapshot a new unit via scope. This exercises the lazy-reload path
     //    (scopedLedgers was cleared by prune) and writes the result to disk.

--- a/src/resources/extensions/gsd/tests/metrics.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics.test.ts
@@ -259,6 +259,7 @@ test("initMetrics creates ledger, snapshotUnitMetrics persists across resets", (
     // Verify file content
     const raw = readFileSync(join(tmpBase, ".gsd", "metrics.json"), "utf-8");
     const parsed: MetricsLedger = JSON.parse(raw);
+    assert.equal(raw, JSON.stringify(parsed) + "\n", "metrics.json should be serialized compactly");
     assert.equal(parsed.version, 1);
     assert.equal(parsed.units.length, 1);
 


### PR DESCRIPTION
## Summary
- Added compact atomic JSON persistence for metrics ledger writes and verified helper behavior plus modified TypeScript syntax checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1041
- [#1041 [Bug]: metrics.json is rewritten with 2-space pretty-printing at unit closeout despite being read only by code](https://github.com/open-gsd/gsd-pi/issues/1041)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1041-bug-metrics-json-is-rewritten-with-2-spa-1782746359`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> On-disk format change for metrics.json only (smaller files, same JSON semantics); atomic write and merge behavior are unchanged.
> 
> **Overview**
> Stops rewriting **`.gsd/metrics.json`** with 2-space pretty-print on every unit closeout, prune, and ledger flush by routing those writes through a new **`saveJsonFileCompact`** helper that uses the same tmp-rename atomic path as **`saveJsonFile`** but serializes with compact **`JSON.stringify`** (still trailing newline).
> 
> **`saveJsonFile`** is unchanged for human-edited or inspectable state (queue order, routing history, etc.). Tests lock in compact output for metrics persistence and confirm pretty-print behavior remains on **`saveJsonFile`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d3b9249df260b9c07e1b44202099243b692b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->