### PR TITLE
fix(issue): [Bug]: milestone-validation prompt is never fed persisted slice-level Q3/Q4 gate flag findings, so closeout's enforcing gate is blind to the requirement/security flags it exists to reconcile

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -27,7 +27,7 @@ import type { GSDPreferences } from "./preferences.js";
 import { join, basename, relative } from "node:path";
 import { existsSync } from "node:fs";
 import { computeBudgets, resolveExecutorContextWindow, truncateAtSectionBoundary, type MinimalModelRegistry } from "./context-budget.js";
-import { getPendingGates, getPendingGatesForTurn } from "./gsd-db.js";
+import { getGateResults, getPendingGates, getPendingGatesForTurn } from "./gsd-db.js";
 import {
   GATE_REGISTRY,
   assertGateCoverage,
@@ -3360,6 +3360,44 @@ export async function buildValidateMilestonePrompt(
     const outstandingBlock = `### Outstanding Items (aggregated from slice summaries)\n\nThese follow-ups and known limitations were documented during slice completion but have not been resolved.\n\n${outstandingItems.join('\n')}`;
     inlined.push(outstandingBlock);
     trackPromptContext(contextTelemetry, "outstanding-items", "inline", outstandingBlock);
+  }
+
+  const persistedGateFlags: string[] = [];
+  try {
+    const gateLabels = {
+      Q3: "Threat Surface",
+      Q4: "Requirement Impact",
+    } as const;
+    for (const sid of seenValSlices) {
+      for (const gate of getGateResults(mid, sid, "slice")) {
+        if (gate.gate_id !== "Q3" && gate.gate_id !== "Q4") continue;
+        const findings = gate.findings.trim();
+        const rationale = gate.rationale.trim();
+        const verdict = gate.verdict ?? "";
+        const hasNonPassVerdict = verdict !== "" && verdict !== "pass" && verdict !== "omitted";
+        if (!findings && !hasNonPassVerdict) continue;
+
+        const displayVerdict = verdict || gate.status;
+        const detail = findings || rationale || "_No findings text recorded; reconcile the persisted non-pass verdict._";
+        persistedGateFlags.push(`- **${sid} / ${gate.gate_id} (${gateLabels[gate.gate_id]}) / ${displayVerdict}:** ${detail}`);
+        if (findings && rationale) persistedGateFlags.push(`  - Rationale: ${rationale}`);
+      }
+    }
+  } catch (err) {
+    logWarning("prompt", `buildValidateMilestonePrompt persisted gate flags lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (persistedGateFlags.length > 0) {
+    const persistedGateFlagsBlock = [
+      "### Persisted Slice-Level Gate Flags (from quality_gates)",
+      "",
+      "These slice gates recorded findings or non-pass verdicts during execution. Reconcile each against the milestone-level evidence before returning MV03/MV04 verdicts.",
+      "",
+      ...persistedGateFlags,
+    ].join("\n");
+    inlined.push(persistedGateFlagsBlock);
+    trackPromptContext(contextTelemetry, "persisted-slice-gate-flags", "inline", persistedGateFlagsBlock);
+  } else {
+    trackPromptContext(contextTelemetry, "persisted-slice-gate-flags", "skipped", null, "none");
   }
 
   // Inline existing VALIDATION file if this is a re-validation round

--- a/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
@@ -12,7 +12,14 @@ import { tmpdir } from "node:os";
 
 import { buildSliceSummaryExcerpt, buildCompleteMilestonePrompt, buildValidateMilestonePrompt } from "../auto-prompts.ts";
 import { invalidateAllCaches } from "../cache.ts";
-import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+import {
+  closeDatabase,
+  insertGateRow,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+  saveGateResult,
+} from "../gsd-db.ts";
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────
 
@@ -363,6 +370,60 @@ test("validate-milestone prompt uses slice excerpts and on-demand paths instead 
   assert.ok(
     !prompt.includes("This very noisy assessment trace should stay out of the prompt."),
     "validate prompt must not inline full assessment traces",
+  );
+});
+
+test("validate-milestone prompt inlines persisted slice-level Q3/Q4 gate flags", async (t) => {
+  const base = createBase();
+  t.after(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    cleanup(base);
+  });
+  invalidateAllCaches();
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Risky Slice", status: "complete" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q8", scope: "slice" });
+  saveGateResult({
+    milestoneId: "M001",
+    sliceId: "S01",
+    gateId: "Q3",
+    verdict: "flag",
+    rationale: "New callback boundary.",
+    findings: "Re-check token exposure in the web callback.",
+  });
+  saveGateResult({
+    milestoneId: "M001",
+    sliceId: "S01",
+    gateId: "Q4",
+    verdict: "flag",
+    rationale: "Requirement touched but not re-tested.",
+    findings: "R012 must be re-tested; revisit decision D-3.",
+  });
+  saveGateResult({
+    milestoneId: "M001",
+    sliceId: "S01",
+    gateId: "Q8",
+    verdict: "flag",
+    rationale: "Operational readiness gap.",
+    findings: "Operational finding should not be milestone validation input.",
+  });
+  writeRoadmap(base, makeRoadmap());
+  writeSummary(base, "S01", makeFatSummary("S01"));
+
+  const prompt = await buildValidateMilestonePrompt("M001", "Test Milestone", base);
+
+  assert.match(prompt, /### Persisted Slice-Level Gate Flags \(from quality_gates\)/);
+  assert.match(prompt, /S01 \/ Q3 \(Threat Surface\) \/ flag/);
+  assert.match(prompt, /Re-check token exposure in the web callback\./);
+  assert.match(prompt, /S01 \/ Q4 \(Requirement Impact\) \/ flag/);
+  assert.match(prompt, /R012 must be re-tested; revisit decision D-3\./);
+  assert.ok(
+    !prompt.includes("Operational finding should not be milestone validation input."),
+    "validate-milestone should not inline unrelated Q8 gate findings",
   );
 });
 


### PR DESCRIPTION
## Summary
- Added Q3/Q4 quality gate findings to validate-milestone context with a focused regression test; whitespace verification passed but test execution was blocked by missing dependencies and offline install failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1124
- [#1124 [Bug]: milestone-validation prompt is never fed persisted slice-level Q3/Q4 gate flag findings, so closeout's enforcing gate is blind to the requirement/security flags it exists to reconcile](https://github.com/open-gsd/gsd-pi/issues/1124)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1124-bug-milestone-validation-prompt-is-never-1782955389`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only DB lookup and prompt text assembly for validate-milestone only; no auth or persistence changes beyond existing gate APIs.
> 
> **Overview**
> **Milestone validation** previously had no visibility into slice-level **Q3 (Threat Surface)** and **Q4 (Requirement Impact)** results stored in `quality_gates`, so closeout could not reconcile the security and requirement flags those gates exist to surface.
> 
> `buildValidateMilestonePrompt` now loads persisted slice gate rows via `getGateResults` and, when any slice has findings or a non-pass verdict, adds a **Persisted Slice-Level Gate Flags** block (slice id, gate label, verdict, findings, optional rationale) with instructions to reconcile before **MV03/MV04**. Other gates (e.g. **Q8**) are excluded. Failures are logged and skipped so prompt build still succeeds.
> 
> A regression test seeds Q3/Q4/Q8 in the DB and asserts the validate prompt includes Q3/Q4 text and omits Q8.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab94cc5bd9cd33003d9b81b7e0e456743dbedd09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->