### PR TITLE
fix(issue): [Bug]: Attempt counter baked into hashed failure context defeats the duplicate-failure-context retry breaker

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2212,7 +2212,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           saveCustomVerifyRetryCounts(s, { logFailure: err => debugLog("postUnit", { phase: "save-verify-retries-failed", error: err instanceof Error ? err.message : String(err) }) });
           s.pendingVerificationRetry = {
             unitId: s.currentUnit.id,
-            failureContext: `${failureDetails} (attempt ${attempt}/${MAX_ARTIFACT_VERIFICATION_RETRIES}).`,
+            failureContext: failureDetails,
             attempt,
           };
           debugLog("postUnit", { phase: "artifact-verify-retry", unitType: s.currentUnit.type, unitId: s.currentUnit.id, attempt });

--- a/src/resources/extensions/gsd/tests/artifact-retry-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-retry-cap.test.ts
@@ -29,21 +29,22 @@ test("#2007 bug 1: MAX_ARTIFACT_VERIFICATION_RETRIES constant is defined", () =>
   assert.equal(MAX_ARTIFACT_VERIFICATION_RETRIES, 3);
 });
 
-test("#2007 bug 1: retry state can represent each allowed attempt before exhaustion", () => {
+test("#2007 bug 1: retry state keeps attempt separate from failure context", () => {
   const s = new AutoSession();
   const retryKey = "execute-task:M001/S01/T01";
+  const failureContext = "Missing expected artifact";
 
   for (let attempt = 1; attempt <= MAX_ARTIFACT_VERIFICATION_RETRIES; attempt++) {
     s.verificationRetryCount.set(retryKey, attempt);
     s.pendingVerificationRetry = {
       unitId: "M001/S01/T01",
-      failureContext: `Missing expected artifact (attempt ${attempt}/${MAX_ARTIFACT_VERIFICATION_RETRIES}).`,
+      failureContext,
       attempt,
     };
 
     assert.equal(s.verificationRetryCount.get(retryKey), attempt);
     assert.equal(s.pendingVerificationRetry.attempt, attempt);
-    assert.match(s.pendingVerificationRetry.failureContext, /attempt \d\/3/);
+    assert.equal(s.pendingVerificationRetry.failureContext, failureContext);
   }
 });
 

--- a/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
@@ -7,6 +7,10 @@ import { join } from "node:path";
 
 import { postUnitPreVerification } from "../auto-post-unit.ts";
 import { AutoSession } from "../auto/session.ts";
+import {
+  decideVerificationRetry,
+  hashVerificationFailureContext,
+} from "../auto/verification-retry-policy.ts";
 import { cleanup, makeTempRepo } from "./test-utils.ts";
 
 function makePostUnitContext(base: string, s: AutoSession, notifications: string[]) {
@@ -223,6 +227,71 @@ test("complete-slice with gsd_replan_slice but no REPLAN artifact retries", asyn
     assert.equal(result, "retry");
     assert.ok(s.pendingVerificationRetry);
     assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("artifact retry context stays stable across attempts while notifications show attempt count", async () => {
+  const base = makeTempRepo("gsd-artifact-retry-stable-context-");
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+    const notifications: string[] = [];
+    const pctx = makePostUnitContext(base, s, notifications);
+    const opts = {
+      skipSettleDelay: true,
+      skipWorktreeSync: true,
+      agentEndMessages: [
+        {
+          role: "toolResult",
+          toolName: "gsd_replan_slice",
+          isError: false,
+          content: "Slice replanned with reopened task T02.",
+        },
+      ],
+    };
+
+    assert.equal(await postUnitPreVerification(pctx, opts), "retry");
+    const firstRetry = s.pendingVerificationRetry;
+    assert.ok(firstRetry);
+    assert.equal(firstRetry.attempt, 1);
+    assert.doesNotMatch(firstRetry.failureContext, /\(attempt \d\/3\)\.$/);
+    const firstFailureHash = hashVerificationFailureContext(firstRetry.failureContext);
+
+    assert.equal(await postUnitPreVerification(pctx, opts), "retry");
+    const secondRetry = s.pendingVerificationRetry;
+    assert.ok(secondRetry);
+    assert.equal(secondRetry.attempt, 2);
+    assert.equal(secondRetry.failureContext, firstRetry.failureContext);
+    assert.equal(hashVerificationFailureContext(secondRetry.failureContext), firstFailureHash);
+    assert.deepEqual(
+      decideVerificationRetry({
+        unitType: s.currentUnit.type,
+        retryInfo: secondRetry,
+        previousFailureHash: firstFailureHash,
+        random: () => 0.5,
+      }),
+      {
+        action: "pause",
+        reason: "duplicate-failure-context",
+        key: "complete-slice:M001/S01",
+        failureHash: firstFailureHash,
+      },
+    );
+    assert.ok(
+      notifications.some((message) => message.includes("Retrying (attempt 1/3).")),
+      `expected first attempt notification, got: ${notifications.join("\n")}`,
+    );
+    assert.ok(
+      notifications.some((message) => message.includes("Retrying (attempt 2/3).")),
+      `expected second attempt notification, got: ${notifications.join("\n")}`,
+    );
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/verification-retry-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-retry-policy.test.ts
@@ -31,9 +31,22 @@ test("verificationRetryDelayMs uses exponential backoff with cap", () => {
   });
 });
 
-test("decideVerificationRetry pauses on duplicate failure context", () => {
+test("decideVerificationRetry pauses on repeated failure context across attempts", () => {
   const failureContext = "lint failed\n";
-  const failureHash = hashVerificationFailureContext(failureContext);
+  const firstDecision = decideVerificationRetry({
+    unitType: "execute-task",
+    retryInfo: {
+      unitId: "M001/S01/T01",
+      failureContext,
+      attempt: 1,
+    },
+    previousFailureHash: undefined,
+    random: () => 0.5,
+  });
+
+  assert.equal(firstDecision.action, "delay");
+  assert.equal(firstDecision.failureHash, hashVerificationFailureContext(failureContext));
+
   const decision = decideVerificationRetry({
     unitType: "execute-task",
     retryInfo: {
@@ -41,7 +54,7 @@ test("decideVerificationRetry pauses on duplicate failure context", () => {
       failureContext,
       attempt: 2,
     },
-    previousFailureHash: failureHash,
+    previousFailureHash: firstDecision.failureHash,
     random: () => 0.5,
   });
 
@@ -49,7 +62,7 @@ test("decideVerificationRetry pauses on duplicate failure context", () => {
     action: "pause",
     reason: "duplicate-failure-context",
     key: verificationRetryKey("execute-task", "M001/S01/T01"),
-    failureHash,
+    failureHash: firstDecision.failureHash,
   });
 });
 


### PR DESCRIPTION
## Summary
- Removed attempt text from hashed artifact retry context and verified the retry policy plus diff checks, with broader tests blocked by missing deps and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1046
- [#1046 [Bug]: Attempt counter baked into hashed failure context defeats the duplicate-failure-context retry breaker](https://github.com/open-gsd/gsd-pi/issues/1046)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1046-bug-attempt-counter-baked-into-hashed-fa-1782778041`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in auto-mode artifact retry state plus test updates; no auth or data-path changes.
> 
> **Overview**
> Fixes a bug where **artifact verification retries** embedded the attempt counter in `pendingVerificationRetry.failureContext`, so each retry produced a different hash and the **duplicate-failure-context** breaker in `decideVerificationRetry` never fired on repeated identical failures.
> 
> **`postUnitPreVerification`** now stores only the raw failure message in `failureContext`; attempt numbering stays on the `attempt` field and in user notifications (`Retrying (attempt N/3)`).
> 
> Tests assert stable `failureContext` across attempts, unchanged failure hashes, and that a second identical failure triggers `duplicate-failure-context` pause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed1004cee5e2fb98207044710246bfca2b03592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->