### PR TITLE
fix(issue): [Bug]: `/gsd undo` unchecks the PLAN.md box but leaves the DB task row closed, so the undo is silently reverted on the next render

### DIFF
--- a/src/resources/extensions/gsd/tests/undo.test.ts
+++ b/src/resources/extensions/gsd/tests/undo.test.ts
@@ -67,6 +67,37 @@ test("handleUndo without --force only warns and leaves completed units intact", 
   }
 });
 
+test("handleUndo execute-task with --force reopens the task row and re-renders plan", async () => {
+  const base = makeTempDir("gsd-undo-execute-task");
+  try {
+    setupTaskFixture(base);
+    mkdirSync(join(base, ".gsd", "activity"), { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "activity", "001-execute-task-M001-S01-T01.jsonl"),
+      "",
+      "utf-8",
+    );
+
+    const { notifications, ctx } = makeCtx();
+    await handleUndo("--force", ctx, {} as any, base);
+
+    const task = getTask("M001", "S01", "T01");
+    assert.equal(task?.status, "pending");
+
+    const planContent = readFileSync(
+      join(base, ".gsd", "phases", "01-test", "01-01-PLAN.md"),
+      "utf-8",
+    );
+    assert.match(planContent, /\[ \] \*\*T01\*\*:/);
+
+    assert.equal(notifications[0]?.level, "success");
+    assert.match(notifications[0]?.message ?? "", /Unchecked task in PLAN/);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("uncheckTaskInPlan flips a checked task back to unchecked", () => {
   const base = makeTempDir("gsd-undo-plan");
   try {

--- a/src/resources/extensions/gsd/tests/undo.test.ts
+++ b/src/resources/extensions/gsd/tests/undo.test.ts
@@ -10,6 +10,7 @@ import {
   handleUndo,
   handleUndoTask,
   handleResetSlice,
+  parseActivityLogFilename,
   uncheckTaskInPlan,
 } from "../undo.ts";
 import {
@@ -183,6 +184,48 @@ test("extractCommitShas ignores malformed commit tokens", () => {
   ].join("\n");
 
   assert.deepEqual(extractCommitShas(content), ["1234567"]);
+});
+
+test("parseActivityLogFilename splits hyphenated unit types from their IDs", () => {
+  // Task-level: unit type and ID both contain hyphens.
+  assert.deepEqual(parseActivityLogFilename("001-execute-task-M001-S01-T01.jsonl"), {
+    unitType: "execute-task",
+    unitId: "M001-S01-T01",
+  });
+  // Variant must win over its shorter prefix ("execute-task").
+  assert.deepEqual(parseActivityLogFilename("002-execute-task-simple-M001-S02-T03.jsonl"), {
+    unitType: "execute-task-simple",
+    unitId: "M001-S02-T03",
+  });
+  // Milestone- and slice-shaped IDs.
+  assert.deepEqual(parseActivityLogFilename("003-research-milestone-M001.jsonl"), {
+    unitType: "research-milestone",
+    unitId: "M001",
+  });
+  assert.deepEqual(parseActivityLogFilename("004-plan-slice-M001-S01.jsonl"), {
+    unitType: "plan-slice",
+    unitId: "M001-S01",
+  });
+});
+
+test("parseActivityLogFilename accepts non-milestone-shaped unit IDs", () => {
+  // Regression (#1057): project-level units use IDs that do not start with
+  // "M<digit>". A milestone-shaped regex made /gsd undo bail out with
+  // "could not parse latest activity log" when one of these was most recent.
+  assert.deepEqual(parseActivityLogFilename("005-discuss-project-PROJECT.jsonl"), {
+    unitType: "discuss-project",
+    unitId: "PROJECT",
+  });
+  assert.deepEqual(parseActivityLogFilename("006-workflow-preferences-WORKFLOW-PREFS.jsonl"), {
+    unitType: "workflow-preferences",
+    unitId: "WORKFLOW-PREFS",
+  });
+});
+
+test("parseActivityLogFilename returns null for unrecognized names", () => {
+  assert.equal(parseActivityLogFilename("007-not-a-real-unit-M001.jsonl"), null);
+  assert.equal(parseActivityLogFilename("no-sequence-prefix.jsonl"), null);
+  assert.equal(parseActivityLogFilename("001-execute-task-M001-S01-T01.txt"), null);
 });
 
 // ─── handleUndoTask tests ────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/undo.ts
+++ b/src/resources/extensions/gsd/undo.ts
@@ -44,8 +44,8 @@ export async function handleUndo(args: string, ctx: ExtensionCommandContext, _pi
 
   // Extract unit type and ID from the most recent activity log filename
   // Format: <seq>-<unitType>-<unitId>.jsonl
-  // unitType may contain hyphens; unitId starts with M (e.g. M001-S01-T01).
-  const match = files[0].match(/^\d+-([\w-]+?)-(M\d[\w-]*)\.jsonl$/);
+  // unitType may contain hyphens; unitId is milestone-shaped (M001-S01-T01) or symbolic (PROJECT).
+  const match = files[0].match(/^\d+-([\w-]+?)-(M\d[\w-]*|[A-Z][\w-]*)\.jsonl$/);
   if (!match) {
     ctx.ui.notify("Nothing to undo — could not parse latest activity log.", "warning");
     return;

--- a/src/resources/extensions/gsd/undo.ts
+++ b/src/resources/extensions/gsd/undo.ts
@@ -44,7 +44,8 @@ export async function handleUndo(args: string, ctx: ExtensionCommandContext, _pi
 
   // Extract unit type and ID from the most recent activity log filename
   // Format: <seq>-<unitType>-<unitId>.jsonl
-  const match = files[0].match(/^\d+-(.+?)-(.+)\.jsonl$/);
+  // unitType may contain hyphens; unitId starts with M (e.g. M001-S01-T01).
+  const match = files[0].match(/^\d+-([\w-]+?)-(M\d[\w-]*)\.jsonl$/);
   if (!match) {
     ctx.ui.notify("Nothing to undo — could not parse latest activity log.", "warning");
     return;
@@ -100,6 +101,11 @@ export async function handleUndo(args: string, ctx: ExtensionCommandContext, _pi
   if (unitType === "execute-task" && task !== undefined && slice !== undefined) {
     const [mid, sid, tid] = [milestone, slice, task];
     planUpdated = uncheckTaskInPlan(basePath, mid, sid, tid);
+    if (getTask(mid, sid, tid)) {
+      updateTaskStatus(mid, sid, tid, "pending");
+      await renderPlanCheckboxes(basePath, mid, sid);
+      planUpdated = true;
+    }
   }
 
   // 3. Try to revert git commits from activity log

--- a/src/resources/extensions/gsd/undo.ts
+++ b/src/resources/extensions/gsd/undo.ts
@@ -15,6 +15,7 @@ import { gsdRoot, resolveTasksDir, resolveSlicePath, resolveSliceFile, resolveTa
 import { sendDesktopNotification } from "./notifications.js";
 import { getTask, getSlice, getSliceTasks, updateTaskStatus, resetSliceCascade } from "./gsd-db.js";
 import { renderPlanCheckboxes, renderRoadmapCheckboxes } from "./markdown-renderer.js";
+import { UNIT_REGISTRY } from "./unit-registry.js";
 
 /**
  * Undo the last completed unit: revert git commits,
@@ -42,17 +43,20 @@ export async function handleUndo(args: string, ctx: ExtensionCommandContext, _pi
     return;
   }
 
-  // Extract unit type and ID from the most recent activity log filename
-  // Format: <seq>-<unitType>-<unitId>.jsonl
-  // unitType may contain hyphens; unitId is milestone-shaped (M001-S01-T01) or symbolic (PROJECT).
-  const match = files[0].match(/^\d+-([\w-]+?)-(M\d[\w-]*|[A-Z][\w-]*)\.jsonl$/);
-  if (!match) {
+  // Extract unit type and ID from the most recent activity log filename.
+  // Both the unit type and the unit ID may contain hyphens, so anchor on the
+  // known unit-type vocabulary instead of guessing the unit-ID shape: a regex
+  // tuned to milestone-shaped IDs rejects project-level units whose IDs are
+  // symbolic (e.g. discuss-project uses PROJECT, workflow-preferences uses
+  // WORKFLOW-PREFS).
+  const parsed = parseActivityLogFilename(files[0]);
+  if (!parsed) {
     ctx.ui.notify("Nothing to undo — could not parse latest activity log.", "warning");
     return;
   }
 
-  const unitType = match[1];
-  const unitId = match[2].replace(/-/g, "/");
+  const unitType = parsed.unitType;
+  const unitId = parsed.unitId.replace(/-/g, "/");
 
   if (!force) {
     ctx.ui.notify(
@@ -384,6 +388,37 @@ export async function handleResetSlice(
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Known unit types sorted longest-first so a more specific type (e.g.
+// "execute-task-simple") matches before a prefix of it ("execute-task") when
+// splitting "<seq>-<unitType>-<unitId>.jsonl".
+const UNIT_TYPES_BY_LENGTH_DESC: readonly string[] = Object.keys(UNIT_REGISTRY).sort(
+  (a, b) => b.length - a.length,
+);
+
+/**
+ * Parse an activity-log filename of the form `<seq>-<unitType>-<unitId>.jsonl`
+ * (the format written by activity-log.ts). Both the unit type and the unit ID
+ * may contain hyphens, so we anchor on the known unit-type vocabulary rather
+ * than guessing the ID shape. This keeps non-milestone IDs (e.g. PROJECT,
+ * WORKFLOW-PREFS) parseable. Returns null when the name has no sequence prefix
+ * or does not start with a recognised unit type.
+ */
+export function parseActivityLogFilename(
+  filename: string,
+): { unitType: string; unitId: string } | null {
+  const seqMatch = filename.match(/^\d+-(.+)\.jsonl$/);
+  if (!seqMatch) return null;
+  const rest = seqMatch[1];
+  for (const unitType of UNIT_TYPES_BY_LENGTH_DESC) {
+    const prefix = `${unitType}-`;
+    if (rest.startsWith(prefix)) {
+      const unitId = rest.slice(prefix.length);
+      if (unitId.length > 0) return { unitType, unitId };
+    }
+  }
+  return null;
+}
 
 export function uncheckTaskInPlan(basePath: string, mid: string, sid: string, tid: string): boolean {
   const slicePath = resolveSlicePath(basePath, mid, sid);


### PR DESCRIPTION
## Summary
- Fixed `/gsd undo` execute-task handling to reopen the DB task row, re-render PLAN checkboxes, added regression coverage, and verified static checks while runtime tests were blocked by offline dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1044
- [#1044 [Bug]: `/gsd undo` unchecks the PLAN.md box but leaves the DB task row closed, so the undo is silently reverted on the next render](https://github.com/open-gsd/gsd-pi/issues/1044)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1044-bug-gsd-undo-unchecks-the-plan-md-box-bu-1782777561`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches undo state reconciliation (DB + markdown projection) for a user-facing command; scope is narrow and aligned with existing undo-task behavior, but incorrect parsing or status updates could affect workflow recovery.
> 
> **Overview**
> Fixes **`/gsd undo`** for **`execute-task`** units so undo stays durable: after unchecking PLAN, the handler now **`updateTaskStatus(..., "pending")`** and **`renderPlanCheckboxes`** when the task exists in the DB, matching **`handleUndoTask`** and treating the DB as the source of truth for checkboxes.
> 
> **Activity log** filename parsing is tightened so hyphenated **`unitType`** values and milestone-style **`unitId`**s (e.g. `M001-S01-T01`) parse correctly instead of mis-splitting on hyphens.
> 
> Adds an integration test that **`handleUndo --force`** leaves the task **pending** and the rendered plan showing an unchecked **T01** box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bc23946555edb68eba5ef96cf165429a09a166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->