### PR TITLE
fix(issue): [Bug]: The "recover missing task plan → plan-slice" auto-dispatch rule re-dispatches `plan-slice` with no retry counter, allowing an uncounted regenerate loop

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1563,17 +1563,17 @@ export const DISPATCH_RULES: DispatchRule[] = [
         !existsSync(projectionTaskPlanPath) &&
         !tasksEmbeddedInSlicePlan
       ) {
-        const MAX_PRE_EXEC_RETRIES = 2;
-        const retryCount = session?.preExecRetryCount?.get(unitId) ?? 0;
-        if (retryCount >= MAX_PRE_EXEC_RETRIES) {
-          session?.preExecRetryCount?.delete(unitId);
+        const MAX_MISSING_TASK_PLAN_RETRIES = 2;
+        const retryCount = session?.missingTaskPlanRetryCount?.get(unitId) ?? 0;
+        if (retryCount >= MAX_MISSING_TASK_PLAN_RETRIES) {
+          session?.missingTaskPlanRetryCount?.delete(unitId);
           return {
             action: "stop",
             reason: `Missing task-plan recovery failed ${retryCount} times for ${unitId} - manual intervention required. Task plan ${tid} is still missing after regenerating the slice plan. Fix the task-plan files manually, then run /gsd auto to resume.`,
             level: "error",
           };
         }
-        session?.preExecRetryCount?.set(unitId, retryCount + 1);
+        session?.missingTaskPlanRetryCount?.set(unitId, retryCount + 1);
         if (isDebugEnabled()) {
           const expectedTaskPlanPath = join(artifactBasePath, relTaskFile(artifactBasePath, mid, sid, tid, "PLAN"));
           const originalProjectRoot = session?.originalBasePath || basePath;
@@ -1610,7 +1610,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         };
       }
 
-      session?.preExecRetryCount?.delete(unitId);
+      session?.missingTaskPlanRetryCount?.delete(unitId);
       return null;
     },
   },

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1523,6 +1523,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const sid = state.activeSlice!.id;
       const sTitle = state.activeSlice!.title;
       const tid = state.activeTask.id;
+      const unitId = `${mid}/${sid}`;
       const artifactBasePath = resolveArtifactBasePath(basePath, mid, session);
 
       // Guard: if the slice plan exists but the individual task plan files are
@@ -1562,6 +1563,17 @@ export const DISPATCH_RULES: DispatchRule[] = [
         !existsSync(projectionTaskPlanPath) &&
         !tasksEmbeddedInSlicePlan
       ) {
+        const MAX_PRE_EXEC_RETRIES = 2;
+        const retryCount = session?.preExecRetryCount?.get(unitId) ?? 0;
+        if (retryCount >= MAX_PRE_EXEC_RETRIES) {
+          session?.preExecRetryCount?.delete(unitId);
+          return {
+            action: "stop",
+            reason: `Missing task-plan recovery failed ${retryCount} times for ${unitId} - manual intervention required. Task plan ${tid} is still missing after regenerating the slice plan. Fix the task-plan files manually, then run /gsd auto to resume.`,
+            level: "error",
+          };
+        }
+        session?.preExecRetryCount?.set(unitId, retryCount + 1);
         if (isDebugEnabled()) {
           const expectedTaskPlanPath = join(artifactBasePath, relTaskFile(artifactBasePath, mid, sid, tid, "PLAN"));
           const originalProjectRoot = session?.originalBasePath || basePath;
@@ -1585,7 +1597,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         return {
           action: "dispatch",
           unitType: "plan-slice",
-          unitId: `${mid}/${sid}`,
+          unitId,
           prompt: await buildPlanSlicePrompt(
             mid,
             midTitle,
@@ -1598,6 +1610,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         };
       }
 
+      session?.preExecRetryCount?.delete(unitId);
       return null;
     },
   },

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -212,6 +212,13 @@ export class AutoSession {
    * the issues after MAX_PRE_EXEC_RETRIES re-attempts.
    */
   readonly preExecRetryCount: Map<string, number> = new Map();
+  /**
+   * Tracks how many times each slice unit has been re-dispatched to plan-slice
+   * because task plan files were missing. Keyed by unitId (e.g. "M001/S01").
+   * Separate from preExecRetryCount so pre-exec gate failures do not block or
+   * conflate with missing-task-plan recovery.
+   */
+  readonly missingTaskPlanRetryCount: Map<string, number> = new Map();
 
   // ── Tool invocation errors (#2883) ──────────────────────────────────
   /** Set when a GSD tool execution ends with isError due to malformed/truncated
@@ -413,6 +420,7 @@ export class AutoSession {
     this.consecutiveCompleteBootstraps = 0;
     this.lastPreExecFailure = null;
     this.preExecRetryCount.clear();
+    this.missingTaskPlanRetryCount.clear();
     this.lastToolInvocationError = null;
     this.toolUnavailableRetries = 0;
     this.lastUnitAgentEndMessages = null;

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -263,6 +263,53 @@ test("dispatch: present legacy task plan clears missing-plan recovery retry coun
     "pre-exec retry counter must not be cleared when task plan is present");
 });
 
+test("dispatch: missing-task-plan recovery loop terminates even when the shared pre-exec key is reset between rounds (#1087)", async (t) => {
+  // The recovery rule re-dispatches plan-slice with unitId "${mid}/${sid}".
+  // That regenerated plan-slice carries the same currentUnit.id, and on a
+  // pre-execution pass the post-unit hook deletes that key from
+  // preExecRetryCount (auto-post-unit.ts). Missing per-task PLAN projection
+  // files do not fail pre-exec checks, so the regenerated plan-slice typically
+  // passes and that delete fires every cycle. If recovery shared
+  // preExecRetryCount, its counter would be wiped to 0 each round and the loop
+  // would never reach the cap. Here we simulate that reset between rounds and
+  // assert the dedicated counter still climbs to MAX and stops.
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-1087-loop-term-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldLegacyMilestoneContext(tmp, "M002");
+  scaffoldLegacySlicePlan(tmp, "M002", "S03");
+
+  const session = {
+    missingTaskPlanRetryCount: new Map<string, number>(),
+    preExecRetryCount: new Map<string, number>(),
+  };
+
+  // Round 1: missing task plan → recover (counter 0 → 1).
+  const r1 = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
+  assert.ok(r1.action === "dispatch" && r1.unitType === "plan-slice",
+    `round 1 should re-dispatch plan-slice, got: ${r1.action === "dispatch" ? r1.unitType : "(stop)"}`);
+  assert.equal(session.missingTaskPlanRetryCount.get("M002/S03"), 1);
+
+  // The regenerated plan-slice passes its post-unit pre-exec check, deleting
+  // the shared "${mid}/${sid}" key from preExecRetryCount.
+  session.preExecRetryCount.delete("M002/S03");
+
+  // Round 2: still missing → recover (counter 1 → 2), unaffected by the reset.
+  const r2 = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
+  assert.ok(r2.action === "dispatch" && r2.unitType === "plan-slice",
+    `round 2 should re-dispatch plan-slice, got: ${r2.action === "dispatch" ? r2.unitType : "(stop)"}`);
+  assert.equal(session.missingTaskPlanRetryCount.get("M002/S03"), 2);
+
+  session.preExecRetryCount.delete("M002/S03");
+
+  // Round 3: cap reached → stop. The loop terminates despite the resets.
+  const r3 = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
+  assert.equal(r3.action, "stop");
+  assert.ok(r3.action === "stop" && r3.level === "error");
+  assert.match(r3.reason, /Missing task-plan recovery failed 2 times for M002\/S03/);
+  assert.equal(session.missingTaskPlanRetryCount.has("M002/S03"), false);
+});
+
 test("dispatch: session milestone mismatch stops before missing-task-plan recovery", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-session-milestone-mismatch-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -96,6 +96,40 @@ function scaffoldMilestoneContext(basePath: string, mid: string): void {
   ].join("\n"));
 }
 
+function scaffoldLegacyMilestoneContext(basePath: string, mid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${mid}-CONTEXT.md`), [
+    `# ${mid}: Test Milestone`,
+    "",
+    "Context for legacy dispatch recovery tests.",
+    "",
+  ].join("\n"));
+}
+
+function scaffoldLegacySlicePlan(basePath: string, mid: string, sid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid, "slices", sid);
+  mkdirSync(join(dir, "tasks"), { recursive: true });
+  writeFileSync(join(dir, `${sid}-PLAN.md`), [
+    `# ${sid}: Legacy Slice`,
+    "",
+    "## Tasks",
+    "- T01: Do something",
+    "",
+  ].join("\n"));
+}
+
+function scaffoldLegacyTaskPlan(basePath: string, mid: string, sid: string, tid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid, "slices", sid, "tasks");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${tid}-PLAN.md`), [
+    `# ${tid}: First Task`,
+    "",
+    "Implement the task.",
+    "",
+  ].join("\n"));
+}
+
 function scaffoldTaskPlan(basePath: string, mid: string, sid: string, tid: string): void {
   // Flat-phase: no per-task plan files. This is a no-op — tasks live as
   // checkboxes inside the slice plan. Kept for backward-compat with tests
@@ -165,6 +199,65 @@ test("dispatch: present task plan proceeds to execute-task normally", async (t) 
     `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
   assert.ok(result.action === "dispatch" && result.unitId === "M002/S03/T01",
     `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
+});
+
+test("dispatch: missing legacy task plan recovery increments a per-slice retry counter", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-1087-retry-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldLegacyMilestoneContext(tmp, "M002");
+  scaffoldLegacySlicePlan(tmp, "M002", "S03");
+
+  const session = {
+    preExecRetryCount: new Map<string, number>(),
+  };
+  const result = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(result.action === "dispatch" && result.unitType === "plan-slice",
+    `unitType should be plan-slice, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
+  assert.ok(result.action === "dispatch" && result.unitId === "M002/S03",
+    `unitId should be M002/S03, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
+  assert.equal(session.preExecRetryCount.get("M002/S03"), 1);
+});
+
+test("dispatch: missing legacy task plan recovery stops when retry counter is exhausted", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-1087-stop-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldLegacyMilestoneContext(tmp, "M002");
+  scaffoldLegacySlicePlan(tmp, "M002", "S03");
+
+  const session = {
+    preExecRetryCount: new Map<string, number>([["M002/S03", 2]]),
+  };
+  const result = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
+
+  assert.equal(result.action, "stop");
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "error");
+  assert.match(result.reason, /Missing task-plan recovery failed 2 times for M002\/S03/);
+  assert.match(result.reason, /manual intervention required/);
+  assert.equal(session.preExecRetryCount.has("M002/S03"), false);
+});
+
+test("dispatch: present legacy task plan clears missing-plan recovery retry counter", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-1087-clear-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldLegacyMilestoneContext(tmp, "M002");
+  scaffoldLegacySlicePlan(tmp, "M002", "S03");
+  scaffoldLegacyTaskPlan(tmp, "M002", "S03", "T01");
+
+  const session = {
+    preExecRetryCount: new Map<string, number>([["M002/S03", 1]]),
+  };
+  const result = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(result.action === "dispatch" && result.unitType === "execute-task",
+    `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
+  assert.equal(session.preExecRetryCount.has("M002/S03"), false);
 });
 
 test("dispatch: session milestone mismatch stops before missing-task-plan recovery", async (t) => {

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -209,7 +209,7 @@ test("dispatch: missing legacy task plan recovery increments a per-slice retry c
   scaffoldLegacySlicePlan(tmp, "M002", "S03");
 
   const session = {
-    preExecRetryCount: new Map<string, number>(),
+    missingTaskPlanRetryCount: new Map<string, number>(),
   };
   const result = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
 
@@ -218,7 +218,7 @@ test("dispatch: missing legacy task plan recovery increments a per-slice retry c
     `unitType should be plan-slice, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
   assert.ok(result.action === "dispatch" && result.unitId === "M002/S03",
     `unitId should be M002/S03, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
-  assert.equal(session.preExecRetryCount.get("M002/S03"), 1);
+  assert.equal(session.missingTaskPlanRetryCount.get("M002/S03"), 1);
 });
 
 test("dispatch: missing legacy task plan recovery stops when retry counter is exhausted", async (t) => {
@@ -229,7 +229,7 @@ test("dispatch: missing legacy task plan recovery stops when retry counter is ex
   scaffoldLegacySlicePlan(tmp, "M002", "S03");
 
   const session = {
-    preExecRetryCount: new Map<string, number>([["M002/S03", 2]]),
+    missingTaskPlanRetryCount: new Map<string, number>([["M002/S03", 2]]),
   };
   const result = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
 
@@ -238,7 +238,7 @@ test("dispatch: missing legacy task plan recovery stops when retry counter is ex
   assert.equal(result.level, "error");
   assert.match(result.reason, /Missing task-plan recovery failed 2 times for M002\/S03/);
   assert.match(result.reason, /manual intervention required/);
-  assert.equal(session.preExecRetryCount.has("M002/S03"), false);
+  assert.equal(session.missingTaskPlanRetryCount.has("M002/S03"), false);
 });
 
 test("dispatch: present legacy task plan clears missing-plan recovery retry counter", async (t) => {
@@ -250,14 +250,17 @@ test("dispatch: present legacy task plan clears missing-plan recovery retry coun
   scaffoldLegacyTaskPlan(tmp, "M002", "S03", "T01");
 
   const session = {
-    preExecRetryCount: new Map<string, number>([["M002/S03", 1]]),
+    missingTaskPlanRetryCount: new Map<string, number>([["M002/S03", 1]]),
+    preExecRetryCount: new Map<string, number>([["M002/S03", 2]]),
   };
   const result = await resolveDispatch(makeContextFor(tmp, "M002", "S03", "T01", session));
 
   assert.equal(result.action, "dispatch");
   assert.ok(result.action === "dispatch" && result.unitType === "execute-task",
     `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
-  assert.equal(session.preExecRetryCount.has("M002/S03"), false);
+  assert.equal(session.missingTaskPlanRetryCount.has("M002/S03"), false);
+  assert.equal(session.preExecRetryCount.get("M002/S03"), 2,
+    "pre-exec retry counter must not be cleared when task plan is present");
 });
 
 test("dispatch: session milestone mismatch stops before missing-task-plan recovery", async (t) => {


### PR DESCRIPTION
## Summary
- Added bounded missing task-plan recovery retries with regression tests; whitespace verification passed, while test execution was blocked by unavailable npm registry access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1087
- [#1087 [Bug]: The "recover missing task plan → plan-slice" auto-dispatch rule re-dispatches `plan-slice` with no retry counter, allowing an uncounted regenerate loop](https://github.com/open-gsd/gsd-pi/issues/1087)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1087-bug-the-recover-missing-task-plan-plan-s-1782847045`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized auto-dispatch circuit-breaker logic mirroring existing pre-exec retries; regression tests cover the new paths with no auth or data-handling impact.
> 
> **Overview**
> Fixes **#1087** by bounding the **executing → recover missing task plan → plan-slice** auto-dispatch path, which could re-dispatch `plan-slice` forever when per-task `PLAN` files never appeared.
> 
> **`AutoSession`** now tracks **`missingTaskPlanRetryCount`** per slice (`M###/S##`), separate from **`preExecRetryCount`**, and clears it on session **`reset()`**. On each recovery dispatch the counter increments; after **2** failed attempts auto-mode **stops** with an error asking for manual fixes. When task plans exist again, the counter is cleared so a later recovery can retry without inheriting stale counts.
> 
> Regression tests use **legacy** `milestones/…/tasks/` layouts to cover increment, exhaustion, and counter clearing without touching pre-exec retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb17d2ed84c9ea8cab210e15f7748ee0b7b08a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->