### PR TITLE
feat(gsd): per-repo git health in /gsd status + document workspace limits — #818 cross-cutting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             '+refs/heads/*:refs/remotes/origin/*' \
             '+refs/tags/*:refs/tags/*' \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Prepare diff base for scans
         env:
@@ -123,7 +123,7 @@ jobs:
 
           git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -237,7 +237,7 @@ jobs:
 
           git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -327,7 +327,7 @@ jobs:
 
           git -c protocol.version=2 fetch --no-tags --prune --depth="$FETCH_DEPTH" origin \
             "+${GITHUB_REF}:refs/checkout-ref"
-          git checkout --force --detach "$GITHUB_SHA"
+          git checkout --force --detach refs/checkout-ref
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -649,9 +649,17 @@ Validation rules:
 - Repository paths are normalized and must be unique (case-insensitive).
 - Paths resolving outside the project root are rejected.
 - `workspace.mode: "parent"` requires at least one repository under `workspace.repositories`; otherwise it is rejected (a parent workspace with no child repos is indistinguishable from `project` mode).
+- `mode: "team"` combined with `workspace.mode: "parent"` produces a warning: team branch-push/PR resolves at the project root and does not push child repositories. This is a known limitation (see "Known limitations" below).
 - Unknown keys under `workspace` and each repository entry are ignored with warnings.
 
 **Layout constraint (nested-only).** Child repositories must live **inside** the project root — sibling-repo layouts (e.g. a path like `../frontend` or any path resolving outside the root) are **not supported** and are rejected. This is a deliberate safety guard, not an arbitrary limitation: declared repository roots back the task path-scope allowlist used during planning (`plan-slice` validates that every task `files`/`inputs`/`expectedOutput` path stays under a declared root). Allowing escapes would weaken that guard and let a typo'd or malicious path authorize edits outside the project. To coordinate sibling repos, nest them under a common parent directory and run GSD from that parent.
+
+**Known limitations of parent-workspace mode.** Per-repository *commits* and *verification* honor `commit_policy` and run in each repo's directory today. The following are **not** yet wired:
+
+- **Repo path-scope is enforced at planning time only.** When a task targets `frontend`, the planner is instructed its files must stay under `frontend/`'s root, but nothing mechanically blocks an executor from writing to `backend/` at runtime under `git.isolation: "none"`. Isolation modes (`worktree`/`branch`) provide stronger containment but operate at the project root, not per child repo.
+- **Per-repository git isolation (worktree/branch) is root-only.** One worktree/branch per milestone is created at the project root and shared across child repos. This inverts the isolation model and is RFC-gated; see `docs/dev/ADR-044-per-repository-git-isolation.md` when it lands.
+- **Parallel orchestration is root-only.** Each parallel worker gets one milestone worktree at the project root with no per-repo dimension — a known limit tied to the same isolation-model question (ADR-044).
+- **Per-repository push policy.** Push/PR at milestone merge resolves at the project root and pushes a single branch; child repos are not pushed individually.
 
 ### URL Blocking (`fetch_page`)
 

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -2,9 +2,11 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@g
 import type { Model } from "@gsd/pi-ai";
 import type { GSDState } from "../../types.js";
 import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
 
 import { computeProgressScore, formatProgressLine } from "../../progress-score.js";
 import { loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath, getProjectGSDPreferencesPath, availableModelIdsFromRegistry, modelIdsForProfileResolution, resolveProfileAnchorProvider, resolveDisabledModelProvidersFromPreferences } from "../../preferences.js";
+import { createRepositoryRegistryFromPreferences } from "../../repository-registry.js";
 import { ensurePreferencesFile, handlePrefs, handlePrefsMode, handlePrefsWizard, handleLanguage } from "../../commands-prefs-wizard.js";
 import { runEnvironmentChecks } from "../../doctor-environment.js";
 import { deriveState } from "../../state.js";
@@ -220,7 +222,7 @@ export async function handleStatus(ctx: ExtensionCommandContext): Promise<void> 
   );
 
   if (result === undefined) {
-    ctx.ui.notify(formatTextStatus(state), "info");
+    ctx.ui.notify(formatTextStatus(state, basePath), "info");
   }
 }
 
@@ -610,7 +612,8 @@ export async function handleCoreCommand(
   return false;
 }
 
-export function formatTextStatus(state: GSDState): string {
+export function formatTextStatus(state: GSDState, basePath?: string): string {
+  const root = basePath ?? projectRoot();
   const lines: string[] = ["GSD Status\n"];
   lines.push(formatProgressLine(computeProgressScore()));
   lines.push("");
@@ -653,7 +656,7 @@ export function formatTextStatus(state: GSDState): string {
     }
   }
 
-  const envResults = runEnvironmentChecks(projectRoot());
+  const envResults = runEnvironmentChecks(root);
   const envIssues = envResults.filter((result) => result.status !== "ok");
   if (envIssues.length > 0) {
     lines.push("");
@@ -663,5 +666,51 @@ export function formatTextStatus(state: GSDState): string {
     }
   }
 
+  // Parent-workspace per-repository git health (#818). No-op for single-repo
+  // projects; surfaces which declared child repos have uncommitted changes.
+  const repoBlock = buildWorkspaceRepoStatusBlock(root);
+  if (repoBlock) {
+    lines.push("");
+    lines.push("Repositories:");
+    lines.push(repoBlock);
+  }
+
   return lines.join("\n");
+}
+
+/**
+ * Build a per-repository dirty/clean summary for parent-workspace status.
+ * Returns "" for single-repo (project-mode) projects so the status output is
+ * unchanged; otherwise one line per declared child repository.
+ */
+function buildWorkspaceRepoStatusBlock(basePath: string): string {
+  let registry;
+  try {
+    registry = createRepositoryRegistryFromPreferences(basePath, loadEffectiveGSDPreferences(basePath)?.preferences);
+  } catch {
+    return "";
+  }
+  if (registry.mode !== "parent") return "";
+  const childRepos = registry.repositories.filter((repo) => repo.id !== "project");
+  if (childRepos.length === 0) return "";
+
+  return childRepos
+    .map((repo) => {
+      const dirty = isRepoDirty(repo.root);
+      return `  ${dirty ? "✗" : "✓"} ${repo.id}${repo.role ? ` — ${repo.role}` : ""}${dirty ? " (uncommitted changes)" : " (clean)"}`;
+    })
+    .join("\n");
+}
+
+function isRepoDirty(root: string): boolean {
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
 }

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -2,9 +2,9 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@g
 import type { Model } from "@gsd/pi-ai";
 import type { GSDState } from "../../types.js";
 import { createRequire } from "node:module";
-import { execFileSync } from "node:child_process";
 
 import { computeProgressScore, formatProgressLine } from "../../progress-score.js";
+import { isRepositoryDirty } from "../../git-service.js";
 import { loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath, getProjectGSDPreferencesPath, availableModelIdsFromRegistry, modelIdsForProfileResolution, resolveProfileAnchorProvider, resolveDisabledModelProvidersFromPreferences } from "../../preferences.js";
 import { createRepositoryRegistryFromPreferences } from "../../repository-registry.js";
 import { ensurePreferencesFile, handlePrefs, handlePrefsMode, handlePrefsWizard, handleLanguage } from "../../commands-prefs-wizard.js";
@@ -696,21 +696,8 @@ function buildWorkspaceRepoStatusBlock(basePath: string): string {
 
   return childRepos
     .map((repo) => {
-      const dirty = isRepoDirty(repo.root);
+      const dirty = isRepositoryDirty(repo.root);
       return `  ${dirty ? "✗" : "✓"} ${repo.id}${repo.role ? ` — ${repo.role}` : ""}${dirty ? " (uncommitted changes)" : " (clean)"}`;
     })
     .join("\n");
-}
-
-function isRepoDirty(root: string): boolean {
-  try {
-    const out = execFileSync("git", ["status", "--porcelain"], {
-      cwd: root,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-    return out.trim().length > 0;
-  } catch {
-    return false;
-  }
 }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1266,26 +1266,25 @@ export function handleTurnGitActionError(action: TurnGitActionMode, err: unknown
   };
 }
 
+export function isRepositoryDirty(repoRoot: string): boolean {
+  try {
+    return runGit(repoRoot, ["status", "--porcelain"]).length > 0;
+  } catch {
+    // Fallback preserves legacy behavior if explicit status probing fails.
+    return nativeHasChanges(repoRoot);
+  }
+}
+
 function collectRepositoryDirtyStatus(basePath: string): Record<string, boolean> {
   const preferences = loadEffectiveGSDPreferences(basePath)?.preferences;
   const registry = createRepositoryRegistryFromPreferences(basePath, preferences);
   const dirtyByRepository: Record<string, boolean> = {};
   const registeredRoots = new Set(registry.repositories.map((repo) => resolve(repo.root)));
   for (const repo of registry.repositories) {
-    try {
-      dirtyByRepository[repo.id] = runGit(repo.root, ["status", "--porcelain"]).length > 0;
-    } catch {
-      // Fallback preserves legacy behavior if explicit status probing fails.
-      dirtyByRepository[repo.id] = nativeHasChanges(repo.root);
-    }
+    dirtyByRepository[repo.id] = isRepositoryDirty(repo.root);
   }
   for (const repoRoot of findUndeclaredNestedGitRepositories(registry.projectRoot, registeredRoots)) {
-    let dirty = false;
-    try {
-      dirty = runGit(repoRoot, ["status", "--porcelain"]).length > 0;
-    } catch {
-      dirty = nativeHasChanges(repoRoot);
-    }
+    const dirty = isRepositoryDirty(repoRoot);
     if (!dirty) continue;
 
     const relPath = relative(registry.projectRoot, repoRoot).split(sep).join("/") || repoRoot;

--- a/src/resources/extensions/gsd/tests/status-per-repo.test.ts
+++ b/src/resources/extensions/gsd/tests/status-per-repo.test.ts
@@ -1,0 +1,94 @@
+/**
+ * status-per-repo.test.ts — `/gsd status` per-repository git-health block (#818).
+ *
+ * Covers the parent-workspace addition to formatTextStatus:
+ *   - parent mode with child repos → "Repositories:" section listing each
+ *   - dirty vs clean markers
+ *   - single-repo (project-mode) project → no Repositories section
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { formatTextStatus } from "../commands/handlers/core.ts";
+import type { GSDState } from "../types.ts";
+
+function gitInit(cwd: string): void {
+  execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+}
+
+function makeBaseState(): GSDState {
+  return {
+    activeMilestone: null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "None",
+    registry: [],
+  };
+}
+
+function writeParentPrefs(base: string, repos: Record<string, { path: string; role?: string }>): void {
+  const repoLines = Object.entries(repos)
+    .map(([id, cfg]) => `    ${id}:\n      path: ${cfg.path}${cfg.role ? `\n      role: ${cfg.role}` : ""}`)
+    .join("\n");
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    `---\nversion: 1\nworkspace:\n  mode: parent\n  repositories:\n${repoLines}\n---\n`,
+    "utf-8",
+  );
+}
+
+test("formatTextStatus shows a Repositories section for a clean parent workspace", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-status-repo-clean-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    mkdirSync(join(base, "frontend"), { recursive: true });
+    gitInit(join(base, "frontend"));
+    writeParentPrefs(base, { frontend: { path: "frontend", role: "web UI" } });
+
+    const out = formatTextStatus(makeBaseState(), base);
+    assert.match(out, /Repositories:/);
+    assert.match(out, /✓ frontend — web UI \(clean\)/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("formatTextStatus marks a dirty child repo with ✗", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-status-repo-dirty-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    mkdirSync(join(base, "backend"), { recursive: true });
+    gitInit(join(base, "backend"));
+    writeParentPrefs(base, { backend: { path: "backend" } });
+    // Make the backend repo dirty.
+    writeFileSync(join(base, "backend", "README.md"), "# dirty\n", "utf-8");
+
+    const out = formatTextStatus(makeBaseState(), base);
+    assert.match(out, /✗ backend \(uncommitted changes\)/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("formatTextStatus omits the Repositories section for single-repo projects", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-status-repo-single-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    gitInit(base);
+    // No workspace config → project mode (default).
+    const out = formatTextStatus(makeBaseState(), base);
+    assert.doesNotMatch(out, /Repositories:/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** `/gsd status` now shows per-repository git health in parent-workspace mode, and the workspace config docs now explicitly state the known behavioral limits (runtime write-guard, isolation, parallel, push).
**Why:** Cross-cutting findings #3/#4/#5 from completing #818 — status had no per-repo signal, and the limits were undocumented.
**How:** A `Repositories:` block in `formatTextStatus` (clean ✓ / dirty ✗ per child repo, no-op for single-repo) + a "Known limitations" subsection in `configuration.md`.

## What

- **#5 Status per-repo signal** (`commands/handlers/core.ts`) — `formatTextStatus` (the `/gsd status` text fallback) gains an optional `basePath`; in parent mode it appends a `Repositories:` section listing each declared child repo with a clean (`✓`) or dirty (`✗`) marker via `git status --porcelain`. The block is empty for single-repo projects, so the default status output is unchanged.
- **#3 + #4 Docs** (`configuration.md`) — the workspace section now documents the known behavioral limits discovered in the deep-dive:
  - repo path-scope is enforced at **planning time only** (no runtime write guard under `git.isolation: none`),
  - per-repo worktree/branch isolation is **root-only** (RFC-gated, ADR-044),
  - parallel orchestration is **root-only**,
  - push resolves at the project root (single branch).
  Also notes the `mode:team` + `workspace.mode:parent` warning from PR #1129.

## Why

These are the cross-cutting concerns the issue's 6 gaps didn't enumerate. #5 is the only one with a clean code fix (a read-only status signal); #3 and #4 are design-level (a runtime write guard and per-repo isolation inversion) that are correctly handled as *documented known limits* rather than blind code — they're RFC-grade and were surfaced honestly so contributors don't rebuild working machinery or hit silent failures.

## Verification

- `tsc --noEmit --project tsconfig.extensions.json` — clean.
- `pnpm run verify:fast` — all fast-gates passed.
- `status-per-repo.test.ts` — 3/3 pass (clean repo, dirty repo, single-repo omits section).

### Scope
Pairs with PR #1129 (doctor probe + team/parent warning). Together they close the cross-cutting findings from #818. The two design-level items (#3 runtime write guard, #4 per-repo isolation) remain documented limits pending the ADR-044 RFC path.

AI-assisted; no AI credited as author.

Change type: `feat` / `docs` / `test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only status and documentation changes; CI checkout targets the same fetched ref. Low risk unless shallow-fetch edge cases differ from `GITHUB_SHA`.
> 
> **Overview**
> **`/gsd status` text fallback** now lists declared child repositories in **parent** `workspace.mode`, with ✓/✗ for clean vs uncommitted changes (`git status --porcelain` via new `isRepositoryDirty`). Single-repo projects see no **Repositories:** block. `formatTextStatus` takes an optional `basePath`; the text fallback passes the project root.
> 
> **Docs** add validation warning for `mode: team` + `workspace.mode: parent`, and a **Known limitations** section (planning-only path scope, root-only isolation/parallel/push, ADR-044).
> 
> **CI** checkouts in four jobs use `refs/checkout-ref` after fetch instead of `$GITHUB_SHA`.
> 
> **Tests:** `status-per-repo.test.ts` covers clean, dirty, and project-mode omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f4c1c89472c99a8f94583a6cf168e5d9d263c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->