### PR TITLE
fix(issue): [Bug]: In `/gsd auto`, the tool-loop-guard block tells the model to "respond to the user in text" — but there is no user, so it induces the repeat that aborts the unit

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -583,6 +583,21 @@ function contextBasePath(ctx?: { cwd?: string }): string {
   return typeof ctx?.cwd === "string" ? ctx.cwd : process.cwd();
 }
 
+const LOOP_GUARD_INTERACTIVE_INSTRUCTIONS = [
+  "Do not retry this tool or call other tools this turn — stop and respond to the user in text.",
+  "Do not retry this tool or pivot to other tools this turn — stop and respond to the user in text.",
+];
+const LOOP_GUARD_AUTO_INSTRUCTION =
+  "Do not re-issue this blocked tool. In /gsd auto, stop tool calls for this turn and return control to the auto-mode recovery/replan path.";
+
+function formatLoopGuardBlockReason(reason: string | undefined): string | undefined {
+  if (!reason || !getAutoRuntimeSnapshot().active) return reason;
+  return LOOP_GUARD_INTERACTIVE_INSTRUCTIONS.reduce(
+    (formatted, instruction) => formatted.replace(instruction, LOOP_GUARD_AUTO_INSTRUCTION),
+    reason,
+  );
+}
+
 function beginSourceObservationStoreForCurrentUnit(
   ctx?: { cwd?: string },
 ): ReturnType<typeof getSourceObservationStore> | null {
@@ -1286,7 +1301,7 @@ export function registerHooks(
     // ── Loop guard: block repeated identical tool calls ──
     const loopCheck = checkToolCallLoop(toolName, event.input as Record<string, unknown>);
     if (loopCheck.block) {
-      return { block: true, reason: loopCheck.reason };
+      return { block: true, reason: formatLoopGuardBlockReason(loopCheck.reason) };
     }
 
     const deferredGateGuard = shouldBlockDeferredApprovalTool(

--- a/src/resources/extensions/gsd/tests/register-hooks-loop-guard-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-loop-guard-auto.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { autoSession } from "../auto-runtime-state.ts";
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { resetToolCallLoopGuard } from "../bootstrap/tool-call-loop-guard.ts";
+
+type Handler = (event: any, ctx?: any) => Promise<any> | any;
+
+function makeHookHarness(): {
+  emitToolCall: (toolName: string, input: Record<string, unknown>) => Promise<any>;
+} {
+  const handlers = new Map<string, Handler[]>();
+  const pi = {
+    on(event: string, handler: Handler) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  };
+  const ctx = {
+    cwd: process.cwd(),
+    ui: { notify: () => undefined },
+  };
+  let callId = 0;
+
+  registerHooks(pi as any, []);
+
+  return {
+    async emitToolCall(toolName: string, input: Record<string, unknown>): Promise<any> {
+      callId += 1;
+      const loopGuardHandler = handlers.get("tool_call")?.[0];
+      assert.ok(loopGuardHandler, "loop-guard tool_call handler should be registered");
+      return loopGuardHandler({ toolCallId: `loop-${callId}`, toolName, input }, ctx);
+    },
+  };
+}
+
+test("register-hooks keeps loop-guard block reason interactive outside auto-mode", async (t) => {
+  autoSession.reset();
+  resetToolCallLoopGuard();
+  t.after(() => {
+    autoSession.reset();
+    resetToolCallLoopGuard();
+  });
+
+  const { emitToolCall } = makeHookHarness();
+
+  for (let i = 0; i < 4; i += 1) {
+    await emitToolCall("web_search", { query: "same query" });
+  }
+  const block = await emitToolCall("web_search", { query: "same query" });
+
+  assert.equal(block?.block, true);
+  assert.match(block.reason, /respond to the user in text/);
+  assert.doesNotMatch(block.reason, /auto-mode recovery\/replan path/);
+});
+
+test("register-hooks rewrites loop-guard block reason for auto-mode identical-args blocks", async (t) => {
+  autoSession.reset();
+  resetToolCallLoopGuard();
+  autoSession.active = true;
+  t.after(() => {
+    autoSession.reset();
+    resetToolCallLoopGuard();
+  });
+
+  const { emitToolCall } = makeHookHarness();
+
+  for (let i = 0; i < 4; i += 1) {
+    await emitToolCall("web_search", { query: "same query" });
+  }
+  const block = await emitToolCall("web_search", { query: "same query" });
+
+  assert.equal(block?.block, true);
+  assert.match(block.reason, /Tool loop detected \(identical args\): web_search/);
+  assert.match(block.reason, /Do not re-issue this blocked tool/);
+  assert.match(block.reason, /auto-mode recovery\/replan path/);
+  assert.doesNotMatch(block.reason, /respond to the user in text/);
+});
+
+test("register-hooks rewrites loop-guard block reason for auto-mode per-tool blocks", async (t) => {
+  autoSession.reset();
+  resetToolCallLoopGuard();
+  autoSession.active = true;
+  t.after(() => {
+    autoSession.reset();
+    resetToolCallLoopGuard();
+  });
+
+  const { emitToolCall } = makeHookHarness();
+
+  for (let i = 0; i < 6; i += 1) {
+    await emitToolCall("gsd_complete_milestone", { milestone: `M${i}` });
+  }
+  const block = await emitToolCall("gsd_complete_milestone", { milestone: "M7" });
+
+  assert.equal(block?.block, true);
+  assert.match(block.reason, /Tool loop detected \(repeated tool\): gsd_complete_milestone/);
+  assert.match(block.reason, /Do not re-issue this blocked tool/);
+  assert.match(block.reason, /auto-mode recovery\/replan path/);
+  assert.doesNotMatch(block.reason, /respond to the user in text/);
+});


### PR DESCRIPTION
## Summary
- Fixed auto-mode loop-guard block reasons to return control to recovery/replan and verified with static/parse checks; dependency-based tests were blocked by npm DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1085
- [#1085 [Bug]: In `/gsd auto`, the tool-loop-guard block tells the model to "respond to the user in text" — but there is no user, so it induces the repeat that aborts the unit](https://github.com/open-gsd/gsd-pi/issues/1085)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1085-bug-in-gsd-auto-the-tool-loop-guard-bloc-1782846442`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook-layer string rewrite gated on auto-mode active; loop-guard logic unchanged and covered by new tests.
> 
> **Overview**
> Fixes **#1085**: in `/gsd auto`, loop-guard blocks no longer tell the model to “respond to the user in text,” which had no user in the loop and encouraged retries that aborted the unit.
> 
> `register-hooks` now runs loop-guard `reason` strings through **`formatLoopGuardBlockReason`**. Outside auto-mode, behavior is unchanged. When **`getAutoRuntimeSnapshot().active`**, the two interactive tail phrases from `tool-call-loop-guard` are swapped for copy that says not to re-issue the blocked tool and to stop tool calls for the turn so **auto-mode recovery/replan** can run.
> 
> New tests in **`register-hooks-loop-guard-auto.test.ts`** cover interactive mode, auto-mode identical-args blocks, and auto-mode per-tool repeat caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca58c4bfa60bc049837b6075e3ce8f1ba6b653b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->