### PR TITLE
fix(issue): [Bug]: migrateToExternalState swallows a per-file copy failure then deletes the backup and reports success

### DIFF
--- a/src/resources/extensions/gsd/migrate-external.ts
+++ b/src/resources/extensions/gsd/migrate-external.ts
@@ -118,6 +118,7 @@ export function migrateToExternalState(basePath: string): MigrationResult {
 
     // Copy contents to external dir, skipping worktrees/
     const entries = readdirSync(migratingPath, { withFileTypes: true });
+    const copyFailures: string[] = [];
     for (const entry of entries) {
       if (entry.name === "worktrees") continue; // worktrees stay local
 
@@ -130,9 +131,14 @@ export function migrateToExternalState(basePath: string): MigrationResult {
         } else {
           cpSync(src, dst, { force: true });
         }
-      } catch {
-        // Non-fatal: continue with other files
+      } catch (copyErr) {
+        copyFailures.push(`${entry.name}: ${getErrorMessage(copyErr)}`);
       }
+    }
+    if (copyFailures.length > 0) {
+      try { rmSync(localGsd, { force: true }); } catch { /* may not exist */ }
+      renameSync(migratingPath, localGsd);
+      return { migrated: false, error: `Migration copy failed: ${copyFailures.join("; ")}` };
     }
 
     // Create symlink .gsd -> external path

--- a/src/resources/extensions/gsd/tests/migrate-external-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-external-worktree.test.ts
@@ -7,7 +7,10 @@ import {
   existsSync,
   mkdirSync,
   realpathSync,
+  readFileSync,
 } from "node:fs";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -112,6 +115,60 @@ describe("migrate-external worktree guard (#2970)", () => {
       assert.equal(result.migrated, true, "should migrate on main repo");
     } finally {
       rmSync(mainBase, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("migrateToExternalState copy failure rollback (#1047)", () => {
+  test("restores .gsd when a source entry fails to copy", () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-migrate-copy-fail-")));
+    const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-state-copy-fail-")));
+    const previousStateDir = process.env.GSD_STATE_DIR;
+    const previousProjectId = process.env.GSD_PROJECT_ID;
+    const originalCpSync = fs.cpSync;
+    process.env.GSD_STATE_DIR = stateDir;
+    process.env.GSD_PROJECT_ID = "copy-fail";
+
+    try {
+      run("git init -b main", base);
+      mkdirSync(join(base, ".gsd"), { recursive: true });
+      writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "# prefs\n", "utf-8");
+      writeFileSync(join(base, ".gsd", "gsd.db"), "state", "utf-8");
+      const failingSource = join(base, ".gsd.migrating", "gsd.db");
+      fs.cpSync = ((...args: Parameters<typeof fs.cpSync>) => {
+        const src = args[0];
+        if (String(src) === failingSource) {
+          const error = new Error("simulated copy failure") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        return originalCpSync(...args);
+      }) as typeof fs.cpSync;
+      syncBuiltinESMExports();
+
+      const result = migrateToExternalState(base);
+
+      assert.equal(result.migrated, false, "copy failure must fail the migration");
+      assert.match(result.error ?? "", /Migration copy failed/);
+      assert.ok(existsSync(join(base, ".gsd", "gsd.db")), "source .gsd must be restored");
+      assert.equal(readFileSync(join(base, ".gsd", "PREFERENCES.md"), "utf-8"), "# prefs\n");
+      assert.ok(!existsSync(join(base, ".gsd.migrating")), "backup staging dir must not remain after restore");
+      assert.ok(!existsSync(join(stateDir, "projects", "copy-fail", "gsd.db")), "failed file must not be reported as migrated");
+    } finally {
+      fs.cpSync = originalCpSync;
+      syncBuiltinESMExports();
+      if (previousStateDir === undefined) {
+        delete process.env.GSD_STATE_DIR;
+      } else {
+        process.env.GSD_STATE_DIR = previousStateDir;
+      }
+      if (previousProjectId === undefined) {
+        delete process.env.GSD_PROJECT_ID;
+      } else {
+        process.env.GSD_PROJECT_ID = previousProjectId;
+      }
+      rmSync(base, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- Fixed migrateToExternalState to fail closed on per-file copy errors and verified the targeted migration rollback path.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1047
- [#1047 [Bug]: migrateToExternalState swallows a per-file copy failure then deletes the backup and reports success](https://github.com/open-gsd/gsd-pi/issues/1047)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1047-bug-migratetoexternalstate-swallows-a-pe-1782824226`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the migration path that moves project GSD state; behavior is safer (fail-closed with rollback) but still affects data layout on upgrade.
> 
> **Overview**
> **`migrateToExternalState` no longer ignores errors while copying individual entries from `.gsd.migrating` to external storage.** Failed copies are recorded; if any fail, the function rolls back by restoring `.gsd` from the staging directory and returns `migrated: false` with a `Migration copy failed` message instead of creating the junction and reporting success.
> 
> A regression test simulates a `cpSync` failure and asserts rollback, intact local state, and no partial external copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2341451f51b89a58ed6c4083372ee3667cd486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->