### PR TITLE
fix(gsd): exempt browser automation tools from arg-independent loop cap

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -25,6 +25,8 @@
 
 import { createHash } from "node:crypto";
 import { INHERENTLY_REPEATABLE_TOOL_SET } from "./core-session-tools.js";
+import { hasBrowserContractPrefix } from "../../shared/browser-contract.js";
+import { canonicalToolName } from "../engine-hook-contract.js";
 
 const MAX_CONSECUTIVE_IDENTICAL_CALLS = 4;
 
@@ -130,8 +132,16 @@ export function checkToolCallLoop(
   perToolLastMutationEpoch.set(toolName, mutationEpoch);
 
   // Read-only navigation tools are normal context gathering; Guard 1 still
-  // catches true reread loops with identical arguments.
-  if (PER_TOOL_CAP_EXEMPT_TOOLS.has(toolName)) {
+  // catches true reread loops with identical arguments. Browser Automation
+  // Contract tools (browser_*) are the same shape: a browser-backed UAT makes
+  // many distinct-arg calls (read a message, count edits, inspect a card, …),
+  // so the arg-independent per-tool cap misfires on legitimate verification;
+  // Guard 1's identical-signature streak still catches a genuinely stuck
+  // browser loop.
+  if (
+    PER_TOOL_CAP_EXEMPT_TOOLS.has(toolName) ||
+    hasBrowserContractPrefix(canonicalToolName(toolName))
+  ) {
     return { block: false, count: consecutiveCount };
   }
 

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -385,3 +385,66 @@ console.log('\n── Loop guard: block reasons tell model to respond in text �
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Distinct-arg browser-automation calls are a legitimate UAT, not a loop (#1120)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: distinct-arg browser automation calls are not capped by per-tool count (#1120) ──');
+
+{
+  // A browser-backed UAT legitimately calls one browser verb many times with
+  // DIFFERENT arguments (read a validation message, count staged edits, inspect
+  // a control card, …). Guard 1's identical-signature streak never trips because
+  // the args vary; Guard 2's arg-independent per-tool cap must NOT block it.
+  for (const toolName of ['browser_evaluate', 'browser_act', 'browser_find']) {
+    resetToolCallLoopGuard();
+    for (let i = 1; i <= 12; i++) {
+      const result = checkToolCallLoop(toolName, { script: `step ${i}` });
+      assert.ok(result.block === false, `distinct ${toolName} call ${i} should be allowed`);
+    }
+  }
+
+  // MCP-prefixed browser tools canonicalize to `browser_*` and are exempt too.
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 12; i++) {
+    const result = checkToolCallLoop('mcp__agent-browser__browser_evaluate', { script: `step ${i}` });
+    assert.ok(result.block === false, `distinct MCP-prefixed browser_evaluate call ${i} should be allowed`);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Identical-arg browser loops are STILL caught by Guard 1 (#1120)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: identical-arg browser loops are still caught by Guard 1 (#1120) ──');
+
+{
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 4; i++) {
+    const result = checkToolCallLoop('browser_evaluate', { script: 'document.title' });
+    assert.ok(result.block === false, `identical browser_evaluate call ${i} should be allowed`);
+  }
+  const blocked = checkToolCallLoop('browser_evaluate', { script: 'document.title' });
+  assert.ok(blocked.block === true, '5th identical browser_evaluate call should be blocked by Guard 1');
+  assert.ok(blocked.reason?.includes('identical args'), 'identical browser loops should be caught by Guard 1, not Guard 2');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The browser exemption must NOT widen to other non-exempt tools (#1120)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: browser exemption does not widen to other tools (#1120) ──');
+
+{
+  // Negative invariant: an arbitrary non-exempt, non-browser tool called past
+  // the default cap with varied args must still be blocked by Guard 2.
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 6; i++) {
+    const result = checkToolCallLoop('some_workflow_tool', { arg: `v${i}` });
+    assert.ok(result.block === false, `non-exempt tool call ${i} should be allowed`);
+  }
+  const blocked = checkToolCallLoop('some_workflow_tool', { arg: 'v7' });
+  assert.ok(blocked.block === true, '7th varied-arg non-exempt call must still trip Guard 2');
+  assert.ok(blocked.reason?.includes('repeated tool'), 'non-exempt overflow should be caught by Guard 2');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## TL;DR

**What:** Exempt Browser Automation Contract tools (`browser_*`) from the tool-call loop guard's arg-independent per-tool cap (Guard 2).
**Why:** A legitimate multi-step browser UAT makes many distinct-arg `browser_*` calls in one turn and was falsely blocked as an "infinite loop."
**How:** Extend the existing read/navigation exemption to also skip browser-contract tools; Guard 1's identical-signature streak still bounds a genuinely stuck loop.

## What

`checkToolCallLoop` in `src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts` runs two independent guards:

1. **Guard 1** — identical-signature streak (`MAX_CONSECUTIVE_IDENTICAL_CALLS = 4`), keyed on `hashToolCall(toolName, args)`.
2. **Guard 2** — per-tool-name cap counted **independent of args** (`PER_TOOL_DEFAULT_CAP = 6`, or `PER_TOOL_REPEATABLE_CAP = 15` for tools in `INHERENTLY_REPEATABLE_TOOL_SET`).

`browser_*` tools were in neither `PER_TOOL_CAP_EXEMPT_TOOLS` nor `INHERENTLY_REPEATABLE_TOOL_SET`, so they got the generic cap of 6. This change adds browser-contract tools to the early exemption from Guard 2, reusing the existing `hasBrowserContractPrefix(canonicalToolName(...))` helpers — the same recognition `register-hooks.ts` and `uat-policy.ts` already use. A regression test is added to `tool-call-loop-guard.test.ts`.

## Why

Closes #1120.

A browser-backed UAT — the exact workflow `/gsd auto` dispatches at slice closeout — legitimately calls one browser verb more than six times in a single turn with **different** arguments (read a validation message, count staged edits, inspect a control card, …). Because the args vary, Guard 1's identical-signature streak never trips, but Guard 2's arg-independent count hits the cap of 6 and blocks the 7th call:

```
Tool loop detected (repeated tool): browser_evaluate called 9 times this turn (cap 6). Blocking to prevent infinite loop.
```

The UAT can't reach a valid PASS and auto-mode is pushed into recovery/replan despite the calls making real progress. Read-only navigation tools (`find`/`glob`/`grep`/`ls`/`read`/`search_and_read`) were already exempted from Guard 2 for exactly this reason; browser UAT is the same shape — inherently many distinct-arg calls.

## How

Extend the existing Guard 2 exemption early-return:

```ts
if (
  PER_TOOL_CAP_EXEMPT_TOOLS.has(toolName) ||
  hasBrowserContractPrefix(canonicalToolName(toolName))
) {
  return { block: false, count: consecutiveCount };
}
```

with two imports (`hasBrowserContractPrefix` from `../../shared/browser-contract.js`, `canonicalToolName` from `../engine-hook-contract.js`). The exemption runs **after** Guard 1, so identical-arg browser loops are still bounded by the signature streak (cap 4), and MCP-prefixed spellings (`mcp__agent-browser__browser_evaluate`) are handled because `canonicalToolName` strips the prefix before the `browser_` check.

Preserved invariants (asserted by tests): (1) a non-exempt, non-browser tool called past `PER_TOOL_DEFAULT_CAP` with varied args still blocks via Guard 2; (2) an identical-arg `browser_evaluate` streak still trips Guard 1.

**Alternatives considered:** adding `browser_*` to `INHERENTLY_REPEATABLE_TOOL_SET` (cap 15) — rejected because a browser UAT still isn't a "loop" at 16 distinct-arg calls, and it would conflate browser tools with mutating/execution tools. The exemption mirrors the read/nav precedent exactly and keeps blast radius to one function.

## Change type

- [x] `fix` — Bug fix

## Testing

Test-first: the new regression case fails before the change (7th distinct `browser_evaluate` blocked at cap 6) and passes after. It imports and exercises `checkToolCallLoop` (not a source-grep test). Run:

```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
```

`pnpm run typecheck:extensions` is clean. `pnpm run verify:merge` is being run before this PR is marked Ready for review.

---

_AI-assisted: this change was prepared with AI assistance and reviewed and understood before submission._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785533116&installation_id=134682257&pr_number=1123&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1123&signature=6acb3caec397ee9cfa5c197a11f0f01fc4cef0f502613a25589c1c0169c8c7e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->