### PR TITLE
fix(issue): [Bug]: Manifest restore truncates artifact projection files when full_content is empty

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-manifest.test.ts
@@ -380,6 +380,60 @@ test('workflow-manifest: bootstrapFromManifest preserves target_repositories', (
   }
 });
 
+test('workflow-manifest: bootstrapFromManifest does not truncate projections when artifact content is empty', () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertMilestone({ id: 'M001', title: 'Projection Milestone' });
+    insertArtifact({
+      path: '.gsd/milestones/M001/M001-PLAN.md',
+      artifact_type: 'PLAN',
+      milestone_id: 'M001',
+      slice_id: null,
+      task_id: null,
+      full_content: '# Manifest Plan',
+    });
+    insertArtifact({
+      path: '.gsd/milestones/M001/M001-VALIDATION.md',
+      artifact_type: 'VALIDATION',
+      milestone_id: 'M001',
+      slice_id: null,
+      task_id: null,
+      full_content: '# Manifest Validation',
+    });
+    writeManifest(base);
+
+    const planPath = path.join(base, '.gsd', 'milestones', 'M001', 'M001-PLAN.md');
+    const validationPath = path.join(base, '.gsd', 'milestones', 'M001', 'M001-VALIDATION.md');
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    fs.writeFileSync(planPath, '# Existing Plan\n\nKeep this.');
+    fs.writeFileSync(validationPath, '# Existing Validation\n\nKeep this.');
+
+    const manifestPath = path.join(base, '.gsd', 'state-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    const artifacts = manifest['artifacts'] as Array<Record<string, unknown>>;
+    const emptyArtifact = artifacts.find((r) => r['path'] === '.gsd/milestones/M001/M001-PLAN.md');
+    const absentArtifact = artifacts.find((r) => r['path'] === '.gsd/milestones/M001/M001-VALIDATION.md');
+    assert.ok(emptyArtifact !== undefined);
+    assert.ok(absentArtifact !== undefined);
+    emptyArtifact['full_content'] = '';
+    delete absentArtifact['full_content'];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    closeDatabase();
+
+    const newDbPath = path.join(base, 'new.db');
+    openDatabase(newDbPath);
+    const restored = bootstrapFromManifest(base);
+    assert.strictEqual(restored, true);
+
+    assert.strictEqual(fs.readFileSync(planPath, 'utf-8'), '# Existing Plan\n\nKeep this.');
+    assert.strictEqual(fs.readFileSync(validationPath, 'utf-8'), '# Existing Validation\n\nKeep this.');
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
 test('workflow-manifest: bootstrapFromManifest preserves optional rows from old manifests', () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -414,9 +414,12 @@ function restoreArtifactProjections(basePath: string, manifest: StateManifest): 
   if (manifest.artifacts === undefined) return;
 
   for (const artifact of manifest.artifacts) {
+    const content = artifact.full_content ?? "";
+    if (content === "") continue;
+
     atomicWriteSync(
       artifactProjectionPath(basePath, artifact.path),
-      artifact.full_content ?? "",
+      content,
     );
   }
 }


### PR DESCRIPTION
## Summary
- Skipped empty manifest artifact projection writes, added regression coverage, and verified the behavior with diff checks plus a dependency-free restore harness.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1050
- [#1050 [Bug]: Manifest restore truncates artifact projection files when full_content is empty](https://github.com/open-gsd/gsd-pi/issues/1050)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1050-bug-manifest-restore-truncates-artifact--1782778401`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to manifest restore file writes with regression coverage; only affects bootstrap when artifact content is empty.
> 
> **Overview**
> Fixes manifest bootstrap **overwriting on-disk artifact projection files** when manifest entries have **empty or missing `full_content`**.
> 
> `restoreArtifactProjections` now **skips `atomicWriteSync`** when resolved content is `""` (including `full_content` omitted, which coerces to empty). Non-empty manifest content still rehydrates projections as before.
> 
> Adds a regression test that pre-seeds projection files, corrupts the manifest with `full_content: ''` and deleted `full_content`, runs `bootstrapFromManifest`, and asserts **existing file bodies are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870dd925fe98c5ae3a198475ca353bf02a192cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->