### PR TITLE
fix(issue): Auto-mode silently ignores undeclared nested git repos: edits never committed, no warning

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -12,6 +12,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import { isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
@@ -1269,6 +1270,7 @@ function collectRepositoryDirtyStatus(basePath: string): Record<string, boolean>
   const preferences = loadEffectiveGSDPreferences(basePath)?.preferences;
   const registry = createRepositoryRegistryFromPreferences(basePath, preferences);
   const dirtyByRepository: Record<string, boolean> = {};
+  const registeredRoots = new Set(registry.repositories.map((repo) => resolve(repo.root)));
   for (const repo of registry.repositories) {
     try {
       dirtyByRepository[repo.id] = runGit(repo.root, ["status", "--porcelain"]).length > 0;
@@ -1277,7 +1279,68 @@ function collectRepositoryDirtyStatus(basePath: string): Record<string, boolean>
       dirtyByRepository[repo.id] = nativeHasChanges(repo.root);
     }
   }
+  for (const repoRoot of findUndeclaredNestedGitRepositories(registry.projectRoot, registeredRoots)) {
+    let dirty = false;
+    try {
+      dirty = runGit(repoRoot, ["status", "--porcelain"]).length > 0;
+    } catch {
+      dirty = nativeHasChanges(repoRoot);
+    }
+    if (!dirty) continue;
+
+    const relPath = relative(registry.projectRoot, repoRoot).split(sep).join("/") || repoRoot;
+    const label = `${relPath} (undeclared)`;
+    dirtyByRepository[label] = true;
+    logWarning(
+      "engine",
+      `undeclared dirty nested git repo ${relPath}; declare it under workspace.repositories or commit manually`,
+      { file: "git-service.ts" },
+    );
+  }
   return dirtyByRepository;
+}
+
+const UNDECLARED_NESTED_REPO_SCAN_MAX_DEPTH = 4;
+const UNDECLARED_NESTED_REPO_SKIP_DIRS = new Set([
+  ".git",
+  ".gsd",
+  ".gsd-worktrees",
+  "node_modules",
+  "dist",
+  "dist-test",
+]);
+
+function findUndeclaredNestedGitRepositories(projectRoot: string, registeredRoots: ReadonlySet<string>): string[] {
+  const found: string[] = [];
+
+  function visit(dir: string, depth: number): void {
+    if (depth >= UNDECLARED_NESTED_REPO_SCAN_MAX_DEPTH) return;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (UNDECLARED_NESTED_REPO_SKIP_DIRS.has(entry.name)) continue;
+
+      const child = join(dir, entry.name);
+      const childRoot = resolve(child);
+      const hasGitDir = existsSync(join(child, ".git"));
+      const isRegistered = registeredRoots.has(childRoot);
+      if (hasGitDir && !isRegistered) {
+        found.push(childRoot);
+        continue;
+      }
+      visit(child, depth + 1);
+    }
+  }
+
+  visit(projectRoot, 0);
+  return found;
 }
 
 function runPerRepositoryCommitAction(args: {

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { execSync } from "node:child_process";
 import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
 import { handleTurnGitActionError, runTurnGitAction } from "../git-service.ts";
+import { _resetLogs, drainLogs } from "../workflow-logger.ts";
 
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, stdio: "pipe", encoding: "utf-8" }).trim();
@@ -107,6 +108,43 @@ workspace:
     assert.equal(result.dirtyRepositories?.frontend, true);
     assert.equal(result.dirtyRepositories?.backend, false);
   } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("uok gitops turn action status-only reports dirty undeclared nested git repositories", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-uok-gitops-nested-"));
+  try {
+    initRepo(root);
+    mkdirSync(join(root, "nested"), { recursive: true });
+    initRepo(join(root, "nested"));
+    writeFileSync(join(root, ".gitignore"), "nested/\n", "utf-8");
+    run("git add .gitignore", root);
+    run('git commit -m "chore: ignore nested repo"', root);
+
+    writeFileSync(join(root, "nested", "README.md"), "# Dirty nested\n", "utf-8");
+
+    _resetLogs();
+    const result = runTurnGitAction({
+      basePath: root,
+      action: "status-only",
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+    const warnings = drainLogs();
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.dirty, true);
+    assert.deepEqual(result.dirtyRepositories, {
+      project: false,
+      "nested (undeclared)": true,
+    });
+    assert.ok(
+      warnings.some((entry) => entry.message.includes("undeclared dirty nested git repo nested")),
+      "dirty undeclared nested repo should be logged as a warning",
+    );
+  } finally {
+    _resetLogs();
     rmSync(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Added dirty undeclared nested Git repo detection and warning coverage; `git diff --check` passed, focused tests were blocked by missing deps and offline install.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1071
- [#1071 Auto-mode silently ignores undeclared nested git repos: edits never committed, no warning](https://github.com/open-gsd/gsd-pi/issues/1071)

## User
- @splichy

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1071-auto-mode-silently-ignores-undeclared-ne-1782810683`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive dirty-status scanning and logging only; registered-repo commit paths are unchanged, with bounded filesystem walk and existing git status fallbacks.
> 
> **Overview**
> **Fixes silent auto-mode blind spots** when edits live in a nested git checkout that is not declared under `workspace.repositories`.
> 
> `collectRepositoryDirtyStatus` (used by every `runTurnGitAction` path) still probes registered repos as before, then **walks the project root** (depth capped at 4, skipping dirs like `node_modules`, `.gsd`, etc.) for directories containing `.git` that are **not** already in the registry. If any such repo has a dirty working tree, the result adds a key like ``nested (undeclared)`` with `true`, sets overall `dirty` accordingly, and emits an **engine warning** telling the user to declare the repo or commit manually.
> 
> Commit behavior for undeclared nested repos is unchanged—they are still not auto-committed—but **status-only / snapshot / commit** turns now surface the problem instead of reporting a clean project repo only.
> 
> A regression test covers a dirty nested repo under a gitignored `nested/` folder and asserts the dirty map plus warning message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05617f1527da1b4bd305d1e07305cec84dff54a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->