### PR TITLE
fix(issue): [Windows][v1.3.0] /gsd auto exits back to PowerShell and headless auto child crashes during bootstrap with code 0xC0000409

### DIFF
--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-client.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-client.ts
@@ -87,11 +87,19 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		this.process = spawn("node", [cliPath, ...args], {
+		let startupError: Error | null = null;
+
+		this.process = spawn(process.execPath, [cliPath, ...args], {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],
 		});
+
+		const onProcessError = (error: Error) => {
+			startupError = this.handleProcessError(error);
+		};
+		this.process.on("error", onProcessError);
+		this.process.stdin?.on("error", onProcessError);
 
 		// Collect stderr for debugging. The agent process can run for hours/days,
 		// so cap the retained tail to avoid unbounded heap growth — only the most
@@ -114,15 +122,16 @@ export class RpcClient {
 			if (this.pendingRequests.size > 0) {
 				const reason = signal ? `signal ${signal}` : `code ${code}`;
 				const error = new Error(`Agent process exited unexpectedly (${reason}). Stderr: ${this.stderr}`);
-				for (const [id, pending] of this.pendingRequests) {
-					this.pendingRequests.delete(id);
-					pending.reject(error);
-				}
+				this.rejectPendingRequests(error);
 			}
 		});
 
 		// Wait a moment for process to initialize
 		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		if (startupError) {
+			throw startupError;
+		}
 
 		if (this.process.exitCode !== null) {
 			throw new Error(`Agent process exited immediately with code ${this.process.exitCode}. Stderr: ${this.stderr}`);
@@ -537,6 +546,20 @@ export class RpcClient {
 			}
 		} catch {
 			// Ignore non-JSON lines
+		}
+	}
+
+	private handleProcessError(error: Error): Error {
+		const stderr = this.stderr ? ` Stderr: ${this.stderr}` : "";
+		const wrapped = new Error(`Agent process error: ${error.message}.${stderr}`, { cause: error });
+		this.rejectPendingRequests(wrapped);
+		return wrapped;
+	}
+
+	private rejectPendingRequests(error: Error): void {
+		for (const [id, pending] of this.pendingRequests) {
+			this.pendingRequests.delete(id);
+			pending.reject(error);
 		}
 	}
 

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-protocol-v2.test.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-protocol-v2.test.ts
@@ -9,6 +9,9 @@
 import { describe, it, beforeEach, afterEach, mock } from "node:test";
 import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
 import type {
 	RpcCommand,
@@ -505,6 +508,29 @@ describe("RpcClient command serialization", () => {
 		assert.equal(parsed.runId, "run-uuid-abc");
 		assert.equal(parsed.command, "prompt");
 		assert.equal(parsed.success, true);
+	});
+});
+
+// ============================================================================
+// RpcClient process bootstrap tests
+// ============================================================================
+
+describe("RpcClient process bootstrap", () => {
+	it("starts the agent with the current Node executable", async () => {
+		const { RpcClient } = await import("./rpc-client.js");
+		const dir = mkdtempSync(join(tmpdir(), "gsd-agent-modes-rpc-client-"));
+		const scriptPath = join(dir, "agent.js");
+		writeFileSync(scriptPath, "setInterval(() => {}, 1000);\n");
+
+		const client = new RpcClient({ cliPath: scriptPath });
+
+		try {
+			await client.start();
+			assert.equal((client as any).process.spawnfile, process.execPath);
+		} finally {
+			await client.stop();
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,11 +35,15 @@ import type { EnsureRtkResult } from './rtk.js'
 
 type PiCodingAgentModule = typeof import('@gsd/pi-coding-agent')
 type AgentCoreModule = typeof import('@gsd/agent-core')
-type AgentModesModule = typeof import('@gsd/agent-modes')
+type InteractiveModeModule = typeof import('@gsd/agent-modes/modes/interactive/interactive-mode.js')
+type PrintModeModule = typeof import('@gsd/agent-modes/modes/print-mode.js')
+type RpcModeModule = typeof import('@gsd/agent-modes/modes/rpc/rpc-mode.js')
 
 let piCodingAgentModulePromise: Promise<PiCodingAgentModule> | undefined
 let agentCoreModulePromise: Promise<AgentCoreModule> | undefined
-let agentModesModulePromise: Promise<AgentModesModule> | undefined
+let interactiveModeModulePromise: Promise<InteractiveModeModule> | undefined
+let printModeModulePromise: Promise<PrintModeModule> | undefined
+let rpcModeModulePromise: Promise<RpcModeModule> | undefined
 
 function loadPiCodingAgentModule(): Promise<PiCodingAgentModule> {
   return (piCodingAgentModulePromise ??= import('@gsd/pi-coding-agent'))
@@ -49,8 +53,16 @@ function loadAgentCoreModule(): Promise<AgentCoreModule> {
   return (agentCoreModulePromise ??= import('@gsd/agent-core'))
 }
 
-function loadAgentModesModule(): Promise<AgentModesModule> {
-  return (agentModesModulePromise ??= import('@gsd/agent-modes'))
+function loadInteractiveModeModule(): Promise<InteractiveModeModule> {
+  return (interactiveModeModulePromise ??= import('@gsd/agent-modes/modes/interactive/interactive-mode.js'))
+}
+
+function loadPrintModeModule(): Promise<PrintModeModule> {
+  return (printModeModulePromise ??= import('@gsd/agent-modes/modes/print-mode.js'))
+}
+
+function loadRpcModeModule(): Promise<RpcModeModule> {
+  return (rpcModeModulePromise ??= import('@gsd/agent-modes/modes/rpc/rpc-mode.js'))
 }
 
 // ---------------------------------------------------------------------------
@@ -569,7 +581,6 @@ const {
   SessionManager,
 } = await loadPiCodingAgentModule()
 const { createAgentSession } = await loadAgentCoreModule()
-const { InteractiveMode, runPrintMode, runRpcMode } = await loadAgentModesModule()
 markStartup('loadPiCodingAgent')
 
 // Pi's tool bootstrap can mis-detect already-installed fd/rg on some systems
@@ -727,6 +738,7 @@ if (isPrintMode) {
   const mode = cliFlags.mode || 'text'
 
   if (mode === 'rpc') {
+    const { runRpcMode } = await loadRpcModeModule()
     printStartupTimings()
     await runRpcMode(session)
     process.exit(0)
@@ -754,6 +766,7 @@ if (isPrintMode) {
     await new Promise(() => {})
   }
 
+  const { runPrintMode } = await loadPrintModeModule()
   printStartupTimings()
   await runPrintMode(session, {
     mode: mode as 'text' | 'json',
@@ -905,6 +918,7 @@ if (!process.stdin.isTTY || !process.stdout.isTTY) {
   printNonTtyErrorAndExit(missing, true)
 }
 
+const { InteractiveMode } = await loadInteractiveModeModule()
 const interactiveMode = new InteractiveMode(session)
 markStartup('InteractiveMode')
 printStartupTimings()

--- a/src/headless-answers.ts
+++ b/src/headless-answers.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync } from 'node:fs'
-import { serializeJsonLine } from '@gsd/agent-modes'
+import { serializeJsonLine } from '@gsd/agent-modes/modes/rpc/jsonl.js'
 import { canonicalHeadlessToolName } from './headless-events.js'
 
 // ---------------------------------------------------------------------------

--- a/src/headless-ui.ts
+++ b/src/headless-ui.ts
@@ -8,7 +8,8 @@
 
 import type { Readable } from 'node:stream'
 
-import { RpcClient, attachJsonlLineReader } from '@gsd/agent-modes'
+import type { RpcClient } from '@gsd/agent-modes/modes/rpc/rpc-client.js'
+import { attachJsonlLineReader } from '@gsd/agent-modes/modes/rpc/jsonl.js'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -17,7 +17,7 @@ import { join } from 'node:path'
 import { resolve } from 'node:path'
 import { ChildProcess } from 'node:child_process'
 
-import { RpcClient } from '@gsd/agent-modes'
+import { RpcClient } from '@gsd/agent-modes/modes/rpc/rpc-client.js'
 import { SessionManager } from '@gsd/pi-coding-agent'
 import type { SessionInfo } from '@gsd/pi-coding-agent'
 import { getProjectSessionsDir } from './project-sessions.js'


### PR DESCRIPTION
## Summary
- Fixed Windows headless/RPC bootstrap by avoiding eager TUI/native imports, using process.execPath for the RPC child, and verifying with syntax and diff checks while package tests were blocked by unavailable dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1074
- [#1074 [Windows][v1.3.0] /gsd auto exits back to PowerShell and headless auto child crashes during bootstrap with code 0xC0000409](https://github.com/open-gsd/gsd-pi/issues/1074)

## User
- @BuXianMeng

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1074-windows-v1-3-0-gsd-auto-exits-back-to-po-1782816085`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI startup and headless/RPC child spawning on all platforms; behavior change is intentional but mis-timed lazy imports could break rarely-used modes.
> 
> **Overview**
> Addresses **Windows v1.3.0** failures where interactive `/gsd` bailed to PowerShell and **headless auto** crashed during RPC child bootstrap (**0xC0000409**).
> 
> **`RpcClient`** now spawns the agent with **`process.execPath`** instead of a hardcoded `node` on `PATH`, listens for **process/stdin errors** during startup, surfaces them after the short init delay, and centralizes **pending RPC rejection** on spawn errors and unexpected exit.
> 
> **`cli.ts`** stops eagerly importing the **`@gsd/agent-modes` barrel** (which pulled in interactive/TUI code). It **lazy-loads** `interactive-mode`, `print-mode`, and `rpc-mode` only on the path that needs them. **`headless.ts`** imports **`RpcClient`** from the **rpc-client subpath** for the same reason.
> 
> A test asserts the RPC child uses **`process.execPath`** as `spawnfile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b6a4cf298d78cfb574c0214295ae9354b481af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->