### PR TITLE
fix(issue): Flat-phase migration deadlocks on Windows/Dropbox: readdirSync count check + no EPERM retry + swallowed failure leave disk (nested) and resolvers (flat) permanently mismatched

### DIFF
--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -179,6 +179,18 @@ Replace the path with the exact global bin directory from your pnpm error messag
 - Close apps that might hold file locks (editors, shells in old worktree paths, antivirus/indexers).
 - Retry the command after a short delay.
 
+### Startup fails during flat-phase migration
+
+**Symptoms:** GSD exits during startup with a message like `flat-phase migration failed` or `flat-phase migration required but the workflow database could not be opened`.
+
+**Cause:** The project still has the legacy nested `.gsd/milestones/` layout. On startup, GSD must migrate it to the flat `.gsd/phases/` layout before path resolvers and state checks run. This migration is fail-closed: if the SQLite database cannot be opened, the backup/rename/delete step fails, or the rendered flat-phase projection cannot be verified, startup stops instead of continuing against mixed disk state.
+
+**Fix:**
+- Make sure you are starting GSD from the project root and that `.gsd/gsd.db*`, `.gsd/`, and `.gsd-backups/` are readable and writable on local disk.
+- Close editors, shells, sync tools, antivirus/indexers, or other processes that may be locking `.gsd/milestones/`, `.gsd/milestones.migrating/`, `.gsd/phases/`, or `.gsd-backups/`.
+- If the database is damaged or missing, restore the database from backup when available. If the rendered markdown is the state you intentionally want to import, use `/gsd recover --confirm` after database access is restored.
+- Start GSD again after fixing the underlying issue. The migration retries on the next startup and can resume an interrupted run from `.gsd/milestones.migrating/`; keep `.gsd-backups/migrate-*` snapshots until the project starts successfully and `/gsd doctor` passes.
+
 ### `command not found: gsd` after install
 
 **Symptoms:** `npm install -g @opengsd/gsd-pi@latest` succeeds but `gsd` isn't found.

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -157,6 +157,14 @@ Auto mode fails milestone entry with an isolation-degraded warning, often after 
 
 **Fix:** Close editors, terminals, antivirus tools, or Git clients that may be locking `.gsd/worktrees/*` paths. Merge salvageable work with `/gsd worktree merge <MID>` or remove a stale worktree with `/gsd worktree remove <MID>`, then run `/gsd doctor fix` and retry `/gsd auto`. If fallback already succeeded, work continues on `milestone/<MID>` in the project root for that milestone.
 
+### Startup fails during flat-phase migration
+
+GSD exits during startup with `flat-phase migration failed` or `flat-phase migration required but the workflow database could not be opened`.
+
+**Cause:** The project still has the legacy nested `.gsd/milestones/` layout. Startup must migrate it to flat `.gsd/phases/` before path resolvers and state checks run. If the SQLite database cannot be opened, filesystem backup/rename/delete work fails, or the rendered projection cannot be verified, GSD stops instead of continuing against mixed disk state.
+
+**Fix:** Start GSD from the project root and make sure `.gsd/gsd.db*`, `.gsd/`, and `.gsd-backups/` are readable and writable on local disk. Close editors, terminals, sync tools, antivirus/indexers, or other processes that may be locking `.gsd/milestones/`, `.gsd/milestones.migrating/`, `.gsd/phases/`, or `.gsd-backups/`. If the database is damaged or missing, restore it from backup when available; use `/gsd recover --confirm` only after database access is restored and markdown is the source you intentionally want to import. Retry by starting GSD again; interrupted migrations resume from `.gsd/milestones.migrating/`, and `.gsd-backups/migrate-*` snapshots should be kept until startup succeeds and `/gsd doctor` passes.
+
 ### `orphan_milestone_dir` doctor warning
 
 `/gsd doctor` can report `orphan_milestone_dir` when `.gsd/milestones/<MID>/` exists on disk but has no DB row, no matching `.gsd/worktrees/<MID>/` worktree, and no milestone content files. This is a disk-only stub, not stranded work, and it can skew future milestone ID generation.

--- a/mintlify-docs/guides/troubleshooting.mdx
+++ b/mintlify-docs/guides/troubleshooting.mdx
@@ -165,6 +165,14 @@ This check is not auto-fixable. `/gsd doctor fix` will not rewrite either side b
     **Fix:** Close tools using `.gsd/worktrees/*`. Merge salvageable work with `/gsd worktree merge <MID>` or remove a stale worktree with `/gsd worktree remove <MID>`, then run `/gsd doctor fix` and retry `/gsd auto`. If fallback already succeeded, work continues on `milestone/<MID>` in the project root for that milestone.
   </Accordion>
 
+  <Accordion title="Startup fails during flat-phase migration">
+    **Symptoms:** GSD exits during startup with `flat-phase migration failed` or `flat-phase migration required but the workflow database could not be opened`.
+
+    **Cause:** The project still has the legacy nested `.gsd/milestones/` layout. Startup must migrate it to flat `.gsd/phases/` before path resolvers and state checks run. If the SQLite database cannot be opened, filesystem backup/rename/delete work fails, or the rendered projection cannot be verified, GSD stops instead of continuing against mixed disk state.
+
+    **Fix:** Start GSD from the project root and make sure `.gsd/gsd.db*`, `.gsd/`, and `.gsd-backups/` are readable and writable on local disk. Close editors, terminals, sync tools, antivirus/indexers, or other processes that may be locking `.gsd/milestones/`, `.gsd/milestones.migrating/`, `.gsd/phases/`, or `.gsd-backups/`. If the database is damaged or missing, restore it from backup when available; use `/gsd recover --confirm` only after database access is restored and markdown is the source you intentionally want to import. Retry by starting GSD again; interrupted migrations resume from `.gsd/milestones.migrating/`, and `.gsd-backups/migrate-*` snapshots should be kept until startup succeeds and `/gsd doctor` passes.
+  </Accordion>
+
   <Accordion title="Worktree isolation stopped working after upgrade to v2.45+">
     **Cause:** The default `git.isolation` mode changed from `worktree` to `none` in v2.45.0.
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1020,7 +1020,7 @@ export function registerHooks(
           } else {
             safetyLogWarning(
               "bootstrap",
-              "flat-phase migration deferred: legacy .gsd/milestones/ layout detected but the workflow database could not be opened — will retry on next session",
+              "flat-phase migration required: legacy .gsd/milestones/ layout detected but the workflow database could not be opened — fix database access before starting GSD",
             );
             throw new Error(
               "flat-phase migration required but the workflow database could not be opened; fix database access before starting GSD",

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1005,8 +1005,8 @@ export function registerHooks(
     await prepareWorkflowMcpForHookContext(ctx, basePath);
 
     // Migrate legacy .gsd/milestones/ to flat-phase .gsd/phases/ when detected.
-    // Best-effort — never blocks session startup. Skipped inside auto-worktrees
-    // (migration already ran on the project root before the worktree was created).
+    // Fail closed on migration errors: resolvers assume flat-phase paths after
+    // startup, so continuing with nested disk state corrupts later checks.
     try {
       const { isInAutoWorktree } = await import("../auto-worktree.js");
       if (!isInAutoWorktree(basePath)) {
@@ -1022,9 +1022,19 @@ export function registerHooks(
               "bootstrap",
               "flat-phase migration deferred: legacy .gsd/milestones/ layout detected but the workflow database could not be opened — will retry on next session",
             );
+            throw new Error(
+              "flat-phase migration required but the workflow database could not be opened; fix database access before starting GSD",
+            );
           }
         }
       }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      safetyLogWarning("bootstrap", `flat-phase migration failed: ${message}`);
+      throw new Error(`flat-phase migration failed: ${message}`);
+    }
+
+    try {
       const projectRoot = resolveWorktreeProjectRoot(basePath);
       const { pruneStaleFlatPhaseBackups } = await import("../flat-phase-migration.js");
       const pruned = pruneStaleFlatPhaseBackups(projectRoot);
@@ -1035,7 +1045,7 @@ export function registerHooks(
         );
       }
     } catch (err) {
-      safetyLogWarning("bootstrap", `flat-phase migration: ${err instanceof Error ? err.message : String(err)}`);
+      safetyLogWarning("bootstrap", `flat-phase backup pruning: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     // Apply show_token_cost preference (#1515)

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -14,9 +14,68 @@ import { LAYOUT_SEGMENTS } from "./layout-policy.js";
 import { canonicalPhaseDirName, milestonesDir, resolveMilestonePath } from "./paths.js";
 
 const LEGACY_MIGRATING_SEGMENT = "milestones.migrating";
+const RETRYABLE_FS_ERROR_CODES = new Set(["EPERM", "EBUSY", "ENOTEMPTY"]);
+const RM_RETRY_OPTIONS = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 } as const;
+
+type FlatPhaseMigrationFsOps = {
+  cpSync: typeof cpSync;
+  renameSync: typeof renameSync;
+  rmSync: typeof rmSync;
+};
+
+let fsOps: FlatPhaseMigrationFsOps = { cpSync, renameSync, rmSync };
+
+export function _setFlatPhaseMigrationFsOpsForTest(
+  overrides: Partial<FlatPhaseMigrationFsOps>,
+): () => void {
+  const previous = fsOps;
+  fsOps = { ...fsOps, ...overrides };
+  return () => {
+    fsOps = previous;
+  };
+}
 
 function legacyMigratingPath(basePath: string): string {
   return join(basePath, ".gsd", LEGACY_MIGRATING_SEGMENT);
+}
+
+function removePathWithRetries(path: string): void {
+  fsOps.rmSync(path, RM_RETRY_OPTIONS);
+}
+
+function isRetryableFsError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === "string" && RETRYABLE_FS_ERROR_CODES.has(code);
+}
+
+function movePathWithCopyDeleteFallback(src: string, dst: string): void {
+  try {
+    fsOps.renameSync(src, dst);
+    return;
+  } catch (err) {
+    if (!isRetryableFsError(err)) throw err;
+  }
+
+  try {
+    fsOps.cpSync(src, dst, { recursive: true, force: true });
+    removePathWithRetries(src);
+  } catch (fallbackErr) {
+    if (existsSync(src) && existsSync(dst)) {
+      try {
+        removePathWithRetries(dst);
+      } catch {
+        // Leave the original error intact; the next run can pre-clean dst.
+      }
+    }
+    throw fallbackErr;
+  }
+}
+
+function expectedPhaseDirs(basePath: string): string[] {
+  return getAllMilestones().map((milestone) =>
+    resolveMilestonePath(basePath, milestone.id) ??
+      join(milestonesDir(basePath), canonicalPhaseDirName(milestone.id, milestone.title)),
+  );
 }
 
 function hasLegacyMilestoneSubdirs(dirPath: string): boolean {
@@ -34,19 +93,26 @@ function rollbackPartialMigration(
   migratingPath?: string,
 ): void {
   // Remove the partially-written phases/ dir.
-  rmSync(join(basePath, ".gsd", LAYOUT_SEGMENTS.level1), { recursive: true, force: true });
+  try {
+    removePathWithRetries(join(basePath, ".gsd", LAYOUT_SEGMENTS.level1));
+  } catch (removeErr) {
+    logWarning(
+      "migration",
+      `rollback: could not remove partial ${LAYOUT_SEGMENTS.level1}/: ${(removeErr as Error).message}`,
+    );
+  }
   // Restore milestones/ — prefer renaming the preserved migrating copy back.
   const milestonesPath = join(basePath, ".gsd", "milestones");
   try {
     if (migratingPath && existsSync(migratingPath) && !existsSync(milestonesPath)) {
-      renameSync(migratingPath, milestonesPath);
+      movePathWithCopyDeleteFallback(migratingPath, milestonesPath);
       return;
     }
     if (existsSync(backupDir)) {
       cpSync(backupDir, milestonesPath, { recursive: true });
     }
     if (migratingPath && existsSync(migratingPath)) {
-      rmSync(migratingPath, { recursive: true, force: true });
+      removePathWithRetries(migratingPath);
     }
   } catch (restoreErr) {
     logWarning(
@@ -162,18 +228,29 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       throw err;
     }
 
+    if (existsSync(migratingPath)) {
+      removePathWithRetries(migratingPath);
+    }
+
     // 3. Rename legacy tree aside before rendering so path resolvers target
     // phases/ instead of writing back into the nested milestones/ layout.
     // Keep the full tree on disk until render+verify succeed (unlike rmSync).
     try {
-      renameSync(milestonesPath, migratingPath);
+      movePathWithCopyDeleteFallback(milestonesPath, migratingPath);
     } catch (err) {
       logWarning("migration", `failed to rename legacy milestones/ before render: ${(err as Error).message}`);
       throw err;
     }
-  } else {
-    // Interrupted run: clear any partial phases/ projection before retrying.
-    rmSync(phasesPath, { recursive: true, force: true });
+  }
+
+  // Clear any stale or partially-rendered flat projection before this run
+  // writes. Verification below checks the current DB render, not leftovers.
+  try {
+    removePathWithRetries(phasesPath);
+  } catch (err) {
+    logWarning("migration", `failed to clear stale phases/ before render: ${(err as Error).message}`);
+    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    throw err;
   }
 
   // 4. Render flat-phase from DB
@@ -211,22 +288,14 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
   }
 
   const db = countDbHierarchy();
-  let renderedDirCount = 0;
-  try {
-    // /^\d+-/ matches any numeric prefix (01-, 10-, 100-) so M100+ milestones
-    // whose dirs start with "100-slug" are counted correctly.
-    renderedDirCount = readdirSync(phasesPath, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && /^\d+-/.test(entry.name)).length;
-  } catch {
-    // phases/ doesn't exist or is unreadable — same as zero dirs
-  }
-  if (db.milestones > 0 && renderedDirCount !== db.milestones) {
+  const missingPhaseDirs = expectedPhaseDirs(basePath).filter((phaseDir) => !existsSync(phaseDir));
+  if (db.milestones > 0 && missingPhaseDirs.length > 0) {
     logWarning(
       "migration",
-      `phases/ dir count mismatch: expected ${db.milestones}, found ${renderedDirCount}`,
+      `flat-phase migration missing ${missingPhaseDirs.length} expected phase dir(s): ${missingPhaseDirs.join(", ")}`,
     );
     rollbackPartialMigration(basePath, backupDir, migratingPath);
-    throw new Error("flat-phase migration verification failed: phases dir milestone count mismatch");
+    throw new Error("flat-phase migration verification failed: missing rendered phase directories");
   }
   if (db.slices > 0 && renderResult.rendered === 0) {
     logWarning(
@@ -239,7 +308,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
 
   // 6. Verified — remove the renamed legacy tree (backup already on disk).
   try {
-    rmSync(migratingPath, { recursive: true, force: true });
+    removePathWithRetries(migratingPath);
   } catch (err) {
     logWarning(
       "migration",

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -11,7 +11,12 @@ import { migrateFromMarkdown } from "./md-importer.js";
 import { countDbHierarchy } from "./migration-auto-check.js";
 import { logWarning } from "./workflow-logger.js";
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
-import { canonicalPhaseDirName, milestonesDir, resolveMilestonePath } from "./paths.js";
+import {
+  canonicalPhaseDirName,
+  dirIsContentBearingLegacyMilestone,
+  milestonesDir,
+  resolveMilestonePath,
+} from "./paths.js";
 
 const LEGACY_MIGRATING_SEGMENT = "milestones.migrating";
 const RETRYABLE_FS_ERROR_CODES = new Set(["EPERM", "EBUSY", "ENOTEMPTY"]);
@@ -81,7 +86,9 @@ function expectedPhaseDirs(basePath: string): string[] {
 function hasLegacyMilestoneSubdirs(dirPath: string): boolean {
   if (!existsSync(dirPath)) return false;
   try {
-    return readdirSync(dirPath).some(e => statSync(join(dirPath, e)).isDirectory());
+    return readdirSync(dirPath).some(
+      (e) => statSync(join(dirPath, e)).isDirectory() && dirIsContentBearingLegacyMilestone(join(dirPath, e)),
+    );
   } catch {
     return false;
   }

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -45,7 +45,7 @@ function legacyMigratingPath(basePath: string): string {
 }
 
 function removePathWithRetries(path: string): void {
-  fsOps.rmSync(path, RM_RETRY_OPTIONS);
+  fsOps.rmSync(path, { recursive: true, force: true, maxRetries: RM_RETRY_OPTIONS.maxRetries, retryDelay: RM_RETRY_OPTIONS.retryDelay });
 }
 
 function isRetryableFsError(err: unknown): boolean {

--- a/src/resources/extensions/gsd/migrate-external.ts
+++ b/src/resources/extensions/gsd/migrate-external.ts
@@ -237,7 +237,7 @@ function isLocalGsdExternalStateJunction(basePath: string, localGsd: string): bo
  * Recover from a failed migration (`.gsd.migrating` exists).
  * Moves `.gsd.migrating` back to `.gsd` if `.gsd` doesn't exist, or removes an
  * orphaned staging directory when `.gsd` is already a verified external state
- * junction with intact current state.
+ * junction, or an intact real directory, with intact current state.
  */
 export function recoverFailedMigration(basePath: string): boolean {
   const localGsd = join(basePath, ".gsd");
@@ -245,8 +245,15 @@ export function recoverFailedMigration(basePath: string): boolean {
 
   if (!existsSync(migratingPath)) return false;
   if (existsSync(localGsd)) {
-    if (!isLocalGsdExternalStateJunction(basePath, localGsd)) return false;
     if (!isCurrentGsdStateIntactForMigratingCleanup(basePath)) return false;
+    if (!isLocalGsdExternalStateJunction(basePath, localGsd)) {
+      try {
+        const stat = lstatSync(localGsd);
+        if (!stat.isDirectory()) return false;
+      } catch {
+        return false;
+      }
+    }
     try {
       rmSync(migratingPath, { recursive: true, force: true });
       return true;

--- a/src/resources/extensions/gsd/tests/auto-migrating-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-migrating-recovery.test.ts
@@ -49,6 +49,24 @@ test("recoverFailedMigration returns false when both .gsd and .gsd.migrating exi
   assert.ok(existsSync(join(base, ".gsd.migrating")), ".gsd.migrating must still exist");
 });
 
+test("recoverFailedMigration removes orphan when .gsd is a real intact directory", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-migrating-real-orphan-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const localGsd = join(base, ".gsd");
+  mkdirSync(join(localGsd, "phases"), { recursive: true });
+  mkdirSync(join(localGsd, "activity"), { recursive: true });
+  writeFileSync(join(localGsd, "STATE.md"), "# State\n", "utf-8");
+  writeFileSync(join(localGsd, "gsd.db"), "not empty\n", "utf-8");
+  mkdirSync(join(base, ".gsd.migrating"), { recursive: true });
+
+  const recovered = recoverFailedMigration(base);
+
+  assert.equal(recovered, true, "expected orphan cleanup to succeed");
+  assert.ok(existsSync(localGsd), ".gsd real directory must remain");
+  assert.ok(!existsSync(join(base, ".gsd.migrating")), ".gsd.migrating orphan must be removed");
+});
+
 test("recoverFailedMigration removes orphan when .gsd is an intact external-state junction", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-migrating-orphan-"));
   const stateDir = mkdtempSync(join(tmpdir(), "gsd-migrating-state-"));

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -2,12 +2,13 @@
 // File Purpose: Tests the one-time migration from nested to flat-phase layout.
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync, utimesSync } from "node:fs";
+import { mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
 import {
+  _setFlatPhaseMigrationFsOpsForTest,
   migrateToFlatPhase,
   needsFlatPhaseMigration,
   pruneStaleFlatPhaseBackups,
@@ -62,6 +63,42 @@ test("migrateToFlatPhase moves content from milestones/ to phases/", async () =>
 
   assert.ok(existsSync(join(base, ".gsd", "phases")), "phases/ should exist");
   assert.ok(!existsSync(join(base, ".gsd", "milestones")), "milestones/ should be removed");
+});
+
+test("migrateToFlatPhase ignores and removes stale phase dirs from prior aborted runs", async () => {
+  const base = makeTmp();
+  const stalePhaseDir = join(base, ".gsd", "phases", "99-stale-aborted-run");
+  mkdirSync(stalePhaseDir, { recursive: true });
+
+  await migrateToFlatPhase(base);
+
+  assert.ok(existsSync(join(base, ".gsd", "phases", "01-foundation")), "current DB phase should render");
+  assert.equal(existsSync(stalePhaseDir), false, "stale pre-existing phase dir should be removed");
+});
+
+test("migrateToFlatPhase falls back to copy-delete when legacy rename is blocked", async (t) => {
+  const base = makeTmp();
+  const milestonesPath = join(base, ".gsd", "milestones");
+  const migratingPath = join(base, ".gsd", "milestones.migrating");
+  let blockedRenameAttempts = 0;
+
+  const restoreFsOps = _setFlatPhaseMigrationFsOpsForTest({
+    renameSync(src, dst) {
+      if (src === milestonesPath && dst === migratingPath) {
+        blockedRenameAttempts++;
+        throw Object.assign(new Error("simulated busy handle"), { code: "EPERM" });
+      }
+      return renameSync(src, dst);
+    },
+  });
+  t.after(restoreFsOps);
+
+  await migrateToFlatPhase(base);
+
+  assert.equal(blockedRenameAttempts, 1, "test should exercise the rename fallback path");
+  assert.ok(existsSync(join(base, ".gsd", "phases", "01-foundation")), "flat phase should render");
+  assert.equal(existsSync(milestonesPath), false, "legacy milestones dir should be removed");
+  assert.equal(existsSync(migratingPath), false, "staging dir should be removed after success");
 });
 
 test("migrateToFlatPhase creates a backup", async () => {

--- a/src/resources/extensions/gsd/tests/register-hooks-flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-flat-phase-migration.test.ts
@@ -56,6 +56,7 @@ test("session_start rejects when required flat-phase migration fails", async (t)
   });
 
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001: Foundation\n", "utf-8");
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Foundation", status: "active" });
   closeDatabase();

--- a/src/resources/extensions/gsd/tests/register-hooks-flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-flat-phase-migration.test.ts
@@ -1,0 +1,72 @@
+// Project/App: gsd-pi
+// File Purpose: Verifies session bootstrap fails closed when flat-phase migration cannot complete.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+
+type HookHandler = (event: unknown, ctx: any) => Promise<void> | void;
+
+function createSessionStartHandler(): HookHandler {
+  const handlers = new Map<string, HookHandler>();
+  const pi = {
+    on(event: string, handler: HookHandler) {
+      handlers.set(event, handler);
+    },
+  };
+
+  registerHooks(pi as any, []);
+  const sessionStart = handlers.get("session_start");
+  assert.ok(sessionStart, "session_start handler should be registered");
+  return sessionStart;
+}
+
+function makeContext(basePath: string) {
+  return {
+    cwd: basePath,
+    hasUI: false,
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWidget: () => {},
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+    },
+    model: null,
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+    },
+    sessionManager: {
+      getSessionId: () => null,
+    },
+    setCompactionThresholdOverride: () => {},
+  };
+}
+
+test("session_start rejects when required flat-phase migration fails", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-bootstrap-flat-migration-"));
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  closeDatabase();
+
+  writeFileSync(join(base, ".gsd-backups"), "not a directory\n", "utf-8");
+
+  const sessionStart = createSessionStartHandler();
+
+  await assert.rejects(
+    () => Promise.resolve(sessionStart({}, makeContext(base))),
+    /flat-phase migration/,
+  );
+  assert.ok(existsSync(join(base, ".gsd", "milestones", "M001")), "legacy layout should remain for recovery");
+});


### PR DESCRIPTION
## Summary
- Fixed flat-phase migration stale verification, EPERM recovery, fail-closed bootstrap behavior, and real-directory orphan cleanup with syntax and diff checks passing.

## Bugs Addressed
- [x] **Flat-phase migration verifies stale folder contents**
- [x] **Flat-phase migration lacks EPERM/EBUSY recovery**
- [x] **Bootstrap hides failed migration and runs mismatched layout**
- [x] **Failed migration recovery leaves orphaned .gsd.migrating**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1144
- [#1144 Flat-phase migration deadlocks on Windows/Dropbox: readdirSync count check + no EPERM retry + swallowed failure leave disk (nested) and resolvers (flat) permanently mismatched](https://github.com/open-gsd/gsd-pi/issues/1144)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1144-flat-phase-migration-deadlocks-on-window-1782959648`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup and on-disk layout migration behavior; failures now block sessions, but rollback, backups, and targeted tests reduce the chance of silent corruption.
> 
> **Overview**
> Hardens the legacy **`.gsd/milestones/` → `.gsd/phases/`** startup migration so GSD no longer continues with flat-path resolvers while disk is still nested or half-migrated.
> 
> **Migration engine (`flat-phase-migration.ts`):** Adds **EPERM/EBUSY/ENOTEMPTY** handling (retried deletes, rename with **copy+delete** fallback), always **wipes stale `phases/`** before rendering, and verifies success by checking **each DB milestone’s expected phase directory** instead of counting `phases/` entries (which could include leftovers from aborted runs). Legacy detection now requires **content-bearing** milestone subdirs via `dirIsContentBearingLegacyMilestone`.
> 
> **Bootstrap (`register-hooks.ts`):** Flat-phase migration is **fail-closed**—unopenable DB or any migration error **aborts `session_start`** with `flat-phase migration failed` / database messages instead of logging and deferring. Backup pruning failures are isolated so they do not mask migration errors.
> 
> **External migrate recovery (`migrate-external.ts`):** `recoverFailedMigration` can drop orphan **`.gsd.migrating`** when **`.gsd`** is an intact **real directory**, not only an external-state junction.
> 
> **Docs:** User, GitBook, and Mintlify troubleshooting add **“Startup fails during flat-phase migration”** with causes and recovery steps. **Tests** cover EPERM fallback, stale phase cleanup, bootstrap rejection, and real-dir orphan recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc27036e07ae4f050a26f1976a44b667d52710f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->