### PR TITLE
fix(issue): [Bug]: Startup orphan-stash audit re-applies a completed-milestone preflight stash onto the working tree without a clean-tree check

### DIFF
--- a/src/resources/extensions/gsd/orphan-stash-audit.ts
+++ b/src/resources/extensions/gsd/orphan-stash-audit.ts
@@ -33,16 +33,75 @@ function _isAlreadyRestoredApplyError(err: unknown): boolean {
 
 export { _isAlreadyRestoredApplyError };
 
+function gitOutput(basePath: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: basePath,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+    env: GIT_NO_PROMPT_ENV,
+  });
+}
+
+function listStashUntrackedPaths(basePath: string, stashRef: string): string[] | null {
+  try {
+    return gitOutput(basePath, ["ls-tree", "-r", "-z", "--name-only", `${stashRef}^3`]).split("\0").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function listStashTrackedPaths(basePath: string, stashRef: string): string[] | null {
+  try {
+    return gitOutput(basePath, ["diff", "--name-only", "-z", `${stashRef}^1`, stashRef]).split("\0").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+interface PorcelainEntry {
+  code: string;
+  path: string;
+}
+
+function readWorkingTreeStatus(basePath: string): PorcelainEntry[] | null {
+  try {
+    return gitOutput(basePath, ["status", "--porcelain", "-z", "--untracked-files=all"])
+      .split("\0")
+      .filter(Boolean)
+      .map((entry) => ({ code: entry.slice(0, 2), path: entry.slice(3) }));
+  } catch {
+    return null;
+  }
+}
+
+function isAlreadyRestoredUntrackedStatus(basePath: string, stashRef: string, statusEntries: PorcelainEntry[]): boolean {
+  if (statusEntries.length === 0 || statusEntries.some((entry) => entry.code !== "??")) return false;
+  const stashTrackedPaths = listStashTrackedPaths(basePath, stashRef);
+  if (!stashTrackedPaths || stashTrackedPaths.length > 0) return false;
+  const stashUntrackedPaths = listStashUntrackedPaths(basePath, stashRef);
+  if (!stashUntrackedPaths || stashUntrackedPaths.length === 0) return false;
+  const stashUntrackedPathSet = new Set(stashUntrackedPaths);
+  return statusEntries.every((entry) => stashUntrackedPathSet.has(entry.path));
+}
+
+function manualApplyWarning(stashRef: string, milestoneId: string, reason: string): string {
+  return (
+    `Pre-merge stash ${stashRef} for milestone ${milestoneId} not auto-applied: ${reason}; ` +
+    `run \`git stash apply ${stashRef}\` manually to restore your pre-merge changes.`
+  );
+}
+
 /**
  * Audit `git stash list` for orphaned `gsd-preflight-stash:M00x:*` entries.
  *
  * The matching merge code in `phases.ts` previously skipped the postflight
  * pop whenever `mergeAndExit` threw, leaking the user's pre-merge working
- * tree into the stash list. For every preflight-stash entry whose milestone
- * is now complete (per the supplied callback), `git stash apply` is invoked —
+ * tree into the stash list. Completed-milestone stashes are only auto-applied
+ * when the working tree is clean and the stash does not modify tracked files.
+ * Dirty trees and tracked-file stashes are left untouched with a manual
+ * recovery warning. When auto-apply is safe, `git stash apply` is invoked —
  * NOT `pop`. The stash entry stays in the list so the user retains a backup
- * if the apply produces unexpected merge results. Idempotent across repeated
- * startup runs.
+ * if the apply produces unexpected merge results.
  *
  * Failures are best-effort: a list error (no repo, git unavailable) returns
  * an empty result. An apply error becomes a warning the user sees alongside
@@ -56,16 +115,7 @@ export function auditOrphanedPreflightStashes(
 
   let listOutput: string;
   try {
-    listOutput = execFileSync(
-      "git",
-      ["stash", "list", "--format=%gd%x00%s"],
-      {
-        cwd: basePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-        env: GIT_NO_PROMPT_ENV,
-      },
-    );
+    listOutput = gitOutput(basePath, ["stash", "list", "--format=%gd%x00%s"]);
   } catch {
     return result;
   }
@@ -93,13 +143,39 @@ export function auditOrphanedPreflightStashes(
     }
     if (!complete) continue;
 
+    const statusEntries = readWorkingTreeStatus(basePath);
+    if (!statusEntries) {
+      result.warnings.push(
+        manualApplyWarning(ref, milestoneId, "could not verify working tree status"),
+      );
+      continue;
+    }
+    if (statusEntries.length > 0) {
+      if (isAlreadyRestoredUntrackedStatus(basePath, ref, statusEntries)) continue;
+      result.warnings.push(manualApplyWarning(ref, milestoneId, "working tree not clean"));
+      continue;
+    }
+
+    const trackedPaths = listStashTrackedPaths(basePath, ref);
+    if (trackedPaths === null) {
+      result.warnings.push(
+        manualApplyWarning(ref, milestoneId, "could not inspect tracked paths in stash"),
+      );
+      continue;
+    }
+    if (trackedPaths.length > 0) {
+      // A retained tracked-file stash has no durable marker showing whether a
+      // clean tree needs first recovery or would be re-mutated by an old backup.
+      const preview = trackedPaths.slice(0, 5).join(", ");
+      const suffix = trackedPaths.length > 5 ? `, and ${trackedPaths.length - 5} more` : "";
+      result.warnings.push(
+        manualApplyWarning(ref, milestoneId, `stash modifies tracked files (${preview}${suffix})`),
+      );
+      continue;
+    }
+
     try {
-      execFileSync("git", ["stash", "apply", "--quiet", ref], {
-        cwd: basePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-        env: GIT_NO_PROMPT_ENV,
-      });
+      gitOutput(basePath, ["stash", "apply", "--quiet", ref]);
       result.applied.push({ milestoneId, stashRef: ref });
     } catch (err) {
       // Idempotent steady state: stash was already applied in a prior audit

--- a/src/resources/extensions/gsd/orphan-stash-audit.ts
+++ b/src/resources/extensions/gsd/orphan-stash-audit.ts
@@ -81,7 +81,19 @@ function isAlreadyRestoredUntrackedStatus(basePath: string, stashRef: string, st
   const stashUntrackedPaths = listStashUntrackedPaths(basePath, stashRef);
   if (!stashUntrackedPaths || stashUntrackedPaths.length === 0) return false;
   const stashUntrackedPathSet = new Set(stashUntrackedPaths);
-  return statusEntries.every((entry) => stashUntrackedPathSet.has(entry.path));
+  const workingTreeUntrackedPathSet = new Set(statusEntries.map((entry) => entry.path));
+  // "Already restored" requires the working tree's untracked paths to match the
+  // stash's untracked paths exactly, in BOTH directions:
+  //   1. every current untracked path comes from the stash (no unexplained user
+  //      work that an apply would clobber), AND
+  //   2. every stash untracked path is already present in the working tree.
+  // Without (2), a partial restore (where only some stash files were recovered)
+  // would be misread as fully restored: the audit would no-op without applying
+  // or warning, leaving the remaining pre-merge files missing.
+  return (
+    statusEntries.every((entry) => stashUntrackedPathSet.has(entry.path)) &&
+    stashUntrackedPaths.every((path) => workingTreeUntrackedPathSet.has(path))
+  );
 }
 
 function manualApplyWarning(stashRef: string, milestoneId: string, reason: string): string {

--- a/src/resources/extensions/gsd/tests/orphan-stash-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphan-stash-audit.test.ts
@@ -1,6 +1,7 @@
 // gsd-pi + src/resources/extensions/gsd/tests/orphan-stash-audit.test.ts
-// Regression: orphaned gsd-preflight-stash entries from completed milestones
-// must be auto-applied at startup so the user's pre-merge work returns.
+// Regression coverage for orphaned gsd-preflight-stash entries from completed
+// milestones: safe startup recovery for untracked work, manual warnings for
+// tracked or dirty-tree cases that would silently mutate user state.
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
@@ -34,6 +35,13 @@ function pushPreflightStash(repo: string, milestoneId: string, fileName: string,
   writeFileSync(join(repo, fileName), content);
   const marker = `gsd-preflight-stash:${milestoneId}:42:1700000000000:abcd`;
   git(repo, "stash", "push", "--include-untracked", "-m", `gsd-preflight-stash [${marker}]`);
+  return marker;
+}
+
+function pushTrackedPreflightStash(repo: string, milestoneId: string, fileName: string, content: string): string {
+  writeFileSync(join(repo, fileName), content);
+  const marker = `gsd-preflight-stash:${milestoneId}:42:1700000000000:tracked`;
+  git(repo, "stash", "push", "-m", `gsd-preflight-stash [${marker}]`);
   return marker;
 }
 
@@ -83,6 +91,23 @@ describe("auditOrphanedPreflightStashes", () => {
     assert.match(list, /gsd-preflight-stash:M002:/);
   });
 
+  test("does not auto-apply a tracked orphan preflight stash onto a clean working tree", () => {
+    pushTrackedPreflightStash(repo, "M006", "seed.txt", "seed\ntracked pre-merge work\n");
+    assert.equal(readFileSync(join(repo, "seed.txt"), "utf-8"), "seed\n");
+
+    const result = auditOrphanedPreflightStashes(repo, () => true);
+
+    assert.equal(result.applied.length, 0);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /not auto-applied/);
+    assert.match(result.warnings[0], /stash modifies tracked files/);
+    assert.match(result.warnings[0], /git stash apply stash@\{\d+\}/);
+    assert.equal(readFileSync(join(repo, "seed.txt"), "utf-8"), "seed\n");
+
+    const list = git(repo, "stash", "list");
+    assert.match(list, /gsd-preflight-stash:M006:/);
+  });
+
   test("ignores stashes whose milestone is not complete", () => {
     pushPreflightStash(repo, "M003", "wip.txt", "still-working\n");
 
@@ -115,23 +140,25 @@ describe("auditOrphanedPreflightStashes", () => {
     assert.match(result.warnings[0], /db unavailable/);
   });
 
-  test("collects a warning when stash apply fails (conflicting working tree)", () => {
-    // Push a stash containing a change to seed.txt; then dirty seed.txt with
-    // a conflicting modification before the audit runs so apply fails.
+  test("collects a warning instead of applying when the working tree is not clean", () => {
+    // Push a stash containing a change to seed.txt; then dirty seed.txt before
+    // the audit runs. Startup recovery must leave the tree untouched and ask
+    // the user to apply the retained backup stash manually.
     writeFileSync(join(repo, "seed.txt"), "stashed\n");
     const marker = `gsd-preflight-stash:M005:42:1700:zz`;
     git(repo, "stash", "push", "-m", `gsd-preflight-stash [${marker}]`);
 
-    // Dirty the working tree so apply will conflict.
     writeFileSync(join(repo, "seed.txt"), "conflicting modification\n");
 
     const result = auditOrphanedPreflightStashes(repo, () => true);
 
     assert.equal(result.applied.length, 0);
     assert.equal(result.warnings.length, 1);
-    assert.match(result.warnings[0], /Could not apply orphaned preflight stash/);
+    assert.match(result.warnings[0], /not auto-applied/);
+    assert.match(result.warnings[0], /working tree not clean/);
     assert.match(result.warnings[0], /M005/);
     assert.match(result.warnings[0], /git stash apply/);
+    assert.equal(readFileSync(join(repo, "seed.txt"), "utf-8"), "conflicting modification\n");
 
     const list = git(repo, "stash", "list");
     assert.match(list, /gsd-preflight-stash:M005:/);

--- a/src/resources/extensions/gsd/tests/orphan-stash-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphan-stash-audit.test.ts
@@ -196,6 +196,63 @@ describe("auditOrphanedPreflightStashes", () => {
       "second run must NOT warn — files are already restored from first run",
     );
   });
+
+  test("warns instead of silently skipping when only some stash untracked files were restored", () => {
+    // Cursor Bugbot caught: isAlreadyRestoredUntrackedStatus treated a dirty
+    // tree as fully restored when every *current* untracked path appeared in
+    // the stash, without requiring every *stash* untracked path to be present.
+    // A partial restore (only some files recovered) was misread as the
+    // idempotent steady state, so the audit no-oped and the remaining pre-merge
+    // files stayed missing with no warning.
+    writeFileSync(join(repo, "first.txt"), "first\n");
+    writeFileSync(join(repo, "second.txt"), "second\n");
+    const marker = `gsd-preflight-stash:M007:42:1700000000000:partial`;
+    git(repo, "stash", "push", "--include-untracked", "-m", `gsd-preflight-stash [${marker}]`);
+
+    // Both files are stashed away.
+    assert.equal(existsSync(join(repo, "first.txt")), false);
+    assert.equal(existsSync(join(repo, "second.txt")), false);
+
+    // Simulate a partial restore: only first.txt came back; second.txt is still
+    // missing from the working tree.
+    writeFileSync(join(repo, "first.txt"), "first\n");
+
+    const result = auditOrphanedPreflightStashes(repo, () => true);
+
+    // Must NOT be treated as already-restored: second.txt is still missing, so
+    // the audit must surface a manual-recovery warning rather than no-op.
+    assert.equal(result.applied.length, 0);
+    assert.equal(result.warnings.length, 1, "partial restore must warn, not silently no-op");
+    assert.match(result.warnings[0], /not auto-applied/);
+    assert.match(result.warnings[0], /working tree not clean/);
+    assert.match(result.warnings[0], /M007/);
+    assert.match(result.warnings[0], /git stash apply/);
+
+    // The stash entry must remain so the user can recover second.txt manually.
+    const list = git(repo, "stash", "list");
+    assert.match(list, /gsd-preflight-stash:M007:/);
+  });
+
+  test("fully restored multi-file untracked stash stays a silent no-op", () => {
+    // Guards the other direction of the set-equality fix: when EVERY stash
+    // untracked file is present in the working tree, the genuine idempotent
+    // steady state must still be recognized and skipped without warning, even
+    // when the stash captured more than one file.
+    writeFileSync(join(repo, "alpha.txt"), "alpha\n");
+    writeFileSync(join(repo, "beta.txt"), "beta\n");
+    const marker = `gsd-preflight-stash:M008:42:1700000000000:multi`;
+    git(repo, "stash", "push", "--include-untracked", "-m", `gsd-preflight-stash [${marker}]`);
+
+    const first = auditOrphanedPreflightStashes(repo, () => true);
+    assert.equal(first.applied.length, 1, "first run applies both files");
+    assert.equal(first.warnings.length, 0);
+    assert.equal(existsSync(join(repo, "alpha.txt")), true);
+    assert.equal(existsSync(join(repo, "beta.txt")), true);
+
+    const second = auditOrphanedPreflightStashes(repo, () => true);
+    assert.equal(second.applied.length, 0, "second run skips");
+    assert.equal(second.warnings.length, 0, "fully restored multi-file stash must not warn");
+  });
 });
 
 test("_isAlreadyRestoredApplyError detects the git stash apply already-exists error", () => {


### PR DESCRIPTION
## Summary
- Added orphan preflight stash safety guards and regression tests; targeted tests and diff check passed, typecheck was blocked by missing node_modules/tsc.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1051
- [#1051 [Bug]: Startup orphan-stash audit re-applies a completed-milestone preflight stash onto the working tree without a clean-tree check](https://github.com/open-gsd/gsd-pi/issues/1051)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1051-bug-startup-orphan-stash-audit-re-applie-1782778762`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GSD startup git recovery behavior and can leave orphaned stashes unapplied until the user acts, but reduces risk of overwriting or conflicting with an in-progress working tree.
> 
> **Overview**
> Tightens **startup orphan preflight stash recovery** so completed-milestone `gsd-preflight-stash` entries are **not** blindly `git stash apply`’d onto whatever is in the working tree.
> 
> **Auto-apply** now runs only when the tree is **clean** and the stash **does not modify tracked files** (untracked-only preflight stashes). **Dirty trees** and **tracked-file stashes** are skipped with a **`not auto-applied`** warning that points users at manual `git stash apply`. If the tree looks dirty but only with **untracked paths already matching** an untracked-only stash, the audit **no-ops** instead of warning.
> 
> Adds git helpers for stash path inspection and porcelain status; tests cover tracked stashes on a clean tree and dirty-tree cases that must not mutate files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d1f753e7f031ada3c753805a4c1c4cd9093c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->