### PR TITLE
fix(issue): [Bug]: Decision-deferred milestone slice is skipped by selection but counted incomplete at closeout, hard-stalling `/gsd auto`

### DIFF
--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -18,7 +18,7 @@ import {
   getWorkflowDatabasePath,
   refreshWorkflowDatabaseFromDisk,
 } from "./db-workspace.js";
-import { isClosedStatus } from "./status-guards.js";
+import { isClosedStatus, isDeferredStatus } from "./status-guards.js";
 import { closeQualityGatesFromEvidence } from "./quality-gate-closure.js";
 import { insertMilestoneValidationGates } from "./milestone-validation-gates.js";
 import { relMilestoneFile, resolveSliceFile } from "./paths.js";
@@ -229,6 +229,7 @@ export function checkCloseoutConsistencyGate(
   }
 
   for (const slice of slices) {
+    if (isDeferredStatus(slice.status)) continue;
     if (!isClosedStatus(slice.status)) {
       return blocked(
         "slice-open",

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -313,6 +313,34 @@ console.log('\n=== complete-milestone: incomplete slices block closeout ===');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: deferred slices are inactive for closeout
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: deferred slices do not block closeout ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const { basePath } = createTempProject();
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass' });
+  insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Deferred Slice', status: 'deferred' });
+  insertTask({
+    id: 'T02',
+    sliceId: 'S02',
+    milestoneId: 'M001',
+    status: 'pending',
+    title: 'Deferred Slice Task',
+  });
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+
+  assertTrue(!('error' in result), 'deferred slice should not block milestone completion');
+  assertEq(getMilestone('M001')!.status, 'complete', 'milestone should complete with deferred inactive slice');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // complete-milestone: deep task check (slice closed, task not)
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
@@ -9,7 +9,15 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
 import { mergeMilestoneToMain } from "../auto-worktree.ts";
-import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+import { checkCloseoutConsistencyGate } from "../closeout-consistency-gate.ts";
+import {
+  closeDatabase,
+  insertAssessment,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -59,5 +67,27 @@ test("mergeMilestoneToMain blocks when project DB closeout is still open", () =>
     closeDatabase();
     process.chdir(savedCwd);
     if (existsSync(repo)) rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("closeout consistency treats deferred slices as inactive", () => {
+  try {
+    assert.equal(openDatabase(":memory:"), true);
+    insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+    insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Done", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S02", title: "Deferred", status: "deferred" });
+    insertTask({ milestoneId: "M001", sliceId: "S02", id: "T02", title: "Deferred", status: "pending" });
+    insertAssessment({
+      path: "milestones/M001/M001-VALIDATION.md",
+      milestoneId: "M001",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
+    });
+
+    assert.deepEqual(checkCloseoutConsistencyGate("M001"), { ok: true });
+  } finally {
+    closeDatabase();
   }
 });

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -23,7 +23,7 @@ import {
 } from "../gsd-db.js";
 import { gsdProjectionRoot, clearPathCache, relMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
-import { isClosedStatus } from "../status-guards.js";
+import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { stripIdPrefix } from "../workflow-projections.js";
@@ -180,7 +180,7 @@ export async function handleCompleteMilestone(
       return;
     }
 
-    const incompleteSlices = slices.filter(s => !isClosedStatus(s.status));
+    const incompleteSlices = slices.filter(s => !isClosedStatus(s.status) && !isDeferredStatus(s.status));
     if (incompleteSlices.length > 0) {
       const incompleteIds = incompleteSlices.map(s => `${s.id} (status: ${s.status})`).join(", ");
       guardError = `incomplete slices: ${incompleteIds}`;
@@ -189,6 +189,7 @@ export async function handleCompleteMilestone(
 
     // Deep check: verify all tasks in all slices are complete
     for (const slice of slices) {
+      if (isDeferredStatus(slice.status)) continue;
       const tasks = getSliceTasks(params.milestoneId, slice.id);
       const incompleteTasks = tasks.filter(t => !isClosedStatus(t.status));
       if (incompleteTasks.length > 0) {


### PR DESCRIPTION
## Summary
- Fixed deferred-slice closeout handling and added focused regressions; whitespace verification passed but tests were blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1054
- [#1054 [Bug]: Decision-deferred milestone slice is skipped by selection but counted incomplete at closeout, hard-stalling `/gsd auto`](https://github.com/open-gsd/gsd-pi/issues/1054)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1054-bug-decision-deferred-milestone-slice-is-1782779123`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes milestone closeout invariants in two shared guards; behavior is narrow and covered by new tests, but incorrect deferral handling could allow premature completion.
> 
> **Overview**
> **Deferred milestone slices no longer block closeout** when they still have open tasks, matching how selection already skips them.
> 
> `complete-milestone` and `checkCloseoutConsistencyGate` now use `isDeferredStatus` to exclude deferred slices from incomplete-slice checks and to skip per-slice task and gate validation. Regression tests cover handler completion and the closeout consistency gate with a deferred slice plus pending tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8d0e4b8833392635e4b767b5bc3da063e189c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->