### PR TITLE
fix(issue): [Bug]: plan-slice verification false-negatives when completed tasks lack T##-PLAN.md — getSliceTasks returns all tasks but only SUMMARY.md exists for completed ones

### DIFF
--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -381,8 +381,9 @@ export function verifyExpectedArtifact(
           if (existsSync(tasksDir)) {
             for (const tid of taskIds) {
               const taskPlanFile = join(tasksDir, `${tid}-PLAN.md`);
-              if (!existsSync(taskPlanFile)) {
-                logWarning("recovery", `verify-fail ${unitType} ${unitId}: task plan missing ${taskPlanFile}`);
+              const taskSummaryFile = join(tasksDir, `${tid}-SUMMARY.md`);
+              if (!existsSync(taskPlanFile) && !existsSync(taskSummaryFile)) {
+                logWarning("recovery", `verify-fail ${unitType} ${unitId}: task artifact missing for ${tid}`);
                 return false;
               }
             }

--- a/src/resources/extensions/gsd/tests/recovery-verify-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/recovery-verify-logs.test.ts
@@ -227,7 +227,7 @@ test("plan-slice verify-fail logs a recovery warning when the tasks dir is missi
   }
 });
 
-test("plan-slice verify-fail logs a recovery warning when an individual task plan file is missing", () => {
+test("plan-slice verify-fail logs a recovery warning when an individual task artifact is missing", () => {
   const base = createFixtureBase("gsd-recovery-logs-taskplan-");
   try {
     const dir = sliceDir(base, "M001", "S01");
@@ -236,17 +236,17 @@ test("plan-slice verify-fail logs a recovery warning when an individual task pla
       "# S01: Has task\n\n## Tasks\n\n- [ ] **T01: A** `est:15m`\n",
       "utf-8",
     );
-    // Create the tasks dir but NOT the T01-PLAN.md file inside it.
+    // Create the tasks dir but NOT any T01 task artifact inside it.
     mkdirSync(join(dir, "tasks"), { recursive: true });
 
     const { result, logs } = verifyAndCaptureLogs("plan-slice", "M001/S01", base);
 
-    assert.equal(result, false, "a missing task plan file must fail verification");
+    assert.equal(result, false, "a missing task artifact must fail verification");
     const recovery = findRecovery(logs);
     assert.ok(recovery, "a recovery warning must be logged");
     assert.match(
       recovery!.message,
-      /verify-fail plan-slice M001\/S01: task plan missing .*T01-PLAN\.md/u,
+      /verify-fail plan-slice M001\/S01: task artifact missing for T01/u,
     );
   } finally {
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
@@ -18,6 +18,7 @@
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { verifyExpectedArtifact } from "../auto-recovery.ts";
 import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
 import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
 import { test } from 'node:test';
@@ -161,6 +162,54 @@ function makeRecordingCtx() {
     const runtime = JSON.parse(readFileSync(join(base, ".gsd", "runtime", "units", "plan-slice-M001-S01.json"), "utf-8"));
     assert.equal(runtime.phase, "recovered", "stale placeholder plan must not be finalized");
     assert.equal(runtime.recoveryAttempts, 1, "steering recovery attempt should be recorded");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+// ═══ plan-slice verification accepts completed task summaries ═══════════════
+
+{
+  console.log("\n=== plan-slice verification accepts completed task summaries ===");
+  const base = mkdtempSync(join(tmpdir(), "gsd-plan-slice-complete-summary-"));
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S05");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S05", milestoneId: "M001", title: "Slice", status: "in_progress" });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S05", title: "Done 1", status: "complete" });
+    insertTask({ id: "T02", milestoneId: "M001", sliceId: "S05", title: "Done 2", status: "complete" });
+    insertTask({ id: "T03", milestoneId: "M001", sliceId: "S05", title: "Pending 1", status: "pending" });
+    insertTask({ id: "T04", milestoneId: "M001", sliceId: "S05", title: "Pending 2", status: "pending" });
+    writeFileSync(
+      join(sliceDir, "S05-PLAN.md"),
+      [
+        "# S05: Slice",
+        "",
+        "## Tasks",
+        "",
+        "- [x] **T01: Done 1** `est:10m`",
+        "- [x] **T02: Done 2** `est:10m`",
+        "- [ ] **T03: Pending 1** `est:10m`",
+        "- [ ] **T04: Pending 2** `est:10m`",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n", "utf-8");
+    writeFileSync(join(tasksDir, "T02-SUMMARY.md"), "# T02 Summary\n", "utf-8");
+    writeFileSync(join(tasksDir, "T03-PLAN.md"), "# T03 Plan\n", "utf-8");
+    writeFileSync(join(tasksDir, "T04-PLAN.md"), "# T04 Plan\n", "utf-8");
+
+    assert.equal(
+      verifyExpectedArtifact("plan-slice", "M001/S05", base),
+      true,
+      "completed DB tasks should be accounted for by SUMMARY files",
+    );
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fixed plan-slice verification to accept completed task summaries and added a regression test; syntax diff check passed but test execution was blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1118
- [#1118 [Bug]: plan-slice verification false-negatives when completed tasks lack T##-PLAN.md — getSliceTasks returns all tasks but only SUMMARY.md exists for completed ones](https://github.com/open-gsd/gsd-pi/issues/1118)

## User
- @gtkpad

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1118-bug-plan-slice-verification-false-negati-1782934168`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to plan-slice recovery verification and tests; slightly relaxes the on-disk check but still requires a plan or summary per task.
> 
> **Overview**
> **plan-slice** artifact verification no longer requires every slice task to have a `T##-PLAN.md` file. For each task ID (from DB or parsed plan), verification now passes if **either** `T##-PLAN.md` **or** `T##-SUMMARY.md` exists under the slice `tasks/` directory.
> 
> This fixes false **verify-fail** results when the DB lists all slice tasks but completed work only left summary artifacts on disk. Recovery log text was generalized from “task plan missing …” to **“task artifact missing for {tid}”**.
> 
> Tests were updated for the new message and a DB-backed regression was added: completed tasks with `SUMMARY` only plus pending tasks with `PLAN` files must verify successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c76e428e381d14a4b5e63a401b86ccb69bddd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->