### PR TITLE
fix(issue): [Bug]: `/gsd doctor` never compares ROADMAP/PLAN checkbox state against authoritative DB status, so DB↔projection divergence is reported as "no problems"

### DIFF
--- a/mintlify-docs/guides/troubleshooting.mdx
+++ b/mintlify-docs/guides/troubleshooting.mdx
@@ -13,6 +13,12 @@ The built-in diagnostic tool validates `.gsd/` integrity:
 
 It checks file structure, referential integrity, completion state consistency, git worktree health, and stale DB-backed runtime records.
 
+### Diagnostic-only DB/markdown drift
+
+If `/gsd doctor` reports `checkbox_db_status_divergence`, a `ROADMAP.md` or `PLAN.md` checkbox disagrees with the canonical SQLite database status for the listed slice or task. For example, the database may still show the unit as open while the markdown checkbox is checked, or the database may show the unit as closed while the checkbox is unchecked.
+
+This check is not auto-fixable. `/gsd doctor fix` will not rewrite either side because the drift can mean a manual markdown edit, a stale projection, or an interrupted status update. Inspect the listed file and unit first. If the database is correct, run `/gsd rebuild markdown` to re-render markdown projections from the DB; if markdown captures real work that is missing from the DB, recover or re-enter that state through the normal GSD workflow instead of treating the checkbox as authoritative.
+
 ## Common issues
 
 <AccordionGroup>

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -1,14 +1,104 @@
-import { existsSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { relative } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
-import { isDbAvailable, _getAdapter } from "./gsd-db.js";
+import { getAllMilestones, getMilestoneSlices, getSliceTasks, isDbAvailable, _getAdapter } from "./gsd-db.js";
 import { isAfter, latestExplicitReopenAt } from "./milestone-reopen-events.js";
-import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
+import { resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "./paths.js";
 import { deriveState } from "./state.js";
+import { isClosedStatus } from "./status-guards.js";
 import { workflowEventLogPath } from "./workflow-event-ledger.js";
 import { readEvents } from "./workflow-events.js";
 import { flushWorkflowProjections } from "./projection-flush.js";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function projectionCheckboxDone(content: string, unitId: string): boolean | null {
+  const id = escapeRegExp(unitId);
+  const match = content.match(new RegExp(`^\\s*-\\s*\\[([ xX])\\]\\s*\\*\\*${id}(?::|\\*\\*)`, "m"));
+  if (!match) return null;
+  return match[1]!.toLowerCase() === "x";
+}
+
+function relativeFile(basePath: string, filePath: string): string {
+  return relative(basePath, filePath).split("\\").join("/");
+}
+
+function reportCheckboxDbStatusDivergence(
+  issues: DoctorIssue[],
+  basePath: string,
+  filePath: string,
+  scope: "slice" | "task",
+  unitId: string,
+  status: string,
+  checkboxDone: boolean,
+): void {
+  const dbDone = isClosedStatus(status);
+  if (checkboxDone === dbDone) return;
+
+  issues.push({
+    severity: "error",
+    code: "checkbox_db_status_divergence",
+    scope,
+    unitId,
+    message: `${scope === "slice" ? "Slice" : "Task"} ${unitId} is ${dbDone ? "closed" : "open"} in the database (status: ${status}) but the markdown checkbox is ${checkboxDone ? "checked" : "unchecked"}.`,
+    file: relativeFile(basePath, filePath),
+    fixable: false,
+  });
+}
+
+function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[], issues: DoctorIssue[]): void {
+  for (const milestoneId of milestoneIds) {
+    const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+    const slices = getMilestoneSlices(milestoneId);
+
+    if (roadmapPath && existsSync(roadmapPath)) {
+      try {
+        const roadmap = readFileSync(roadmapPath, "utf-8");
+        for (const slice of slices) {
+          const checkboxDone = projectionCheckboxDone(roadmap, slice.id);
+          if (checkboxDone === null) continue;
+          reportCheckboxDbStatusDivergence(
+            issues,
+            basePath,
+            roadmapPath,
+            "slice",
+            `${milestoneId}/${slice.id}`,
+            slice.status,
+            checkboxDone,
+          );
+        }
+      } catch {
+        // Non-fatal — checkbox drift diagnostics must never block doctor.
+      }
+    }
+
+    for (const slice of slices) {
+      const planPath = resolveSliceFile(basePath, milestoneId, slice.id, "PLAN");
+      if (!planPath || !existsSync(planPath)) continue;
+      try {
+        const plan = readFileSync(planPath, "utf-8");
+        for (const task of getSliceTasks(milestoneId, slice.id)) {
+          const checkboxDone = projectionCheckboxDone(plan, task.id);
+          if (checkboxDone === null) continue;
+          reportCheckboxDbStatusDivergence(
+            issues,
+            basePath,
+            planPath,
+            "task",
+            `${milestoneId}/${slice.id}/${task.id}`,
+            task.status,
+            checkboxDone,
+          );
+        }
+      } catch {
+        // Non-fatal — checkbox drift diagnostics must never block doctor.
+      }
+    }
+  }
+}
 
 export async function checkEngineHealth(
   basePath: string,
@@ -289,6 +379,7 @@ export async function checkEngineHealth(
           }
         }
       }
+      checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
     }
   } catch {
     // Non-fatal — projection drift check must never block doctor

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -384,7 +384,16 @@ export async function checkEngineHealth(
     // Non-fatal — projection drift check must never block doctor
   }
 
-  if (isDbAvailable()) {
-    checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
+  // Checkbox-vs-DB divergence detection runs independently of the projection
+  // drift pass above, and inside its own try/catch: getAllMilestones /
+  // getMilestoneSlices / getSliceTasks issue prepared queries that can throw on
+  // a corrupt or locked DB, and like every other DB-touching check here this
+  // diagnostic must never block doctor.
+  try {
+    if (isDbAvailable()) {
+      checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
+    }
+  } catch {
+    // Non-fatal: checkbox-vs-DB divergence check must never block doctor
   }
 }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -11,17 +11,7 @@ import { workflowEventLogPath } from "./workflow-event-ledger.js";
 import { readEvents } from "./workflow-events.js";
 import { flushWorkflowProjections } from "./projection-flush.js";
 import { parseRoadmapSlices } from "./roadmap-slices.js";
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function projectionCheckboxDone(content: string, unitId: string): boolean | null {
-  const id = escapeRegExp(unitId);
-  const match = content.match(new RegExp(`^\\s*-\\s*\\[([ xX])\\]\\s*\\*\\*${id}(?::|\\*\\*)`, "m"));
-  if (!match) return null;
-  return match[1]!.toLowerCase() === "x";
-}
+import { parsePlan } from "./parsers-legacy.js";
 
 function relativeFile(basePath: string, filePath: string): string {
   return relative(basePath, filePath).split("\\").join("/");
@@ -82,9 +72,14 @@ function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[
       if (!planPath || !existsSync(planPath)) continue;
       try {
         const plan = readFileSync(planPath, "utf-8");
+        // parsePlan reads the authoritative task checkboxes (the flat-phase
+        // <tasks> block / ## Tasks section), so a stray task-style checkbox
+        // line elsewhere in PLAN.md (e.g. a Must-Haves or Verification bullet
+        // above <tasks>) can no longer hide real drift or fake a divergence.
+        const taskDoneById = new Map(parsePlan(plan).tasks.map((entry) => [entry.id, entry.done]));
         for (const task of getSliceTasks(milestoneId, slice.id)) {
-          const checkboxDone = projectionCheckboxDone(plan, task.id);
-          if (checkboxDone === null) continue;
+          const checkboxDone = taskDoneById.get(task.id);
+          if (checkboxDone === undefined) continue;
           reportCheckboxDbStatusDivergence(
             issues,
             basePath,

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -365,6 +365,7 @@ export async function checkEngineHealth(
   // ── Projection drift detection ──────────────────────────────────────────
   // If the DB is available, check whether markdown projections are stale
   // relative to the event log and re-render them.
+  const reRenderedMilestoneIds: string[] = [];
   try {
     if (isDbAvailable()) {
       const eventLogPath = workflowEventLogPath(basePath);
@@ -379,6 +380,7 @@ export async function checkEngineHealth(
             try {
               await flushWorkflowProjections(basePath, { milestoneId: milestone.id });
               fixesApplied.push(`re-rendered missing projections for ${milestone.id}`);
+              reRenderedMilestoneIds.push(milestone.id);
             } catch {
               // Non-fatal — projection re-render failed
             }
@@ -389,6 +391,7 @@ export async function checkEngineHealth(
             try {
               await flushWorkflowProjections(basePath, { milestoneId: milestone.id });
               fixesApplied.push(`re-rendered stale projections for ${milestone.id}`);
+              reRenderedMilestoneIds.push(milestone.id);
             } catch {
               // Non-fatal — projection re-render failed
             }
@@ -398,5 +401,17 @@ export async function checkEngineHealth(
     }
   } catch {
     // Non-fatal — projection drift check must never block doctor
+  }
+
+  if (reRenderedMilestoneIds.length > 0) {
+    const reRendered = new Set(reRenderedMilestoneIds);
+    for (let i = issues.length - 1; i >= 0; i--) {
+      const issue = issues[i]!;
+      if (issue.code !== "checkbox_db_status_divergence") continue;
+      const milestoneId = issue.unitId.split("/")[0] ?? "";
+      if (reRendered.has(milestoneId)) {
+        issues.splice(i, 1);
+      }
+    }
   }
 }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -408,6 +408,9 @@ export async function checkEngineHealth(
     for (let i = issues.length - 1; i >= 0; i--) {
       const issue = issues[i]!;
       if (issue.code !== "checkbox_db_status_divergence") continue;
+      // flushWorkflowProjections only re-renders milestone shell projections (e.g.
+      // ROADMAP.md), not slice PLAN.md files — keep task-level PLAN divergences.
+      if (issue.scope !== "slice") continue;
       const milestoneId = issue.unitId.split("/")[0] ?? "";
       if (reRendered.has(milestoneId)) {
         issues.splice(i, 1);

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -10,6 +10,7 @@ import { isClosedStatus } from "./status-guards.js";
 import { workflowEventLogPath } from "./workflow-event-ledger.js";
 import { readEvents } from "./workflow-events.js";
 import { flushWorkflowProjections } from "./projection-flush.js";
+import { parseRoadmapSlices } from "./roadmap-slices.js";
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -57,9 +58,10 @@ function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[
     if (roadmapPath && existsSync(roadmapPath)) {
       try {
         const roadmap = readFileSync(roadmapPath, "utf-8");
+        const sliceDoneById = new Map(parseRoadmapSlices(roadmap).map((entry) => [entry.id, entry.done]));
         for (const slice of slices) {
-          const checkboxDone = projectionCheckboxDone(roadmap, slice.id);
-          if (checkboxDone === null) continue;
+          const checkboxDone = sliceDoneById.get(slice.id);
+          if (checkboxDone === undefined) continue;
           reportCheckboxDbStatusDivergence(
             issues,
             basePath,
@@ -346,6 +348,20 @@ export async function checkEngineHealth(
     // Non-fatal — DB constraint checks failed entirely
   }
 
+  // Checkbox-vs-DB divergence detection runs before projection drift auto-fix
+  // so stale re-renders cannot overwrite manually edited markdown first. Runs
+  // inside its own try/catch: getAllMilestones / getMilestoneSlices /
+  // getSliceTasks issue prepared queries that can throw on a corrupt or locked
+  // DB, and like every other DB-touching check here this diagnostic must never
+  // block doctor.
+  try {
+    if (isDbAvailable()) {
+      checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
+    }
+  } catch {
+    // Non-fatal: checkbox-vs-DB divergence check must never block doctor
+  }
+
   // ── Projection drift detection ──────────────────────────────────────────
   // If the DB is available, check whether markdown projections are stale
   // relative to the event log and re-render them.
@@ -382,18 +398,5 @@ export async function checkEngineHealth(
     }
   } catch {
     // Non-fatal — projection drift check must never block doctor
-  }
-
-  // Checkbox-vs-DB divergence detection runs independently of the projection
-  // drift pass above, and inside its own try/catch: getAllMilestones /
-  // getMilestoneSlices / getSliceTasks issue prepared queries that can throw on
-  // a corrupt or locked DB, and like every other DB-touching check here this
-  // diagnostic must never block doctor.
-  try {
-    if (isDbAvailable()) {
-      checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
-    }
-  } catch {
-    // Non-fatal: checkbox-vs-DB divergence check must never block doctor
   }
 }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -379,9 +379,12 @@ export async function checkEngineHealth(
           }
         }
       }
-      checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
     }
   } catch {
     // Non-fatal — projection drift check must never block doctor
+  }
+
+  if (isDbAvailable()) {
+    checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
   }
 }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -102,6 +102,23 @@ function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[
   }
 }
 
+function isClearedByMilestoneShellProjectionFlush(
+  basePath: string,
+  issue: DoctorIssue,
+  reRenderedMilestoneIds: Set<string>,
+): boolean {
+  if (issue.code !== "checkbox_db_status_divergence") return false;
+  if (issue.scope !== "slice") return false;
+
+  const milestoneId = issue.unitId.split("/")[0] ?? "";
+  if (!reRenderedMilestoneIds.has(milestoneId)) return false;
+
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  if (!roadmapPath || !issue.file) return false;
+
+  return issue.file === relativeFile(basePath, roadmapPath);
+}
+
 export async function checkEngineHealth(
   basePath: string,
   issues: DoctorIssue[],
@@ -407,12 +424,9 @@ export async function checkEngineHealth(
     const reRendered = new Set(reRenderedMilestoneIds);
     for (let i = issues.length - 1; i >= 0; i--) {
       const issue = issues[i]!;
-      if (issue.code !== "checkbox_db_status_divergence") continue;
-      // flushWorkflowProjections only re-renders milestone shell projections (e.g.
-      // ROADMAP.md), not slice PLAN.md files — keep task-level PLAN divergences.
-      if (issue.scope !== "slice") continue;
-      const milestoneId = issue.unitId.split("/")[0] ?? "";
-      if (reRendered.has(milestoneId)) {
+      // flushWorkflowProjections re-renders milestone shell projections (not
+      // slice PLAN.md files), so only clear stale ROADMAP checkbox diagnostics.
+      if (isClearedByMilestoneShellProjectionFlush(basePath, issue, reRendered)) {
         issues.splice(i, 1);
       }
     }

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -85,6 +85,7 @@ export type DoctorIssueCode =
   | "db_orphaned_slice"
   | "db_done_task_no_summary"
   | "artifact_db_status_divergence"
+  | "checkbox_db_status_divergence"
   | "completed_milestone_reopened"
   | "db_duplicate_id"
   | "db_unavailable"

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, test } from "node:test";
 import assert from "node:assert/strict";
-import { _getAdapter, closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { _getAdapter, closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { filterDoctorIssues } from "../doctor-format.ts";
 import { checkEngineHealth } from "../doctor-engine-checks.ts";
 import { appendEvent } from "../workflow-events.ts";
+import { renderPlanFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
 
 afterEach(() => {
   closeDatabase();
@@ -59,6 +60,35 @@ test("checkEngineHealth reports db_unavailable when gsd.db exists but the DB is 
   assert.ok(dbIssue, "doctor should surface degraded DB mode when a DB file exists");
   assert.equal(dbIssue.unitId, "project");
   assert.equal(dbIssue.file, ".gsd/gsd.db");
+});
+
+test("checkEngineHealth reports checkbox divergence against DB status", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-checkbox-drift-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending", risk: "low", depends: [], sequence: 1 });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "complete", sequence: 1 });
+
+  const roadmap = await renderRoadmapFromDb(base, "M001");
+  if ("skipped" in roadmap) assert.fail("planned milestone should render a roadmap");
+  const plan = await renderPlanFromDb(base, "M001", "S01");
+
+  writeFileSync(roadmap.roadmapPath, readFileSync(roadmap.roadmapPath, "utf-8").replace("- [ ] **S01:", "- [x] **S01:"), "utf-8");
+  writeFileSync(plan.planPath, readFileSync(plan.planPath, "utf-8").replace("- [x] **T01**:", "- [ ] **T01**:"), "utf-8");
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const divergences = issues.filter((issue) => issue.code === "checkbox_db_status_divergence");
+  assert.deepEqual(
+    divergences.map((issue) => issue.unitId).sort(),
+    ["M001/S01", "M001/S01/T01"],
+  );
 });
 
 test("checkEngineHealth reads canonical reopen events from worktree bases", async (t) => {

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -130,6 +130,44 @@ test("checkEngineHealth keeps PLAN checkbox divergence after stale projection fl
   assert.match(readFileSync(plan.planPath, "utf-8"), /- \[ \] \*\*T01\*\*:/);
 });
 
+test("checkEngineHealth reads task checkboxes from the <tasks> block, not a stray line above it", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-task-section-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending", risk: "low", depends: [], sequence: 1 });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "complete", sequence: 1 });
+
+  const roadmap = await renderRoadmapFromDb(base, "M001");
+  if ("skipped" in roadmap) assert.fail("planned milestone should render a roadmap");
+  const plan = await renderPlanFromDb(base, "M001", "S01");
+
+  // Flip the authoritative <tasks> checkbox so it disagrees with the DB
+  // (DB: complete, markdown: unchecked = real drift), then inject a *checked*
+  // decoy line for the same task above the <tasks> block. The old whole-file
+  // regex matched the decoy first and hid the real drift; parsePlan reads the
+  // authoritative <tasks> block and still reports it. No events are appended,
+  // so the projection-drift re-render never runs and the crafted file stands.
+  const rendered = readFileSync(plan.planPath, "utf-8")
+    .replace("- [x] **T01**:", "- [ ] **T01**:")
+    .replace("<tasks>\n", "- [x] **T01**: stale duplicate above the tasks block\n\n<tasks>\n");
+  writeFileSync(plan.planPath, rendered, "utf-8");
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const divergences = issues.filter((issue) => issue.code === "checkbox_db_status_divergence");
+  assert.deepEqual(
+    divergences.map((issue) => issue.unitId),
+    ["M001/S01/T01"],
+    "task drift must be read from the authoritative <tasks> block, not a stray checkbox above it",
+  );
+});
+
 test("checkEngineHealth reads canonical reopen events from worktree bases", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-reopen-worktree-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -91,6 +91,45 @@ test("checkEngineHealth reports checkbox divergence against DB status", async (t
   );
 });
 
+test("checkEngineHealth keeps PLAN checkbox divergence after stale projection flush", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-checkbox-plan-drift-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending", risk: "low", depends: [], sequence: 1 });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "complete", sequence: 1 });
+
+  const roadmap = await renderRoadmapFromDb(base, "M001");
+  if ("skipped" in roadmap) assert.fail("planned milestone should render a roadmap");
+  const plan = await renderPlanFromDb(base, "M001", "S01");
+
+  writeFileSync(roadmap.roadmapPath, readFileSync(roadmap.roadmapPath, "utf-8").replace("- [ ] **S01:", "- [x] **S01:"), "utf-8");
+  writeFileSync(plan.planPath, readFileSync(plan.planPath, "utf-8").replace("- [x] **T01**:", "- [ ] **T01**:"), "utf-8");
+  appendEvent(base, {
+    cmd: "complete-task",
+    params: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    ts: "2999-01-01T00:00:00.000Z",
+    actor: "agent",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes);
+
+  const divergences = issues.filter((issue) => issue.code === "checkbox_db_status_divergence");
+  assert.deepEqual(
+    divergences.map((issue) => issue.unitId),
+    ["M001/S01/T01"],
+    "stale ROADMAP divergence is cleared after re-render, but stale PLAN task divergence remains",
+  );
+  assert.ok(fixes.includes("re-rendered stale projections for M001"));
+  assert.match(readFileSync(plan.planPath, "utf-8"), /- \[ \] \*\*T01\*\*:/);
+});
+
 test("checkEngineHealth reads canonical reopen events from worktree bases", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-reopen-worktree-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
@@ -58,6 +58,8 @@ const ALLOWED_IMPORTERS = new Set([
   "gsd/artifact-verification.ts",
   // diagnostics-only surfaces: report on projections, make no dispatch decisions
   "gsd/doctor.ts",
+  // diagnostics-only: compares PLAN.md task checkboxes against DB status
+  "gsd/doctor-engine-checks.ts",
   // display/telemetry-only surfaces
   "gsd/workspace-index.ts",
   "gsd/visualizer-data.ts",


### PR DESCRIPTION
## Summary
- Added doctor checkbox-vs-DB divergence detection and regression coverage; diff check passed, but focused tests were blocked by missing dependencies and npm DNS failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1089
- [#1089 [Bug]: `/gsd doctor` never compares ROADMAP/PLAN checkbox state against authoritative DB status, so DB↔projection divergence is reported as "no problems"](https://github.com/open-gsd/gsd-pi/issues/1089)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1089-bug-gsd-doctor-never-compares-roadmap-pl-1782847402`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostics and docs; ordering with projection flush only affects which reported issues are cleared after re-render, not DB writes.
> 
> **Overview**
> **`/gsd doctor` now flags when `ROADMAP.md` slice or `PLAN.md` task checkboxes disagree with canonical SQLite status**, emitting non-fixable `checkbox_db_status_divergence` errors instead of reporting a clean bill of health.
> 
> The new check runs **before** stale projection auto-re-render so a flush cannot mask drift from manual markdown edits. After doctor re-renders milestone shell projections, **stale ROADMAP slice mismatches cleared by that re-render are dropped**; **PLAN task checkbox drift is kept** because flush does not rewrite slice plans.
> 
> Troubleshooting docs explain recovery (`/gsd rebuild markdown` vs normal workflow when markdown is authoritative). Regression tests cover ROADMAP/PLAN divergence and post-flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f1d9a976a6c20f08053b27af53265259b01e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->