### PR TITLE
feat(gsd): parent-workspace discovery UX + document nested-only layout — #818 slices 5+6/6

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Simplified Chinese translation: [`zh-CN/`](./zh-CN/).
 | [Cost Management](./user-docs/cost-management.md) | Budget ceilings, cost tracking, projections, and enforcement modes |
 | [Git Strategy](./user-docs/git-strategy.md) | Worktree isolation, branching model, and merge behavior |
 | [Parallel Orchestration](./user-docs/parallel-orchestration.md) | Run multiple milestones simultaneously with worker isolation and coordination |
+| [Multi-Repo Workspace](./user-docs/multi-repo-workspace.md) | Coordinate planning, verification, and commits across multiple child repositories |
 | [Subagents](./user-docs/subagents.md) | Delegate, inspect, and resume isolated child-agent runs |
 | [Working in Teams](./user-docs/working-in-teams.md) | Unique milestone IDs, `.gitignore` setup, and shared planning artifacts |
 | [Skills](./user-docs/skills.md) | Bundled skills, skill discovery, and custom skill authoring |

--- a/docs/dev/ADR-044-per-repository-git-isolation.md
+++ b/docs/dev/ADR-044-per-repository-git-isolation.md
@@ -1,0 +1,71 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: ADR (proposed) for per-repository git isolation in parent workspaces — records the Tier A (push policy) / Tier B (worktree/branch isolation) split and why Tier B needs an RFC. -->
+
+# ADR-044: Per-Repository Git Isolation (Parent Workspace)
+
+**Status:** Proposed — Tier B requires an RFC before adoption (see "Trigger")
+**Date:** 2026-07-01
+**Author:** GSD architecture review
+**Related:** [open-gsd/gsd-pi#818](https://github.com/open-gsd/gsd-pi/issues/818) (parent-workspace epic, Gap 4), ADR-043 (parent-workspace mode contract), ADR-001 (branchless worktree architecture), `CONTEXT.md` worktree lifecycle
+
+## Context
+
+### What Gap 4 asks for — and what already works
+
+The parent-workspace epic's fourth gap: *"Extend git isolation per repository. Allow worktree/branch isolation and commit/push strategy to be resolved per child repo (using `commit_policy` and a per-repo branch/push policy), not just at the root."*
+
+**The gap is narrower than that framing suggests.** The issue's two stated Gap 4 use cases are **already delivered** by code that predates the epic:
+
+| Issue use case | Mechanism | Status |
+|---|---|---|
+| "a slice verified and committed in its own repo" | per-repo verification (`auto-verification.ts`, `cwd: repo.root`) + per-repo commit (`runPerRepositoryCommitAction`) | ✅ wired |
+| "`commit_policy: skip` on `infra` … never auto-commits there" | per-repo `commit_policy` (`git-service.ts`, `if (repo.commitPolicy === "skip") skip`) | ✅ wired |
+
+So a contributor picking up "Gap 4" should **not** rebuild per-repo commit or verification — they already loop the registry. What genuinely remains is the one piece the issue's *description* mentions but its *use cases* do not exercise: **per-repo worktree/branch/push isolation.** That is the subject of the Tier A / Tier B split below.
+
+### Why the remaining gap is two distinct problems
+
+The existing seam splits cleanly along the commit axis vs. the isolation/push axis:
+
+- **Per-repo commit and verification already loop.** `runPerRepositoryCommitAction` (`git-service.ts`) commits per declared repository, honoring each repo's `commit_policy` (`auto`/`skip`); `collectRepositoryDirtyStatus` probes each repo independently; verification runs with `cwd: repo.root`.
+- **Branch, worktree, and push do not.** The milestone branch is `milestone/<MID>` (single, repo-agnostic — `auto-worktree.ts:846`). The worktree is one per milestone at the project root (`worktree-placement.ts`). `publishMilestone` pushes a single `integrationBranch`/`milestoneBranch` from a single `basePath` with scalar `auto_push`/`push_branches`/`remote` preferences (`publication.ts:67`). The squash-merge transaction (`mergeMilestoneToMain`) is single-root.
+
+This is the basis for the Tier A / Tier B split below.
+
+## Decision
+
+### Tier A — per-repository push policy (proposed, lower-risk)
+
+Add per-repo push/branch policy alongside the existing `commit_policy` on `WorkspaceRepositoryPreference`, and loop the registry in `publishMilestone` so push is resolved per declared repository. This is **additive to the existing per-repo commit seam** — it extends the registry and the publication path, both of which already have a per-repo dimension.
+
+Tier A does **not** touch worktree creation, branch-mode entry, the session root, or the merge transaction.
+
+### Tier B — per-repository worktree/branch isolation (NOT adopted; RFC required)
+
+Inverting the one-worktree-per-milestone model to one-worktree-per-repo-per-milestone is an architectural change that crosses the systems CONTRIBUTING.md flags as RFC-trigger zones (`auto-mode`, `agent-core`, `orchestration`). Specifically it would require changing:
+
+| Concern | Location | Why it's load-bearing |
+|---|---|---|
+| Isolation mode resolution | `preferences.ts` (`getIsolationMode`) | Global pref; would need to become per-repo |
+| Worktree creation | `auto-worktree.ts` (`createAutoWorktree`) | Single `basePath`, single `chdir`, single `activeWorkspace` |
+| Branch-mode entry | `auto-worktree.ts` (`enterBranchModeForMilestone`) | Single `basePath` |
+| Milestone entry dispatch | `worktree-lifecycle.ts` (`_enterMilestoneCore`) | Resolves a single `mode` per milestone |
+| Per-turn safety validation | `orchestrator.ts` (`prepareWorktreeForUnit`) | `buildExpectedBranch` returns one branch |
+| Merge transaction | `auto-worktree.ts` (`mergeMilestoneToMain`) | Single squash-merge, branch delete, worktree remove |
+| Session root / `activeWorkspace` | `auto-worktree.ts` | A singleton; per-repo worktrees break the "one active workspace" invariant |
+
+The deepest blocker is the **session-root singleton**: the agent runs in one working directory (`process.chdir` to one `activeWorkspace`). Per-repo worktrees would require either multiple concurrent cwd contexts (breaks agent-core) or a primary-worktree-plus-per-repo-branch-checkouts model. Either is a design-level change to the isolation lifecycle, not a surgical edit.
+
+**Blast-radius note:** Tier B only affects teams that opt into `git.isolation: "worktree"` or `"branch"` — the default is `"none"` (`preferences.ts:1042`), under which there is no worktree to make per-repo and per-repo commit/verification already work as-is. So Tier B is RFC-grade both because of the systems it touches and because it serves a non-default configuration.
+
+Tier B is **recorded here, not implemented**. It should go through the RFC/ADR review process with a concrete design for the session-root question before any code lands.
+
+## Consequences
+
+- **The substance of Gap 4 is already delivered.** The issue's two stated use cases (per-repo verify+commit, `commit_policy: skip`) work today via the existing per-repo commit/verification loops — no part of this ADR is required to satisfy them. A future contributor should treat that as done.
+- **Tier A** (per-repo push policy) is *beyond the issue's stated scope* — the use cases don't mention push — but is a low-blast-radius option (e.g. "push `frontend` and `backend` but never push `infra`") if a real need surfaces. Recorded, not built, per the simplicity-first rule.
+- **Tier B remains open.** Until it is designed and approved via RFC, parent-workspace *worktree/branch isolation* stays root-only: one worktree/branch per milestone at the project root, shared across child repos. This only matters under `git.isolation: worktree|branch`; under the default `none`, per-repo commit/verification already work. Documented as a known limit in `docs/user-docs/multi-repo-workspace.md`.
+
+## Trigger
+
+Tier A may be implemented as a focused slice when a contributor picks up the per-repo push-policy use case. Tier B requires an RFC describing how the session-root singleton and the merge transaction accommodate per-repo isolation before implementation begins.

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -644,7 +644,10 @@ Validation rules:
 - Repository IDs must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`.
 - Repository paths are normalized and must be unique (case-insensitive).
 - Paths resolving outside the project root are rejected.
+- `workspace.mode: "parent"` requires at least one repository under `workspace.repositories`; otherwise it is rejected (a parent workspace with no child repos is indistinguishable from `project` mode).
 - Unknown keys under `workspace` and each repository entry are ignored with warnings.
+
+**Layout constraint (nested-only).** Child repositories must live **inside** the project root — sibling-repo layouts (e.g. a path like `../frontend` or any path resolving outside the root) are **not supported** and are rejected. This is a deliberate safety guard, not an arbitrary limitation: declared repository roots back the task path-scope allowlist used during planning (`plan-slice` validates that every task `files`/`inputs`/`expectedOutput` path stays under a declared root). Allowing escapes would weaken that guard and let a typo'd or malicious path authorize edits outside the project. To coordinate sibling repos, nest them under a common parent directory and run GSD from that parent.
 
 ### URL Blocking (`fetch_page`)
 

--- a/docs/user-docs/multi-repo-workspace.md
+++ b/docs/user-docs/multi-repo-workspace.md
@@ -1,0 +1,88 @@
+# Multi-Repository Parent Workspace
+
+Many products span more than one git repository — a `frontend/`, a `backend/`, maybe `workers/` or `infra/` — each with its own `.git`. GSD's **parent workspace** mode lets one `.gsd/` directory plan, verify, and commit across all of them as a single coordinated project, instead of running a separate GSD instance per repo.
+
+## When to use it
+
+Use parent workspace mode when:
+
+- One milestone's work naturally touches more than one repository (e.g. an API contract change that updates both `backend` and `frontend`).
+- You want a shared roadmap, shared requirements, and dependency ordering across repos.
+- You want per-repository verification commands and commit policies (e.g. verify `infra` but never auto-commit it).
+
+If your project is a single git repository (or a monorepo with one `.git`), you do **not** need this — the default `project` mode is correct and parent mode adds nothing.
+
+## Layout requirement
+
+Parent workspace mode requires child repositories to be **nested inside the project root**. Sibling-repo layouts are not supported.
+
+```
+my-product/              ← run GSD here (the project root)
+├── .gsd/                ← single GSD state directory
+├── frontend/            ← child repo (its own .git)
+├── backend/             ← child repo (its own .git)
+└── workers/             ← child repo (its own .git)
+```
+
+This is a deliberate safety guard: declared repository roots back the task path-scope allowlist that `plan-slice` enforces, so paths must stay under the project root. To coordinate sibling repos, nest them under a common parent and run GSD from that parent.
+
+## Setup
+
+### Option A: via the wizard (`/gsd prefs`)
+
+1. Run `/gsd prefs` and choose **Workspace**.
+2. Set **Workspace mode** to `parent`.
+3. Use **Add repository** for each child repo — give it an id (e.g. `frontend`), its path relative to the project root (e.g. `frontend`), and optionally a role, verification commands, and a commit policy (`auto` or `skip`).
+4. Choose **Done**, then **Save & Exit**.
+
+The `project` repository is always available implicitly (it points at the project root) and cannot be redefined.
+
+### Option B: by hand
+
+Create or edit `.gsd/PREFERENCES.md` at the project root:
+
+```yaml
+---
+version: 1
+workspace:
+  mode: parent
+  repositories:
+    frontend:
+      path: frontend
+      role: web UI
+      verification:
+        - npm test
+        - npm run lint
+      commit_policy: auto
+    backend:
+      path: ./backend
+      role: API server
+      verification:
+        - go test ./...
+      commit_policy: auto
+    infra:
+      path: infra
+      role: deployment
+      commit_policy: skip        # plan + verify, but never auto-commit
+---
+```
+
+Validation rules: repository ids must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`; `project` is reserved; paths must be relative, unique, and resolve inside the project root; `mode: parent` requires at least one repository. See [configuration.md](./configuration.md#workspace) for the full schema.
+
+## How it behaves
+
+Once configured, parent mode changes four things — all of which default to single-repo behavior when `mode` is `project` (the default):
+
+- **Repository targeting.** When a slice or task omits `targetRepositories`, GSD defaults to the declared child repositories rather than the root, so work is attributed to the repo it touches. The planner is prompted to assign `targetRepositories` per task from the declared list.
+- **Codebase map.** `CODEBASE.md` enumerates tracked files per declared repository and renders a unified, repo-labelled map, so planning context spans the whole workspace.
+- **Per-repository verification.** Each repo's `verification` commands run with that repo's directory as the working directory.
+- **Per-repository commits.** Closeout commits honor each repo's `commit_policy` — `auto` commits in that repo, `skip` plans and verifies but leaves the repo untouched.
+
+## What is not yet supported
+
+Parent workspace mode is being completed incrementally. The following are tracked as separate pieces of work and are **not** yet wired:
+
+- **Per-repository git isolation** (worktree/branch per child repo). Isolation still operates at the project root; see ADR-044 for the design.
+- **Per-repository push policy.** Push is resolved at the project root.
+
+For the current status of each piece, see the parent-workspace epic ([#818](https://github.com/open-gsd/gsd-pi/issues/818)).

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -551,6 +551,17 @@ export function buildCategorySummaries(prefs: Record<string, unknown>): Record<s
     if (parts.length > 0) integrationsSummary = parts.join(", ");
   }
 
+  // Workspace (parent-workspace multi-repo)
+  const workspace = prefs.workspace as Record<string, unknown> | undefined;
+  const workspaceRepos = workspace?.repositories as Record<string, unknown> | undefined;
+  let workspaceSummary = "(single-repo)";
+  {
+    const parts: string[] = [];
+    if (workspace?.mode) parts.push(`mode: ${workspace.mode}`);
+    if (workspaceRepos && Object.keys(workspaceRepos).length > 0) parts.push(`${Object.keys(workspaceRepos).length} repo(s)`);
+    if (parts.length > 0) workspaceSummary = parts.join(", ");
+  }
+
   return {
     mode: modeSummary,
     models: modelsSummary,
@@ -568,6 +579,7 @@ export function buildCategorySummaries(prefs: Record<string, unknown>): Record<s
     hooks: hooksSummary,
     uok: uokSummary,
     integrations: integrationsSummary,
+    workspace: workspaceSummary,
   };
 }
 
@@ -966,6 +978,114 @@ async function configureSkills(ctx: ExtensionCommandContext, prefs: Record<strin
   // Skill staleness days
   const staleness = await promptInteger(ctx, "Skill staleness days (0 to disable)", prefs.skill_staleness_days, "60");
   applyNumber(prefs, "skill_staleness_days", staleness);
+}
+
+async function configureWorkspace(ctx: ExtensionCommandContext, prefs: Record<string, unknown>): Promise<void> {
+  type RepoConfig = { path: string; role?: string; verification?: string[]; commit_policy?: "auto" | "skip" };
+  let workspace = (prefs.workspace ?? {}) as { mode?: "project" | "parent"; repositories?: Record<string, RepoConfig> };
+
+  // Mode
+  const mode = await promptEnum(ctx, "Workspace mode", workspace.mode, ["project", "parent"]);
+  if (mode !== undefined) workspace = { ...workspace, mode: mode as "project" | "parent" };
+
+  if (workspace.mode !== "parent") {
+    // Single-repo mode: drop any declared repositories and persist.
+    if (workspace.repositories && Object.keys(workspace.repositories).length > 0) {
+      const clear = await promptBoolean(ctx, "Clear declared repositories (switch to single-repo)?", false, false);
+      if (clear) workspace = { mode: workspace.mode };
+    }
+    persistWorkspace(prefs, workspace);
+    return;
+  }
+
+  // Parent mode — edit child repositories via a sub-menu.
+  let repositories = { ...(workspace.repositories ?? {}) };
+  while (true) {
+    const ids = Object.keys(repositories).sort();
+    const summary = ids.length === 0 ? "(no repositories — parent mode requires at least one)" : `${ids.length} repo(s)`;
+    const listLabels = ids.map((id) => {
+      const r = repositories[id];
+      const roleStr = r.role ? ` — ${r.role}` : "";
+      const policyStr = r.commit_policy === "skip" ? " [skip]" : "";
+      return `${id} (${r.path})${roleStr}${policyStr}`;
+    });
+    const choice = await ctx.ui.select(`Declared repositories — ${summary}`, [...listLabels, "Add repository", "Done"]);
+    const pick = typeof choice === "string" ? choice : "";
+    if (!pick || pick === "Done") break;
+    if (pick === "Add repository") {
+      const idInput = await ctx.ui.input("Repository id (letters, digits, . _ -; 'project' is reserved):", "");
+      const id = typeof idInput === "string" ? idInput.trim() : "";
+      if (!id || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id)) {
+        ctx.ui.notify("Invalid repository id — must match ^[A-Za-z0-9][A-Za-z0-9._-]*$ and cannot be 'project'.", "warning");
+        continue;
+      }
+      if (id === "project" || repositories[id]) {
+        ctx.ui.notify(`Repository id "${id}" is reserved or already declared.`, "warning");
+        continue;
+      }
+      const pathInput = await ctx.ui.input("Repository path (relative to project root, e.g. frontend):", "");
+      const path = typeof pathInput === "string" ? pathInput.trim() : "";
+      if (!path) { ctx.ui.notify("Repository path is required.", "warning"); continue; }
+      const repo: RepoConfig = { path };
+      const roleInput = await ctx.ui.input("Role/label (optional):", "");
+      if (typeof roleInput === "string" && roleInput.trim()) repo.role = roleInput.trim();
+      const verifyInput = await ctx.ui.input("Verification commands (comma- or newline-separated, optional):", "");
+      if (typeof verifyInput === "string" && verifyInput.trim()) {
+        const cmds = parseStringList(verifyInput);
+        if (cmds.length > 0) repo.verification = cmds;
+      }
+      const policy = await promptEnum(ctx, "Commit policy", undefined, ["auto", "skip"]);
+      if (policy === "skip") repo.commit_policy = "skip";
+      repositories[id] = repo;
+    } else {
+      // Edit/delete an existing repo (the first token is the id).
+      const id = pick.split(" ")[0];
+      if (!repositories[id]) continue;
+      const editChoice = await ctx.ui.select(
+        `Repository ${id}`,
+        ["Edit path", "Edit role", "Edit verification", "Edit commit policy", "Delete repository", "Cancel"],
+      );
+      const ec = typeof editChoice === "string" ? editChoice : "";
+      if (!ec || ec === "Cancel") continue;
+      if (ec === "Delete repository") {
+        delete repositories[id];
+      } else if (ec === "Edit path") {
+        const v = await ctx.ui.input("Repository path:", repositories[id].path);
+        if (typeof v === "string" && v.trim()) repositories[id] = { ...repositories[id], path: v.trim() };
+      } else if (ec === "Edit role") {
+        const v = await ctx.ui.input("Role/label (blank to clear):", repositories[id].role ?? "");
+        if (typeof v === "string" && v.trim()) repositories[id] = { ...repositories[id], role: v.trim() };
+        else if (typeof v === "string") { const { role, ...rest } = repositories[id]; void role; repositories[id] = rest; }
+      } else if (ec === "Edit verification") {
+        const v = await ctx.ui.input("Verification commands (blank to clear):", (repositories[id].verification ?? []).join(", "));
+        if (typeof v === "string" && v.trim()) {
+          const cmds = parseStringList(v);
+          if (cmds.length > 0) repositories[id] = { ...repositories[id], verification: cmds };
+        } else if (typeof v === "string") {
+          const { verification, ...rest } = repositories[id]; void verification; repositories[id] = rest;
+        }
+      } else if (ec === "Edit commit policy") {
+        const policy = await promptEnum(ctx, "Commit policy", repositories[id].commit_policy, ["auto", "skip"]);
+        if (policy === "skip") repositories[id] = { ...repositories[id], commit_policy: "skip" };
+        else { const { commit_policy, ...rest } = repositories[id]; void commit_policy; repositories[id] = rest; }
+      }
+    }
+  }
+
+  if (Object.keys(repositories).length === 0) {
+    ctx.ui.notify("Parent mode requires at least one repository — mode not saved.", "warning");
+    return;
+  }
+  persistWorkspace(prefs, { mode: "parent", repositories });
+}
+
+/** Persist the workspace config onto prefs, dropping it entirely when empty. */
+function persistWorkspace(prefs: Record<string, unknown>, workspace: { mode?: string; repositories?: Record<string, unknown> }): void {
+  if (!workspace.mode && (!workspace.repositories || Object.keys(workspace.repositories).length === 0)) {
+    delete prefs.workspace;
+    return;
+  }
+  prefs.workspace = workspace;
 }
 
 async function configureSkillRules(ctx: ExtensionCommandContext, prefs: Record<string, unknown>): Promise<void> {
@@ -1621,6 +1741,7 @@ export async function handlePrefsWizard(
       `Hooks           ${summaries.hooks}`,
       `UoK             ${summaries.uok}`,
       `Integrations    ${summaries.integrations}`,
+      `Workspace       ${summaries.workspace}`,
       `Advanced        ${summaries.advanced}`,
       `── Save & Exit ──`,
     ];
@@ -1644,6 +1765,7 @@ export async function handlePrefsWizard(
     else if (choice.startsWith("Hooks"))         await configureHooks(ctx, prefs);
     else if (choice.startsWith("UoK"))           await configureUoK(ctx, prefs);
     else if (choice.startsWith("Integrations"))  await configureIntegrations(ctx, prefs);
+    else if (choice.startsWith("Workspace"))     await configureWorkspace(ctx, prefs);
     else if (choice.startsWith("Advanced"))      await configureAdvanced(ctx, prefs);
   }
 

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -203,11 +203,14 @@ test("category summaries expose the wizard menu surface for configured prefs", (
       "timeouts",
       "uok",
       "verification",
+      "workspace",
     ],
   );
   assert.match(summaries.models, /phase/);
   assert.match(summaries.integrations, /remote: C123/);
   assert.match(summaries.verification, /1 cmd/);
+  assert.match(summaries.workspace, /mode: parent/);
+  assert.match(summaries.workspace, /1 repo/);
 });
 
 test("models wizard offers discovered models for enabled providers", async () => {
@@ -272,6 +275,81 @@ test("models wizard offers discovered models for enabled providers", async () =>
     const saved = readFileSync(prefsPath, "utf-8");
     assert.match(saved, /research:\s+local\/discovered-model/);
     assert.doesNotMatch(saved, /hidden-model/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("workspace wizard category configures parent mode with a declared repository", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-prefs-wizard-workspace-"));
+  const prefsPath = join(dir, "PREFERENCES.md");
+  try {
+    // Drive: Workspace → parent mode → Add repository (id=frontend, path=frontend,
+    // role=ui, verification=npm test, commit policy auto) → Done → Save & Exit.
+    const selects = [
+      "Workspace       (single-repo)",       // pick the Workspace category
+      "parent",                               // promptEnum: workspace mode
+      "Add repository",                       // sub-menu
+      "(keep current)",                       // promptEnum: commit policy -> keep auto default
+      "Done",                                 // exit repo sub-menu
+      "── Save & Exit ──",                    // exit wizard
+    ];
+    const inputs = [
+      "frontend",                             // repository id
+      "frontend",                             // repository path
+      "ui",                                   // role
+      "npm test",                             // verification commands
+    ];
+    const ctx = {
+      ui: {
+        notify() {},
+        select: async () => selects.shift(),
+        input: async () => inputs.shift(),
+      },
+      waitForIdle: async () => {},
+      reload: async () => {},
+    } as any;
+
+    await handlePrefsWizard(ctx, "project", {}, { pathOverride: prefsPath });
+
+    const saved = readFileSync(prefsPath, "utf-8");
+    assert.match(saved, /mode: parent/);
+    assert.match(saved, /frontend:/);
+    assert.match(saved, /path: frontend/);
+    assert.match(saved, /role: ui/);
+    assert.match(saved, /npm test/);
+    assert.equal(selects.length, 0, "all queued selects should be consumed");
+    assert.equal(inputs.length, 0, "all queued inputs should be consumed");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("workspace wizard does not save parent mode when no repository is declared", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-prefs-wizard-workspace-empty-"));
+  const prefsPath = join(dir, "PREFERENCES.md");
+  try {
+    // parent mode with no repos added → should warn and not persist workspace.
+    const selects = [
+      "Workspace       (single-repo)",
+      "parent",
+      "Done",                                 // add nothing
+      "── Save & Exit ──",
+    ];
+    const ctx = {
+      ui: {
+        notify() {},
+        select: async () => selects.shift(),
+        input: async () => "",
+      },
+      waitForIdle: async () => {},
+      reload: async () => {},
+    } as any;
+
+    await handlePrefsWizard(ctx, "project", {}, { pathOverride: prefsPath });
+
+    const saved = readFileSync(prefsPath, "utf-8");
+    assert.doesNotMatch(saved, /mode: parent/, "parent mode must not persist without a declared repo");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## TL;DR

**What:** Adds the missing discovery surface for parent-workspace mode (a **Workspace** wizard category + a how-to guide) and documents the nested-only child-repo layout constraint with its security rationale.
**Why:** Gaps 5 & 6 of #818 — parent-workspace mode couldn't be discovered via any `/gsd` flow, and the layout constraint (sibling repos unsupported) was undocumented.
**How:** New `configureWorkspace` wizard function + `multi-repo-workspace.md` how-to + a configuration.md note explaining *why* sibling repos are rejected (path-scope safety).

Closes Gaps 5 & 6 of 6 in #818.

## What

**Gap 6 — discovery UX (low-risk, additive):**
- `commands-prefs-wizard.ts` — new **Workspace** category in the `/gsd prefs` menu + `configureWorkspace(ctx, prefs)`: set mode (`project`/`parent`), and in parent mode add/edit/delete child repositories (id, path, role, verification commands, commit policy). Also a `workspace` line in `buildCategorySummaries`. The validation/types/registry layers were already complete — this only adds the UI.
- `docs/user-docs/multi-repo-workspace.md` — new how-to guide: when to use it, the nested layout requirement, setup via wizard or by hand, how parent mode changes behavior (targeting, codebase map, per-repo verification/commits), and what's not yet supported. Linked from `docs/README.md`.

**Gap 5 — layout constraint (docs-only, deliberate):**
- `docs/user-docs/configuration.md` — added a **Layout constraint (nested-only)** note to the workspace validation rules explaining that sibling-repo layouts are unsupported *because* declared repository roots back the `plan-slice` task path-scope allowlist, and allowing escapes would weaken that guard.

## Why

- **Gap 6:** The issue lists "No discovery/UX surface" as a gap — parent mode was configurable only by hand-editing `PREFERENCES.md`, with no wizard path and no guide. The exploration confirmed the model/validation/registry were all already complete, so this is purely additive UI + docs (no plumbing).
- **Gap 5:** The issue offers two acceptable outcomes for the sibling-repo constraint: implement support, *or* document the nested-only requirement. The exploration found `assertInsideProjectRoot` is load-bearing for security — declared repo roots feed the `plan-slice` task-path-scope allowlist (`resolveAllowedRootsForPathScope`), so relaxing it naively opens a path-traversal into that allowlist. Documenting the constraint (with the rationale) is the responsible choice; implementing sibling support would need a new safety invariant and a design decision.

## How / Verification

- `tsc --noEmit --project tsconfig.extensions.json` — clean.
- `pnpm run verify:fast` — all fast-gates passed (docs injection, test matrix, pi boundary).
- `prefs-wizard-coverage.test.ts` — 7/7 pass: updated the category-summary key set to include `workspace` (with content assertions), plus 2 new end-to-end wizard tests driving `configureWorkspace` (parent mode + add repo persists correctly; parent mode with no repo does not persist).

### Scope boundary
Gaps 5 & 6 of 6. **Gap 4** (per-repo git isolation) is deliberately **not** implemented here — it crosses RFC-trigger zones (auto-mode/orchestration: it inverts the one-worktree-per-milestone model). It's captured as ADR-044 (Tier A per-repo push policy / Tier B per-repo worktree isolation) for a separate, reviewed path. Stacks cleanly with the prior slices (#1111 mode contract, #1113 codebase map, #1114 planner wiring) — all reuse the registry seam already on `main`.

AI-assisted; no AI credited as author.

Change type: `feat` / `docs` / `test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive prefs wizard UI and documentation only; no changes to auto-mode git isolation, orchestration, or preference validation logic beyond what users configure through the wizard.
> 
> **Overview**
> Adds **discovery and documentation** for parent-workspace multi-repo mode (#818 gaps 5–6), without changing runtime git/orchestration behavior.
> 
> **`/gsd prefs` — Workspace category:** New menu entry with `configureWorkspace` to set `project` vs `parent` mode and manage child repos (id, path, role, verification commands, `commit_policy`). Parent mode is **not saved** unless at least one repository is declared; switching back to single-repo can clear declared repos. `buildCategorySummaries` shows workspace mode and repo count.
> 
> **Docs:** New `multi-repo-workspace.md` (when to use, nested layout, wizard/manual setup, behavior, known limits). `configuration.md` now requires at least one repo for `mode: parent` and documents the **nested-only** layout rule tied to `plan-slice` path-scope safety. `docs/README.md` links the guide. **ADR-044** records that per-repo verify/commit already exist; future work splits **Tier A** (per-repo push policy) vs **Tier B** (per-repo worktree isolation, RFC required).
> 
> **Tests:** Wizard coverage extended for `workspace` summaries and two E2E flows (parent + repo persists; parent without repos does not persist).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58dc840fbf91646aee79e8afd069c5c49f79bdce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->