### PR TITLE
fix(issue): [Bug]: Verification-gate retry hashes volatile stderr, defeating the duplicate-failure breaker for host-check failures

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -29,6 +29,7 @@ import {
   runVerificationGate,
   runVerificationGateForTargets,
   formatFailureContext,
+  formatFailureSignature,
   captureRuntimeErrors,
   runDependencyAudit,
 } from "./verification-gate.js";
@@ -871,10 +872,13 @@ export async function runPostUnitVerification(
         );
       }
       const nextAttempt = attempt + 1;
+      const failureContext = verdict.failureContext || formatFailureContext(result);
+      const failureSignature = formatFailureSignature(result);
       s.verificationRetryCount.set(retryKey, nextAttempt);
       s.pendingVerificationRetry = {
         unitId: s.currentUnit.id,
-        failureContext: verdict.failureContext || formatFailureContext(result),
+        failureContext,
+        ...(failureSignature ? { signature: failureSignature } : {}),
         attempt: nextAttempt,
       };
       const failedCmds = result.checks

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -56,6 +56,7 @@ export type ThinkingLevelSnapshot = ReturnType<ExtensionAPI["getThinkingLevel"]>
 export interface PendingVerificationRetry {
   unitId: string;
   failureContext: string;
+  signature?: string;
   attempt: number;
 }
 

--- a/src/resources/extensions/gsd/auto/verification-retry-policy.ts
+++ b/src/resources/extensions/gsd/auto/verification-retry-policy.ts
@@ -63,7 +63,9 @@ export function decideVerificationRetry(input: {
   }
 
   const key = verificationRetryKey(unitType, retryInfo.unitId);
-  const failureHash = hashVerificationFailureContext(retryInfo.failureContext);
+  const failureHash = hashVerificationFailureContext(
+    retryInfo.signature ?? retryInfo.failureContext,
+  );
   if (input.previousFailureHash === failureHash) {
     return {
       action: "pause",

--- a/src/resources/extensions/gsd/tests/verification-retry-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-retry-policy.test.ts
@@ -11,6 +11,8 @@ import {
   verificationRetryKey,
   VERIFICATION_RETRY_MAX_DELAY_MS,
 } from "../auto/verification-retry-policy.ts";
+import { formatFailureContext, formatFailureSignature } from "../verification-gate.ts";
+import type { VerificationResult } from "../types.ts";
 
 test("verificationRetryDelayMs uses exponential backoff with cap", () => {
   assert.deepEqual(verificationRetryDelayMs(1, () => 0.5), {
@@ -69,6 +71,56 @@ test("decideVerificationRetry delays changed failure context", () => {
   assert.equal(decision.key, verificationRetryKey("execute-task", "M001/S01/T01"));
   assert.equal(decision.delayMs, 4_000);
   assert.equal(decision.baseDelayMs, 4_000);
+});
+
+test("decideVerificationRetry pauses duplicate host-check failures with volatile stderr", () => {
+  const makeResult = (stderr: string): VerificationResult => ({
+    passed: false,
+    discoverySource: "package-json",
+    timestamp: Date.now(),
+    checks: [
+      {
+        command: "npm test",
+        exitCode: 1,
+        stdout: "",
+        stderr,
+        durationMs: 100,
+      },
+    ],
+  });
+  const first = makeResult("failed after 120ms in /tmp/gsd-a worker pid 101");
+  const second = makeResult("failed after 133ms in /tmp/gsd-b worker pid 202");
+  const firstContext = formatFailureContext(first);
+  const secondContext = formatFailureContext(second);
+
+  assert.notEqual(
+    hashVerificationFailureContext(firstContext),
+    hashVerificationFailureContext(secondContext),
+  );
+
+  const signature = formatFailureSignature(first);
+  assert.equal(signature, "npm test#1");
+  assert.equal(formatFailureSignature(second), signature);
+
+  const failureHash = hashVerificationFailureContext(signature);
+  const decision = decideVerificationRetry({
+    unitType: "execute-task",
+    retryInfo: {
+      unitId: "M001/S01/T01",
+      failureContext: secondContext,
+      signature: formatFailureSignature(second),
+      attempt: 2,
+    },
+    previousFailureHash: failureHash,
+    random: () => 0.5,
+  });
+
+  assert.deepEqual(decision, {
+    action: "pause",
+    reason: "duplicate-failure-context",
+    key: verificationRetryKey("execute-task", "M001/S01/T01"),
+    failureHash,
+  });
 });
 
 test("decideVerificationRetry pauses when retry context is missing", () => {

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -244,6 +244,14 @@ export function formatFailureContext(result: VerificationResult): string {
   return header + body;
 }
 
+export function formatFailureSignature(result: VerificationResult): string {
+  return result.checks
+    .filter((check) => check.exitCode !== 0)
+    .map((check) => `${check.command.trim()}#${check.exitCode}`)
+    .sort()
+    .join("\n");
+}
+
 // ─── Gate Execution ─────────────────────────────────────────────────────────
 
 /** Characters that indicate shell control syntax when unquoted in a command string. */


### PR DESCRIPTION
## Summary
- Added stable verification retry signatures and verified the focused retry-policy regression plus diff whitespace check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1053
- [#1053 [Bug]: Verification-gate retry hashes volatile stderr, defeating the duplicate-failure breaker for host-check failures](https://github.com/open-gsd/gsd-pi/issues/1053)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1053-bug-verification-gate-retry-hashes-volat-1782776842`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to retry hashing and session payload; behavior improves loop safety with a test-backed regression.
> 
> **Overview**
> Fixes auto-mode verification retries where the **duplicate-failure breaker** never fired because it hashed the full `failureContext` (including volatile stderr), so repeated host-check failures looked “new” every time.
> 
> Adds **`formatFailureSignature`**, which builds a stable key from failed commands and exit codes (e.g. `npm test#1`), and threads an optional **`signature`** on **`PendingVerificationRetry`**. **`decideVerificationRetry`** now hashes `signature ?? failureContext`, while prompts still get the rich stderr block via **`failureContext`**. A regression test covers volatile stderr with identical signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927b5058ca90d9ae98d33d70d90a5fca1df6b074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->