### PR TITLE
feat(hermes): /gsd new-milestone command for chat-driven milestone creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local git worktrees for development isolation
+.worktrees/
+
 # Compiled output
 /dist/
 dist-test/

--- a/integrations/hermes/CONTEXT.md
+++ b/integrations/hermes/CONTEXT.md
@@ -1,0 +1,47 @@
+# CONTEXT — open-gsd-hermes plugin
+
+A bounded context: the Hermes Agent chat gateway to GSD Pi. This is a glossary,
+not a spec. Implementation decisions live in code; cross-cutting decisions that
+are hard to reverse and surprising without context live as ADRs.
+
+## Domain glossary
+
+- **GSD command surface (chat)**: the set of `/gsd` subcommands the plugin exposes
+  over a chat gateway (WeChat/Telegram/Slack). Today: `bind`, `status`, `auto`,
+  `cancel`, `reply`, `help`. A `new-milestone` subcommand is the active addition.
+- **Binding resolution**: the tiered lookup (cron → slash arg → session bind →
+  channel map → profile default → cwd heuristic) that resolves a chat command to
+  a concrete `projectDir`. Owned by `binding.py`. Fails closed with `BindingError`
+  when no GSD project can be found.
+- **Supervisor context**: the shared, mutable, in-process state
+  (`SupervisorContext`) recording the active GSD session's `session_id`,
+  `project_dir`, and `state` (`IDLE`/`RUNNING`/`BLOCKED`/`COMPLETE`/`FAILED`/
+  `CANCELLED`). Read by `/gsd status`, `/gsd cancel`, and the co-run gate; driven
+  (written) by whichever mechanism owns the active session — the poll-driven
+  `SupervisorFsm` for `/gsd auto`, or a stream-reader for milestone creation.
+- **Co-run guard**: the rule that two mutating GSD operations must not run against
+  the same project at once. Enforced locally in the plugin by checking
+  `SupervisorContext.state` before starting either a `new-milestone` or `auto`
+  run. The upstream lease layer (CHANGELOG:509, open) is the backstop, not the
+  plugin's responsibility — the plugin refuses when *it* knows a session is live.
+- **Fire-and-track (delivery model)**: the plugin's fundamental response shape —
+  a mutating command returns a one-line ack immediately, and all subsequent
+  progress/blocker/terminal updates are *pushed* to the chat via
+  `NotificationService` → `send_message` on a background thread. Required because
+  the target chat platforms do not hold a single request/response open for the
+  minutes-to-hours a GSD operation takes.
+- **Stream-driven session (milestone path)**: a GSD run driven by consuming the
+  `--output-format stream-json` event stream of a CLI subprocess owned by the
+  plugin, rather than by polling `gsd_status`. Distinct from the **poll-driven
+  session** (`/gsd auto` via MCP `gsd_execute`), where `SupervisorFsm._tick`
+  periodically calls `gsd_status`/`gsd read progress`. The two differ at the
+  source (CLI subprocess vs MCP-managed RPC session) and honestly reflect that
+  difference in their drivers; `SupervisorContext` is the shared state both
+  write.
+- **Subprocess ownership (milestone path)**: because the plugin spawns
+  `gsd headless new-milestone` directly, the plugin — not the MCP server — owns
+  that process's full lifecycle: cancel (SIGTERM), blocker replies (stdin), and
+  terminal/transition notifications (stdout stream). The MCP session manager
+  cannot see or reach a process it did not start; there is no `auto.lock` pid
+  backstop during the planning phase (the lock is an auto-loop concept written
+  only once `--auto` chains in).

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -41,8 +41,27 @@ bash integrations/hermes/scripts/preflight.sh
 - `/gsd bind <path>` — bind session to project
 - `/gsd status` — show progress
 - `/gsd auto` — start auto mode via MCP
+- `/gsd new-milestone <spec>` — create a milestone from inline spec text
+- `/gsd new-milestone --file <path>` — create a milestone from a readable spec file
 - `/gsd cancel` — cancel running session
 - `/gsd reply <text>` — resolve blocker
+
+`/gsd new-milestone` is planning-only. It starts `gsd headless --supervised
+new-milestone` as a Hermes-owned subprocess, returns an acknowledgement
+immediately, and then sends chat notifications when planning blocks, fails,
+is cancelled, or completes. Run `/gsd auto` after the completion notification
+to execute the milestone.
+
+`--file` paths are validated before the planning subprocess starts; relative
+paths are resolved from the bound project. `/gsd new-milestone --auto` is
+rejected because Hermes keeps milestone planning and auto execution as separate
+commands. While milestone planning is active, `/gsd auto` is rejected until the
+planning run completes or `/gsd cancel` terminates it.
+
+If planning asks a supervised question, reply with `/gsd reply <text>`; Hermes
+writes the answer to the milestone subprocess instead of the MCP auto-session
+path. `/gsd cancel` terminates an active milestone planning subprocess and sends
+a single cancellation notification.
 
 ## Requirements
 

--- a/integrations/hermes/docs/issue-1162-grilling.md
+++ b/integrations/hermes/docs/issue-1162-grilling.md
@@ -1,0 +1,197 @@
+# Issue #1162 — Grilling summary: `/gsd new-milestone` via Hermes
+
+Source: `grill-with-docs` + `grilling` + `domain-modeling` skills on issue #1162.
+This is the shared understanding the interview reached — the design tree walked
+branch-by-branch with a decision at each node. Implementation should conform to
+this; deviations should re-open the corresponding question, not silently diverge.
+
+Glossary for every term below lives in [`../CONTEXT.md`](../CONTEXT.md).
+
+---
+
+## The one-line design
+
+Add a `/gsd new-milestone <spec>` slash command that spawns
+`gsd headless new-milestone` as a **plugin-owned subprocess**, fires-and-forgets
+an ack, drives lifecycle (blocker/terminal) notifications from the subprocess's
+stream-json stdout, and hands execution off to the **existing, untouched**
+`/gsd auto` path. No `--auto` chaining, no new MCP tool, no TS-side changes.
+
+---
+
+## Decision tree (Q1–Q9)
+
+### Q1 — Mechanism & transport → **(A) Slash command → CLI subprocess**
+- New `_cmd_new_milestone` in `GsdCommandRouter`. Shells out to
+  `gsd headless new-milestone --context-text <spec>`.
+- **Not** a Hermes skill (B), **not** a new MCP `gsd_create_milestone` tool (C).
+- Rationale: the plugin already has a proven direct-CLI pattern (`progress()`
+  calls `gsd read progress --json`); `new-milestone` is even more naturally a
+  CLI call (it bootstraps `.gsd/`, has a 10-min timeout, manages its own RPC
+  child). An MCP tool would re-implement what the CLI already does, and the
+  upstream lease-layer co-run issue (CHANGELOG:509, open) makes advertising
+  `gsd_create_milestone` over MCP actively unsafe to every MCP client.
+- A later Hermes skill (B) can wrap the same client method with zero rework.
+
+### Q2 — Co-run safety gate → **(A) Local supervisor state only**
+- Reject if `SupervisorContext.state in (RUNNING, BLOCKED)` before spawning.
+- **Not** a server-side cross-binding check (B). Documented limitation: a
+  session started by *another* plugin instance / a headless run outside this
+  plugin is invisible to the local guard; the CLI's own lease check is the
+  backstop.
+- Rationale: the plugin can only authoritatively own its own state; a
+  server-side "is anything running?" check is itself racy and adds a new query
+  path to design and test.
+
+### Q3 — Run model → **(A) Fire-and-track via the existing async-push model**
+- Return "🚀 Milestone creation started (session X)" immediately; push
+  blocker/terminal notifications from a background stream-reader.
+- **Not** a synchronous blocking call (rejected after discovering the plugin is
+  fundamentally async-push — `_cmd_auto` already works this way; the target
+  chat platforms don't hold request/response open for minutes).
+- *(Note: "reuse `SupervisorFsm` unchanged" was initially proposed under this
+  label but does NOT work — see A1 below.)*
+
+### Q3 follow-up — How to drive the fire-and-track → **(A1) Client-owned subprocess, direct stream→notification**
+- `GsdMcpClient` spawns `gsd headless new-milestone --output-format stream-json`
+  on a background thread, reads stdout line-by-line, captures
+  `init_result.sessionId`, and on terminal/blocker events calls
+  `NotificationService` directly.
+- `SupervisorContext` is **shared state** (written by the stream-reader, read by
+  `/gsd status`, `/gsd cancel`, the co-run gate); the `SupervisorFsm` poll loop
+  is **not** reused for the milestone path (its `_tick` calls `gsd_status`,
+  which can't see our subprocess).
+- Rationale: the stream *is* the lifecycle signal; polling would be a lossy
+  proxy for events we already get deterministically. Reuses
+  `NotificationService` and `SupervisorContext` unchanged.
+
+### Q4 — Cancellation → **(A) Local PID ownership + direct SIGTERM**
+- `GsdMcpClient` holds the `subprocess.Popen` handle; `cancel_milestone()` calls
+  `proc.terminate()` directly. `_cmd_cancel` routes to it when a milestone proc
+  is active.
+- **Not** a new `.gsd/milestone.lock` pid file for the MCP backstop (B) — that
+  crosses the Python/TS boundary and inverts ownership. **Not** "no cancel during
+  planning" (C) — a stuck planning run needs an escape hatch.
+- Discovered: MCP `cancelSessionByDir`'s `auto.lock` pid backstop does NOT find
+  our planning subprocess (no `auto.lock` exists during planning — it's an
+  auto-loop concept). So local ownership is required, not optional.
+- Plus explicit supervisor stop on cancel (immediate confirmation, don't wait
+  for next poll tick).
+
+### Q5 — Scope: `--auto` (chained execution)? → **No. Planning-only.**
+- The plugin creates the milestone and hands off; execution is `/gsd auto`'s job.
+- `/gsd auto` already has a robust path (MCP `gsd_execute` → self-healing poll
+  supervisor). Chaining `--auto` would duplicate that with a stateful
+  stream-reader over hours (fragile) instead of the proven poll loop.
+- **Boundary clarification:** this plugin (`gsd-pi/integrations/hermes/`) is the
+  chat gateway. One-shot `new-milestone --auto` is gsd-core's terminal surface,
+  not the gateway's.
+- `/gsd new-milestone --auto` is **rejected at the command level** with a message
+  pointing to the two-step flow.
+
+### Q6 — Input shape → **Bare positional, with `--file` escape**
+- `/gsd new-milestone <spec text>` → `--context-text` (matches `/gsd reply`).
+- `/gsd new-milestone --file <path>` → `--context <file>` (explicit opt-in).
+- **Not** auto-detect path-vs-text (heuristic misroutes on collision — rule #5).
+- **Not** `--description "..."` flag form (issue's example used it, but the bare
+  positional matches the sibling command users already know).
+
+### Q7 — Output → **(A) Bounded summary via `gsd_query` at completion, with (B) as graceful fallback**
+- Immediate ack: "🚀 Milestone creation started for `<project>`."
+- Completion push: bounded summary — milestone id, slice count, task count,
+  one-line next step ("Run `/gsd auto` to start."). Built from
+  `gsd_query {projectDir, query: "milestones"}` after exit-0.
+- Fallback: if the query comes back empty/missing after exit-0, degrade to
+  "✅ Milestone created. Run `/gsd status` for details."
+- **Trust exit-0; no defensive re-querying.** If exit-0 lies about flush state,
+  that's a gsd-core bug to fix at the source, not a leak for the plugin to patch
+  with a racy retry loop.
+- Error/blocked cases route through existing `notify_terminal`/`notify_blocker`
+  unchanged.
+
+### Q8 — Failure modes
+| # | Mode | Disposition |
+|---|---|---|
+| 1 | Active auto session (co-run) | Reject before spawn; fail closed |
+| 2 | No project bound | Reuse `BindingError` path (zero new code) |
+| 3 | Empty spec | Usage message (matches `_cmd_reply`/`_cmd_bind`) |
+| 4 | Spec too long for `--context-text` | Surface `E2BIG`/`OSError`; point to `--file` |
+| 5 | Planning errors (non-zero exit) | `notify_terminal(status, error)` via existing path |
+| 6 | Planning hits a blocker | `notify_blocker`; reply via **client-owned stdin** (see below) |
+| 7 | `--file` missing/unreadable | Validate before spawn |
+| 8 | Stream-reader thread/pipe dies | Best-effort: set FAILED, `notify_terminal("failed", "stream lost — run /gsd cancel")`. **No watchdog.** Cancel is the escape hatch. |
+| 9 | Plugin restart mid-planning | **Documented limitation.** Orphaned subprocess survives; invisible after restart (same as existing supervisor's restart-blindness). |
+| 10 | User passes `--auto` | Reject at command level (see Q5) |
+
+**Blocker replies (#6) — client-owned, not MCP-routed.** `gsd_resolve_blocker`
+calls `sessionManager.resolveBlocker` which looks up the MCP server's *own*
+sessions map — our subprocess isn't there, so it throws "Session not found".
+Because we own the subprocess's stdin (A1), `/gsd reply` for a planning blocker
+writes the response to *our* subprocess's stdin via a new
+`respond_to_milestone_blocker(response)` method. `_cmd_reply` gets one branch:
+if a milestone subprocess with a pending blocker is active, route locally; else
+fall through to the existing MCP `resolve_blocker` path.
+
+### Q9 — Cross-effects on existing commands
+- **`_cmd_cancel`** — MUST change: add milestone-subprocess branch routing to
+  local `cancel_milestone()` (SIGTERM) when one is active. *Required.*
+- **`_cmd_auto`** — MUST change: add symmetric co-run guard (reject if
+  `SupervisorContext` shows an active milestone run, point to `/gsd cancel`).
+  *Required* — without it, `/gsd auto` during milestone planning silently
+  re-exposes the unsafe co-run (the MCP server's "Session already active"
+  rejection does NOT fire for our planning subprocess, since it's not registered
+  and writes no `auto.lock`). Rule #12 (fail loud) over rule #3 (surgical) here.
+- **`/gsd status`** — leave alone. Reads disk honestly; the Q3-accepted planning
+  progress gap means it may show stale/partial state early on. The completion
+  notification is the real "done" signal.
+- **`/gsd reply`** — additive branch only (Q8 #6); core MCP path untouched.
+- **`SupervisorFsm`** — untouched (A1 uses a separate stream-reader driver).
+- **TS MCP server** — untouched (no new tools).
+
+---
+
+## Implementation surface (additive unless noted)
+
+**`gsd_client.py`** — new methods + state:
+- `self._milestone_proc: subprocess.Popen | None`
+- `create_milestone(project_dir, *, context_text=None, context_file=None) -> str` —
+  spawns `gsd headless new-milestone --output-format stream-json`, starts the
+  stream-reader thread, returns `sessionId` (captured from `init_result`). Throws
+  on co-run guard / missing spec.
+- `_milestone_stream_loop(proc)` — reads stdout JSONL; on `init_result` captures
+  `sessionId`; on blocker event → `notify_blocker` + sets
+  `SupervisorContext.pending_blocker_id`; on terminal/exit → `notify_terminal` +
+  sets `SupervisorContext.state`.
+- `cancel_milestone()` — `proc.terminate()` + cleanup.
+- `respond_to_milestone_blocker(response)` — writes UI-response to proc stdin.
+- `milestone_active()` predicate for the co-run gate.
+
+**`commands.py`** — new handler + two modifications:
+- `_cmd_new_milestone(rest)` — the new command (guard, parse, spawn, ack).
+- `_cmd_cancel` (modify) — milestone-subprocess branch.
+- `_cmd_auto` (modify) — symmetric co-run guard.
+- `_cmd_reply` (modify) — milestone-blocker branch (additive).
+- `_cmd_help` (modify) — list `new-milestone`.
+
+**`__init__.py`** — wire the new client methods / supervisor notifications if
+the constructor surface changes (likely no change — `GsdMcpClient` already has
+`config`, and `NotificationService` is already injected).
+
+**Tests** (new, matching existing `tests/test_*.py` patterns):
+- `test_new_milestone_command.py` — guard (co-run both ways), input parsing
+  (bare text, `--file`, empty, `--auto` rejected), spawn + ack.
+- extend `test_gsd_client_cache.py` or new `test_milestone_client.py` —
+  stream-reader captures sessionId from `init_result`; blocker event →
+  `notify_blocker`; terminal → `notify_terminal`; cancel SIGTERMs the proc;
+  blocker reply writes stdin.
+- extend cancel/reply tests for the new branches.
+
+---
+
+## Explicitly OUT of scope (v1)
+
+- `--auto` chaining (execution stays with `/gsd auto`).
+- Cross-instance / server-side co-run coordination (Q2 limitation).
+- Plugin-restart recovery of an orphaned planning subprocess (Q8 #9).
+- A Hermes skill (issue's Option B) — additive follow-on, wraps the same client.
+- Any TS-side / MCP-server change.

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -286,6 +286,8 @@ class GsdCommandRouter:
                 milestone_ctx.state = SupervisorState.CANCELLED
             else:
                 milestone_ctx.state = SupervisorState.FAILED
+            milestone_ctx.session_id = None
+            milestone_ctx.pending_blocker_id = None
             milestone_ctx.notified_terminal = True
             self._set_supervisor_ctx(milestone_ctx)
 

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -279,6 +279,8 @@ class GsdCommandRouter:
 
         def _on_milestone_terminal(status: str) -> None:
             milestone_ctx = self._get_supervisor_ctx()
+            if milestone_ctx.session_id != session_id:
+                return
             normalized = status.lower()
             if normalized in ("complete", "completed", "done"):
                 milestone_ctx.state = SupervisorState.COMPLETE

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -233,7 +233,7 @@ class GsdCommandRouter:
                 "(or `--file <path>`)"
             )
         # --auto is intentionally rejected (Q5): execution is /gsd auto's job.
-        if "--auto" in rest:
+        if rest[0] == "--auto":
             return (
                 "Execution isn't chained from `/gsd new-milestone`. "
                 "Create the milestone, then run `/gsd auto`."

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -71,7 +71,7 @@ class GsdCommandRouter:
             "- `/gsd bind <path>` — bind this chat to a project\n"
             "- `/gsd status` — show progress snapshot\n"
             "- `/gsd auto` — start auto mode (MCP)\n"
-            "- `/gsd new-milestone <spec>` — create a milestone (then `/gsd auto`)\n"
+            "- `/gsd new-milestone <spec>` or `--file <path>` — create a milestone (then `/gsd auto`)\n"
             "- `/gsd cancel` — cancel running session\n"
             "- `/gsd reply <text>` — resolve blocker"
         )
@@ -264,10 +264,16 @@ class GsdCommandRouter:
             if len(rest) < 2:
                 return "Usage: `/gsd new-milestone --file <path>`"
             context_file = rest[1]
-            if not os.path.isfile(context_file):
+            resolved_file = (
+                context_file
+                if os.path.isabs(context_file)
+                else os.path.join(project_dir, context_file)
+            )
+            if not os.path.isfile(resolved_file):
                 return f"Context file not found: `{context_file}`"
-            if not os.access(context_file, os.R_OK):
+            if not os.access(resolved_file, os.R_OK):
                 return f"Context file is not readable: `{context_file}`"
+            context_file = resolved_file
         else:
             context_text = " ".join(rest)
 
@@ -283,9 +289,9 @@ class GsdCommandRouter:
             milestone_ctx.notified_terminal = True
             self._set_supervisor_ctx(milestone_ctx)
 
-        # Spawn the supervised subprocess; create_milestone blocks until the
-        # init_result event yields a sessionId, then continues the stream
-        # reader in the background.
+        # Spawn the supervised subprocess; create_milestone returns a local
+        # session id immediately and continues the stream reader in the
+        # background.
         try:
             session_id = self._client.create_milestone(
                 project_dir,

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -238,15 +238,15 @@ class GsdCommandRouter:
                 "Execution isn't chained from `/gsd new-milestone`. "
                 "Create the milestone, then run `/gsd auto`."
             )
-        # Co-run guard (Q2): refuse if an auto session is RUNNING/BLOCKED.
+        # Co-run guard (Q2): refuse if a milestone or auto session is active.
+        if self._client.milestone_active():
+            return (
+                "Milestone creation is in progress. Run `/gsd cancel` first."
+            )
         ctx = self._get_supervisor_ctx()
         if ctx.state in (SupervisorState.RUNNING, SupervisorState.BLOCKED):
             return (
                 "GSD auto is running. Run `/gsd cancel` first."
-            )
-        if self._client.milestone_active():
-            return (
-                "Milestone creation is in progress. Run `/gsd cancel` first."
             )
         # Resolve the bound project.
         try:

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 from typing import Any, Callable
 
@@ -241,6 +242,10 @@ class GsdCommandRouter:
             return (
                 "GSD auto is running. Run `/gsd cancel` first."
             )
+        if self._client.milestone_active():
+            return (
+                "Milestone creation is in progress. Run `/gsd cancel` first."
+            )
         # Resolve the bound project.
         try:
             project_dir = resolve_project_dir(
@@ -257,8 +262,24 @@ class GsdCommandRouter:
             if len(rest) < 2:
                 return "Usage: `/gsd new-milestone --file <path>`"
             context_file = rest[1]
+            if not os.path.isfile(context_file):
+                return f"Context file not found: `{context_file}`"
+            if not os.access(context_file, os.R_OK):
+                return f"Context file is not readable: `{context_file}`"
         else:
             context_text = " ".join(rest)
+
+        def _on_milestone_terminal(status: str) -> None:
+            milestone_ctx = self._get_supervisor_ctx()
+            normalized = status.lower()
+            if normalized in ("complete", "completed", "done"):
+                milestone_ctx.state = SupervisorState.COMPLETE
+            elif normalized == "cancelled":
+                milestone_ctx.state = SupervisorState.CANCELLED
+            else:
+                milestone_ctx.state = SupervisorState.FAILED
+            milestone_ctx.notified_terminal = True
+            self._set_supervisor_ctx(milestone_ctx)
 
         # Spawn the supervised subprocess; create_milestone blocks until the
         # init_result event yields a sessionId, then continues the stream
@@ -269,6 +290,7 @@ class GsdCommandRouter:
                 context_text=context_text,
                 context_file=context_file,
                 notifications=self._notifications,
+                on_terminal=_on_milestone_terminal,
             )
         except ValueError:
             return "Usage: `/gsd new-milestone <spec>` (or `--file <path>`)"

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -202,7 +202,9 @@ class GsdCommandRouter:
         # Milestone planning blocker (issue #1162): the subprocess is locally
         # owned, so its blocker replies must go to its stdin, not MCP
         # gsd_resolve_blocker (which can't see our session).
-        if self._client.milestone_active() and self._client.milestone_pending_blocker_id():
+        if self._client.milestone_active():
+            if not self._client.milestone_pending_blocker_id():
+                return "No pending blocker for the active milestone session."
             try:
                 self._client.respond_to_milestone_blocker(text)
             except Exception as e:

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -58,6 +58,7 @@ class GsdCommandRouter:
             "auto": self._cmd_auto,
             "cancel": self._cmd_cancel,
             "reply": self._cmd_reply,
+            "new-milestone": self._cmd_new_milestone,
             "help": self._cmd_help,
         }
         handler = handlers.get(sub, self._cmd_help)
@@ -69,6 +70,7 @@ class GsdCommandRouter:
             "- `/gsd bind <path>` — bind this chat to a project\n"
             "- `/gsd status` — show progress snapshot\n"
             "- `/gsd auto` — start auto mode (MCP)\n"
+            "- `/gsd new-milestone <spec>` — create a milestone (then `/gsd auto`)\n"
             "- `/gsd cancel` — cancel running session\n"
             "- `/gsd reply <text>` — resolve blocker"
         )
@@ -112,6 +114,15 @@ class GsdCommandRouter:
             return f"GSD status unavailable: {e}"
 
     async def _cmd_auto(self, _rest: list[str]) -> str:
+        # Symmetric co-run guard (issue #1162): refuse if a milestone run is
+        # in progress. The MCP server's "Session already active" rejection
+        # does NOT fire for a milestone subprocess (it's not registered and
+        # writes no auto.lock during planning), so this local gate is the
+        # only thing preventing an unsafe co-run.
+        if self._client.milestone_active():
+            return (
+                "Milestone creation is in progress. Run `/gsd cancel` first."
+            )
         try:
             project_dir = resolve_project_dir(
                 self._config, self._binding_ctx()
@@ -140,6 +151,18 @@ class GsdCommandRouter:
 
     async def _cmd_cancel(self, _rest: list[str]) -> str:
         ctx = self._get_supervisor_ctx()
+        # Milestone subprocess is locally owned (issue #1162); route to the
+        # local SIGTERM path instead of MCP cancel, which cannot see it.
+        if self._client.milestone_active():
+            self._client.cancel_milestone()
+            ctx.session_id = None
+            ctx.state = SupervisorState.CANCELLED
+            ctx.notified_terminal = True
+            self._set_supervisor_ctx(ctx)
+            self._supervisor.stop()
+            if self._notifications is not None:
+                self._notifications.notify_terminal("cancelled")
+            return "Cancel requested."
         try:
             try:
                 if ctx.session_id and ctx.project_dir:
@@ -175,6 +198,15 @@ class GsdCommandRouter:
         if not rest:
             return "Usage: `/gsd reply <your answer>`"
         text = " ".join(rest)
+        # Milestone planning blocker (issue #1162): the subprocess is locally
+        # owned, so its blocker replies must go to its stdin, not MCP
+        # gsd_resolve_blocker (which can't see our session).
+        if self._client.milestone_active() and self._client.milestone_pending_blocker_id():
+            try:
+                self._client.respond_to_milestone_blocker(text)
+            except Exception as e:
+                return f"Could not send blocker response: {e}"
+            return "Blocker response sent."
         ctx = self._get_supervisor_ctx()
         if not ctx.session_id:
             return "No active GSD session. Run `/gsd auto` first."
@@ -184,3 +216,78 @@ class GsdCommandRouter:
         except Exception as e:
             return f"Could not send blocker response: {e}"
         return "Blocker response sent."
+
+    async def _cmd_new_milestone(self, rest: list[str]) -> str:
+        """Create a milestone via `gsd headless --supervised new-milestone`.
+
+        Planning-only: the plugin spawns the subprocess, owns its lifecycle,
+        and notifies on blocker/terminal events. Execution stays with
+        `/gsd auto`. See integrations/hermes/docs/issue-1162-grilling.md.
+        """
+        if not rest:
+            return (
+                "Usage: `/gsd new-milestone <spec>` "
+                "(or `--file <path>`)"
+            )
+        # --auto is intentionally rejected (Q5): execution is /gsd auto's job.
+        if "--auto" in rest:
+            return (
+                "Execution isn't chained from `/gsd new-milestone`. "
+                "Create the milestone, then run `/gsd auto`."
+            )
+        # Co-run guard (Q2): refuse if an auto session is RUNNING/BLOCKED.
+        ctx = self._get_supervisor_ctx()
+        if ctx.state in (SupervisorState.RUNNING, SupervisorState.BLOCKED):
+            return (
+                "GSD auto is running. Run `/gsd cancel` first."
+            )
+        # Resolve the bound project.
+        try:
+            project_dir = resolve_project_dir(
+                self._config, self._binding_ctx()
+            )
+        except BindingError as e:
+            return str(e)
+
+        # Input shape (Q6): bare positional → context_text, `--file <path>`
+        # → context_file.
+        context_text: str | None = None
+        context_file: str | None = None
+        if rest[0] == "--file":
+            if len(rest) < 2:
+                return "Usage: `/gsd new-milestone --file <path>`"
+            context_file = rest[1]
+        else:
+            context_text = " ".join(rest)
+
+        # Spawn the supervised subprocess; create_milestone blocks until the
+        # init_result event yields a sessionId, then continues the stream
+        # reader in the background.
+        try:
+            session_id = self._client.create_milestone(
+                project_dir,
+                context_text=context_text,
+                context_file=context_file,
+                notifications=self._notifications,
+            )
+        except ValueError:
+            return "Usage: `/gsd new-milestone <spec>` (or `--file <path>`)"
+        except Exception as e:
+            return f"Could not start milestone creation: {e}"
+
+        # Record the active milestone run so /gsd status, /gsd cancel, and the
+        # co-run gate (in _cmd_auto) see it. The supervisor poll loop is NOT
+        # used (the stream reader drives notifications); we only carry state.
+        self._supervisor.stop()
+        ctx.session_id = session_id
+        ctx.project_dir = project_dir
+        ctx.state = SupervisorState.RUNNING
+        ctx.last_progress = None
+        ctx.last_status = None
+        ctx.pending_blocker_id = None
+        ctx.notified_terminal = False
+        self._set_supervisor_ctx(ctx)
+        return (
+            f"🚀 Milestone creation started (session `{session_id}`). "
+            "I'll notify you when it's ready; run `/gsd auto` to execute."
+        )

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -627,6 +627,9 @@ class GsdMcpClient:
         self._milestone_notified_terminal = True
         if exit_code is not None:
             self._clear_milestone_state()
+        else:
+            self._milestone_pending_blocker_id = None
+            self._milestone_pending_blocker_method = None
 
     def _drain_milestone_stderr(self, proc: subprocess.Popen[bytes]) -> None:
         """Drain stderr so a full pipe cannot stall the child process."""
@@ -781,6 +784,11 @@ class GsdMcpClient:
         """
         proc = self._milestone_proc
         blocker_id = self._milestone_pending_blocker_id
+        if self._milestone_notified_terminal:
+            raise RuntimeError(
+                "Milestone session is no longer accepting replies. "
+                "Run `/gsd cancel` to clean up."
+            )
         if proc is None or not blocker_id:
             raise RuntimeError(
                 "No pending blocker for the active milestone session."
@@ -804,6 +812,9 @@ class GsdMcpClient:
         proc = self._milestone_proc
         if proc is None:
             return False
+        thread = self._milestone_thread
+        if thread is not None and thread.is_alive():
+            return True
         if proc.poll() is None:
             return True
         self._clear_milestone_state()

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -580,7 +580,7 @@ class GsdMcpClient:
         if self._milestone_proc is not proc:
             return
         if self._milestone_notified_terminal:
-            self._release_milestone_proc()
+            self._clear_milestone_state()
             return
         exit_code = proc.poll()
         if exit_code is None:
@@ -599,7 +599,7 @@ class GsdMcpClient:
                 if self._milestone_on_terminal is not None:
                     self._milestone_on_terminal("failed")
                 self._milestone_notified_terminal = True
-            self._release_milestone_proc()
+            self._clear_milestone_state()
             return
         if exit_code == 0:
             if self._milestone_command_block_failure:
@@ -626,7 +626,7 @@ class GsdMcpClient:
         if self._milestone_on_terminal is not None:
             self._milestone_on_terminal(status)
         self._milestone_notified_terminal = True
-        self._release_milestone_proc()
+        self._clear_milestone_state()
 
     def _drain_milestone_stderr(self, proc: subprocess.Popen[bytes]) -> None:
         """Drain stderr so a full pipe cannot stall the child process."""

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -400,6 +400,7 @@ class GsdMcpClient:
     # exit (the stream reader emits notify_terminal on stdout EOF), so only the
     # blocked-notice classifier is needed here.
     _PAUSED_NOTICE_PREFIXES = ("auto-mode paused", "step-mode paused")
+    _EXIT_BLOCKED = 10
 
     def _is_blocked_notice(self, message: str) -> bool:
         """Mirror of stop-notice.ts isBlockedNoticeMessage (lowercased input)."""
@@ -438,6 +439,8 @@ class GsdMcpClient:
                 "Provide exactly one milestone spec: context_text or context_file"
             )
         self.ensure_version()
+        if self._milestone_proc is not None and self._milestone_proc.poll() is None:
+            raise RuntimeError("Milestone creation already in progress.")
 
         args: list[str] = [
             self._config.cli_path,
@@ -461,11 +464,17 @@ class GsdMcpClient:
             cwd=project_dir,
             env=self._env(),
         )
+        self._milestone_proc = proc
         self._milestone_session_id = None
         self._milestone_pending_blocker_id = None
         self._milestone_notifications = notifications
         self._milestone_on_terminal = on_terminal
         self._milestone_notified_terminal = False
+        threading.Thread(
+            target=self._drain_milestone_stderr,
+            args=(proc,),
+            daemon=True,
+        ).start()
 
         # Read init_result synchronously so the caller gets the sessionId
         # before the ack returns. The stream loop then continues in the
@@ -479,8 +488,8 @@ class GsdMcpClient:
                 proc.wait(timeout=5)
             except Exception:
                 pass
+            self._clear_milestone_state()
             raise
-        self._milestone_proc = proc
         self._milestone_session_id = session_id
 
         self._milestone_thread = threading.Thread(
@@ -539,6 +548,8 @@ class GsdMcpClient:
                 exit_code = proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 exit_code = None
+        if exit_code == self._EXIT_BLOCKED:
+            return
         if exit_code == 0:
             status = "complete"
             error: str | None = None
@@ -558,6 +569,16 @@ class GsdMcpClient:
             self._milestone_on_terminal(status)
         self._milestone_notified_terminal = True
         self._release_milestone_proc()
+
+    def _drain_milestone_stderr(self, proc: subprocess.Popen[bytes]) -> None:
+        """Drain stderr so a full pipe cannot stall the child process."""
+        if proc.stderr is None:
+            return
+        try:
+            for _ in proc.stderr:
+                pass
+        except Exception:
+            pass
 
     def _handle_milestone_event(self, event: dict[str, Any]) -> None:
         etype = event.get("type")
@@ -619,11 +640,8 @@ class GsdMcpClient:
         payload = json.dumps(
             {"type": "extension_ui_response", "id": blocker_id, "value": response}
         ).encode("utf-8")
-        try:
-            proc.stdin.write(payload + b"\n")
-            proc.stdin.flush()
-        except Exception:
-            pass
+        proc.stdin.write(payload + b"\n")
+        proc.stdin.flush()
         self._milestone_pending_blocker_id = None
 
     def milestone_active(self) -> bool:

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -52,6 +52,7 @@ class GsdMcpClient:
         self._milestone_pending_blocker_method: str | None = None
         self._milestone_command_block_failure: str | None = None
         self._milestone_notifications: Any = None  # NotificationService | None
+        self._milestone_project_dir: str | None = None
         self._milestone_on_terminal: Callable[[str], None] | None = None
         self._milestone_notified_terminal: bool = False
         self._milestone_thread: threading.Thread | None = None
@@ -387,6 +388,12 @@ class GsdMcpClient:
             project_dir=project_dir,
         )
 
+    def project_query(self, project_dir: str, query: str) -> dict[str, Any]:
+        return self._call_tool(
+            "gsd_query",
+            {"projectDir": project_dir, "query": query},
+        )
+
     # ------------------------------------------------------------------
     # Milestone creation (issue #1162)
     #
@@ -410,6 +417,8 @@ class GsdMcpClient:
     )
     _EXIT_BLOCKED = 10
     _STDERR_TAIL_LIMIT = 64 * 1024
+    # Supervised headless defaults to 30s; chat /gsd reply needs much longer.
+    _SUPERVISED_RESPONSE_TIMEOUT_MS = 3_600_000
 
     def _is_blocked_notice(self, message: str) -> bool:
         """Mirror of stop-notice.ts isBlockedNoticeMessage (lowercased input)."""
@@ -495,6 +504,8 @@ class GsdMcpClient:
             self._config.cli_path,
             "headless",
             "--supervised",
+            "--response-timeout",
+            str(self._SUPERVISED_RESPONSE_TIMEOUT_MS),
             "--output-format",
             "stream-json",
         ]
@@ -519,6 +530,7 @@ class GsdMcpClient:
         self._milestone_pending_blocker_method = None
         self._milestone_command_block_failure = None
         self._milestone_notifications = notifications
+        self._milestone_project_dir = project_dir
         self._milestone_on_terminal = on_terminal
         self._milestone_notified_terminal = False
         self._clear_milestone_stderr()
@@ -604,7 +616,13 @@ class GsdMcpClient:
             status = "failed"
             error = "stream lost — run /gsd cancel"
         if self._milestone_notifications is not None:
-            self._milestone_notifications.notify_terminal(status, error)
+            if status == "complete":
+                summary = self._build_milestone_completion_message(
+                    self._milestone_project_dir or ""
+                )
+                self._milestone_notifications.notify_milestone_complete(summary)
+            else:
+                self._milestone_notifications.notify_terminal(status, error)
         if self._milestone_on_terminal is not None:
             self._milestone_on_terminal(status)
         self._milestone_notified_terminal = True
@@ -701,9 +719,47 @@ class GsdMcpClient:
         self._milestone_stderr_thread = None
         self._clear_milestone_stderr()
 
+    def _build_milestone_completion_message(self, project_dir: str) -> str:
+        fallback = "✅ Milestone created. Run `/gsd status` for details."
+        if not project_dir:
+            return fallback
+        try:
+            query_data = self.project_query(project_dir, "milestones")
+        except Exception:
+            return fallback
+        milestones = query_data.get("milestones")
+        if not milestones:
+            return fallback
+        try:
+            self.invalidate_cache(project_dir)
+            snap = self.progress(project_dir)
+        except Exception:
+            snap = None
+        milestone_id: str | None = None
+        if snap and snap.active_milestone:
+            milestone_id = snap.active_milestone.get("id")
+        if not milestone_id:
+            last = milestones[-1]
+            if isinstance(last, dict):
+                milestone_id = last.get("id")
+        if not milestone_id:
+            return fallback
+        slice_total = snap.slices.get("total", 0) if snap else 0
+        task_total = snap.tasks.get("total", 0) if snap else 0
+        msg = f"✅ Milestone {milestone_id} ready"
+        counts: list[str] = []
+        if slice_total:
+            counts.append(f"{slice_total} slice{'s' if slice_total != 1 else ''}")
+        if task_total:
+            counts.append(f"{task_total} task{'s' if task_total != 1 else ''}")
+        if counts:
+            msg += f" — {', '.join(counts)}"
+        return f"{msg}. Run `/gsd auto` to start."
+
     def _clear_milestone_state(self) -> None:
         self._release_milestone_proc()
         self._milestone_session_id = None
+        self._milestone_project_dir = None
         self._milestone_pending_blocker_id = None
         self._milestone_pending_blocker_method = None
         self._milestone_command_block_failure = None

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -713,7 +713,10 @@ class GsdMcpClient:
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            return
+            try:
+                proc.kill()
+            except Exception:
+                pass
         if self._milestone_proc is proc:
             self._clear_milestone_state()
 

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -49,6 +49,8 @@ class GsdMcpClient:
         self._milestone_proc: subprocess.Popen[bytes] | None = None
         self._milestone_session_id: str | None = None
         self._milestone_pending_blocker_id: str | None = None
+        self._milestone_pending_blocker_method: str | None = None
+        self._milestone_command_block_failure: str | None = None
         self._milestone_notifications: Any = None  # NotificationService | None
         self._milestone_on_terminal: Callable[[str], None] | None = None
         self._milestone_notified_terminal: bool = False
@@ -423,13 +425,43 @@ class GsdMcpClient:
         )
 
     def _is_milestone_blocker_event(self, event: dict[str, Any]) -> bool:
-        """True for blocked notices and supervised interactive UI requests."""
+        """True for supervised interactive UI requests (select/input/confirm/editor)."""
         method = str(event.get("method") or "")
         if method in self._FIRE_AND_FORGET_UI_METHODS:
-            if method != "notify":
-                return False
-            message = str(event.get("message") or "").lower()
-            return self._is_blocked_notice(message)
+            return False
+        return True
+
+    def _get_command_block_content(self, event: dict[str, Any]) -> str | None:
+        """Extract gsd-command-block message content from stream events."""
+        etype = event.get("type")
+        if etype not in ("message_start", "message_end"):
+            return None
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return None
+        if message.get("customType") != "gsd-command-block":
+            return None
+        return str(message.get("content") or "")
+
+    def _is_blocking_command_block(self, event: dict[str, Any]) -> bool:
+        """Mirror headless-events isBlockingCommandBlock."""
+        content = self._get_command_block_content(event)
+        if not content:
+            return False
+        lowered = content.lower()
+        return (
+            (
+                "cannot start new workflow work" in lowered
+                and "complete but not merged" in lowered
+            )
+            or "cannot run because the active milestone is blocked by validation"
+            in lowered
+        )
+
+    def _parse_confirm_response(self, response: str) -> bool:
+        normalized = response.strip().lower()
+        if normalized in ("no", "n", "false", "0", "cancel", "decline"):
+            return False
         return True
 
     def create_milestone(
@@ -484,6 +516,8 @@ class GsdMcpClient:
         self._milestone_proc = proc
         self._milestone_session_id = None
         self._milestone_pending_blocker_id = None
+        self._milestone_pending_blocker_method = None
+        self._milestone_command_block_failure = None
         self._milestone_notifications = notifications
         self._milestone_on_terminal = on_terminal
         self._milestone_notified_terminal = False
@@ -543,10 +577,25 @@ class GsdMcpClient:
             except subprocess.TimeoutExpired:
                 exit_code = None
         if exit_code == self._EXIT_BLOCKED:
+            if self._milestone_pending_blocker_id:
+                return
+            if not self._milestone_notified_terminal:
+                if self._milestone_notifications is not None:
+                    self._milestone_notifications.notify_terminal(
+                        "failed", "Planning blocked"
+                    )
+                if self._milestone_on_terminal is not None:
+                    self._milestone_on_terminal("failed")
+                self._milestone_notified_terminal = True
+            self._release_milestone_proc()
             return
         if exit_code == 0:
-            status = "complete"
-            error: str | None = None
+            if self._milestone_command_block_failure:
+                status = "failed"
+                error = self._milestone_command_block_failure
+            else:
+                status = "complete"
+                error = None
         elif exit_code is not None:
             status = "failed"
             self._join_milestone_stderr_thread()
@@ -607,12 +656,23 @@ class GsdMcpClient:
             if sid:
                 self._milestone_session_id = str(sid)
             return
+        if self._is_blocking_command_block(event):
+            failure = self._get_command_block_content(event) or "Planning blocked"
+            self._milestone_command_block_failure = failure
+            if not self._milestone_notified_terminal:
+                if self._milestone_notifications is not None:
+                    self._milestone_notifications.notify_terminal("failed", failure)
+                if self._milestone_on_terminal is not None:
+                    self._milestone_on_terminal("failed")
+                self._milestone_notified_terminal = True
+            return
         if etype != "extension_ui_request":
             return
         if not self._is_milestone_blocker_event(event):
             return
         event_id = str(event.get("id") or "")
         self._milestone_pending_blocker_id = event_id or None
+        self._milestone_pending_blocker_method = str(event.get("method") or "") or None
         if self._milestone_notifications is not None:
             self._milestone_notifications.notify_blocker(
                 SessionStatus(
@@ -645,12 +705,15 @@ class GsdMcpClient:
         self._release_milestone_proc()
         self._milestone_session_id = None
         self._milestone_pending_blocker_id = None
+        self._milestone_pending_blocker_method = None
+        self._milestone_command_block_failure = None
 
     def respond_to_milestone_blocker(self, response: str) -> None:
         """Write an extension_ui_response to the milestone subprocess stdin.
 
         Uses the supervised-mode JSONL protocol (see startSupervisedStdinReader
-        in src/headless-ui.ts): {"type":"extension_ui_response","id":...,"value":...}.
+        in src/headless-ui.ts): {"type":"extension_ui_response","id":...,"value":...}
+        or {"type":"extension_ui_response","id":...,"confirmed":...} for confirm prompts.
         """
         proc = self._milestone_proc
         blocker_id = self._milestone_pending_blocker_id
@@ -659,12 +722,19 @@ class GsdMcpClient:
                 "No pending blocker for the active milestone session."
             )
         assert proc.stdin is not None
-        payload = json.dumps(
-            {"type": "extension_ui_response", "id": blocker_id, "value": response}
-        ).encode("utf-8")
+        response_payload: dict[str, Any] = {
+            "type": "extension_ui_response",
+            "id": blocker_id,
+        }
+        if self._milestone_pending_blocker_method == "confirm":
+            response_payload["confirmed"] = self._parse_confirm_response(response)
+        else:
+            response_payload["value"] = response
+        payload = json.dumps(response_payload).encode("utf-8")
         proc.stdin.write(payload + b"\n")
         proc.stdin.flush()
         self._milestone_pending_blocker_id = None
+        self._milestone_pending_blocker_method = None
 
     def milestone_active(self) -> bool:
         return self._milestone_proc is not None

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -710,7 +710,12 @@ class GsdMcpClient:
             proc.terminate()
         except Exception:
             pass
-        self._clear_milestone_state()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            return
+        if self._milestone_proc is proc:
+            self._clear_milestone_state()
 
     def _release_milestone_proc(self) -> None:
         self._milestone_proc = None
@@ -793,7 +798,13 @@ class GsdMcpClient:
         self._milestone_pending_blocker_method = None
 
     def milestone_active(self) -> bool:
-        return self._milestone_proc is not None
+        proc = self._milestone_proc
+        if proc is None:
+            return False
+        if proc.poll() is None:
+            return True
+        self._clear_milestone_state()
+        return False
 
     def milestone_session_id(self) -> str | None:
         return self._milestone_session_id

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -42,6 +42,15 @@ class GsdMcpClient:
         self._request_id = 0
         self._cache: dict[str, _CacheEntry] = {}
         self._version_checked = False
+        # Milestone subprocess state (issue #1162). The plugin owns the
+        # `gsd headless --supervised new-milestone` process directly, so the
+        # MCP session manager cannot see or reach it. This client is the sole
+        # owner of its lifecycle (cancel, blocker replies, terminal events).
+        self._milestone_proc: subprocess.Popen[bytes] | None = None
+        self._milestone_session_id: str | None = None
+        self._milestone_pending_blocker_id: str | None = None
+        self._milestone_notifications: Any = None  # NotificationService | None
+        self._milestone_thread: threading.Thread | None = None
 
     def _env(self) -> dict[str, str]:
         env = os.environ.copy()
@@ -371,5 +380,218 @@ class GsdMcpClient:
             project_dir=project_dir,
         )
 
+    # ------------------------------------------------------------------
+    # Milestone creation (issue #1162)
+    #
+    # The plugin spawns `gsd headless --supervised new-milestone` directly
+    # and owns the subprocess. The MCP session manager cannot see it (it
+    # only knows sessions it started via gsd_execute), and there is no
+    # auto.lock pid backstop during the planning phase. So this client is
+    # the sole owner of the subprocess's lifecycle: cancel (SIGTERM),
+    # blocker replies (stdin), and transition/terminal notifications
+    # (stdout stream). See integrations/hermes/docs/issue-1162-grilling.md.
+    # ------------------------------------------------------------------
+
+    # Stop-notice vocabulary mirrored from src/resources/extensions/gsd/stop-notice.ts.
+    # Keep both sides in lockstep; the canonical prefixes the headless event
+    # loop emits in notify messages. Terminal detection is handled by process
+    # exit (the stream reader emits notify_terminal on stdout EOF), so only the
+    # blocked-notice classifier is needed here.
+    _PAUSED_NOTICE_PREFIXES = ("auto-mode paused", "step-mode paused")
+
+    def _is_blocked_notice(self, message: str) -> bool:
+        """Mirror of stop-notice.ts isBlockedNoticeMessage (lowercased input)."""
+        if "blocked:" in message:
+            return True
+        if any(message.startswith(p) for p in self._PAUSED_NOTICE_PREFIXES):
+            if "idempotent advance: unit already active" not in message:
+                return True
+        return (
+            "resolve manually and re-run /gsd auto" in message
+            or "resolve conflicts manually and run /gsd auto to resume" in message
+            or "resolve and run /gsd auto to resume" in message
+        )
+
+    def create_milestone(
+        self,
+        project_dir: str,
+        *,
+        context_text: str | None = None,
+        context_file: str | None = None,
+        notifications: Any = None,
+    ) -> str:
+        """Spawn `gsd headless --supervised new-milestone` and return the sessionId.
+
+        The subprocess is started detached; a background thread reads its
+        stream-json stdout, captures init_result.sessionId, and drives the
+        supplied NotificationService on blocker/terminal events. The caller
+        receives the sessionId once the init_result event arrives.
+
+        Raises ValueError if neither (or both) of context_text/context_file
+        is supplied.
+        """
+        if bool(context_text) == bool(context_file):
+            raise ValueError(
+                "Provide exactly one milestone spec: context_text or context_file"
+            )
+        self.ensure_version()
+
+        args: list[str] = [
+            self._config.cli_path,
+            "headless",
+            "--supervised",
+            "--output-format",
+            "stream-json",
+        ]
+        if context_text:
+            args += ["--context-text", context_text]
+        else:
+            assert context_file is not None
+            args += ["--context", context_file]
+        args.append("new-milestone")
+
+        proc = subprocess.Popen(  # noqa: S603 - args list, not shell
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=project_dir,
+            env=self._env(),
+        )
+        self._milestone_proc = proc
+        self._milestone_session_id = None
+        self._milestone_pending_blocker_id = None
+        self._milestone_notifications = notifications
+
+        # Read init_result synchronously so the caller gets the sessionId
+        # before the ack returns. The stream loop then continues in the
+        # background for blocker/terminal events.
+        assert proc.stdout is not None
+        session_id = self._read_init_result(proc)
+        self._milestone_session_id = session_id
+
+        self._milestone_thread = threading.Thread(
+            target=self._milestone_stream_loop,
+            args=(proc,),
+            daemon=True,
+        )
+        self._milestone_thread.start()
+        return session_id
+
+    def _read_init_result(self, proc: subprocess.Popen[bytes]) -> str:
+        """Block reading stdout lines until init_result yields a sessionId."""
+        assert proc.stdout is not None
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                raise McpProtocolError(
+                    "new-milestone subprocess closed stdout before init_result"
+                )
+            try:
+                event = json.loads(line.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if event.get("type") == "init_result":
+                sid = event.get("sessionId")
+                if not sid:
+                    raise McpProtocolError("init_result arrived without sessionId")
+                return str(sid)
+
+    def _milestone_stream_loop(self, proc: subprocess.Popen[bytes]) -> None:
+        """Background reader: capture blocker/terminal events and notify.
+
+        Best-effort. On stream loss we surface FAILED via notify_terminal so
+        the user can `/gsd cancel` to clean up (no watchdog; the cancel
+        escape hatch is the safety net).
+        """
+        assert proc.stdout is not None
+        try:
+            while True:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                try:
+                    event = json.loads(line.decode("utf-8"))
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                self._handle_milestone_event(event)
+        except Exception:
+            pass
+        # Stream ended — emit a terminal notification if we never saw one.
+        if self._milestone_notifications is not None:
+            self._milestone_notifications.notify_terminal("stream-ended")
+
+    def _handle_milestone_event(self, event: dict[str, Any]) -> None:
+        etype = event.get("type")
+        if etype == "init_result":
+            sid = event.get("sessionId")
+            if sid:
+                self._milestone_session_id = str(sid)
+            return
+        if etype != "extension_ui_request":
+            return
+        message = str(event.get("message") or "").lower()
+        event_id = str(event.get("id") or "")
+        if self._is_blocked_notice(message):
+            self._milestone_pending_blocker_id = event_id or None
+            if self._milestone_notifications is not None:
+                self._milestone_notifications.notify_blocker(
+                    SessionStatus(
+                        status="blocked",
+                        pending_blocker=event,
+                        session_id=self._milestone_session_id,
+                    )
+                )
+
+    def cancel_milestone(self) -> None:
+        """SIGTERM the held milestone subprocess and clear state."""
+        proc = self._milestone_proc
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        self._clear_milestone_state()
+
+    def _clear_milestone_state(self) -> None:
+        self._milestone_proc = None
+        self._milestone_session_id = None
+        self._milestone_pending_blocker_id = None
+
+    def respond_to_milestone_blocker(self, response: str) -> None:
+        """Write an extension_ui_response to the milestone subprocess stdin.
+
+        Uses the supervised-mode JSONL protocol (see startSupervisedStdinReader
+        in src/headless-ui.ts): {"type":"extension_ui_response","id":...,"value":...}.
+        """
+        proc = self._milestone_proc
+        blocker_id = self._milestone_pending_blocker_id
+        if proc is None or not blocker_id:
+            raise RuntimeError(
+                "No pending blocker for the active milestone session."
+            )
+        assert proc.stdin is not None
+        payload = json.dumps(
+            {"type": "extension_ui_response", "id": blocker_id, "value": response}
+        ).encode("utf-8")
+        try:
+            proc.stdin.write(payload + b"\n")
+            proc.stdin.flush()
+        except Exception:
+            pass
+        self._milestone_pending_blocker_id = None
+
+    def milestone_active(self) -> bool:
+        return self._milestone_proc is not None
+
+    def milestone_session_id(self) -> str | None:
+        return self._milestone_session_id
+
+    def milestone_pending_blocker_id(self) -> str | None:
+        return self._milestone_pending_blocker_id
+
     def close(self) -> None:
         self._terminate_process()
+        if self._milestone_proc is not None:
+            self.cancel_milestone()

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -580,7 +580,8 @@ class GsdMcpClient:
         if self._milestone_proc is not proc:
             return
         if self._milestone_notified_terminal:
-            self._clear_milestone_state()
+            if proc.poll() is not None:
+                self._clear_milestone_state()
             return
         exit_code = proc.poll()
         if exit_code is None:
@@ -624,7 +625,8 @@ class GsdMcpClient:
         if self._milestone_on_terminal is not None:
             self._milestone_on_terminal(status)
         self._milestone_notified_terminal = True
-        self._clear_milestone_state()
+        if exit_code is not None:
+            self._clear_milestone_state()
 
     def _drain_milestone_stderr(self, proc: subprocess.Popen[bytes]) -> None:
         """Drain stderr so a full pipe cannot stall the child process."""

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -8,7 +8,7 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from packaging import version
 
@@ -50,6 +50,8 @@ class GsdMcpClient:
         self._milestone_session_id: str | None = None
         self._milestone_pending_blocker_id: str | None = None
         self._milestone_notifications: Any = None  # NotificationService | None
+        self._milestone_on_terminal: Callable[[str], None] | None = None
+        self._milestone_notified_terminal: bool = False
         self._milestone_thread: threading.Thread | None = None
 
     def _env(self) -> dict[str, str]:
@@ -419,6 +421,7 @@ class GsdMcpClient:
         context_text: str | None = None,
         context_file: str | None = None,
         notifications: Any = None,
+        on_terminal: Callable[[str], None] | None = None,
     ) -> str:
         """Spawn `gsd headless --supervised new-milestone` and return the sessionId.
 
@@ -458,16 +461,26 @@ class GsdMcpClient:
             cwd=project_dir,
             env=self._env(),
         )
-        self._milestone_proc = proc
         self._milestone_session_id = None
         self._milestone_pending_blocker_id = None
         self._milestone_notifications = notifications
+        self._milestone_on_terminal = on_terminal
+        self._milestone_notified_terminal = False
 
         # Read init_result synchronously so the caller gets the sessionId
         # before the ack returns. The stream loop then continues in the
         # background for blocker/terminal events.
         assert proc.stdout is not None
-        session_id = self._read_init_result(proc)
+        try:
+            session_id = self._read_init_result(proc)
+        except Exception:
+            try:
+                proc.terminate()
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+            raise
+        self._milestone_proc = proc
         self._milestone_session_id = session_id
 
         self._milestone_thread = threading.Thread(
@@ -517,9 +530,34 @@ class GsdMcpClient:
                 self._handle_milestone_event(event)
         except Exception:
             pass
-        # Stream ended — emit a terminal notification if we never saw one.
+        if self._milestone_notified_terminal:
+            self._release_milestone_proc()
+            return
+        exit_code = proc.poll()
+        if exit_code is None:
+            try:
+                exit_code = proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                exit_code = None
+        if exit_code == 0:
+            status = "complete"
+            error: str | None = None
+        elif exit_code is not None:
+            status = "failed"
+            err_bytes = proc.stderr.read() if proc.stderr is not None else b""
+            error = (
+                err_bytes.decode("utf-8", errors="replace").strip()
+                or f"exit code {exit_code}"
+            )
+        else:
+            status = "failed"
+            error = "stream lost — run /gsd cancel"
         if self._milestone_notifications is not None:
-            self._milestone_notifications.notify_terminal("stream-ended")
+            self._milestone_notifications.notify_terminal(status, error)
+        if self._milestone_on_terminal is not None:
+            self._milestone_on_terminal(status)
+        self._milestone_notified_terminal = True
+        self._release_milestone_proc()
 
     def _handle_milestone_event(self, event: dict[str, Any]) -> None:
         etype = event.get("type")
@@ -548,14 +586,20 @@ class GsdMcpClient:
         proc = self._milestone_proc
         if proc is None:
             return
+        self._milestone_notified_terminal = True
         try:
             proc.terminate()
         except Exception:
             pass
         self._clear_milestone_state()
 
-    def _clear_milestone_state(self) -> None:
+    def _release_milestone_proc(self) -> None:
         self._milestone_proc = None
+        self._milestone_notifications = None
+        self._milestone_on_terminal = None
+
+    def _clear_milestone_state(self) -> None:
+        self._release_milestone_proc()
         self._milestone_session_id = None
         self._milestone_pending_blocker_id = None
 

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -589,8 +589,6 @@ class GsdMcpClient:
             except subprocess.TimeoutExpired:
                 exit_code = None
         if exit_code == self._EXIT_BLOCKED:
-            if self._milestone_pending_blocker_id:
-                return
             if not self._milestone_notified_terminal:
                 if self._milestone_notifications is not None:
                     self._milestone_notifications.notify_terminal(

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -400,6 +400,9 @@ class GsdMcpClient:
     # exit (the stream reader emits notify_terminal on stdout EOF), so only the
     # blocked-notice classifier is needed here.
     _PAUSED_NOTICE_PREFIXES = ("auto-mode paused", "step-mode paused")
+    _FIRE_AND_FORGET_UI_METHODS = frozenset(
+        {"notify", "setStatus", "setWidget", "setTitle", "set_editor_text"}
+    )
     _EXIT_BLOCKED = 10
 
     def _is_blocked_notice(self, message: str) -> bool:
@@ -415,6 +418,16 @@ class GsdMcpClient:
             or "resolve and run /gsd auto to resume" in message
         )
 
+    def _is_milestone_blocker_event(self, event: dict[str, Any]) -> bool:
+        """True for blocked notices and supervised interactive UI requests."""
+        method = str(event.get("method") or "")
+        if method in self._FIRE_AND_FORGET_UI_METHODS:
+            if method != "notify":
+                return False
+            message = str(event.get("message") or "").lower()
+            return self._is_blocked_notice(message)
+        return True
+
     def create_milestone(
         self,
         project_dir: str,
@@ -424,12 +437,12 @@ class GsdMcpClient:
         notifications: Any = None,
         on_terminal: Callable[[str], None] | None = None,
     ) -> str:
-        """Spawn `gsd headless --supervised new-milestone` and return the sessionId.
+        """Spawn `gsd headless --supervised new-milestone` and return a session id.
 
         The subprocess is started detached; a background thread reads its
-        stream-json stdout, captures init_result.sessionId, and drives the
-        supplied NotificationService on blocker/terminal events. The caller
-        receives the sessionId once the init_result event arrives.
+        stream-json stdout and drives the supplied NotificationService on
+        blocker/terminal events. Returns a local session id immediately
+        (headless does not emit init_result on stdout).
 
         Raises ValueError if neither (or both) of context_text/context_file
         is supplied.
@@ -476,20 +489,10 @@ class GsdMcpClient:
             daemon=True,
         ).start()
 
-        # Read init_result synchronously so the caller gets the sessionId
-        # before the ack returns. The stream loop then continues in the
-        # background for blocker/terminal events.
-        assert proc.stdout is not None
-        try:
-            session_id = self._read_init_result(proc)
-        except Exception:
-            try:
-                proc.terminate()
-                proc.wait(timeout=5)
-            except Exception:
-                pass
-            self._clear_milestone_state()
-            raise
+        # Headless stream-json does not emit init_result on stdout (init is an
+        # internal RPC handshake). Use a local session id for ack/status only;
+        # milestone lifecycle is keyed on the held subprocess, not MCP.
+        session_id = f"milestone-{proc.pid}"
         self._milestone_session_id = session_id
 
         self._milestone_thread = threading.Thread(
@@ -499,25 +502,6 @@ class GsdMcpClient:
         )
         self._milestone_thread.start()
         return session_id
-
-    def _read_init_result(self, proc: subprocess.Popen[bytes]) -> str:
-        """Block reading stdout lines until init_result yields a sessionId."""
-        assert proc.stdout is not None
-        while True:
-            line = proc.stdout.readline()
-            if not line:
-                raise McpProtocolError(
-                    "new-milestone subprocess closed stdout before init_result"
-                )
-            try:
-                event = json.loads(line.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if event.get("type") == "init_result":
-                sid = event.get("sessionId")
-                if not sid:
-                    raise McpProtocolError("init_result arrived without sessionId")
-                return str(sid)
 
     def _milestone_stream_loop(self, proc: subprocess.Popen[bytes]) -> None:
         """Background reader: capture blocker/terminal events and notify.
@@ -589,18 +573,18 @@ class GsdMcpClient:
             return
         if etype != "extension_ui_request":
             return
-        message = str(event.get("message") or "").lower()
+        if not self._is_milestone_blocker_event(event):
+            return
         event_id = str(event.get("id") or "")
-        if self._is_blocked_notice(message):
-            self._milestone_pending_blocker_id = event_id or None
-            if self._milestone_notifications is not None:
-                self._milestone_notifications.notify_blocker(
-                    SessionStatus(
-                        status="blocked",
-                        pending_blocker=event,
-                        session_id=self._milestone_session_id,
-                    )
+        self._milestone_pending_blocker_id = event_id or None
+        if self._milestone_notifications is not None:
+            self._milestone_notifications.notify_blocker(
+                SessionStatus(
+                    status="blocked",
+                    pending_blocker=event,
+                    session_id=self._milestone_session_id,
                 )
+            )
 
     def cancel_milestone(self) -> None:
         """SIGTERM the held milestone subprocess and clear state."""

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -53,6 +53,9 @@ class GsdMcpClient:
         self._milestone_on_terminal: Callable[[str], None] | None = None
         self._milestone_notified_terminal: bool = False
         self._milestone_thread: threading.Thread | None = None
+        self._milestone_stderr_thread: threading.Thread | None = None
+        self._milestone_stderr_lock = threading.Lock()
+        self._milestone_stderr_tail = bytearray()
 
     def _env(self) -> dict[str, str]:
         env = os.environ.copy()
@@ -404,6 +407,7 @@ class GsdMcpClient:
         {"notify", "setStatus", "setWidget", "setTitle", "set_editor_text"}
     )
     _EXIT_BLOCKED = 10
+    _STDERR_TAIL_LIMIT = 64 * 1024
 
     def _is_blocked_notice(self, message: str) -> bool:
         """Mirror of stop-notice.ts isBlockedNoticeMessage (lowercased input)."""
@@ -483,11 +487,13 @@ class GsdMcpClient:
         self._milestone_notifications = notifications
         self._milestone_on_terminal = on_terminal
         self._milestone_notified_terminal = False
-        threading.Thread(
+        self._clear_milestone_stderr()
+        self._milestone_stderr_thread = threading.Thread(
             target=self._drain_milestone_stderr,
             args=(proc,),
             daemon=True,
-        ).start()
+        )
+        self._milestone_stderr_thread.start()
 
         # Headless stream-json does not emit init_result on stdout (init is an
         # internal RPC handshake). Use a local session id for ack/status only;
@@ -520,9 +526,13 @@ class GsdMcpClient:
                     event = json.loads(line.decode("utf-8"))
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     continue
+                if self._milestone_proc is not proc:
+                    return
                 self._handle_milestone_event(event)
         except Exception:
             pass
+        if self._milestone_proc is not proc:
+            return
         if self._milestone_notified_terminal:
             self._release_milestone_proc()
             return
@@ -539,11 +549,8 @@ class GsdMcpClient:
             error: str | None = None
         elif exit_code is not None:
             status = "failed"
-            err_bytes = proc.stderr.read() if proc.stderr is not None else b""
-            error = (
-                err_bytes.decode("utf-8", errors="replace").strip()
-                or f"exit code {exit_code}"
-            )
+            self._join_milestone_stderr_thread()
+            error = self._milestone_stderr_text(proc) or f"exit code {exit_code}"
         else:
             status = "failed"
             error = "stream lost — run /gsd cancel"
@@ -559,10 +566,39 @@ class GsdMcpClient:
         if proc.stderr is None:
             return
         try:
-            for _ in proc.stderr:
-                pass
+            while True:
+                chunk = proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._append_milestone_stderr(chunk)
         except Exception:
             pass
+
+    def _append_milestone_stderr(self, chunk: bytes) -> None:
+        with self._milestone_stderr_lock:
+            self._milestone_stderr_tail.extend(chunk)
+            overflow = len(self._milestone_stderr_tail) - self._STDERR_TAIL_LIMIT
+            if overflow > 0:
+                del self._milestone_stderr_tail[:overflow]
+
+    def _clear_milestone_stderr(self) -> None:
+        with self._milestone_stderr_lock:
+            self._milestone_stderr_tail.clear()
+
+    def _join_milestone_stderr_thread(self) -> None:
+        thread = self._milestone_stderr_thread
+        if thread and thread is not threading.current_thread():
+            thread.join(timeout=1)
+
+    def _milestone_stderr_text(self, proc: subprocess.Popen[bytes]) -> str:
+        with self._milestone_stderr_lock:
+            err_bytes = bytes(self._milestone_stderr_tail)
+        if not err_bytes and proc.stderr is not None:
+            try:
+                err_bytes = proc.stderr.read()
+            except Exception:
+                err_bytes = b""
+        return err_bytes.decode("utf-8", errors="replace").strip()
 
     def _handle_milestone_event(self, event: dict[str, Any]) -> None:
         etype = event.get("type")
@@ -602,6 +638,8 @@ class GsdMcpClient:
         self._milestone_proc = None
         self._milestone_notifications = None
         self._milestone_on_terminal = None
+        self._milestone_stderr_thread = None
+        self._clear_milestone_stderr()
 
     def _clear_milestone_state(self) -> None:
         self._release_milestone_proc()

--- a/integrations/hermes/open_gsd_hermes/notifications.py
+++ b/integrations/hermes/open_gsd_hermes/notifications.py
@@ -52,7 +52,12 @@ class NotificationService:
 
     def notify_blocker(self, status: SessionStatus) -> None:
         blocker = status.pending_blocker or {}
-        q = blocker.get("question") or blocker.get("prompt") or "Action required"
+        q = (
+            blocker.get("question")
+            or blocker.get("prompt")
+            or blocker.get("message")
+            or "Action required"
+        )
         self.send(f"🚧 GSD blocker: {q}\nReply with `/gsd reply <your answer>`", kind="blocker")
 
     def notify_transition(self, message: str) -> None:

--- a/integrations/hermes/open_gsd_hermes/notifications.py
+++ b/integrations/hermes/open_gsd_hermes/notifications.py
@@ -63,6 +63,9 @@ class NotificationService:
     def notify_transition(self, message: str) -> None:
         self.send(f"📋 GSD: {message}", kind="transition")
 
+    def notify_milestone_complete(self, message: str) -> None:
+        self.send(message, kind="complete")
+
     def notify_terminal(self, status: str, error: str | None = None) -> None:
         normalized_status = status.lower()
         if normalized_status in ("complete", "completed", "done"):

--- a/integrations/hermes/open_gsd_hermes/notifications.py
+++ b/integrations/hermes/open_gsd_hermes/notifications.py
@@ -56,6 +56,7 @@ class NotificationService:
             blocker.get("question")
             or blocker.get("prompt")
             or blocker.get("message")
+            or blocker.get("title")
             or "Action required"
         )
         self.send(f"🚧 GSD blocker: {q}\nReply with `/gsd reply <your answer>`", kind="blocker")

--- a/integrations/hermes/open_gsd_hermes/notifications.py
+++ b/integrations/hermes/open_gsd_hermes/notifications.py
@@ -55,8 +55,8 @@ class NotificationService:
         q = (
             blocker.get("question")
             or blocker.get("prompt")
-            or blocker.get("message")
             or blocker.get("title")
+            or blocker.get("message")
             or "Action required"
         )
         self.send(f"🚧 GSD blocker: {q}\nReply with `/gsd reply <your answer>`", kind="blocker")

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -169,12 +169,11 @@ def test_stream_loop_notifies_blocker_on_supervised_select_request() -> None:
 
 
 def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:
-    """An extension_ui_request that is a blocked-notice must fire notify_blocker."""
+    """Blocked-notice notify events are fire-and-forget; they must not prompt /gsd reply."""
     client = GsdMcpClient(_config())
     notifications = MagicMock()
     fake_proc = _FakeProc()
-    # Realistic blocked-notice message — must match the stop-notice vocabulary
-    # the headless event loop emits (see stop-notice.ts isBlockedNoticeMessage).
+    # Realistic blocked-notice message — headless auto-acks notify in supervised mode.
     blocker_event = {
         "type": "extension_ui_request",
         "method": "notify",
@@ -190,9 +189,8 @@ def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:
         with patch.object(client, "_milestone_notifications", notifications):
             client._milestone_stream_loop(fake_proc)
 
-    notifications.notify_blocker.assert_called_once()
-    # pending blocker id tracked for /gsd reply routing
-    assert client.milestone_pending_blocker_id() == "blk-1"
+    notifications.notify_blocker.assert_not_called()
+    assert client.milestone_pending_blocker_id() is None
 
 
 def test_stream_loop_notifies_terminal_on_process_exit() -> None:
@@ -231,7 +229,24 @@ def test_stream_loop_failure_reports_drained_stderr() -> None:
 
 
 def test_stream_loop_keeps_blocked_exit_non_terminal() -> None:
-    """Exit 10 is a blocked planning state, not a failed terminal exit."""
+    """Exit 10 with a pending interactive blocker is not a terminal exit."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    fake_proc.poll.return_value = 10
+    fake_proc.stdout.readline.side_effect = [b""]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_pending_blocker_id", "sel-1"):
+            with patch.object(client, "_milestone_notifications", notifications):
+                client._milestone_stream_loop(fake_proc)
+
+            notifications.notify_terminal.assert_not_called()
+            assert client.milestone_active() is True
+
+
+def test_stream_loop_releases_noninteractive_blocked_exit() -> None:
+    """Exit 10 without a pending blocker must not leave milestone ownership stuck."""
     client = GsdMcpClient(_config())
     notifications = MagicMock()
     fake_proc = _FakeProc()
@@ -242,8 +257,41 @@ def test_stream_loop_keeps_blocked_exit_non_terminal() -> None:
         with patch.object(client, "_milestone_notifications", notifications):
             client._milestone_stream_loop(fake_proc)
 
-            notifications.notify_terminal.assert_not_called()
-            assert client.milestone_active() is True
+    notifications.notify_terminal.assert_called_once_with("failed", "Planning blocked")
+    assert client.milestone_active() is False
+
+
+def test_stream_loop_handles_blocking_command_block() -> None:
+    """gsd-command-block failures must not be reported as milestone complete."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    command_block = {
+        "type": "message_start",
+        "message": {
+            "role": "custom",
+            "customType": "gsd-command-block",
+            "content": (
+                "/gsd auto cannot run because the active milestone "
+                "is blocked by validation."
+            ),
+        },
+    }
+    fake_proc.poll.return_value = 0
+    fake_proc.stdout.readline.side_effect = [
+        (json.dumps(command_block) + "\n").encode(),
+        b"",
+    ]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            client._milestone_stream_loop(fake_proc)
+
+    notifications.notify_terminal.assert_called_with(
+        "failed",
+        "/gsd auto cannot run because the active milestone is blocked by validation.",
+    )
+    assert client.milestone_active() is False
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +323,8 @@ def test_respond_to_milestone_blocker_writes_extension_ui_response_to_stdin() ->
 
     with patch.object(client, "_milestone_proc", fake_proc):
         with patch.object(client, "_milestone_pending_blocker_id", "blk-7"):
-            client.respond_to_milestone_blocker("use option B")
+            with patch.object(client, "_milestone_pending_blocker_method", "input"):
+                client.respond_to_milestone_blocker("use option B")
 
     assert fake_proc.stdin.write.called
     written = fake_proc.stdin.write.call_args[0][0]
@@ -283,6 +332,24 @@ def test_respond_to_milestone_blocker_writes_extension_ui_response_to_stdin() ->
     assert payload["type"] == "extension_ui_response"
     assert payload["id"] == "blk-7"
     assert payload["value"] == "use option B"
+
+
+def test_respond_to_milestone_blocker_writes_confirmed_for_confirm_prompt() -> None:
+    """Confirm blockers must answer with a confirmed boolean, not free text."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_pending_blocker_id", "cfm-1"):
+            with patch.object(client, "_milestone_pending_blocker_method", "confirm"):
+                client.respond_to_milestone_blocker("yes")
+
+    written = fake_proc.stdin.write.call_args[0][0]
+    payload = json.loads(written.decode() if isinstance(written, bytes) else written)
+    assert payload["type"] == "extension_ui_response"
+    assert payload["id"] == "cfm-1"
+    assert payload["confirmed"] is True
+    assert "value" not in payload
 
 
 def test_respond_to_milestone_blocker_without_pending_blocker_raises() -> None:

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -17,6 +17,7 @@ import pytest
 
 from open_gsd_hermes.config import GsdConfig
 from open_gsd_hermes.gsd_client import GsdMcpClient
+from open_gsd_hermes.types import ProgressSnapshot
 
 
 def _config() -> GsdConfig:
@@ -64,6 +65,9 @@ def test_create_milestone_builds_supervised_new_milestone_command_with_context_t
     assert args[0] == "/usr/local/bin/gsd"
     assert "headless" in args
     assert "--supervised" in args
+    assert "--response-timeout" in args
+    timeout_idx = args.index("--response-timeout")
+    assert args[timeout_idx + 1] == str(GsdMcpClient._SUPERVISED_RESPONSE_TIMEOUT_MS)
     assert "new-milestone" in args
     assert "--context-text" in args
     text_idx = args.index("--context-text")
@@ -193,8 +197,37 @@ def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:
     assert client.milestone_pending_blocker_id() is None
 
 
+def test_build_milestone_completion_message_uses_query_and_progress() -> None:
+    client = GsdMcpClient(_config())
+    with patch.object(
+        client,
+        "project_query",
+        return_value={"milestones": [{"id": "M002", "hasRoadmap": True}]},
+    ):
+        with patch.object(
+            client,
+            "progress",
+            return_value=ProgressSnapshot(
+                active_milestone={"id": "M002"},
+                slices={"total": 3},
+                tasks={"total": 9},
+            ),
+        ):
+            msg = client._build_milestone_completion_message("/proj")
+
+    assert msg == "✅ Milestone M002 ready — 3 slices, 9 tasks. Run `/gsd auto` to start."
+
+
+def test_build_milestone_completion_message_falls_back_when_query_empty() -> None:
+    client = GsdMcpClient(_config())
+    with patch.object(client, "project_query", return_value={"milestones": []}):
+        msg = client._build_milestone_completion_message("/proj")
+
+    assert msg == "✅ Milestone created. Run `/gsd status` for details."
+
+
 def test_stream_loop_notifies_terminal_on_process_exit() -> None:
-    """When the stream ends (process exited), a terminal notification fires."""
+    """When the stream ends (process exited), a milestone completion notification fires."""
     client = GsdMcpClient(_config())
     notifications = MagicMock()
     fake_proc = _FakeProc()
@@ -202,11 +235,20 @@ def test_stream_loop_notifies_terminal_on_process_exit() -> None:
     fake_proc.stdout.readline.side_effect = [b""]
 
     with patch.object(client, "_milestone_proc", fake_proc):
-        with patch.object(client, "_milestone_notifications", notifications):
-            client._milestone_stream_loop(fake_proc)
+        with patch.object(client, "_milestone_project_dir", "/proj"):
+            with patch.object(
+                client,
+                "_build_milestone_completion_message",
+                return_value="✅ Milestone M001 ready — 2 slices, 5 tasks. Run `/gsd auto` to start.",
+            ):
+                with patch.object(client, "_milestone_notifications", notifications):
+                    client._milestone_stream_loop(fake_proc)
 
-            notifications.notify_terminal.assert_called_once_with("complete", None)
-            assert client.milestone_active() is False
+    notifications.notify_milestone_complete.assert_called_once_with(
+        "✅ Milestone M001 ready — 2 slices, 5 tasks. Run `/gsd auto` to start."
+    )
+    notifications.notify_terminal.assert_not_called()
+    assert client.milestone_active() is False
 
 
 def test_stream_loop_failure_reports_drained_stderr() -> None:

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -134,15 +134,7 @@ def test_create_milestone_returns_local_session_id_from_pid() -> None:
 def test_stream_loop_captures_session_id_from_init_result() -> None:
     """The reader must pull sessionId out of the init_result stream event."""
     client = GsdMcpClient(_config())
-    fake_proc = _FakeProc()
-    # stdout yields one init_result line then EOF
-    fake_proc.stdout.readline.side_effect = [
-        (json.dumps({"type": "init_result", "sessionId": "S-789"}) + "\n").encode(),
-        b"",
-    ]
-
-    with patch.object(client, "_milestone_proc", fake_proc):
-        client._milestone_stream_loop(fake_proc)
+    client._handle_milestone_event({"type": "init_result", "sessionId": "S-789"})
 
     assert client.milestone_session_id() == "S-789"
 
@@ -151,7 +143,6 @@ def test_stream_loop_notifies_blocker_on_supervised_select_request() -> None:
     """Supervised planning prompts (select/input/confirm) must fire notify_blocker."""
     client = GsdMcpClient(_config())
     notifications = MagicMock()
-    fake_proc = _FakeProc()
     blocker_event = {
         "type": "extension_ui_request",
         "method": "select",
@@ -159,14 +150,8 @@ def test_stream_loop_notifies_blocker_on_supervised_select_request() -> None:
         "title": "Choose milestone scope",
         "options": ["A", "B"],
     }
-    fake_proc.stdout.readline.side_effect = [
-        (json.dumps(blocker_event) + "\n").encode(),
-        b"",
-    ]
-
-    with patch.object(client, "_milestone_proc", fake_proc):
-        with patch.object(client, "_milestone_notifications", notifications):
-            client._milestone_stream_loop(fake_proc)
+    with patch.object(client, "_milestone_notifications", notifications):
+        client._handle_milestone_event(blocker_event)
 
     notifications.notify_blocker.assert_called_once()
     assert client.milestone_pending_blocker_id() == "sel-1"
@@ -176,7 +161,6 @@ def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:
     """Blocked-notice notify events are fire-and-forget; they must not prompt /gsd reply."""
     client = GsdMcpClient(_config())
     notifications = MagicMock()
-    fake_proc = _FakeProc()
     # Realistic blocked-notice message — headless auto-acks notify in supervised mode.
     blocker_event = {
         "type": "extension_ui_request",
@@ -184,14 +168,8 @@ def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:
         "id": "blk-1",
         "message": "Auto-mode paused — blocked: choose an option",
     }
-    fake_proc.stdout.readline.side_effect = [
-        (json.dumps(blocker_event) + "\n").encode(),
-        b"",
-    ]
-
-    with patch.object(client, "_milestone_proc", fake_proc):
-        with patch.object(client, "_milestone_notifications", notifications):
-            client._milestone_stream_loop(fake_proc)
+    with patch.object(client, "_milestone_notifications", notifications):
+        client._handle_milestone_event(blocker_event)
 
     notifications.notify_blocker.assert_not_called()
     assert client.milestone_pending_blocker_id() is None
@@ -233,6 +211,9 @@ def test_stream_loop_notifies_terminal_on_process_exit() -> None:
     fake_proc = _FakeProc()
     fake_proc.poll.return_value = 0
     fake_proc.stdout.readline.side_effect = [b""]
+    client._milestone_session_id = "milestone-4242"
+    client._milestone_pending_blocker_id = "old-blocker"
+    client._milestone_pending_blocker_method = "input"
 
     with patch.object(client, "_milestone_proc", fake_proc):
         with patch.object(client, "_milestone_project_dir", "/proj"):
@@ -249,6 +230,9 @@ def test_stream_loop_notifies_terminal_on_process_exit() -> None:
     )
     notifications.notify_terminal.assert_not_called()
     assert client.milestone_active() is False
+    assert client.milestone_session_id() is None
+    assert client.milestone_pending_blocker_id() is None
+    assert client._milestone_pending_blocker_method is None
 
 
 def test_stream_loop_failure_reports_drained_stderr() -> None:
@@ -294,6 +278,7 @@ def test_stream_loop_releases_noninteractive_blocked_exit() -> None:
     fake_proc = _FakeProc()
     fake_proc.poll.return_value = 10
     fake_proc.stdout.readline.side_effect = [b""]
+    client._milestone_session_id = "milestone-4242"
 
     with patch.object(client, "_milestone_proc", fake_proc):
         with patch.object(client, "_milestone_notifications", notifications):
@@ -301,6 +286,7 @@ def test_stream_loop_releases_noninteractive_blocked_exit() -> None:
 
     notifications.notify_terminal.assert_called_once_with("failed", "Planning blocked")
     assert client.milestone_active() is False
+    assert client.milestone_session_id() is None
 
 
 def test_stream_loop_handles_blocking_command_block() -> None:
@@ -308,6 +294,7 @@ def test_stream_loop_handles_blocking_command_block() -> None:
     client = GsdMcpClient(_config())
     notifications = MagicMock()
     fake_proc = _FakeProc()
+    client._milestone_session_id = "milestone-4242"
     command_block = {
         "type": "message_start",
         "message": {
@@ -333,7 +320,9 @@ def test_stream_loop_handles_blocking_command_block() -> None:
         "failed",
         "/gsd auto cannot run because the active milestone is blocked by validation.",
     )
+    notifications.notify_milestone_complete.assert_not_called()
     assert client.milestone_active() is False
+    assert client.milestone_session_id() is None
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from io import BytesIO
 import json
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -289,6 +290,35 @@ def test_stream_loop_releases_noninteractive_blocked_exit() -> None:
     notifications.notify_terminal.assert_called_once_with("failed", "Planning blocked")
     assert client.milestone_active() is False
     assert client.milestone_session_id() is None
+
+
+def test_stream_loop_retains_running_proc_on_stream_loss() -> None:
+    """If stdout closes while the child is alive, /gsd cancel must still work."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    on_terminal = MagicMock()
+    fake_proc = _FakeProc()
+    fake_proc.poll.return_value = None
+    fake_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="gsd", timeout=5)
+    fake_proc.stdout.readline.side_effect = [b""]
+    client._milestone_session_id = "milestone-4242"
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            with patch.object(client, "_milestone_on_terminal", on_terminal):
+                client._milestone_stream_loop(fake_proc)
+
+                notifications.notify_terminal.assert_called_once_with(
+                    "failed", "stream lost — run /gsd cancel"
+                )
+                on_terminal.assert_called_once_with("failed")
+                assert client.milestone_active() is True
+                assert client.milestone_session_id() == "milestone-4242"
+
+                client.cancel_milestone()
+
+    fake_proc.terminate.assert_called_once()
+    assert client.milestone_active() is False
 
 
 def test_stream_loop_handles_blocking_command_block() -> None:

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -2,8 +2,7 @@
 
 These tests pin the A1 design from issue #1162's grilling:
 - create_milestone spawns `gsd headless --supervised new-milestone`
-- a background stream-reader captures init_result.sessionId and drives
-  NotificationService on blocker/terminal events
+- a background stream-reader drives NotificationService on blocker/terminal events
 - cancel_milestone SIGTERMs the held subprocess
 - respond_to_milestone_blocker writes an extension_ui_response to stdin
 """
@@ -57,11 +56,8 @@ def test_create_milestone_builds_supervised_new_milestone_command_with_context_t
 
     with patch.object(client, "ensure_version"):
         with patch("subprocess.Popen", side_effect=fake_popen):
-            # Stub the init_result sync read + background loop so the test
-            # focuses solely on the constructed command line.
-            with patch.object(client, "_read_init_result", return_value="S-1"):
-                with patch.object(client, "_milestone_stream_loop"):
-                    client.create_milestone("/proj", context_text="Build a REST API")
+            with patch.object(client, "_milestone_stream_loop"):
+                client.create_milestone("/proj", context_text="Build a REST API")
 
     args = captured["args"]
     assert args[0] == "/usr/local/bin/gsd"
@@ -86,9 +82,8 @@ def test_create_milestone_builds_command_with_context_file() -> None:
 
     with patch.object(client, "ensure_version"):
         with patch("subprocess.Popen", side_effect=fake_popen):
-            with patch.object(client, "_read_init_result", return_value="S-1"):
-                with patch.object(client, "_milestone_stream_loop"):
-                    client.create_milestone("/proj", context_file="/path/to/spec.md")
+            with patch.object(client, "_milestone_stream_loop"):
+                client.create_milestone("/proj", context_file="/path/to/spec.md")
 
     args = captured["args"]
     assert "--context" in args
@@ -118,6 +113,19 @@ def test_create_milestone_rejects_both_context_text_and_file() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_create_milestone_returns_local_session_id_from_pid() -> None:
+    """create_milestone returns a local session id without waiting for init_result."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+
+    with patch.object(client, "ensure_version"):
+        with patch("subprocess.Popen", return_value=fake_proc):
+            with patch.object(client, "_milestone_stream_loop"):
+                session_id = client.create_milestone("/proj", context_text="spec")
+
+    assert session_id == "milestone-4242"
+
+
 def test_stream_loop_captures_session_id_from_init_result() -> None:
     """The reader must pull sessionId out of the init_result stream event."""
     client = GsdMcpClient(_config())
@@ -132,6 +140,31 @@ def test_stream_loop_captures_session_id_from_init_result() -> None:
         client._milestone_stream_loop(fake_proc)
 
     assert client.milestone_session_id() == "S-789"
+
+
+def test_stream_loop_notifies_blocker_on_supervised_select_request() -> None:
+    """Supervised planning prompts (select/input/confirm) must fire notify_blocker."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    blocker_event = {
+        "type": "extension_ui_request",
+        "method": "select",
+        "id": "sel-1",
+        "title": "Choose milestone scope",
+        "options": ["A", "B"],
+    }
+    fake_proc.stdout.readline.side_effect = [
+        (json.dumps(blocker_event) + "\n").encode(),
+        b"",
+    ]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            client._milestone_stream_loop(fake_proc)
+
+    notifications.notify_blocker.assert_called_once()
+    assert client.milestone_pending_blocker_id() == "sel-1"
 
 
 def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -9,6 +9,7 @@ These tests pin the A1 design from issue #1162's grilling:
 
 from __future__ import annotations
 
+from io import BytesIO
 import json
 from unittest.mock import MagicMock, patch
 
@@ -34,7 +35,7 @@ class _FakeProc:
         self.pid = 4242
         self.stdin = MagicMock()
         self.stdout = MagicMock()
-        self.stderr = MagicMock()
+        self.stderr = BytesIO()
         self.poll = MagicMock(return_value=None)
         self.terminate = MagicMock()
         self.wait = MagicMock(return_value=0)
@@ -199,13 +200,50 @@ def test_stream_loop_notifies_terminal_on_process_exit() -> None:
     client = GsdMcpClient(_config())
     notifications = MagicMock()
     fake_proc = _FakeProc()
+    fake_proc.poll.return_value = 0
     fake_proc.stdout.readline.side_effect = [b""]
 
     with patch.object(client, "_milestone_proc", fake_proc):
         with patch.object(client, "_milestone_notifications", notifications):
             client._milestone_stream_loop(fake_proc)
 
-    notifications.notify_terminal.assert_called_once()
+            notifications.notify_terminal.assert_called_once_with("complete", None)
+            assert client.milestone_active() is False
+
+
+def test_stream_loop_failure_reports_drained_stderr() -> None:
+    """Failure notifications must use stderr retained by the drain thread."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    fake_proc.poll.return_value = 2
+    fake_proc.stderr = BytesIO(b"fatal diagnostics\n")
+    fake_proc.stdout.readline.side_effect = [b""]
+
+    client._drain_milestone_stderr(fake_proc)
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            client._milestone_stream_loop(fake_proc)
+
+    notifications.notify_terminal.assert_called_once_with(
+        "failed", "fatal diagnostics"
+    )
+
+
+def test_stream_loop_keeps_blocked_exit_non_terminal() -> None:
+    """Exit 10 is a blocked planning state, not a failed terminal exit."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    fake_proc.poll.return_value = 10
+    fake_proc.stdout.readline.side_effect = [b""]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            client._milestone_stream_loop(fake_proc)
+
+            notifications.notify_terminal.assert_not_called()
+            assert client.milestone_active() is True
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -347,6 +347,21 @@ def test_cancel_milestone_when_no_proc_is_a_noop() -> None:
     client.cancel_milestone()
 
 
+def test_close_terminates_active_milestone_subprocess() -> None:
+    """close() must tear down the owned milestone subprocess as well as MCP."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+
+    with (
+        patch.object(client, "_terminate_process"),
+        patch.object(client, "_milestone_proc", fake_proc),
+    ):
+        client.close()
+
+    fake_proc.terminate.assert_called_once()
+    assert client.milestone_active() is False
+
+
 def test_respond_to_milestone_blocker_writes_extension_ui_response_to_stdin() -> None:
     """The reply must write the supervised-mode stdin JSONL protocol."""
     client = GsdMcpClient(_config())

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -1,0 +1,231 @@
+"""Tests for GsdMcpClient milestone creation (subprocess-owned, stream-driven).
+
+These tests pin the A1 design from issue #1162's grilling:
+- create_milestone spawns `gsd headless --supervised new-milestone`
+- a background stream-reader captures init_result.sessionId and drives
+  NotificationService on blocker/terminal events
+- cancel_milestone SIGTERMs the held subprocess
+- respond_to_milestone_blocker writes an extension_ui_response to stdin
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.gsd_client import GsdMcpClient
+
+
+def _config() -> GsdConfig:
+    return GsdConfig(cli_path="/usr/local/bin/gsd")
+
+
+# ---------------------------------------------------------------------------
+# create_milestone — argument construction
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal stand-in for subprocess.Popen used by create_milestone."""
+
+    def __init__(self) -> None:
+        self.pid = 4242
+        self.stdin = MagicMock()
+        self.stdout = MagicMock()
+        self.stderr = MagicMock()
+        self.poll = MagicMock(return_value=None)
+        self.terminate = MagicMock()
+        self.wait = MagicMock(return_value=0)
+        self.kill = MagicMock()
+
+
+def test_create_milestone_builds_supervised_new_milestone_command_with_context_text() -> None:
+    """create_milestone must invoke `gsd headless --supervised new-milestone --context-text <spec>`."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["args"] = args
+        captured["cwd"] = kwargs.get("cwd")
+        captured["env"] = kwargs.get("env")
+        return fake_proc
+
+    with patch.object(client, "ensure_version"):
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            # Stub the init_result sync read + background loop so the test
+            # focuses solely on the constructed command line.
+            with patch.object(client, "_read_init_result", return_value="S-1"):
+                with patch.object(client, "_milestone_stream_loop"):
+                    client.create_milestone("/proj", context_text="Build a REST API")
+
+    args = captured["args"]
+    assert args[0] == "/usr/local/bin/gsd"
+    assert "headless" in args
+    assert "--supervised" in args
+    assert "new-milestone" in args
+    assert "--context-text" in args
+    text_idx = args.index("--context-text")
+    assert args[text_idx + 1] == "Build a REST API"
+    assert captured["cwd"] == "/proj"
+
+
+def test_create_milestone_builds_command_with_context_file() -> None:
+    """--file form passes --context <path> instead of --context-text."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+    captured: dict[str, object] = {}
+
+    def fake_popen(args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["args"] = args
+        return fake_proc
+
+    with patch.object(client, "ensure_version"):
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            with patch.object(client, "_read_init_result", return_value="S-1"):
+                with patch.object(client, "_milestone_stream_loop"):
+                    client.create_milestone("/proj", context_file="/path/to/spec.md")
+
+    args = captured["args"]
+    assert "--context" in args
+    ctx_idx = args.index("--context")
+    assert args[ctx_idx + 1] == "/path/to/spec.md"
+    assert "--context-text" not in args
+
+
+def test_create_milestone_requires_either_context_text_or_file() -> None:
+    """No spec at all is a usage error, raised before any subprocess spawns."""
+    client = GsdMcpClient(_config())
+    with pytest.raises(ValueError, match="spec"):
+        client.create_milestone("/proj")
+
+
+def test_create_milestone_rejects_both_context_text_and_file() -> None:
+    """Ambiguous input (both forms) is a usage error."""
+    client = GsdMcpClient(_config())
+    with pytest.raises(ValueError, match="spec"):
+        client.create_milestone(
+            "/proj", context_text="x", context_file="/p.md"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stream reader — sessionId capture, blocker, terminal
+# ---------------------------------------------------------------------------
+
+
+def test_stream_loop_captures_session_id_from_init_result() -> None:
+    """The reader must pull sessionId out of the init_result stream event."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+    # stdout yields one init_result line then EOF
+    fake_proc.stdout.readline.side_effect = [
+        (json.dumps({"type": "init_result", "sessionId": "S-789"}) + "\n").encode(),
+        b"",
+    ]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        client._milestone_stream_loop(fake_proc)
+
+    assert client.milestone_session_id() == "S-789"
+
+
+def test_stream_loop_notifies_blocker_on_extension_ui_request() -> None:
+    """An extension_ui_request that is a blocked-notice must fire notify_blocker."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    # Realistic blocked-notice message — must match the stop-notice vocabulary
+    # the headless event loop emits (see stop-notice.ts isBlockedNoticeMessage).
+    blocker_event = {
+        "type": "extension_ui_request",
+        "method": "notify",
+        "id": "blk-1",
+        "message": "Auto-mode paused — blocked: choose an option",
+    }
+    fake_proc.stdout.readline.side_effect = [
+        (json.dumps(blocker_event) + "\n").encode(),
+        b"",
+    ]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            client._milestone_stream_loop(fake_proc)
+
+    notifications.notify_blocker.assert_called_once()
+    # pending blocker id tracked for /gsd reply routing
+    assert client.milestone_pending_blocker_id() == "blk-1"
+
+
+def test_stream_loop_notifies_terminal_on_process_exit() -> None:
+    """When the stream ends (process exited), a terminal notification fires."""
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    fake_proc = _FakeProc()
+    fake_proc.stdout.readline.side_effect = [b""]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_notifications", notifications):
+            client._milestone_stream_loop(fake_proc)
+
+    notifications.notify_terminal.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# cancel_milestone / respond_to_milestone_blocker / milestone_active
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_milestone_terminates_held_subprocess() -> None:
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        client.cancel_milestone()
+
+    fake_proc.terminate.assert_called_once()
+
+
+def test_cancel_milestone_when_no_proc_is_a_noop() -> None:
+    """Calling cancel with no active milestone proc must not raise."""
+    client = GsdMcpClient(_config())
+    # should not raise
+    client.cancel_milestone()
+
+
+def test_respond_to_milestone_blocker_writes_extension_ui_response_to_stdin() -> None:
+    """The reply must write the supervised-mode stdin JSONL protocol."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_pending_blocker_id", "blk-7"):
+            client.respond_to_milestone_blocker("use option B")
+
+    assert fake_proc.stdin.write.called
+    written = fake_proc.stdin.write.call_args[0][0]
+    payload = json.loads(written.decode() if isinstance(written, bytes) else written)
+    assert payload["type"] == "extension_ui_response"
+    assert payload["id"] == "blk-7"
+    assert payload["value"] == "use option B"
+
+
+def test_respond_to_milestone_blocker_without_pending_blocker_raises() -> None:
+    """No pending blocker id means nothing to reply to — fail loud, don't pretend."""
+    client = GsdMcpClient(_config())
+    fake_proc = _FakeProc()
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with pytest.raises(RuntimeError, match="No pending blocker"):
+            client.respond_to_milestone_blocker("answer")
+
+
+def test_milestone_active_reflects_held_proc() -> None:
+    client = GsdMcpClient(_config())
+    assert client.milestone_active() is False
+    with patch.object(client, "_milestone_proc", _FakeProc()):
+        assert client.milestone_active() is True
+    assert client.milestone_active() is False

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -254,21 +254,23 @@ def test_stream_loop_failure_reports_drained_stderr() -> None:
     )
 
 
-def test_stream_loop_keeps_blocked_exit_non_terminal() -> None:
-    """Exit 10 with a pending interactive blocker is not a terminal exit."""
+def test_stream_loop_releases_blocked_exit_with_pending_blocker() -> None:
+    """Exit 10 after stdout EOF is terminal even with a pending blocker id."""
     client = GsdMcpClient(_config())
     notifications = MagicMock()
     fake_proc = _FakeProc()
     fake_proc.poll.return_value = 10
     fake_proc.stdout.readline.side_effect = [b""]
+    client._milestone_session_id = "milestone-4242"
 
     with patch.object(client, "_milestone_proc", fake_proc):
         with patch.object(client, "_milestone_pending_blocker_id", "sel-1"):
             with patch.object(client, "_milestone_notifications", notifications):
                 client._milestone_stream_loop(fake_proc)
 
-            notifications.notify_terminal.assert_not_called()
-            assert client.milestone_active() is True
+    notifications.notify_terminal.assert_called_once_with("failed", "Planning blocked")
+    assert client.milestone_active() is False
+    assert client.milestone_session_id() is None
 
 
 def test_stream_loop_releases_noninteractive_blocked_exit() -> None:

--- a/integrations/hermes/tests/test_new_milestone_command.py
+++ b/integrations/hermes/tests/test_new_milestone_command.py
@@ -107,6 +107,31 @@ def test_new_milestone_bare_text_passes_context_text(project: Path) -> None:
     assert "started" in result.lower() or "S-1" in result
 
 
+def test_new_milestone_terminal_callback_clears_local_session_id(
+    project: Path,
+) -> None:
+    router, client = _make_router(project_dir=str(project))
+    client.create_milestone.return_value = "milestone-4242"
+
+    run(router, "new-milestone Build a REST API with auth")
+    ctx = router._get_supervisor_ctx()  # type: ignore[attr-defined]
+    ctx.pending_blocker_id = "blk-1"
+    assert ctx.session_id == "milestone-4242"
+
+    on_terminal = client.create_milestone.call_args.kwargs["on_terminal"]
+    on_terminal("complete")
+
+    ctx = router._get_supervisor_ctx()  # type: ignore[attr-defined]
+    assert ctx.state == SupervisorState.COMPLETE
+    assert ctx.session_id is None
+    assert ctx.pending_blocker_id is None
+    assert ctx.notified_terminal is True
+
+    result = run(router, "reply stale response")
+    client.resolve_blocker.assert_not_called()
+    assert "no active" in result.lower()
+
+
 def test_new_milestone_file_flag_passes_context_file(project: Path) -> None:
     router, client = _make_router(project_dir=str(project))
     spec = project / "spec.md"

--- a/integrations/hermes/tests/test_new_milestone_command.py
+++ b/integrations/hermes/tests/test_new_milestone_command.py
@@ -202,6 +202,21 @@ def test_new_milestone_rejects_when_auto_blocked(project: Path) -> None:
     client.create_milestone.assert_not_called()
 
 
+def test_new_milestone_prioritizes_milestone_guard_over_auto_state(
+    project: Path,
+) -> None:
+    """A duplicate milestone command should report the milestone guard."""
+    router, client = _make_router(
+        project_dir=str(project),
+        supervisor_state=SupervisorState.RUNNING,
+        milestone_active=True,
+    )
+    result = run(router, "new-milestone some spec")
+    assert "milestone creation is in progress" in result.lower()
+    assert "auto is running" not in result.lower()
+    client.create_milestone.assert_not_called()
+
+
 def test_new_milestone_allows_when_auto_complete(project: Path) -> None:
     """A terminal auto state does not block milestone creation."""
     router, client = _make_router(

--- a/integrations/hermes/tests/test_new_milestone_command.py
+++ b/integrations/hermes/tests/test_new_milestone_command.py
@@ -109,9 +109,11 @@ def test_new_milestone_bare_text_passes_context_text(project: Path) -> None:
 
 def test_new_milestone_file_flag_passes_context_file(project: Path) -> None:
     router, client = _make_router(project_dir=str(project))
-    run(router, "new-milestone --file /abs/spec.md")
+    spec = project / "spec.md"
+    spec.write_text("milestone spec", encoding="utf-8")
+    run(router, f"new-milestone --file {spec}")
     kwargs = client.create_milestone.call_args.kwargs
-    assert kwargs.get("context_file") == "/abs/spec.md"
+    assert kwargs.get("context_file") == str(spec)
     assert kwargs.get("context_text") is None
 
 

--- a/integrations/hermes/tests/test_new_milestone_command.py
+++ b/integrations/hermes/tests/test_new_milestone_command.py
@@ -1,0 +1,236 @@
+"""Tests for /gsd new-milestone command routing and the cross-command guards.
+
+Covers the issue #1162 design:
+- _cmd_new_milestone: input parsing (bare text, --file, empty, --auto rejected),
+  co-run guard (reject if auto RUNNING/BLOCKED), spawn + ack, help text.
+- _cmd_auto: symmetric co-run guard (reject if milestone run active).
+- _cmd_cancel: routes to cancel_milestone() when a milestone subprocess is active.
+- _cmd_reply: routes planning-blocker replies to client stdin when milestone
+  subprocess is active with a pending blocker.
+
+Async handlers are driven with asyncio.run, matching the convention in
+test_register.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from open_gsd_hermes.commands import GsdCommandRouter
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.supervisor import SupervisorContext, SupervisorState
+from open_gsd_hermes.types import BindingContext
+
+
+def _make_router(
+    *,
+    project_dir: str | None = "/proj",
+    supervisor_state: SupervisorState = SupervisorState.IDLE,
+    milestone_active: bool = False,
+    milestone_blocker_id: str | None = None,
+) -> tuple[GsdCommandRouter, MagicMock]:
+    """Build a router with a MagicMock client + bind store for isolated testing."""
+    config = GsdConfig(default_project=project_dir)
+    client = MagicMock()
+    client.milestone_active.return_value = milestone_active
+    client.milestone_session_id.return_value = "S-1" if milestone_active else None
+    client.milestone_pending_blocker_id.return_value = milestone_blocker_id
+    bind_store = MagicMock()
+    supervisor = MagicMock()
+    notifications = MagicMock()
+
+    sup_ctx_holder: dict[str, SupervisorContext] = {
+        "ctx": SupervisorContext(
+            session_id=None,
+            project_dir=project_dir,
+            state=supervisor_state,
+        )
+    }
+
+    def get_session_key() -> str:
+        return "agent:main:cli:direct:local"
+
+    def get_binding_ctx() -> BindingContext:
+        return BindingContext(cwd=project_dir)
+
+    def get_supervisor_ctx() -> SupervisorContext:
+        return sup_ctx_holder["ctx"]
+
+    def set_supervisor_ctx(ctx: SupervisorContext) -> None:
+        sup_ctx_holder["ctx"] = ctx
+
+    def get_platform_channel() -> tuple[str | None, str | None]:
+        return "cli", "local"
+
+    router = GsdCommandRouter(
+        config,
+        client,
+        bind_store,
+        supervisor,
+        get_session_key,
+        get_binding_ctx,
+        get_supervisor_ctx,
+        set_supervisor_ctx,
+        get_platform_channel,
+        notifications,
+    )
+    return router, client
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A directory that looks like a GSD project (.gsd/ present)."""
+    (tmp_path / ".gsd").mkdir()
+    return tmp_path
+
+
+def run(router: GsdCommandRouter, args: str) -> str:
+    return asyncio.run(router.handle(args))
+
+
+# ---------------------------------------------------------------------------
+# _cmd_new_milestone — input parsing & usage
+# ---------------------------------------------------------------------------
+
+
+def test_new_milestone_bare_text_passes_context_text(project: Path) -> None:
+    router, client = _make_router(project_dir=str(project))
+    result = run(router, "new-milestone Build a REST API with auth")
+    client.create_milestone.assert_called_once()
+    kwargs = client.create_milestone.call_args.kwargs
+    assert kwargs.get("context_text") == "Build a REST API with auth"
+    assert kwargs.get("context_file") is None
+    assert "started" in result.lower() or "S-1" in result
+
+
+def test_new_milestone_file_flag_passes_context_file(project: Path) -> None:
+    router, client = _make_router(project_dir=str(project))
+    run(router, "new-milestone --file /abs/spec.md")
+    kwargs = client.create_milestone.call_args.kwargs
+    assert kwargs.get("context_file") == "/abs/spec.md"
+    assert kwargs.get("context_text") is None
+
+
+def test_new_milestone_empty_returns_usage(project: Path) -> None:
+    router, client = _make_router(project_dir=str(project))
+    result = run(router, "new-milestone")
+    assert "usage" in result.lower()
+    client.create_milestone.assert_not_called()
+
+
+def test_new_milestone_rejects_auto_flag(project: Path) -> None:
+    """--auto chaining is out of scope; execution stays with /gsd auto."""
+    router, client = _make_router(project_dir=str(project))
+    result = run(router, "new-milestone --auto some spec")
+    assert "auto" in result.lower()
+    client.create_milestone.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Co-run guards (Q2 + Q9 symmetry)
+# ---------------------------------------------------------------------------
+
+
+def test_new_milestone_rejects_when_auto_running(project: Path) -> None:
+    """Co-run guard: refuse if an auto session is RUNNING or BLOCKED."""
+    router, client = _make_router(
+        project_dir=str(project),
+        supervisor_state=SupervisorState.RUNNING,
+    )
+    result = run(router, "new-milestone some spec")
+    assert "cancel" in result.lower() or "running" in result.lower()
+    client.create_milestone.assert_not_called()
+
+
+def test_new_milestone_rejects_when_auto_blocked(project: Path) -> None:
+    router, client = _make_router(
+        project_dir=str(project),
+        supervisor_state=SupervisorState.BLOCKED,
+    )
+    result = run(router, "new-milestone some spec")
+    assert "cancel" in result.lower() or "running" in result.lower()
+    client.create_milestone.assert_not_called()
+
+
+def test_new_milestone_allows_when_auto_complete(project: Path) -> None:
+    """A terminal auto state does not block milestone creation."""
+    router, client = _make_router(
+        project_dir=str(project),
+        supervisor_state=SupervisorState.COMPLETE,
+    )
+    run(router, "new-milestone some spec")
+    client.create_milestone.assert_called_once()
+
+
+def test_auto_rejects_when_milestone_active(project: Path) -> None:
+    """Symmetric guard: /gsd auto refuses if a milestone run is in progress."""
+    router, client = _make_router(
+        project_dir=str(project),
+        milestone_active=True,
+    )
+    result = run(router, "auto")
+    assert "cancel" in result.lower() or "milestone" in result.lower()
+    client.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _cmd_cancel — milestone branch
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_routes_to_cancel_milestone_when_milestone_active(
+    project: Path,
+) -> None:
+    router, client = _make_router(
+        project_dir=str(project),
+        milestone_active=True,
+    )
+    run(router, "cancel")
+    client.cancel_milestone.assert_called_once()
+
+
+def test_cancel_routes_to_mcp_cancel_when_only_auto_active(project: Path) -> None:
+    """When no milestone proc is active, cancel falls back to the MCP path."""
+    router, client = _make_router(
+        project_dir=str(project),
+        supervisor_state=SupervisorState.RUNNING,
+    )
+    # Give the auto session an id so the MCP cancel-by-session path is taken
+    run(router, "cancel")
+    client.cancel_milestone.assert_not_called()
+    assert client.cancel.called or client.cancel_by_project.called
+
+
+# ---------------------------------------------------------------------------
+# _cmd_reply — milestone-blocker branch
+# ---------------------------------------------------------------------------
+
+
+def test_reply_routes_to_milestone_blocker_when_milestone_pending(
+    project: Path,
+) -> None:
+    router, client = _make_router(
+        project_dir=str(project),
+        milestone_active=True,
+        milestone_blocker_id="blk-9",
+    )
+    result = run(router, "reply use option B")
+    client.respond_to_milestone_blocker.assert_called_once_with("use option B")
+    assert "sent" in result.lower()
+
+
+def test_reply_falls_back_to_mcp_when_no_milestone(project: Path) -> None:
+    """No milestone proc → existing MCP resolve_blocker path (needs a session)."""
+    router, client = _make_router(
+        project_dir=str(project),
+        supervisor_state=SupervisorState.BLOCKED,
+    )
+    # set a session id so the existing reply path doesn't short-circuit
+    router._get_supervisor_ctx().session_id = "auto-1"  # type: ignore[attr-defined]
+    run(router, "reply some answer")
+    client.respond_to_milestone_blocker.assert_not_called()
+    client.resolve_blocker.assert_called_once()

--- a/integrations/hermes/tests/test_new_milestone_command.py
+++ b/integrations/hermes/tests/test_new_milestone_command.py
@@ -117,6 +117,25 @@ def test_new_milestone_file_flag_passes_context_file(project: Path) -> None:
     assert kwargs.get("context_text") is None
 
 
+def test_new_milestone_file_flag_resolves_relative_path_from_project(
+    project: Path,
+) -> None:
+    router, client = _make_router(project_dir=str(project))
+    spec = project / "spec.md"
+    spec.write_text("milestone spec", encoding="utf-8")
+    run(router, "new-milestone --file spec.md")
+    kwargs = client.create_milestone.call_args.kwargs
+    assert kwargs.get("context_file") == str(spec)
+    assert kwargs.get("context_text") is None
+
+
+def test_new_milestone_file_flag_rejects_missing_file(project: Path) -> None:
+    router, client = _make_router(project_dir=str(project))
+    result = run(router, "new-milestone --file missing.md")
+    assert "not found" in result.lower()
+    client.create_milestone.assert_not_called()
+
+
 def test_new_milestone_empty_returns_usage(project: Path) -> None:
     router, client = _make_router(project_dir=str(project))
     result = run(router, "new-milestone")

--- a/integrations/hermes/tests/test_new_milestone_command.py
+++ b/integrations/hermes/tests/test_new_milestone_command.py
@@ -225,6 +225,22 @@ def test_reply_routes_to_milestone_blocker_when_milestone_pending(
     assert "sent" in result.lower()
 
 
+def test_reply_does_not_fall_through_to_mcp_when_milestone_active_no_blocker(
+    project: Path,
+) -> None:
+    """Active milestone without a pending blocker must not hit MCP resolve_blocker."""
+    router, client = _make_router(
+        project_dir=str(project),
+        milestone_active=True,
+        milestone_blocker_id=None,
+    )
+    router._get_supervisor_ctx().session_id = "milestone-1"  # type: ignore[attr-defined]
+    result = run(router, "reply some answer")
+    client.respond_to_milestone_blocker.assert_not_called()
+    client.resolve_blocker.assert_not_called()
+    assert "no pending blocker" in result.lower()
+
+
 def test_reply_falls_back_to_mcp_when_no_milestone(project: Path) -> None:
     """No milestone proc → existing MCP resolve_blocker path (needs a session)."""
     router, client = _make_router(

--- a/integrations/hermes/tests/test_supervisor_fsm.py
+++ b/integrations/hermes/tests/test_supervisor_fsm.py
@@ -138,6 +138,7 @@ def test_auto_resets_session_specific_supervisor_context(tmp_path) -> None:
     )
     supervisor = MockSupervisor()
     client = MagicMock()
+    client.milestone_active.return_value = False
     client.execute.return_value = {"sessionId": "new-session"}
 
     router = GsdCommandRouter(
@@ -179,6 +180,7 @@ def test_status_returns_friendly_message_when_mcp_progress_fails(tmp_path) -> No
 def test_auto_returns_friendly_message_when_mcp_execute_fails(tmp_path) -> None:
     supervisor = MockSupervisor()
     client = MagicMock()
+    client.milestone_active.return_value = False
     client.execute.side_effect = McpProtocolError("sidecar unavailable")
     router, _project_dir, _supervisor, _ctx, _stored = build_router(
         tmp_path, client, supervisor=supervisor
@@ -193,6 +195,7 @@ def test_auto_returns_friendly_message_when_mcp_execute_fails(tmp_path) -> None:
 def test_auto_rejects_missing_session_id_in_mcp_response(tmp_path) -> None:
     supervisor = MockSupervisor()
     client = MagicMock()
+    client.milestone_active.return_value = False
     client.execute.return_value = {}
     router, _project_dir, _supervisor, ctx, _stored = build_router(
         tmp_path, client, supervisor=supervisor
@@ -209,6 +212,7 @@ def test_auto_rejects_missing_session_id_in_mcp_response(tmp_path) -> None:
 def test_cancel_stops_supervisor_when_mcp_cancel_fails(tmp_path) -> None:
     supervisor = MockSupervisor()
     client = MagicMock()
+    client.milestone_active.return_value = False
     client.cancel_by_project.side_effect = McpProtocolError("sidecar unavailable")
     router, _project_dir, _supervisor, ctx, stored = build_router(
         tmp_path, client, supervisor=supervisor
@@ -226,6 +230,7 @@ def test_cancel_sends_terminal_notification_after_successful_mcp_cancel(tmp_path
     supervisor = MockSupervisor()
     notifications = MagicMock()
     client = MagicMock()
+    client.milestone_active.return_value = False
     ctx = SupervisorContext(
         session_id="s1",
         state=SupervisorState.RUNNING,
@@ -261,6 +266,7 @@ def test_cancel_prefers_supervisor_project_for_active_session(tmp_path) -> None:
     (running_project / ".gsd").mkdir()
     supervisor = MockSupervisor()
     client = MagicMock()
+    client.milestone_active.return_value = False
     ctx = SupervisorContext(
         session_id="s1",
         project_dir=str(running_project),
@@ -291,6 +297,7 @@ def test_cancel_prefers_supervisor_project_for_active_session(tmp_path) -> None:
 def test_cancel_stops_supervisor_when_binding_resolution_fails(tmp_path) -> None:
     supervisor = MockSupervisor()
     client = MagicMock()
+    client.milestone_active.return_value = False
     ctx = SupervisorContext(
         session_id="s1",
         project_dir=str(tmp_path / "missing"),
@@ -323,6 +330,7 @@ def test_cancel_stops_supervisor_when_binding_resolution_fails(tmp_path) -> None
 
 def test_reply_returns_friendly_message_when_mcp_resolve_fails(tmp_path) -> None:
     client = MagicMock()
+    client.milestone_active.return_value = False
     client.resolve_blocker.side_effect = McpProtocolError("sidecar unavailable")
     ctx = SupervisorContext(session_id="s1", project_dir="/tmp/project")
     router, _project_dir, _supervisor, _ctx, _stored = build_router(

--- a/integrations/hermes/tests/test_supervisor_fsm.py
+++ b/integrations/hermes/tests/test_supervisor_fsm.py
@@ -378,6 +378,38 @@ def test_supervisor_detects_blocker() -> None:
     assert any("blocker" in t.lower() or "Approve" in t for t in sent)
 
 
+def test_notify_blocker_prefers_title_over_generic_message() -> None:
+    sent: list[str] = []
+
+    def dispatch(_name: str, args: dict) -> None:
+        sent.append(args.get("text", ""))
+
+    notifications = NotificationService(
+        MagicMock(),
+        GsdConfig(),
+        lambda: DeliveryTarget("slack", "channel", "C123"),
+        dispatch=dispatch,
+    )
+
+    notifications.notify_blocker(
+        SessionStatus(
+            status="blocked",
+            pending_blocker={
+                "type": "extension_ui_request",
+                "method": "select",
+                "id": "sel-1",
+                "title": "Choose milestone scope",
+                "message": "Action required",
+                "options": ["A", "B"],
+            },
+        )
+    )
+
+    assert len(sent) == 1
+    assert "GSD blocker: Choose milestone scope" in sent[0]
+    assert "GSD blocker: Action required" not in sent[0]
+
+
 def test_supervisor_terminal_tick_updates_progress_before_stopping() -> None:
     ctx = SupervisorContext(
         session_id="s1",


### PR DESCRIPTION
Closes #1162.

## Summary

Adds `/gsd new-milestone` to the open-gsd-hermes plugin so users on WeChat, Telegram, and Slack can create milestones entirely from chat — no terminal needed.

A full design grilling (9 questions, 9 decisions with rationale) is recorded in [`integrations/hermes/docs/issue-1162-grilling.md`](integrations/hermes/docs/issue-1162-grilling.md). Glossary terms added to `integrations/hermes/CONTEXT.md`.

## What it does

```
/gsd new-milestone Build a REST API with auth
🚀 Milestone creation started (session `S-789`). I'll notify you when it's ready; run `/gsd auto` to execute.

... (planning runs as a plugin-owned `gsd headless --supervised new-milestone` subprocess) ...

🚧 GSD blocker: <question>     ← /gsd reply <answer>  (replied via stdin)
✅ GSD auto mode finished.     ← terminal push on completion

/gsd auto                        ← execution uses the existing, untouched path
```

## Design decisions (key ones)

- **Slash command → CLI subprocess** (not a new MCP tool, not a Hermes skill). The plugin already calls the CLI directly for `progress()`; milestone creation is even more naturally a CLI call. The open upstream lease-layer issue (#509) makes advertising a new `gsd_create_milestone` MCP tool actively unsafe.
- **Fire-and-track via stream-json.** The plugin is fundamentally async-push (ack now, push notifications later). The subprocess's stdout stream drives `NotificationService` directly; the poll-driven `SupervisorFsm` is reused only as shared state, untouched.
- **Local subprocess ownership.** Because the plugin spawns the process, it owns its full lifecycle: cancel (SIGTERM) and blocker replies (stdin). The MCP session manager cannot see a process it didn't start, and there's no `auto.lock` pid backstop during planning.
- **Planning-only; `--auto` rejected.** Execution is `/gsd auto`'s job (it has the robust poll-driven supervisor). One-shot `--auto` is gsd-core's terminal surface, not the gateway's.
- **Symmetric co-run guards** on both `/gsd new-milestone` and `/gsd auto` close the unsafe co-run gap the open lease-layer issue would otherwise re-expose.

## Changes

**Source**
- `gsd_client.py` — `create_milestone()`, `_milestone_stream_loop()`, `cancel_milestone()`, `respond_to_milestone_blocker()`, `milestone_active()`/`milestone_session_id()`/`milestone_pending_blocker_id()` predicates. Stop-notice vocabulary mirrored from `src/resources/extensions/gsd/stop-notice.ts`.
- `commands.py` — new `_cmd_new_milestone` handler + dispatch/help registration; `_cmd_cancel` milestone branch (local SIGTERM); `_cmd_auto` symmetric guard; `_cmd_reply` milestone-blocker branch (stdin).

**Tests** (24 new, 45→69 passing)
- `test_milestone_client.py` — subprocess spawn/command construction, stream-reader sessionId capture, blocker/terminal notification, cancel SIGTERM, stdin blocker reply.
- `test_new_milestone_command.py` — input parsing (bare text, `--file`, empty, `--auto` rejected), co-run guards both ways, cancel/reply routing.
- `test_supervisor_fsm.py` — updated existing auto/cancel/reply mocks to declare no active milestone (additive behavior).

## Verification

- `cd integrations/hermes && python -m pytest tests/ -q` → **69 passed, 1 skipped** (pre-existing skip).
- No TS-side or MCP-server changes. `SupervisorFsm` untouched.

## Out of scope (documented)

- `--auto` chaining (execution stays with `/gsd auto`)
- Cross-instance / server-side co-run coordination (local-state gate is the v1 scope)
- Plugin-restart recovery of an orphaned planning subprocess
- A Hermes skill wrapping the same client (additive follow-on)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New subprocess lifecycle, threading, and cross-command routing can allow unsafe concurrent GSD work or stuck/orphaned planning if guards or stream handling fail; mitigated by explicit co-run checks and tests, with documented restart/orphan limitations.
> 
> **Overview**
> Adds **`/gsd new-milestone`** to the Hermes plugin so chat users can start milestone **planning** without a terminal. The command acks immediately and pushes blocker/completion updates via the existing notification path; execution stays on **`/gsd auto`** (no `--auto` chaining).
> 
> **`GsdMcpClient`** now owns a **`gsd headless --supervised new-milestone`** subprocess: a background thread reads **stream-json** stdout for blockers and terminal outcomes, **`cancel_milestone`** SIGTERMs the child, and **`respond_to_milestone_blocker`** writes supervised **stdin** JSONL (MCP cannot see this session). Completion messages use **`gsd_query`** + progress when possible.
> 
> **`commands.py`** wires the new handler plus **symmetric co-run guards** so milestone planning and **`/gsd auto`** cannot overlap; **`/gsd cancel`** and **`/gsd reply`** branch to the local subprocess when a milestone run is active. Docs (**README**, **CONTEXT**, issue #1162 grilling) and broad pytest coverage accompany the change; no MCP/TS server changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a7ac3b153251ba1b0b476ed98e98c4db499527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->