### PR TITLE
fix(issue): [Bug]: writeManifest performs a synchronous full-manifest disk write on the streaming tool-executor thread during a workflow tool call

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -18,6 +18,7 @@ import { registerShortcuts } from "./register-shortcuts.js";
 import { writeCrashLog } from "./crash-log.js";
 import { logWarning, isGsdExtensionStderrEnabled } from "../workflow-logger.js";
 import { UNIT_TOOL_CONTRACTS } from "../unit-tool-contracts.js";
+import { installManifestFlushOnProcessTeardown } from "../workflow-manifest.js";
 // Static import so cmux event listeners are registered synchronously during
 // extension bootstrap. Prior implementation used `void import().then()` which
 // queued listener registration as a microtask — any CMUX_CHANNELS emit fired
@@ -196,6 +197,7 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     });
 
   installEpipeGuard();
+  installManifestFlushOnProcessTeardown();
 
   // Ecosystem handlers captured by the GSDExtensionAPI wrapper for the
   // GSD-owned `before_agent_start` dispatch step (#3338).

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1081,7 +1081,19 @@ export function registerHooks(
     const { handleAgentEnd } = await import("./agent-end-recovery.js");
     const agentEndBasePath = contextBasePath(ctx);
     try {
-      await flushAllManifests();
+      // The manifest is a non-critical projection (the append-only event log is
+      // the authoritative recovery source), so a flush failure must not skip
+      // agent_end recovery. drainManifestWrites still propagates write failures
+      // to explicit flush callers; here we deliberately log and continue so
+      // handleAgentEnd (and the finally below) always run.
+      try {
+        await flushAllManifests();
+      } catch (err) {
+        safetyLogWarning(
+          "manifest",
+          `flushAllManifests on agent_end failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       await handleAgentEnd(pi, event, ctx);
     } finally {
       activateDeferredApprovalGate(agentEndBasePath);

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1080,8 +1080,8 @@ export function registerHooks(
     await resetAskUserQuestionsTurnCache();
     const { handleAgentEnd } = await import("./agent-end-recovery.js");
     const agentEndBasePath = contextBasePath(ctx);
-    await flushAllManifests();
     try {
+      await flushAllManifests();
       await handleAgentEnd(pi, event, ctx);
     } finally {
       activateDeferredApprovalGate(agentEndBasePath);

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -76,6 +76,7 @@ import { supportsSourceObservationsForUnit } from "../source-observations.js";
 import { clearPendingAutoStart } from "../pending-auto-start.js";
 import { resolveWorkflowToolBasePath } from "./dynamic-tools.js";
 import { getRequiredWorkflowToolsForUnit } from "../unit-tool-contracts.js";
+import { flushAllManifests } from "../workflow-manifest.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -1079,6 +1080,7 @@ export function registerHooks(
     await resetAskUserQuestionsTurnCache();
     const { handleAgentEnd } = await import("./agent-end-recovery.js");
     const agentEndBasePath = contextBasePath(ctx);
+    await flushAllManifests();
     try {
       await handleAgentEnd(pi, event, ctx);
     } finally {

--- a/src/resources/extensions/gsd/tests/post-mutation-hook.test.ts
+++ b/src/resources/extensions/gsd/tests/post-mutation-hook.test.ts
@@ -10,7 +10,7 @@ import * as os from 'node:os';
 import { openDatabase, closeDatabase } from '../gsd-db.ts';
 import { handleCompleteTask } from '../tools/complete-task.ts';
 import { readEvents } from '../workflow-events.ts';
-import { readManifest } from '../workflow-manifest.ts';
+import { flushManifest, readManifest } from '../workflow-manifest.ts';
 
 function tempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-post-hook-'));
@@ -115,8 +115,9 @@ test('post-mutation-hook: state-manifest.json exists after handleCompleteTask', 
     const result = await handleCompleteTask(makeCompleteTaskParams(), base);
     assert.ok(!('error' in result), `handler should succeed, got: ${JSON.stringify(result)}`);
 
+    await flushManifest(base);
     const manifestPath = path.join(base, '.gsd', 'state-manifest.json');
-    assert.ok(fs.existsSync(manifestPath), 'state-manifest.json should exist after handler completes');
+    assert.ok(fs.existsSync(manifestPath), 'state-manifest.json should exist after manifest flush');
   } finally {
     closeDatabase();
     cleanupDir(base);
@@ -131,6 +132,7 @@ test('post-mutation-hook: manifest has version 1 and includes completed task', a
 
   try {
     await handleCompleteTask(makeCompleteTaskParams(), base);
+    await flushManifest(base);
 
     const manifest = readManifest(base);
     assert.ok(manifest !== null, 'manifest should be readable');

--- a/src/resources/extensions/gsd/tests/workflow-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-manifest.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../gsd-db.ts';
 import {
   writeManifest,
+  flushManifest,
   readManifest,
   snapshotState,
   bootstrapFromManifest,
@@ -40,6 +41,11 @@ function tempDbPath(base: string): string {
 
 function cleanupDir(dirPath: string): void {
   try { fs.rmSync(dirPath, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+async function writeManifestAndFlush(base: string): Promise<void> {
+  writeManifest(base);
+  await flushManifest(base);
 }
 
 function insertMemoryBackedDecision(id: string): void {
@@ -83,12 +89,14 @@ test('workflow-manifest: readManifest returns null when file does not exist', ()
 
 // ─── writeManifest + readManifest round-trip ─────────────────────────────
 
-test('workflow-manifest: writeManifest creates state-manifest.json with version 1', () => {
+test('workflow-manifest: writeManifest creates state-manifest.json with version 1 after flush', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
     writeManifest(base);
     const manifestPath = path.join(base, '.gsd', 'state-manifest.json');
+    assert.equal(fs.existsSync(manifestPath), false, 'writeManifest should not synchronously write state-manifest.json');
+    await flushManifest(base);
     assert.ok(fs.existsSync(manifestPath), 'state-manifest.json should exist');
     const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
     assert.strictEqual(raw.version, 1);
@@ -98,11 +106,11 @@ test('workflow-manifest: writeManifest creates state-manifest.json with version 
   }
 });
 
-test('workflow-manifest: readManifest parses manifest written by writeManifest', () => {
+test('workflow-manifest: readManifest parses manifest written by writeManifest', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
-    writeManifest(base);
+    await writeManifestAndFlush(base);
     const manifest = readManifest(base);
     assert.ok(manifest !== null);
     assert.strictEqual(manifest!.version, 1);
@@ -118,6 +126,25 @@ test('workflow-manifest: readManifest parses manifest written by writeManifest',
     assert.ok(Array.isArray(manifest!.quality_gates));
     assert.ok(Array.isArray(manifest!.milestone_commit_attributions));
     assert.ok(Array.isArray(manifest!.verification_evidence));
+  } finally {
+    closeDatabase();
+    cleanupDir(base);
+  }
+});
+
+test('workflow-manifest: flushManifest writes the latest queued payload', async () => {
+  const base = tempDir();
+  openDatabase(tempDbPath(base));
+  try {
+    insertMilestone({ id: 'M001', title: 'First Milestone' });
+    writeManifest(base);
+    insertMilestone({ id: 'M002', title: 'Latest Milestone' });
+    writeManifest(base);
+
+    await flushManifest(base);
+
+    const manifest = readManifest(base);
+    assert.ok(manifest?.milestones.some((m) => m.id === 'M002'), 'latest queued write should be durable');
   } finally {
     closeDatabase();
     cleanupDir(base);
@@ -181,7 +208,7 @@ test('workflow-manifest: snapshotState captures memory-backed decisions', () => 
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest restores extended correctness rows', () => {
+test('workflow-manifest: bootstrapFromManifest restores extended correctness rows', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
@@ -256,7 +283,7 @@ test('workflow-manifest: bootstrapFromManifest restores extended correctness row
       createdAt: '2026-06-05T00:00:00.000Z',
     });
 
-    writeManifest(base);
+    await writeManifestAndFlush(base);
     closeDatabase();
 
     const newDbPath = path.join(base, 'new.db');
@@ -306,7 +333,7 @@ test('workflow-manifest: bootstrapFromManifest returns false when no manifest fi
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest restores DB from manifest (round-trip)', () => {
+test('workflow-manifest: bootstrapFromManifest restores DB from manifest (round-trip)', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
@@ -326,7 +353,7 @@ test('workflow-manifest: bootstrapFromManifest restores DB from manifest (round-
       status: 'complete',
       planning: { fullPlanMd: '# Full Task Plan\n\nKeep this body.', targetRepositories: ['project'] },
     });
-    writeManifest(base);
+    await writeManifestAndFlush(base);
     closeDatabase();
 
     // Open a fresh DB and bootstrap from manifest
@@ -356,14 +383,14 @@ test('workflow-manifest: bootstrapFromManifest restores DB from manifest (round-
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest preserves target_repositories', () => {
+test('workflow-manifest: bootstrapFromManifest preserves target_repositories', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
     insertMilestone({ id: 'M001', title: 'Restored Milestone' });
     insertSlice({ id: 'S01', milestoneId: 'M001', planning: { targetRepositories: ['frontend'] } });
     insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', planning: { targetRepositories: ['backend'] } });
-    writeManifest(base);
+    await writeManifestAndFlush(base);
     closeDatabase();
 
     const newDbPath = path.join(base, 'new.db');
@@ -380,7 +407,7 @@ test('workflow-manifest: bootstrapFromManifest preserves target_repositories', (
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest does not truncate projections when artifact content is empty', () => {
+test('workflow-manifest: bootstrapFromManifest does not truncate projections when artifact content is empty', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
@@ -401,7 +428,7 @@ test('workflow-manifest: bootstrapFromManifest does not truncate projections whe
       task_id: null,
       full_content: '# Manifest Validation',
     });
-    writeManifest(base);
+    await writeManifestAndFlush(base);
 
     const planPath = path.join(base, '.gsd', 'milestones', 'M001', 'M001-PLAN.md');
     const validationPath = path.join(base, '.gsd', 'milestones', 'M001', 'M001-VALIDATION.md');
@@ -434,14 +461,14 @@ test('workflow-manifest: bootstrapFromManifest does not truncate projections whe
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest preserves optional rows from old manifests', () => {
+test('workflow-manifest: bootstrapFromManifest preserves optional rows from old manifests', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
     insertMilestone({ id: 'M001', title: 'Old Manifest Milestone' });
     insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Old Manifest Slice' });
     insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Old Manifest Task' });
-    writeManifest(base);
+    await writeManifestAndFlush(base);
 
     const manifestPath = path.join(base, '.gsd', 'state-manifest.json');
     const oldManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
@@ -504,12 +531,12 @@ test('workflow-manifest: bootstrapFromManifest preserves optional rows from old 
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest restores memory-backed decisions', () => {
+test('workflow-manifest: bootstrapFromManifest restores memory-backed decisions', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
     insertMemoryBackedDecision('D901');
-    writeManifest(base);
+    await writeManifestAndFlush(base);
     closeDatabase();
 
     const newDbPath = path.join(base, 'new.db');
@@ -526,12 +553,12 @@ test('workflow-manifest: bootstrapFromManifest restores memory-backed decisions'
   }
 });
 
-test('workflow-manifest: bootstrapFromManifest replaces stale memory-backed decisions', () => {
+test('workflow-manifest: bootstrapFromManifest replaces stale memory-backed decisions', async () => {
   const base = tempDir();
   openDatabase(tempDbPath(base));
   try {
     insertMemoryBackedDecision('D902');
-    writeManifest(base);
+    await writeManifestAndFlush(base);
     closeDatabase();
 
     const newDbPath = path.join(base, 'new.db');

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -354,6 +354,8 @@ interface ManifestWriteState {
   filePath: string;
   latestJson: string | null;
   inFlightJson: string | null;
+  /** Set by sync exit flush so an in-flight async write cannot leave stale data on disk. */
+  syncFlushJson: string | null;
   active: Promise<void> | null;
 }
 
@@ -378,14 +380,21 @@ function logManifestWriteFailure(filePath: string, err: unknown): void {
 }
 
 async function drainManifestWrites(key: string, state: ManifestWriteState): Promise<void> {
+  let lastWriteError: unknown = null;
   try {
-    while (state.latestJson !== null) {
+    while (state.latestJson !== null && state.syncFlushJson === null) {
       const json = state.latestJson;
       state.latestJson = null;
       state.inFlightJson = json;
       try {
         await atomicWriteAsync(state.filePath, json);
+        if (state.syncFlushJson !== null) {
+          atomicWriteSync(state.filePath, state.syncFlushJson);
+          break;
+        }
+        lastWriteError = null;
       } catch (err) {
+        lastWriteError = err;
         logManifestWriteFailure(state.filePath, err);
       } finally {
         state.inFlightJson = null;
@@ -397,6 +406,9 @@ async function drainManifestWrites(key: string, state: ManifestWriteState): Prom
       manifestWrites.delete(key);
     }
   }
+  if (lastWriteError !== null && state.syncFlushJson === null) {
+    throw lastWriteError;
+  }
 }
 
 function enqueueManifestWrite(basePath: string, json: string): void {
@@ -407,6 +419,7 @@ function enqueueManifestWrite(basePath: string, json: string): void {
       filePath: manifestFilePath(basePath),
       latestJson: null,
       inFlightJson: null,
+      syncFlushJson: null,
       active: null,
     };
     manifestWrites.set(key, state);
@@ -455,6 +468,7 @@ function flushAllManifestsSync(): void {
       atomicWriteSync(state.filePath, json);
       state.latestJson = null;
       state.inFlightJson = null;
+      state.syncFlushJson = json;
       manifestWrites.delete(key);
     } catch (err) {
       logManifestWriteFailure(state.filePath, err);

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -427,7 +427,9 @@ function enqueueManifestWrite(basePath: string, json: string): void {
 
   state.latestJson = json;
   if (!state.active) {
-    state.active = drainManifestWrites(key, state);
+    const active = drainManifestWrites(key, state);
+    void active.catch(() => {});
+    state.active = active;
   }
 }
 

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -10,11 +10,12 @@ import type { ArtifactRow, MilestoneRow } from "./db-milestone-artifact-rows.js"
 import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { VerificationEvidenceRow } from "./db-verification-evidence-rows.js";
 import type { Decision, GateRow, Requirement } from "./types.js";
-import { atomicWriteSync } from "./atomic-write.js";
+import { atomicWriteAsync, atomicWriteSync } from "./atomic-write.js";
 import { getAllDecisionsFromMemories } from "./context-store.js";
 import { backfillDecisionsToMemories } from "./memory-backfill.js";
 import { invalidateAllCaches } from "./cache.js";
-import { readFileSync, existsSync, mkdirSync } from "node:fs";
+import { logWarning } from "./workflow-logger.js";
+import { readFileSync, existsSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 // ─── Manifest Types ──────────────────────────────────────────────────────
@@ -349,16 +350,130 @@ export function snapshotState(): StateManifest {
 
 // ─── writeManifest ───────────────────────────────────────────────────────
 
+interface ManifestWriteState {
+  filePath: string;
+  latestJson: string | null;
+  inFlightJson: string | null;
+  active: Promise<void> | null;
+}
+
+const manifestWrites = new Map<string, ManifestWriteState>();
+let processTeardownFlushInstalled = false;
+let beforeExitFlushStarted = false;
+
+function manifestWriteKey(basePath: string): string {
+  return resolve(basePath);
+}
+
+function manifestFilePath(basePath: string): string {
+  return join(resolve(basePath), ".gsd", "state-manifest.json");
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function logManifestWriteFailure(filePath: string, err: unknown): void {
+  logWarning("manifest", `state manifest write failed: ${describeError(err)}`, { file: filePath });
+}
+
+async function drainManifestWrites(key: string, state: ManifestWriteState): Promise<void> {
+  try {
+    while (state.latestJson !== null) {
+      const json = state.latestJson;
+      state.latestJson = null;
+      state.inFlightJson = json;
+      try {
+        await atomicWriteAsync(state.filePath, json);
+      } catch (err) {
+        logManifestWriteFailure(state.filePath, err);
+      } finally {
+        state.inFlightJson = null;
+      }
+    }
+  } finally {
+    state.active = null;
+    if (state.latestJson === null && state.inFlightJson === null) {
+      manifestWrites.delete(key);
+    }
+  }
+}
+
+function enqueueManifestWrite(basePath: string, json: string): void {
+  const key = manifestWriteKey(basePath);
+  let state = manifestWrites.get(key);
+  if (!state) {
+    state = {
+      filePath: manifestFilePath(basePath),
+      latestJson: null,
+      inFlightJson: null,
+      active: null,
+    };
+    manifestWrites.set(key, state);
+  }
+
+  state.latestJson = json;
+  if (!state.active) {
+    state.active = drainManifestWrites(key, state);
+  }
+}
+
 /**
- * Write current DB state to .gsd/state-manifest.json via atomicWriteSync.
+ * Queue current DB state for an async atomic write to .gsd/state-manifest.json.
  * Uses JSON.stringify with 2-space indent for git three-way merge friendliness.
  */
 export function writeManifest(basePath: string): void {
   const manifest = snapshotState();
   const json = JSON.stringify(manifest, null, 2);
-  const dir = join(basePath, ".gsd");
-  mkdirSync(dir, { recursive: true });
-  atomicWriteSync(join(dir, "state-manifest.json"), json);
+  enqueueManifestWrite(basePath, json);
+}
+
+async function flushManifestByKey(key: string): Promise<void> {
+  for (;;) {
+    const active = manifestWrites.get(key)?.active;
+    if (!active) return;
+    await active;
+  }
+}
+
+/**
+ * Wait for any queued manifest write for this base path to become durable.
+ */
+export async function flushManifest(basePath: string): Promise<void> {
+  await flushManifestByKey(manifestWriteKey(basePath));
+}
+
+export async function flushAllManifests(): Promise<void> {
+  await Promise.all(Array.from(manifestWrites.keys(), key => flushManifestByKey(key)));
+}
+
+function flushAllManifestsSync(): void {
+  for (const [key, state] of manifestWrites) {
+    const json = state.latestJson ?? state.inFlightJson;
+    if (json === null) continue;
+    try {
+      atomicWriteSync(state.filePath, json);
+      state.latestJson = null;
+      state.inFlightJson = null;
+      manifestWrites.delete(key);
+    } catch (err) {
+      logManifestWriteFailure(state.filePath, err);
+    }
+  }
+}
+
+export function installManifestFlushOnProcessTeardown(): void {
+  if (processTeardownFlushInstalled) return;
+  processTeardownFlushInstalled = true;
+
+  process.once("beforeExit", () => {
+    if (beforeExitFlushStarted) return;
+    beforeExitFlushStarted = true;
+    void flushAllManifests();
+  });
+  process.once("exit", () => {
+    flushAllManifestsSync();
+  });
 }
 
 // ─── readManifest ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replaced synchronous manifest disk writes with coalesced async writes plus agent-end/teardown flushing, with syntax and diff checks passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1042
- [#1042 [Bug]: writeManifest performs a synchronous full-manifest disk write on the streaming tool-executor thread during a workflow tool call](https://github.com/open-gsd/gsd-pi/issues/1042)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1042-bug-writemanifest-performs-a-synchronous-1782824229`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recovery substrate persistence timing (manifest may lag until flush) and adds process teardown hooks; incorrect flush ordering could affect crash recovery, but agent_end and exit sync mitigate that.
> 
> **Overview**
> **`writeManifest` no longer blocks the tool thread** with a synchronous full snapshot write to `.gsd/state-manifest.json`. It now queues the latest JSON and drains writes via **`atomicWriteAsync`**, coalescing rapid calls so only the newest payload is persisted.
> 
> **Durability is explicit:** **`flushManifest` / `flushAllManifests`** wait for queued work; **`agent_end`** awaits **`flushAllManifests`** before agent-end recovery; bootstrap installs **`installManifestFlushOnProcessTeardown`** (`beforeExit` async flush, **`exit`** sync flush so in-flight async cannot leave stale disk state). Write failures are logged via **`workflow-logger`**.
> 
> Tests were updated to **`flushManifest`** after **`writeManifest`** and to assert coalescing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136a254f95448b2f9f868d86678f97f144d726da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->