### PR TITLE
feat(gsd): make CODEBASE.md workspace-aware in parent mode — #818 slice 3/6

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -144,7 +144,7 @@ See [Parallel Orchestration](./parallel-orchestration.md) for full documentation
 | `/gsd backlog` | Manage backlog items (`add`, `promote`, `remove`, `list`) |
 | `/gsd add-tests` | Generate tests for completed slices |
 | `/gsd scan` | Run a rapid codebase assessment (`--focus tech`, `arch`, `quality`, `concerns`, `tech+arch`) |
-| `/gsd codebase` | Generate, refresh, and inspect the `.gsd/CODEBASE.md` cache (`generate`, `update`, `stats`) |
+| `/gsd codebase` | Generate, refresh, and inspect the `.gsd/CODEBASE.md` cache (`generate`, `update`, `stats`); parent workspaces include declared child repositories under repo-labeled sections |
 
 ## Additional Prompt-Driven Workflows
 

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -477,6 +477,7 @@ workspace:
 - `workspace.repositories.<id>.commit_policy`: optional per-repository auto-commit policy (`auto` or `skip`).
 - Omitted slice/task `targetRepositories` default to `["project"]` in `project` mode, and to the declared child repository IDs in `parent` mode.
 - In parent workspaces, `gsd_plan_slice.targetRepositories` sets a slice-wide default and `gsd_plan_task.targetRepositories` records the repository IDs an individual task touches. Use only declared repository IDs, plus the implicit `project` ID; omit these fields in single-repo projects.
+- In parent mode with declared child repositories, `/gsd codebase generate` and automatic `CODEBASE.md` refreshes include the implicit `project` repository plus each child repository, using workspace-relative paths and repo-labeled sections.
 
 ### `reactive_execution`
 
@@ -636,6 +637,8 @@ workspace:
 `project` is always available as an implicit repository ID pointing at the project root. If plan/task `targetRepositories` is omitted, GSD defaults to `["project"]` in `project` mode, and to the declared child repository IDs in `parent` mode.
 
 In parent workspaces, use `gsd_plan_slice.targetRepositories` to set a slice-wide repository default. Use `gsd_plan_task.targetRepositories` when an individual task touches a different or more specific set of declared repositories.
+
+In parent mode with declared child repositories, `/gsd codebase generate` and automatic `.gsd/CODEBASE.md` refreshes enumerate the implicit `project` repository plus each child repository. Generated maps group files under `## [repo-id]` sections, preserve workspace-relative paths, and record repository IDs in map metadata so registry changes refresh stale maps.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -860,6 +863,8 @@ workspace:
 - `gsd_plan_task.targetRepositories` records or overrides the repository IDs for an individual task.
 - Absolute and relative paths are both checked; paths that resolve outside declared repository roots are rejected.
 - Use only repository IDs declared under `workspace.repositories`, plus the implicit `project` ID. If no explicit `targetRepositories` are provided, planning defaults to `["project"]` in `project` mode, and to the declared child repository IDs in `parent` mode.
+
+**Codebase-map behavior:** In parent mode with declared child repositories, `/gsd codebase generate` and automatic `.gsd/CODEBASE.md` refreshes include `project` plus each child repository, render repo-labeled `## [repo-id]` sections, and store repository metadata for freshness checks.
 
 ### `notifications`
 

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -205,6 +205,8 @@ Validation rules:
 - Paths resolving outside the project root are rejected.
 - Unknown `workspace` keys are ignored with warnings.
 
+When `workspace.mode` is `parent` and child repositories are declared, `/gsd codebase generate` and automatic `CODEBASE.md` refreshes enumerate the implicit `project` repository plus each child repository. The generated `.gsd/CODEBASE.md` uses workspace-relative paths, groups files under `## [repo-id]` sections, and records the repository IDs in its metadata so changes to the workspace registry refresh the map.
+
 ### `phases`
 
 Fine-grained control over which phases run:

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -56,6 +56,7 @@
 | `/gsd recover --confirm` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
 | `/gsd rebuild markdown` | Rebuild markdown projections from the canonical database; stale completion projections are quarantined, not imported |
 | `/gsd rebuild database` | Reserved for DB-native rebuilds; does not import markdown projections |
+| `/gsd codebase [generate\|update\|stats]` | Manage `.gsd/CODEBASE.md`; parent workspaces include declared child repositories under repo-labeled sections |
 
 ## Milestone Management
 

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -10,10 +10,15 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join, dirname, extname } from "node:path";
+import { join, dirname, extname, relative, sep } from "node:path";
 
 import { execSync } from "node:child_process";
 import { gsdRoot } from "./paths.js";
+import {
+  createRepositoryRegistryFromPreferences,
+  type RepositoryRegistry,
+} from "./repository-registry.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -28,6 +33,8 @@ export interface CodebaseMapMetadata {
   fingerprint: string;
   fileCount: number;
   truncated: boolean;
+  /** Repo ids whose files appear in a workspace-aware map (parent mode only). */
+  repositories?: string[];
 }
 
 export interface EnsureCodebaseMapOptions {
@@ -48,12 +55,16 @@ export interface EnsureCodebaseMapResult {
 interface FileEntry {
   path: string;
   description: string;
+  /** Declaring repo id for workspace-aware maps (parent mode); undefined otherwise. */
+  repo?: string;
 }
 
 interface DirectoryGroup {
   path: string;
   files: FileEntry[];
   collapsed: boolean;
+  /** Repo id this group belongs to for workspace-aware maps; undefined otherwise. */
+  repo?: string;
 }
 
 interface ResolvedCodebaseMapOptions {
@@ -66,6 +77,8 @@ interface ResolvedCodebaseMapOptions {
 interface EnumeratedFiles {
   files: string[];
   truncated: boolean;
+  /** Per-file repo labels aligned with `files` (workspace-aware maps only). */
+  repos?: string[];
 }
 
 // ─── Defaults ────────────────────────────────────────────────────────────────
@@ -209,11 +222,67 @@ function lsFiles(basePath: string): string[] {
  * Enumerate tracked files, applying exclusions and the maxFiles cap.
  * Returns both the file list and whether truncation occurred.
  */
-function enumerateFiles(basePath: string, excludes: string[], maxFiles: number): { files: string[]; truncated: boolean } {
+function enumerateFiles(basePath: string, excludes: string[], maxFiles: number): EnumeratedFiles {
   const allFiles = lsFiles(basePath);
   const filtered = allFiles.filter((f) => !shouldExclude(f, excludes));
   const truncated = filtered.length > maxFiles;
   return { files: truncated ? filtered.slice(0, maxFiles) : filtered, truncated };
+}
+
+/**
+ * Build a workspace-aware registry for parent mode, or null when the project is
+ * single-repo (no declared child repositories). Returns null so the caller falls
+ * back to the legacy single-root enumeration and produces byte-identical output.
+ */
+function loadWorkspaceRegistry(basePath: string): RepositoryRegistry | null {
+  let registry: RepositoryRegistry;
+  try {
+    registry = createRepositoryRegistryFromPreferences(basePath, loadEffectiveGSDPreferences(basePath)?.preferences);
+  } catch {
+    return null;
+  }
+  // Parent mode is only meaningful with at least one declared child repo; the
+  // implicit "project" repo is always present, so require >1 entry.
+  const hasChildRepo = registry.repositories.some((repo) => repo.id !== "project");
+  return registry.mode === "parent" && hasChildRepo ? registry : null;
+}
+
+/**
+ * Enumerate tracked files across every declared repository in a parent workspace.
+ * Child-repo paths are rewritten to be workspace-relative (e.g. `frontend/src/x`)
+ * and tagged with their declaring repo id so the map can render repo-labelled
+ * sections. The maxFiles cap is applied across the union of all repositories.
+ */
+function enumerateWorkspaceFiles(
+  registry: RepositoryRegistry,
+  excludes: string[],
+  maxFiles: number,
+): EnumeratedFiles {
+  const files: string[] = [];
+  const repos: string[] = [];
+  const seen = new Set<string>();
+  let totalTrackable = 0;
+
+  for (const repo of registry.repositories) {
+    const rawFiles = lsFiles(repo.root);
+    const repoPrefix = relative(registry.projectRoot, repo.root).split(sep).join("/");
+
+    for (const file of rawFiles) {
+      if (shouldExclude(file, excludes)) continue;
+      totalTrackable++;
+      // Rewrite to a workspace-relative path so locations are unambiguous across repos.
+      const workspacePath = repoPrefix ? `${repoPrefix}/${file}` : file;
+      if (seen.has(workspacePath)) continue;
+      seen.add(workspacePath);
+      files.push(workspacePath);
+      repos.push(repo.id);
+      if (files.length >= maxFiles) {
+        return { files, repos, truncated: true };
+      }
+    }
+  }
+
+  return { files, repos, truncated: totalTrackable > files.length };
 }
 
 function resolveGeneratorOptions(options?: CodebaseMapOptions): ResolvedCodebaseMapOptions {
@@ -252,10 +321,12 @@ function groupByDirectory(
   files: string[],
   descriptions: Map<string, string>,
   collapseThreshold: number,
+  repos?: string[],
 ): DirectoryGroup[] {
   const dirMap = new Map<string, FileEntry[]>();
 
-  for (const file of files) {
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
     const dir = dirname(file);
     const dirKey = dir === "." ? "" : dir;
     if (!dirMap.has(dirKey)) {
@@ -264,6 +335,7 @@ function groupByDirectory(
     dirMap.get(dirKey)!.push({
       path: file,
       description: descriptions.get(file) ?? "",
+      repo: repos?.[i],
     });
   }
 
@@ -278,6 +350,8 @@ function groupByDirectory(
       path: dir,
       files: dirFiles,
       collapsed: dirFiles.length > collapseThreshold,
+      // A directory lives in exactly one repo in workspace-aware mode.
+      repo: dirFiles[0]?.repo,
     });
   }
 
@@ -304,7 +378,19 @@ function renderCodebaseMap(
   }
   lines.push("");
 
+  let emittedRepo: string | undefined;
   for (const group of groups) {
+    // In a workspace-aware map, partition directories under their declaring
+    // repository. `## [repo-id]` headings are used (not `###`) so they never
+    // collide with the per-directory `### <dir>/` headings or the
+    // `parseCodebaseMap` list-item regexes. Groups are path-sorted with
+    // workspace-relative prefixes, so a repo's directories are contiguous.
+    if (group.repo && group.repo !== emittedRepo) {
+      emittedRepo = group.repo;
+      lines.push(`## [${group.repo}]`);
+      lines.push("");
+    }
+
     const heading = group.path || "(root)";
     lines.push(`### ${heading}/`);
 
@@ -361,13 +447,15 @@ function buildCodebaseMap(
 } {
   const listed = enumerated ?? enumerateFiles(basePath, resolved.excludes, resolved.maxFiles);
   const descriptions = existingDescriptions ?? new Map<string, string>();
-  const groups = groupByDirectory(listed.files, descriptions, resolved.collapseThreshold);
+  const groups = groupByDirectory(listed.files, descriptions, resolved.collapseThreshold, listed.repos);
   const generatedAt = new Date().toISOString().split(".")[0] + "Z";
+  const repoIds = listed.repos ? Array.from(new Set(listed.repos)) : undefined;
   const metadata: CodebaseMapMetadata = {
     generatedAt,
     fingerprint: computeCodebaseFingerprint(listed.files, resolved, listed.truncated),
     fileCount: listed.files.length,
     truncated: listed.truncated,
+    ...(repoIds ? { repositories: repoIds } : {}),
   };
   const content = renderCodebaseMap(groups, listed.files.length, listed.truncated, metadata);
 
@@ -387,13 +475,28 @@ function buildCodebaseMap(
  * Generate a fresh CODEBASE.md from scratch.
  * Preserves existing descriptions if `existingDescriptions` is provided.
  */
+/**
+ * Resolve workspace-aware enumeration for parent mode, or undefined to fall
+ * back to the legacy single-root enumeration. Centralized so all three public
+ * entry points (generate/update/ensure) share one discovery path.
+ */
+function resolveWorkspaceEnumeration(
+  basePath: string,
+  resolved: ResolvedCodebaseMapOptions,
+): EnumeratedFiles | undefined {
+  const registry = loadWorkspaceRegistry(basePath);
+  if (!registry) return undefined;
+  return enumerateWorkspaceFiles(registry, resolved.excludes, resolved.maxFiles);
+}
+
 export function generateCodebaseMap(
   basePath: string,
   options?: CodebaseMapOptions,
   existingDescriptions?: Map<string, string>,
 ): { content: string; fileCount: number; truncated: boolean; files: string[]; fingerprint: string; generatedAt: string } {
   const resolved = resolveGeneratorOptions(options);
-  return buildCodebaseMap(basePath, resolved, existingDescriptions);
+  const enumerated = resolveWorkspaceEnumeration(basePath, resolved);
+  return buildCodebaseMap(basePath, resolved, existingDescriptions, enumerated);
 }
 
 /**
@@ -427,7 +530,8 @@ export function updateCodebaseMap(
 
   // Generate new map preserving descriptions — reuse the returned file list
   // to avoid a second enumeration (prevents race between content and stats).
-  const result = buildCodebaseMap(basePath, resolved, existingDescriptions);
+  const enumerated = resolveWorkspaceEnumeration(basePath, resolved);
+  const result = buildCodebaseMap(basePath, resolved, existingDescriptions, enumerated);
   const currentSet = new Set(result.files);
 
   // Count changes
@@ -481,7 +585,8 @@ export function ensureCodebaseMapFresh(
   }
 
   const existing = readCodebaseMap(basePath);
-  const listed = enumerateFiles(basePath, resolved.excludes, resolved.maxFiles);
+  const listed = resolveWorkspaceEnumeration(basePath, resolved)
+    ?? enumerateFiles(basePath, resolved.excludes, resolved.maxFiles);
   const fingerprint = computeCodebaseFingerprint(listed.files, resolved, listed.truncated);
 
   const cacheAndReturn = (result: EnsureCodebaseMapResult): EnsureCodebaseMapResult => {

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -341,14 +341,16 @@ function groupByDirectory(
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     const dir = dirname(file);
-    const dirKey = dir === "." ? "" : dir;
-    if (!dirMap.has(dirKey)) {
-      dirMap.set(dirKey, []);
+    const dirPath = dir === "." ? "" : dir;
+    const repoId = repos?.[i];
+    const groupKey = repoId !== undefined ? `${repoId}\0${dirPath}` : dirPath;
+    if (!dirMap.has(groupKey)) {
+      dirMap.set(groupKey, []);
     }
-    dirMap.get(dirKey)!.push({
+    dirMap.get(groupKey)!.push({
       path: file,
       description: descriptions.get(file) ?? "",
-      repo: repos?.[i],
+      repo: repoId,
     });
   }
 
@@ -371,15 +373,16 @@ function groupByDirectory(
     return a.localeCompare(b);
   });
 
-  for (const dir of sortedDirs) {
-    const dirFiles = dirMap.get(dir)!;
+  for (const groupKey of sortedDirs) {
+    const dirFiles = dirMap.get(groupKey)!;
     dirFiles.sort((a, b) => a.path.localeCompare(b.path));
+    const dirPath = repos ? groupKey.slice(groupKey.indexOf("\0") + 1) : groupKey;
 
     groups.push({
-      path: dir,
+      path: dirPath,
       files: dirFiles,
       collapsed: dirFiles.length > collapseThreshold,
-      // A directory lives in exactly one repo in workspace-aware mode.
+      // Each group is scoped to one repo in workspace-aware mode.
       repo: dirFiles[0]?.repo,
     });
   }

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -258,31 +258,47 @@ function enumerateWorkspaceFiles(
   excludes: string[],
   maxFiles: number,
 ): EnumeratedFiles {
-  const files: string[] = [];
-  const repos: string[] = [];
+  type WorkspaceEntry = { workspacePath: string; repoId: string };
+  const perRepo: WorkspaceEntry[][] = [];
   const seen = new Set<string>();
-  let totalTrackable = 0;
+  let totalEligible = 0;
 
   for (const repo of registry.repositories) {
     const rawFiles = lsFiles(repo.root);
     const repoPrefix = relative(registry.projectRoot, repo.root).split(sep).join("/");
+    const repoEntries: WorkspaceEntry[] = [];
 
     for (const file of rawFiles) {
-      if (shouldExclude(file, excludes)) continue;
-      totalTrackable++;
-      // Rewrite to a workspace-relative path so locations are unambiguous across repos.
+      // Rewrite before exclusion so workspace-relative patterns (e.g. frontend/…) apply.
       const workspacePath = repoPrefix ? `${repoPrefix}/${file}` : file;
+      if (shouldExclude(workspacePath, excludes)) continue;
       if (seen.has(workspacePath)) continue;
       seen.add(workspacePath);
-      files.push(workspacePath);
-      repos.push(repo.id);
-      if (files.length >= maxFiles) {
-        return { files, repos, truncated: true };
-      }
+      totalEligible++;
+      repoEntries.push({ workspacePath, repoId: repo.id });
     }
+    perRepo.push(repoEntries);
   }
 
-  return { files, repos, truncated: totalTrackable > files.length };
+  const files: string[] = [];
+  const repos: string[] = [];
+  const indices = new Array(perRepo.length).fill(0);
+
+  while (files.length < maxFiles) {
+    let progressed = false;
+    for (let i = 0; i < perRepo.length; i++) {
+      if (indices[i] < perRepo[i].length) {
+        const entry = perRepo[i][indices[i]++];
+        files.push(entry.workspacePath);
+        repos.push(entry.repoId);
+        progressed = true;
+        if (files.length >= maxFiles) break;
+      }
+    }
+    if (!progressed) break;
+  }
+
+  return { files, repos, truncated: totalEligible > files.length };
 }
 
 function resolveGeneratorOptions(options?: CodebaseMapOptions): ResolvedCodebaseMapOptions {

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -321,10 +321,12 @@ function computeCodebaseFingerprint(
   files: string[],
   resolved: ResolvedCodebaseMapOptions,
   truncated: boolean,
+  repos?: string[],
 ): string {
   return createHash("sha1")
     .update(JSON.stringify({
       files,
+      ...(repos ? { repos } : {}),
       truncated,
       optionSignature: resolved.optionSignature,
     }))
@@ -356,7 +358,23 @@ function groupByDirectory(
   }
 
   const groups: DirectoryGroup[] = [];
-  const sortedDirs = [...dirMap.keys()].sort();
+  const repoOrder = new Map<string, number>();
+  if (repos) {
+    for (let i = 0; i < repos.length; i++) {
+      if (!repoOrder.has(repos[i])) {
+        repoOrder.set(repos[i], repoOrder.size);
+      }
+    }
+  }
+  const sortedDirs = [...dirMap.keys()].sort((a, b) => {
+    if (!repos) return a.localeCompare(b);
+    const repoA = dirMap.get(a)![0]?.repo ?? "";
+    const repoB = dirMap.get(b)![0]?.repo ?? "";
+    const orderA = repoOrder.get(repoA) ?? 0;
+    const orderB = repoOrder.get(repoB) ?? 0;
+    if (orderA !== orderB) return orderA - orderB;
+    return a.localeCompare(b);
+  });
 
   for (const dir of sortedDirs) {
     const dirFiles = dirMap.get(dir)!;
@@ -399,8 +417,8 @@ function renderCodebaseMap(
     // In a workspace-aware map, partition directories under their declaring
     // repository. `## [repo-id]` headings are used (not `###`) so they never
     // collide with the per-directory `### <dir>/` headings or the
-    // `parseCodebaseMap` list-item regexes. Groups are path-sorted with
-    // workspace-relative prefixes, so a repo's directories are contiguous.
+    // `parseCodebaseMap` list-item regexes. Groups are sorted by declaring
+    // repo (enumeration order) then directory path so each repo is contiguous.
     if (group.repo && group.repo !== emittedRepo) {
       emittedRepo = group.repo;
       lines.push(`## [${group.repo}]`);
@@ -468,7 +486,7 @@ function buildCodebaseMap(
   const repoIds = listed.repos ? Array.from(new Set(listed.repos)) : undefined;
   const metadata: CodebaseMapMetadata = {
     generatedAt,
-    fingerprint: computeCodebaseFingerprint(listed.files, resolved, listed.truncated),
+    fingerprint: computeCodebaseFingerprint(listed.files, resolved, listed.truncated, listed.repos),
     fileCount: listed.files.length,
     truncated: listed.truncated,
     ...(repoIds ? { repositories: repoIds } : {}),
@@ -603,7 +621,7 @@ export function ensureCodebaseMapFresh(
   const existing = readCodebaseMap(basePath);
   const listed = resolveWorkspaceEnumeration(basePath, resolved)
     ?? enumerateFiles(basePath, resolved.excludes, resolved.maxFiles);
-  const fingerprint = computeCodebaseFingerprint(listed.files, resolved, listed.truncated);
+  const fingerprint = computeCodebaseFingerprint(listed.files, resolved, listed.truncated, listed.repos);
 
   const cacheAndReturn = (result: EnsureCodebaseMapResult): EnsureCodebaseMapResult => {
     freshnessCache.set(cacheKey, { checkedAt: now, result });

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -242,6 +242,18 @@ function loadWorkspaceRegistry(basePath: string): RepositoryRegistry | null {
   return registry.mode === "parent" && hasChildRepo ? registry : null;
 }
 
+/** Stable key fragment for workspace-aware enumeration inputs (mode + declared repos). */
+function workspaceEnumerationSignature(basePath: string): string {
+  const registry = loadWorkspaceRegistry(basePath);
+  if (!registry) return "single-root";
+  return JSON.stringify({
+    mode: registry.mode,
+    repositories: registry.repositories
+      .map((repo) => ({ id: repo.id, root: repo.root }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  });
+}
+
 /**
  * Enumerate tracked files across every declared repository in a parent workspace.
  * Child-repo paths are rewritten to be workspace-relative (e.g. `frontend/src/x`)
@@ -603,7 +615,7 @@ export function ensureCodebaseMapFresh(
   ensureOptions?: EnsureCodebaseMapOptions,
 ): EnsureCodebaseMapResult {
   const resolved = resolveGeneratorOptions(options);
-  const cacheKey = `${basePath}::${resolved.optionSignature}`;
+  const cacheKey = `${basePath}::${resolved.optionSignature}::${workspaceEnumerationSignature(basePath)}`;
   const ttlMs = ensureOptions?.ttlMs ?? DEFAULT_REFRESH_TTL_MS;
   const force = ensureOptions?.force === true;
   const now = Date.now();

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -376,7 +376,12 @@ function groupByDirectory(
     }
   }
   const sortedDirs = [...dirMap.keys()].sort((a, b) => {
-    if (!repos) return a.localeCompare(b);
+    // Single-repo (project) mode must stay byte-identical to the pre-workspace
+    // output, which ordered directories with a bare `.sort()` (UTF-16 code-unit
+    // order, so uppercase sorts before lowercase). localeCompare would diverge
+    // for mixed-case names (e.g. "Zoo" before "apple" flips), so preserve
+    // code-unit ordering here; only the repo-partitioning key is added on top.
+    if (!repos) return a < b ? -1 : a > b ? 1 : 0;
     const repoA = dirMap.get(a)![0]?.repo ?? "";
     const repoB = dirMap.get(b)![0]?.repo ?? "";
     const orderA = repoOrder.get(repoA) ?? 0;

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -235,11 +235,18 @@ function enumerateFiles(basePath: string, excludes: string[], maxFiles: number):
  * back to the legacy single-root enumeration and produces byte-identical output.
  */
 function loadWorkspaceRegistry(basePath: string): RepositoryRegistry | null {
-  const registry = createRepositoryRegistryFromPreferences(basePath, loadEffectiveGSDPreferences(basePath)?.preferences);
+  const preferences = loadEffectiveGSDPreferences(basePath)?.preferences;
+  const workspace = preferences?.workspace;
+  const mode = workspace?.mode ?? "project";
   // Parent mode is only meaningful with at least one declared child repo; the
-  // implicit "project" repo is always present, so require >1 entry.
-  const hasChildRepo = registry.repositories.some((repo) => repo.id !== "project");
-  return registry.mode === "parent" && hasChildRepo ? registry : null;
+  // implicit "project" repo is always present, so require a declared non-project id.
+  const hasDeclaredChildRepo = workspace?.repositories
+    ? Object.keys(workspace.repositories).some((id) => id !== "project")
+    : false;
+  if (mode !== "parent" || !hasDeclaredChildRepo) {
+    return null;
+  }
+  return createRepositoryRegistryFromPreferences(basePath, preferences);
 }
 
 /** Stable key fragment for workspace-aware enumeration inputs (mode + declared repos). */

--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -235,12 +235,7 @@ function enumerateFiles(basePath: string, excludes: string[], maxFiles: number):
  * back to the legacy single-root enumeration and produces byte-identical output.
  */
 function loadWorkspaceRegistry(basePath: string): RepositoryRegistry | null {
-  let registry: RepositoryRegistry;
-  try {
-    registry = createRepositoryRegistryFromPreferences(basePath, loadEffectiveGSDPreferences(basePath)?.preferences);
-  } catch {
-    return null;
-  }
+  const registry = createRepositoryRegistryFromPreferences(basePath, loadEffectiveGSDPreferences(basePath)?.preferences);
   // Parent mode is only meaningful with at least one declared child repo; the
   // implicit "project" repo is always present, so require >1 entry.
   const hasChildRepo = registry.repositories.some((repo) => repo.id !== "project");

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -172,6 +172,7 @@ Diagnostics record the file path, scope (global/project), severity (error/warnin
     - `verification`: optional array of verification commands for that repo.
     - `commit_policy`: optional `"auto"` or `"skip"` to include or skip commit actions per repo.
   - Planning tools consume repository IDs through `targetRepositories`: `gsd_plan_slice.targetRepositories` sets a slice-wide default, and `gsd_plan_task.targetRepositories` records the repositories an individual task touches. Values must be declared IDs or the implicit `project`; omit these fields in single-repo projects.
+  - In parent mode with declared child repositories, `/gsd codebase generate` and automatic `.gsd/CODEBASE.md` refreshes enumerate `project` plus each child repository, render repo-labeled sections, and store repository IDs in map metadata.
 
 ## Workspace Example
 
@@ -308,6 +309,7 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - `project` is always an implicit repository target mapped to the project root for backward compatibility.
   - `targetRepositories` on `gsd_plan_slice` sets the slice-wide default. `targetRepositories` on `gsd_plan_task` records or overrides the repository IDs for an individual task.
   - Values must match declared repository IDs or the implicit `project`; omitted plan/task `targetRepositories` defaults to `["project"]`.
+  - `/gsd codebase` is workspace-aware in parent mode with declared child repositories: generated `.gsd/CODEBASE.md` uses workspace-relative paths, groups files under `## [repo-id]` headings, and refreshes when repository registry metadata changes.
 
 - `verification_commands`: string[] — shell commands to run as verification after task execution (e.g., `["npm test", "npm run lint"]`). Commands run in order; if any fails, the task is marked as needing fixes.
 

--- a/src/resources/extensions/gsd/skills/gsd-headless/references/commands.md
+++ b/src/resources/extensions/gsd/skills/gsd-headless/references/commands.md
@@ -22,6 +22,7 @@ All commands can be run via `gsd headless [command]`.
 | `status` | Progress dashboard (TUI overlay — useful interactively, not for parsing) |
 | `visualize` | Workflow visualizer (deps, metrics, timeline) |
 | `history` | Execution history (supports --cost, --phase, --model, limit) |
+| `codebase` | Manage `.gsd/CODEBASE.md`; parent workspaces include declared child repositories under repo-labeled sections |
 
 ## Unit Control
 

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -994,3 +994,96 @@ test("single-repo: directory order stays byte-identical code-unit sort (not loca
     cleanup(base);
   }
 });
+
+test("workspace-aware: an invalid workspace registry surfaces an error instead of silently falling back", () => {
+  // Regression guard: a broken parent-mode config (here a child path escaping the
+  // project root) must propagate as an error. Swallowing it and falling back to a
+  // single-root map would silently drop every child repo from planning context.
+  const base = makeTmpRepo();
+  try {
+    addFile(base, "src/main.ts");
+    writeFileSync(
+      join(base, ".gsd", "PREFERENCES.md"),
+      `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n    frontend:\n      path: ../escapes-root\n---\n`,
+      "utf-8",
+    );
+
+    assert.throws(() => generateCodebaseMap(base), /resolves outside project root/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: files sharing a directory across repos keep their own repo heading", () => {
+  // Regression guard: the implicit project repo and a child repo can own different
+  // files under the same workspace-relative directory (lib/). Groups are keyed by
+  // (repo, dir), so each file must render under its own `## [repo-id]` heading
+  // instead of collapsing into one section labelled with a single (wrong) repo.
+  const base = join(tmpdir(), `gsd-codebase-parent-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  execSync("git init", { cwd: base, stdio: "ignore" });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n    lib:\n      path: lib\n---\n`,
+    "utf-8",
+  );
+  try {
+    // Project repo tracks lib/app.ts before lib becomes its own repo; the child
+    // repo then tracks helper.ts → workspace path lib/helper.ts. Different files,
+    // same directory, different repos.
+    addFile(base, "lib/app.ts");
+    execSync("git init", { cwd: join(base, "lib"), stdio: "ignore" });
+    writeFileSync(join(base, "lib", "helper.ts"), "// helper\n", "utf-8");
+    execSync("git add helper.ts", { cwd: join(base, "lib"), stdio: "ignore" });
+
+    const content = generateCodebaseMap(base).content;
+
+    // Both files present, each under its own repo section (not merged under one).
+    assert.match(content, /## \[project\]/);
+    assert.match(content, /## \[lib\]/);
+    const projectIdx = content.indexOf("## [project]");
+    const appIdx = content.indexOf("`lib/app.ts`");
+    const libIdx = content.indexOf("## [lib]");
+    const helperIdx = content.indexOf("`lib/helper.ts`");
+    assert.ok(
+      projectIdx < appIdx && appIdx < libIdx && libIdx < helperIdx,
+      "lib/app.ts must sit under [project] and lib/helper.ts under [lib]",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("ensureCodebaseMapFresh: editing declared repos within the TTL window bypasses the cache", () => {
+  // Regression guard: the freshness TTL cache key folds in the workspace signature
+  // (mode + declared repos). Adding a child repo must miss the cache and re-enumerate
+  // rather than serve a stale map that omits the new repo until the TTL expires.
+  const base = makeTmpParentWorkspace(["frontend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+
+    const initial = ensureCodebaseMapFresh(base, undefined, { ttlMs: 60_000 });
+    assert.equal(initial.status, "generated");
+    assert.doesNotMatch(readCodebaseMap(base)!, /## \[backend\]/);
+
+    // Declare a second child repo and back it with a real nested repo + file.
+    mkdirSync(join(base, "backend"), { recursive: true });
+    execSync("git init", { cwd: join(base, "backend"), stdio: "ignore" });
+    addChildFile(base, "backend", "src/server.ts");
+    writeFileSync(
+      join(base, ".gsd", "PREFERENCES.md"),
+      `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n    frontend:\n      path: frontend\n    backend:\n      path: backend\n---\n`,
+      "utf-8",
+    );
+
+    // Same TTL window, no force: the changed workspace signature must miss the cache.
+    const refreshed = ensureCodebaseMapFresh(base, undefined, { ttlMs: 60_000 });
+    const written = readCodebaseMap(base)!;
+
+    assert.equal(refreshed.status, "updated");
+    assert.match(written, /## \[backend\]/);
+    assert.match(written, /`backend\/src\/server\.ts`/);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -916,3 +916,81 @@ test("workspace-aware: overlapping paths dedupe without falsely reporting trunca
     cleanup(base);
   }
 });
+
+test("workspace-aware: project directories interleaving child prefixes stay under one heading", () => {
+  // Regression guard: the implicit project repo has an empty prefix, so its
+  // root-level dirs (aaa/, zzz/) sort lexically around a child prefix (mmm/).
+  // Groups must be ordered per repo so `## [project]` is emitted exactly once.
+  const base = makeTmpParentWorkspace(["mmm"]);
+  try {
+    addFile(base, "aaa/x.ts"); // project repo, sorts before "mmm"
+    addFile(base, "zzz/y.ts"); // project repo, sorts after "mmm"
+    addChildFile(base, "mmm", "src/thing.ts");
+
+    const result = generateCodebaseMap(base);
+
+    const projectHeadings = (result.content.match(/^## \[project\]$/gm) ?? []).length;
+    const mmmHeadings = (result.content.match(/^## \[mmm\]$/gm) ?? []).length;
+    const allHeadings = (result.content.match(/^## \[.+\]$/gm) ?? []).length;
+
+    assert.equal(projectHeadings, 1, "project section must not be split across headings");
+    assert.equal(mmmHeadings, 1);
+    assert.equal(allHeadings, 2);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: renaming a declared repo id invalidates map freshness", () => {
+  // Regression guard: repo identity is rendered into the map, so renaming a repo id
+  // (path unchanged → identical file paths) must be caught by the freshness
+  // fingerprint rather than leaving a stale `## [old-id]` heading in place.
+  const base = makeTmpParentWorkspace(["frontend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+
+    ensureCodebaseMapFresh(base, undefined, { ttlMs: 0, force: true });
+    assert.match(readCodebaseMap(base)!, /^## \[frontend\]$/m);
+
+    // Rename the repo id to `web`; the path (and therefore the file paths) is unchanged.
+    writeFileSync(
+      join(base, ".gsd", "PREFERENCES.md"),
+      `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n    web:\n      path: frontend\n---\n`,
+      "utf-8",
+    );
+
+    const refreshed = ensureCodebaseMapFresh(base, undefined, { ttlMs: 0, force: true });
+    const written = readCodebaseMap(base)!;
+
+    assert.equal(refreshed.status, "updated");
+    assert.match(written, /^## \[web\]$/m);
+    assert.doesNotMatch(written, /^## \[frontend\]$/m);
+    assert.deepEqual(parseCodebaseMapMetadata(written)?.repositories, ["web"]);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("single-repo: directory order stays byte-identical code-unit sort (not locale-aware)", () => {
+  // Byte-identical single-repo invariant: pre-workspace output ordered
+  // directories with a bare `.sort()` (UTF-16 code-unit order), so uppercase
+  // sorts before lowercase ("Zoo" < "apple"). A locale-aware comparator inverts
+  // these and silently changes project-mode CODEBASE.md, so guard the ordering.
+  const base = makeTmpRepo();
+  try {
+    addFile(base, "Zoo/keeper.ts"); // 'Z' (0x5A) < 'a' (0x61) → sorts first
+    addFile(base, "apple/tree.ts");
+
+    const content = generateCodebaseMap(base).content;
+    const zooIdx = content.indexOf("### Zoo/");
+    const appleIdx = content.indexOf("### apple/");
+
+    assert.notEqual(zooIdx, -1);
+    assert.notEqual(appleIdx, -1);
+    assert.ok(zooIdx < appleIdx, "code-unit order must place Zoo/ before apple/");
+    // Project mode emits no repo partition heading.
+    assert.doesNotMatch(content, /^## \[.+\]$/m);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -722,3 +722,130 @@ test("ensureCodebaseMapFresh: uses TTL cache before enumerating files", () => {
     cleanup(base);
   }
 });
+
+// ─── Workspace-aware (parent mode) ───────────────────────────────────────
+
+/**
+ * Build a parent workspace: a parent git repo whose .gsd/PREFERENCES.md declares
+ * child repositories, each child being its own separate git repo nested inside.
+ */
+function makeTmpParentWorkspace(children: string[]): string {
+  const base = join(tmpdir(), `gsd-codebase-parent-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  execSync("git init", { cwd: base, stdio: "ignore" });
+
+  const repoLines = children.map((id) => `    ${id}:\n      path: ${id}`).join("\n");
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n${repoLines}\n---\n`,
+    "utf-8",
+  );
+
+  for (const child of children) {
+    const childPath = join(base, child);
+    mkdirSync(childPath, { recursive: true });
+    execSync("git init", { cwd: childPath, stdio: "ignore" });
+  }
+  return base;
+}
+
+function addChildFile(base: string, child: string, path: string, content = ""): void {
+  const childRoot = join(base, child);
+  const fullPath = join(childRoot, path);
+  mkdirSync(join(fullPath, ".."), { recursive: true });
+  writeFileSync(fullPath, content || `// ${child}/${path}\n`, "utf-8");
+  execSync(`git add "${path}"`, { cwd: childRoot, stdio: "ignore" });
+}
+
+test("workspace-aware: parent mode enumerates each declared child repo under a repo heading", () => {
+  const base = makeTmpParentWorkspace(["frontend", "backend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+    addChildFile(base, "backend", "src/server.ts");
+
+    const result = generateCodebaseMap(base);
+
+    // Both repos appear as labelled sections.
+    assert.match(result.content, /## \[frontend\]/);
+    assert.match(result.content, /## \[backend\]/);
+    // Child files are rewritten to workspace-relative paths.
+    assert.match(result.content, /`frontend\/src\/App\.tsx`/);
+    assert.match(result.content, /`backend\/src\/server\.ts`/);
+    assert.equal(result.fileCount, 2);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: metadata records the repositories whose files appear in the map", () => {
+  const base = makeTmpParentWorkspace(["frontend", "backend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+    addChildFile(base, "backend", "src/server.ts");
+
+    const result = generateCodebaseMap(base);
+    const metadata = parseCodebaseMapMetadata(result.content);
+
+    assert.ok(metadata, "metadata should be present");
+    assert.deepEqual(metadata?.repositories?.sort(), ["backend", "frontend"]);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: parseCodebaseMap recovers descriptions across repo sections", () => {
+  const base = makeTmpParentWorkspace(["frontend", "backend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+    addChildFile(base, "backend", "src/server.ts");
+
+    // Seed descriptions keyed by the workspace-relative paths.
+    const descriptions = new Map<string, string>([
+      ["frontend/src/App.tsx", "React entry"],
+      ["backend/src/server.ts", "Express API"],
+    ]);
+    const result = generateCodebaseMap(base, undefined, descriptions);
+    writeCodebaseMap(base, result.content);
+
+    const parsed = parseCodebaseMap(readCodebaseMap(base)!);
+    assert.equal(parsed.get("frontend/src/App.tsx"), "React entry");
+    assert.equal(parsed.get("backend/src/server.ts"), "Express API");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: project mode (no declared children) stays single-section", () => {
+  // A plain single repo with no workspace config must render exactly as before.
+  const base = makeTmpRepo();
+  try {
+    addFile(base, "src/main.ts");
+
+    const result = generateCodebaseMap(base);
+
+    assert.doesNotMatch(result.content, /## \[/);
+    assert.match(result.content, /`src\/main\.ts`/);
+    const metadata = parseCodebaseMapMetadata(result.content);
+    assert.equal(metadata?.repositories, undefined);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: updateCodebaseMap tracks child-repo file additions", () => {
+  const base = makeTmpParentWorkspace(["frontend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+    const first = updateCodebaseMap(base);
+    writeCodebaseMap(base, first.content);
+    assert.equal(first.added, 1);
+
+    addChildFile(base, "frontend", "src/index.tsx");
+    const second = updateCodebaseMap(base);
+    assert.equal(second.added, 1);
+    assert.equal(second.removed, 0);
+    assert.equal(second.fileCount, 2);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -849,3 +849,41 @@ test("workspace-aware: updateCodebaseMap tracks child-repo file additions", () =
     cleanup(base);
   }
 });
+
+test("workspace-aware: workspace-relative exclude patterns filter child-repo files", () => {
+  // Regression guard: exclude patterns like `frontend/` are workspace-relative,
+  // so they must be matched against the rewritten path, not the child-relative one.
+  const base = makeTmpParentWorkspace(["frontend", "backend"]);
+  try {
+    addChildFile(base, "frontend", "src/App.tsx");
+    addChildFile(base, "backend", "src/server.ts");
+
+    const result = generateCodebaseMap(base, { excludePatterns: ["frontend/"] });
+
+    assert.doesNotMatch(result.content, /frontend\/src\/App\.tsx/);
+    assert.match(result.content, /backend\/src\/server\.ts/);
+    assert.equal(result.fileCount, 1);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("workspace-aware: maxFiles cap does not starve child repos for the project repo", () => {
+  // The implicit project repo is enumerated alongside children; the cap must be
+  // applied fairly (round-robin) so a large project repo cannot crowd out children.
+  const base = makeTmpParentWorkspace(["frontend", "backend"]);
+  try {
+    addChildFile(base, "frontend", "a.ts");
+    addChildFile(base, "frontend", "b.ts");
+    addChildFile(base, "backend", "c.ts");
+
+    // Cap at 2 files — with fair distribution both repos should appear.
+    const result = generateCodebaseMap(base, { maxFiles: 2 });
+    const repoSections = (result.content.match(/^## \[.+\]/gm) ?? []).length;
+
+    assert.equal(result.fileCount, 2);
+    assert.ok(repoSections >= 2, "both child repos should be represented under a tight cap");
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -887,3 +887,32 @@ test("workspace-aware: maxFiles cap does not starve child repos for the project 
     cleanup(base);
   }
 });
+
+test("workspace-aware: overlapping paths dedupe without falsely reporting truncation", () => {
+  // Regression guard: a path tracked by both the implicit project repo and a child
+  // repo collapses to one workspace-relative entry. Deduplicated duplicates must not
+  // count toward the maxFiles cap, so the map must not be flagged as truncated.
+  const base = join(tmpdir(), `gsd-codebase-parent-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  execSync("git init", { cwd: base, stdio: "ignore" });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n    lib:\n      path: lib\n---\n`,
+    "utf-8",
+  );
+  try {
+    // The project repo tracks lib/util.ts before lib becomes its own repo; the child
+    // repo then tracks util.ts, so both resolve to the same workspace path lib/util.ts.
+    addFile(base, "lib/util.ts");
+    execSync("git init", { cwd: join(base, "lib"), stdio: "ignore" });
+    execSync("git add util.ts", { cwd: join(base, "lib"), stdio: "ignore" });
+
+    const result = generateCodebaseMap(base);
+
+    assert.equal(result.fileCount, 1);
+    assert.equal(result.truncated, false);
+    assert.equal((result.content.match(/`lib\/util\.ts`/g) ?? []).length, 1);
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** In parent-workspace mode, `CODEBASE.md` now enumerates files per declared child repository and renders a unified, repo-labelled map instead of only scanning the project root.
**Why:** The codebase map — the planning context that orients fresh agent contexts — ignored child repos entirely, so cross-repo decomposition lost visibility of half the workspace.
**How:** Per-repo `git ls-files` with workspace-relative path rewriting + `## [repo-id]` section headings; single-repo behavior is byte-identical.

Closes Gap 3 of 6 in #818.

## What

`src/resources/extensions/gsd/codebase-generator.ts`:
- New `loadWorkspaceRegistry` — resolves the `RepositoryRegistry`; returns `null` (→ legacy path) unless `mode: parent` with ≥1 declared child repo.
- New `enumerateWorkspaceFiles` — runs `git ls-files` per declared repository, rewrites each path to be workspace-relative (e.g. `frontend/src/App.tsx`), tags each file with its declaring repo id, dedups, and applies the `maxFiles` cap across the union.
- `groupByDirectory` / `renderCodebaseMap` thread an optional per-file `repo` label; in workspace mode, directories are rendered under `## [repo-id]` section headings (contiguous because paths are sorted + workspace-prefixed).
- `CodebaseMapMetadata` gains an optional `repositories: string[]` field (parsed additively; the four existing fields remain the validated shape).
- All three public entry points (`generateCodebaseMap`, `updateCodebaseMap`, `ensureCodebaseMapFresh`) resolve workspace enumeration through one shared helper, falling back to single-root enumeration otherwise.

`tests/codebase-generator.test.ts`: 5 new tests covering repo headings, workspace-relative paths, metadata `repositories`, cross-section description recovery via `parseCodebaseMap`, project-mode backward compatibility (no `## [` headings, no `repositories` field), and `updateCodebaseMap` tracking child-repo additions.

## Why

Gap 3 from #818: *"The codebase map ignores child repos. `codebase-generator.ts` runs a single `git ls-files` at the project root, so child-repo files never enter planning context."* A parent workspace planning one milestone across `frontend`/`backend`/`workers` needs the map to span the whole workspace — otherwise the agent decomposes work blind to everything outside the parent dir.

## How

**Backward compatibility is the load-bearing decision.** The workspace path is taken *only* when `mode: parent` with at least one declared child repo; otherwise the legacy single-root enumeration produces byte-identical output. Verified: all 40 pre-existing tests pass unchanged.

**Why `## [repo-id]` headings.** The map has two downstream consumers:
1. `parseCodebaseMap` — matches list items (`` - `path` — desc ``); headings don't match, so descriptions still recover correctly across repo sections (tested).
2. `system-context.ts` prompt injection — passes the map through as raw markdown (stripping only the volatile metadata line); `##` headings are safely additive and never collide with the existing `### <dir>/` directory headings.

**Why workspace-relative paths.** `git ls-files` in a child repo returns paths relative to that child (`src/App.tsx`); rewriting to `frontend/src/App.tsx` makes locations unambiguous across repos and keeps `parseCodebaseMap` keys unique.

### Verification
- `tsc --noEmit --project tsconfig.extensions.json` — clean.
- `pnpm run verify:fast` — all fast-gates passed.
- `codebase-generator.test.ts` — 45/45 pass (40 existing single-repo + 5 new workspace-aware).

### Scope boundary
Gap 3 of 6. Still open on the same epic (tracked in ADR-043 on #1111): planner prompt wiring (Gap 2), per-repo git isolation (Gap 4), sibling-repo layout (Gap 5), UX/wizard discovery (Gap 6). This slice is independent and stacks cleanly with the mode-contract (#1111) — the registry seam it reuses already exists on `main`.

AI-assisted; no AI credited as author.

Change type: `feat` / `test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how planning/orientation context is built for multi-repo parent workspaces and runs multiple `git ls-files` invocations, but single-repo mode is explicitly preserved and invalid workspace config fails closed.
> 
> **Overview**
> **Parent workspaces** with declared child repos now get a unified `.gsd/CODEBASE.md` that spans the implicit `project` root and every child repository, instead of only listing files from a single `git ls-files` at the project root.
> 
> `codebase-generator.ts` loads the workspace `RepositoryRegistry` when `workspace.mode` is `parent` and at least one non-`project` child is declared; otherwise it keeps the legacy single-root path so **project-mode output stays byte-identical**. Workspace mode runs `git ls-files` per repo, rewrites paths to workspace-relative form, dedupes overlaps, applies `maxFiles` with round-robin fairness, groups directories by `(repo, dir)`, and renders contiguous **`## [repo-id]`** sections above the existing `### <dir>/` headings. Map metadata gains optional **`repositories`**, and fingerprints / `ensureCodebaseMapFresh` TTL cache keys include workspace registry identity so repo renames or new children invalidate stale maps. Invalid parent registry config (e.g. paths outside the root) **throws** rather than silently falling back to single-repo.
> 
> User and internal docs (`/gsd codebase`, `workspace` preferences) describe the new behavior. **`codebase-generator.test.ts`** adds broad regression coverage (headings, metadata, excludes, truncation, freshness, ordering, cross-repo same-directory files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0767df2b7ea04aeb7f99fb1f2d46f5526ae89b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->