### PR TITLE
fix(issue): open-gsd-hermes plugin /gsd auto hangs or returns nothing — no timeout in MCP _read_message() and no version-fallback in execute()

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -28,6 +28,8 @@ hermes plugins enable open-gsd-hermes
 
 `~/.hermes/gsd.yaml` — see [`docs/setup.md`](docs/setup.md) for Slack/Telegram gateway checklist.
 
+Common `gsd:` keys include `cli_path`, `mcp_server_path`, `default_project`, `bindings`, and `mcp_read_timeout_seconds`. The MCP read timeout defaults to 60 seconds; tune it only when Hermes times out waiting for `gsd-mcp-server` responses that complete locally on slow projects or filesystems.
+
 **Before gateway testing:**
 
 ```bash

--- a/integrations/hermes/docs/setup.md
+++ b/integrations/hermes/docs/setup.md
@@ -79,6 +79,7 @@ gsd:
   default_project: ~/code/myapp         # optional fallback
   poll_interval_seconds: 12
   cache_ttl_seconds: 45
+  mcp_read_timeout_seconds: 60          # per-response MCP read timeout
   notification_level: normal            # quiet | normal | verbose
   bindings:
     slack:
@@ -88,6 +89,8 @@ gsd:
 ```
 
 **Binding tiers (first match wins):** cron explicit → slash argument → `/gsd bind` session binding → channel map → `default_project` → cwd heuristic.
+
+**MCP read timeout:** `gsd.mcp_read_timeout_seconds` defaults to `60` seconds and bounds each response read from the `gsd-mcp-server` sidecar. Increase it for very slow projects, machines, or network-backed filesystems where Hermes reports MCP response timeouts but the same GSD command eventually completes locally; lower it only when you prefer faster failure detection. When the timeout fires, the plugin terminates the stuck sidecar and the next project-scoped call starts a fresh server in the bound project directory.
 
 **Credentials:** With `credential_source: gsd`, ensure GSD’s normal provider keys are configured (`~/.gsd/` or env). Hermes passthrough (`credential_source: hermes`) is 6b+.
 
@@ -224,6 +227,7 @@ Verify on **one** platform (Slack or Telegram):
 | `GsdVersionError` on start | `gsd` outside semver range | Set `gsd_version_min` in `gsd.yaml` or upgrade gsd |
 | MCP spawn fails | Wrong `mcp_server_path` | `which gsd-mcp-server`; set absolute path |
 | `/gsd status` hangs | MCP sidecar stuck | Check `GSD_CLI_PATH`; restart gateway; kill orphaned `gsd-mcp-server` |
+| MCP response times out after 60s | Slow project or filesystem, or wedged sidecar | Confirm the command locally; tune `mcp_read_timeout_seconds` if it completes after 60s |
 | No push notifications | Invalid session key / target | Key must match `agent:main:{platform}:{chat_type}:{chat_id}`; check Hermes gateway logs |
 | Notifications in CLI but not Slack | `DeliveryTarget.from_session_key` returned None | Run checklist in **gateway** mode, not CLI-only |
 | Cancel ignored | Stale session id | `/gsd cancel` uses `gsd_cancel_by_project` fallback when no session id |

--- a/integrations/hermes/open_gsd_hermes/config.py
+++ b/integrations/hermes/open_gsd_hermes/config.py
@@ -19,6 +19,7 @@ class GsdConfig:
     bindings: dict[str, dict[str, str]] = field(default_factory=dict)
     poll_interval_seconds: int = 12
     cache_ttl_seconds: int = 45
+    mcp_read_timeout_seconds: float = 60.0
     notification_level: str = "normal"
     gsd_version_min: str = "2.53"
     gsd_version_max: str = "3.0"
@@ -35,6 +36,7 @@ class GsdConfig:
             bindings=dict(gsd.get("bindings") or {}),
             poll_interval_seconds=int(gsd.get("poll_interval_seconds", 12)),
             cache_ttl_seconds=int(gsd.get("cache_ttl_seconds", 45)),
+            mcp_read_timeout_seconds=float(gsd.get("mcp_read_timeout_seconds", 60.0)),
             notification_level=str(gsd.get("notification_level", "normal")),
             gsd_version_min=str(gsd.get("gsd_version_min", "2.53")),
             gsd_version_max=str(gsd.get("gsd_version_max", "3.0")),

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -36,6 +36,8 @@ class GsdMcpClient:
     def __init__(self, config: GsdConfig) -> None:
         self._config = config
         self._proc: subprocess.Popen[bytes] | None = None
+        self._proc_cwd: str | None = None
+        self._stdout_buffer = b""
         self._lock = threading.Lock()
         self._request_id = 0
         self._cache: dict[str, _CacheEntry] = {}
@@ -72,42 +74,122 @@ class GsdMcpClient:
             )
         self._version_checked = True
 
-    def _ensure_process(self) -> subprocess.Popen[bytes]:
+    def _ensure_process(self, project_dir: str | None = None) -> subprocess.Popen[bytes]:
+        cwd = os.path.abspath(project_dir) if project_dir else None
         if self._proc is not None and self._proc.poll() is None:
-            return self._proc
+            if cwd is None or self._proc_cwd == cwd:
+                return self._proc
+            self._terminate_process()
+        self._stdout_buffer = b""
+        self._proc_cwd = cwd
         self._proc = subprocess.Popen(
             [self._config.mcp_server_path],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=self._env(),
+            cwd=cwd,
         )
-        self._initialize()
+        try:
+            self._initialize()
+        except Exception:
+            self._terminate_process()
+            raise
         return self._proc
 
-    def _send(self, payload: dict[str, Any]) -> None:
-        proc = self._ensure_process()
+    def _terminate_process(self) -> None:
+        proc = self._proc
+        self._proc = None
+        self._proc_cwd = None
+        self._stdout_buffer = b""
+        if proc is None or proc.poll() is not None:
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    def _send(self, payload: dict[str, Any], *, project_dir: str | None = None) -> None:
+        proc = self._ensure_process(project_dir)
         assert proc.stdin is not None
         body = json.dumps(payload).encode("utf-8")
         header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
         proc.stdin.write(header + body)
         proc.stdin.flush()
 
-    def _read_message(self) -> dict[str, Any]:
+    def _read_stdout_chunk(self, deadline: float) -> None:
         proc = self._ensure_process()
         assert proc.stdout is not None
-        headers: dict[str, str] = {}
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            self._raise_read_timeout()
+
+        chunks: list[bytes] = []
+        errors: list[BaseException] = []
+
+        def read_chunk() -> None:
+            try:
+                chunks.append(os.read(proc.stdout.fileno(), 65536))
+            except BaseException as e:
+                errors.append(e)
+
+        reader = threading.Thread(target=read_chunk, daemon=True)
+        reader.start()
+        reader.join(remaining)
+        if reader.is_alive():
+            self._raise_read_timeout()
+        if errors:
+            self._terminate_process()
+            raise McpProtocolError(f"MCP server stdout read failed: {errors[0]}")
+        chunk = chunks[0] if chunks else b""
+        if not chunk:
+            self._terminate_process()
+            raise McpProtocolError("MCP server closed stdout")
+        self._stdout_buffer += chunk
+
+    def _raise_read_timeout(self) -> None:
+        self._terminate_process()
+        raise McpProtocolError(
+            f"MCP server response timed out after "
+            f"{self._config.mcp_read_timeout_seconds:g}s"
+        )
+
+    def _read_header(self, deadline: float) -> bytes:
         while True:
-            line = proc.stdout.readline()
-            if not line:
-                raise McpProtocolError("MCP server closed stdout")
-            decoded = line.decode("utf-8").strip()
-            if decoded == "":
-                break
+            crlf_idx = self._stdout_buffer.find(b"\r\n\r\n")
+            lf_idx = self._stdout_buffer.find(b"\n\n")
+            candidates = [
+                (idx, sep_len)
+                for idx, sep_len in ((crlf_idx, 4), (lf_idx, 2))
+                if idx >= 0
+            ]
+            if candidates:
+                idx, sep_len = min(candidates)
+                header = self._stdout_buffer[:idx]
+                self._stdout_buffer = self._stdout_buffer[idx + sep_len :]
+                return header
+            self._read_stdout_chunk(deadline)
+
+    def _read_exact(self, length: int, deadline: float) -> bytes:
+        while len(self._stdout_buffer) < length:
+            self._read_stdout_chunk(deadline)
+        body = self._stdout_buffer[:length]
+        self._stdout_buffer = self._stdout_buffer[length:]
+        return body
+
+    def _read_message(self) -> dict[str, Any]:
+        deadline = time.monotonic() + self._config.mcp_read_timeout_seconds
+        header = self._read_header(deadline)
+        headers: dict[str, str] = {}
+        for raw_line in header.splitlines():
+            decoded = raw_line.decode("utf-8").strip()
+            if not decoded:
+                continue
             key, _, val = decoded.partition(":")
             headers[key.strip().lower()] = val.strip()
         length = int(headers.get("content-length", "0"))
-        body = proc.stdout.read(length)
+        body = self._read_exact(length, deadline)
         return json.loads(body.decode("utf-8"))
 
     def _initialize(self) -> None:
@@ -128,7 +210,12 @@ class GsdMcpClient:
         self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
 
     def _call_tool(
-        self, name: str, arguments: dict[str, Any], *, check_version: bool = True
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        *,
+        check_version: bool = True,
+        project_dir: str | None = None,
     ) -> dict[str, Any]:
         with self._lock:
             if check_version:
@@ -141,7 +228,8 @@ class GsdMcpClient:
                     "id": req_id,
                     "method": "tools/call",
                     "params": {"name": name, "arguments": arguments},
-                }
+                },
+                project_dir=project_dir,
             )
             while True:
                 msg = self._read_message()
@@ -219,6 +307,7 @@ class GsdMcpClient:
                     "gsd_progress",
                     {"projectDir": project_dir},
                     check_version=False,
+                    project_dir=project_dir,
                 )
                 return ProgressSnapshot.from_mcp(data)
 
@@ -231,21 +320,36 @@ class GsdMcpClient:
 
     def execute(self, project_dir: str, *, command: str = "/gsd auto") -> dict[str, Any]:
         self.invalidate_cache(project_dir)
-        return self._call_tool(
-            "gsd_execute",
-            {"projectDir": project_dir, "command": command},
-        )
+        args = {"projectDir": project_dir, "command": command}
+        try:
+            return self._call_tool("gsd_execute", args, project_dir=project_dir)
+        except GsdVersionError:
+            return self._call_tool(
+                "gsd_execute",
+                args,
+                check_version=False,
+                project_dir=project_dir,
+            )
 
-    def cancel(self, *, session_id: str | None = None, project_dir: str | None = None) -> dict[str, Any]:
+    def cancel(
+        self,
+        *,
+        session_id: str | None = None,
+        project_dir: str | None = None,
+    ) -> dict[str, Any]:
         args: dict[str, Any] = {}
         if session_id:
             args["sessionId"] = session_id
         if project_dir:
             args["projectDir"] = project_dir
-        return self._call_tool("gsd_cancel", args)
+        return self._call_tool("gsd_cancel", args, project_dir=project_dir)
 
     def cancel_by_project(self, project_dir: str) -> dict[str, Any]:
-        return self._call_tool("gsd_cancel_by_project", {"projectDir": project_dir})
+        return self._call_tool(
+            "gsd_cancel_by_project",
+            {"projectDir": project_dir},
+            project_dir=project_dir,
+        )
 
     def resolve_blocker(self, session_id: str, response: str) -> dict[str, Any]:
         return self._call_tool(
@@ -257,13 +361,8 @@ class GsdMcpClient:
         return self._call_tool(
             "gsd_memory_query",
             {"projectDir": project_dir, "query": query},
+            project_dir=project_dir,
         )
 
     def close(self) -> None:
-        if self._proc and self._proc.poll() is None:
-            self._proc.terminate()
-            try:
-                self._proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self._proc.kill()
-        self._proc = None
+        self._terminate_process()

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -75,7 +75,11 @@ class GsdMcpClient:
         self._version_checked = True
 
     def _ensure_process(self, project_dir: str | None = None) -> subprocess.Popen[bytes]:
-        cwd = os.path.abspath(project_dir) if project_dir else None
+        cwd = (
+            os.path.abspath(project_dir)
+            if project_dir is not None
+            else self._proc_cwd
+        )
         if self._proc is not None and self._proc.poll() is None:
             if cwd is None or self._proc_cwd == cwd:
                 return self._proc

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -123,7 +123,10 @@ class GsdMcpClient:
         proc.stdin.flush()
 
     def _read_stdout_chunk(self, deadline: float) -> None:
-        proc = self._ensure_process()
+        proc = self._proc
+        if proc is None or proc.poll() is not None:
+            self._terminate_process()
+            raise McpProtocolError("MCP server closed stdout")
         assert proc.stdout is not None
         remaining = deadline - time.monotonic()
         if remaining <= 0:

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -32,6 +32,10 @@ config_schema:
         cache_ttl_seconds:
           type: integer
           default: 45
+        mcp_read_timeout_seconds:
+          type: number
+          default: 60
+          description: Seconds to wait for one gsd-mcp-server response before resetting the MCP sidecar
         notification_level:
           type: string
           enum: [quiet, normal, verbose]

--- a/integrations/hermes/tests/test_config.py
+++ b/integrations/hermes/tests/test_config.py
@@ -21,6 +21,12 @@ def test_dict_fallback_gsd_version_range_matches_plugin_release_train() -> None:
     assert config.gsd_version_max == "3.0"
 
 
+def test_mcp_read_timeout_can_be_configured() -> None:
+    config = GsdConfig.from_dict({"gsd": {"mcp_read_timeout_seconds": 12.5}})
+
+    assert config.mcp_read_timeout_seconds == 12.5
+
+
 def test_config_path_respects_hermes_home(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("HERMES_GSD_CONFIG", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))

--- a/integrations/hermes/tests/test_gsd_client_cache.py
+++ b/integrations/hermes/tests/test_gsd_client_cache.py
@@ -70,6 +70,7 @@ def test_progress_falls_back_to_mcp_when_cli_binary_is_missing() -> None:
         "gsd_progress",
         {"projectDir": "/tmp/p"},
         check_version=False,
+        project_dir="/tmp/p",
     )
 
 
@@ -90,6 +91,7 @@ def test_progress_falls_back_to_mcp_when_cli_version_is_unsupported() -> None:
         "gsd_progress",
         {"projectDir": "/tmp/p"},
         check_version=False,
+        project_dir="/tmp/p",
     )
 
 
@@ -117,4 +119,5 @@ def test_progress_falls_back_to_mcp_when_cli_json_has_unexpected_shape() -> None
         "gsd_progress",
         {"projectDir": "/tmp/p"},
         check_version=False,
+        project_dir="/tmp/p",
     )

--- a/integrations/hermes/tests/test_gsd_client_execute.py
+++ b/integrations/hermes/tests/test_gsd_client_execute.py
@@ -1,0 +1,35 @@
+"""Unit tests for MCP-backed GSD execution."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.gsd_client import GsdMcpClient, GsdVersionError
+
+
+def test_execute_falls_back_to_mcp_when_cli_version_is_unsupported() -> None:
+    client = GsdMcpClient(GsdConfig())
+
+    with patch.object(client, "_call_tool") as call_tool:
+        call_tool.side_effect = [
+            GsdVersionError("old gsd"),
+            {"sessionId": "session-1"},
+        ]
+
+        result = client.execute("/tmp/p")
+
+    assert result == {"sessionId": "session-1"}
+    assert call_tool.call_args_list[0].args == (
+        "gsd_execute",
+        {"projectDir": "/tmp/p", "command": "/gsd auto"},
+    )
+    assert call_tool.call_args_list[0].kwargs == {"project_dir": "/tmp/p"}
+    assert call_tool.call_args_list[1].args == (
+        "gsd_execute",
+        {"projectDir": "/tmp/p", "command": "/gsd auto"},
+    )
+    assert call_tool.call_args_list[1].kwargs == {
+        "check_version": False,
+        "project_dir": "/tmp/p",
+    }

--- a/integrations/hermes/tests/test_gsd_client_process_cwd.py
+++ b/integrations/hermes/tests/test_gsd_client_process_cwd.py
@@ -1,0 +1,22 @@
+"""Unit tests for MCP server process cwd selection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.gsd_client import GsdMcpClient
+
+
+def test_ensure_process_starts_server_in_project_cwd(tmp_path) -> None:
+    client = GsdMcpClient(GsdConfig())
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+
+    with patch.object(client, "_initialize") as initialize:
+        with patch("subprocess.Popen", return_value=fake_proc) as popen:
+            proc = client._ensure_process(str(tmp_path))
+
+    assert proc is fake_proc
+    initialize.assert_called_once_with()
+    assert popen.call_args.kwargs["cwd"] == str(tmp_path)

--- a/integrations/hermes/tests/test_gsd_client_timeout.py
+++ b/integrations/hermes/tests/test_gsd_client_timeout.py
@@ -1,0 +1,58 @@
+"""Unit tests for MCP stdio read timeouts."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.gsd_client import GsdMcpClient, McpProtocolError
+
+
+def test_read_message_times_out_waiting_for_headers() -> None:
+    client = GsdMcpClient(GsdConfig(mcp_read_timeout_seconds=0.05))
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(10)"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    client._proc = proc
+
+    try:
+        with pytest.raises(McpProtocolError, match="timed out"):
+            client._read_message()
+        assert client._proc is None
+        assert proc.poll() is not None
+    finally:
+        proc.kill()
+
+
+def test_read_message_times_out_waiting_for_body() -> None:
+    client = GsdMcpClient(GsdConfig(mcp_read_timeout_seconds=0.05))
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys, time; "
+                "sys.stdout.buffer.write(b'Content-Length: 2\\r\\n\\r\\n{'); "
+                "sys.stdout.flush(); "
+                "time.sleep(10)"
+            ),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    client._proc = proc
+
+    try:
+        with pytest.raises(McpProtocolError, match="timed out"):
+            client._read_message()
+        assert client._proc is None
+        assert proc.poll() is not None
+    finally:
+        proc.kill()

--- a/integrations/hermes/tests/test_gsd_client_timeout.py
+++ b/integrations/hermes/tests/test_gsd_client_timeout.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -56,3 +57,42 @@ def test_read_message_times_out_waiting_for_body() -> None:
         assert proc.poll() is not None
     finally:
         proc.kill()
+
+
+def test_read_message_fails_without_respawning_when_stdout_closes_mid_body(
+    tmp_path,
+) -> None:
+    client = GsdMcpClient(GsdConfig(mcp_read_timeout_seconds=1))
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "sys.stdout.buffer.write(b'Content-Length: 20\\r\\n\\r\\n{'); "
+                "sys.stdout.flush()"
+            ),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    client._proc = proc
+    client._proc_cwd = str(tmp_path)
+
+    try:
+        with patch.object(
+            client,
+            "_ensure_process",
+            side_effect=AssertionError("read must not respawn MCP server"),
+        ) as ensure_process:
+            with pytest.raises(McpProtocolError, match="closed stdout"):
+                client._read_message()
+
+        ensure_process.assert_not_called()
+        assert client._proc is None
+        assert client._proc_cwd is None
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=1)

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -119,7 +119,7 @@ export class SessionManager extends EventEmitter {
 
     const cliPath = options.cliPath ?? SessionManager.resolveCLIPath();
 
-    const args: string[] = ['--mode', 'rpc'];
+    const args: string[] = [];
     if (options.model) args.push('--model', options.model);
     if (options.bare) args.push('--bare');
 

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, join, resolve } from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -291,6 +291,68 @@ describe('SessionManager', () => {
     await sm.startSession('/tmp/test-cmd', { cliPath: '/usr/bin/gsd', command: '/gsd auto --resume' });
     assert.ok(sm.lastClient);
     assert.deepEqual(sm.lastClient.prompted, ['/gsd auto --resume']);
+  });
+
+  it('startSession delegates rpc mode to RpcClient exactly once', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-session-argv-'));
+    const argvPath = join(dir, 'argv.json');
+    const scriptPath = join(dir, 'agent.cjs');
+    writeFileSync(
+      scriptPath,
+      `
+        const fs = require('node:fs');
+        fs.writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));
+        let buffer = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', (chunk) => {
+          buffer += chunk;
+          let idx;
+          while ((idx = buffer.indexOf('\\n')) >= 0) {
+            const line = buffer.slice(0, idx).trim();
+            buffer = buffer.slice(idx + 1);
+            if (!line) continue;
+            const msg = JSON.parse(line);
+            if (msg.type === 'init') {
+              process.stdout.write(JSON.stringify({
+                type: 'response',
+                id: msg.id,
+                success: true,
+                data: { protocolVersion: 2, sessionId: 'real-session', capabilities: {} },
+              }) + '\\n');
+            } else if (msg.id) {
+              process.stdout.write(JSON.stringify({
+                type: 'response',
+                id: msg.id,
+                success: true,
+                data: {},
+              }) + '\\n');
+            }
+          }
+        });
+        setInterval(() => {}, 1000);
+      `,
+    );
+    const manager = new SessionManager();
+
+    try {
+      const sessionId = await manager.startSession(dir, {
+        cliPath: scriptPath,
+        model: 'claude-sonnet',
+        bare: true,
+      });
+
+      assert.equal(sessionId, 'real-session');
+      assert.deepEqual(JSON.parse(readFileSync(argvPath, 'utf8')), [
+        '--mode',
+        'rpc',
+        '--model',
+        'claude-sonnet',
+        '--bare',
+      ]);
+    } finally {
+      await manager.cleanup();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('startSession rejects duplicate projectDir', async () => {

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -113,7 +113,7 @@ export class SessionManager {
 
     const cliPath = options.cliPath ?? SessionManager.resolveCLIPath();
 
-    const args: string[] = ['--mode', 'rpc'];
+    const args: string[] = [];
     if (options.model) args.push('--model', options.model);
     if (options.bare) args.push('--bare');
 

--- a/packages/rpc-client/src/rpc-client.test.ts
+++ b/packages/rpc-client/src/rpc-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -332,6 +332,34 @@ describe("RpcClient construction", () => {
 		try {
 			await client.start();
 			assert.equal((client as any).process.spawnfile, process.execPath);
+		} finally {
+			await client.stop();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("starts rpc mode exactly once before additional args", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "rpc-client-"));
+		const argvPath = join(dir, "argv.json");
+		const scriptPath = join(dir, "agent.js");
+		writeFileSync(
+			scriptPath,
+			`
+				const fs = require("node:fs");
+				fs.writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));
+				setInterval(() => {}, 1000);
+			`,
+		);
+
+		const client = new RpcClient({
+			cliPath: scriptPath,
+			args: ["--model", "claude-sonnet", "--bare"],
+		});
+
+		try {
+			await client.start();
+			const argv = JSON.parse(readFileSync(argvPath, "utf8"));
+			assert.deepEqual(argv, ["--mode", "rpc", "--model", "claude-sonnet", "--bare"]);
 		} finally {
 			await client.stop();
 			rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fixed MCP read timeout handling, execute version fallback, duplicate RPC args, and project cwd startup with dependency-free verification passing.

## Bugs Addressed
- [x] **MCP message reads can block forever**
- [x] **`execute()` lacks version-check fallback**
- [x] **RPC mode flag is passed twice**
- [x] **MCP server starts without project cwd**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1166
- [#1166 open-gsd-hermes plugin /gsd auto hangs or returns nothing — no timeout in MCP _read_message() and no version-fallback in execute()](https://github.com/open-gsd/gsd-pi/issues/1166)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1166-open-gsd-hermes-plugin-gsd-auto-hangs-or-1783010136`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Hermes gateway MCP I/O and GSD auto-mode session spawning; misbehavior could affect `/gsd auto` reliability but changes are bounded with new unit tests and a config default.
> 
> **Overview**
> Fixes **open-gsd-hermes** `/gsd auto` hanging or returning nothing by hardening the MCP stdio client and aligning session startup with `RpcClient`.
> 
> **Hermes MCP client (`GsdMcpClient`):** Adds configurable **`mcp_read_timeout_seconds`** (default 60s) so `_read_message()` no longer blocks indefinitely on headers or body; on timeout or broken stdout it **terminates the sidecar** so the next call can spawn fresh. Spawns **`gsd-mcp-server` in the bound project `cwd`**, restarting when the project changes. Project-scoped tools pass **`project_dir`** into spawn/send. **`execute()`** retries MCP with **`check_version=False`** after `GsdVersionError`, matching the existing progress fallback. Docs and `plugin.yaml` document the new setting.
> 
> **GSD session managers:** Removes redundant **`--mode rpc`** from `SessionManager` args in **daemon** and **mcp-server** because `RpcClient.start()` already injects it once—avoids duplicate flags. New tests assert argv shape end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76afa0f760bde864f1b435b5c0ba4be3a91f2838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->