### PR TITLE
feat(gsd): doctor probe + validation for parent-workspace repos — #818 cross-cutting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             '+refs/heads/*:refs/remotes/origin/*' \
             '+refs/tags/*:refs/tags/*' \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Prepare diff base for scans
         env:
@@ -123,7 +123,7 @@ jobs:
 
           git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -237,7 +237,7 @@ jobs:
 
           git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -327,7 +327,7 @@ jobs:
 
           git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/docs/user-docs/multi-repo-workspace.md
+++ b/docs/user-docs/multi-repo-workspace.md
@@ -69,6 +69,17 @@ workspace:
 
 Validation rules: repository ids must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`; `project` is reserved; paths must be relative, unique, and resolve inside the project root; `mode: parent` requires at least one repository. See [configuration.md](./configuration.md#workspace) for the full schema.
 
+## Doctor and preference warnings
+
+Run `/gsd doctor` after changing parent-workspace preferences. In `workspace.mode: parent`, doctor checks each declared child repository path:
+
+| Issue code | What it means | Remediation |
+|------------|---------------|-------------|
+| `workspace_repo_path_missing` | The configured child repository path does not exist on disk. | Create or clone the child repository at that path, or fix the `workspace.repositories.<id>.path` value. |
+| `workspace_repo_not_a_repo` | The path exists, but it is not a git repository at its own root. A plain directory nested inside the parent repo is not enough. | Clone the child repo into that directory, run `git init` there if it should be a new repo, or point the preference at the actual child repo root. |
+
+GSD also warns when the effective merged preferences combine `mode: team` with `workspace.mode: parent`. Team branch-push and PR behavior still resolves at the project root, so it will not push child repositories. Keep using parent workspace mode for coordinated planning, verification, and commits, but push or open PRs for child repos manually, or use `mode: solo` if team branch automation is not needed.
+
 ## How it behaves
 
 Once configured, parent mode changes four things — all of which default to single-repo behavior when `mode` is `project` (the default):

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -269,6 +269,16 @@ For common provider setup issues (role errors, streaming errors, model ID mismat
 
 **Fix:** Run `/gsd doctor` to see the file path, the parse/validation message, and (for YAML errors) the line and column. Fix the reported issue in the named file, then rerun the command. Auto-mode re-surfaces these diagnostics at preflight so they are visible before long-running automation proceeds.
 
+### Parent workspace repository warnings
+
+**Symptoms:** `/gsd doctor` reports `workspace_repo_path_missing` or `workspace_repo_not_a_repo` for a repository declared under `workspace.repositories` in `.gsd/PREFERENCES.md`.
+
+**What it means:** In `workspace.mode: parent`, each declared child path must exist and be a git repository at its own root. A typo such as `frontned` produces `workspace_repo_path_missing`; an ordinary directory inside the parent repo produces `workspace_repo_not_a_repo`.
+
+**Fix:** Create or clone the child repository at the configured path, initialize git in that directory if it should become a repository, or update `workspace.repositories.<id>.path` to the actual child repo root. Parent workspace paths must still resolve inside the project root; sibling paths such as `../frontend` are rejected by preference validation.
+
+If preferences combine `mode: team` with `workspace.mode: parent`, GSD also warns that team branch-push and PR behavior is still root-scoped and will not push child repositories. Push or open PRs for child repos manually, or switch to `mode: solo` when team branch automation is not needed.
+
 ### Auto mode says another session is running
 
 **Symptoms:** Auto mode won't start, says another session is running.

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -94,7 +94,10 @@ export type DoctorIssueCode =
   | "projection_drift"
   // Milestone filesystem/DB drift (#4996)
   | "orphan_milestone_dir"
-  | "orphan_milestone_db";
+  | "orphan_milestone_db"
+  // Parent-workspace declared repository checks (#818)
+  | "workspace_repo_path_missing"
+  | "workspace_repo_not_a_repo";
 
 /**
  * Issue codes that represent global or completion-critical state.

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -383,7 +383,8 @@ function checkWorkspaceRepositoryHealth(
     // /var vs /private/var) don't cause a false mismatch.
     const toplevel = resolveGitToplevel(repo.root);
     const declaredReal = realpathSafe(repo.root);
-    if (toplevel !== declaredReal) {
+    const toplevelReal = toplevel ? realpathSafe(toplevel) : null;
+    if (toplevelReal !== declaredReal) {
       issues.push({
         severity: "warning",
         code: "workspace_repo_not_a_repo",

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, lstatSync, readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
 
 import { loadFile, parseSummary, saveFile, parseTaskPlanMustHaves, countMustHavesMentionedInSummary } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
@@ -16,6 +17,7 @@ import { isClosedStatus } from "./status-guards.js";
 import type { DoctorIssue, DoctorIssueCode, DoctorReport } from "./doctor-types.js";
 import { GLOBAL_STATE_CODES } from "./doctor-types.js";
 import type { RoadmapSliceEntry } from "./types.js";
+import { createRepositoryRegistryFromPreferences } from "./repository-registry.js";
 import { checkGitHealth, checkRuntimeHealth, checkGlobalHealth, checkEngineHealth } from "./doctor-checks.js";
 import { checkEnvironmentHealth } from "./doctor-environment.js";
 import { runProviderChecks } from "./doctor-providers.js";
@@ -308,6 +310,92 @@ export async function readDoctorHistory(basePath: string, lastN = 50): Promise<D
   } catch { return []; }
 }
 
+/**
+ * Resolve the git working-tree root for a path, or null if it is not a repo.
+ * Used by the workspace-repository probe to check that a declared child path is
+ * itself a git repository (not merely nested inside the parent's repo).
+ */
+function resolveGitToplevel(cwd: string): string | null {
+  try {
+    const out = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+    return out ? resolve(out) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** realpath that falls back to the resolved path if the link cannot be read. */
+function realpathSafe(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/**
+ * Parent-workspace probe (#818): validate that every declared child repository
+ * exists on disk and is a git repository at its own root. The registry only
+ * checks paths stay inside the project root; it never checks existence or
+ * git-ness, so a typo'd path (e.g. `frontned`) would otherwise build cleanly
+ * and silently produce "no problems found." No-op for single-repo projects.
+ */
+function checkWorkspaceRepositoryHealth(
+  basePath: string,
+  prefs: GSDPreferences | undefined,
+  issues: DoctorIssue[],
+): void {
+  if (prefs?.workspace?.mode !== "parent") return;
+  let registry;
+  try {
+    registry = createRepositoryRegistryFromPreferences(basePath, prefs);
+  } catch (err) {
+    issues.push({
+      severity: "error",
+      code: "invalid_preferences",
+      scope: "project",
+      unitId: "workspace",
+      message: `workspace registry failed to build: ${err instanceof Error ? err.message : String(err)}`,
+      fixable: false,
+    });
+    return;
+  }
+  for (const repo of registry.repositories) {
+    if (repo.id === "project") continue;
+    if (!existsSync(repo.root)) {
+      issues.push({
+        severity: "error",
+        code: "workspace_repo_path_missing",
+        scope: "project",
+        unitId: `workspace.repositories.${repo.id}`,
+        message: `declared repository "${repo.id}" path does not exist on disk: ${repo.root}`,
+        fixable: false,
+      });
+      continue;
+    }
+    // Must be a repo at its OWN root — a plain dir nested in the parent repo
+    // would otherwise pass a bare `nativeIsRepo` check via the enclosing
+    // parent's .git. Compare on realpath so symlinked temp roots (macOS
+    // /var vs /private/var) don't cause a false mismatch.
+    const toplevel = resolveGitToplevel(repo.root);
+    const declaredReal = realpathSafe(repo.root);
+    if (toplevel !== declaredReal) {
+      issues.push({
+        severity: "warning",
+        code: "workspace_repo_not_a_repo",
+        scope: "project",
+        unitId: `workspace.repositories.${repo.id}`,
+        message: `declared repository "${repo.id}" path is not a git repository at its own root: ${repo.root}`,
+        fixable: false,
+      });
+    }
+  }
+}
+
 export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; dryRun?: boolean; scope?: string; fixLevel?: "task" | "all"; isolationMode?: "none" | "worktree" | "branch"; includeBuild?: boolean; includeTests?: boolean }): Promise<DoctorReport> {
   const issues: DoctorIssue[] = [];
   const fixesApplied: string[] = [];
@@ -366,6 +454,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
     (prefs?.preferences?.git?.isolation === "worktree" ? "worktree" :
     prefs?.preferences?.git?.isolation === "branch" ? "branch" : "none");
   await checkGitHealth(basePath, issues, fixesApplied, shouldFix, isolationMode, dryRun);
+  checkWorkspaceRepositoryHealth(basePath, prefs?.preferences, issues);
   const gitMs = Date.now() - t0git;
 
   // Runtime health checks — timed

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -17,6 +17,7 @@ import { isClosedStatus } from "./status-guards.js";
 import type { DoctorIssue, DoctorIssueCode, DoctorReport } from "./doctor-types.js";
 import { GLOBAL_STATE_CODES } from "./doctor-types.js";
 import type { RoadmapSliceEntry } from "./types.js";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { createRepositoryRegistryFromPreferences } from "./repository-registry.js";
 import { checkGitHealth, checkRuntimeHealth, checkGlobalHealth, checkEngineHealth } from "./doctor-checks.js";
 import { checkEnvironmentHealth } from "./doctor-environment.js";
@@ -321,6 +322,7 @@ function resolveGitToplevel(cwd: string): string | null {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
       encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
     }).trim();
     return out ? resolve(out) : null;
   } catch {

--- a/src/resources/extensions/gsd/preferences-diagnostics.ts
+++ b/src/resources/extensions/gsd/preferences-diagnostics.ts
@@ -1,8 +1,10 @@
 import type { PreferenceDiagnostic } from "./preferences-types.js";
 import {
+  loadEffectiveGSDPreferences,
   loadGlobalGSDPreferences,
   loadProjectGSDPreferences,
 } from "./preferences.js";
+import { crossAxisPreferenceWarnings } from "./preferences-validation.js";
 
 interface PreferenceNotificationContext {
   ui: {
@@ -30,6 +32,28 @@ export function collectPreferenceDiagnostics(basePath?: string): PreferenceDiagn
     seen.add(signature);
     unique.push(diagnostic);
   }
+
+  const effective = loadEffectiveGSDPreferences(basePath);
+  if (effective) {
+    const existingMessages = new Set(unique.map((diagnostic) => diagnostic.message));
+    for (const message of crossAxisPreferenceWarnings(effective.preferences)) {
+      if (existingMessages.has(message)) continue;
+      const diagnostic: PreferenceDiagnostic = {
+        path: effective.path,
+        scope: effective.scope,
+        severity: "warning",
+        kind: "validation",
+        message,
+        sanitized: true,
+      };
+      const signature = preferenceDiagnosticSignature(diagnostic);
+      if (seen.has(signature)) continue;
+      seen.add(signature);
+      existingMessages.add(message);
+      unique.push(diagnostic);
+    }
+  }
+
   return unique;
 }
 

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -51,6 +51,16 @@ const VALID_POST_UNIT_HOOK_ON_BLOCK_ACTIONS = new Set([
 ]);
 const VALID_GATE_EVALUATE_SLICE_GATES = new Set<string>(getGateIdsForTurn("gate-evaluate"));
 
+/** Cross-axis warnings that only apply to the effective (merged) preference shape. */
+export function crossAxisPreferenceWarnings(preferences: GSDPreferences): string[] {
+  if (preferences.mode === "team" && preferences.workspace?.mode === "parent") {
+    return [
+      "mode:team + workspace.mode:parent: team branch-push/PR resolves at the project root and will not push child repositories — see docs/dev/ADR-044",
+    ];
+  }
+  return [];
+}
+
 export function validatePreferences(preferences: GSDPreferences): {
   preferences: GSDPreferences;
   errors: string[];
@@ -1586,6 +1596,8 @@ export function validatePreferences(preferences: GSDPreferences): {
       errors.push(`language must be a non-empty string up to 50 characters with no newlines (e.g. "Chinese", "de", "日本語")`);
     }
   }
+
+  warnings.push(...crossAxisPreferenceWarnings(validated));
 
   return { preferences: validated, errors, warnings };
 }

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1505,6 +1505,15 @@ export function validatePreferences(preferences: GSDPreferences): {
         errors.push('workspace.mode "parent" requires at least one repository under workspace.repositories');
       }
     }
+
+    // Cross-axis: team mode's branch-push/PR cycle runs through publishMilestone,
+    // which is single-root (publication.ts). Combining mode:team with
+    // workspace.mode:parent silently degrades team push/PR to the root repo only.
+    if (validated.mode === "team" && validated.workspace?.mode === "parent") {
+      warnings.push(
+        "mode:team + workspace.mode:parent: team branch-push/PR resolves at the project root and will not push child repositories — see docs/dev/ADR-044",
+      );
+    }
   }
 
   // ─── Enhanced Verification ──────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1516,14 +1516,6 @@ export function validatePreferences(preferences: GSDPreferences): {
       }
     }
 
-    // Cross-axis: team mode's branch-push/PR cycle runs through publishMilestone,
-    // which is single-root (publication.ts). Combining mode:team with
-    // workspace.mode:parent silently degrades team push/PR to the root repo only.
-    if (validated.mode === "team" && validated.workspace?.mode === "parent") {
-      warnings.push(
-        "mode:team + workspace.mode:parent: team branch-push/PR resolves at the project root and will not push child repositories — see docs/dev/ADR-044",
-      );
-    }
   }
 
   // ─── Enhanced Verification ──────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -39,7 +39,7 @@ import {
   type SkillDiscoveryMode,
   formatSkillRef,
 } from "./preferences-types.js";
-import { validatePreferences } from "./preferences-validation.js";
+import { crossAxisPreferenceWarnings, validatePreferences } from "./preferences-validation.js";
 import { gsdHome } from "./gsd-home.js";
 
 // ─── Re-exports: types ──────────────────────────────────────────────────────
@@ -416,9 +416,36 @@ export function loadEffectiveGSDPreferences(
   }
 
   result = stripInheritedPlanningDepth(result, projectHasPlanningDepth);
+  result = appendCrossAxisPreferenceWarnings(result);
 
   cacheEffectivePreferences(cacheKey, result);
   return result;
+}
+
+function appendCrossAxisPreferenceWarnings(loaded: LoadedGSDPreferences): LoadedGSDPreferences {
+  const crossWarnings = crossAxisPreferenceWarnings(loaded.preferences);
+  const existingMessages = new Set([
+    ...(loaded.warnings ?? []),
+    ...(loaded.diagnostics ?? []).map((diagnostic) => diagnostic.message),
+  ]);
+  const newWarnings = crossWarnings.filter((message) => !existingMessages.has(message));
+  if (newWarnings.length === 0) return loaded;
+
+  return {
+    ...loaded,
+    warnings: [...(loaded.warnings ?? []), ...newWarnings],
+    diagnostics: [
+      ...(loaded.diagnostics ?? []),
+      ...newWarnings.map((message): PreferenceDiagnostic => ({
+        path: loaded.path,
+        scope: loaded.scope,
+        severity: "warning",
+        kind: "validation",
+        message,
+        sanitized: true,
+      })),
+    ],
+  };
 }
 
 function withoutProfilePhaseDefaults(defaults: Partial<GSDPreferences>): Partial<GSDPreferences> {

--- a/src/resources/extensions/gsd/tests/doctor-workspace.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-workspace.test.ts
@@ -1,0 +1,130 @@
+/**
+ * doctor-workspace.test.ts — Parent-workspace declared-repository probe (#818).
+ *
+ * Covers:
+ *   - declared child repo path missing on disk → workspace_repo_path_missing
+ *   - declared child repo path exists but is not a git repo → workspace_repo_not_a_repo
+ *   - valid child repos → no workspace issues
+ *   - single-repo (project-mode) project → probe is a no-op
+ *   - non-git parent root is handled gracefully (the common layout)
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { runGSDDoctor } from "../doctor.ts";
+
+function gitInit(cwd: string): void {
+  execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+}
+
+function writeParentPrefs(base: string, repos: Record<string, { path: string }>): void {
+  const repoLines = Object.entries(repos)
+    .map(([id, cfg]) => `    ${id}:\n      path: ${cfg.path}`)
+    .join("\n");
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n${repoLines}\n---\n`,
+    "utf-8",
+  );
+}
+
+test("doctor flags a declared child repo whose path is missing on disk", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-ws-missing-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    // `frontend` is declared but never created on disk.
+    writeParentPrefs(base, { frontend: { path: "frontend" } });
+
+    const report = await runGSDDoctor(base);
+    const issue = report.issues.find((i) => i.code === "workspace_repo_path_missing");
+    assert.ok(issue, "expected a workspace_repo_path_missing issue");
+    assert.equal(issue?.unitId, "workspace.repositories.frontend");
+    assert.match(issue?.message ?? "", /does not exist on disk/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("doctor flags a declared child repo path that is not a git repository", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-ws-notrepo-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    // `backend` exists as a plain directory but is not a git repo.
+    mkdirSync(join(base, "backend"), { recursive: true });
+    writeParentPrefs(base, { backend: { path: "backend" } });
+
+    const report = await runGSDDoctor(base);
+    const issue = report.issues.find((i) => i.code === "workspace_repo_not_a_repo");
+    assert.ok(issue, "expected a workspace_repo_not_a_repo issue");
+    assert.equal(issue?.unitId, "workspace.repositories.backend");
+    assert.match(issue?.message ?? "", /not a git repository/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("doctor reports no workspace issues when declared child repos are valid", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-ws-valid-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    mkdirSync(join(base, "frontend"), { recursive: true });
+    gitInit(join(base, "frontend"));
+    writeParentPrefs(base, { frontend: { path: "frontend" } });
+
+    const report = await runGSDDoctor(base);
+    const wsIssues = report.issues.filter(
+      (i) => i.code === "workspace_repo_path_missing" || i.code === "workspace_repo_not_a_repo",
+    );
+    assert.deepEqual(wsIssues, []);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("doctor workspace probe is a no-op for single-repo (project-mode) projects", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-ws-noproj-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    // No workspace config → project mode (default).
+    const report = await runGSDDoctor(base);
+    const wsIssues = report.issues.filter(
+      (i) => i.code === "workspace_repo_path_missing" || i.code === "workspace_repo_not_a_repo",
+    );
+    assert.deepEqual(wsIssues, []);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("doctor runs cleanly when the parent root is itself not a git repo (common layout)", async () => {
+  // Regression guard (#818 cross-cutting): a parent folder holding child git
+  // repos need not be a git repo itself. Doctor must not crash and must not
+  // treat the parent as a missing/non-repo child.
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-ws-nongitparent-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    // NOTE: no gitInit(base) — parent is a plain folder.
+    mkdirSync(join(base, "frontend"), { recursive: true });
+    gitInit(join(base, "frontend"));
+    writeParentPrefs(base, { frontend: { path: "frontend" } });
+
+    const report = await runGSDDoctor(base);
+    // The declared child repo is valid; the non-git parent must not produce a
+    // child-repo issue or crash the run.
+    const wsIssues = report.issues.filter(
+      (i) => i.code === "workspace_repo_path_missing" || i.code === "workspace_repo_not_a_repo",
+    );
+    assert.deepEqual(wsIssues, []);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/doctor-workspace.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-workspace.test.ts
@@ -11,12 +11,13 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
 import { runGSDDoctor } from "../doctor.ts";
+import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
 
 function gitInit(cwd: string): void {
   execFileSync("git", ["init"], { cwd, stdio: "ignore" });
@@ -87,6 +88,82 @@ test("doctor reports no workspace issues when declared child repos are valid", a
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("doctor workspace git probe uses safe env and canonical toplevel comparison", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX-only git shim regression");
+    return;
+  }
+
+  const originalProcessGitDir = process.env.GIT_DIR;
+  const originalProcessGitWorkTree = process.env.GIT_WORK_TREE;
+  const originalGitEnvPath = GIT_NO_PROMPT_ENV.PATH;
+  const originalGitEnvRealGit = GIT_NO_PROMPT_ENV.GSD_REAL_GIT;
+  const originalGitEnvFakeCwd = GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL_CWD;
+  const originalGitEnvFakeToplevel = GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL;
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-ws-safeenv-"));
+
+  t.after(() => {
+    if (originalProcessGitDir === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = originalProcessGitDir;
+    if (originalProcessGitWorkTree === undefined) delete process.env.GIT_WORK_TREE;
+    else process.env.GIT_WORK_TREE = originalProcessGitWorkTree;
+    if (originalGitEnvPath === undefined) delete GIT_NO_PROMPT_ENV.PATH;
+    else GIT_NO_PROMPT_ENV.PATH = originalGitEnvPath;
+    if (originalGitEnvRealGit === undefined) delete GIT_NO_PROMPT_ENV.GSD_REAL_GIT;
+    else GIT_NO_PROMPT_ENV.GSD_REAL_GIT = originalGitEnvRealGit;
+    if (originalGitEnvFakeCwd === undefined) delete GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL_CWD;
+    else GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL_CWD = originalGitEnvFakeCwd;
+    if (originalGitEnvFakeToplevel === undefined) delete GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL;
+    else GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL = originalGitEnvFakeToplevel;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  const realChild = join(base, "frontend-real");
+  const linkedChild = join(base, "frontend");
+  mkdirSync(realChild, { recursive: true });
+  gitInit(realChild);
+  symlinkSync(realChild, linkedChild, "dir");
+  writeParentPrefs(base, { frontend: { path: "frontend" } });
+
+  const shimDir = join(base, "bin");
+  mkdirSync(shimDir, { recursive: true });
+  const realGit = execFileSync("which", ["git"], { encoding: "utf-8" }).trim();
+  const shim = join(shimDir, "git");
+  writeFileSync(
+    shim,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "if [ -n \"${GIT_DIR:-}\" ] || [ -n \"${GIT_WORK_TREE:-}\" ]; then",
+      "  echo \"leaked git env\" >&2",
+      "  exit 97",
+      "fi",
+      "if [ \"${1:-}\" = \"rev-parse\" ] && [ \"${2:-}\" = \"--show-toplevel\" ] && [ \"$(pwd -P)\" = \"$GSD_FAKE_TOPLEVEL_CWD\" ]; then",
+      "  printf '%s\\n' \"$GSD_FAKE_TOPLEVEL\"",
+      "  exit 0",
+      "fi",
+      "exec \"$GSD_REAL_GIT\" \"$@\"",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  chmodSync(shim, 0o755);
+
+  process.env.GIT_DIR = join(base, ".git");
+  process.env.GIT_WORK_TREE = base;
+  GIT_NO_PROMPT_ENV.PATH = `${shimDir}${delimiter}${process.env.PATH ?? ""}`;
+  GIT_NO_PROMPT_ENV.GSD_REAL_GIT = realGit;
+  GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL_CWD = realChild;
+  GIT_NO_PROMPT_ENV.GSD_FAKE_TOPLEVEL = linkedChild;
+
+  const report = await runGSDDoctor(base);
+  const wsIssues = report.issues.filter(
+    (i) => i.code === "workspace_repo_path_missing" || i.code === "workspace_repo_not_a_repo",
+  );
+  assert.deepEqual(wsIssues, []);
 });
 
 test("doctor workspace probe is a no-op for single-repo (project-mode) projects", async () => {

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -369,6 +369,35 @@ test("workspace.mode parent with declared repositories is valid", () => {
   assert.equal(errors.length, 0);
 });
 
+test("mode:team + workspace.mode:parent warns about root-only push/PR", () => {
+  const { warnings } = validatePreferences({
+    mode: "team",
+    workspace: {
+      mode: "parent",
+      repositories: {
+        frontend: { path: "frontend" },
+      },
+    },
+  });
+
+  assert.ok(
+    warnings.some((w) =>
+      w.includes("mode:team + workspace.mode:parent") && w.includes("ADR-044"),
+    ),
+    "expected a cross-axis warning naming ADR-044",
+  );
+});
+
+test("mode:team without workspace.mode:parent does not warn about push", () => {
+  const { warnings } = validatePreferences({
+    mode: "team",
+  });
+
+  assert.ok(
+    !warnings.some((w) => w.includes("workspace.mode:parent")),
+    "team mode alone must not trigger the parent-workspace push warning",
+  );
+});
 
 test("workspace is a recognized preference key (no unknown warning)", () => {
   const { warnings } = validatePreferences({

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -379,13 +379,72 @@ test("mode:team + workspace.mode:parent warns about root-only push/PR", () => {
       },
     },
   });
+  const crossAxisWarnings = warnings.filter((w) => w.includes("mode:team + workspace.mode:parent"));
 
   assert.ok(
-    warnings.some((w) =>
-      w.includes("mode:team + workspace.mode:parent") && w.includes("ADR-044"),
+    crossAxisWarnings.some((w) =>
+      w.includes("ADR-044"),
     ),
     "expected a cross-axis warning naming ADR-044",
   );
+  assert.equal(crossAxisWarnings.length, 1, "expected exactly one cross-axis warning");
+});
+
+test("mode:team + workspace.mode:parent warns after global/project merge", (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-cross-axis-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-cross-axis-home-"));
+
+  t.after(() => {
+    clearGSDPreferencesCache();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+  clearGSDPreferencesCache();
+
+  writeFileSync(getGlobalGSDPreferencesPath(), "---\nversion: 1\nmode: team\n---\n", "utf-8");
+  writeFileSync(
+    getProjectGSDPreferencesPath(tempProject),
+    [
+      "---",
+      "version: 1",
+      "workspace:",
+      "  mode: parent",
+      "  repositories:",
+      "    frontend:",
+      "      path: frontend",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const rawGlobalWarnings = loadGlobalGSDPreferences()?.warnings ?? [];
+  const rawProjectWarnings = loadProjectGSDPreferences(tempProject)?.warnings ?? [];
+  assert.equal(rawGlobalWarnings.filter((w) => w.includes("workspace.mode:parent")).length, 0);
+  assert.equal(rawProjectWarnings.filter((w) => w.includes("mode:team + workspace.mode:parent")).length, 0);
+
+  const loaded = loadEffectiveGSDPreferences(tempProject);
+  assert.equal(loaded?.preferences.mode, "team");
+  assert.equal(loaded?.preferences.workspace?.mode, "parent");
+  assert.equal(
+    (loaded?.warnings ?? []).filter((w) => w.includes("mode:team + workspace.mode:parent")).length,
+    1,
+  );
+
+  const diagnostics = collectPreferenceDiagnostics(tempProject).filter((diagnostic) =>
+    diagnostic.message.includes("mode:team + workspace.mode:parent"),
+  );
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0]?.scope, "project");
 });
 
 test("mode:team without workspace.mode:parent does not warn about push", () => {


### PR DESCRIPTION
## TL;DR

**What:** Cross-cutting parent-workspace fixes found while completing #818: a `/gsd doctor` probe that validates declared child repos, and a validation warning for the `mode:team` + `workspace.mode:parent` footgun.
**Why:** Doctor reported "no problems" for a typo'd child-repo path, and team+parent silently degraded push/PR to the root repo.
**How:** New `checkWorkspaceRepositoryHealth` doctor probe (no-op for project mode) + a cross-axis preferences warning pointing at ADR-044.

## What

- **#1 Doctor probe** (`doctor.ts`, `doctor-types.ts`) — `checkWorkspaceRepositoryHealth`: for parent-mode projects, flags `workspace_repo_path_missing` (declared path absent on disk) and `workspace_repo_not_a_repo` (path exists but isn't a git repo at its **own** root). The registry only checked paths stay inside the project root — never existence or git-ness — so `path: frontned` (typo) built cleanly and doctor reported clean. The git-repo check compares against `git rev-parse --show-toplevel` (realpath-normalized) so a plain dir nested in the parent repo can't pass via the enclosing parent's `.git`.
- **#2 Validation warning** (`preferences-validation.ts`) — `mode:team` + `workspace.mode:parent` now warns that team branch-push/PR resolves at the project root and won't push child repos, pointing at ADR-044. Previously this combination was silently broken (push/PR root-only).
- **#6 Regression guard** — a new doctor test asserts the common layout (parent is a plain folder holding child git repos, not itself a git repo) is handled gracefully.

## Why

These are cross-cutting concerns the issue's 6 gaps didn't enumerate:
- Doctor is the natural place users diagnose misconfiguration; a silent typo is the worst failure mode.
- The two `mode` axes (team vs parent-workspace) both touch git/push but were never cross-checked, so the combination silently lost team mode's push value.

## How / Verification

- `tsc --noEmit --project tsconfig.extensions.json` — clean.
- `pnpm run verify:fast` — all fast-gates passed.
- `doctor-workspace.test.ts` — 5/5 pass (missing path, not-a-repo, valid repos, project-mode no-op, non-git parent).
- `preferences.test.ts` — 102/102 pass (2 new: team+parent warns; team alone doesn't).
- `doctor-empty-worktree.test.ts` — 3/3 pass (existing doctor probes unaffected).

### Scope
This is a focused diagnostics/validation bundle. Two related findings are handled separately:
- **#5** (`/gsd status` per-repo signal) — its own follow-up.
- **#3 / #4** (runtime repo write-guard; parallel orchestration) — design-level / RFC-blocked; documented in ADR-044, not blind-coded here.

AI-assisted; no AI credited as author.

Change type: `feat` / `test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive diagnostics, docs, and a CI checkout tweak; no auth, data migration, or runtime execution-path changes beyond read-only git probes during doctor.
> 
> **Overview**
> Adds **parent-workspace diagnostics** so misconfigured child repos are visible instead of a clean doctor run, plus a **merged-preference warning** when team mode and parent workspace are combined.
> 
> **`/gsd doctor`** (parent `workspace.mode` only) now validates each declared child repo: missing paths raise `workspace_repo_path_missing`; paths that are not a git root (including dirs that only inherit the parent’s `.git`) raise `workspace_repo_not_a_repo`, using `git rev-parse --show-toplevel` with realpath normalization and `GIT_NO_PROMPT_ENV`.
> 
> **Preferences** emit a cross-axis warning when effective settings are `mode: team` and `workspace.mode: parent` (root-only push/PR; ADR-044), via `crossAxisPreferenceWarnings` on validation, effective load, and doctor/preflight diagnostics.
> 
> User docs cover the new doctor codes and the team+parent footgun. **CI** checkouts detach `refs/checkout-ref` after fetch instead of `$GITHUB_SHA`. New tests cover workspace doctor cases and preference merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8945dfcfb9eca599f2ab37c81beb3d1d5d64049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->