### PR TITLE
Normalize malformed tool result content

### DIFF
--- a/packages/gsd-agent-core/src/export-html/template.js
+++ b/packages/gsd-agent-core/src/export-html/template.js
@@ -894,15 +894,64 @@
         const isError = result?.isError || false;
         const statusClass = result ? (isError ? 'error' : 'success') : 'pending';
 
+        // This template runs as a standalone browser script in exported HTML,
+        // so it cannot import normalizeToolResultContent from @gsd/pi-ai.
+        // Keep these fallback semantics aligned with that helper.
+        const stringifyResultContent = (content) => {
+          try {
+            const value = JSON.stringify(content);
+            if (typeof value === 'string') return value;
+          } catch {
+            // Fall through to String(content). JSON.stringify can throw for cycles.
+          }
+
+          try {
+            return String(content);
+          } catch {
+            return '[unstringifiable tool result content]';
+          }
+        };
+
+        const serializableCacheControl = (block) => {
+          if (!block || typeof block !== 'object' || !('cache_control' in block)) return {};
+          try {
+            JSON.stringify(block.cache_control);
+            return { cache_control: block.cache_control };
+          } catch {
+            return {};
+          }
+        };
+
+        const normalizeResultContentBlock = (block) => {
+          if (typeof block === 'string') return { type: 'text', text: block };
+          if (block && typeof block === 'object') {
+            const cacheControl = serializableCacheControl(block);
+            if (block.type === 'text' && typeof block.text === 'string') return { type: 'text', text: block.text, ...cacheControl };
+            if (block.type === 'image' && typeof block.data === 'string' && typeof block.mimeType === 'string') {
+              return { type: 'image', data: block.data, mimeType: block.mimeType, ...cacheControl };
+            }
+          }
+          return { type: 'text', text: stringifyResultContent(block) };
+        };
+
+        const getResultContent = () => {
+          if (!result) return [];
+          if (Array.isArray(result.content)) {
+            const blocks = result.content.map(normalizeResultContentBlock);
+            return blocks.length > 0 ? blocks : [{ type: 'text', text: '' }];
+          }
+          if (typeof result.content === 'string') return [{ type: 'text', text: result.content }];
+          if (result.content == null) return [{ type: 'text', text: '' }];
+          return [{ type: 'text', text: stringifyResultContent(result.content) }];
+        };
+
         const getResultText = () => {
-          if (!result) return '';
-          const textBlocks = result.content.filter(c => c.type === 'text');
+          const textBlocks = getResultContent().filter(c => c.type === 'text');
           return textBlocks.map(c => c.text).join('\n');
         };
 
         const getResultImages = () => {
-          if (!result) return [];
-          return result.content.filter(c => c.type === 'image');
+          return getResultContent().filter(c => c.type === 'image');
         };
 
         const renderResultImages = () => {

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.ts
@@ -1,5 +1,6 @@
 // Project/App: gsd-pi
 // File Purpose: Interactive TUI chat stream controller.
+import { normalizeToolResultContent } from "@gsd/pi-ai";
 import { Loader, Spacer, Text } from "@gsd/pi-tui";
 
 import type { InteractiveModeEvent, InteractiveModeStateHost } from "../interactive-mode-state.js";
@@ -202,7 +203,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				const innerEvent = event.assistantMessageEvent;
 
 				let externalToolResult:
-					| { toolCallId: string; content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; details: Record<string, unknown>; isError: boolean }
+					| { toolCallId: string; content: ReturnType<typeof normalizeToolResultContent>; details: Record<string, unknown>; isError: boolean }
 					| undefined;
 				if (innerEvent.type === "toolcall_end" && innerEvent.toolCall) {
 					const tc = innerEvent.toolCall as any;
@@ -210,7 +211,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					if (ext) {
 						externalToolResult = {
 							toolCallId: tc.id,
-							content: ext.content ?? [{ type: "text", text: "" }],
+							content: normalizeToolResultContent(ext.content),
 							// Preserve undefined when MCP omits structuredContent — an empty
 							// object is truthy and makes ask_user_questions renderResult show
 							// "Cancelled" despite a successful text payload (#cc-elicitation).
@@ -225,7 +226,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					if (block?.id && ext) {
 						externalToolResult = {
 							toolCallId: block.id,
-							content: ext.content ?? [{ type: "text", text: "" }],
+							content: normalizeToolResultContent(ext.content),
 							details: ext.details,
 							isError: ext.isError ?? false,
 						};

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -13,6 +13,7 @@ import {
 	isEmptyPathToolArguments,
 	isToolSearchToolName,
 	streamSimple,
+	normalizeToolResultContent,
 	type ToolResultMessage,
 	validateToolArguments,
 } from "@gsd/pi-ai";
@@ -519,7 +520,7 @@ async function executeToolCallsSequential(
 			}
 			finalized = {
 				toolCall,
-				result: preparation.result,
+				result: normalizeAgentToolResult(preparation.result),
 				isError: preparation.isError,
 			};
 		} else {
@@ -578,7 +579,7 @@ async function executeToolCallsParallel(
 			}
 			const finalized = {
 				toolCall,
-				result: preparation.result,
+				result: normalizeAgentToolResult(preparation.result),
 				isError: preparation.isError,
 			} satisfies FinalizedToolCallOutcome;
 			await emitToolExecutionEnd(finalized, emit);
@@ -681,10 +682,7 @@ async function prepareToolCall(
 		return {
 			kind: "immediate",
 			result: {
-				content:
-					externalResult.content && externalResult.content.length > 0
-						? (externalResult.content as AgentToolResult<any>["content"])
-						: [{ type: "text", text: "" }],
+				content: normalizeToolResultContent(externalResult.content),
 				details: externalResult.details ?? {},
 				// The provider (claude-code-cli) already executed this tool inside its
 				// own agentic session and emitted ONE final assistant message carrying
@@ -879,7 +877,7 @@ async function finalizeExecutedToolCall(
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 ): Promise<FinalizedToolCallOutcome> {
-	let result = executed.result;
+	let result = normalizeAgentToolResult(executed.result);
 	let isError = executed.isError;
 
 	if (config.afterToolCall) {
@@ -896,11 +894,11 @@ async function finalizeExecutedToolCall(
 				signal,
 			);
 			if (afterResult) {
-				result = {
+				result = normalizeAgentToolResult({
 					content: afterResult.content ?? result.content,
 					details: afterResult.details ?? result.details,
 					terminate: afterResult.terminate ?? result.terminate,
-				};
+				});
 				isError = afterResult.isError ?? isError;
 			}
 		} catch (error) {
@@ -920,6 +918,14 @@ function createErrorToolResult(message: string, displayReason?: string): AgentTo
 	return {
 		content: [{ type: "text", text: message }],
 		details: displayReason ? { displayReason } : {},
+	};
+}
+
+function normalizeAgentToolResult(result: Partial<AgentToolResult<any>> | undefined): AgentToolResult<any> {
+	return {
+		content: normalizeToolResultContent(result?.content),
+		details: result?.details,
+		terminate: result?.terminate,
 	};
 }
 

--- a/packages/pi-agent-core/test/agent-loop.test.ts
+++ b/packages/pi-agent-core/test/agent-loop.test.ts
@@ -9,7 +9,7 @@ import {
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { agentLoop, agentLoopContinue } from "../src/agent-loop.ts";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool, AgentToolResult } from "../src/types.ts";
 
 // Mock stream for testing - mimics MockAssistantStream
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -391,6 +391,74 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("normalizes missing tool result content before appending transcript messages", async () => {
+		const toolSchema = Type.Object({});
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "empty-result",
+			label: "Empty result",
+			description: "Returns a malformed result with no content",
+			parameters: toolSchema,
+			async execute() {
+				return { details: {} } as unknown as AgentToolResult<Record<string, never>>;
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+		const userPrompt: AgentMessage = createUserMessage("run empty result");
+		let afterToolCallContent: unknown;
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			afterToolCall(event) {
+				afterToolCallContent = event.result.content;
+			},
+		};
+
+		let callIndex = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: createAssistantMessage(
+							[{ type: "toolCall", id: "tool-1", name: "empty-result", arguments: {} }],
+							"toolUse",
+						),
+					});
+				} else {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage([{ type: "text", text: "done" }]) });
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+		for await (const event of stream) events.push(event);
+
+		const expectedContent = [{ type: "text", text: "" }];
+		expect(afterToolCallContent).toEqual(expectedContent);
+
+		const toolEnd = events.find((event) => event.type === "tool_execution_end");
+		expect(toolEnd).toBeDefined();
+		if (toolEnd?.type === "tool_execution_end") {
+			expect(toolEnd.result.content).toEqual(expectedContent);
+		}
+
+		const toolResultMessage = events.find((event) => event.type === "message_end" && event.message.role === "toolResult");
+		expect(toolResultMessage).toBeDefined();
+		if (toolResultMessage?.type === "message_end" && toolResultMessage.message.role === "toolResult") {
+			expect(toolResultMessage.message.content).toEqual(expectedContent);
+		}
+	});
+
 	it("should execute mutated beforeToolCall args without revalidation", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: Array<string | number> = [];
@@ -768,11 +836,11 @@ describe("agentLoop with AgentMessage", () => {
 								name: "Glob",
 								arguments: { pattern: "*.ts" },
 								externalResult: {
-									content: [{ type: "text", text: "src/index.ts" }],
+									content: "src/index.ts",
 									details: { source: "claude-code" },
 									isError: false,
 								},
-							} as any,
+							},
 							{
 								type: "toolCall",
 								id: "tool-gsd",
@@ -783,7 +851,7 @@ describe("agentLoop with AgentMessage", () => {
 									details: { source: "gsd-workflow" },
 									isError: false,
 								},
-							} as any,
+							},
 						],
 						"toolUse",
 					);

--- a/packages/pi-ai/src/index.ts
+++ b/packages/pi-ai/src/index.ts
@@ -38,6 +38,7 @@ export * from "./providers/api-family.js";
 export * from "./session-resources.js";
 export * from "./stream.js";
 export * from "./types.js";
+export * from "./tool-result-content.js";
 export * from "./utils/diagnostics.js";
 export * from "./utils/event-stream.js";
 export * from "./utils/json-parse.js";

--- a/packages/pi-ai/src/providers/transform-messages.ts
+++ b/packages/pi-ai/src/providers/transform-messages.ts
@@ -8,6 +8,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.js";
+import { normalizeToolResultContent } from "../tool-result-content.js";
 
 export interface ProviderSwitchReport {
 	fromApi: string;
@@ -93,7 +94,7 @@ function downgradeUnsupportedImages<TApi extends Api>(messages: Message[], model
 			};
 		}
 
-		if (msg.role === "toolResult") {
+		if (msg.role === "toolResult" && Array.isArray(msg.content)) {
 			return {
 				...msg,
 				content: replaceImagesWithPlaceholder(msg.content, NON_VISION_TOOL_IMAGE_PLACEHOLDER),
@@ -125,7 +126,10 @@ export function transformMessagesWithReport<TApi extends Api>(
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
-	const imageAwareMessages = downgradeUnsupportedImages(messages, model);
+	const contentNormalizedMessages = messages.map((msg) =>
+		msg.role === "toolResult" ? { ...msg, content: normalizeToolResultContent(msg.content) } : msg,
+	);
+	const imageAwareMessages = downgradeUnsupportedImages(contentNormalizedMessages, model);
 	const report = makeEmptyReport(sourceApi ?? model.api, model.api);
 
 	// First pass: transform messages (unsupported image downgrade, thinking blocks, tool call ID normalization)
@@ -135,7 +139,9 @@ export function transformMessagesWithReport<TApi extends Api>(
 			return msg;
 		}
 
-		// Handle toolResult messages - normalize toolCallId if we have a mapping
+		// Handle toolResult messages - normalize toolCallId if we have a mapping,
+		// and defensively hydrate content for older transcripts or tools that
+		// returned no visible payload. Downstream providers expect an array.
 		if (msg.role === "toolResult") {
 			const normalizedId = toolCallIdMap.get(msg.toolCallId);
 			if (normalizedId && normalizedId !== msg.toolCallId) {

--- a/packages/pi-ai/src/tool-result-content.ts
+++ b/packages/pi-ai/src/tool-result-content.ts
@@ -1,0 +1,59 @@
+import type { ImageContent, TextContent, ToolResultMessage } from "./types.js";
+
+function stringifyToolResultContent(content: unknown): string {
+	try {
+		const value = JSON.stringify(content);
+		if (typeof value === "string") return value;
+	} catch {
+		// Fall through to String(content). JSON.stringify can throw for cycles.
+	}
+
+	try {
+		return String(content);
+	} catch {
+		return "[unstringifiable tool result content]";
+	}
+}
+
+/**
+ * Normalise untrusted tool-result content into the transcript/provider shape.
+ *
+ * Tool implementations are typed to return content arrays, but external tools
+ * and older transcripts may violate that contract. Keep the runtime boundary
+ * defensive so downstream providers, hooks, renderers, and resume paths always
+ * see an array of content blocks.
+ */
+function serializableCacheControl(candidate: Record<string, unknown>): Record<string, unknown> {
+	if (!("cache_control" in candidate)) return {};
+	try {
+		JSON.stringify(candidate.cache_control);
+		return { cache_control: candidate.cache_control };
+	} catch {
+		return {};
+	}
+}
+
+function normalizeToolResultContentBlock(block: unknown): TextContent | ImageContent {
+	if (typeof block === "string") return { type: "text", text: block } satisfies TextContent;
+	if (block && typeof block === "object") {
+		const candidate = block as Record<string, unknown>;
+		const cacheControl = serializableCacheControl(candidate);
+		if (candidate.type === "text" && typeof candidate.text === "string") {
+			return { type: "text", text: candidate.text, ...cacheControl } as unknown as TextContent;
+		}
+		if (candidate.type === "image" && typeof candidate.data === "string" && typeof candidate.mimeType === "string") {
+			return { type: "image", data: candidate.data, mimeType: candidate.mimeType, ...cacheControl } as unknown as ImageContent;
+		}
+	}
+	return { type: "text", text: stringifyToolResultContent(block) } satisfies TextContent;
+}
+
+export function normalizeToolResultContent(content: unknown): ToolResultMessage["content"] {
+	if (Array.isArray(content)) {
+		const blocks = content.map((block) => normalizeToolResultContentBlock(block));
+		return blocks.length > 0 ? blocks : [{ type: "text", text: "" } satisfies TextContent];
+	}
+	if (typeof content === "string") return [{ type: "text", text: content } satisfies TextContent];
+	if (content == null) return [{ type: "text", text: "" } satisfies TextContent];
+	return [{ type: "text", text: stringifyToolResultContent(content) } satisfies TextContent];
+}

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -247,6 +247,13 @@ export interface ImageContent {
 	mimeType: string; // e.g., "image/jpeg", "image/png"
 }
 
+export interface ExternalToolResult {
+	/** Raw content from an externally executed tool. Normalized at runtime before consumers receive it. */
+	content?: unknown;
+	details?: Record<string, unknown>;
+	isError?: boolean;
+}
+
 export interface ToolCall {
 	type: "toolCall";
 	id: string;
@@ -254,11 +261,7 @@ export interface ToolCall {
 	arguments: Record<string, any>;
 	thoughtSignature?: string; // Google-specific: opaque signature for reusing thought context
 	/** Result from an externally executed tool (e.g. Claude Code SDK). Skips local dispatch. */
-	externalResult?: {
-		content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
-		details?: Record<string, unknown>;
-		isError?: boolean;
-	};
+	externalResult?: ExternalToolResult;
 }
 
 /** GSD compat: server-side tool invocation block (e.g. web search). */
@@ -268,11 +271,7 @@ export interface ServerToolUse {
 	name: string;
 	input: unknown;
 	caller?: unknown;
-	externalResult?: {
-		content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
-		details?: Record<string, unknown>;
-		isError?: boolean;
-	};
+	externalResult?: ExternalToolResult;
 }
 
 /** GSD compat: server-side tool result block paired with serverToolUse. */

--- a/packages/pi-ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/pi-ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { transformMessages } from "../src/providers/transform-messages.ts";
+import { normalizeToolResultContent } from "../src/tool-result-content.ts";
 import type { AssistantMessage, Message, Model, ToolCall } from "../src/types.ts";
 
 // Normalize function matching what anthropic.ts uses
@@ -131,6 +132,52 @@ describe("OpenAI to Anthropic session migration for Copilot Claude", () => {
 		const toolCall = assistantMsg.content.find((b) => b.type === "toolCall") as ToolCall;
 
 		expect(toolCall.thoughtSignature).toBeUndefined();
+	});
+
+	it("hydrates missing tool result content before provider transforms", () => {
+		const model = makeCopilotClaudeModel();
+		const messages: Message[] = [
+			{
+				role: "toolResult",
+				toolCallId: "call_123",
+				toolName: "deathloop_run",
+				isError: false,
+				timestamp: Date.now(),
+			} as unknown as Message,
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+		const toolResult = result[0];
+
+		expect(toolResult?.role).toBe("toolResult");
+		if (toolResult?.role === "toolResult") {
+			expect(toolResult.content).toEqual([{ type: "text", text: "" }]);
+		}
+	});
+
+	it("stringifies malformed non-json tool result content safely", () => {
+		expect(normalizeToolResultContent([])).toEqual([{ type: "text", text: "" }]);
+		expect(normalizeToolResultContent(["hello"])).toEqual([{ type: "text", text: "hello" }]);
+		const cyclicTextBlock = {
+			type: "text",
+			text: "ok",
+			cache_control: { type: "ephemeral" },
+		} as { type: "text"; text: string; cache_control: { type: "ephemeral" }; self?: unknown };
+		cyclicTextBlock.self = cyclicTextBlock;
+		expect(normalizeToolResultContent([cyclicTextBlock])).toEqual([
+			{ type: "text", text: "ok", cache_control: { type: "ephemeral" } },
+		]);
+		expect(normalizeToolResultContent(Symbol("bad"))).toEqual([{ type: "text", text: "Symbol(bad)" }]);
+		const functionContent = normalizeToolResultContent(() => undefined);
+		expect(functionContent[0]?.type).toBe("text");
+		expect(typeof functionContent[0]?.text).toBe("string");
+		expect(functionContent[0]?.text.length).toBeGreaterThan(0);
+
+		const unstringifiable = Object.create(null) as { self?: unknown };
+		unstringifiable.self = unstringifiable;
+		expect(normalizeToolResultContent(unstringifiable)).toEqual([
+			{ type: "text", text: "[unstringifiable tool result content]" },
+		]);
 	});
 
 	it("adds synthetic tool results for trailing orphaned tool calls", () => {


### PR DESCRIPTION
## Summary

- normalize untrusted tool-result content at the runtime boundary so transcript, hook, event, provider-transform, live TUI, and exported HTML paths always receive content blocks
- add a shared `normalizeToolResultContent` helper for missing, string, empty-array, malformed-array, cyclic, and unstringifiable payloads
- widen external tool-result content typing to reflect that externally executed tools can provide raw/untrusted payloads
- add focused regressions for missing `content`, string external results, empty arrays, array strings, cyclic blocks, and `cache_control` preservation

## Repro / motivation

A successful externally executed tool can currently be persisted as a `toolResult` message with no `content` field. On resume/provider conversion, downstream code assumes `content` is an array and crashes with errors like:

```text
Cannot read properties of undefined (reading 'filter')
```

This was observed with a `deathloop_run` tool result that had `role: "toolResult"`, `isError: false`, and no `content` field.

## Verification

- `pnpm --filter @gsd/pi-ai run build`
- `pnpm --filter @gsd/pi-agent-core run build`
- `pnpm --filter @gsd/agent-modes run build`
- `pnpm --filter @gsd/pi-agent-core exec vitest --run test/agent-loop.test.ts --reporter=dot`
- `pnpm --filter @gsd/pi-ai exec vitest --run test/transform-messages-copilot-openai-to-anthropic.test.ts --reporter=dot`
- `node --check packages/gsd-agent-core/src/export-html/template.js`
- `git diff --check`

## Review

Ran local blind deathloop review against the working diff before opening the PR. Final round: `/tmp/deathloop.gHLw0M` reported no actionable implementation findings from Codex and LGTM/no actionable findings from Antigravity. Earlier rounds found issues that were fixed in this PR, including live TUI normalization, immediate external-result normalization, canonical block cloning, public external-result typing, and safe `cache_control` preservation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785457600&installation_id=134682257&pr_number=1107&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1107&signature=d8e1bd06f1e27e4038abafcb9dacbb480a0aea1aa5827217885475e8058c8c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->