### PR TITLE
fix(hermes): support directory plugin loading

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -1,0 +1,31 @@
+"""open-gsd-hermes — Hermes Agent plugin directory-loader bridge."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_package() -> ModuleType:
+    package_dir = Path(__file__).resolve().parent / "open_gsd_hermes"
+    init_file = package_dir / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        "open_gsd_hermes",
+        init_file,
+        submodule_search_locations=[str(package_dir)],
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load open_gsd_hermes from {init_file}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["open_gsd_hermes"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_package = _load_package()
+register = _package.register
+
+__all__ = ["register"]

--- a/integrations/hermes/tests/test_directory_loader.py
+++ b/integrations/hermes/tests/test_directory_loader.py
@@ -1,0 +1,37 @@
+"""Directory-loader compatibility tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def load_plugin_directory(plugin_root: Path) -> ModuleType:
+    """Load the Hermes plugin the same way its directory loader does."""
+    init_file = plugin_root / "__init__.py"
+    if not init_file.exists():
+        raise FileNotFoundError(f"No __init__.py in {plugin_root}")
+
+    spec = importlib.util.spec_from_file_location(
+        "open_gsd_hermes_directory_loader",
+        init_file,
+        submodule_search_locations=[str(plugin_root)],
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plugin_root_supports_hermes_directory_loader() -> None:
+    plugin_root = Path(__file__).resolve().parents[1]
+
+    module = load_plugin_directory(plugin_root)
+
+    assert callable(module.register)
+    assert module.__all__ == ["register"]


### PR DESCRIPTION
## TL;DR

**What:** Add a root `integrations/hermes/__init__.py` bridge for Hermes directory-based plugin loading.
**Why:** `gsd hermes install` copies the plugin as a directory, and Hermes requires a plugin-root initializer before it can call `open_gsd_hermes.register`.
**How:** Load the existing `open_gsd_hermes` package from the root bridge and expose its `register` entry point, with a regression test that simulates the Hermes directory loader.

## What

This change adds a root initializer to the Hermes integration directory and a focused compatibility test:

- `integrations/hermes/__init__.py` loads the existing `open_gsd_hermes` package and re-exports `register` for directory-based plugin loaders.
- `integrations/hermes/tests/test_directory_loader.py` simulates Hermes' plugin-directory import path and verifies the copied plugin root exposes a callable `register`.

## Why

When installed through `gsd hermes install`, the plugin is copied into `~/.hermes/plugins/open-gsd-hermes/`. Hermes' directory loader expects `~/.hermes/plugins/open-gsd-hermes/__init__.py`; without it, loading fails before the existing package entry point can register `/gsd` commands, hooks, or tools.

Closes #1159

## How

The new bridge builds an import spec for `open_gsd_hermes/__init__.py`, registers that package name in `sys.modules` before execution, and exposes the package's existing `register` function at the plugin root. This keeps the editable-install entry point unchanged while supporting Hermes' directory loader.

## Validation

- [x] `cd integrations/hermes && python3 -m pytest tests/test_directory_loader.py -q`
- [x] `cd integrations/hermes && python3 -m pytest tests/test_directory_loader.py tests/test_register.py -q`
- [x] `cd integrations/hermes && python3 -m pytest tests/ -q`
- [x] Sabotage check: temporarily removed `integrations/hermes/__init__.py`; `tests/test_directory_loader.py` failed with `FileNotFoundError: No __init__.py in .../integrations/hermes`; restored the file and the test passed again.
- [ ] `bash integrations/hermes/scripts/preflight.sh` — Python contract suite passed, but local preflight also requires `gsd` and `gsd-mcp-server` on `PATH`; those binaries are not available in this worktree environment.

## Impact analysis

- Blast radius: narrow.
- Affected workflows: Hermes plugin installs that use copied directory loading via `gsd hermes install`.
- Compatibility notes: editable `pip install -e integrations/hermes` still uses the existing `open_gsd_hermes` package entry point; this adds a directory-loader path without changing package internals.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow integration-only change: import wiring and a compatibility test; no changes to `open_gsd_hermes` registration logic or security-sensitive paths.
> 
> **Overview**
> Fixes Hermes installs that copy the plugin as a directory (`gsd hermes install`) by adding **`integrations/hermes/__init__.py`**, which Hermes’ directory loader imports before it can call **`register`**.
> 
> The new root module dynamically loads **`open_gsd_hermes`** (registers it in **`sys.modules`**, then runs its **`__init__.py`**) and re-exports **`register`** with **`__all__ = ["register"]`**, so behavior stays on the existing package entry point while editable installs are unchanged.
> 
> Adds **`test_directory_loader.py`**, which loads the plugin root the same way Hermes does and asserts **`register`** is callable and the public surface matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447cb863271169cbda12c704a1b2cd70352a466d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->