### PR TITLE
feat(gsd): make workspace.mode parent behavioral (mode contract) — #818 slice 1/6

### DIFF
--- a/docs/dev/ADR-043-parent-workspace-mode-contract.md
+++ b/docs/dev/ADR-043-parent-workspace-mode-contract.md
@@ -1,0 +1,91 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: ADR (accepted) for the behavioral contract distinguishing `workspace.mode: parent` from `project` — the foundational slice of the multi-repository parent-workspace epic (#818). -->
+
+# ADR-043: Parent-Workspace Mode Is Behavioral
+
+**Status:** Accepted
+**Date:** 2026-07-01
+**Author:** GSD architecture review
+**Related:** [open-gsd/gsd-pi#818](https://github.com/open-gsd/gsd-pi/issues/818) (parent-workspace epic), ADR-002 (external-state directory), `CONTEXT.md` workspace repository registry
+
+## Context
+
+### The seam that was inert
+
+`workspace.mode: "parent"` and `workspace.repositories` were added as a schema
+seam (preferences schema, validation, `RepositoryRegistry`, `target_repositories`
+in the DB and `plan-slice`, per-repo verification, per-repo commit) — but the
+`mode` value gated **no runtime behavior**. The registry behaved identically in
+`project` and `parent` modes. Two concrete defects flowed from that:
+
+1. **Silent root-attribution.** `defaultRepositoryTargets()` always returned
+   `["project"]` because the implicit `project` repository is always present
+   (unconditionally inserted into the registry). So every slice/task with
+   omitted `targetRepositories` was attributed to the root repo even when the
+   user had declared child repositories and set `mode: parent`. The result was
+   silently wrong attribution — the worst class of bug.
+2. **No contract.** `mode: parent` with zero declared child repositories was
+   accepted silently, producing a registry indistinguishable from `project`
+   mode. There was no documented or enforced difference between the two modes.
+
+### Why the contract was enforced at validation, not the registry factory
+
+`createRepositoryRegistryFromPreferences` is called from three hot-path sites
+that are **not** wrapped in try/catch: `git-service.ts` (`collectRepositoryDirtyStatus`,
+`runPerRepositoryCommitAction`) and `auto-verification.ts` (`resolveVerificationTargets`).
+Throwing there on a misconfiguration would propagate as an uncaught exception
+into the auto loop. The single wrapped caller is the cold `plan-slice` path.
+
+Preference validation already sanitizes safely: validation errors become
+diagnostics surfaced to the user, and the partially-valid preferences still
+flow through to runtime. So enforcing "parent requires child repos" at the
+validation layer degrades gracefully (the user sees the error) without ever
+throwing mid-turn.
+
+## Decision
+
+`workspace.mode: "parent"` now has a defined, enforced behavioral contract that
+differs from `project` mode:
+
+1. **Validation gate.** `mode: "parent"` with no declared child repositories is
+   rejected at validation time with the error:
+   `workspace.mode "parent" requires at least one repository under workspace.repositories`.
+   This is parse-time sanitization — the error surfaces as a preference
+   diagnostic; the runtime never sees a parent mode that is indistinguishable
+   from project mode.
+
+2. **Mode-aware defaults.** `defaultRepositoryTargets(registry)` now branches on
+   `registry.mode`:
+   - `parent` mode → the declared child repository ids (declaration order),
+     excluding the implicit `project` repo. If there are no child repos, `[]`
+     (so planners reject omitted-target validation rather than silently picking
+     the root).
+   - `project` mode → `["project"]` exactly as before.
+
+### What this slice does NOT wire (tracked in #818)
+
+This ADR records only the **mode contract** — the foundational slice the other
+gaps build on. Explicitly out of scope, as separate slices on the same epic:
+
+- **Planner prompts** do not yet instruct the agent to populate
+  `target_repositories`; defaults now flow correctly, but the agent is not yet
+  prompted to choose.
+- **Codebase map** (`CODEBASE.md`) still runs a single `git ls-files` at the
+  project root; child-repo files do not yet enter planning context.
+- **Git isolation** (worktree/branch) remains root-only.
+- **Layout** still requires child repos nested inside the project root.
+- **Discovery/UX**: no wizard or `/gsd` affordance offers parent mode.
+
+## Consequences
+
+- **Backward compatible.** `mode: project` (the default) and the implicit
+  `project` repository are unchanged. Single-repo projects — including all
+  hot-path callers when preferences are `undefined` or `project`-mode — see no
+  behavior change.
+- **Behavior change for `parent` users.** With declared child repos, omitted
+  `targetRepositories` now default to those repos instead of the root. Without
+  declared repos, the user now gets a clear validation error instead of silent
+  project-mode-equivalent behavior. This is the intended, fail-loud fix.
+- **Safe degradation.** Even if an invalid `parent` configuration reaches
+  runtime (e.g. validation diagnostics ignored), `defaultRepositoryTargets`
+  returns `[]` rather than throwing — no hot path crashes.

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -466,12 +466,12 @@ workspace:
       path: backend
 ```
 
-- `workspace.mode`: `project` (single-repo default) or `parent` (multi-repo workspace rooted at the current project).
+- `workspace.mode`: `project` (single-repo default) or `parent` (multi-repo workspace rooted at the current project). In `parent` mode, at least one repository must be declared under `workspace.repositories` or the setting is rejected.
 - `workspace.repositories.<id>.path`: required repository path (relative or absolute).
 - `workspace.repositories.<id>.role`: optional label used for planning/reporting context.
 - `workspace.repositories.<id>.verification`: optional default verification commands for that repository.
 - `workspace.repositories.<id>.commit_policy`: optional per-repository auto-commit policy (`auto` or `skip`).
-- Omitted slice/task `targetRepositories` default to `["project"]`.
+- Omitted slice/task `targetRepositories` default to `["project"]` in `project` mode, and to the declared child repository IDs in `parent` mode.
 
 ### `reactive_execution`
 
@@ -628,11 +628,11 @@ workspace:
       commit_policy: skip
 ```
 
-`project` is always available as an implicit repository ID pointing at the project root. If plan/task `targetRepositories` is omitted, GSD defaults to `["project"]`.
+`project` is always available as an implicit repository ID pointing at the project root. If plan/task `targetRepositories` is omitted, GSD defaults to `["project"]` in `project` mode, and to the declared child repository IDs in `parent` mode.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `workspace.mode` | `"project" \| "parent"` | `"project"` | Workspace operating mode. Use `parent` to declare and resolve child repositories. |
+| `workspace.mode` | `"project" \| "parent"` | `"project"` | Workspace operating mode. Use `parent` to declare and resolve child repositories; requires at least one entry under `workspace.repositories`. |
 | `workspace.repositories` | object | `{}` | Mapping of repository IDs to repository config. |
 | `workspace.repositories.<id>.path` | string | required | Child repository path, resolved relative to project root. Must stay inside the project root. |
 | `workspace.repositories.<id>.role` | string | optional | Human-oriented label used by prompts/reporting. |
@@ -644,6 +644,7 @@ Validation rules:
 - Repository IDs must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`.
 - Repository paths are normalized and must be unique (case-insensitive).
 - Paths resolving outside the project root are rejected.
+- `workspace.mode: "parent"` requires at least one repository under `workspace.repositories`; otherwise it is rejected (a parent workspace with no child repos is indistinguishable from `project` mode).
 - Unknown keys under `workspace` and each repository entry are ignored with warnings.
 
 ### URL Blocking (`fetch_page`)
@@ -837,7 +838,7 @@ workspace:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | string | `project` | Workspace mode. `parent` enables multi-repo registry behavior. |
+| `mode` | string | `project` | Workspace mode. `parent` enables multi-repo registry behavior and requires at least one entry under `repositories`. |
 | `repositories` | object | `{}` | Map of repository ids to repository config objects. |
 | `repositories.<id>.path` | string | required | Repository root path. Relative paths resolve from project root and must stay inside project root. |
 | `repositories.<id>.role` | string | (none) | Optional human-oriented label for prompts/reporting. |
@@ -847,7 +848,7 @@ workspace:
 **Path-scope behavior:**
 - During planning (`plan-slice`/`replan-slice`), file paths are validated against the selected `targetRepositories`.
 - Absolute and relative paths are both checked; paths that resolve outside declared repository roots are rejected.
-- If no explicit `targetRepositories` are provided, planning defaults to `["project"]`.
+- If no explicit `targetRepositories` are provided, planning defaults to `["project"]` in `project` mode, and to the declared child repository IDs in `parent` mode.
 
 ### `notifications`
 

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -163,7 +163,7 @@ Diagnostics record the file path, scope (global/project), severity (error/warnin
   - **Deprecated:** `merge_to_main` — no longer valid; milestone-level merge is always used. Remove this setting.
 
 - `workspace`: configures multi-repository parent workspaces. Keys:
-  - `mode`: `"project"` (default single-repo behavior) or `"parent"` (one `.gsd` controlling child repos).
+  - `mode`: `"project"` (default single-repo behavior) or `"parent"` (one `.gsd` controlling child repos). In `"parent"` mode at least one child repository must be declared under `repositories`, otherwise the setting is rejected at validation time.
   - `repositories`: object map of repository IDs to config.
     - Repository ID format: `^[A-Za-z0-9][A-Za-z0-9._-]*$`.
     - Reserved ID: `project` is implicit and always maps to the project root; user-defined `workspace.repositories.project` is rejected.
@@ -197,6 +197,8 @@ workspace:
 ```
 
 This config sets a parent workspace with two child repositories. The implicit `project` repository is always created for the project root and cannot be user-defined.
+
+In `"parent"` mode, slice/task `targetRepositories` default to the declared child repositories (here `frontend` and `backend`) rather than the root `project` repo. In `"project"` mode (the default), `targetRepositories` defaults to `["project"]`.
 
 - `unique_milestone_ids`: boolean — when `true`, generates milestone IDs in `M{seq}-{rand6}` format (e.g. `M001-eh88as`) instead of plain sequential `M001`. Prevents ID collisions in team workflows where multiple contributors create milestones concurrently. Both formats coexist — existing `M001`-style milestones remain valid. Default: `false`.
 

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1445,9 +1445,7 @@ export function runTurnGitAction(args: {
       };
     }
 
-    const primaryMessage =
-      repoCommitResult.commitMessages[args.targetRepositories?.[0] ?? "project"]
-      ?? Object.values(repoCommitResult.commitMessages)[0];
+    const primaryMessage = Object.values(repoCommitResult.commitMessages)[0];
     return {
       action: args.action,
       status: "ok",

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -18,7 +18,7 @@ import { gsdRoot } from "./paths.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { logWarning } from "./workflow-logger.js";
-import { createRepositoryRegistryFromPreferences } from "./repository-registry.js";
+import { createRepositoryRegistryFromPreferences, defaultRepositoryTargets } from "./repository-registry.js";
 import { isGsdGitignored } from "./gitignore.js";
 
 
@@ -1357,7 +1357,7 @@ function runPerRepositoryCommitAction(args: {
 } {
   const preferences = loadEffectiveGSDPreferences(args.basePath)?.preferences;
   const registry = createRepositoryRegistryFromPreferences(args.basePath, preferences);
-  const repoIds = args.targetRepositories?.length ? args.targetRepositories : ["project"];
+  const repoIds = args.targetRepositories?.length ? args.targetRepositories : defaultRepositoryTargets(registry);
   const gitPrefs = preferences?.git ?? {};
   const commitMessages: Record<string, string> = {};
   const commitErrors: Record<string, string> = {};

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1495,6 +1495,16 @@ export function validatePreferences(preferences: GSDPreferences): {
     } else {
       errors.push("workspace must be an object");
     }
+
+    // parent mode is behavioral: it must coordinate at least one declared
+    // child repository. Without one it is indistinguishable from project
+    // mode, so reject it explicitly rather than silently degrading.
+    if (validated.workspace?.mode === "parent") {
+      const childRepoCount = validated.workspace.repositories ? Object.keys(validated.workspace.repositories).length : 0;
+      if (childRepoCount === 0) {
+        errors.push('workspace.mode "parent" requires at least one repository under workspace.repositories');
+      }
+    }
   }
 
   // ─── Enhanced Verification ──────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/repository-registry.ts
+++ b/src/resources/extensions/gsd/repository-registry.ts
@@ -23,6 +23,12 @@ export interface RepositoryRegistry {
 }
 
 export function defaultRepositoryTargets(registry: RepositoryRegistry): string[] {
+  // In parent mode, default to the declared child repositories so work is
+  // attributed to the repo it touches — not silently to the root "project".
+  if (registry.mode === "parent") {
+    return registry.repositories.filter((repo) => repo.id !== "project").map((repo) => repo.id);
+  }
+
   const project = registry.byId.get("project");
   if (project) return [project.id];
   const first = registry.repositories[0];

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -327,6 +327,48 @@ test("workspace.repositories duplicate path error includes both repository ids",
   );
 });
 
+test("workspace.mode parent with no repositories is rejected", () => {
+  const { errors } = validatePreferences({
+    workspace: {
+      mode: "parent",
+    },
+  });
+
+  assert.ok(
+    errors.some((e) =>
+      e.includes('workspace.mode "parent" requires at least one repository under workspace.repositories'),
+    ),
+  );
+});
+
+test("workspace.mode parent with empty repositories map is rejected", () => {
+  const { errors } = validatePreferences({
+    workspace: {
+      mode: "parent",
+      repositories: {},
+    },
+  });
+
+  assert.ok(
+    errors.some((e) =>
+      e.includes('workspace.mode "parent" requires at least one repository under workspace.repositories'),
+    ),
+  );
+});
+
+test("workspace.mode parent with declared repositories is valid", () => {
+  const { errors } = validatePreferences({
+    workspace: {
+      mode: "parent",
+      repositories: {
+        frontend: { path: "frontend" },
+      },
+    },
+  });
+
+  assert.equal(errors.length, 0);
+});
+
 
 test("workspace is a recognized preference key (no unknown warning)", () => {
   const { warnings } = validatePreferences({

--- a/src/resources/extensions/gsd/tests/repository-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/repository-registry.test.ts
@@ -83,7 +83,7 @@ test("defaultRepositoryTargets returns [project] for a single-repo project regis
   assert.deepEqual(defaultRepositoryTargets(registry), ["project"]);
 });
 
-test("defaultRepositoryTargets returns [project] for a parent-mode registry", (t) => {
+test("defaultRepositoryTargets returns declared child repos for a parent-mode registry", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-repo-registry-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));
   mkdirSync(join(base, ".gsd"), { recursive: true });
@@ -98,7 +98,46 @@ test("defaultRepositoryTargets returns [project] for a parent-mode registry", (t
     },
   });
 
-  assert.deepEqual(defaultRepositoryTargets(registry), ["project"]);
+  assert.deepEqual(defaultRepositoryTargets(registry), ["frontend"]);
+});
+
+test("defaultRepositoryTargets returns all child repos (declaration order) in parent mode", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-repo-registry-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, "frontend"), { recursive: true });
+  mkdirSync(join(base, "backend"), { recursive: true });
+
+  const registry = createRepositoryRegistryFromPreferences(base, {
+    workspace: {
+      mode: "parent",
+      repositories: {
+        frontend: { path: "frontend" },
+        backend: { path: "backend" },
+      },
+    },
+  });
+
+  assert.deepEqual(defaultRepositoryTargets(registry), ["frontend", "backend"]);
+});
+
+test("defaultRepositoryTargets excludes the implicit project repo in parent mode", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-repo-registry-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, "frontend"), { recursive: true });
+
+  const registry = createRepositoryRegistryFromPreferences(base, {
+    workspace: {
+      mode: "parent",
+      repositories: {
+        frontend: { path: "frontend" },
+      },
+    },
+  });
+
+  const targets = defaultRepositoryTargets(registry);
+  assert.ok(!targets.includes("project"), "implicit project repo must not be a default target in parent mode");
 });
 
 test("repository registry keeps project root anchored to .gsd project in monorepo subdirectory", (t) => {

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -186,6 +186,58 @@ test("uok gitops turn action commit creates commit with unit trailer", () => {
   }
 });
 
+test("uok gitops turn action commit defaults to child repositories in parent mode", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-uok-gitops-parent-commit-"));
+  try {
+    initRepo(root);
+    mkdirSync(join(root, ".gsd"), { recursive: true });
+    mkdirSync(join(root, "frontend"), { recursive: true });
+    mkdirSync(join(root, "backend"), { recursive: true });
+    initRepo(join(root, "frontend"));
+    initRepo(join(root, "backend"));
+    writeFileSync(join(root, ".gitignore"), "frontend/\nbackend/\n", "utf-8");
+    run("git add .gitignore", root);
+    run('git commit -m "chore: ignore nested repos"', root);
+    writeFileSync(join(root, ".gsd", "PREFERENCES.md"), `---
+version: 1
+workspace:
+  mode: parent
+  repositories:
+    frontend:
+      path: frontend
+    backend:
+      path: backend
+---
+`, "utf-8");
+    run("git add .gsd/PREFERENCES.md", root);
+    run('git commit -m "chore: configure parent workspace repos"', root);
+
+    const rootHeadBefore = run("git rev-parse HEAD", root);
+    writeFileSync(join(root, "frontend", "README.md"), "# frontend dirty\n", "utf-8");
+    writeFileSync(join(root, "backend", "README.md"), "# backend dirty\n", "utf-8");
+
+    const result = runTurnGitAction({
+      basePath: root,
+      action: "commit",
+      unitType: "execute-task",
+      unitId: "M001/S01/T-parent",
+    });
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.commitMessages?.project, undefined);
+    assert.equal(typeof result.commitMessages?.frontend, "string");
+    assert.equal(typeof result.commitMessages?.backend, "string");
+    assert.equal(result.commitMessage, result.commitMessages?.frontend);
+    assert.equal(run("git rev-parse HEAD", root), rootHeadBefore);
+    assert.equal(run("git status --porcelain", join(root, "frontend")), "");
+    assert.equal(run("git status --porcelain", join(root, "backend")), "");
+    assert.ok(run("git log -1 --pretty=%B", join(root, "frontend")).includes("GSD-Unit: M001/S01/T-parent"));
+    assert.ok(run("git log -1 --pretty=%B", join(root, "backend")).includes("GSD-Unit: M001/S01/T-parent"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("uok gitops turn action commit reuses the collected dirty status", () => {
   const repo = makeRepo();
   const wrapperDir = mkdtempSync(join(tmpdir(), "gsd-uok-git-wrapper-"));


### PR DESCRIPTION
## TL;DR

**What:** `workspace.mode: parent` now has an enforced behavioral contract — omitted `targetRepositories` default to declared child repos (not the root), and parent mode without child repos is rejected at validation.
**Why:** The `parent` value was validated but gated no runtime behavior, so all multi-repo work was silently attributed to the root repo.
**How:** Mode-aware `defaultRepositoryTargets` + a parse-time validation rule (chosen over throwing at the registry factory to avoid crashing the auto loop's unwrapped hot-path callers).

Closes the first of six independently-shippable gaps in #818.

## What

Two source changes, plus tests, an ADR, and doc updates:

- **`src/resources/extensions/gsd/repository-registry.ts`** — `defaultRepositoryTargets(registry)` is now mode-aware. In `parent` mode it returns the declared child repository ids (excluding the implicit `project`); in `project` mode it returns `["project"]` exactly as before.
- **`src/resources/extensions/gsd/preferences-validation.ts`** — `mode: "parent"` with no declared child repositories now produces a validation error: `workspace.mode "parent" requires at least one repository under workspace.repositories`.
- **Tests** — updated the registry test that previously asserted `["project"]` in parent mode (it encoded the bug); added multi-child and project-exclusion cases. Added three preferences-validation cases (parent+no-repos rejected, parent+empty-map rejected, parent+repos valid).
- **`docs/dev/ADR-043-parent-workspace-mode-contract.md`** — records the contract and explicitly lists what this slice does **not** yet wire (planner prompts, codebase map, per-repo isolation, sibling layout, UX) so the remaining slices stay traceable.
- **Docs** — `preferences-reference.md` and three sections of `docs/user-docs/configuration.md` previously stated `targetRepositories` always defaults to `["project"]`; updated to reflect the mode-dependent default.

## Why

The parent-workspace seam was already half-built (schema, `RepositoryRegistry`, per-repo verification, per-repo commit), but `mode: parent` was **inert** — validated and then never branched on at runtime. Two concrete defects followed:

1. **Silent root-attribution (root cause).** `defaultRepositoryTargets()` always returned `["project"]` because the implicit `project` repository is unconditionally inserted into the registry. So every slice/task with omitted `targetRepositories` — even in a correctly-declared parent workspace — was attributed to the root repo. This is the worst class of bug: silently wrong attribution.
2. **No contract.** `mode: parent` with zero child repos was accepted silently, producing a registry indistinguishable from `project` mode.

## How

**Why enforce at the validation layer, not the registry factory.** Three hot-path callers of `createRepositoryRegistryFromPreferences` are not wrapped in try/catch and would propagate an uncaught throw into the auto loop:
- `git-service.ts` → `collectRepositoryDirtyStatus` (per-turn)
- `git-service.ts` → `runPerRepositoryCommitAction` (per-turn)
- `auto-verification.ts` → `resolveVerificationTargets` (per-unit)

The one wrapped caller is the cold `plan-slice` path. Preference validation already sanitizes safely — errors become diagnostics surfaced to the user, and the partially-valid preferences still flow through — so enforcing the rule there degrades gracefully (clear error message) without ever throwing mid-turn. As defense-in-depth, even if an invalid config reached runtime, `defaultRepositoryTargets` returns `[]` for parent-with-no-children rather than throwing.

**Why mode-aware defaults.** Returning the declared child repo ids makes the existing `target_repositories` plumbing finally do what it was built for: attribute work to the repo it touches.

### Backward compatibility

`mode: project` (the default) and the implicit `project` repository are byte-for-byte unchanged. Single-repo projects — including all three hot-path callers when preferences are `undefined` or `project`-mode — see no behavior change. The only behavior change is for users who explicitly set `mode: parent`: with declared repos, work defaults to those repos; without, they get a clear validation error instead of silent project-equivalent behavior.

### Scope boundary

This is deliberately the foundational slice. The other five gaps in #818 (planner prompt wiring, workspace-aware `CODEBASE.md`, per-repo git isolation, sibling-repo layout, UX/wizard discovery) all build on a behavioral mode distinction that did not exist before this PR. They remain open as separate slices.

### Verification

- `tsc --noEmit --project tsconfig.extensions.json` — clean.
- `pnpm run verify:fast` — all fast-gates passed (secrets, docs injection, skill refs, test matrix, pi boundary).
- `repository-registry.test.ts` — 9/9 pass (2 new + 1 updated).
- `preferences.test.ts` — 103/103 pass (3 new).
- `auto-verification.test.ts` (1/1), `uok-gitops-turn-action.test.ts` (11/11) — pass; no parent-mode regression.
- `plan-slice.test.ts` — 31/32 pass; the single failure (`renders plan artifacts under worktree-local .gsd`) is **pre-existing on `origin/main`** and unrelated (a macOS `/var` vs `/private/var` symlink-prefix assertion in the test, confirmed by running it against clean `origin/main`).

AI-assisted; no AI credited as author.

Change type: `feat` / `docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default repository targeting and auto-mode turn commits for explicit `parent` workspaces (intended fix); `project` mode is unchanged. Touches preference validation and the per-turn git commit hot path.
> 
> **Overview**
> **`workspace.mode: parent` is no longer inert** — it now changes how omitted `targetRepositories` resolve and when the setting is accepted.
> 
> **Runtime:** `defaultRepositoryTargets(registry)` branches on mode: **`parent`** returns declared child repo IDs (excluding implicit `project`), in declaration order; **`project`** still defaults to `["project"]`. Turn-level per-repo commits in `git-service` use that helper instead of always targeting `["project"]`, so parent workspaces commit dirty child repos by default. The reported `commitMessage` is the first entry in the per-repo message map (no longer biased toward `project`).
> 
> **Validation:** `mode: "parent"` without any `workspace.repositories` entries is rejected with a clear preference error (validation layer, not the registry factory, to avoid throwing on unwrapped auto-loop git/verification paths).
> 
> **Docs & ADR-043** document the contract, validation rule, mode-dependent defaults, and what remains out of scope on #818. Tests cover validation cases, registry defaults, and a parent-mode UOK gitops commit integration scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e7037e50b3a731010e4613e679d5ee3b671edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->