### PR TITLE
fix(issue): [Bug]: `/gsd doctor` has no probe for a never-built or desynced `memories_fts` index, so memory search silently degrades to a LIKE fallback

### DIFF
--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -2,7 +2,15 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { relative } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
-import { getAllMilestones, getMilestoneSlices, getSliceTasks, isDbAvailable, _getAdapter } from "./gsd-db.js";
+import {
+  getAllMilestones,
+  getMilestoneSlices,
+  getSliceTasks,
+  isDbAvailable,
+  isMemoriesFtsAvailable,
+  _getAdapter,
+} from "./gsd-db.js";
+import { MEMORIES_FTS_REBUILT_KEY } from "./db-memory-fts-schema.js";
 import { isAfter, latestExplicitReopenAt } from "./milestone-reopen-events.js";
 import { resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "./paths.js";
 import { deriveState } from "./state.js";
@@ -137,6 +145,32 @@ export async function checkEngineHealth(
   try {
     if (isDbAvailable()) {
       const adapter = _getAdapter()!;
+
+      try {
+        if (isMemoriesFtsAvailable(adapter)) {
+          const runtimeKv = adapter
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='runtime_kv'")
+            .get();
+          const marker = runtimeKv
+            ? adapter.prepare(
+                "SELECT 1 as present FROM runtime_kv WHERE scope = 'global' AND scope_id = '' AND key = :key",
+              ).get({ ":key": MEMORIES_FTS_REBUILT_KEY })
+            : undefined;
+          if (!marker) {
+            issues.push({
+              severity: "warning",
+              code: "memories_fts_rebuild_missing",
+              scope: "project",
+              unitId: "project",
+              message: `Memory full-text index exists but runtime_kv has no ${MEMORIES_FTS_REBUILT_KEY} marker. The index may be stale or incomplete, so memory search can silently degrade to the LIKE fallback.`,
+              file: ".gsd/gsd.db",
+              fixable: false,
+            });
+          }
+        }
+      } catch {
+        // Non-fatal — memory FTS health check failed
+      }
 
       // a. Orphaned tasks (task.slice_id points to non-existent slice)
       try {

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -89,6 +89,7 @@ export type DoctorIssueCode =
   | "completed_milestone_reopened"
   | "db_duplicate_id"
   | "db_unavailable"
+  | "memories_fts_rebuild_missing"
   | "projection_drift"
   // Milestone filesystem/DB drift (#4996)
   | "orphan_milestone_dir"

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { filterDoctorIssues } from "../doctor-format.ts";
 import { checkEngineHealth } from "../doctor-engine-checks.ts";
+import { MEMORIES_FTS_REBUILT_KEY } from "../db-memory-fts-schema.ts";
 import { appendEvent } from "../workflow-events.ts";
 import { renderPlanFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
 
@@ -60,6 +61,33 @@ test("checkEngineHealth reports db_unavailable when gsd.db exists but the DB is 
   assert.ok(dbIssue, "doctor should surface degraded DB mode when a DB file exists");
   assert.equal(dbIssue.unitId, "project");
   assert.equal(dbIssue.file, ".gsd/gsd.db");
+});
+
+test("checkEngineHealth reports memories_fts without the rebuild marker", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-memory-fts-marker-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  const adapter = _getAdapter()!;
+  const fts = adapter.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='memories_fts'").get();
+  if (!fts) return;
+
+  adapter.prepare(
+    "DELETE FROM runtime_kv WHERE scope = 'global' AND scope_id = '' AND key = :key",
+  ).run({ ":key": MEMORIES_FTS_REBUILT_KEY });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const ftsIssue = issues.find((issue) => issue.code === "memories_fts_rebuild_missing");
+  assert.ok(ftsIssue, "doctor should surface a potentially desynced memory FTS index");
+  assert.equal(ftsIssue.severity, "warning");
+  assert.equal(ftsIssue.unitId, "project");
+  assert.equal(ftsIssue.file, ".gsd/gsd.db");
+  assert.equal(ftsIssue.fixable, false);
 });
 
 test("checkEngineHealth reports checkbox divergence against DB status", async (t) => {


### PR DESCRIPTION
## Summary
- Added a doctor engine warning for memories_fts indexes missing the rebuild marker, with regression coverage and focused verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1090
- [#1090 [Bug]: `/gsd doctor` has no probe for a never-built or desynced `memories_fts` index, so memory search silently degrades to a LIKE fallback](https://github.com/open-gsd/gsd-pi/issues/1090)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1090-bug-gsd-doctor-has-no-probe-for-a-never--1782859866`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only change in doctor engine checks with a new warning code and test; no change to search or rebuild behavior.
> 
> **Overview**
> **`/gsd doctor` now surfaces a project-level warning when `memories_fts` exists but `runtime_kv` has no `memories_fts_rebuilt_at` marker**, so users are not left with memory search silently falling back to LIKE.
> 
> The new **`memories_fts_rebuild_missing`** issue is emitted from `checkEngineHealth` (non-fatal, not auto-fixable) alongside existing DB constraint checks. **`DoctorIssueCode`** is extended accordingly, and a regression test deletes the marker and asserts the warning shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec0825246a31ae53d627ea957705ac356531bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->