### PR TITLE
fix(issue): fix: new-milestone discuss handoff fails — checkAutoStartAfterDiscuss uses legacy paths, misses flat-phase CONTEXT.md, auto-start proceeds without DB row

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -22,7 +22,7 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 - **Reassess** — checks if the roadmap still makes sense
 - **Validate Milestone** — reconciliation gate after all slices complete; compares roadmap success criteria against actual results, catches gaps before sealing the milestone
 
-When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in `M###-ROADMAP.md` with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
+When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in the milestone roadmap projection (`NN-ROADMAP.md` under `.gsd/phases/<NN-slug>/` for flat-phase projects) with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
 
 ### Idempotent Milestone Completion
 
@@ -77,7 +77,7 @@ Workflow Preferences -> Project Context -> Requirements -> Research Decision -> 
 | `.gsd/REQUIREMENTS.md` | `discuss-requirements` | Capability contract using `R###` requirements grouped by Active, Validated, Deferred, and Out of Scope |
 | `.gsd/runtime/research-decision.json` | `research-decision` | Records `research` or `skip`; this unit only asks the question and writes the marker |
 | `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`, only when the decision is `research` | Four scout-backed project research outputs for stack, feature norms, architecture, and pitfalls |
-| `.gsd/milestones/<MID>/M###-CONTEXT.md` and `M###-ROADMAP.md` | Normal milestone discussion/planning | Milestone-specific context and executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice` |
+| `.gsd/phases/<NN-slug>/<NN>-CONTEXT.md` and `<NN>-ROADMAP.md` | Normal milestone discussion/planning | Milestone-specific context and executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice`. Legacy projects may still resolve to `.gsd/milestones/<MID>/<MID>-*.md` until migrated. |
 
 `REQUIREMENTS.md` is rendered from the requirements stored in the GSD database. Agents should save individual requirements with `gsd_requirement_save`; a final `gsd_summary_save` for `REQUIREMENTS` will fail if no active requirement rows exist instead of treating caller-supplied markdown as canonical.
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -347,7 +347,7 @@ In these states GSD does not auto-stash and does not auto-fix; it stops so you c
 
 ### `/gsd doctor` reports `artifact_file_missing`
 
-**Symptoms:** `/gsd doctor` shows an error with issue code `artifact_file_missing`, a scope such as `project`, `milestone`, `slice`, or `task`, and a file path like `milestones/M001/M001-ROADMAP.md`.
+**Symptoms:** `/gsd doctor` shows an error with issue code `artifact_file_missing`, a scope such as `project`, `milestone`, `slice`, or `task`, and a file path like `phases/01-foundation/01-CONTEXT.md` or `milestones/M001/M001-ROADMAP.md`.
 
 **What it means:** The canonical database has an `artifacts` row for that path, but the rendered markdown file is missing from disk. In worktree mode, doctor checks both the active worktree-local `.gsd/` projection root and the project `.gsd/` root before reporting the issue, so the error usually means the artifact was deleted, skipped during a failed write, or left dangling by an interrupted migration/rebuild.
 

--- a/docs/user-docs/working-in-teams.md
+++ b/docs/user-docs/working-in-teams.md
@@ -35,6 +35,8 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 .gsd/worktrees/
 .gsd-worktrees/
 .gsd-backups/
+.gsd/phases/**/continue.md
+.gsd/phases/**/*-CONTINUE.md
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
 ```
@@ -44,7 +46,8 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 - `.gsd/PROJECT.md` — living project description
 - `.gsd/REQUIREMENTS.md` — requirement contract
 - `.gsd/DECISIONS.md` — architectural decisions
-- `.gsd/milestones/` — roadmaps, plans, summaries, research
+- `.gsd/phases/` — flat-phase roadmaps, plans, summaries, and research
+- `.gsd/milestones/` — legacy milestone artifacts, if the project has not migrated yet
 
 **What stays local** (gitignored):
 - Database files, metrics, state projections, runtime records, worktrees, activity logs, and migration backups under `.gsd-backups/`. Stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the flat-phase `.gsd/phases/` migration is complete.
@@ -86,9 +89,9 @@ If you have an existing project with `.gsd/` blanket-ignored:
 
 ## Plan Review Workflow
 
-Teams configured to track planning artifacts in git (i.e. with `mode: team` and `.gsd/milestones/` not gitignored) can use a two-PR cycle to get plan approval before any code is written:
+Teams configured to track planning artifacts in git (i.e. with `mode: team` and `.gsd/phases/` not gitignored) can use a two-PR cycle to get plan approval before any code is written:
 
-1. **Plan PR** — developer runs `/gsd discuss` on `main`, which writes planning artifacts to `.gsd/milestones/<MID>/` (milestone files `<MID>-CONTEXT.md` and `<MID>-ROADMAP.md`) and updates the top-level `.gsd/REQUIREMENTS.md` and `.gsd/DECISIONS.md`. The developer commits these and opens a docs-only PR.
+1. **Plan PR** — developer runs `/gsd discuss` on `main`, which writes flat-phase planning artifacts to `.gsd/phases/<NN-slug>/` (phase files `<NN>-CONTEXT.md` and `<NN>-ROADMAP.md`) and updates the top-level `.gsd/REQUIREMENTS.md` and `.gsd/DECISIONS.md`. Legacy projects may still resolve to `.gsd/milestones/<MID>/<MID>-*.md` until migration. The developer commits these and opens a docs-only PR.
 2. **Review** — the team reviews scope, risks, slice breakdown, and definition of done directly in GitHub. No code to review yet, just the plan.
 3. **Code PR** — after the plan PR is merged, the developer pulls `main` and runs `/gsd auto`. GSD creates a worktree and executes against the approved plan. The result is a second PR with the actual implementation.
 
@@ -96,8 +99,8 @@ Teams configured to track planning artifacts in git (i.e. with `mode: team` and 
 
 ### What reviewers should look for
 
-- **`<MID>-CONTEXT.md`** — is the scope well-defined? Are constraints and non-goals clear?
-- **`<MID>-ROADMAP.md`** — does the slice breakdown make sense? Are slices ordered by dependency?
+- **`<NN>-CONTEXT.md`** — is the scope well-defined? Are constraints and non-goals clear?
+- **`<NN>-ROADMAP.md`** — does the slice breakdown make sense? Are slices ordered by dependency?
 - **`.gsd/DECISIONS.md`** — are the architectural choices justified?
 
 ### Steering during execution
@@ -123,7 +126,7 @@ Multiple developers can run auto mode simultaneously on different milestones. Ea
 - Works on a unique `milestone/<MID>` branch
 - Squash-merges to main independently
 
-Milestone dependencies can be declared in `M00X-CONTEXT.md` frontmatter:
+Milestone dependencies can be declared in the phase context frontmatter:
 
 ```yaml
 ---

--- a/docs/zh-CN/user-docs/getting-started.md
+++ b/docs/zh-CN/user-docs/getting-started.md
@@ -383,13 +383,12 @@ Milestone  →  一个可交付版本（4-10 个 slice）
   DECISIONS.md        — 追加式架构决策记录
   KNOWLEDGE.md        — 手写 Rules，加上 memory 支撑的 Patterns/Lessons
   STATE.md            — 一眼可见的状态摘要
-  milestones/
-    M001/
-      M001-ROADMAP.md — 带依赖关系的 slice 计划
-      slices/
-        S01/
-          S01-PLAN.md     — task 拆解
-          S01-SUMMARY.md  — 实际发生了什么
+  phases/
+    01-foundation/
+      01-CONTEXT.md     — discussion 中形成的范围和目标
+      01-ROADMAP.md     — 带依赖关系的 slice 计划
+      01-01-PLAN.md     — 第一个 slice 的 task 拆解
+      01-01-SUMMARY.md  — 第一个 slice 实际发生了什么
 ```
 
 ---

--- a/docs/zh-CN/user-docs/working-in-teams.md
+++ b/docs/zh-CN/user-docs/working-in-teams.md
@@ -34,6 +34,8 @@ mode: team
 .gsd/runtime/
 .gsd/worktrees/
 .gsd-worktrees/
+.gsd/phases/**/continue.md
+.gsd/phases/**/*-CONTINUE.md
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
 ```
@@ -44,7 +46,8 @@ mode: team
 - `.gsd/PROJECT.md`：持续维护的项目描述
 - `.gsd/REQUIREMENTS.md`：需求契约
 - `.gsd/DECISIONS.md`：架构决策
-- `.gsd/milestones/`：roadmaps、plans、summaries 和 research
+- `.gsd/phases/`：flat-phase roadmaps、plans、summaries 和 research
+- `.gsd/milestones/`：尚未迁移项目中的 legacy milestone 产物
 
 **仅保留本地的内容**（gitignore）：
 
@@ -93,7 +96,7 @@ git:
 - 在独立的 `milestone/<MID>` 分支上工作
 - 独立地 squash merge 回主分支
 
-milestone 依赖可以通过 `M00X-CONTEXT.md` frontmatter 声明：
+milestone 依赖可以通过 phase context frontmatter 声明：
 
 ```yaml
 ---

--- a/gitbook/core-concepts/project-structure.md
+++ b/gitbook/core-concepts/project-structure.md
@@ -53,18 +53,13 @@ The `.gsd/` directory looks like this:
   RUNTIME.md          — runtime context: API endpoints, env vars, services
   STATE.md            — quick-glance status of current work
   PREFERENCES.md      — project-level preferences (optional)
-  milestones/
-    M001/
-      M001-ROADMAP.md — slice plan with risk levels and dependencies
-      M001-CONTEXT.md — scope and goals from discussion phase
-      slices/
-        S01/
-          S01-PLAN.md     — task decomposition for this slice
-          S01-SUMMARY.md  — what was built and what changed
-          S01-UAT.md      — human test script
-          tasks/
-            T01-PLAN.md   — detailed plan for this task
-            T01-SUMMARY.md — what the task accomplished
+  phases/
+    01-foundation/
+      01-CONTEXT.md     — scope and goals from discussion phase
+      01-ROADMAP.md     — slice plan with risk levels and dependencies
+      01-01-PLAN.md     — task decomposition for the first slice
+      01-01-SUMMARY.md  — what was built and what changed
+      01-01-UAT.md      — human test script
 ```
 
 GSD may also create sibling runtime directories next to `.gsd/`. `.gsd-worktrees/` holds isolated milestone checkouts, and `.gsd-backups/` holds migration snapshots such as `.gsd-backups/migrate-*`. These sibling directories are local-only and gitignored; stale `migrate-*` backup snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.

--- a/gitbook/features/teams.md
+++ b/gitbook/features/teams.md
@@ -41,6 +41,8 @@ Share planning artifacts while keeping runtime files local:
 .gsd/runtime/
 .gsd/worktrees/
 .gsd-backups/
+.gsd/phases/**/continue.md
+.gsd/phases/**/*-CONTINUE.md
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
 ```
@@ -50,7 +52,8 @@ Share planning artifacts while keeping runtime files local:
 - `.gsd/PROJECT.md` — living project description
 - `.gsd/REQUIREMENTS.md` — requirement contract
 - `.gsd/DECISIONS.md` — architectural decisions
-- `.gsd/milestones/` — roadmaps, plans, summaries, research
+- `.gsd/phases/` — flat-phase roadmaps, plans, summaries, and research
+- `.gsd/milestones/` — legacy milestone artifacts, if the project has not migrated yet
 
 **What stays local** (gitignored):
 - Database files, lock files, metrics, state projections, activity logs, worktrees, and migration backups under `.gsd-backups/`. Stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the flat-phase `.gsd/phases/` migration is complete.
@@ -81,10 +84,9 @@ Multiple developers can run auto mode simultaneously on different milestones. Ea
 - Works on a unique `milestone/<MID>` branch
 - Squash-merges to main independently
 
-Milestone dependencies can be declared:
+Milestone dependencies can be declared in the phase context frontmatter:
 
 ```yaml
-# In M00X-CONTEXT.md frontmatter
 ---
 depends_on: [M001-eh88as]
 ---

--- a/gitbook/getting-started/first-project.md
+++ b/gitbook/getting-started/first-project.md
@@ -108,18 +108,13 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
   DECISIONS.md        — projection of architectural decisions from memory store
   KNOWLEDGE.md        — manual Rules plus memory-backed Patterns/Lessons
   STATE.md            — quick-glance status rendered from the database
-  milestones/
-    M001/
-      M001-ROADMAP.md — slice plan with dependencies
-      M001-CONTEXT.md — scope and goals
-      slices/
-        S01/
-          S01-PLAN.md     — task decomposition
-          S01-SUMMARY.md  — what happened
-          S01-UAT.md      — test script
-          tasks/
-            T01-PLAN.md
-            T01-SUMMARY.md
+  phases/
+    01-foundation/
+      01-CONTEXT.md     — scope and goals
+      01-ROADMAP.md     — slice plan with dependencies
+      01-01-PLAN.md     — task decomposition for the first slice
+      01-01-SUMMARY.md  — what happened in the first slice
+      01-01-UAT.md      — test script
 ```
 
 GSD may also create sibling runtime directories next to `.gsd/`: `.gsd-worktrees/` for isolated milestone checkouts and `.gsd-backups/` for migration snapshots. Keep those directories local and gitignored; stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.

--- a/mintlify-docs/getting-started.mdx
+++ b/mintlify-docs/getting-started.mdx
@@ -139,18 +139,13 @@ All state lives on disk in `.gsd/`:
   KNOWLEDGE.md        — manual rules plus memory-projected patterns and lessons
   RUNTIME.md          — runtime context: API endpoints, env vars, services
   STATE.md            — quick-glance status
-  milestones/
-    M001/
-      M001-ROADMAP.md — slice plan with risk levels and dependencies
-      M001-CONTEXT.md — scope and goals from discussion
-      slices/
-        S01/
-          S01-PLAN.md     — task decomposition
-          S01-SUMMARY.md  — what happened
-          S01-UAT.md      — human test script
-          tasks/
-            T01-PLAN.md
-            T01-SUMMARY.md
+  phases/
+    01-foundation/
+      01-CONTEXT.md     — scope and goals from discussion
+      01-ROADMAP.md     — slice plan with risk levels and dependencies
+      01-01-PLAN.md     — task decomposition for the first slice
+      01-01-SUMMARY.md  — what happened in the first slice
+      01-01-UAT.md      — human test script
 ```
 </Accordion>
 

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -19,7 +19,7 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 - **Reassess** — checks if the roadmap still makes sense
 - **Validate** — reconciliation gate after all slices; catches gaps before sealing the milestone
 
-When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in `M###-ROADMAP.md` with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
+When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in the milestone roadmap projection (`NN-ROADMAP.md` under `.gsd/phases/<NN-slug>/` for flat-phase projects) with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
 
 `complete-milestone` enforces hard closeout prerequisites: every slice must have a UAT assessment with verdict `PASS`, and the latest `milestone-validation` assessment for the milestone must exist with verdict `pass`. If UAT is missing or non-PASS, auto mode stops with guidance to run `/gsd dispatch uat`, request a slice-specific UAT rerun when needed, inspect `/gsd status`, or add remediation slices with `/gsd dispatch reassess`. If milestone validation is `fail`, `partial`, or missing, closeout is blocked until `validate-milestone` records a fresh passing verdict.
 
@@ -44,7 +44,7 @@ Workflow Preferences -> Project Context -> Requirements -> Research Decision -> 
 | `.gsd/REQUIREMENTS.md`                                                    | `discuss-requirements`            | Capability contract with Active, Validated, Deferred, and Out of Scope requirements |
 | `.gsd/runtime/research-decision.json`                                     | `research-decision`               | Records whether to run project research or skip it                                  |
 | `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`                | Optional four-way project research when the decision is `research`                  |
-| `.gsd/milestones/<MID>/M###-ROADMAP.md`                                   | `plan-milestone`                  | Executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice`           |
+| `.gsd/phases/<NN-slug>/<NN>-CONTEXT.md` and `<NN>-ROADMAP.md`             | `discuss-milestone` / `plan-milestone` | Milestone context and executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice`. Legacy projects may still resolve to `.gsd/milestones/<MID>/<MID>-*.md` until migrated. |
 
 The research-decision unit only records the choice. If the decision is `research`, the next gate fans out four project research passes. Those outputs inform planning and requirement review; they do not silently create binding requirements.
 

--- a/mintlify-docs/guides/working-in-teams.mdx
+++ b/mintlify-docs/guides/working-in-teams.mdx
@@ -36,11 +36,13 @@ Share planning artifacts while keeping runtime files local:
 .gsd/journal/
 .gsd/doctor-history.jsonl
 .gsd/event-log.jsonl
+.gsd/phases/**/continue.md
+.gsd/phases/**/*-CONTINUE.md
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
 ```
 
-**Shared** (committed): preferences, PROJECT.md, REQUIREMENTS.md, DECISIONS.md, milestones.
+**Shared** (committed): preferences, PROJECT.md, REQUIREMENTS.md, DECISIONS.md, and flat-phase artifacts under `.gsd/phases/`. Legacy projects may still share `.gsd/milestones/` until migrated.
 
 **Local** (gitignored): metrics, state cache, worktrees, activity logs, database files, journals.
 
@@ -64,10 +66,9 @@ Adds `.gsd/` to `.gitignore` entirely. The developer gets structured planning wi
 
 ## Parallel development
 
-Multiple developers run auto mode simultaneously on different milestones. Each developer gets their own worktree and unique `milestone/<MID>` branch. Milestone dependencies can be declared:
+Multiple developers run auto mode simultaneously on different milestones. Each developer gets their own worktree and unique `milestone/<MID>` branch. Milestone dependencies can be declared in the phase context frontmatter:
 
 ```yaml
-# M00X-CONTEXT.md frontmatter
 ---
 depends_on: [M001-eh88as]
 ---

--- a/src/resources/GSD-WORKFLOW.md
+++ b/src/resources/GSD-WORKFLOW.md
@@ -5,7 +5,7 @@
 > **When to read this:** At the start of any session working on GSD-managed work, or when loaded by `/gsd`.
 >
 > **After reading this, always read `.gsd/STATE.md` to find out what's next.**
-> If the milestone has a `CONTEXT.md`, read that too. If the active slice has an `S##-CONTEXT.md`, read that as well — these files contain project-specific decisions, reference paths, and implementation guidance that this generic methodology doc does not.
+> If the milestone has a `NN-CONTEXT.md`, read that too. If the active slice has an `NN-MM-CONTEXT.md`, read that as well — these files contain project-specific decisions, reference paths, and implementation guidance that this generic methodology doc does not.
 
 ---
 
@@ -14,10 +14,10 @@
 Read these files in order and act on what they say:
 
 1. **`.gsd/STATE.md`** — Where are we? What's the next action?
-2. **`.gsd/phases/<active>/ROADMAP.md`** — What's the plan? Which slices are done? (`STATE.md` tells you which milestone is active)
-3. **`.gsd/phases/<active>/CONTEXT.md`** — Milestone-level project decisions, reference paths, constraints. Read this before doing implementation work.
-4. If a slice is active and has one, read **`S##-CONTEXT.md`** — Slice-specific decisions and constraints.
-5. If a slice is active, read its **`S##-PLAN.md`** — Which tasks exist? Which are done?
+2. **`.gsd/phases/<NN-slug>/<NN>-ROADMAP.md`** — What's the plan? Which slices are done? (`STATE.md` tells you which milestone is active)
+3. **`.gsd/phases/<NN-slug>/<NN>-CONTEXT.md`** — Milestone-level project decisions, reference paths, constraints. Read this before doing implementation work.
+4. If a slice is active and has one, read **`<NN>-<MM>-CONTEXT.md`** — Slice-specific decisions and constraints.
+5. If a slice is active, read its **`<NN>-<MM>-PLAN.md`** — Which tasks exist? Which are done?
 6. If `.gsd/CODEBASE.md` exists, skim it for fast structural orientation before broad code exploration.
 7. If a task was interrupted, check for **`continue.md`** in the active slice directory — Resume from there.
 
@@ -47,22 +47,17 @@ All artifacts live in `.gsd/` at the project root:
   DECISIONS.md                              # Append-only decisions register
   CODEBASE.md                               # Generated codebase map cache (auto-refreshed by GSD)
   phases/
-    M001/
-      M001-ROADMAP.md                       # Milestone plan (checkboxes = state)
-      M001-CONTEXT.md                       # Optional: user decisions from discuss phase
-      M001-RESEARCH.md                      # Optional: codebase/tech research
-      M001-SUMMARY.md                       # Milestone rollup (updated as slices complete)
-      slices/
-        S01/
-          S01-PLAN.md                       # Task decomposition for this slice
-          S01-CONTEXT.md                    # Optional: slice-level user decisions
-          S01-RESEARCH.md                   # Optional: slice-level research
-          S01-SUMMARY.md                    # Slice summary (written on completion)
-          S01-UAT.md                        # Non-blocking human test script (written on completion)
-          continue.md                       # Ephemeral: resume point if interrupted
-          tasks/
-            T01-PLAN.md                     # Individual task plan
-            T01-SUMMARY.md                  # Task summary with frontmatter
+    01-foundation/
+      01-ROADMAP.md                         # Milestone plan (checkboxes = state)
+      01-CONTEXT.md                         # Optional: user decisions from discuss phase
+      01-RESEARCH.md                        # Optional: codebase/tech research
+      01-SUMMARY.md                         # Milestone rollup (updated as slices complete)
+      01-01-PLAN.md                         # Task decomposition for the first slice
+      01-01-CONTEXT.md                      # Optional: slice-level user decisions
+      01-01-RESEARCH.md                     # Optional: slice-level research
+      01-01-SUMMARY.md                      # Slice summary (written on completion)
+      01-01-UAT.md                          # Non-blocking human test script (written on completion)
+      01-01-CONTINUE.md                     # Ephemeral: resume point if interrupted
 ```
 
 ---
@@ -424,7 +419,7 @@ key_decisions:
 patterns_established:
   - "Pattern name and where it lives"
 drill_down_paths:
-  - .gsd/phases/M001/slices/S01/tasks/T01-PLAN.md
+  - .gsd/phases/01-foundation/01-01-PLAN.md
 duration: 15min
 verification_result: pass
 completed_at: 2026-03-07T16:00:00Z
@@ -635,10 +630,10 @@ These are soft caps — exceed them when genuinely needed, but don't let summari
 
 This methodology doc is generic. Project-specific guidance belongs in the milestone and slice context files:
 
-- **`.gsd/phases/<active>/CONTEXT.md`** — milestone-level architecture decisions, reference file paths, and implementation constraints
-- **`.gsd/phases/<active>/slices/S##/S##-CONTEXT.md`** — slice-level decisions, edge cases, and narrow implementation guidance when present
+- **`.gsd/phases/<NN-slug>/<NN>-CONTEXT.md`** — milestone-level architecture decisions, reference file paths, and implementation constraints
+- **`.gsd/phases/<NN-slug>/<NN>-<MM>-CONTEXT.md`** — slice-level decisions, edge cases, and narrow implementation guidance when present
 
-**Always read the active milestone's `CONTEXT.md` before starting implementation work.** If the active slice also has `S##-CONTEXT.md`, read that too. These files tell you what decisions are locked, what files to reference, and how to verify your work in this specific project.
+**Always read the active milestone's `<NN>-CONTEXT.md` before starting implementation work.** If the active slice also has `<NN>-<MM>-CONTEXT.md`, read that too. These files tell you what decisions are locked, what files to reference, and how to verify your work in this specific project.
 
 ---
 

--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -45,8 +45,6 @@ import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
 import { proveMilestoneCloseout } from "./milestone-closeout-proof.js";
-import { parseRoadmapSlices } from "./roadmap-slices.js";
-
 /**
  * Optional override for the legacy roadmap parser used by verifyExpectedArtifact.
  * Production leaves this null so the real parseLegacyRoadmap runs; tests inject
@@ -75,10 +73,7 @@ function parseRoadmapForRecovery(content: string): ReturnType<NonNullable<typeof
 
 /** Slice count for plan-milestone verification; shared by scoped and legacy paths. */
 export function countPlanMilestoneRoadmapSlices(content: string): number {
-  if (_roadmapParserFn) {
-    return parseRoadmapForRecovery(content).slices.length;
-  }
-  return parseRoadmapSlices(content).length;
+  return parseRoadmapForRecovery(content).slices.length;
 }
 
 export function diagnoseWorktreeIntegrityFailure(basePath: string): string | null {

--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -45,6 +45,7 @@ import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { hasImplementationArtifacts } from "./milestone-implementation-evidence.js";
 import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
 import { proveMilestoneCloseout } from "./milestone-closeout-proof.js";
+import { parseRoadmapSlices } from "./roadmap-slices.js";
 
 /**
  * Optional override for the legacy roadmap parser used by verifyExpectedArtifact.
@@ -70,6 +71,14 @@ export function _setRoadmapParserFnForTests(
 function parseRoadmapForRecovery(content: string): ReturnType<NonNullable<typeof _roadmapParserFn>> {
   if (_roadmapParserFn) return _roadmapParserFn(content);
   return parseLegacyRoadmap(content) as unknown as ReturnType<NonNullable<typeof _roadmapParserFn>>;
+}
+
+/** Slice count for plan-milestone verification; shared by scoped and legacy paths. */
+export function countPlanMilestoneRoadmapSlices(content: string): number {
+  if (_roadmapParserFn) {
+    return parseRoadmapForRecovery(content).slices.length;
+  }
+  return parseRoadmapSlices(content).length;
 }
 
 export function diagnoseWorktreeIntegrityFailure(basePath: string): string | null {
@@ -336,8 +345,7 @@ export function verifyExpectedArtifact(
 
   if (unitType === "plan-milestone") {
     try {
-      const roadmap = parseRoadmapForRecovery(readFileSync(absPath, "utf-8"));
-      if (roadmap.slices.length === 0) {
+      if (countPlanMilestoneRoadmapSlices(readFileSync(absPath, "utf-8")) === 0) {
         logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap has zero slices at ${absPath}`);
         return false;
       }

--- a/src/resources/extensions/gsd/discussion-handoff.ts
+++ b/src/resources/extensions/gsd/discussion-handoff.ts
@@ -82,7 +82,13 @@ function ensureMilestoneRowForAcceptedHandoff(
   entry: PendingAutoStartEntry,
   contextFile: string | null,
 ): boolean {
-  if (!isDbAvailable()) return true;
+  if (!isDbAvailable()) {
+    logWarning(
+      "guided",
+      `R3b: milestone ${entry.milestoneId} DB-row recovery skipped because DB is unavailable`,
+    );
+    return false;
+  }
 
   const { basePath, milestoneId } = entry;
   const milestoneRow = getMilestone(milestoneId);
@@ -122,12 +128,14 @@ function ensureMilestoneRowForAcceptedHandoff(
     `(attempt ${entry.r3bRecoveryCount + 1}/${MAX_DB_ROW_RECOVERIES})`,
   );
 
+  let inserted = false;
   try {
-    insertMilestone({ id: milestoneId, title: milestoneId, status: "queued" });
+    inserted = insertMilestone({ id: milestoneId, title: milestoneId, status: "queued" });
   } catch (e) {
     logWarning("guided", `R3b: insertMilestone failed: ${(e as Error).message}`);
   }
 
+  if (inserted) return true;
   if (getMilestone(milestoneId)) return true;
 
   noteDbRowRecoveryMiss(entry);

--- a/src/resources/extensions/gsd/discussion-handoff.ts
+++ b/src/resources/extensions/gsd/discussion-handoff.ts
@@ -87,7 +87,7 @@ function ensureMilestoneRowForAcceptedHandoff(
       "guided",
       `R3b: milestone ${entry.milestoneId} DB-row recovery skipped because DB is unavailable`,
     );
-    return false;
+    return true;
   }
 
   const { basePath, milestoneId } = entry;

--- a/src/resources/extensions/gsd/discussion-handoff.ts
+++ b/src/resources/extensions/gsd/discussion-handoff.ts
@@ -87,7 +87,7 @@ function ensureMilestoneRowForAcceptedHandoff(
       "guided",
       `R3b: milestone ${entry.milestoneId} DB-row recovery skipped because DB is unavailable`,
     );
-    return true;
+    return false;
   }
 
   const { basePath, milestoneId } = entry;

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -164,7 +164,7 @@ export const _scheduleAutoStartAfterIdleForTest = scheduleAutoStartAfterIdle;
 // These thin wrappers accept a MilestoneScope so callers that already hold a
 // pinned scope never have to re-derive (basePath, milestoneId) separately.
 // The underlying implementations in auto-recovery.ts / auto-artifact-paths.ts /
-// state.ts are unchanged — only the call surface in guided-flow.ts is migrated.
+// state.ts remain the default for non-scope-specific units.
 
 /**
  * Scope-based overload of verifyExpectedArtifact.
@@ -178,12 +178,35 @@ export function verifyExpectedArtifactForScope(
 ): boolean {
   if (
     unitId === scope.milestoneId &&
-    (unitType === "discuss-milestone" || unitType === "plan-milestone")
+    unitType === "discuss-milestone"
   ) {
     const path = resolveExpectedArtifactPathForScope(scope, unitType, unitId);
     return path ? existsSync(path) : false;
   }
+  if (unitId === scope.milestoneId && unitType === "plan-milestone") {
+    const path = resolveExpectedArtifactPathForScope(scope, unitType, unitId);
+    return verifyScopedPlanMilestoneArtifact(path, unitType, unitId);
+  }
   return verifyExpectedArtifact(unitType, unitId, scope.workspace.projectRoot);
+}
+
+function verifyScopedPlanMilestoneArtifact(
+  path: string | null,
+  unitType: string,
+  unitId: string,
+): boolean {
+  if (!path || !existsSync(path)) return false;
+  try {
+    const roadmapContent = readFileSync(path, "utf-8");
+    if (!_roadmapHasParseableSlicesForTest(roadmapContent)) {
+      logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap has zero slices at ${path}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    logWarning("recovery", `plan-milestone roadmap verification failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -176,10 +176,7 @@ export function verifyExpectedArtifactForScope(
   unitType: string,
   unitId: string,
 ): boolean {
-  if (
-    (unitType === "discuss-milestone" || unitType === "plan-milestone") &&
-    unitId === scope.milestoneId
-  ) {
+  if (unitType === "discuss-milestone" && unitId === scope.milestoneId) {
     const path = resolveExpectedArtifactPathForScope(scope, unitType, unitId);
     return path ? existsSync(path) : false;
   }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -42,7 +42,7 @@ import { gsdHome } from "./gsd-home.js";
 import {
   gsdRoot, milestonesDir, legacyMilestonesDir, resolveMilestoneFile,
   resolveSliceFile, resolveSlicePath, resolveGsdRootFile, relGsdRootFile,
-  relMilestoneFile, relSliceFile,
+  relMilestoneFile, relSliceFile, clearPathCache,
 } from "./paths.js";
 import { join } from "node:path";
 import { readFileSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
@@ -101,6 +101,7 @@ import {
   formatPriorContextBrief,
 } from "./preparation.js";
 import { verifyExpectedArtifact } from "./auto-recovery.js";
+import { countPlanMilestoneRoadmapSlices } from "./artifact-verification.js";
 import type { MilestoneScope } from "./workspace.js";
 import { clearPendingGate, extractDepthVerificationMilestoneId, getPendingGate } from "./bootstrap/write-gate.js";
 import {
@@ -178,6 +179,14 @@ export function verifyExpectedArtifactForScope(
 ): boolean {
   if (
     unitId === scope.milestoneId &&
+    (unitType === "discuss-milestone" || unitType === "plan-milestone")
+  ) {
+    // Layout-aware scope paths use resolveMilestoneFile; clear stale dir listings
+    // primed before discuss/plan wrote CONTEXT.md or ROADMAP.md (see checkAutoStartAfterDiscuss).
+    clearPathCache();
+  }
+  if (
+    unitId === scope.milestoneId &&
     unitType === "discuss-milestone"
   ) {
     const path = resolveExpectedArtifactPathForScope(scope, unitType, unitId);
@@ -198,7 +207,7 @@ function verifyScopedPlanMilestoneArtifact(
   if (!path || !existsSync(path)) return false;
   try {
     const roadmapContent = readFileSync(path, "utf-8");
-    if (!_roadmapHasParseableSlicesForTest(roadmapContent)) {
+    if (countPlanMilestoneRoadmapSlices(roadmapContent) === 0) {
       logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap has zero slices at ${path}`);
       return false;
     }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -176,6 +176,13 @@ export function verifyExpectedArtifactForScope(
   unitType: string,
   unitId: string,
 ): boolean {
+  if (
+    (unitType === "discuss-milestone" || unitType === "plan-milestone") &&
+    unitId === scope.milestoneId
+  ) {
+    const path = resolveExpectedArtifactPathForScope(scope, unitType, unitId);
+    return path ? existsSync(path) : false;
+  }
   return verifyExpectedArtifact(unitType, unitId, scope.workspace.projectRoot);
 }
 
@@ -188,6 +195,10 @@ export function resolveExpectedArtifactPathForScope(
   unitType: string,
   unitId: string,
 ): string | null {
+  if (unitId === scope.milestoneId) {
+    if (unitType === "discuss-milestone") return scope.contextFile();
+    if (unitType === "plan-milestone") return scope.roadmapFile();
+  }
   return resolveExpectedArtifactPath(unitType, unitId, scope.workspace.projectRoot);
 }
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -176,7 +176,10 @@ export function verifyExpectedArtifactForScope(
   unitType: string,
   unitId: string,
 ): boolean {
-  if (unitType === "discuss-milestone" && unitId === scope.milestoneId) {
+  if (
+    unitId === scope.milestoneId &&
+    (unitType === "discuss-milestone" || unitType === "plan-milestone")
+  ) {
     const path = resolveExpectedArtifactPathForScope(scope, unitType, unitId);
     return path ? existsSync(path) : false;
   }

--- a/src/resources/extensions/gsd/skills/gsd-headless/SKILL.md
+++ b/src/resources/extensions/gsd/skills/gsd-headless/SKILL.md
@@ -211,17 +211,15 @@ All state lives in `.gsd/` as markdown files (version-controllable):
 
 ```
 .gsd/
-  milestones/M001/
-    M001-CONTEXT.md      # Requirements, scope, decisions
-    M001-ROADMAP.md      # Slices with tasks, dependencies, checkboxes
-    M001-SUMMARY.md      # Completion summary
-    slices/S01/
-      S01-PLAN.md        # Task list
-      S01-SUMMARY.md     # Slice summary with frontmatter
-      tasks/T01-PLAN.md  # Individual task spec
+  phases/01-foundation/
+    01-CONTEXT.md        # Requirements, scope, decisions
+    01-ROADMAP.md        # Slices with tasks, dependencies, checkboxes
+    01-SUMMARY.md        # Completion summary
+    01-01-PLAN.md        # First slice task list
+    01-01-SUMMARY.md     # First slice summary with frontmatter
 ```
 
-State is derived from files on disk — checkboxes in ROADMAP.md are the source of truth for completion.
+Runtime state is stored in the project-root database; markdown files are reviewable projections written under `.gsd/phases/`. Legacy projects may still resolve to `.gsd/milestones/<MID>/` until migrated.
 
 ## All Headless Commands
 

--- a/src/resources/extensions/gsd/tests/auto-session-scope.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-session-scope.test.ts
@@ -121,8 +121,8 @@ describe("AutoSession.scope — project mode (basePath equals originalBasePath)"
 
     assert.ok(s.scope, "scope should be set");
     const gsd = join(projectDir, ".gsd");
-    assert.equal(s.scope.contextFile(), join(gsd, "milestones", mid, `${mid}-CONTEXT.md`));
-    assert.equal(s.scope.roadmapFile(), join(gsd, "milestones", mid, `${mid}-ROADMAP.md`));
+    assert.equal(s.scope.contextFile(), join(gsd, "phases", "02-m002", "02-CONTEXT.md"));
+    assert.equal(s.scope.roadmapFile(), join(gsd, "phases", "02-m002", "02-ROADMAP.md"));
     assert.equal(s.scope.stateFile(), join(gsd, "STATE.md"));
   });
 });
@@ -236,8 +236,8 @@ describe("AutoSession.scope — milestoneId change rebuilds scope", () => {
     assert.ok(ctxM001, "M001 contextFile should be set");
     assert.ok(ctxM002, "M002 contextFile should be set");
     assert.notEqual(ctxM001, ctxM002, "contextFile must differ between milestone IDs");
-    assert.ok(ctxM001.includes("M001"), "M001 path should contain M001");
-    assert.ok(ctxM002.includes("M002"), "M002 path should contain M002");
+    assert.ok(ctxM001.includes("01-m001"), "M001 path should contain its phase directory");
+    assert.ok(ctxM002.includes("02-m002"), "M002 path should contain its phase directory");
   });
 });
 

--- a/src/resources/extensions/gsd/tests/auto-start-bootstrap-await-3420.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-bootstrap-await-3420.test.ts
@@ -17,14 +17,17 @@ import {
   clearPendingAutoStart,
   setPendingAutoStart,
 } from "../guided-flow.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
 
 test.afterEach(() => {
+  closeDatabase();
   clearPendingAutoStart();
 });
 
 test("checkAutoStartAfterDiscuss waits until discussion artifacts exist before re-entering auto-mode", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-bootstrap-await-"));
   const notifications: string[] = [];
+  openDatabase(":memory:");
   t.after(() => rmSync(base, { recursive: true, force: true }));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
   setPendingAutoStart(base, {

--- a/src/resources/extensions/gsd/tests/auto-warning-noise-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-warning-noise-regression.test.ts
@@ -34,6 +34,11 @@ import {
   clearPendingAutoStart,
   setPendingAutoStart,
 } from "../guided-flow.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+} from "../gsd-db.ts";
 
 // ─── Bug 2: this-binding regression ─────────────────────────────────────
 
@@ -89,6 +94,8 @@ test("checkAutoStartAfterDiscuss completes when discussion manifest is absent", 
     mkdirSync(milestoneDir, { recursive: true });
     writeFileSync(join(milestoneDir, "M001-CONTEXT.md"), "# Context\n", "utf-8");
     writeFileSync(join(base, ".gsd", "STATE.md"), "# State\n", "utf-8");
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "M001", status: "queued" });
     setPendingAutoStart(base, {
       basePath: base,
       milestoneId: "M001",
@@ -110,6 +117,7 @@ test("checkAutoStartAfterDiscuss completes when discussion manifest is absent", 
       },
     ]);
   } finally {
+    closeDatabase();
     clearPendingAutoStart(base);
     rmSync(base, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/check-auto-start-ready-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/check-auto-start-ready-guard.test.ts
@@ -13,6 +13,7 @@ import {
   checkAutoStartAfterDiscuss,
   setPendingAutoStart,
   clearPendingAutoStart,
+  _getPendingAutoStart,
 } from "../guided-flow.ts";
 import { drainLogs } from "../workflow-logger.ts";
 import {
@@ -77,6 +78,7 @@ describe("checkAutoStartAfterDiscuss ready-notify DB guard (R3b)", () => {
   let cap: MockCapture;
 
   beforeEach(() => {
+    closeDatabase();
     clearPendingAutoStart();
     drainLogs();
   });
@@ -127,6 +129,33 @@ describe("checkAutoStartAfterDiscuss ready-notify DB guard (R3b)", () => {
         level: "success",
       },
     ]);
+  });
+
+  test("fails closed and keeps pending handoff when DB is unavailable", () => {
+    base = mkBase();
+    closeDatabase();
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      startAuto: false,
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    const result = checkAutoStartAfterDiscuss();
+    assert.equal(result, false, "DB-unavailable handoff must fail closed");
+    assert.equal(
+      _getPendingAutoStart(base)?.milestoneId,
+      "M001",
+      "failed closed handoff must remain pending for a later retry",
+    );
+    assert.equal(
+      cap.notifies.some(n => n.level === "success"),
+      false,
+      "must not notify success before the milestone row is verified",
+    );
   });
 
   test("announces 'ready' when DB row has executable slices", () => {

--- a/src/resources/extensions/gsd/tests/gate-1b-orphan-discrimination.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-1b-orphan-discrimination.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 
 import {
   checkAutoStartAfterDiscuss,
+  _getPendingAutoStart,
   setPendingAutoStart,
   clearPendingAutoStart,
 } from "../guided-flow.ts";
@@ -21,6 +22,7 @@ import { drainLogs } from "../workflow-logger.ts";
 import {
   openDatabase,
   closeDatabase,
+  getMilestone,
   insertMilestone,
 } from "../gsd-db.ts";
 
@@ -59,9 +61,22 @@ function mkBase(): string {
   return base;
 }
 
+function mkFlatBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-gate1b-flat-"));
+  mkdirSync(join(base, ".gsd", "phases", "01-m001"), { recursive: true });
+  return base;
+}
+
 function writeContext(base: string): void {
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001: Test Milestone\n\nContext written by discuss phase.\n",
+  );
+}
+
+function writeFlatContext(base: string): void {
+  writeFileSync(
+    join(base, ".gsd", "phases", "01-m001", "01-CONTEXT.md"),
     "# M001: Test Milestone\n\nContext written by discuss phase.\n",
   );
 }
@@ -141,5 +156,79 @@ describe("Gate 1b discussion handoff in checkAutoStartAfterDiscuss", () => {
       (e) => e.component === "guided" && /Gate 1b/.test(e.message),
     );
     assert.equal(gate1bLog, undefined, "Gate 1b must not log when CONTEXT.md is absent");
+  });
+
+  test("flat-phase CONTEXT.md accepts handoff without a legacy milestone context file", () => {
+    base = mkFlatBase();
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "queued" });
+    writeFlatContext(base);
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      startAuto: false,
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    const result = checkAutoStartAfterDiscuss();
+
+    assert.equal(result, true, "flat-phase context must be found by the handoff");
+    assert.equal(cap.messages.length, 0, "startAuto=false must suppress scheduling");
+    assert.deepEqual(cap.notifies[0], {
+      msg: "Milestone M001 context captured. Continuing the planning pipeline.",
+      level: "success",
+    });
+  });
+
+  test("DB-unavailable recovery blocks handoff instead of reporting success", () => {
+    base = mkFlatBase();
+    writeFlatContext(base);
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      startAuto: false,
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    const result = checkAutoStartAfterDiscuss();
+
+    assert.equal(result, false, "handoff must fail closed when the DB row cannot be confirmed");
+    assert.equal(cap.messages.length, 0, "must not schedule auto-start when DB is unavailable");
+    assert.equal(
+      cap.notifies.some(n => n.level === "success"),
+      false,
+      "must not report a successful handoff when DB recovery was skipped",
+    );
+    assert.ok(_getPendingAutoStart(base), "pending handoff should remain for a later recovery attempt");
+  });
+
+  test("missing DB row with CONTEXT.md inserts a queued row and accepts handoff", () => {
+    base = mkFlatBase();
+    openDatabase(":memory:");
+    writeFlatContext(base);
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      startAuto: false,
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    const result = checkAutoStartAfterDiscuss();
+
+    assert.equal(result, true, "successful insert should recover the missing row");
+    assert.equal(getMilestone("M001")?.status, "queued");
+    assert.deepEqual(cap.notifies[0], {
+      msg: "Milestone M001 context captured. Continuing the planning pipeline.",
+      level: "success",
+    });
   });
 });

--- a/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts
@@ -20,6 +20,7 @@ import {
   clearPendingAutoStart,
   checkAutoStartAfterDiscuss,
 } from "../guided-flow.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
 
 function pendingInput(basePath: string, milestoneId: string) {
   return {
@@ -34,6 +35,7 @@ function pendingInput(basePath: string, milestoneId: string) {
 
 describe("#2985 Bug 3 — concurrent discuss sessions must be independent", () => {
   beforeEach(() => {
+    closeDatabase();
     clearPendingAutoStart();
   });
 
@@ -75,6 +77,7 @@ describe("#2985 Bug 3 — concurrent discuss sessions must be independent", () =
 
 describe("#2985 Bug 4 — getDiscussionMilestoneId must be keyed by basePath", () => {
   beforeEach(() => {
+    closeDatabase();
     clearPendingAutoStart();
   });
 
@@ -110,6 +113,7 @@ describe("#2985 Bug 4 — getDiscussionMilestoneId must be keyed by basePath", (
 test("checkAutoStartAfterDiscuss ignores missing manifest for single-milestone discuss on established project", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-auto-start-manifest-"));
   try {
+    openDatabase(":memory:");
     const gsdDir = join(base, ".gsd");
     const milestoneDir = join(gsdDir, "milestones", "M001");
     mkdirSync(milestoneDir, { recursive: true });
@@ -132,6 +136,7 @@ test("checkAutoStartAfterDiscuss ignores missing manifest for single-milestone d
     const started = checkAutoStartAfterDiscuss();
     assert.equal(started, true, "project history alone should not require a manifest");
   } finally {
+    closeDatabase();
     clearPendingAutoStart();
     rmSync(base, { recursive: true, force: true });
   }
@@ -151,6 +156,7 @@ test("checkAutoStartAfterDiscuss(basePath) selects the matching pending entry wh
   }
 
   try {
+    openDatabase(":memory:");
     clearPendingAutoStart();
     writeReadyArtifacts(projectA, "M001");
     writeReadyArtifacts(projectB, "M002");
@@ -172,6 +178,7 @@ test("checkAutoStartAfterDiscuss(basePath) selects the matching pending entry wh
     assert.equal(getDiscussionMilestoneId(projectA), "M001", "projectA should remain pending");
     assert.equal(getDiscussionMilestoneId(projectB), null, "projectB should be cleared after start");
   } finally {
+    closeDatabase();
     clearPendingAutoStart();
     rmSync(projectA, { recursive: true, force: true });
     rmSync(projectB, { recursive: true, force: true });
@@ -183,6 +190,7 @@ test("checkAutoStartAfterDiscuss can accept context handoff without scheduling a
   let waitForIdleCalls = 0;
   const notifications: string[] = [];
   try {
+    openDatabase(":memory:");
     const gsdDir = join(base, ".gsd");
     const milestoneDir = join(gsdDir, "milestones", "M001");
     mkdirSync(milestoneDir, { recursive: true });
@@ -215,6 +223,7 @@ test("checkAutoStartAfterDiscuss can accept context handoff without scheduling a
     assert.equal(waitForIdleCalls, 0, "headless-owned auto start must not schedule guided-flow auto");
     assert.equal(getDiscussionMilestoneId(base), null, "accepted handoff should still be cleared");
   } finally {
+    closeDatabase();
     clearPendingAutoStart();
     rmSync(base, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts
+++ b/src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts
@@ -55,8 +55,8 @@ describe("pendingAutoStart scope pinning (C1)", () => {
     assert.ok(entry.scope, "entry.scope should be set");
     assert.equal(entry.scope.milestoneId, "M001");
 
-    const expectedContext = join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md");
-    const expectedRoadmap = join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md");
+    const expectedContext = join(base, ".gsd", "phases", "01-m001", "01-CONTEXT.md");
+    const expectedRoadmap = join(base, ".gsd", "phases", "01-m001", "01-ROADMAP.md");
     const expectedState = join(base, ".gsd", "STATE.md");
 
     assert.equal(entry.scope.contextFile(), expectedContext);

--- a/src/resources/extensions/gsd/tests/validator-scope-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/validator-scope-parity.test.ts
@@ -257,4 +257,35 @@ describe("validator-scope-parity: scope uses canonical projectRoot not worktree 
       "scoped plan-milestone verification must parse roadmap content, not only check existence",
     );
   });
+
+  test("verifyExpectedArtifactForScope verifies the scoped plan-milestone roadmap path", () => {
+    const ws = createWorkspace(base);
+    const realScope = scopeMilestone(ws, "M001");
+    const scopedRoadmap = join(base, "scoped-M001-ROADMAP.md");
+    const scope = {
+      ...realScope,
+      roadmapFile: () => scopedRoadmap,
+    };
+
+    writeFileSync(scopedRoadmap, [
+      "# M001: Scoped roadmap",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First slice** `risk:low` `depends:[]`",
+      "  > After this: a real slice exists.",
+      "",
+    ].join("\n"));
+
+    assert.equal(
+      resolveExpectedArtifactPathForScope(scope, "plan-milestone", "M001"),
+      scopedRoadmap,
+      "scoped plan-milestone artifact path must come from scope.roadmapFile()",
+    );
+    assert.equal(
+      verifyExpectedArtifactForScope(scope, "plan-milestone", "M001"),
+      true,
+      "scoped plan-milestone verification must read the roadmap from scope.roadmapFile()",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/validator-scope-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/validator-scope-parity.test.ts
@@ -236,4 +236,25 @@ describe("validator-scope-parity: scope uses canonical projectRoot not worktree 
       "verifyExpectedArtifactForScope should return false when artifact is absent",
     );
   });
+
+  test("verifyExpectedArtifactForScope rejects zero-slice scoped plan-milestone roadmaps", () => {
+    const ws = createWorkspace(base);
+    const scope = scopeMilestone(ws, "M001");
+
+    writeFileSync(scope.roadmapFile(), [
+      "# M001: Placeholder",
+      "",
+      "## Slices",
+      "",
+      "_TBD_",
+      "",
+    ].join("\n"));
+
+    const ready = verifyExpectedArtifactForScope(scope, "plan-milestone", "M001");
+    assert.equal(
+      ready,
+      false,
+      "scoped plan-milestone verification must parse roadmap content, not only check existence",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/validator-scope-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/validator-scope-parity.test.ts
@@ -23,7 +23,7 @@ import {
 
 function makeProjectDir(label = "gsd-vsp-"): string {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), label)));
-  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(dir, ".gsd", "phases", "01-m001"), { recursive: true });
   return dir;
 }
 

--- a/src/resources/extensions/gsd/tests/workspace.test.ts
+++ b/src/resources/extensions/gsd/tests/workspace.test.ts
@@ -8,6 +8,7 @@ import {
   rmSync,
   realpathSync,
   symlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -118,17 +119,17 @@ describe("scopeMilestone path methods", () => {
     rmSync(projectDir, { recursive: true, force: true });
   });
 
-  test("produces correct paths for a known milestone ID", () => {
+  test("produces flat-phase paths for a known milestone ID", () => {
     const ws = createWorkspace(projectDir);
     const scope = scopeMilestone(ws, MID);
     const gsd = ws.contract.projectGsd;
 
     assert.equal(scope.milestoneId, MID);
-    assert.equal(scope.contextFile(), join(gsd, "milestones", MID, `${MID}-CONTEXT.md`));
-    assert.equal(scope.roadmapFile(), join(gsd, "milestones", MID, `${MID}-ROADMAP.md`));
+    assert.equal(scope.contextFile(), join(gsd, "phases", "01-m001", "01-CONTEXT.md"));
+    assert.equal(scope.roadmapFile(), join(gsd, "phases", "01-m001", "01-ROADMAP.md"));
     assert.equal(scope.stateFile(), join(gsd, "STATE.md"));
     assert.equal(scope.dbPath(), ws.contract.projectDb);
-    assert.equal(scope.milestoneDir(), join(gsd, "milestones", MID));
+    assert.equal(scope.milestoneDir(), join(gsd, "phases", "01-m001"));
     assert.equal(scope.metaJson(), join(gsd, `${MID}-META.json`));
   });
 
@@ -143,6 +144,19 @@ describe("scopeMilestone path methods", () => {
     assert.equal(scope1.dbPath(), scope2.dbPath());
     assert.equal(scope1.milestoneDir(), scope2.milestoneDir());
     assert.equal(scope1.metaJson(), scope2.metaJson());
+  });
+
+  test("uses legacy milestone paths when legacy content exists", () => {
+    const legacyDir = join(projectDir, ".gsd", "milestones", MID);
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, `${MID}-CONTEXT.md`), "# Legacy context\n");
+
+    const ws = createWorkspace(projectDir);
+    const scope = scopeMilestone(ws, MID);
+
+    assert.equal(scope.contextFile(), join(legacyDir, `${MID}-CONTEXT.md`));
+    assert.equal(scope.roadmapFile(), join(legacyDir, `${MID}-ROADMAP.md`));
+    assert.equal(scope.milestoneDir(), legacyDir);
   });
 });
 

--- a/src/resources/extensions/gsd/workspace.ts
+++ b/src/resources/extensions/gsd/workspace.ts
@@ -1,7 +1,17 @@
 // gsd-pi + Workspace handle: single source of truth for path resolution per milestone
 
-import { join, resolve } from "node:path";
-import { type GsdPathContract, resolveGsdPathContract, normalizeRealPath } from "./paths.js";
+import { dirname, join, resolve } from "node:path";
+import {
+  buildMilestoneFileName,
+  canonicalPhaseDirName,
+  isLegacyMilestonesLayout,
+  milestonesDir,
+  type GsdPathContract,
+  resolveGsdPathContract,
+  resolveMilestoneFile,
+  resolveMilestonePath,
+  normalizeRealPath,
+} from "./paths.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 export type GsdWorkspaceMode = "project" | "worktree";
@@ -29,6 +39,29 @@ export interface MilestoneScope {
 
 function tryRealpath(p: string): string {
   return normalizeRealPath(p);
+}
+
+function isLegacyMilestoneDirectory(dir: string): boolean {
+  const parent = dirname(dir);
+  return parent.endsWith("/milestones") || parent.endsWith("\\milestones");
+}
+
+function scopeMilestoneDir(basePath: string, milestoneId: string): string {
+  return resolveMilestonePath(basePath, milestoneId) ?? join(
+    milestonesDir(basePath),
+    isLegacyMilestonesLayout(basePath) ? milestoneId : canonicalPhaseDirName(milestoneId),
+  );
+}
+
+function scopeMilestoneFile(basePath: string, milestoneId: string, suffix: string): string {
+  const existing = resolveMilestoneFile(basePath, milestoneId, suffix);
+  if (existing) return existing;
+
+  const dir = scopeMilestoneDir(basePath, milestoneId);
+  const filename = isLegacyMilestoneDirectory(dir)
+    ? `${milestoneId}-${suffix}.md`
+    : buildMilestoneFileName(milestoneId, suffix);
+  return join(dir, filename);
 }
 
 /**
@@ -73,22 +106,23 @@ export function createWorkspace(rawBasePath: string): GsdWorkspace {
  * Bind a milestoneId to a workspace, producing an immutable MilestoneScope
  * with path-returning closures for DB-authoritative project state.
  *
- * These scope paths intentionally route to contract.projectGsd. In-flight
- * markdown artifact readers outside this scope use the projection-aware
- * resolvers in paths.ts so worktree units can see worktree-local projections.
+ * DB paths route to contract.projectGsd. Milestone artifact paths resolve from
+ * the pinned project root with the layout-aware resolvers, so flat-phase and
+ * legacy projects use the same scope surface.
  */
 export function scopeMilestone(workspace: GsdWorkspace, milestoneId: string): MilestoneScope {
   const { contract } = workspace;
   const gsd = contract.projectGsd;
+  const basePath = workspace.projectRoot;
 
   const scope: MilestoneScope = Object.freeze({
     workspace,
     milestoneId,
-    contextFile: () => join(gsd, "milestones", milestoneId, `${milestoneId}-CONTEXT.md`),
-    roadmapFile: () => join(gsd, "milestones", milestoneId, `${milestoneId}-ROADMAP.md`),
+    contextFile: () => scopeMilestoneFile(basePath, milestoneId, "CONTEXT"),
+    roadmapFile: () => scopeMilestoneFile(basePath, milestoneId, "ROADMAP"),
     stateFile: () => join(gsd, "STATE.md"),
     dbPath: () => contract.projectDb,
-    milestoneDir: () => join(gsd, "milestones", milestoneId),
+    milestoneDir: () => scopeMilestoneDir(basePath, milestoneId),
     metaJson: () => join(gsd, `${milestoneId}-META.json`),
   });
 


### PR DESCRIPTION
## Summary
- Fixed flat-phase context handoff and DB-row recovery behavior, with focused scope tests passing and broader handoff tests blocked by missing dependencies/network.

## Bugs Addressed
- [x] **Flat-phase context lookup uses legacy milestone path**
- [x] **DB-unavailable handoff recovery reports success**
- [x] **Milestone insert result is ignored during recovery**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1110
- [#1110 fix: new-milestone discuss handoff fails — checkAutoStartAfterDiscuss uses legacy paths, misses flat-phase CONTEXT.md, auto-start proceeds without DB row](https://github.com/open-gsd/gsd-pi/issues/1110)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1110-fix-new-milestone-discuss-handoff-fails--1782955403`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-discuss auto-start and milestone path resolution path, which can block or mis-route planning if wrong, but behavior is heavily regression-tested and limited to GSD workflow handoff—not auth or data migration logic.
> 
> **Overview**
> Fixes **new-milestone discuss handoff** so post-discuss auto-start finds **flat-phase** `NN-CONTEXT.md` under `.gsd/phases/<NN-slug>/` instead of only legacy `.gsd/milestones/<MID>/` paths, and tightens **DB row recovery** so handoff does not report success when the database is unavailable or `insertMilestone` fails.
> 
> **Runtime changes:** `scopeMilestone` / `MilestoneScope` now resolve context, roadmap, and milestone dirs via layout-aware path helpers (flat-phase by default, legacy when content exists). Scoped `verifyExpectedArtifactForScope` uses `scope.contextFile()` / `scope.roadmapFile()`, clears the path cache before discuss/plan checks, and validates **plan-milestone** roadmaps for at least one slice via shared `countPlanMilestoneRoadmapSlices`. **R3b** recovery in `discussion-handoff` fails closed when the DB is unavailable and only treats recovery as successful when insert actually succeeds.
> 
> **Docs:** User, GitBook, Mintlify, zh-CN, `GSD-WORKFLOW.md`, and headless skill docs are updated to describe the **`.gsd/phases/`** flat layout, legacy milestone paths until migration, and related gitignore/team workflow wording.
> 
> **Tests** cover flat-phase CONTEXT acceptance, DB-unavailable handoff, missing-row insert recovery, and scoped plan-milestone verification parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4faf3c6748709faffa5a890347423055de019727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->