### PR TITLE
fix(issue): [Bug]: UAT NEEDS-HUMAN checks leave no durable follow-up marker, so a PASS-with-NEEDS-HUMAN sign-off obligation is silently dropped

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -37,6 +37,11 @@ import {
   executeValidateMilestone,
   executeUatResultSave,
 } from "../tools/workflow-tool-executors.ts";
+import {
+  initNotificationStore,
+  readNotifications,
+  _resetNotificationStore,
+} from "../notification-store.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-workflow-executors-${randomUUID()}`);
@@ -1100,13 +1105,14 @@ test("executeUatResultSave merges canonical plan ID and read-only tools when pre
   }
 });
 
-test("executeUatResultSave surfaces the worktree validation path for NEEDS-HUMAN checks", async () => {
+test("executeUatResultSave surfaces the worktree validation path and notification for NEEDS-HUMAN checks", async () => {
   const base = makeTmpBase();
   const worktree = join(base, ".gsd", "worktrees", "M001");
   const worktreeExecDir = join(worktree, ".gsd", "exec");
   const evidenceId = "uat-human-validation-evidence";
   try {
     openTestDb(base);
+    initNotificationStore(base);
     seedMilestone("M001", "Milestone One");
     seedSlice("M001", "S07", "complete");
     mkdirSync(worktreeExecDir, { recursive: true });
@@ -1166,7 +1172,17 @@ test("executeUatResultSave surfaces the worktree validation path for NEEDS-HUMAN
     assert.match(assessment, /## Manual Validation/);
     assert.ok(assessment.includes(worktree), "assessment should include the worktree checkout path");
     assert.match(assessment, /git worktree/);
+
+    const notifications = readNotifications(base, { kind: "uat-needs-human", scope: "M001/S07" });
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0].severity, "warning");
+    assert.equal(notifications[0].source, "notify");
+    assert.equal(
+      notifications[0].message,
+      "UAT for M001/S07 has NEEDS-HUMAN checks awaiting human validation",
+    );
   } finally {
+    _resetNotificationStore();
     closeDatabase();
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -58,6 +58,7 @@ import {
   saveUatAttemptArtifact,
   type UatResultSaveParams,
 } from "../uat-run.js";
+import { appendNotification } from "../notification-store.js";
 import { registerAutoWorker, markWorkerStopping, getAutoWorker } from "../db/auto-workers.js";
 import {
   claimMilestoneLease,
@@ -1268,6 +1269,14 @@ export async function executeUatResultSave(
       evaluatedAt: run.evaluatedAt,
     });
     invalidateStateCache();
+    if (run.hasHuman) {
+      appendNotification(
+        `UAT for ${run.params.milestoneId}/${run.params.sliceId} has NEEDS-HUMAN checks awaiting human validation`,
+        "warning",
+        "notify",
+        { kind: "uat-needs-human", scope: `${run.params.milestoneId}/${run.params.sliceId}` },
+      );
+    }
     const savedText = `UAT result saved for ${run.params.milestoneId}/${run.params.sliceId}: ${run.params.verdict}`;
     return {
       content: [{


### PR DESCRIPTION
## Summary
- Added durable UAT NEEDS-HUMAN notifications with regression coverage; whitespace verification passed, but dependency-backed tests were blocked by missing install and network restrictions.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1126
- [#1126 [Bug]: UAT NEEDS-HUMAN checks leave no durable follow-up marker, so a PASS-with-NEEDS-HUMAN sign-off obligation is silently dropped](https://github.com/open-gsd/gsd-pi/issues/1126)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1126-bug-uat-needs-human-checks-leave-no-dura-1782955377`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change on the UAT save path using the existing notification store; tests cover the new behavior with no auth or data-model changes.
> 
> **Overview**
> When **`gsd_uat_result_save`** completes with **NEEDS-HUMAN** checks (`run.hasHuman`), it now writes a **durable warning** via **`appendNotification`** so PASS-with-pending-human sign-off is not only in tool text and assessment markdown.
> 
> The notification uses **`kind: uat-needs-human`**, **`scope: <milestoneId>/<sliceId>`**, severity **warning**, and source **`notify`**, alongside existing manual-validation guidance in the tool response and assessment.
> 
> Regression coverage in **`workflow-tool-executors.test.ts`** initializes the notification store and asserts the stored message and metadata after a mixed PASS / NEEDS-HUMAN UAT save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f9f2fcb029030e6867084ec9f42208577eaea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->