### PR TITLE
fix(issue): [Bug]: finished claude-code turn renders its tool-call list twice — orphaned tool components are re-added without dedup at message-end rebuild

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-controller.test.ts
@@ -674,6 +674,64 @@ test("handleAgentEvent: assistant error finalization does not fail completed too
 	assert.doesNotMatch(rendered, /Model hit a transient error/);
 });
 
+test("handleAgentEvent: message_end reattaches orphaned tool components only once", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	const host = createStreamingHost(chatContainer);
+	const toolA = { type: "serverToolUse", id: "mcp-a", name: "mcp__gsd__ls", input: { path: ".gsd" } };
+	const toolB = { type: "serverToolUse", id: "mcp-b", name: "mcp__gsd__read", input: { path: "PLAN.md" } };
+	function makeMessage(content: any[]): any {
+		return {
+			id: "a-mcp-tools",
+			role: "assistant",
+			provider: "claude-code",
+			model: "claude-opus-4-8",
+			timestamp: 1,
+			stopReason: "stop",
+			content,
+		};
+	}
+	const countChild = (component: unknown) =>
+		chatContainer.children.filter((child) => child === component).length;
+
+	await handleAgentEvent(host, { type: "message_start", message: makeMessage([]) } as any);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: makeMessage([toolA]),
+		assistantMessageEvent: { type: "server_tool_use", contentIndex: 0, partial: makeMessage([toolA]) },
+	} as any);
+
+	const toolAComponent = host.pendingTools.get(toolA.id);
+	assert.ok(toolAComponent);
+	assert.equal(countChild(toolAComponent), 1);
+
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: makeMessage([]),
+		assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "", partial: makeMessage([]) },
+	} as any);
+	assert.equal(host.streamingRenderState.renderedSegments.length, 0);
+	assert.equal(countChild(toolAComponent), 1);
+
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: makeMessage([toolB]),
+		assistantMessageEvent: { type: "server_tool_use", contentIndex: 0, partial: makeMessage([toolB]) },
+	} as any);
+
+	const toolBComponent = host.pendingTools.get(toolB.id);
+	assert.ok(toolBComponent);
+	assert.equal(countChild(toolBComponent), 1);
+
+	await handleAgentEvent(host, {
+		type: "message_end",
+		message: makeMessage([toolA, toolB]),
+	} as any);
+
+	assert.equal(countChild(toolAComponent), 1);
+	assert.equal(countChild(toolBComponent), 1);
+});
+
 test("handleAgentEvent: Claude Code MCP post-tool text does not erase user-facing pre-tool prose", async () => {
 	initTheme("dark", false);
 	const chatContainer = new Container();

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-segment-walker.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-segment-walker.ts
@@ -338,6 +338,7 @@ export function rebuildSegmentsOnMessageEnd(
 				toolComponentsById.set(finalBlock.id, component);
 			}
 			if (component) {
+				host.chatContainer.removeChild(component);
 				host.chatContainer.addChild(component);
 				rs.renderedSegments.push({ kind: "tool", contentIndex: seg.contentIndex, component });
 			}


### PR DESCRIPTION
## Summary
- Fixed duplicate finished-turn tool rendering by idempotently reattaching message-end tool components and verified with focused controller and package tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1152
- [#1152 [Bug]: finished claude-code turn renders its tool-call list twice — orphaned tool components are re-added without dedup at message-end rebuild](https://github.com/open-gsd/gsd-pi/issues/1152)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1152-bug-finished-claude-code-turn-renders-it-1782984090`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI rendering change in interactive chat segment rebuild with a focused regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **duplicate tool-call UI** when a Claude Code turn finishes after streaming content **shrinks** (e.g. transient empty updates) and tool cards were left in the chat container as orphans.
> 
> In **`rebuildSegmentsOnMessageEnd`**, tool components are now **`removeChild`’d before `addChild`** when reattaching them at turn end, so the same `ToolExecutionComponent` instance is not stacked twice when it was already present from streaming/orphan state.
> 
> Adds a controller test that streams two MCP `serverToolUse` tools, triggers a shrink that orphans the first tool, then asserts **`message_end`** leaves each tool component attached **exactly once**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d130a63cc51c506ab26c90d6dc9992c21b832c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->