### PR TITLE
fix(issue): [Bug]: dispatch rule named "uat-verdict-gate (non-PASS blocks progression)" never blocks progression — the name asserts a control-flow guarantee the body does not implement

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -838,7 +838,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
-    name: "uat-verdict-gate (non-PASS blocks progression)",
+    name: "uat-verdict-gate (non-PASS observed; closeout enforces)",
     match: async ({ mid, basePath, prefs }) => {
       // Only applies when UAT dispatch is enabled
       if (!prefs?.uat_dispatch) return null;
@@ -852,9 +852,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
         const { verdict, uatType } = result;
 
         if (!isAcceptableUatVerdict(verdict, uatType)) {
-          // Do not hard-stop auto-mode on non-PASS verdicts. Allow progression
-          // so follow-up slices can remediate, while complete-milestone still
-          // enforces manual UAT PASS sign-off before closure.
+          // Observe non-PASS verdicts without hard-stopping auto-mode. Allow
+          // progression so follow-up slices can remediate, while
+          // complete-milestone still enforces manual UAT PASS sign-off before closure.
           continue;
         }
       }

--- a/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
@@ -90,6 +90,8 @@ import { clearPathCache } from "../../paths.ts";
 // Fixture Helpers
 // ═══════════════════════════════════════════════════════════════════════════
 
+const UAT_VERDICT_GATE_RULE_NAME = "uat-verdict-gate (non-PASS observed; closeout enforces)";
+
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "gsd-edge-cases-"));
 }
@@ -280,7 +282,7 @@ function buildDispatchCtx(
 
 function getUatVerdictGate(): import("../../auto-dispatch.ts").DispatchRule {
   const rule = DISPATCH_RULES.find(
-    r => r.name === "uat-verdict-gate (non-PASS blocks progression)",
+    r => r.name === UAT_VERDICT_GATE_RULE_NAME,
   );
   assert.ok(rule, "uat-verdict-gate rule should be registered");
   return rule;
@@ -867,7 +869,7 @@ describe("dispatch failure modes", () => {
     // Verify critical ordering constraints
     const summarizeIdx = ruleNames.indexOf("summarizing → complete-slice");
     const runUatIdx = ruleNames.indexOf("run-uat (post-completion)");
-    const uatGateIdx = ruleNames.indexOf("uat-verdict-gate (non-PASS blocks progression)");
+    const uatGateIdx = ruleNames.indexOf(UAT_VERDICT_GATE_RULE_NAME);
     const executeIdx = ruleNames.indexOf("executing → execute-task");
 
     // summarizing should come before execute-task


### PR DESCRIPTION
## Summary
- Renamed the misleading UAT dispatch rule/comment and verified the text change with static checks; the focused integration test was blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1131
- [#1131 [Bug]: dispatch rule named "uat-verdict-gate (non-PASS blocks progression)" never blocks progression — the name asserts a control-flow guarantee the body does not implement](https://github.com/open-gsd/gsd-pi/issues/1131)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1131-bug-dispatch-rule-named-uat-verdict-gate-1782956365`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test string updates only; no change to dispatch control flow.
> 
> **Overview**
> Fixes misleading auto-dispatch naming for **#1131**: the `uat-verdict-gate` rule was labeled as if non-PASS UAT verdicts **block** auto-mode progression, but the matcher only scans closed slices and **`continue`s** on unacceptable verdicts (always falling through with `null`).
> 
> The rule is now named **`uat-verdict-gate (non-PASS observed; closeout enforces)`**, with comments that state non-PASS is observed without a hard stop and that **`complete-milestone`** still enforces manual UAT PASS before closure. Integration tests reference the new name via a shared constant; **dispatch logic is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e740a3e0b546aaea887e3fc0cb611ec534e79e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->