### PR TITLE
fix(issue): [Bug]: GSD startup never calls `configureHttpDispatcher()`, so the `httpIdleTimeoutMs` setting is silently ignored and streamed LLM requests are pinned to undici's fixed 300s idle timeout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -603,6 +603,9 @@ markStartup('ModelRegistry')
 const settingsManager = SettingsManager.create(process.cwd(), agentDir)
 applySecurityOverrides(settingsManager)
 markStartup('SettingsManager.create')
+const { configureHttpDispatcher } = await import('@gsd/pi-coding-agent/core/http-dispatcher.js')
+configureHttpDispatcher(settingsManager.getHttpIdleTimeoutMs())
+markStartup('configureHttpDispatcher')
 
 // Run onboarding wizard on first launch (no LLM provider configured)
 if (!isPrintMode && shouldRunOnboarding(authStorage, settingsManager.getDefaultProvider())) {

--- a/src/tests/app-smoke.test.ts
+++ b/src/tests/app-smoke.test.ts
@@ -115,6 +115,11 @@ test("loader sets all 4 GSD_ env vars and PI_PACKAGE_DIR", async (t) => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
+test("startup wires httpIdleTimeoutMs through configureHttpDispatcher", () => {
+  const cliSource = readFileSync(join(projectRoot, "src", "cli.ts"), "utf-8");
+  assert.match(cliSource, /configureHttpDispatcher\(\s*settingsManager\.getHttpIdleTimeoutMs\(\)\s*\)/);
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 2b. loader runtime dependency checks
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Wired startup to apply httpIdleTimeoutMs through configureHttpDispatcher and verified with the focused smoke test plus diff check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1025
- [#1025 [Bug]: GSD startup never calls `configureHttpDispatcher()`, so the `httpIdleTimeoutMs` setting is silently ignored and streamed LLM requests are pinned to undici's fixed 300s idle timeout](https://github.com/open-gsd/gsd-pi/issues/1025)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1025-bug-gsd-startup-never-calls-configurehtt-1782824269`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted startup change to HTTP client timeouts for LLM traffic; no auth or data-path changes.
> 
> **Overview**
> **GSD startup now applies the `httpIdleTimeoutMs` setting** to the global undici HTTP dispatcher, so streamed LLM requests respect user/project timeout configuration instead of staying on undici’s fixed default idle timeout.
> 
> After `SettingsManager` is created in `cli.ts`, the CLI dynamically imports `configureHttpDispatcher` and calls it with `settingsManager.getHttpIdleTimeoutMs()`, with a startup timing marker added for that step.
> 
> A smoke test in `app-smoke.test.ts` asserts that `cli.ts` keeps this wiring (`configureHttpDispatcher(settingsManager.getHttpIdleTimeoutMs())`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c8f14170204870be703b2da42af422ddf73e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->