### PR TITLE
fix(issue): [Bug]: per-tool durations in a finished claude-code turn show descending turn-elapsed times because synthetic toolcall_end is skipped once the message builder is cleared

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -2199,6 +2199,8 @@ interface SdkAttemptMessageState {
 	builder: PartialMessageBuilder | null;
 	intermediateToolBlocks: AssistantMessage["content"];
 	toolResultsById: Map<string, ExternalToolResultPayload>;
+	toolCompletionTargetsById: Map<string, { partial: AssistantMessage; contentIndex: number }>;
+	emittedExternalToolResultIds: Set<string>;
 }
 
 function createSdkAttemptMessageState(): SdkAttemptMessageState {
@@ -2206,6 +2208,8 @@ function createSdkAttemptMessageState(): SdkAttemptMessageState {
 		builder: null,
 		intermediateToolBlocks: [],
 		toolResultsById: new Map<string, ExternalToolResultPayload>(),
+		toolCompletionTargetsById: new Map<string, { partial: AssistantMessage; contentIndex: number }>(),
+		emittedExternalToolResultIds: new Set<string>(),
 	};
 }
 
@@ -2341,7 +2345,13 @@ async function pumpSdkMessages(
 
 			sdkAttemptLoop:
 			for (let readinessAttempt = 0; ; readinessAttempt++) {
-				let { builder, intermediateToolBlocks, toolResultsById } = createSdkAttemptMessageState();
+				let {
+					builder,
+					intermediateToolBlocks,
+					toolResultsById,
+					toolCompletionTargetsById,
+					emittedExternalToolResultIds,
+				} = createSdkAttemptMessageState();
 				const controller = new AbortController();
 				const forwardAbort = (): void => controller.abort();
 				if (options?.signal) {
@@ -2475,7 +2485,7 @@ async function pumpSdkMessages(
 						case "user": {
 							// Capture content from the completed turn before resetting
 							if (builder) {
-								for (const block of builder.message.content) {
+								for (const [contentIndex, block] of builder.message.content.entries()) {
 									if (block.type === "text" && block.text) {
 										lastTextContent = block.text;
 									} else if (block.type === "thinking" && block.thinking) {
@@ -2483,6 +2493,10 @@ async function pumpSdkMessages(
 									} else if (block.type === "toolCall" || block.type === "serverToolUse") {
 										// Collect tool blocks for externalToolExecution rendering
 										intermediateToolBlocks.push(block);
+										toolCompletionTargetsById.set(block.id, {
+											partial: builder.message,
+											contentIndex,
+										});
 									}
 								}
 							}
@@ -2497,59 +2511,63 @@ async function pumpSdkMessages(
 							// Push a synthetic toolcall_end for each tool call from this turn
 							// so the TUI can render tool results in real-time during the SDK
 							// session instead of waiting until the entire session completes.
-							if (builder) {
-								for (const block of builder.message.content) {
-									const extResult = (block as ToolCallWithExternalResult).externalResult;
-									if (!extResult) continue;
-									const contentIndex = builder.message.content.indexOf(block);
-									if (contentIndex < 0) continue;
-									const suppressDuplicateUnavailable = shouldSuppressDuplicateToolUnavailableBlock(
-										block,
-										builder.message.content,
-									);
-									// Push synthetic completion events with result attached so the
-									// chat-controller can update pending ToolExecutionComponents.
-									if (block.type === "toolCall") {
-										if (suppressDuplicateUnavailable) {
-											delete (block as ToolCallWithExternalResult).externalResult;
-											stream.push({
-												type: "toolcall_end",
-												contentIndex,
-												toolCall: block,
-												partial: builder.message,
-											});
-											(block as ToolCallWithExternalResult).externalResult = extResult;
-											continue;
-										}
-										try {
-											await onExternalToolResult?.({
-												toolCall: block,
-												result: extResult,
-											});
-										} catch (error) {
-											console.warn("[claude-code] onExternalToolResult callback failed:", error);
-										}
+							for (const block of intermediateToolBlocks) {
+								if (block.type !== "toolCall" && block.type !== "serverToolUse") continue;
+								if (emittedExternalToolResultIds.has(block.id)) continue;
+								const target = toolCompletionTargetsById.get(block.id);
+								if (!target) continue;
+
+								const extResult = (block as ToolCallWithExternalResult).externalResult;
+								if (!extResult) continue;
+								const suppressDuplicateUnavailable = shouldSuppressDuplicateToolUnavailableBlock(
+									block,
+									target.partial.content,
+								);
+								// Push synthetic completion events with result attached so the
+								// chat-controller can update pending ToolExecutionComponents.
+								if (block.type === "toolCall") {
+									if (suppressDuplicateUnavailable) {
+										delete (block as ToolCallWithExternalResult).externalResult;
 										stream.push({
 											type: "toolcall_end",
-											contentIndex,
+											contentIndex: target.contentIndex,
 											toolCall: block,
-											partial: builder.message,
+											partial: target.partial,
 										});
-									} else if (block.type === "serverToolUse") {
-										try {
-											await onExternalToolResult?.({
-												toolCall: serverToolUseToToolCallLike(block),
-												result: extResult,
-											});
-										} catch (error) {
-											console.warn("[claude-code] onExternalToolResult callback failed:", error);
-										}
-										stream.push({
-											type: "server_tool_use",
-											contentIndex,
-											partial: builder.message,
-										});
+										(block as ToolCallWithExternalResult).externalResult = extResult;
+										emittedExternalToolResultIds.add(block.id);
+										continue;
 									}
+									try {
+										await onExternalToolResult?.({
+											toolCall: block,
+											result: extResult,
+										});
+									} catch (error) {
+										console.warn("[claude-code] onExternalToolResult callback failed:", error);
+									}
+									stream.push({
+										type: "toolcall_end",
+										contentIndex: target.contentIndex,
+										toolCall: block,
+										partial: target.partial,
+									});
+									emittedExternalToolResultIds.add(block.id);
+								} else if (block.type === "serverToolUse") {
+									try {
+										await onExternalToolResult?.({
+											toolCall: serverToolUseToToolCallLike(block),
+											result: extResult,
+										});
+									} catch (error) {
+										console.warn("[claude-code] onExternalToolResult callback failed:", error);
+									}
+									stream.push({
+										type: "server_tool_use",
+										contentIndex: target.contentIndex,
+										partial: target.partial,
+									});
+									emittedExternalToolResultIds.add(block.id);
 								}
 							}
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -661,6 +661,150 @@ describe("stream-adapter — no transcript fabrication (#4102)", () => {
 });
 
 describe("stream-adapter — Claude Code external tool results", () => {
+	test("emits one synthetic completion per tool when SDK sends consecutive user result messages (#1153)", async () => {
+		const stream = streamViaClaudeCode(
+			{ id: "claude-sonnet-4-6" } as any,
+			{ messages: [{ role: "user", content: "Read and grep." } as Message] },
+			{
+				_skipWorkflowMcpPreflightForTest: true,
+				async *_sdkQueryForTest() {
+					yield {
+						type: "stream_event",
+						event: { type: "message_start", message: { model: "claude-sonnet-4-6" } },
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "stream_event",
+						event: {
+							type: "content_block_start",
+							index: 0,
+							content_block: { type: "tool_use", id: "tool-read-1", name: "Read", input: {} },
+						},
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "stream_event",
+						event: {
+							type: "content_block_delta",
+							index: 0,
+							delta: { type: "input_json_delta", partial_json: "{\"file_path\":\"a.txt\"}" },
+						},
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "stream_event",
+						event: { type: "content_block_stop", index: 0 },
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "stream_event",
+						event: {
+							type: "content_block_start",
+							index: 1,
+							content_block: { type: "tool_use", id: "tool-grep-1", name: "Grep", input: {} },
+						},
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "stream_event",
+						event: {
+							type: "content_block_delta",
+							index: 1,
+							delta: { type: "input_json_delta", partial_json: "{\"pattern\":\"needle\"}" },
+						},
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "stream_event",
+						event: { type: "content_block_stop", index: 1 },
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "user",
+						uuid: "user-result-1",
+						session_id: "session-1",
+						parent_tool_use_id: "tool-read-1",
+						message: {
+							role: "user",
+							content: [{
+								type: "tool_result",
+								tool_use_id: "tool-read-1",
+								content: "read result",
+								is_error: false,
+							}],
+						},
+					};
+					yield {
+						type: "user",
+						uuid: "user-result-2",
+						session_id: "session-1",
+						parent_tool_use_id: "tool-grep-1",
+						message: {
+							role: "user",
+							content: [{
+								type: "tool_result",
+								tool_use_id: "tool-grep-1",
+								content: "grep result",
+								is_error: false,
+							}],
+						},
+					};
+					yield {
+						type: "result",
+						subtype: "success",
+						uuid: "result-1",
+						session_id: "session-1",
+						duration_ms: 1,
+						duration_api_ms: 1,
+						is_error: false,
+						num_turns: 1,
+						result: "done",
+						stop_reason: "end_turn",
+						total_cost_usd: 0,
+						usage: {
+							input_tokens: 0,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					};
+				},
+			} as any,
+		);
+
+		const events: any[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const syntheticCompletions = events.filter(
+			(event) => event.type === "toolcall_end" && event.toolCall?.externalResult,
+		);
+
+		assert.deepEqual(
+			syntheticCompletions.map((event) => event.toolCall.id),
+			["tool-read-1", "tool-grep-1"],
+		);
+		assert.deepEqual(
+			syntheticCompletions.map((event) => event.toolCall.externalResult.content[0]?.text),
+			["read result", "grep result"],
+		);
+	});
+
 	test("serverToolUseToToolCallLike preserves object input for extension tool_result routing", () => {
 		const toolCall = serverToolUseToToolCallLike({
 			id: "srv-1",

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -662,11 +662,28 @@ describe("stream-adapter — no transcript fabrication (#4102)", () => {
 
 describe("stream-adapter — Claude Code external tool results", () => {
 	test("emits one synthetic completion per tool when SDK sends consecutive user result messages (#1153)", async () => {
+		// Capture synthetic completions through onExternalToolResult, which the
+		// adapter invokes exactly once per tool at emission time. Filtering the
+		// collected toolcall_end events afterwards is unreliable here: the streaming
+		// toolcall_end (content_block_stop) and the synthetic completion reference
+		// the SAME tool-call block, and attachExternalResultsToToolBlocks mutates
+		// that block later, so a post-hoc `event.toolCall.externalResult` check also
+		// matches the earlier streaming ends and double-counts each tool.
+		const syntheticCompletions: Array<{ id: string; text: string | undefined }> = [];
 		const stream = streamViaClaudeCode(
 			{ id: "claude-sonnet-4-6" } as any,
 			{ messages: [{ role: "user", content: "Read and grep." } as Message] },
 			{
 				_skipWorkflowMcpPreflightForTest: true,
+				onExternalToolResult(event: {
+					toolCall: { id: string };
+					result: { content?: Array<{ text?: string }> };
+				}) {
+					syntheticCompletions.push({
+						id: event.toolCall.id,
+						text: event.result.content?.[0]?.text,
+					});
+				},
 				async *_sdkQueryForTest() {
 					yield {
 						type: "stream_event",
@@ -786,21 +803,19 @@ describe("stream-adapter — Claude Code external tool results", () => {
 			} as any,
 		);
 
+		// Drain the stream so the adapter processes every SDK message and fires
+		// onExternalToolResult for each synthetic completion.
 		const events: any[] = [];
 		for await (const event of stream) {
 			events.push(event);
 		}
 
-		const syntheticCompletions = events.filter(
-			(event) => event.type === "toolcall_end" && event.toolCall?.externalResult,
-		);
-
 		assert.deepEqual(
-			syntheticCompletions.map((event) => event.toolCall.id),
+			syntheticCompletions.map((completion) => completion.id),
 			["tool-read-1", "tool-grep-1"],
 		);
 		assert.deepEqual(
-			syntheticCompletions.map((event) => event.toolCall.externalResult.content[0]?.text),
+			syntheticCompletions.map((completion) => completion.text),
 			["read result", "grep result"],
 		);
 	});


### PR DESCRIPTION
## Summary
- Fixed claude-code synthetic tool completion emission after builder reset and added a regression fixture; lightweight syntax/diff checks pass, but focused tests are dependency-blocked.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1153
- [#1153 [Bug]: per-tool durations in a finished claude-code turn show descending turn-elapsed times because synthetic toolcall_end is skipped once the message builder is cleared](https://github.com/open-gsd/gsd-pi/issues/1153)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1153-bug-per-tool-durations-in-a-finished-cla-1782984447`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time stream event emission in the Claude Code SDK adapter, which affects TUI tool timing and external-tool callbacks, but scope is limited to the user-message completion path with deduplication guards.
> 
> **Overview**
> Fixes **#1153**, where finished Claude Code turns showed **wrong per-tool durations** (often descending turn-elapsed times) because synthetic `toolcall_end` events were only emitted while the partial message **builder** was still set.
> 
> **`stream-adapter.ts`** now records each tool’s **`partial` message and `contentIndex`** when tool blocks are collected, tracks which tool IDs already got a completion event, and drives synthetic `toolcall_end` / `server_tool_use` from **`intermediateToolBlocks`** instead of re-walking `builder.message.content` after `builder` is cleared. Each tool still gets **one** completion when its result arrives, including when the SDK sends **back-to-back synthetic `user` tool-result messages**.
> 
> Adds a regression test that simulates two consecutive user result messages and asserts both tools receive `toolcall_end` with the correct external results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87aa0b6bbbd52517957420dfb6242f0d25fd5692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->