### PR TITLE
Add live workflow release smoke

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -496,6 +496,18 @@ jobs:
       - name: Build release
         run: pnpm run build
 
+      - name: Run live workflow LLM tests (optional)
+        continue-on-error: true
+        run: |
+          chmod +x dist/loader.js
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
+          pnpm run test:live-workflow || echo "::warning::Live workflow LLM tests failed - non-blocking, but worth investigating"
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GSD_LIVE_TESTS: "1"
+          GSD_LIVE_WORKFLOW_MODEL: openai/gpt-5.4-mini
+
       - name: Run live regression tests (against release build)
         run: |
           chmod +x dist/loader.js

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -179,6 +179,27 @@ test("main package publish validates tarball before publishing", () => {
   assert.ok(prodSteps.indexOf(prodValidate) < prodPublishIndex);
 });
 
+test("production release runs optional live workflow test on the configured OpenAI model", () => {
+  const steps = workflow.jobs["prod-release"].steps;
+  const idx = (name) => steps.findIndex((step) => step.name === name);
+
+  const buildRelease = idx("Build release");
+  const liveWorkflow = idx("Run live workflow LLM tests (optional)");
+  const liveRegression = idx("Run live regression tests (against release build)");
+
+  assert.ok(liveWorkflow > -1, "prod-release must include optional live workflow coverage");
+  assert.ok(buildRelease > -1 && buildRelease < liveWorkflow, "live workflow must use the built release binary");
+  assert.ok(liveWorkflow < liveRegression, "live workflow should run before non-LLM live regression checks");
+
+  const step = steps[liveWorkflow];
+  assert.equal(step["continue-on-error"], true);
+  assert.match(step.run, /GSD_SMOKE_BINARY="\$\(pwd\)\/dist\/loader\.js"/);
+  assert.match(step.run, /pnpm run test:live-workflow/);
+  assert.equal(step.env.OPENAI_API_KEY, "${{ secrets.OPENAI_API_KEY }}");
+  assert.equal(step.env.GSD_LIVE_TESTS, "1");
+  assert.equal(step.env.GSD_LIVE_WORKFLOW_MODEL, "openai/gpt-5.4-mini");
+});
+
 test("production release publishes workspace packages and verifies ALL packages before cutting the GitHub release", () => {
   const steps = workflow.jobs["prod-release"].steps;
   const idx = (name) => steps.findIndex((s) => s.name === name);

--- a/tests/live-workflow/README.md
+++ b/tests/live-workflow/README.md
@@ -10,12 +10,13 @@ This is the live counterpart to the other two test layers:
 | --- | --- | --- | --- | --- |
 | Fake-LLM e2e | `tests/e2e` | scripted JSONL transcript | none | yes (required gate) |
 | Provider smoke | `tests/live` | real API, transport only | yes | no (manual) |
-| **Workflow** | `tests/live-workflow` | **real agent, single unit** | yes | no (manual) |
+| **Workflow** | `tests/live-workflow` | **real agent, single unit** | yes | optional release CI + manual |
 
 These exist to answer one question the other layers can't: *does a real agent,
 given a real plan, actually execute a dispatched unit to a correct, durable
 outcome through gsd's real gates?* They are slow and cost real tokens, so they
-never run in the default suite.
+never run in the default suite. Production release CI runs them as a non-blocking
+optional smoke against the configured live workflow model.
 
 > **Why `next`, not `auto`?** The harness dispatches a single unit with
 > `gsd headless next` rather than running the full `auto` loop. A real agent
@@ -50,7 +51,7 @@ failing.
 | `GSD_LIVE_TESTS` | — | Must be `1` or the suite is skipped entirely. |
 | `GSD_SMOKE_BINARY` | `gsd` on PATH | Built binary to drive (recommended). |
 | `*_API_KEY` / `*_OAUTH_TOKEN` | — | Provider credential, forwarded to the child. At least one required. Provider-agnostic. |
-| `GSD_LIVE_WORKFLOW_MODEL` | auto-resolved | Force a model id. Unset = gsd picks the default for whichever provider's credential is present. |
+| `GSD_LIVE_WORKFLOW_MODEL` | auto-resolved (`openai/gpt-5.4-mini` in optional release CI) | Force a model id. Unset = gsd picks the default for whichever provider's credential is present. |
 | `GSD_LIVE_WORKFLOW_TIMEOUT_MS` | `300000` | Per-run dispatch timeout (wall-clock budget). Raise for slower models. |
 | `GSD_LIVE_WORKFLOW_OUTPUT` | `text` | Output format. `text` = readable transcript; `stream-json` = machine-parseable JSONL. |
 


### PR DESCRIPTION
## TL;DR

**What:** Add a non-blocking production release CI step that runs the live workflow smoke test against `openai/gpt-5.4-mini`.
**Why:** Release CI should exercise the real workflow loop with an explicit usable model instead of leaving live workflow coverage manual-only.
**How:** Reuse the built release binary, pass `OPENAI_API_KEY`, set `GSD_LIVE_WORKFLOW_MODEL=openai/gpt-5.4-mini`, and add parsed-workflow coverage plus README notes.

## What

- Adds an optional `Run live workflow LLM tests` step to the production release job in `.github/workflows/npm-publish.yml`.
- Sets `GSD_LIVE_WORKFLOW_MODEL` to `openai/gpt-5.4-mini` for that optional release smoke.
- Adds a workflow contract test that asserts the step exists, uses the built release binary, remains non-blocking, and pins the intended model.
- Updates the live-workflow README to document optional release CI coverage.

## Why

The live workflow suite tests the real agent workflow path, but it was documented as manual-only. Release CI now gets a non-blocking signal that the workflow smoke still runs with a concrete model that resolves through the repo model registry.

## How

The new CI step runs after the release build so it can set `GSD_SMOKE_BINARY` to `dist/loader.js`, then invokes `pnpm run test:live-workflow`. It is `continue-on-error` and also emits a warning on failure so release publishing is not blocked by live model/network flakiness.

Validation:

- `node --test scripts/__tests__/npm-publish-workflow.test.mjs`
- `git diff --check`

Sabotage check:

- Temporarily changed the workflow model to `openai/gpt-5.4`; the workflow contract test failed on the expected model assertion, then passed after restoring `openai/gpt-5.4-mini`.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785469123&installation_id=134682257&pr_number=1109&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1109&signature=91c85f97b13a9d19a2176b1f1b9e09949ea8fa5cb75f373870bf1ce4fb4413df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only optional smoke with continue-on-error; no change to release gates or product runtime behavior.
> 
> **Overview**
> Production **latest** release CI now runs the **live workflow** suite as an **optional, non-blocking** smoke after **Build release** and before live regression tests.
> 
> The new step drives the built `dist/loader.js` via `GSD_SMOKE_BINARY`, enables `GSD_LIVE_TESTS`, passes `OPENAI_API_KEY`, and pins **`GSD_LIVE_WORKFLOW_MODEL=openai/gpt-5.4-mini`**. Failures use `continue-on-error` and emit a workflow warning so publishing is not blocked.
> 
> A **workflow contract test** locks step order, env, model pin, and non-blocking behavior. The **live-workflow README** notes optional release CI coverage alongside manual runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6ff12c0ab9e9b5599df427674790688fa980ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->