### PR TITLE
fix(gsd): soften context warning session reroot

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -1046,13 +1046,13 @@ disabled_model_providers:
 
 ### `context_management`
 
-Controls observation masking and tool result truncation during auto-mode sessions. Reduces context bloat between compactions with zero LLM overhead.
+Controls observation masking and tool result truncation during auto-mode sessions. Reduces context bloat between compactions with zero LLM overhead. In step mode, the configurable threshold is a soft warning; automatic session re-rooting happens only at the fixed 90% hard context boundary.
 
 ```yaml
 context_management:
   observation_masking: true          # replace old tool results with placeholders (default: true)
   observation_mask_turns: 8          # keep results from last N user turns (1-50, default: 8)
-  compaction_threshold_percent: 0.60 # target compaction at 60% context usage (0.5-0.95, default: 0.60)
+  compaction_threshold_percent: 0.60 # soft warning at 60% context usage (0.5-0.95, default: 0.60)
   tool_result_max_chars: 800         # cap individual tool result content (200-10000, default: 800)
 ```
 

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -735,13 +735,13 @@ dynamic_routing:
 
 ### `context_management`
 
-控制自动模式会话中的 observation masking 和 tool result truncation。可在不增加 LLM 开销的前提下，减少 compaction 之间的上下文膨胀。
+控制自动模式会话中的 observation masking 和 tool result truncation。可在不增加 LLM 开销的前提下，减少 compaction 之间的上下文膨胀。在 step mode 中，可配置阈值只触发软警告；自动 session re-root 只会在固定的 90% 硬上下文边界触发。
 
 ```yaml
 context_management:
   observation_masking: true          # 用占位符替换旧 tool result（默认：true）
   observation_mask_turns: 8          # 保留最近 N 个 user turn 的结果（1-50，默认：8）
-  compaction_threshold_percent: 0.60 # 在 60% 上下文使用率处触发 compaction（0.5-0.95，默认：0.60）
+  compaction_threshold_percent: 0.60 # 在 60% 上下文使用率处触发软警告（0.5-0.95，默认：0.60）
   tool_result_max_chars: 800         # 单个 tool result 的最大字符数（200-10000，默认：800）
 ```
 

--- a/src/resources/extensions/gsd/auto-budget.ts
+++ b/src/resources/extensions/gsd/auto-budget.ts
@@ -79,12 +79,23 @@ export function resolveCompactionThresholdPercent(raw: number | undefined): numb
   return value <= 1 ? value * 100 : value;
 }
 
-export function shouldRerootStepSessionForContext(
+export const HARD_CONTEXT_REROOT_THRESHOLD_PERCENT = 90;
+
+export function shouldWarnStepSessionForContext(
   contextPercent: number | null | undefined,
   compactionThresholdPercent?: number,
 ): boolean {
   return getContextPauseAction(
     contextPercent,
     resolveCompactionThresholdPercent(compactionThresholdPercent),
+  ) === "pause";
+}
+
+export function shouldRerootStepSessionForContext(
+  contextPercent: number | null | undefined,
+): boolean {
+  return getContextPauseAction(
+    contextPercent,
+    HARD_CONTEXT_REROOT_THRESHOLD_PERCENT,
   ) === "pause";
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -99,6 +99,7 @@ import {
   getContextPauseAction,
   resolveCompactionThresholdPercent,
   shouldRerootStepSessionForContext,
+  shouldWarnStepSessionForContext,
 } from "./auto-budget.js";
 import {
   markToolStart as _markToolStart,
@@ -701,6 +702,7 @@ export {
   getContextPauseAction,
   resolveCompactionThresholdPercent,
   shouldRerootStepSessionForContext,
+  shouldWarnStepSessionForContext,
 } from "./auto-budget.js";
 
 function closeOutSignalInterruptedUnit(currentBasePath: string): void {
@@ -1392,7 +1394,7 @@ export async function maybeRerootStepSessionForHighContext(
   const prefs = loadEffectiveGSDPreferences(workspaceRoot);
   const compactionThreshold = prefs?.preferences.context_management?.compaction_threshold_percent;
 
-  if (!shouldRerootStepSessionForContext(contextPercent, compactionThreshold)) {
+  if (!shouldWarnStepSessionForContext(contextPercent, compactionThreshold)) {
     return { rerooted: false };
   }
 
@@ -1403,6 +1405,14 @@ export async function maybeRerootStepSessionForHighContext(
 
   const displayPercent = (contextPercent as number).toFixed(1);
   const thresholdDisplay = resolveCompactionThresholdPercent(compactionThreshold).toFixed(0);
+  if (!shouldRerootStepSessionForContext(contextPercent)) {
+    ctx.ui.notify(
+      `Step complete — context at ${displayPercent}% (soft threshold: ${thresholdDisplay}%). Use /compact when convenient; continuing in this session is still safe.`,
+      "info",
+    );
+    return { rerooted: false };
+  }
+
   const result = await rerootCommandSession(cmdCtx, workspaceRoot);
   if (result.status === "ok") {
     ctx.ui.notify(

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1394,7 +1394,19 @@ export async function maybeRerootStepSessionForHighContext(
   const prefs = loadEffectiveGSDPreferences(workspaceRoot);
   const compactionThreshold = prefs?.preferences.context_management?.compaction_threshold_percent;
 
-  if (!shouldWarnStepSessionForContext(contextPercent, compactionThreshold)) {
+  const shouldWarn = shouldWarnStepSessionForContext(contextPercent, compactionThreshold);
+  const shouldReroot = shouldRerootStepSessionForContext(contextPercent);
+  if (!shouldWarn && !shouldReroot) {
+    return { rerooted: false };
+  }
+
+  const displayPercent = (contextPercent as number).toFixed(1);
+  const thresholdDisplay = resolveCompactionThresholdPercent(compactionThreshold).toFixed(0);
+  if (!shouldReroot) {
+    ctx.ui.notify(
+      `Step complete — context at ${displayPercent}% (soft threshold: ${thresholdDisplay}%). Use /compact when convenient; continuing in this session is still safe.`,
+      "info",
+    );
     return { rerooted: false };
   }
 
@@ -1402,16 +1414,6 @@ export async function maybeRerootStepSessionForHighContext(
   const snapshotBase = resolveWorktreeProjectRoot(workspaceRoot, originalBasePath);
   const { writeContextModeCompactionSnapshot } = await import("./context-mode-snapshot.js");
   await writeContextModeCompactionSnapshot(snapshotBase);
-
-  const displayPercent = (contextPercent as number).toFixed(1);
-  const thresholdDisplay = resolveCompactionThresholdPercent(compactionThreshold).toFixed(0);
-  if (!shouldRerootStepSessionForContext(contextPercent)) {
-    ctx.ui.notify(
-      `Step complete — context at ${displayPercent}% (soft threshold: ${thresholdDisplay}%). Use /compact when convenient; continuing in this session is still safe.`,
-      "info",
-    );
-    return { rerooted: false };
-  }
 
   const result = await rerootCommandSession(cmdCtx, workspaceRoot);
   if (result.status === "ok") {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -97,6 +97,7 @@ import {
   getNewBudgetAlertLevel,
   getBudgetEnforcementAction,
   getContextPauseAction,
+  HARD_CONTEXT_REROOT_THRESHOLD_PERCENT,
   resolveCompactionThresholdPercent,
   shouldRerootStepSessionForContext,
   shouldWarnStepSessionForContext,
@@ -1418,7 +1419,7 @@ export async function maybeRerootStepSessionForHighContext(
   const result = await rerootCommandSession(cmdCtx, workspaceRoot);
   if (result.status === "ok") {
     ctx.ui.notify(
-      `Step complete — context at ${displayPercent}% (threshold: ${thresholdDisplay}%). Fresh session ready for /gsd next.`,
+      `Step complete — context at ${displayPercent}% (hard threshold: ${HARD_CONTEXT_REROOT_THRESHOLD_PERCENT}%). Fresh session ready for /gsd next.`,
       "info",
     );
     return { rerooted: true };

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1378,9 +1378,10 @@ export async function rerootCommandSession(
 }
 
 /**
- * After a completed step-mode unit, reclaim context headroom when usage is at
- * or above the compaction threshold. Writes a context-mode snapshot first, then
- * re-roots the visible command session while leaving the NEXT progress surface.
+ * After a completed step-mode unit, warn when usage reaches the configurable
+ * soft context threshold. At the fixed hard boundary, write a context-mode
+ * snapshot and re-root the visible command session while leaving the NEXT
+ * progress surface.
  */
 export async function maybeRerootStepSessionForHighContext(
   ctx: ExtensionContext,

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1228,7 +1228,7 @@ async function configureContextCodebase(ctx: ExtensionCommandContext, prefs: Rec
   const maskTurns = await promptInteger(ctx, "Observation mask turns (1–50)", cm.observation_mask_turns, "8");
   if (maskTurns !== undefined && maskTurns !== "clear") cm.observation_mask_turns = maskTurns;
   else if (maskTurns === "clear") delete cm.observation_mask_turns;
-  const thresh = await promptNumber(ctx, "Compaction threshold percent (0.5–0.95)", cm.compaction_threshold_percent, "0.60");
+  const thresh = await promptNumber(ctx, "Soft context warning threshold percent (0.5–0.95)", cm.compaction_threshold_percent, "0.60");
   if (thresh !== undefined && thresh !== "clear") cm.compaction_threshold_percent = thresh;
   else if (thresh === "clear") delete cm.compaction_threshold_percent;
   const toolMax = await promptInteger(ctx, "Tool result max chars (200–10000)", cm.tool_result_max_chars, "800");

--- a/src/resources/extensions/gsd/commands-usage.ts
+++ b/src/resources/extensions/gsd/commands-usage.ts
@@ -112,7 +112,7 @@ function formatThresholdLines(): string[] {
 
   const compactionThreshold = prefs?.context_management?.compaction_threshold_percent;
   if (typeof compactionThreshold === "number") {
-    lines.push(`Compaction: ${Math.round(compactionThreshold * 100)}%`);
+    lines.push(`Soft context warning: ${Math.round(compactionThreshold * 100)}%`);
   }
 
   return lines;

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -273,10 +273,10 @@ This config sets a parent workspace with two child repositories. The implicit `p
   - `audit_unified.enabled`: boolean — dual-write unified audit envelope events. Default: `true`.
   - `plan_v2.enabled`: boolean — enable bounded clarify/research/draft/compile planning flow. Default: `true`.
 
-- `context_management`: configures context hygiene for auto-mode sessions. Keys:
+- `context_management`: configures context hygiene for auto-mode sessions. In step mode, the configurable threshold is a soft warning; automatic session re-rooting happens only at the fixed 90% hard context boundary. Keys:
   - `observation_masking`: boolean — mask old tool results to reduce context bloat. Default: `true`.
   - `observation_mask_turns`: number — keep this many recent turns verbatim (1-50). Default: `8`.
-  - `compaction_threshold_percent`: number — trigger compaction at this % of context window (0.5-0.95). Lower values fire compaction earlier, reducing drift. Default: `0.60`.
+  - `compaction_threshold_percent`: number — show a soft context warning at this fraction of the context window (0.5-0.95). Lower values warn earlier so operators can compact manually before drift accumulates. Default: `0.60`.
   - `tool_result_max_chars`: number — max chars per tool result in GSD sessions (200-10000). Default: `800`.
 
 - `auto_visualize`: boolean — show a visualizer hint after each milestone completion in auto-mode. Default: `false`.

--- a/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
@@ -8,6 +8,7 @@ import {
   getNewBudgetAlertLevel,
   resolveCompactionThresholdPercent,
   shouldRerootStepSessionForContext,
+  shouldWarnStepSessionForContext,
 } from "../auto.js";
 import {
   getUnitCostSpikeAction,
@@ -73,11 +74,19 @@ test("resolveCompactionThresholdPercent defaults to 60 and accepts ratio prefs",
   assert.equal(resolveCompactionThresholdPercent(0.4), 60);
 });
 
-test("shouldRerootStepSessionForContext uses compaction threshold pref", () => {
-  assert.equal(shouldRerootStepSessionForContext(59.9, 0.6), false);
-  assert.equal(shouldRerootStepSessionForContext(60, 0.6), true);
-  assert.equal(shouldRerootStepSessionForContext(273.8, 0.6), true);
-  assert.equal(shouldRerootStepSessionForContext(undefined, 0.6), false);
+test("shouldWarnStepSessionForContext uses compaction threshold pref", () => {
+  assert.equal(shouldWarnStepSessionForContext(59.9, 0.6), false);
+  assert.equal(shouldWarnStepSessionForContext(60, 0.6), true);
+  assert.equal(shouldWarnStepSessionForContext(72, 0.6), true);
+  assert.equal(shouldWarnStepSessionForContext(undefined, 0.6), false);
+});
+
+test("shouldRerootStepSessionForContext only fires at the hard context threshold", () => {
+  assert.equal(shouldRerootStepSessionForContext(72), false);
+  assert.equal(shouldRerootStepSessionForContext(89.9), false);
+  assert.equal(shouldRerootStepSessionForContext(90), true);
+  assert.equal(shouldRerootStepSessionForContext(273.8), true);
+  assert.equal(shouldRerootStepSessionForContext(undefined), false);
 });
 
 test("resolveUnitCostSpikeMultiplier disables the spike pause for burn-max", () => {

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -478,8 +478,8 @@ test("cleanupAfterLoopExit preserves step-mode surface and worktree session afte
   }
 });
 
-test("cleanupAfterLoopExit re-roots step-mode session when context exceeds compaction threshold", async (t) => {
-  const base = mkdtempSync(join(tmpdir(), "gsd-step-reroot-"));
+test("cleanupAfterLoopExit warns but does not re-root step-mode session at soft compaction threshold", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-step-soft-context-"));
   const worktree = join(base, ".gsd", "worktrees", "M001");
   const previousCwd = process.cwd();
   const newSessionWorkspaces: string[] = [];
@@ -515,7 +515,59 @@ test("cleanupAfterLoopExit re-roots step-mode session when context exceeds compa
       },
     } as any);
 
-    assert.deepEqual(newSessionWorkspaces, [worktree], "hot step-mode cleanup should re-root in the active worktree");
+    assert.deepEqual(newSessionWorkspaces, [], "soft context pressure must not force a new command session");
+    assert.equal(
+      notifyMessages.some((msg) => msg.includes("context at 72.0%") && msg.includes("Use /compact")),
+      true,
+      "soft threshold should warn with a non-disruptive compaction prompt",
+    );
+    assert.equal(autoSession.basePath, worktree);
+    assert.equal(realpathSync(process.cwd()), realpathSync(worktree));
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("cleanupAfterLoopExit re-roots step-mode session at hard context threshold", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-step-reroot-"));
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const previousCwd = process.cwd();
+  const newSessionWorkspaces: string[] = [];
+  const notifyMessages: string[] = [];
+
+  t.mock.method(WorktreeLifecycle.prototype, "restoreToProjectRoot", function () {});
+
+  mkdirSync(worktree, { recursive: true });
+  process.chdir(worktree);
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = false;
+  autoSession.stepMode = true;
+  autoSession.preserveStepSurfaceAfterLoopExit = true;
+  autoSession.basePath = worktree;
+  autoSession.originalBasePath = base;
+  autoSession.cmdCtx = {
+    getContextUsage: () => ({ percent: 92, tokens: 920_000, contextWindow: 1_000_000 }),
+    newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+      newSessionWorkspaces.push(workspaceRoot);
+      return { cancelled: false };
+    },
+  } as any;
+
+  try {
+    await cleanupAfterLoopExit({
+      hasUI: true,
+      ui: {
+        setStatus: () => {},
+        setWidget: () => {},
+        setHeader: () => {},
+        notify: (_msg: string) => notifyMessages.push(_msg),
+      },
+    } as any);
+
+    assert.deepEqual(newSessionWorkspaces, [worktree], "critical context pressure should re-root in the active worktree");
     assert.equal(
       notifyMessages.some((msg) => msg.includes("Fresh session ready for /gsd next")),
       true,

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -621,10 +621,19 @@ test("maybeRerootStepSessionForHighContext re-roots at the hard threshold even w
 
     assert.equal(result.rerooted, true, "92% usage must re-root even when the soft pref is 95%");
     assert.deepEqual(newSessionWorkspaces, [project], "hard context pressure must re-root the command session");
+    const rerootMessage = notifyMessages.find((msg) => msg.includes("Fresh session ready for /gsd next"));
+    assert.ok(rerootMessage, "hard re-root should notify the user");
+    // The re-root was triggered by the 90% hard limit, so the notification must
+    // cite that limit and not the configured 95% soft compaction threshold.
+    assert.match(
+      rerootMessage,
+      /hard threshold: 90%/,
+      "hard re-root notification must cite the 90% hard threshold",
+    );
     assert.equal(
-      notifyMessages.some((msg) => msg.includes("Fresh session ready for /gsd next")),
-      true,
-      "hard re-root should notify the user",
+      rerootMessage.includes("95%"),
+      false,
+      "hard re-root notification must not cite the configured soft compaction threshold",
     );
   } finally {
     process.chdir(previousCwd);

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -3,13 +3,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 
 import {
   anchorProcessCwdForAutoResume,
   cleanupAfterLoopExit,
+  maybeRerootStepSessionForHighContext,
   pauseAuto,
   rerootCommandSession,
   stopAuto,
@@ -579,6 +580,122 @@ test("cleanupAfterLoopExit re-roots step-mode session at hard context threshold"
     autoSession.reset();
     process.chdir(previousCwd);
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("maybeRerootStepSessionForHighContext re-roots at the hard threshold even when the soft pref is set above it", async () => {
+  // Regression: the hard 90% re-root must not be gated behind the configurable
+  // soft warn threshold, which is allowed up to 0.95. At 92% usage with a 0.95
+  // soft pref the soft warn predicate is false, but the session must still
+  // re-root because usage crossed the fixed hard boundary.
+  const dir = mkdtempSync(join(tmpdir(), "gsd-hard-reroot-high-soft-"));
+  const project = join(dir, "project");
+  const gsdHomeDir = join(dir, "home");
+  const previousCwd = process.cwd();
+  const previousGsdHome = process.env.GSD_HOME;
+
+  mkdirSync(join(project, ".gsd"), { recursive: true });
+  mkdirSync(gsdHomeDir, { recursive: true });
+  writeFileSync(
+    join(project, ".gsd", "PREFERENCES.md"),
+    ["---", "version: 1", "context_management:", "  compaction_threshold_percent: 0.95", "---", ""].join("\n"),
+    "utf-8",
+  );
+
+  process.env.GSD_HOME = gsdHomeDir;
+  process.chdir(project);
+
+  const newSessionWorkspaces: string[] = [];
+  const notifyMessages: string[] = [];
+  const cmdCtx = {
+    getContextUsage: () => ({ percent: 92, tokens: 920_000, contextWindow: 1_000_000 }),
+    newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+      newSessionWorkspaces.push(workspaceRoot);
+      return { cancelled: false };
+    },
+  } as any;
+  const ctx = { ui: { notify: (msg: string) => notifyMessages.push(msg) } } as any;
+
+  try {
+    const result = await maybeRerootStepSessionForHighContext(ctx, project, cmdCtx, project);
+
+    assert.equal(result.rerooted, true, "92% usage must re-root even when the soft pref is 95%");
+    assert.deepEqual(newSessionWorkspaces, [project], "hard context pressure must re-root the command session");
+    assert.equal(
+      notifyMessages.some((msg) => msg.includes("Fresh session ready for /gsd next")),
+      true,
+      "hard re-root should notify the user",
+    );
+  } finally {
+    process.chdir(previousCwd);
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("maybeRerootStepSessionForHighContext writes a compaction snapshot only at the hard boundary", async () => {
+  // Regression: the snapshot is reserved for the hard re-root. Soft-only
+  // pressure must warn without writing a compaction snapshot.
+  const dir = mkdtempSync(join(tmpdir(), "gsd-soft-no-snapshot-"));
+  const project = join(dir, "project");
+  const gsdHomeDir = join(dir, "home");
+  const previousCwd = process.cwd();
+  const previousGsdHome = process.env.GSD_HOME;
+
+  mkdirSync(join(project, ".gsd"), { recursive: true });
+  mkdirSync(gsdHomeDir, { recursive: true });
+  writeFileSync(
+    join(project, ".gsd", "PREFERENCES.md"),
+    ["---", "version: 1", "context_management:", "  compaction_threshold_percent: 0.6", "---", ""].join("\n"),
+    "utf-8",
+  );
+
+  process.env.GSD_HOME = gsdHomeDir;
+  process.chdir(project);
+
+  const newSessionWorkspaces: string[] = [];
+  const notifyMessages: string[] = [];
+  let contextPercent = 72;
+  const cmdCtx = {
+    getContextUsage: () => ({ percent: contextPercent, tokens: contextPercent * 10_000, contextWindow: 1_000_000 }),
+    newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+      newSessionWorkspaces.push(workspaceRoot);
+      return { cancelled: false };
+    },
+  } as any;
+  const ctx = { ui: { notify: (msg: string) => notifyMessages.push(msg) } } as any;
+  const snapshotPath = join(project, ".gsd", "last-snapshot.md");
+
+  try {
+    const softResult = await maybeRerootStepSessionForHighContext(ctx, project, cmdCtx, project);
+    assert.equal(softResult.rerooted, false, "soft pressure must not re-root");
+    assert.deepEqual(newSessionWorkspaces, [], "soft pressure must not open a new session");
+    assert.equal(
+      existsSync(snapshotPath),
+      false,
+      "soft-only pressure must not write a compaction snapshot",
+    );
+    assert.equal(
+      notifyMessages.some((msg) => msg.includes("context at 72.0%") && msg.includes("Use /compact")),
+      true,
+      "soft threshold should warn with a non-disruptive compaction prompt",
+    );
+
+    contextPercent = 92;
+    const hardResult = await maybeRerootStepSessionForHighContext(ctx, project, cmdCtx, project);
+    assert.equal(hardResult.rerooted, true, "hard pressure must re-root");
+    assert.deepEqual(newSessionWorkspaces, [project], "hard pressure should re-root once");
+    assert.equal(
+      existsSync(snapshotPath),
+      true,
+      "hard boundary must write the compaction snapshot",
+    );
+  } finally {
+    process.chdir(previousCwd);
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Linked issue

Closes #1063

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Separates soft context-pressure warnings from hard step-mode session re-rooting.
**Why:** Step-mode should not force a fresh session around the normal compaction threshold when there is still usable context headroom.
**How:** Adds a soft warning predicate at the configured compaction threshold and reserves automatic session re-rooting for the existing critical 90% context threshold.

## What

- Adds `shouldWarnStepSessionForContext` for the configurable soft compaction threshold.
- Keeps `shouldRerootStepSessionForContext` for hard context pressure only, currently 90%.
- Changes step-mode loop cleanup to warn and suggest `/compact` at soft pressure without calling `newSession`.
- Preserves automatic session re-rooting at critical pressure.
- Adds regression coverage for soft-threshold and hard-threshold behavior.

## Why

The issue reports that context warnings interrupt long-running tasks too early by asking users to open a new session while enough context remains. The prior step-mode cleanup path treated the compaction threshold as a hard re-root boundary, which could force a fresh command session around 60–70% usage.

## How

The decision helpers now model two separate boundaries:

- Soft boundary: configured `context_management.compaction_threshold_percent`; emits a user-facing warning and leaves the current session active.
- Hard boundary: 90% context usage; continues to write the context snapshot and re-root the command session to avoid overflow/truncation risk.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Targeted local verification:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts`
- `pnpm run typecheck:extensions`
- `git diff --check`
- `pnpm run verify:fast`

Regression proof:

- RED: the new soft-threshold cleanup test failed before the implementation because 72% context usage called `newSession`.
- Sabotage: temporarily lowering `HARD_CONTEXT_REROOT_THRESHOLD_PERCENT` to 60 made the soft-threshold cleanup test fail for the same reason; restored to 90 and re-ran green.

## AI disclosure

- [ ] This PR includes AI-assisted code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785416815&installation_id=134682257&pr_number=1082&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1082&signature=ccd02a38f581a4b76632af88a99ad82153e60ed17ca3139dcd2a37eb496ced3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes step-mode session lifecycle at context boundaries (when users get a new session vs a nudge), which affects long-running workflows but is scoped to GSD step mode with regression tests.
> 
> **Overview**
> Step-mode no longer forces a **fresh command session** when context usage crosses the configurable `compaction_threshold_percent` (often ~60%). That preference now drives a **soft warning** that suggests `/compact` while the current session stays active.
> 
> **Automatic re-rooting** (context snapshot + `newSession`) is reserved for a fixed **90% hard boundary** via `HARD_CONTEXT_REROOT_THRESHOLD_PERCENT` and `shouldRerootStepSessionForContext`, independent of the soft threshold.
> 
> `maybeRerootStepSessionForHighContext` and step loop cleanup use `shouldWarnStepSessionForContext` vs hard re-root separately. Docs, prefs wizard, usage labels, and tests were updated to match the two-tier behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec3e8d875e78bf1e8a9335548a78ee54096f7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->