### PR TITLE
fix(issue): [Bug]: saveEvidenceToDisk rewrites the entire evidence file 3 times per native tool call within an execute-task unit

### DIFF
--- a/src/resources/extensions/gsd/safety/evidence-collector.ts
+++ b/src/resources/extensions/gsd/safety/evidence-collector.ts
@@ -65,12 +65,16 @@ const MCP_EXECUTION_TOOL_RE = /^mcp__.+__gsd_(?:uat_)?exec(?:_search)?$/;
 // ─── Module State ───────────────────────────────────────────────────────────
 
 let unitEvidence: EvidenceEntry[] = [];
+let lastWritePath: string | null = null;
+let lastWriteSig: string | null = null;
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 /** Reset all evidence for a new unit. Call at unit start. */
 export function resetEvidence(): void {
   unitEvidence = [];
+  lastWritePath = null;
+  lastWriteSig = null;
 }
 
 /** Get a read-only view of all evidence collected for the current unit. */
@@ -145,10 +149,15 @@ export function saveEvidenceToDisk(
 ): void {
   try {
     const path = evidencePath(basePath, milestoneId, sliceId, taskId);
+    const body = JSON.stringify(unitEvidence, null, 2) + "\n";
+    if (path === lastWritePath && body === lastWriteSig) return;
+
     mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp.${randomBytes(4).toString("hex")}`;
-    writeFileSync(tmp, JSON.stringify(unitEvidence, null, 2) + "\n", "utf-8");
+    writeFileSync(tmp, body, "utf-8");
     renameSync(tmp, path);
+    lastWritePath = path;
+    lastWriteSig = body;
   } catch {
     // Non-fatal — don't let persistence failures break unit execution
   }
@@ -167,6 +176,8 @@ export function loadEvidenceFromDisk(
   taskId: string,
 ): void {
   try {
+    lastWritePath = null;
+    lastWriteSig = null;
     const path = evidencePath(basePath, milestoneId, sliceId, taskId);
     if (!existsSync(path)) return;
     const raw = readFileSync(path, "utf-8");
@@ -194,6 +205,10 @@ export function clearEvidenceFromDisk(
     const path = evidencePath(basePath, milestoneId, sliceId, taskId);
     if (existsSync(path)) {
       unlinkSync(path);
+    }
+    if (path === lastWritePath) {
+      lastWritePath = null;
+      lastWriteSig = null;
     }
   } catch {
     // Non-fatal

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -15,14 +15,20 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   resetEvidence,
   getEvidence,
   recordToolCall,
   recordToolResult,
+  saveEvidenceToDisk,
   type BashEvidence,
 } from "../safety/evidence-collector.js";
+
+const waitForMtimeTick = () => new Promise(resolve => setTimeout(resolve, 25));
 
 describe("evidence-collector: toolCallId-based matching (A-3)", () => {
   beforeEach(() => {
@@ -118,5 +124,29 @@ describe("evidence-collector: toolCallId-based matching (A-3)", () => {
     assert.equal(entries[0].command, "pnpm test");
     assert.equal(entries[1].kind, "bash");
     assert.equal(entries[1].command, "rg TODO");
+  });
+
+  it("skips byte-identical evidence file rewrites", async (t) => {
+    const base = mkdtempSync(join(tmpdir(), "gsd-evidence-dedupe-"));
+    t.after(() => rmSync(base, { recursive: true, force: true }));
+
+    recordToolCall("tc-bash-1", "bash", { command: "pnpm test" });
+    saveEvidenceToDisk(base, "M001", "S01", "T03");
+
+    const evidenceFile = join(base, ".gsd", "safety", "evidence-M001-S01-T03.json");
+    const firstMtime = statSync(evidenceFile, { bigint: true }).mtimeNs;
+
+    await waitForMtimeTick();
+    saveEvidenceToDisk(base, "M001", "S01", "T03");
+    const secondMtime = statSync(evidenceFile, { bigint: true }).mtimeNs;
+
+    assert.equal(secondMtime, firstMtime, "unchanged evidence must not rewrite the evidence file");
+
+    await waitForMtimeTick();
+    recordToolResult("tc-bash-1", "bash", "Command exited with code 0\nok\n", false);
+    saveEvidenceToDisk(base, "M001", "S01", "T03");
+    const thirdMtime = statSync(evidenceFile, { bigint: true }).mtimeNs;
+
+    assert.ok(thirdMtime > secondMtime, "changed evidence must still be persisted");
   });
 });


### PR DESCRIPTION
## Summary
- Added evidence-save deduplication and verified it with focused collector/cross-reference tests plus git diff --check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1040
- [#1040 [Bug]: saveEvidenceToDisk rewrites the entire evidence file 3 times per native tool call within an execute-task unit](https://github.com/open-gsd/gsd-pi/issues/1040)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1040-bug-saveevidencetodisk-rewrites-the-enti-1782824233`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized safety persistence optimization with cache invalidation on load/clear; behavior change is skipping no-op writes only.
> 
> **Overview**
> **`saveEvidenceToDisk`** now compares the target path and serialized evidence body to the last successful write and **returns early** when nothing changed, so repeated hook calls during a single native tool (dispatch, execution start, result) no longer rewrite the same JSON file.
> 
> Module state tracks **`lastWritePath`** / **`lastWriteSig`**, cleared on **`resetEvidence`**, **`loadEvidenceFromDisk`**, and when **`clearEvidenceFromDisk`** removes the cached file. A regression test asserts unchanged evidence keeps **`mtime`** stable and updated evidence still persists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f565a20d61a0bd6cdd7d628e9c04fc2547945222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->