### PR TITLE
fix(issue): [Bug]: Tool-call loop guard blocks legitimate distinct `read` calls in read-heavy turns — the 16th distinct file read in one turn is misclassified as a "repeated tool" / "infinite loop"

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -42,6 +42,7 @@ const MAX_CONSECUTIVE_STRICT = 1;
  */
 const PER_TOOL_DEFAULT_CAP = 6;
 const PER_TOOL_REPEATABLE_CAP = 15;
+const PER_TOOL_CAP_EXEMPT_TOOLS = new Set(["read"]);
 
 let consecutiveCount = 0;
 let lastSignature = "";
@@ -116,6 +117,13 @@ export function checkToolCallLoop(
   // varied args (e.g. retrying a missing workflow tool via bash/node -e/CLI).
   const perToolCount = (perToolCounts.get(toolName) ?? 0) + 1;
   perToolCounts.set(toolName, perToolCount);
+
+  // Reading many distinct files is normal context gathering; Guard 1 still
+  // catches true reread loops with identical arguments.
+  if (PER_TOOL_CAP_EXEMPT_TOOLS.has(toolName)) {
+    return { block: false, count: consecutiveCount };
+  }
+
   const perToolCap = INHERENTLY_REPEATABLE_TOOL_SET.has(toolName)
     ? PER_TOOL_REPEATABLE_CAP
     : PER_TOOL_DEFAULT_CAP;

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -224,6 +224,31 @@ console.log('\n── Loop guard: repeatable tools get the higher cap (#783) ─
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Distinct read calls are read-heavy context gathering, not repeated-tool loops.
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: distinct read calls are not capped by per-tool count ──');
+
+{
+  resetToolCallLoopGuard();
+
+  for (let i = 1; i <= 20; i++) {
+    const result = checkToolCallLoop('read', { path: `file-${i}.ts` });
+    assert.ok(result.block === false, `distinct read call ${i} should be allowed`);
+  }
+
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 4; i++) {
+    const result = checkToolCallLoop('read', { path: 'same-file.ts' });
+    assert.ok(result.block === false, `identical read call ${i} should be allowed`);
+  }
+
+  const blocked = checkToolCallLoop('read', { path: 'same-file.ts' });
+  assert.ok(blocked.block === true, '5th identical read call should still be blocked');
+  assert.ok(blocked.reason?.includes('identical args'), 'read loops should be caught by Guard 1');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Per-tool counts are independent per tool and reset together
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- Exempted distinct read calls from the per-tool loop cap, added regression coverage, and verified with the focused guard test plus diff check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1067
- [#1067 [Bug]: Tool-call loop guard blocks legitimate distinct `read` calls in read-heavy turns — the 16th distinct file read in one turn is misclassified as a "repeated tool" / "infinite loop"](https://github.com/open-gsd/gsd-pi/issues/1067)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1067-bug-tool-call-loop-guard-blocks-legitima-1782799880`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard tweak for one tool name with tests; only increases allowance for `read`, leaving bash/workflow caps and identical-call detection unchanged.
> 
> **Overview**
> Fixes false positives where read-heavy turns hit the **per-tool-name cap** (Guard 2) after many **distinct** `read` paths—e.g. the 16th file when `read` was treated like other repeatable tools with a ceiling of 15.
> 
> Adds `PER_TOOL_CAP_EXEMPT_TOOLS` containing **`read`**. After Guard 1 runs, exempt tools skip Guard 2 entirely so normal context gathering across many files is not blocked. **Identical** repeated reads are still limited by the **identical-signature** guard (5th same path blocks).
> 
> Regression tests cover 20+ distinct reads allowed and that the 5th identical `read` still blocks with an `identical args` reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e45ac9fa96aac5ff3d43d90310da08ee7094b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->