### PR TITLE
fix(issue): [Bug]: `/gsd prefs` wizard omits `per_unit_cost_cap_usd`, so the per-unit cost cap can only be changed by hand-editing PREFERENCES.md

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1176,6 +1176,14 @@ async function configureVerification(ctx: ExtensionCommandContext, prefs: Record
   const maxRetries = await promptInteger(ctx, "Verification max retries", prefs.verification_max_retries, "2");
   applyNumber(prefs, "verification_max_retries", maxRetries);
 
+  const perUnitCap = await promptNumber(
+    ctx,
+    "Per-unit cost cap (USD; retry cost ceiling, blank = clear to default)",
+    prefs.per_unit_cost_cap_usd,
+    "5.0",
+  );
+  applyNumber(prefs, "per_unit_cost_cap_usd", perUnitCap);
+
   const ev = await promptBoolean(ctx, "Enhanced verification (master toggle)", prefs.enhanced_verification, true);
   if (ev !== undefined) prefs.enhanced_verification = ev;
   const evPre = await promptBoolean(ctx, "Enhanced verification — pre-execution checks", prefs.enhanced_verification_pre, true);
@@ -1780,6 +1788,7 @@ export function serializePreferencesToFrontmatter(prefs: Record<string, unknown>
     "reactive_execution", "gate_evaluation",
     "auto_visualize", "auto_report",
     "verification_commands", "verification_auto_fix", "verification_max_retries",
+    "per_unit_cost_cap_usd",
     "enhanced_verification", "enhanced_verification_pre",
     "enhanced_verification_post", "enhanced_verification_strict",
     "safety_harness",

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -182,6 +182,70 @@ test("prefs wizard save path preserves every known preference key", async () => 
   }
 });
 
+test("verification wizard prompts for per-unit cost cap and persists it (regression #1121)", async () => {
+  // Regression for #1121: the `/gsd prefs` Verification category never prompted for
+  // `per_unit_cost_cap_usd`, so the per-unit cost cap could only be set by hand-editing
+  // PREFERENCES.md. Drive the wizard into Verification, answer the cap prompt, and assert
+  // the prompt exists and the entered value is serialized + round-trips back as a number.
+  const dir = mkdtempSync(join(tmpdir(), "gsd-prefs-wizard-"));
+  const prefsPath = join(dir, "PREFERENCES.md");
+
+  const inputLabels: string[] = [];
+  let topMenuVisits = 0;
+
+  const ctx = {
+    ui: {
+      notify() {},
+      select: async (label: string, options: string[]) => {
+        if (label === "GSD Preferences") {
+          topMenuVisits += 1;
+          if (topMenuVisits === 1) {
+            const verification = options.find((o) => o.startsWith("Verification"));
+            assert.ok(verification, "wizard menu must offer a Verification category");
+            return verification;
+          }
+          return "── Save & Exit ──";
+        }
+        // verification_commands string-list sub-menu — leave it untouched
+        if (options.includes("Done")) return "Done";
+        // boolean/enum prompts within the category — keep the current value
+        if (options.includes("(keep current)")) return "(keep current)";
+        return options[options.length - 1];
+      },
+      input: async (label: string) => {
+        inputLabels.push(label);
+        if (label.includes("Per-unit cost cap")) return "12.5";
+        return null; // escape every other numeric/string prompt (no change)
+      },
+    },
+    waitForIdle: async () => {},
+    reload: async () => {},
+  } as any;
+
+  try {
+    await handlePrefsWizard(ctx, "project", {}, { pathOverride: prefsPath });
+
+    // The Verification wizard must actually ask for the per-unit cost cap.
+    assert.ok(
+      inputLabels.some((l) => l.includes("Per-unit cost cap")),
+      `Verification wizard must prompt for the per-unit cost cap; prompts seen:\n${inputLabels.join("\n")}`,
+    );
+
+    // The entered value must be serialized to PREFERENCES.md...
+    const saved = readFileSync(prefsPath, "utf-8");
+    assert.match(saved, /per_unit_cost_cap_usd:\s*12\.5(\s|$)/m);
+
+    // ...and round-trip back through the parser/validator as a number.
+    const parsed = parsePreferencesMarkdown(saved);
+    assert.notEqual(parsed, null);
+    const { errors, preferences } = validatePreferences(parsed!);
+    assert.deepEqual(errors, []);
+    assert.equal(preferences.per_unit_cost_cap_usd, 12.5);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("category summaries expose the wizard menu surface for configured prefs", () => {
   const summaries = buildCategorySummaries(PREF_SAMPLE_VALUES);
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- Added the Verification wizard per-unit cost cap prompt and passed dependency-free checks; dependency-backed tests were blocked by registry DNS during install.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1121
- [#1121 [Bug]: `/gsd prefs` wizard omits `per_unit_cost_cap_usd`, so the per-unit cost cap can only be changed by hand-editing PREFERENCES.md](https://github.com/open-gsd/gsd-pi/issues/1121)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1121-bug-gsd-prefs-wizard-omits-per-unit-cost-1782936337`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only prefs wizard and serialization wiring; no changes to how the cap is enforced at runtime.
> 
> **Overview**
> The **`/gsd prefs` Verification category** now prompts for **`per_unit_cost_cap_usd`** (USD retry cost ceiling, default hint `5.0`, blank clears to default), using the same `promptNumber` / `applyNumber` flow as other numeric prefs.
> 
> **`serializePreferencesToFrontmatter`** includes `per_unit_cost_cap_usd` in the ordered verification keys so wizard saves write it consistently to `PREFERENCES.md` instead of requiring hand edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb4755bb49d25691bb963367e9de076722078f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->