### PR TITLE
fix(issue): [Bug]: auto-mode "requires discussion" pause banner hides that the just-closed slice's UAT verdict was non-PASS

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1130,9 +1130,21 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // call site.
       const sliceContextFile = resolveSliceFile(basePath, mid, state.activeSlice.id, "CONTEXT");
       if (sliceContextFile && existsSync(sliceContextFile)) return null; // discussion already done, proceed
+
+      const closedSliceIds = getClosedSliceIds(mid);
+      const justClosedSliceId = closedSliceIds[closedSliceIds.length - 1];
+      let priorVerdictWarning = "";
+      if (justClosedSliceId) {
+        const prior = await readUatGateVerdict(basePath, mid, justClosedSliceId);
+        if (prior && !isAcceptableUatVerdict(prior.verdict, prior.uatType)) {
+          priorVerdictWarning =
+            ` Note: the slice just closed (${justClosedSliceId}) recorded a non-PASS UAT verdict (${prior.verdict.toUpperCase()}); review before continuing.`;
+        }
+      }
+
       return {
         action: "stop" as const,
-        reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
+        reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.${priorVerdictWarning}`,
         level: "warning" as const,
       };
     },

--- a/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
@@ -16,6 +16,13 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import {
+  closeDatabase,
+  insertAssessment,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+} from "../gsd-db.ts";
 import type { GSDState } from "../types.ts";
 import type { GSDPreferences } from "../preferences.ts";
 
@@ -84,6 +91,54 @@ describe("require_slice_discussion dispatch rule (#3454)", () => {
       }
     } finally {
       rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("includes prior non-PASS UAT warning when the just-closed slice failed", async () => {
+    const basePath = makeBasePath("prior-fail");
+    const dbDir = mkdtempSync(join(tmpdir(), "gsd-req-slice-db-"));
+    const dbPath = join(dbDir, "test.db");
+    try {
+      openDatabase(dbPath);
+      mkdirSync(join(basePath, ".gsd", "milestones", "M001", "slices", "S02"), { recursive: true });
+
+      insertMilestone({ id: "M001", title: "Test milestone" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Completed slice", status: "complete", sequence: 1 });
+      insertSlice({ id: "S02", milestoneId: "M001", title: "Next slice", status: "pending", sequence: 2 });
+
+      const assessmentPath = ".gsd/milestones/M001/slices/S01/S01-ASSESSMENT.md";
+      const assessmentBody = [
+        "---",
+        "verdict: fail",
+        "---",
+        "",
+        "# S01 UAT Assessment",
+      ].join("\n");
+      writeFileSync(join(basePath, assessmentPath), assessmentBody, "utf-8");
+      insertAssessment({
+        path: assessmentPath,
+        milestoneId: "M001",
+        sliceId: "S01",
+        status: "fail",
+        scope: "run-uat",
+        fullContent: assessmentBody,
+      });
+
+      const prefs = { phases: { require_slice_discussion: true } } as unknown as GSDPreferences;
+      const state = buildState({ activeSlice: { id: "S02", title: "Next slice" } });
+      const action = await findRule().match(buildCtx(basePath, prefs, state));
+
+      assert.ok(action, "rule must still pause for discussion");
+      assert.strictEqual(action!.action, "stop");
+      if (action!.action === "stop") {
+        assert.match(action!.reason, /S02 requires discussion/);
+        assert.match(action!.reason, /slice just closed \(S01\)/);
+        assert.match(action!.reason, /non-PASS UAT verdict \(FAIL\)/);
+      }
+    } finally {
+      closeDatabase();
+      rmSync(basePath, { recursive: true, force: true });
+      rmSync(dbDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- Added the prior non-PASS UAT warning and verified diff hygiene; focused tests were blocked by dependency install DNS failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1125
- [#1125 [Bug]: auto-mode "requires discussion" pause banner hides that the just-closed slice's UAT verdict was non-PASS](https://github.com/open-gsd/gsd-pi/issues/1125)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1125-bug-auto-mode-requires-discussion-pause--1782955385`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to stop-message text in one dispatch rule, reusing existing UAT verdict helpers; behavior when discussion is required is unchanged aside from the added warning.
> 
> **Overview**
> When auto-mode stops in **planning** because `require_slice_discussion` is on and the active slice has no CONTEXT yet, the pause message now also checks the **last closed slice** in milestone order.
> 
> If that slice has a **non-PASS** UAT verdict (via `readUatGateVerdict` and `isAcceptableUatVerdict`), the existing “run `/gsd discuss`” reason gets an extra note naming the closed slice and the verdict (e.g. FAIL), so the banner no longer hides a failed UAT on the slice that just finished.
> 
> A dispatch regression test seeds a completed S01 with a fail assessment and asserts S02’s discussion pause includes the warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd07aa3e31cc6d73a9d5a77f9d3506c02d6844a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->