### PR TITLE
fix(issue): [Bug]: The per-tool loop guard accumulates a tool's count across the entire auto unit with no progress signal, blocking a legitimately progressing tool-heavy unit

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -34,7 +34,7 @@ import {
 } from "../auto-runtime-state.js";
 import { applyProviderPayloadPolicy } from "../provider-payload-policy.js";
 
-import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
+import { checkToolCallLoop, recordToolCallLoopMutation, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { MINIMAL_AUTO_BASE_TOOL_NAMES } from "./core-session-tools.js";
 import { maybePauseAutoForApprovalGate, resetPendingGatePauseGuard } from "./pending-gate-pause.js";
 import { saveActivityLog } from "../activity-log.js";
@@ -1572,6 +1572,7 @@ export function registerHooks(
       }
     }
     if (!event.isError) {
+      recordToolCallLoopMutation(toolName);
       refreshSourceObservationAfterMutation(toolName, event.input, ctx);
       clearSourceObservationsAfterShell(toolName);
     }

--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -14,10 +14,12 @@
  * to stop tooling for the rest of that turn and answer in text.
  *
  * The per-tool-name check (#783 Brief C) tracks call counts within a
- * turn regardless of args. This catches improvisation
+ * turn regardless of args, decaying after successful state-mutating tools.
+ * This catches improvisation
  * loops where the model attempts the same missing workflow tool through
  * varied surfaces (bash → `node -e` → CLI), each with a different
- * signature, so the identical-args streak never trips. Whichever guard
+ * signature, so the identical-args streak never trips, while allowing
+ * tool-heavy turns that are making file-mutation progress. Whichever guard
  * trips first blocks.
  */
 
@@ -43,6 +45,7 @@ const MAX_CONSECUTIVE_STRICT = 1;
 const PER_TOOL_DEFAULT_CAP = 6;
 const PER_TOOL_REPEATABLE_CAP = 15;
 const PER_TOOL_CAP_EXEMPT_TOOLS = new Set(["find", "glob", "grep", "ls", "read", "search_and_read"]);
+const STATE_MUTATING_TOOL_SET = new Set(["edit", "write", "multi_edit", "notebook_edit"]);
 
 let consecutiveCount = 0;
 let lastSignature = "";
@@ -51,6 +54,8 @@ let enabled = true;
 
 /** Per-tool-name call counts within the current turn (#783 Brief C). */
 const perToolCounts = new Map<string, number>();
+let mutationEpoch = 0;
+const perToolLastMutationEpoch = new Map<string, number>();
 
 /** Hash tool name + args into a compact signature for comparison. */
 function hashToolCall(toolName: string, args: Record<string, unknown>): string {
@@ -78,7 +83,8 @@ function hashToolCall(toolName: string, args: Record<string, unknown>): string {
  *  1. Identical-signature streak (MAX_CONSECUTIVE_IDENTICAL_CALLS, strict for
  *     ask_user_questions).
  *  2. Per-tool-name cap (PER_TOOL_DEFAULT_CAP / PER_TOOL_REPEATABLE_CAP),
- *     independent of args — catches improvisation loops (#783).
+ *     independent of args, reset after file-mutation progress — catches
+ *     improvisation loops (#783).
  */
 export function checkToolCallLoop(
   toolName: string,
@@ -115,8 +121,13 @@ export function checkToolCallLoop(
   // ── Guard 2: per-tool-name cap, independent of args (#783 Brief C) ──
   // Catches improvisation loops where the same tool is invoked many times with
   // varied args (e.g. retrying a missing workflow tool via bash/node -e/CLI).
-  const perToolCount = (perToolCounts.get(toolName) ?? 0) + 1;
+  const priorPerToolCount =
+    (perToolLastMutationEpoch.get(toolName) ?? mutationEpoch) < mutationEpoch
+      ? 0
+      : (perToolCounts.get(toolName) ?? 0);
+  const perToolCount = priorPerToolCount + 1;
   perToolCounts.set(toolName, perToolCount);
+  perToolLastMutationEpoch.set(toolName, mutationEpoch);
 
   // Read-only navigation tools are normal context gathering; Guard 1 still
   // catches true reread loops with identical arguments.
@@ -143,6 +154,13 @@ export function checkToolCallLoop(
   return { block: false, count: consecutiveCount };
 }
 
+/** Record successful mutation progress so Guard 2 can decay on the next count. */
+export function recordToolCallLoopMutation(toolName: string): void {
+  if (!enabled) return;
+  if (!STATE_MUTATING_TOOL_SET.has(toolName)) return;
+  mutationEpoch++;
+}
+
 /** Reset the guard state. Call at agent turn boundaries. */
 export function resetToolCallLoopGuard(): void {
   consecutiveCount = 0;
@@ -150,6 +168,8 @@ export function resetToolCallLoopGuard(): void {
   lastToolName = "";
   enabled = true;
   perToolCounts.clear();
+  mutationEpoch = 0;
+  perToolLastMutationEpoch.clear();
 }
 
 /** Disable the guard (e.g. during shutdown). */
@@ -159,6 +179,8 @@ export function disableToolCallLoopGuard(): void {
   lastSignature = "";
   lastToolName = "";
   perToolCounts.clear();
+  mutationEpoch = 0;
+  perToolLastMutationEpoch.clear();
 }
 
 /** Get current consecutive count for diagnostics. */

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   checkToolCallLoop,
+  recordToolCallLoopMutation,
   resetToolCallLoopGuard,
   disableToolCallLoopGuard,
   getToolCallLoopCount,
@@ -221,6 +222,33 @@ console.log('\n── Loop guard: repeatable tools get the higher cap (#783) ─
   const blocked = checkToolCallLoop('bash', { command: 'echo 16' });
   assert.ok(blocked.block === true, '16th bash call (varied args) should be blocked by per-tool cap');
   assert.ok(blocked.reason!.includes('cap 15'), 'reason should mention the repeatable cap');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Mutation progress decays per-tool counts (#1092)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: mutation progress decays per-tool counts (#1092) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  // bash is called more than the repeatable cap, but each count is separated
+  // by a successful file mutation. Guard 2 should treat that as progress and
+  // avoid blocking the progressing unit.
+  for (let i = 1; i <= 20; i++) {
+    const result = checkToolCallLoop('bash', { command: `echo ${i}` });
+    assert.ok(result.block === false, `bash call ${i} after mutation progress should be allowed`);
+    assert.deepStrictEqual(getToolCallCountForTool('bash'), 1, `bash count should decay before call ${i}`);
+
+    const mutationTool = i % 2 === 0 ? 'write' : 'edit';
+    const mutation = checkToolCallLoop(mutationTool, {
+      path: `file-${i}.ts`,
+      content: `content ${i}`,
+    });
+    assert.ok(mutation.block === false, `${mutationTool} mutation ${i} should be allowed`);
+    recordToolCallLoopMutation(mutationTool);
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Decayed per-tool loop counts after successful mutation progress and verified with the focused guard test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1092
- [#1092 [Bug]: The per-tool loop guard accumulates a tool's count across the entire auto unit with no progress signal, blocking a legitimately progressing tool-heavy unit](https://github.com/open-gsd/gsd-pi/issues/1092)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1092-bug-the-per-tool-loop-guard-accumulates--1782845963`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to loop-guard counting and hook wiring on successful tool results; covered by a focused test, with no auth or data-path changes.
> 
> **Overview**
> Fixes **#1092** by treating successful file edits as progress so Guard 2 (per-tool-name cap) does not keep blocking tools like `bash` across a long, legitimately mutating auto unit.
> 
> **`tool-call-loop-guard`**: Adds a **mutation epoch** and resets each tool’s per-turn count when its last recorded epoch is older than the current one after a successful **`edit` / `write` / `multi_edit` / `notebook_edit`**. Improvisation-loop detection (#783) is unchanged when there is no mutation progress.
> 
> **`register-hooks`**: On successful **`tool_result`**, calls **`recordToolCallLoopMutation`** so decay runs on real completions, not only at `checkToolCallLoop` time.
> 
> **Tests**: New scenario with 20+ `bash` calls interleaved with `write`/`edit` plus **`recordToolCallLoopMutation`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e7e3c91359611da3a63101dcbcbf42186cdaab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->