### PR TITLE
fix(issue): bug: preferences validator rejects remote_questions: false with misleading error

### DIFF
--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -509,8 +509,11 @@ export function validatePreferences(preferences: GSDPreferences): {
 
   // ─── Remote Questions ───────────────────────────────────────────────
   if (preferences.remote_questions !== undefined) {
-    if (preferences.remote_questions && typeof preferences.remote_questions === "object") {
-      validated.remote_questions = preferences.remote_questions;
+    const remoteQuestions = preferences.remote_questions as unknown;
+    if (typeof remoteQuestions === "object" && remoteQuestions !== null) {
+      validated.remote_questions = remoteQuestions as GSDPreferences["remote_questions"];
+    } else if (remoteQuestions === false) {
+      // Explicit disable for a globally-configured remote questions channel.
     } else {
       errors.push("remote_questions must be an object");
     }

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -141,6 +141,26 @@ test("invalid value types produce errors and fall back to undefined", () => {
   }
 });
 
+test("remote_questions accepts object config and false disables without error", () => {
+  const disabled = validatePreferences({ remote_questions: false } as any);
+  assert.equal(disabled.errors.length, 0);
+  assert.equal(disabled.preferences.remote_questions, undefined);
+
+  const configured = validatePreferences({
+    remote_questions: { channel: "telegram", channel_id: "12345" },
+  });
+  assert.equal(configured.errors.length, 0);
+  assert.deepEqual(configured.preferences.remote_questions, {
+    channel: "telegram",
+    channel_id: "12345",
+  });
+
+  for (const value of ["telegram", 0]) {
+    const invalid = validatePreferences({ remote_questions: value } as any);
+    assert.ok(invalid.errors.includes("remote_questions must be an object"));
+  }
+});
+
 test("flat_rate_providers: accepts string array", () => {
   const { errors, preferences } = validatePreferences({
     flat_rate_providers: ["my-proxy", "private-cli"],


### PR DESCRIPTION
## Summary
- Fixed remote_questions false validation with regression coverage and verified syntax plus diff checks; full tests were blocked by missing dependencies/DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1139
- [#1139 bug: preferences validator rejects remote_questions: false with misleading error](https://github.com/open-gsd/gsd-pi/issues/1139)

## User
- @gtkpad

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1139-bug-preferences-validator-rejects-remote-1782957205`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to preference validation and tests only; no runtime behavior beyond allowing a documented disable value.
> 
> **Overview**
> **`validatePreferences`** no longer treats `remote_questions: false` as invalid. Project prefs can explicitly turn off a globally configured remote-questions channel without triggering *"remote_questions must be an object"*.
> 
> Validation now accepts a non-null **object** (unchanged pass-through) or **`false`** (no validation error; the key is omitted from sanitized output so disable wins over inherited config). Other types still fail with the same error message.
> 
> Regression tests cover disable-without-error, valid object config, and invalid scalar values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c302015acb46bf816d1c1fcf2708782ea3e95134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->