### PR TITLE
fix(issue): [Bug]: `gsd_exec` is capped at 6 calls per unit by the tool-loop guard while equivalent execution tools get 15, blocking legitimate tool-heavy `/gsd auto` units

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/core-session-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/core-session-tools.ts
@@ -28,6 +28,7 @@ const NON_REPEATABLE_FROM_MINIMAL_BASE = new Set<string>([
 
 /** Additional core tools not in MINIMAL_AUTO_BASE but routinely multi-called per turn. */
 const EXTRA_INHERENTLY_REPEATABLE = [
+  "gsd_exec",
   "multi_edit",
   "todo_write",
   "notebook_edit",

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -275,14 +275,14 @@ console.log('\n── Loop guard: per-tool counts are independent and reset toge
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Non-exempt repeatable tools from core-session-tools.ts get the higher cap.
-// Read-only navigation tools are exempted earlier; mutating repeatable tools
-// must still trip the per-tool cap.
+// Read-only navigation tools are exempted earlier; mutating/execution repeatable
+// tools (e.g. gsd_exec) must still trip the per-tool cap.
 // ═══════════════════════════════════════════════════════════════════════════
 
 console.log('\n── Loop guard: non-exempt repeatable tools get high cap ──');
 
 {
-  for (const toolName of ['bg_shell', 'write']) {
+  for (const toolName of ['bg_shell', 'gsd_exec', 'write']) {
     resetToolCallLoopGuard();
 
     // Should allow up to 15 varied calls without blocking.


### PR DESCRIPTION
## Summary
- Added gsd_exec to the repeatable tool set and verified the focused loop-guard regression test passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1086
- [#1086 [Bug]: `gsd_exec` is capped at 6 calls per unit by the tool-loop guard while equivalent execution tools get 15, blocking legitimate tool-heavy `/gsd auto` units](https://github.com/open-gsd/gsd-pi/issues/1086)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1086-bug-gsd-exec-is-capped-at-6-calls-per-un-1782846325`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-tool classification change plus test updates; no auth, data, or broad behavioral refactors.
> 
> **Overview**
> **Raises the per-turn tool-loop guard limit for `gsd_exec` from the default cap (6) to the repeatable-tool cap (15)**, aligning it with tools like `bash` and `search_and_read`.
> 
> This is done by adding `gsd_exec` to `EXTRA_INHERENTLY_REPEATABLE` in `core-session-tools.ts`, which feeds `INHERENTLY_REPEATABLE_TOOL_SET` used by the loop guard. The focused regression test now asserts that `gsd_exec` allows 15 varied calls per turn before blocking on the 16th.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3395e2872086a36d8114c7831793135d0ce719ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->