### PR TITLE
fix(issue): [Bug]: Context-fill counter reads a short claude-code turn as 853k–2.9M tokens (up to 230% of a 1M window) and triggers a compaction that then finds no history to summarize

### DIFF
--- a/packages/gsd-agent-core/src/compaction/compaction.test.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.test.ts
@@ -197,13 +197,26 @@ describe("chunkMessages", () => {
 });
 
 describe("calculateContextTokens", () => {
-	it("uses prompt-relevant usage only (input + cacheRead + cacheWrite)", () => {
+	it("uses provider-authoritative totalTokens when present", () => {
 		const usage = {
 			input: 65,
 			output: 39_846,
 			cacheRead: 2_945_563,
 			cacheWrite: 243_452,
-			totalTokens: 3_228_926,
+			totalTokens: 283_363,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		assert.equal(calculateContextTokens(usage), 283_363);
+	});
+
+	it("falls back to component context tokens when totalTokens is not available", () => {
+		const usage = {
+			input: 65,
+			output: 39_846,
+			cacheRead: 2_945_563,
+			cacheWrite: 243_452,
+			totalTokens: 0,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 

--- a/packages/gsd-agent-core/src/compaction/compaction.test.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.test.ts
@@ -197,7 +197,12 @@ describe("chunkMessages", () => {
 });
 
 describe("calculateContextTokens", () => {
-	it("uses provider-authoritative totalTokens when present", () => {
+	it("excludes cumulative output for claude-code totalTokens (de-cumulated live context)", () => {
+		// claude-code adapter reports totalTokens = input + output + cacheWrite
+		// (65 + 39_846 + 243_452), deliberately excluding the turn-cumulative
+		// cacheRead. Subtracting output yields input + cacheWrite = 243_517, the
+		// de-cumulated live-context proxy — not the inflated 283_363 nor the
+		// cumulative component sum.
 		const usage = {
 			input: 65,
 			output: 39_846,
@@ -207,7 +212,23 @@ describe("calculateContextTokens", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		assert.equal(calculateContextTokens(usage), 283_363);
+		assert.equal(calculateContextTokens(usage), 243_517);
+	});
+
+	it("subtracts output for direct-API totalTokens (behavior-preserving vs. the component sum)", () => {
+		// Direct-API providers report a per-request totalTokens =
+		// input + output + cacheRead + cacheWrite (component-consistent), so
+		// totalTokens - output === input + cacheRead + cacheWrite exactly.
+		const usage = {
+			input: 65,
+			output: 39_846,
+			cacheRead: 2_945_563,
+			cacheWrite: 243_452,
+			totalTokens: 3_228_926,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		assert.equal(calculateContextTokens(usage), 3_189_080);
 	});
 
 	it("falls back to component context tokens when totalTokens is not available", () => {

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -131,10 +131,11 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 // ============================================================================
 
 /**
- * Calculate prompt-side context tokens from usage.
- * Completion/output tokens are not part of the reusable conversation context.
+ * Calculate context tokens from usage.
+ * Providers can normalize cumulative SDK usage into totalTokens.
  */
 export function calculateContextTokens(usage: Usage): number {
+	if (usage.totalTokens > 0) return usage.totalTokens;
 	return usage.input + usage.cacheRead + usage.cacheWrite;
 }
 

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -131,11 +131,23 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 // ============================================================================
 
 /**
- * Calculate context tokens from usage.
- * Providers can normalize cumulative SDK usage into totalTokens.
+ * Calculate prompt-side context tokens from usage.
+ *
+ * Providers can normalize cumulative SDK usage into `totalTokens`, so prefer it
+ * when present. Completion/output tokens are not part of the reusable
+ * conversation context, so they are excluded — `totalTokens` includes them
+ * (direct-API providers report `input + output + cacheRead + cacheWrite`; the
+ * claude-code adapter reports `input + output + cacheWrite`), hence the
+ * subtraction. When `totalTokens` is unavailable, fall back to the prompt-side
+ * component sum.
+ *
+ * - Direct-API: `totalTokens - output === input + cacheRead + cacheWrite`
+ *   (behavior-preserving, token-for-token, vs. the fallback).
+ * - claude-code: `totalTokens - output === input + cacheWrite`, the
+ *   de-cumulated live-context proxy (the cumulative `cacheRead` is excluded).
  */
 export function calculateContextTokens(usage: Usage): number {
-	if (usage.totalTokens > 0) return usage.totalTokens;
+	if (usage.totalTokens > 0) return Math.max(0, usage.totalTokens - usage.output);
 	return usage.input + usage.cacheRead + usage.cacheWrite;
 }
 


### PR DESCRIPTION
## Summary
- Corrected `calculateContextTokens` to use provider `totalTokens` **minus completion/output tokens** for prompt-side context, with a component-sum fallback when `totalTokens` is unavailable. Output is excluded because it is not part of the reusable conversation context: this keeps direct-API accounting token-for-token identical to the prior component sum (`totalTokens - output === input + cacheRead + cacheWrite`) and yields the de-cumulated live-context value (`input + cacheWrite`) for claude-code, whose end-of-turn usage is cumulative. Returning raw `totalTokens` had over-counted context on every provider and regressed the direct-API path.
- Added regression coverage for the claude-code shape (totalTokens excludes cumulative cacheRead), the direct-API behavior-preserving case, and the `totalTokens === 0` fallback.

```ts
export function calculateContextTokens(usage: Usage): number {
	if (usage.totalTokens > 0) return Math.max(0, usage.totalTokens - usage.output);
	return usage.input + usage.cacheRead + usage.cacheWrite;
}
```

## Verification
- Verified the token arithmetic for all three cases (claude-code de-cumulated = 243,517; direct-API = 3,189,080; fallback = 3,189,080) plus zero/guard edge cases. The full package test suite relies on CI (local run blocked by offline registry / missing dependencies).

## Related Issue
- Closes #1149
- [#1149 [Bug]: Context-fill counter reads a short claude-code turn as 853k–2.9M tokens (up to 230% of a 1M window) and triggers a compaction that then finds no history to summarize](https://github.com/open-gsd/gsd-pi/issues/1149)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1149-bug-context-fill-counter-reads-a-short-c-1782983729`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how compaction decides the session is “full,” which can delay or avoid auto-compaction; behavior is limited to token accounting with a documented fallback when totalTokens is missing.
> 
> **Overview**
> Fixes **context-fill / compaction threshold** logic so it no longer treats summed `input + cacheRead + cacheWrite` as the live context size when the provider already supplies a normalized **`totalTokens`** value.
> 
> **`calculateContextTokens`** now returns **`usage.totalTokens`** whenever it is greater than zero; otherwise it keeps the previous component sum as a fallback. That stops short turns from showing inflated context usage (e.g. ~853k–2.9M tokens) and **premature auto-compaction** when cache-related usage fields are cumulative or overlap.
> 
> Tests were updated to assert the **authoritative `totalTokens` path** and the **fallback when `totalTokens` is 0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b51237ceda4362822ad3e2d566d67fc0e981c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
