### PR TITLE
fix(issue): [Bug]: memories_fts stays empty when FTS5 becomes available after schema V19 already ran without it

### DIFF
--- a/src/resources/extensions/gsd/db-memory-fts-schema.ts
+++ b/src/resources/extensions/gsd/db-memory-fts-schema.ts
@@ -2,9 +2,16 @@
 // File Purpose: Memory FTS5 SQLite schema helpers for the GSD database facade.
 
 import type { DbAdapter } from "./db-adapter.js";
+import { createRuntimeKvTableV25 } from "./db-runtime-kv-schema.js";
+
+export const MEMORIES_FTS_REBUILT_KEY = "memories_fts_rebuilt_at";
 
 export interface MemoryFtsSchemaOptions {
   onUnavailable?: (message: string) => void;
+}
+
+export interface MemoryFtsRebuildOptions {
+  onRebuildFailed?: (message: string) => void;
 }
 
 function formatFtsUnavailableError(err: unknown): string {
@@ -62,5 +69,43 @@ export function isMemoriesFtsAvailableSchema(db: DbAdapter): boolean {
     return !!row;
   } catch {
     return false;
+  }
+}
+
+export function rebuildMemoriesFtsSchemaOnce(
+  db: DbAdapter,
+  options: MemoryFtsRebuildOptions = {},
+): void {
+  if (!isMemoriesFtsAvailableSchema(db)) return;
+
+  createRuntimeKvTableV25(db);
+  const marker = db.prepare(
+    "SELECT 1 as present FROM runtime_kv WHERE scope = 'global' AND scope_id = '' AND key = :key",
+  ).get({ ":key": MEMORIES_FTS_REBUILT_KEY });
+  if (marker) return;
+
+  const now = new Date().toISOString();
+  try {
+    db.exec("BEGIN");
+    db.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')");
+    db.prepare(
+      `INSERT INTO runtime_kv (scope, scope_id, key, value_json, updated_at)
+       VALUES ('global', '', :key, :value_json, :updated_at)
+       ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+         value_json = excluded.value_json,
+         updated_at = excluded.updated_at`,
+    ).run({
+      ":key": MEMORIES_FTS_REBUILT_KEY,
+      ":value_json": JSON.stringify(now),
+      ":updated_at": now,
+    });
+    db.exec("COMMIT");
+  } catch (err) {
+    try {
+      db.exec("ROLLBACK");
+    } catch {
+      // Best effort: leave startup alive and retry the rebuild on next open.
+    }
+    options.onRebuildFailed?.(`FTS5 rebuild failed: ${(err as Error).message}`);
   }
 }

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -47,7 +47,11 @@ import {
   applyMigrationV28MemoryLastHitAt,
   applyMigrationV29RepositoryTargets,
 } from "../db-migration-steps.js";
-import { isMemoriesFtsAvailableSchema, tryCreateMemoriesFtsSchema } from "../db-memory-fts-schema.js";
+import {
+  isMemoriesFtsAvailableSchema,
+  rebuildMemoriesFtsSchemaOnce,
+  tryCreateMemoriesFtsSchema,
+} from "../db-memory-fts-schema.js";
 import { createDbOpenState, type DbOpenPhase } from "../db-open-state.js";
 import { createRuntimeKvTableV25 } from "../db-runtime-kv-schema.js";
 import { getCurrentSchemaVersion, recordSchemaVersion } from "../db-schema-metadata.js";
@@ -134,6 +138,9 @@ function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): 
   }
 
   migrateSchema(db, dbPath);
+  rebuildMemoriesFtsSchemaOnce(db, {
+    onRebuildFailed: (message) => logWarning("db", message),
+  });
 }
 
 export function _isLikelyWslDrvFsPathForTest(dbPath: string | null): boolean {

--- a/src/resources/extensions/gsd/tests/db-memory-fts-schema.test.ts
+++ b/src/resources/extensions/gsd/tests/db-memory-fts-schema.test.ts
@@ -3,11 +3,16 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import {
+  MEMORIES_FTS_REBUILT_KEY,
   isMemoriesFtsAvailableSchema,
+  rebuildMemoriesFtsSchemaOnce,
   tryCreateMemoriesFtsSchema,
 } from "../db-memory-fts-schema.ts";
-import type { DbAdapter, DbStatement } from "../db-adapter.ts";
+import { createDbAdapter, type DbAdapter, type DbStatement } from "../db-adapter.ts";
+
+const _require = createRequire(import.meta.url);
 
 class FakeStatement implements DbStatement {
   private readonly row: Record<string, unknown> | undefined;
@@ -32,6 +37,7 @@ class FakeStatement implements DbStatement {
 class FakeAdapter implements DbAdapter {
   readonly execCalls: string[] = [];
   hasFts = false;
+  hasRebuildMarker = false;
   failExec = false;
 
   exec(sql: string): void {
@@ -39,11 +45,24 @@ class FakeAdapter implements DbAdapter {
     if (this.failExec) throw new Error("fts unavailable");
   }
 
-  prepare(): DbStatement {
-    return new FakeStatement(this.hasFts ? { name: "memories_fts" } : undefined);
+  prepare(sql: string): DbStatement {
+    if (sql.includes("sqlite_master")) {
+      return new FakeStatement(this.hasFts ? { name: "memories_fts" } : undefined);
+    }
+    if (sql.includes("runtime_kv")) {
+      return new FakeStatement(this.hasRebuildMarker ? { present: 1 } : undefined);
+    }
+    return new FakeStatement(undefined);
   }
 
   close(): void {}
+}
+
+function openMemoryAdapter(): { db: DbAdapter; close: () => void } {
+  const sqlite = _require("node:sqlite") as { DatabaseSync: new (path: string) => unknown };
+  const raw = new sqlite.DatabaseSync(":memory:");
+  const db = createDbAdapter(raw);
+  return { db, close: () => db.close() };
 }
 
 describe("db-memory-fts-schema", () => {
@@ -82,5 +101,41 @@ describe("db-memory-fts-schema", () => {
 
     db.hasFts = true;
     assert.equal(isMemoriesFtsAvailableSchema(db), true);
+  });
+
+  test("rebuilds the external-content index once and records a marker", () => {
+    const { db, close } = openMemoryAdapter();
+    try {
+      db.exec("CREATE TABLE memories (seq INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL)");
+      db.exec("INSERT INTO memories (content) VALUES ('pre FTS auth memory must be searchable')");
+
+      const ok = tryCreateMemoriesFtsSchema(db);
+      if (!ok) return;
+
+      const before = db.prepare("SELECT rowid FROM memories_fts WHERE memories_fts MATCH 'auth'").all();
+      assert.equal(before.length, 0, "external-content FTS starts empty for existing rows");
+
+      rebuildMemoriesFtsSchemaOnce(db);
+
+      const after = db.prepare("SELECT rowid FROM memories_fts WHERE memories_fts MATCH 'auth'").all();
+      assert.deepEqual(after.map((row) => row["rowid"]), [1]);
+      const marker = db.prepare(
+        "SELECT value_json FROM runtime_kv WHERE scope = 'global' AND scope_id = '' AND key = :key",
+      ).get({ ":key": MEMORIES_FTS_REBUILT_KEY });
+      assert.ok(marker, "rebuild marker should be stored");
+    } finally {
+      close();
+    }
+  });
+
+  test("skips rebuild when marker already exists", () => {
+    const db = new FakeAdapter();
+    db.hasFts = true;
+    db.hasRebuildMarker = true;
+
+    rebuildMemoriesFtsSchemaOnce(db);
+
+    assert.ok(db.execCalls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS runtime_kv")));
+    assert.ok(!db.execCalls.some((sql) => sql.includes("VALUES('rebuild')")));
   });
 });

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -5,6 +5,9 @@ import {
   SCHEMA_VERSION,
   _getAdapter,
 } from '../gsd-db.ts';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import {
   _resetLogs,
   peekLogs,
@@ -22,12 +25,23 @@ import {
   markUnitProcessed,
   decayStaleMemories,
   enforceMemoryCap,
+  queryMemoriesRanked,
   applyMemoryActions,
   formatMemoriesForPrompt,
 } from '../memory-store.ts';
 import type { MemoryAction } from '../memory-store.ts';
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-memory-store-test-'));
+  return path.join(dir, 'test.db');
+}
+
+function cleanupDbPath(dbPath: string): void {
+  closeDatabase();
+  fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // memory-store: fallback when DB not open
@@ -364,6 +378,40 @@ test('memory-store: schema includes memories table', () => {
   assert.deepStrictEqual(version?.["v"], SCHEMA_VERSION, `schema version should be ${SCHEMA_VERSION}`);
 
   closeDatabase();
+});
+
+test('memory-store: reopening rebuilds FTS index for pre-FTS memories', () => {
+  const dbPath = tempDbPath();
+  try {
+    openDatabase(dbPath);
+    const id = createMemory({ category: 'gotcha', content: 'pre FTS auth memory must become searchable' });
+    assert.equal(id, 'MEM001');
+
+    const adapter = _getAdapter()!;
+    const fts = adapter.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='memories_fts'").get();
+    if (!fts) return;
+
+    adapter.exec('DROP TRIGGER IF EXISTS memories_ai');
+    adapter.exec('DROP TRIGGER IF EXISTS memories_ad');
+    adapter.exec('DROP TRIGGER IF EXISTS memories_au');
+    adapter.exec('DROP TABLE IF EXISTS memories_fts');
+    adapter.prepare(
+      "DELETE FROM runtime_kv WHERE scope = 'global' AND scope_id = '' AND key = 'memories_fts_rebuilt_at'",
+    ).run();
+    closeDatabase();
+
+    openDatabase(dbPath);
+    const reopened = _getAdapter()!;
+    const marker = reopened.prepare(
+      "SELECT value_json FROM runtime_kv WHERE scope = 'global' AND scope_id = '' AND key = 'memories_fts_rebuilt_at'",
+    ).get();
+    assert.ok(marker, 'FTS rebuild marker should be set after reopening');
+
+    const hits = queryMemoriesRanked({ query: 'auth', k: 5 }).map((hit) => hit.memory.id);
+    assert.deepEqual(hits, ['MEM001']);
+  } finally {
+    cleanupDbPath(dbPath);
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Added one-shot FTS rebuild on schema open with runtime_kv marker and verified the focused FTS schema regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1052
- [#1052 [Bug]: memories_fts stays empty when FTS5 becomes available after schema V19 already ran without it](https://github.com/open-gsd/gsd-pi/issues/1052)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1052-bug-memories-fts-stays-empty-when-fts5-b-1782824219`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to startup when FTS exists; failures roll back and retry on next open; marker prevents repeat rebuilds.
> 
> **Overview**
> Fixes **empty `memories_fts`** when FTS5 was unavailable during migration V19 (or the external-content index was never populated for rows that already existed).
> 
> Adds **`rebuildMemoriesFtsSchemaOnce`**, which runs after schema init/migrations on DB open: if `memories_fts` exists and there is no `runtime_kv` marker (`memories_fts_rebuilt_at`), it runs FTS5 **`rebuild`** in a transaction, records the marker, and logs failures without blocking startup.
> 
> **Tests** cover the helper (rebuild + skip-if-marked) and an integration path where reopening the DB makes pre-existing memories searchable via `queryMemoriesRanked`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179a9785d49363b468f224a698718a58d43290b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->