### PR TITLE
fix(issue): gsd_exec bash runtime spawns bare "bash" instead of using getShellConfig() — routes into WSL on Windows

### DIFF
--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -12,7 +12,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
-import { killProcessTree, SIGKILL_GRACE_MS, HARD_DEADLINE_MS } from "@gsd/pi-coding-agent";
+import { getShellConfig, killProcessTree, SIGKILL_GRACE_MS, HARD_DEADLINE_MS } from "@gsd/pi-coding-agent";
 
 export interface ExecSandboxRequest {
   /** Interpreter to use. */
@@ -138,7 +138,12 @@ function clampTimeout(request: ExecSandboxRequest, opts: ExecSandboxOptions): nu
 function resolveCommand(runtime: ExecSandboxRequest["runtime"]): { cmd: string; args: string[] } {
   switch (runtime) {
     case "bash":
-      return { cmd: "bash", args: ["-c"] };
+      try {
+        const { shell, args } = getShellConfig();
+        return { cmd: shell, args };
+      } catch {
+        return { cmd: "bash", args: ["-c"] };
+      }
     case "node":
       return { cmd: process.execPath, args: ["-e"] };
     case "python":

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:f
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { getShellConfig } from '@gsd/pi-coding-agent';
 import { EXEC_DEFAULTS, runExecSandbox, type ExecSandboxOptions } from '../exec-sandbox.ts';
 import { buildExecOptions, executeGsdExec } from '../tools/exec-tool.ts';
 import { isContextModeEnabled } from '../preferences-types.ts';
@@ -48,6 +49,21 @@ test('runExecSandbox: captures stdout, persists artifacts, returns digest', asyn
     const meta = JSON.parse(readFileSync(result.meta_path, 'utf-8')) as Record<string, unknown>;
     assert.equal(meta.runtime, 'bash');
     assert.equal(meta.exit_code, 0);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('runExecSandbox: bash runtime uses resolved shell config', async () => {
+  const base = freshBase();
+  try {
+    const { shell } = getShellConfig();
+    const result = await runExecSandbox(
+      { runtime: 'bash', script: 'printf "%s" "$0"' },
+      baseOpts(base),
+    );
+    assert.equal(result.exit_code, 0);
+    assert.equal(readFileSync(result.stdout_path, 'utf-8'), shell);
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Fixed gsd_exec bash shell resolution via getShellConfig and verified syntax/diff checks, with full tests blocked by unavailable registry DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1070
- [#1070 gsd_exec bash runtime spawns bare "bash" instead of using getShellConfig() — routes into WSL on Windows](https://github.com/open-gsd/gsd-pi/issues/1070)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1070-gsd-exec-bash-runtime-spawns-bare-bash-i-1782810321`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized spawn change aligned with existing shell tooling; fallback preserves prior behavior if getShellConfig fails.
> 
> **Overview**
> **gsd_exec**’s `bash` runtime no longer hardcodes `bash -c`; it now uses **`getShellConfig()`** from `@gsd/pi-coding-agent` (same path as async bash and bg-shell), with a fallback to `bash -c` if resolution fails.
> 
> On Windows this avoids routing through bare `bash` (e.g. into WSL) and uses the configured shell instead. A regression test asserts the spawned process matches the resolved shell path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3952ddd08c3b270c418b38527708d048fb3ebeb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->