### PR TITLE
fix(issue): [Bug]: Harness tool-loop-guard blocks are counted as tool-schema validation failures, tripping the consecutive-failure breaker and aborting the auto unit

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -514,7 +514,7 @@ async function executeToolCallsSequential(
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		let finalized: FinalizedToolCallOutcome;
 		if (preparation.kind === "immediate") {
-			if (preparation.isError) {
+			if (preparation.isError && preparation.countsTowardValidationFailure !== false) {
 				preparationErrorCount++;
 			}
 			finalized = {
@@ -573,7 +573,7 @@ async function executeToolCallsParallel(
 
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		if (preparation.kind === "immediate") {
-			if (preparation.isError) {
+			if (preparation.isError && preparation.countsTowardValidationFailure !== false) {
 				preparationErrorCount++;
 			}
 			const finalized = {
@@ -635,6 +635,7 @@ type ImmediateToolCallOutcome = {
 	kind: "immediate";
 	result: AgentToolResult<any>;
 	isError: boolean;
+	countsTowardValidationFailure?: boolean;
 };
 
 type ExecutedToolCallOutcome = {
@@ -761,6 +762,7 @@ async function prepareToolCall(
 					kind: "immediate",
 					result: createErrorToolResult(reason, beforeResult.displayReason),
 					isError: true,
+					countsTowardValidationFailure: false,
 				};
 			}
 		}

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -522,6 +522,86 @@ describe("agentLoop with AgentMessage", () => {
 		);
 	});
 
+	it("should not count beforeToolCall blocks toward consecutive validation failures", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		let executed = false;
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				executed = true;
+				throw new Error("tool should have been blocked");
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			beforeToolCall: async () => ({
+				block: true,
+				reason: "Loop guard blocked repeated tool call.",
+			}),
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (streamCallCount <= 3) {
+					const message = createAssistantMessage(
+						[
+							{
+								type: "toolCall",
+								id: `tool-${streamCallCount}`,
+								name: "echo",
+								arguments: { value: "hello" },
+							},
+						],
+						"toolUse",
+					);
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "recovered after blocks" }]),
+					});
+				}
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo repeatedly")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const lastAssistant = [...messages].reverse().find((message) => message.role === "assistant");
+		const blockedResults = events.filter(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end",
+		);
+
+		expect(executed).toBe(false);
+		expect(streamCallCount).toBe(4);
+		expect(blockedResults).toHaveLength(3);
+		expect(blockedResults.every((event) => event.isError)).toBe(true);
+		expect(lastAssistant?.stopReason).toBe("stop");
+		expect(lastAssistant?.content).toEqual([{ type: "text", text: "recovered after blocks" }]);
+		expect(lastAssistant?.errorMessage).toBeUndefined();
+	});
+
 	it("should prepare tool arguments for validation", async () => {
 		const replaceSchema = Type.Object({ oldText: Type.String(), newText: Type.String() });
 		const toolSchema = Type.Object({ edits: Type.Array(replaceSchema) });


### PR DESCRIPTION
## Summary
- Fixed hook-block accounting so loop-guard blocks do not trip schema overload, with a focused regression test and diff hygiene verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1094
- [#1094 [Bug]: Harness tool-loop-guard blocks are counted as tool-schema validation failures, tripping the consecutive-failure breaker and aborting the auto unit](https://github.com/open-gsd/gsd-pi/issues/1094)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1094-bug-harness-tool-loop-guard-blocks-are-c-1782847883`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to agent-loop accounting with a focused regression test; real schema/not-found preparation errors still trip the breaker as before.
> 
> **Overview**
> **Fixes harness auto-units aborting** when the tool-loop guard repeatedly blocks the same tool via `beforeToolCall`: those outcomes still surface as tool errors to the model, but they no longer increment `preparationErrorCount` toward the consecutive schema-validation cap (`MAX_CONSECUTIVE_VALIDATION_FAILURES`).
> 
> Immediate preparation outcomes can set **`countsTowardValidationFailure: false`**; hook blocks use that flag. Sequential and parallel tool execution only count preparation errors when that flag is not explicitly `false`.
> 
> Adds a regression test simulating three blocked turns followed by a normal stop, asserting the agent does not emit the schema-overload stop message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe4840d933791fd86e2695dad7a3d5150a7971d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->