### PR TITLE
fix(issue): [Bug]: `/gsd pause` reports "paused" but never interrupts the in-flight agent turn (auto-mode keeps streaming tool calls until the model ends the turn)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2102,7 +2102,7 @@ export function _selectStopAutoWorktreeExit(args: {
 /**
  * Pause auto-mode without destroying state. Context is preserved.
  * The user can interact with the agent, then `/gsd auto` resumes
- * from disk state. Called when the user presses Escape during auto-mode.
+ * from disk state. Called when the user presses Escape or runs `/gsd pause`.
  */
 export async function pauseAuto(
   ctx?: ExtensionContext,
@@ -2129,6 +2129,7 @@ export async function pauseAuto(
 
   s.active = false;
   s.paused = true;
+  if (options.abortActiveTurn && ctx && !ctx.isIdle()) ctx.abort();
   clearUnitTimeout();
   stopAutoCommandPolling();
 

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -52,6 +52,7 @@ export type PauseAutoUnitIdentity = {
 
 export interface PauseAutoOptions {
   expectedCurrentUnit?: PauseAutoUnitIdentity | null;
+  abortActiveTurn?: boolean;
 }
 
 type PauseAutoFn = (

--- a/src/resources/extensions/gsd/commands/handlers/auto.ts
+++ b/src/resources/extensions/gsd/commands/handlers/auto.ts
@@ -200,7 +200,7 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
       }
       return true;
     }
-    await pauseAuto(ctx, pi);
+    await pauseAuto(ctx, pi, undefined, { abortActiveTurn: true });
     return true;
   }
 

--- a/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-pause-double-entry-guard.test.ts
@@ -14,6 +14,7 @@ import { capturePauseAutoUnitIdentity, pauseAuto, isAutoActive } from "../auto.t
 import { _resetPendingResolve, _setCurrentResolve } from "../auto/resolve.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { _isPauseOriginCancelledResult } from "../auto/phase-helpers.ts";
+import { handleAutoCommand } from "../commands/handlers/auto.ts";
 
 test("pauseAuto sets s.active = false synchronously before first await (blocks concurrent re-entry)", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-double-pause-guard-"));
@@ -76,6 +77,41 @@ test("pauseAuto marks paused and cancels the in-flight unit before first await",
     await pausePromise.catch(() => {});
   } finally {
     _resetPendingResolve();
+    autoSession.reset();
+  }
+});
+
+test("/gsd pause aborts the active pi turn before first await", async () => {
+  autoSession.reset();
+  autoSession.active = true;
+  let abortCount = 0;
+  const ctx = {
+    hasUI: false,
+    isIdle: () => false,
+    abort: () => {
+      abortCount += 1;
+    },
+    sessionManager: {
+      getSessionFile: () => null,
+    },
+    ui: {
+      setStatus() {},
+      setWidget() {},
+      notify() {},
+    },
+  } as any;
+
+  try {
+    const pausePromise = handleAutoCommand("pause", ctx, {} as any);
+
+    assert.equal(
+      abortCount,
+      1,
+      "pauseAuto must abort the active pi turn before reporting auto-mode paused",
+    );
+
+    await pausePromise.catch(() => {});
+  } finally {
     autoSession.reset();
   }
 });


### PR DESCRIPTION
## Summary
- Fixed /gsd pause to abort active pi turns before pausing and added a regression test; diff check passed but test execution was blocked by missing dependencies from restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1066
- [#1066 [Bug]: `/gsd pause` reports "paused" but never interrupts the in-flight agent turn (auto-mode keeps streaming tool calls until the model ends the turn)](https://github.com/open-gsd/gsd-pi/issues/1066)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1066-bug-gsd-pause-reports-paused-but-never-i-1782799402`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in change on the pause path using the existing `ctx.abort()` API; scope is limited to the `/gsd pause` command handler plus a unit test.
> 
> **Overview**
> Fixes **#1066**: auto-mode could show **paused** while an in-flight agent turn kept streaming tool calls until the model finished.
> 
> **`/gsd auto pause`** now passes `{ abortActiveTurn: true }` into `pauseAuto`. When that flag is set and the session is not idle, **`pauseAuto` calls `ctx.abort()`** right after flipping `active`/`paused`, before the rest of pause cleanup (timeouts, queue flush, unit cancellation).
> 
> `PauseAutoOptions` gains optional **`abortActiveTurn`**; other `pauseAuto` callers are unchanged unless they opt in. Docs note pause is triggered by Escape or **`/gsd pause`**.
> 
> A regression test asserts **`handleAutoCommand("pause", …)` aborts synchronously** before the first await when `isIdle()` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc180c9872d55bff92cc76cd241cde805dd2c82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->