### PR TITLE
fix(issue): [Bug]: Read-only navigation tools (`ls`/`glob`/`grep`/`find`/`search_and_read`) are capped at 15 by the loop guard, risking false-positive blocks on legitimate exploration

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -42,7 +42,7 @@ const MAX_CONSECUTIVE_STRICT = 1;
  */
 const PER_TOOL_DEFAULT_CAP = 6;
 const PER_TOOL_REPEATABLE_CAP = 15;
-const PER_TOOL_CAP_EXEMPT_TOOLS = new Set(["read"]);
+const PER_TOOL_CAP_EXEMPT_TOOLS = new Set(["find", "glob", "grep", "ls", "read", "search_and_read"]);
 
 let consecutiveCount = 0;
 let lastSignature = "";
@@ -118,7 +118,7 @@ export function checkToolCallLoop(
   const perToolCount = (perToolCounts.get(toolName) ?? 0) + 1;
   perToolCounts.set(toolName, perToolCount);
 
-  // Reading many distinct files is normal context gathering; Guard 1 still
+  // Read-only navigation tools are normal context gathering; Guard 1 still
   // catches true reread loops with identical arguments.
   if (PER_TOOL_CAP_EXEMPT_TOOLS.has(toolName)) {
     return { block: false, count: consecutiveCount };

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -224,28 +224,32 @@ console.log('\n── Loop guard: repeatable tools get the higher cap (#783) ─
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Distinct read calls are read-heavy context gathering, not repeated-tool loops.
+// Distinct read-only navigation calls are context gathering, not repeated-tool loops.
 // ═══════════════════════════════════════════════════════════════════════════
 
-console.log('\n── Loop guard: distinct read calls are not capped by per-tool count ──');
+console.log('\n── Loop guard: distinct read-only navigation calls are not capped by per-tool count ──');
 
 {
-  resetToolCallLoopGuard();
+  const exemptTools = ['find', 'glob', 'grep', 'ls', 'read', 'search_and_read'];
 
-  for (let i = 1; i <= 20; i++) {
-    const result = checkToolCallLoop('read', { path: `file-${i}.ts` });
-    assert.ok(result.block === false, `distinct read call ${i} should be allowed`);
+  for (const toolName of exemptTools) {
+    resetToolCallLoopGuard();
+
+    for (let i = 1; i <= 20; i++) {
+      const result = checkToolCallLoop(toolName, { path: `file-${i}.ts` });
+      assert.ok(result.block === false, `distinct ${toolName} call ${i} should be allowed`);
+    }
+
+    resetToolCallLoopGuard();
+    for (let i = 1; i <= 4; i++) {
+      const result = checkToolCallLoop(toolName, { path: 'same-file.ts' });
+      assert.ok(result.block === false, `identical ${toolName} call ${i} should be allowed`);
+    }
+
+    const blocked = checkToolCallLoop(toolName, { path: 'same-file.ts' });
+    assert.ok(blocked.block === true, `5th identical ${toolName} call should still be blocked`);
+    assert.ok(blocked.reason?.includes('identical args'), `${toolName} loops should be caught by Guard 1`);
   }
-
-  resetToolCallLoopGuard();
-  for (let i = 1; i <= 4; i++) {
-    const result = checkToolCallLoop('read', { path: 'same-file.ts' });
-    assert.ok(result.block === false, `identical read call ${i} should be allowed`);
-  }
-
-  const blocked = checkToolCallLoop('read', { path: 'same-file.ts' });
-  assert.ok(blocked.block === true, '5th identical read call should still be blocked');
-  assert.ok(blocked.reason?.includes('identical args'), 'read loops should be caught by Guard 1');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -270,15 +274,15 @@ console.log('\n── Loop guard: per-tool counts are independent and reset toge
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Newly-repeatable tools from core-session-tools.ts get the higher cap.
-// bg_shell, find, ls, search_and_read were added to INHERENTLY_REPEATABLE_TOOL_SET
-// in the code-quality consolidation PR (previously only bash/read/write/etc).
+// Non-exempt repeatable tools from core-session-tools.ts get the higher cap.
+// Read-only navigation tools are exempted earlier; mutating repeatable tools
+// must still trip the per-tool cap.
 // ═══════════════════════════════════════════════════════════════════════════
 
-console.log('\n── Loop guard: new repeatable tools (bg_shell, find, ls, search_and_read) get high cap ──');
+console.log('\n── Loop guard: non-exempt repeatable tools get high cap ──');
 
 {
-  for (const toolName of ['bg_shell', 'find', 'ls', 'search_and_read']) {
+  for (const toolName of ['bg_shell', 'write']) {
     resetToolCallLoopGuard();
 
     // Should allow up to 15 varied calls without blocking.


### PR DESCRIPTION
## Summary
- Exempted read-only navigation tools from the per-tool loop cap and verified the focused loop-guard regression test passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1093
- [#1093 [Bug]: Read-only navigation tools (`ls`/`glob`/`grep`/`find`/`search_and_read`) are capped at 15 by the loop guard, risking false-positive blocks on legitimate exploration](https://github.com/open-gsd/gsd-pi/issues/1093)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1093-bug-read-only-navigation-tools-ls-glob-g-1782845843`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist change in loop-guard logic with focused regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes false-positive loop blocks when agents make many **read-only navigation** tool calls in one turn (`find`, `glob`, `grep`, `ls`, `read`, `search_and_read`).
> 
> Those tools are added to **`PER_TOOL_CAP_EXEMPT_TOOLS`**, so Guard 2’s per-tool count cap (15 for repeatable tools) no longer applies to them. **Guard 1** still blocks the 5th identical-args call, so true reread loops stay protected.
> 
> Tests now cover all exempt tools for uncapped varied calls and unchanged identical-args blocking, and repeatable-cap cases use non-exempt tools like `bg_shell` and `write` instead of navigation tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ead1e5e1cbea6d14c9bf05c195e2aca5e747167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->