### PR TITLE
fix(git): start workflow and quick-task branches from main, not HEAD

### DIFF
--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -23,7 +23,7 @@ import {
 } from "./workflow-templates.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
-import { createGitService, runGit } from "./git-service.js";
+import { createGitService, runGit, taskBranchArgs } from "./git-service.js";
 import { isAutoActive, isAutoPaused } from "./auto.js";
 import { getErrorMessage } from "./error-utils.js";
 import { resolvePlugin, type WorkflowPlugin } from "./workflow-plugins.js";
@@ -464,7 +464,7 @@ export async function handleStart(
         try {
           git.autoCommit("workflow-template", templateId, []);
         } catch { /* nothing to commit */ }
-        runGit(basePath, ["checkout", "-b", branchName]);
+        runGit(basePath, taskBranchArgs(basePath, branchName, current));
         branchCreated = true;
       }
     } catch (err) {
@@ -636,7 +636,7 @@ export function dispatchMarkdownPhasePlugin(
       const current = git.getCurrentBranch();
       if (current !== branchName) {
         try { git.autoCommit("workflow-template", templateId, []); } catch { /* nothing to commit */ }
-        runGit(basePath, ["checkout", "-b", branchName]);
+        runGit(basePath, taskBranchArgs(basePath, branchName, current));
         branchCreated = true;
       }
     } catch (err) {

--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -464,7 +464,7 @@ export async function handleStart(
         try {
           git.autoCommit("workflow-template", templateId, []);
         } catch { /* nothing to commit */ }
-        runGit(basePath, taskBranchArgs(basePath, branchName, current));
+        runGit(basePath, taskBranchArgs(basePath, branchName, current, git.getMainBranch()));
         branchCreated = true;
       }
     } catch (err) {
@@ -636,7 +636,7 @@ export function dispatchMarkdownPhasePlugin(
       const current = git.getCurrentBranch();
       if (current !== branchName) {
         try { git.autoCommit("workflow-template", templateId, []); } catch { /* nothing to commit */ }
-        runGit(basePath, taskBranchArgs(basePath, branchName, current));
+        runGit(basePath, taskBranchArgs(basePath, branchName, current, git.getMainBranch()));
         branchCreated = true;
       }
     } catch (err) {

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -704,6 +704,25 @@ export function runGit(basePath: string, args: string[], options: { allowFailure
   }
 }
 
+/**
+ * Arguments for creating a task/workflow branch. The new branch starts from the
+ * repo's main branch, not from whatever branch happens to be checked out —
+ * branching from HEAD silently stacks consecutive workflow branches on top of
+ * each other, so every new gsd/* branch (and its eventual PR) drags along the
+ * previous workflow's commits. Falls back to branching from HEAD when no main
+ * branch can be detected or the current branch is already the main branch.
+ */
+export function taskBranchArgs(basePath: string, branchName: string, currentBranch: string): string[] {
+  const args = ["checkout", "-b", branchName];
+  try {
+    const main = nativeDetectMainBranch(basePath);
+    if (main && main !== currentBranch) args.push(main);
+  } catch {
+    // Detection failed — keep legacy branch-from-HEAD behavior.
+  }
+  return args;
+}
+
 // ─── Commit Type Inference ─────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -705,21 +705,55 @@ export function runGit(basePath: string, args: string[], options: { allowFailure
 }
 
 /**
- * Arguments for creating a task/workflow branch. The new branch starts from the
- * repo's main branch, not from whatever branch happens to be checked out —
- * branching from HEAD silently stacks consecutive workflow branches on top of
- * each other, so every new gsd/* branch (and its eventual PR) drags along the
- * previous workflow's commits. Falls back to branching from HEAD when no main
- * branch can be detected or the current branch is already the main branch.
+ * Arguments for creating a task/workflow branch.
+ *
+ * When the current branch is a leftover GSD task branch (workflow template,
+ * quick task, or slice), the new branch starts from `baseBranch` — the
+ * caller's resolved integration branch, normally `GitServiceImpl.getMainBranch()`
+ * so `main_branch` preference, milestone integration branch, and worktree base
+ * all take priority over repo-default detection. Branching from HEAD there
+ * silently stacks consecutive workflow branches on top of each other, so every
+ * new gsd/* branch (and its eventual PR) drags along the previous workflow's
+ * commits.
+ *
+ * On any other branch (a user's feature branch, a worktree base, the main
+ * branch itself) the legacy branch-from-HEAD behavior is kept: basing new work
+ * on the branch the user chose to stand on is intentional there.
+ *
+ * Falls back to branch-from-HEAD, with a logged warning, when the base branch
+ * has no local ref or the working tree is still dirty (a start point that
+ * changes the tree would abort the checkout or strand in-flight changes).
+ * The base is the local ref — deliberately no fetch, so branch creation stays
+ * offline-safe even if the local base is behind its remote.
  */
-export function taskBranchArgs(basePath: string, branchName: string, currentBranch: string): string[] {
+export function taskBranchArgs(basePath: string, branchName: string, currentBranch: string, baseBranch: string): string[] {
   const args = ["checkout", "-b", branchName];
+  const onTaskBranch =
+    WORKFLOW_BRANCH_RE.test(currentBranch) ||
+    QUICK_BRANCH_RE.test(currentBranch) ||
+    SLICE_BRANCH_RE.test(currentBranch);
+  if (!onTaskBranch || !baseBranch || baseBranch === currentBranch) return args;
   try {
-    const main = nativeDetectMainBranch(basePath);
-    if (main && main !== currentBranch) args.push(main);
+    if (!nativeBranchExists(basePath, baseBranch)) {
+      logWarning(
+        "engine",
+        `taskBranchArgs: base branch "${baseBranch}" has no local ref — branching ${branchName} from HEAD (${currentBranch})`,
+        { file: "git-service.ts" },
+      );
+      return args;
+    }
+    if (nativeHasChanges(basePath)) {
+      logWarning(
+        "engine",
+        `taskBranchArgs: working tree still dirty after auto-commit — branching ${branchName} from HEAD (${currentBranch}) to preserve in-flight changes`,
+        { file: "git-service.ts" },
+      );
+      return args;
+    }
   } catch {
-    // Detection failed — keep legacy branch-from-HEAD behavior.
+    return args;
   }
+  args.push(baseBranch);
   return args;
 }
 

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -15,7 +15,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { QUICK_BRANCH_RE } from "./branch-patterns.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
-import { GitServiceImpl, runGit } from "./git-service.js";
+import { GitServiceImpl, runGit, taskBranchArgs } from "./git-service.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { nativeBranchExists, nativeDetectMainBranch, nativeDiffNumstat } from "./native-git-bridge.js";
 import { nativeHasStagedChanges } from "./native-git-bridge.js";
@@ -381,7 +381,7 @@ export async function handleQuick(
           }
         } catch { /* nothing to commit — fine */ }
 
-        runGit(basePath, ["checkout", "-b", branchName]);
+        runGit(basePath, taskBranchArgs(basePath, branchName, current));
         branchCreated = true;
       }
     } catch (err) {

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -365,6 +365,7 @@ export async function handleQuick(
   const git = new GitServiceImpl(basePath, gitPrefs);
   const branchName = `gsd/quick/${taskNum}-${slug}`;
   let originalBranch = git.getCurrentBranch();
+  let returnBranch = originalBranch;
 
   const { getIsolationMode } = await import("./preferences.js");
   const usesBranch = getIsolationMode() !== "none" && isGitOpsEnabled();
@@ -381,7 +382,14 @@ export async function handleQuick(
           }
         } catch { /* nothing to commit — fine */ }
 
-        runGit(basePath, taskBranchArgs(basePath, branchName, current));
+        const branchArgs = taskBranchArgs(basePath, branchName, current, git.getMainBranch());
+        const startPoint = branchArgs[3];
+        // When the quick branch is redirected off a stale task branch, the
+        // squash-merge on closeout must return to the same base — merging a
+        // base-branch-rooted quick branch back into the stale task branch
+        // would drag the base's newer history into it.
+        if (startPoint) returnBranch = startPoint;
+        runGit(basePath, branchArgs);
         branchCreated = true;
       }
     } catch (err) {
@@ -395,7 +403,7 @@ export async function handleQuick(
   if (actualBranch === branchName && originalBranch !== branchName) {
     persistPendingReturn({
       basePath,
-      originalBranch,
+      originalBranch: returnBranch,
       quickBranch: branchName,
       taskNum,
       slug,

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -15,6 +15,7 @@ import {
   RUNTIME_EXCLUSION_PATHS,
   VALID_BRANCH_NAME,
   runGit,
+  taskBranchArgs,
   readIntegrationBranch,
   resolveMilestoneIntegrationBranch,
   writeIntegrationBranch,
@@ -1118,6 +1119,40 @@ process.exit(result.status ?? 0);
 
     rmSync(repo, { recursive: true, force: true });
   }
+
+  // ─── taskBranchArgs ───────────────────────────────────────────────────
+
+  test('taskBranchArgs starts new workflow branches from main, not from HEAD', () => {
+    const repo = initBranchTestRepo();
+
+    assert.deepStrictEqual(
+      taskBranchArgs(repo, "gsd/spike/first", "main"),
+      ["checkout", "-b", "gsd/spike/first"],
+      "branching while on main needs no explicit start point",
+    );
+
+    // Simulate a finished workflow left checked out with its own commit.
+    run("git checkout -b gsd/spike/first", repo);
+    createFile(repo, "first.txt", "first workflow output");
+    runGit(repo, ["add", "-A"]);
+    runGit(repo, ["commit", "-m", "first workflow work"]);
+
+    const args = taskBranchArgs(repo, "gsd/spike/second", "gsd/spike/first");
+    assert.deepStrictEqual(
+      args,
+      ["checkout", "-b", "gsd/spike/second", "main"],
+      "next workflow branch starts from main so workflows do not stack",
+    );
+
+    runGit(repo, args);
+    assert.deepStrictEqual(
+      run("git rev-parse HEAD", repo),
+      run("git rev-parse main", repo),
+      "second workflow branch points at main, without the first workflow's commit",
+    );
+
+    rmSync(repo, { recursive: true, force: true });
+  });
 
   // ═══════════════════════════════════════════════════════════════════════
   // S05: Enhanced features — snapshots, pre-merge checks

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1122,13 +1122,13 @@ process.exit(result.status ?? 0);
 
   // ─── taskBranchArgs ───────────────────────────────────────────────────
 
-  test('taskBranchArgs starts new workflow branches from main, not from HEAD', () => {
+  test('taskBranchArgs starts new workflow branches from the base branch, not from HEAD', () => {
     const repo = initBranchTestRepo();
 
     assert.deepStrictEqual(
-      taskBranchArgs(repo, "gsd/spike/first", "main"),
+      taskBranchArgs(repo, "gsd/spike/first", "main", "main"),
       ["checkout", "-b", "gsd/spike/first"],
-      "branching while on main needs no explicit start point",
+      "branching while on the base branch itself needs no explicit start point",
     );
 
     // Simulate a finished workflow left checked out with its own commit.
@@ -1136,19 +1136,60 @@ process.exit(result.status ?? 0);
     createFile(repo, "first.txt", "first workflow output");
     runGit(repo, ["add", "-A"]);
     runGit(repo, ["commit", "-m", "first workflow work"]);
+    _resetHasChangesCache();
 
-    const args = taskBranchArgs(repo, "gsd/spike/second", "gsd/spike/first");
+    const args = taskBranchArgs(repo, "gsd/spike/second", "gsd/spike/first", "main");
     assert.deepStrictEqual(
       args,
       ["checkout", "-b", "gsd/spike/second", "main"],
-      "next workflow branch starts from main so workflows do not stack",
+      "next workflow branch starts from the base so workflows do not stack",
     );
 
     runGit(repo, args);
     assert.deepStrictEqual(
       run("git rev-parse HEAD", repo),
       run("git rev-parse main", repo),
-      "second workflow branch points at main, without the first workflow's commit",
+      "second workflow branch points at the base, without the first workflow's commit",
+    );
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('taskBranchArgs keeps branch-from-HEAD on user branches and unsafe states', () => {
+    const repo = initBranchTestRepo();
+
+    // Manual feature branch: the user chose to stand here — new workflow
+    // branches base on it, never silently jump to main.
+    run("git checkout -b feature/login", repo);
+    createFile(repo, "feature.txt", "feature work");
+    runGit(repo, ["add", "-A"]);
+    runGit(repo, ["commit", "-m", "feature work"]);
+    _resetHasChangesCache();
+    assert.deepStrictEqual(
+      taskBranchArgs(repo, "gsd/spike/from-feature", "feature/login", "main"),
+      ["checkout", "-b", "gsd/spike/from-feature"],
+      "a manual feature branch is a deliberate base — no redirect to main",
+    );
+
+    // Base branch without a local ref (e.g. origin/HEAD names a branch that
+    // was never checked out locally): fall back to HEAD instead of failing.
+    run("git checkout -b gsd/spike/stale", repo);
+    _resetHasChangesCache();
+    assert.deepStrictEqual(
+      taskBranchArgs(repo, "gsd/spike/next", "gsd/spike/stale", "no-such-branch"),
+      ["checkout", "-b", "gsd/spike/next"],
+      "missing local base ref falls back to branch-from-HEAD",
+    );
+
+    // Dirty tree on a task branch: a tree-changing start point would abort
+    // the checkout or strand the changes — fall back to HEAD.
+    createFile(repo, "dirty.txt", "uncommitted");
+    runGit(repo, ["add", "-A"]);
+    _resetHasChangesCache();
+    assert.deepStrictEqual(
+      taskBranchArgs(repo, "gsd/spike/next", "gsd/spike/stale", "main"),
+      ["checkout", "-b", "gsd/spike/next"],
+      "dirty working tree falls back to branch-from-HEAD",
     );
 
     rmSync(repo, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Workflow templates (`commands-workflow-templates.ts`, both the legacy and plugin paths) and quick tasks (`quick.ts`) create their working branch with a bare `git checkout -b <branch>`, which branches from whatever is currently checked out.

When a workflow finishes, GSD leaves its `gsd/<template>/<slug>` branch checked out. The next workflow therefore branches on top of it, and the one after that on top of both. In practice this silently produces a stacked chain: every new `gsd/*` branch — and any PR opened from it — drags along all commits from every previous workflow. We hit this in a real repo where a docs-only workflow PR ended up containing 50 files from three earlier workflows.

## Fix

New shared helper `taskBranchArgs()` in `git-service.ts`, used at all three call sites. Design constraints, in order:

1. **Redirection is gated to leftover GSD task branches.** The start-point override only fires when the current branch matches `WORKFLOW_BRANCH_RE` / `QUICK_BRANCH_RE` / `SLICE_BRANCH_RE` — i.e. a branch GSD itself created and abandoned. On a user's own branch (feature branch, worktree base, the main branch itself) the legacy branch-from-HEAD behavior is unchanged: basing new work on the branch the user chose to stand on is intentional there.
2. **The base comes from `GitServiceImpl.getMainBranch()`**, passed in by the callers, so the explicit `main_branch` preference, milestone integration branch, and worktree base branch all outrank repo-default detection. The helper never detects on its own.
3. **No new failure paths.** A base branch with no local ref (e.g. `origin/HEAD` naming a branch never checked out locally) and a tree still dirty after the pre-switch auto-commit both fall back to branch-from-HEAD with a logged warning — branch creation cannot fail anywhere it previously could not.
4. **Quick tasks stay coherent with their closeout.** A redirected quick branch records the base as its squash-merge return target, so main-rooted quick work is not merged back into the stale task branch it started on.

The pre-switch `autoCommit` snapshot is untouched — dirty state is still committed to the branch it was made on before switching away. The base is the local ref, deliberately without a fetch, so branch creation stays offline-safe.

## Tests

Added to `tests/integration/git-service.test.ts`:
- anti-stacking: a second workflow branch created after a finished one points at the base, with none of the first workflow's commits;
- manual feature branch: no redirect;
- base branch with no local ref: falls back to branch-from-HEAD;
- dirty working tree on a task branch: falls back to branch-from-HEAD.

```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/git-service.test.ts
```

75 pass / 2 fail — the 2 failures (autoCommit pre-commit-retry tests) fail identically on an unmodified checkout in my environment and are unrelated to this change.