### PR TITLE
fix(issue): [Bug]: Root-write-leak guard flags `.gsd-backups/` and `.gsd-worktrees/` as leaks, hard-pausing `/gsd auto`

### DIFF
--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -24,7 +24,7 @@ import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
  * With external state (symlink), these are a no-op in most cases,
  * but retained for backwards compatibility during migration.
  */
-const GSD_RUNTIME_PATTERNS = [
+export const GSD_RUNTIME_PATTERNS = [
   ".gsd-worktrees/",
   ".gsd-backups/",
   ".gsd/activity/",

--- a/src/resources/extensions/gsd/root-write-leak-guard.ts
+++ b/src/resources/extensions/gsd/root-write-leak-guard.ts
@@ -5,8 +5,18 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { GSD_RUNTIME_PATTERNS } from "./gitignore.js";
 
 const MAX_SYNC_FINGERPRINT_BYTES = 1_500_000_000;
+const ROOT_RUNTIME_PATH_PREFIXES = Array.from(
+  new Set(
+    GSD_RUNTIME_PATTERNS.map((pattern) => {
+      const path = pattern.replace(/\/+$/, "");
+      const slash = path.indexOf("/");
+      return slash === -1 ? path : path.slice(0, slash);
+    }),
+  ),
+);
 
 export interface RootDirtyEntry {
   path: string;
@@ -25,7 +35,9 @@ export interface RootWriteLeak {
 export type RootDirtySnapshot = Map<string, RootDirtyEntry>;
 
 function isRootRuntimePath(path: string): boolean {
-  return path === ".gsd" || path.startsWith(".gsd/");
+  return ROOT_RUNTIME_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
 }
 
 function fileFingerprint(rootPath: string, relPath: string): string {

--- a/src/resources/extensions/gsd/tests/root-write-leak-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/root-write-leak-guard.test.ts
@@ -7,7 +7,26 @@ import { closeSync, ftruncateSync, openSync, statSync, writeFileSync } from "nod
 import { join } from "node:path";
 
 import { captureRootDirtySnapshot } from "../root-write-leak-guard.ts";
-import { cleanup, git, makeTempRepo } from "./test-utils.ts";
+import { cleanup, createFile, git, makeTempRepo } from "./test-utils.ts";
+
+test("captureRootDirtySnapshot ignores unignored GSD root runtime directories", () => {
+  const base = makeTempRepo("gsd-root-dirty-runtime-");
+  try {
+    createFile(base, ".gsd/STATE.md", "state\n");
+    createFile(base, ".gsd-backups/snap-001", "backup\n");
+    createFile(base, ".gsd-worktrees/M001/file.txt", "worktree\n");
+    createFile(base, "src/foo.ts", "export {};\n");
+
+    const snapshot = captureRootDirtySnapshot(base);
+
+    assert.equal(snapshot.has(".gsd/STATE.md"), false);
+    assert.equal(snapshot.has(".gsd-backups/snap-001"), false);
+    assert.equal(snapshot.has(".gsd-worktrees/M001/file.txt"), false);
+    assert.equal(snapshot.has("src/foo.ts"), true);
+  } finally {
+    cleanup(base);
+  }
+});
 
 test("captureRootDirtySnapshot does not read dirty files larger than Node's Buffer limit", () => {
   const base = makeTempRepo("gsd-root-dirty-large-");


### PR DESCRIPTION
## Summary
- Derived the root-write leak guard allowlist from GSD runtime patterns and verified the focused regression test passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1049
- [#1049 [Bug]: Root-write-leak guard flags `.gsd-backups/` and `.gsd-worktrees/` as leaks, hard-pausing `/gsd auto`](https://github.com/open-gsd/gsd-pi/issues/1049)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1049-bug-root-write-leak-guard-flags-gsd-back-1782824223`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to auto-mode dirty-snapshot filtering with a focused regression test; no auth, data, or broad workflow refactors.
> 
> **Overview**
> Fixes false **root-write leak** detections that could hard-stop `/gsd auto` when legitimate GSD runtime paths under `.gsd-backups/` or `.gsd-worktrees/` (and other canonical runtime dirs) show up as dirty in the project root.
> 
> The leak guard’s runtime allowlist is no longer limited to `.gsd/*`. It now derives top-level path prefixes from the exported **`GSD_RUNTIME_PATTERNS`** in `gitignore.ts`, keeping it in sync with the documented source of truth for runtime ignores.
> 
> A regression test asserts that `captureRootDirtySnapshot` skips those runtime paths but still records normal source changes like `src/foo.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78e6bcdeb3b1878158eee98f6eccefb0eaa26de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->