### PR TITLE
fix(issue): [Bug]: A single throwing row aborts the entire decisions/knowledge to memories backfill, leaving a permanent tail desync

### DIFF
--- a/src/resources/extensions/gsd/knowledge-backfill.ts
+++ b/src/resources/extensions/gsd/knowledge-backfill.ts
@@ -35,8 +35,8 @@ interface SynthesizedRow {
  * - Idempotent (per-row): each migrated memory carries
  *   `structured_fields.sourceKnowledgeId = "<P|L>NNN"`. Rows whose ID is
  *   already present in the memory store are skipped.
- * - Best-effort: never throws. Logs and returns 0 on failure so a broken
- *   backfill cannot block agent startup.
+ * - Best-effort: never throws. Failed memory inserts are logged and skipped;
+ *   setup/read failures log and return 0 so backfill cannot block startup.
  * - Rules (K###) are intentionally skipped — they remain manually maintained
  *   in `KNOWLEDGE.md` per ADR-013.
  *
@@ -69,14 +69,20 @@ export function backfillKnowledgeToMemories(basePath: string): number {
       const matchPattern = `%"sourceKnowledgeId":"${synth.id}"%`;
       if (checkExisting.get({ ":pattern": matchPattern })) continue;
 
-      const id = createMemory({
-        category: synth.category,
-        content: synth.content,
-        scope: synth.scope,
-        confidence: 0.85,
-        structuredFields: synth.structuredFields,
-      });
-      if (id) written += 1;
+      try {
+        const id = createMemory({
+          category: synth.category,
+          content: synth.content,
+          scope: synth.scope,
+          confidence: 0.85,
+          structuredFields: synth.structuredFields,
+        });
+        if (id) written += 1;
+      } catch (rowErr) {
+        const message = rowErr instanceof Error ? rowErr.message : String(rowErr);
+        logWarning("knowledge-backfill", `KNOWLEDGE.md -> memories backfill skipped ${synth.id}: ${message}`);
+        continue;
+      }
     }
 
     return written;

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -49,8 +49,8 @@ type DecisionContentFields = Pick<DecisionRow, "decision" | "choice" | "rational
  *   decision is checked individually; only decisions whose id is already
  *   present in the memory store are skipped. A user-authored memory with
  *   their own `sourceDecisionId` does NOT abort the backfill.
- * - Best-effort: never throws. Logs and returns 0 on failure so a broken
- *   backfill cannot block agent startup.
+ * - Best-effort: never throws. Failed memory inserts are logged and skipped;
+ *   setup/read failures log and return 0 so backfill cannot block startup.
  * - Full migration (ADR-013 Stage 2a): both active and superseded rows are
  *   migrated. `structured_fields.superseded_by` preserves the supersedes
  *   chain so the DECISIONS.md projection regen can source from memories
@@ -146,24 +146,30 @@ export function backfillDecisionsToMemories(): number {
       }
 
       const content = synthesizeDecisionMemoryContent(row);
-      const id = createMemory({
-        category: "architecture",
-        content,
-        scope: row.scope || "project",
-        confidence: 0.85,
-        structuredFields: {
-          sourceDecisionId: row.id,
-          when_context: row.when_context,
-          scope: row.scope,
-          decision: row.decision,
-          choice: row.choice,
-          rationale: row.rationale,
-          made_by: row.made_by,
-          revisable: row.revisable,
-          superseded_by: row.superseded_by,
-        },
-      });
-      if (id) written += 1;
+      try {
+        const id = createMemory({
+          category: "architecture",
+          content,
+          scope: row.scope || "project",
+          confidence: 0.85,
+          structuredFields: {
+            sourceDecisionId: row.id,
+            when_context: row.when_context,
+            scope: row.scope,
+            decision: row.decision,
+            choice: row.choice,
+            rationale: row.rationale,
+            made_by: row.made_by,
+            revisable: row.revisable,
+            superseded_by: row.superseded_by,
+          },
+        });
+        if (id) written += 1;
+      } catch (rowErr) {
+        const message = rowErr instanceof Error ? rowErr.message : String(rowErr);
+        logWarning("memory-backfill", `decisions->memories backfill skipped ${row.id}: ${message}`);
+        continue;
+      }
     }
 
     if (healed > 0) {

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -142,6 +142,57 @@ test("backfill is idempotent — re-running over migrated rows is a no-op", () =
   }
 });
 
+test("backfill skips a decision whose memory insert throws and continues later rows", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "before poison",
+      choice: "A",
+      rationale: "first row",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "poison",
+      choice: "B",
+      rationale: "this insert throws",
+    });
+    seedRawDecision({
+      id: "D003",
+      when_context: "M001",
+      scope: "M001",
+      decision: "after poison",
+      choice: "C",
+      rationale: "tail row",
+    });
+
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    adapter.exec(`
+      CREATE TRIGGER fail_d002_memory_insert
+      BEFORE INSERT ON memories
+      WHEN json_extract(NEW.structured_fields, '$.sourceDecisionId') = 'D002'
+      BEGIN
+        SELECT RAISE(ABORT, 'poison decision D002');
+      END
+    `);
+
+    const written = backfillDecisionsToMemories();
+    assert.equal(written, 2, "one poisoned row should not abort the batch");
+    assert.deepEqual(
+      getAllDecisionsFromMemories().map((d) => d.id),
+      ["D001", "D003"],
+      "rows after the poisoned decision should still be migrated",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 // ─── Drift auto-heal ───────────────────────────────────────────────────────
 
 test("backfill auto-heals when a source decision's superseded_by changes after migration", () => {

--- a/src/resources/extensions/gsd/tests/knowledge-backfill-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-backfill-projection.test.ts
@@ -161,6 +161,41 @@ test("backfill is idempotent — second run on the same file is a no-op", () => 
   }
 });
 
+test("backfill skips a knowledge row whose memory insert throws and continues later rows", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    adapter.exec(`
+      CREATE TRIGGER fail_p002_memory_insert
+      BEFORE INSERT ON memories
+      WHEN json_extract(NEW.structured_fields, '$.sourceKnowledgeId') = 'P002'
+      BEGIN
+        SELECT RAISE(ABORT, 'poison knowledge P002');
+      END
+    `);
+
+    const written = backfillKnowledgeToMemories(base);
+    assert.equal(written, 2, "one poisoned row should not abort the batch");
+
+    const rows = adapter
+      .prepare(
+        "SELECT structured_fields FROM memories WHERE structured_fields LIKE '%\"sourceKnowledgeId\":\"%' ORDER BY seq",
+      )
+      .all() as Array<{ structured_fields: string }>;
+
+    assert.deepEqual(
+      rows.map((row) => JSON.parse(row.structured_fields).sourceKnowledgeId),
+      ["P001", "L001"],
+      "rows after the poisoned knowledge entry should still be migrated",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("backfill returns 0 when KNOWLEDGE.md is absent", () => {
   const base = makeTmpBase();
   try {


### PR DESCRIPTION
## Summary
- Added row-level backfill error quarantine and regression tests; patch checks passed, but dependency install/tests were blocked by registry ENOTFOUND.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1048
- [#1048 [Bug]: A single throwing row aborts the entire decisions/knowledge to memories backfill, leaving a permanent tail desync](https://github.com/open-gsd/gsd-pi/issues/1048)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1048-bug-a-single-throwing-row-aborts-the-ent-1782777206`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized startup backfill resilience and logging; behavior change is skipping bad rows instead of aborting the batch.
> 
> **Overview**
> Fixes a bug where **one failing `createMemory` insert** could abort the whole decisions or KNOWLEDGE.md → memories backfill, leaving later rows permanently unmigrated.
> 
> **`backfillDecisionsToMemories`** and **`backfillKnowledgeToMemories`** now wrap each insert in **try/catch**: failures are **logged** (with decision/knowledge id) and the loop **continues** so the rest of the batch still migrates. Doc comments clarify that best-effort applies to **per-row** insert failures vs setup/read failures that still return 0.
> 
> Regression tests use SQLite **BEFORE INSERT** triggers to force a single row to throw and assert **tail rows** still land in memories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8937462c0a2adb7a299b5bc8b60bd32015661003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->