### PR TITLE
fix(issue): [Bug]: `writeReactiveExecuteBlocker` force-flips a `deferred` task to complete/skipped because it exempts only `isClosedStatus`, not `isInactiveStatus`

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -35,7 +35,7 @@ import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
 import { readIntegrationBranch } from "./git-service.js";
-import { isClosedStatus } from "./status-guards.js";
+import { isClosedStatus, isInactiveStatus } from "./status-guards.js";
 import {
   resolveSlicePath,
   resolveSliceFile,
@@ -295,7 +295,7 @@ export function writeReactiveExecuteBlocker(
   transaction(() => {
     for (const tid of summaryPresent) {
       const task = getTask(mid, sid, tid);
-      if (!task || isClosedStatus(task.status)) {
+      if (!task || isInactiveStatus(task.status)) {
         unchangedTaskIds.push(tid);
         continue;
       }
@@ -304,7 +304,7 @@ export function writeReactiveExecuteBlocker(
     }
     for (const tid of summaryMissing) {
       const task = getTask(mid, sid, tid);
-      if (!task || isClosedStatus(task.status)) {
+      if (!task || isInactiveStatus(task.status)) {
         unchangedTaskIds.push(tid);
         continue;
       }

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1917,6 +1917,41 @@ test("#57: writeReactiveExecuteBlocker reconciles batch task statuses and append
   }
 });
 
+test("#1088: writeReactiveExecuteBlocker preserves deferred batch task statuses", () => {
+  const base = makeTmpBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "One", status: "deferred" });
+    insertTask({ id: "T02", milestoneId: "M001", sliceId: "S01", title: "Two", status: "deferred" });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+      "# T01 Summary\n",
+      "utf-8",
+    );
+
+    const recovery = writeReactiveExecuteBlocker(
+      "M001/S01/reactive+T01,T02",
+      base,
+      "verification retries exhausted",
+    );
+
+    assert.ok(recovery, "recovery should run with DB available");
+    assert.deepEqual(recovery!.completedTaskIds, []);
+    assert.deepEqual(recovery!.skippedTaskIds, []);
+    assert.deepEqual(recovery!.unchangedTaskIds, ["T01", "T02"]);
+    assert.equal(getTask("M001", "S01", "T01")?.status, "deferred");
+    assert.equal(getTask("M001", "S01", "T02")?.status, "deferred");
+
+    const events = readEvents(join(base, ".gsd", "event-log.jsonl"));
+    assert.equal(events.some((e) => e.params.taskId === "T01" || e.params.taskId === "T02"), false);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("#4414: verifyExpectedArtifact parallel-research succeeds when all research-ready slices have RESEARCH", () => {
   const base = makeTmpBase();
   try {


### PR DESCRIPTION
## Summary
- Fixed reactive execute recovery to preserve deferred task statuses and added a regression test; whitespace verification passed while dependency-backed tests were blocked by registry DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1088
- [#1088 [Bug]: `writeReactiveExecuteBlocker` force-flips a `deferred` task to complete/skipped because it exempts only `isClosedStatus`, not `isInactiveStatus`](https://github.com/open-gsd/gsd-pi/issues/1088)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1088-bug-writereactiveexecuteblocker-force-fl-1782846802`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to auto-recovery status guards with a regression test; no auth or external API surface.
> 
> **Overview**
> Fixes **reactive-execute batch recovery** so it no longer overwrites **`deferred`** task rows when reconciling a failed batch after verification retries.
> 
> `writeReactiveExecuteBlocker` now skips status updates when a task is **inactive** (`isInactiveStatus`), not only when it is **closed** (`isClosedStatus`). Deferred tasks stay deferred, are listed in `unchangedTaskIds`, and do not get `complete-task` / `skip-task` events. A regression test covers issue **#1088**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530c28008f9c90baf19e7fe8d7556b0de04007c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->