### PR TITLE
fix(gsd): guard lifecycle milestone merges

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,7 +197,7 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
 
   See `docs/dev/ADR-033-unit-type-registry.md`.
 
-- The merge verb's full contract moves into Worktree Lifecycle. Publication is already split out, and guarded milestone-merge preflight/postflight stash ordering now enters through the `exitMilestone(..., { guardedMerge })` interface. The remaining step is relocating the merge core out of `auto-worktree.ts`. Push and PR creation stay in the **Publication module**, called after a successful milestone merge.
+- The merge verb's full contract moves into Worktree Lifecycle. Publication is already split out, and guarded milestone-merge preflight/postflight stash ordering now enters through the `exitMilestone(..., { merge: true, guardedMerge })` interface. The remaining step is relocating the merge core out of `auto-worktree.ts`. Push and PR creation stay in the **Publication module**, called after a successful milestone merge.
 
   See `docs/dev/ADR-034-milestone-merge-publication-split.md`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,7 +197,7 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
 
   See `docs/dev/ADR-033-unit-type-registry.md`.
 
-- The merge verb's full contract moves into Worktree Lifecycle. Publication is already split out, and guarded milestone-merge preflight/postflight stash ordering now lives behind the Lifecycle seam as `runGuardedMilestoneMerge`; the remaining step is folding that helper into `exitMilestone` and relocating the merge core out of `auto-worktree.ts`. Push and PR creation stay in the **Publication module**, called after a successful milestone merge.
+- The merge verb's full contract moves into Worktree Lifecycle. Publication is already split out, and guarded milestone-merge preflight/postflight stash ordering now enters through the `exitMilestone(..., { guardedMerge })` interface. The remaining step is relocating the merge core out of `auto-worktree.ts`. Push and PR creation stay in the **Publication module**, called after a successful milestone merge.
 
   See `docs/dev/ADR-034-milestone-merge-publication-split.md`.
 

--- a/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
+++ b/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
@@ -106,7 +106,7 @@ Lifecycle calls Projection. Projection has no Lifecycle dependency. Lifecycle in
 - `Projection.projectRootToWorktree(scope)` from `enterMilestone` after a successful create or enter, before any Unit dispatches.
 - `Projection.finalizeProjectionForMerge(scope)` from `exitMilestone` after a successful merge, before teardown.
 
-Lifecycle entry/exit paths (`enterMilestone` and `exitMilestone`) construct the `MilestoneScope` from the active `milestoneId` and session root state before invoking `Projection.projectRootToWorktree(scope)` or `Projection.finalizeProjectionForMerge(scope)`; callers do not pass a pre-built `s.scope` into Lifecycle. When callers pass `guardedMerge`, `exitMilestone` also owns the root-clean merge guard: preflight runs before the merge attempt, postflight stash restore runs after every attempted merge path, and guard failures are returned through the same `ExitResult` union.
+Lifecycle entry/exit paths (`enterMilestone` and `exitMilestone`) construct the `MilestoneScope` from the active `milestoneId` and session root state before invoking `Projection.projectRootToWorktree(scope)` or `Projection.finalizeProjectionForMerge(scope)`; callers do not pass a pre-built `s.scope` into Lifecycle. When callers pass `merge: true` with `guardedMerge`, `exitMilestone` also owns the root-clean merge guard: preflight runs before the merge attempt, postflight stash restore runs after every attempted merge path, and guard failures are returned through the same `ExitResult` union.
 
 `Projection.projectWorktreeToRoot(scope)` is called by callers outside Lifecycle (post-unit pipeline; pre-merge sync paths). Lifecycle does not own that verb's invocation.
 

--- a/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
+++ b/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
@@ -34,7 +34,12 @@ interface WorktreeLifecycle {
   enterMilestone(milestoneId: string, ctx: NotifyCtx): EnterResult;
   exitMilestone(
     milestoneId: string,
-    opts: { merge: boolean },
+    opts: {
+      merge: boolean;
+      preserveBranch?: boolean;
+      preserveWorktree?: boolean;
+      guardedMerge?: GuardedMilestoneMergeOptions;
+    },
     ctx: NotifyCtx,
   ): ExitResult;
   degradeToBranchMode(milestoneId: string, ctx: NotifyCtx): void;
@@ -49,7 +54,33 @@ type EnterResult =
 
 type ExitResult =
   | { ok: true; merged: boolean; codeFilesChanged: boolean }
-  | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
+  | {
+      ok: false;
+      reason:
+        | "merge-conflict"
+        | "teardown-failed"
+        | "preflight-dirty-overlap"
+        | "preflight-unmerged-conflicts"
+        | "merge-failed"
+        | "postflight-stash-restore-failed";
+      cause?: unknown;
+      postflight?: PostflightResult;
+    };
+
+interface GuardedMilestoneMergeOptions {
+  projectRoot: string;
+  preflightCleanRoot(
+    basePath: string,
+    milestoneId: string,
+    notify: NotifyCtx["notify"],
+  ): PreflightResult;
+  postflightPopStash(
+    basePath: string,
+    milestoneId: string,
+    stashMarker: string | undefined,
+    notify: NotifyCtx["notify"],
+  ): PostflightResult;
+}
 ```
 
 Constructor takes a small dep set (notify, leaseStore, gitServiceFactory, journal, telemetry). The 28-field `WorktreeResolverDeps` is retired.
@@ -75,7 +106,7 @@ Lifecycle calls Projection. Projection has no Lifecycle dependency. Lifecycle in
 - `Projection.projectRootToWorktree(scope)` from `enterMilestone` after a successful create or enter, before any Unit dispatches.
 - `Projection.finalizeProjectionForMerge(scope)` from `exitMilestone` after a successful merge, before teardown.
 
-Lifecycle entry/exit paths (`enterMilestone` and `exitMilestone`) construct the `MilestoneScope` from the active `milestoneId` and session root state before invoking `Projection.projectRootToWorktree(scope)` or `Projection.finalizeProjectionForMerge(scope)`; callers do not pass a pre-built `s.scope` into Lifecycle.
+Lifecycle entry/exit paths (`enterMilestone` and `exitMilestone`) construct the `MilestoneScope` from the active `milestoneId` and session root state before invoking `Projection.projectRootToWorktree(scope)` or `Projection.finalizeProjectionForMerge(scope)`; callers do not pass a pre-built `s.scope` into Lifecycle. When callers pass `guardedMerge`, `exitMilestone` also owns the root-clean merge guard: preflight runs before the merge attempt, postflight stash restore runs after every attempted merge path, and guard failures are returned through the same `ExitResult` union.
 
 `Projection.projectWorktreeToRoot(scope)` is called by callers outside Lifecycle (post-unit pipeline; pre-merge sync paths). Lifecycle does not own that verb's invocation.
 

--- a/docs/dev/ADR-032-unit-closeout-seam.md
+++ b/docs/dev/ADR-032-unit-closeout-seam.md
@@ -104,8 +104,9 @@ Extending ADR-016's fail-closed principle to completion: when the interactive
 adapter closes a milestone boundary and `git.isolation !== "none"`, it
 computes a **Closeout Git Verdict**:
 
-- Work already in a proven milestone worktree/branch → merge via
-  `exitMilestone({ merge: true })`, exactly as auto mode.
+- Work already in a proven milestone worktree/branch → merge via the
+  Worktree Lifecycle `exitMilestone` verb. Auto-mode closeout uses the same
+  verb with its guarded merge option for preflight/postflight stash discipline.
 - Work on the integration branch with uncommitted changes (the observed
   failure) → commit on the current branch, record the verdict as
   `isolation-bypassed`, and surface a **Needs Attention** notice naming the

--- a/docs/dev/ADR-034-milestone-merge-publication-split.md
+++ b/docs/dev/ADR-034-milestone-merge-publication-split.md
@@ -25,7 +25,7 @@ an 875-line function that owns, in one implementation:
 
 Above it, the auto closeout adapter still translates merge outcomes into loop
 policy, but the stash-restore choreography itself now enters the Worktree
-Lifecycle module through the `exitMilestone(..., { guardedMerge })` interface.
+Lifecycle module through the `exitMilestone(..., { merge: true, guardedMerge })` interface.
 The lifecycle verb owns the preflight → merge → postflight ordering, including
 the invariant that a successful local merge is recorded before a postflight
 stash recovery stop.
@@ -46,7 +46,7 @@ ADR-032) can publish without dragging the merge machinery along.
 
 The Worktree Lifecycle module absorbs the stash-restore choreography that the
 auto closeout path used to carry inline. The guarded path now enters through
-`exitMilestone(..., { guardedMerge })`, so the merge verb owns preflight
+`exitMilestone(..., { merge: true, guardedMerge })`, so the merge verb owns preflight
 dirty/conflict checks, always-attempted postflight stash restore after an
 attempted merge, and typed merge/postflight results. The remaining end-state is
 to move the merge implementation (dirty-commit, squash, conflict
@@ -112,7 +112,7 @@ auto-PR, nothing-to-commit short-circuit, missing remote.
 **Shipped 2026-07-02:** the stash guard moved behind the Worktree Lifecycle
 seam. Auto closeout first consumed it through the internal
 `runGuardedMilestoneMerge` helper, then the guard was folded into the
-`exitMilestone(..., { guardedMerge })` interface. Auto closeout now consumes
+`exitMilestone(..., { merge: true, guardedMerge })` interface. Auto closeout now consumes
 the lifecycle verb's typed result instead of owning the merge transaction
 ordering directly, and marks the milestone merge complete before stopping for
 postflight stash recovery so a resume does not re-run an already completed

--- a/docs/dev/ADR-034-milestone-merge-publication-split.md
+++ b/docs/dev/ADR-034-milestone-merge-publication-split.md
@@ -25,9 +25,10 @@ an 875-line function that owns, in one implementation:
 
 Above it, the auto closeout adapter still translates merge outcomes into loop
 policy, but the stash-restore choreography itself now enters the Worktree
-Lifecycle module through `runGuardedMilestoneMerge`. The helper owns the
-preflight → `exitMilestone` → postflight ordering, including the invariant that
-a successful local merge is recorded before a postflight stash recovery stop.
+Lifecycle module through the `exitMilestone(..., { guardedMerge })` interface.
+The lifecycle verb owns the preflight → merge → postflight ordering, including
+the invariant that a successful local merge is recorded before a postflight
+stash recovery stop.
 
 ### Two distinct concerns fused
 
@@ -44,12 +45,11 @@ ADR-032) can publish without dragging the merge machinery along.
 ### 1. The merge verb's full contract moves inside Worktree Lifecycle
 
 The Worktree Lifecycle module absorbs the stash-restore choreography that the
-auto closeout path used to carry inline. During migration this is exposed as
-`runGuardedMilestoneMerge`, a lifecycle helper around `exitMilestone({ merge:
-true })` that owns preflight dirty/conflict checks, always-attempted postflight
-stash restore after an attempted merge, and typed merge/postflight results. The
-remaining end-state is still to fold that helper into the `exitMilestone` verb
-and move the merge implementation (dirty-commit, squash, conflict
+auto closeout path used to carry inline. The guarded path now enters through
+`exitMilestone(..., { guardedMerge })`, so the merge verb owns preflight
+dirty/conflict checks, always-attempted postflight stash restore after an
+attempted merge, and typed merge/postflight results. The remaining end-state is
+to move the merge implementation (dirty-commit, squash, conflict
 classification) out of `auto-worktree.ts`, making the CONTEXT.md ownership
 statement true.
 
@@ -96,10 +96,9 @@ network/credential stubs; publication tests stop needing merge fixtures.
   same seam auto mode uses — `auto_push`/`auto_pr` stop being auto-only
   preferences in practice.
 - **Migration order:** extract Publication first (mechanical tail-split, low
-  blast radius), move the stash choreography behind the Lifecycle seam (first
-  via `runGuardedMilestoneMerge`, then folded into `exitMilestone`), then
-  relocate the merge core. Each step is independently shippable and
-  behaviour-neutral.
+  blast radius), move the stash choreography behind the Lifecycle seam, fold it
+  into `exitMilestone`, then relocate the merge core. Each step is
+  independently shippable and behaviour-neutral.
 
 ## Implementation status (2026-06-10)
 
@@ -111,11 +110,13 @@ remote git fixtures (`tests/publication.test.ts`) — push, suppression under
 auto-PR, nothing-to-commit short-circuit, missing remote.
 
 **Shipped 2026-07-02:** the stash guard moved behind the Worktree Lifecycle
-seam as `runGuardedMilestoneMerge`. Auto closeout now consumes its typed
-result instead of owning the merge transaction ordering directly, and marks the
-milestone merge complete before stopping for postflight stash recovery so a
-resume does not re-run an already completed merge.
+seam. Auto closeout first consumed it through the internal
+`runGuardedMilestoneMerge` helper, then the guard was folded into the
+`exitMilestone(..., { guardedMerge })` interface. Auto closeout now consumes
+the lifecycle verb's typed result instead of owning the merge transaction
+ordering directly, and marks the milestone merge complete before stopping for
+postflight stash recovery so a resume does not re-run an already completed
+merge.
 
-**Remaining:** fold `runGuardedMilestoneMerge` into `exitMilestone` and
-relocate the merge core out of `auto-worktree.ts` into the Worktree Lifecycle
-module.
+**Remaining:** relocate the merge core out of `auto-worktree.ts` into the
+Worktree Lifecycle module.

--- a/docs/dev/FILE-SYSTEM-MAP.md
+++ b/docs/dev/FILE-SYSTEM-MAP.md
@@ -476,7 +476,9 @@
 | gsd/index.ts | GSD Workflow | Main GSD extension bootstrap and registration |
 | gsd/auto.ts | Auto Engine | Automatic workflow execution and loop management |
 | gsd/auto-dashboard.ts | Auto Engine, Web Mode | Real-time dashboard for auto-run progress |
-| gsd/auto-worktree.ts | Auto Engine, Worktree | Automatic worktree creation and branch management |
+| gsd/worktree-lifecycle.ts | Auto Engine, Worktree | Worktree Lifecycle module for milestone enter/exit, guarded merge ordering, teardown, and session root mutation |
+| gsd/auto/closeout.ts | Auto Engine | Auto closeout adapter for milestone merge results and stash recovery stops |
+| gsd/auto-worktree.ts | Auto Engine, Worktree | Lower-level worktree helpers and inner milestone merge primitive |
 | gsd/auto-recovery.ts | Auto Engine | Recovery for crashed/stalled workflows |
 | gsd/auto-start.ts | Auto Engine | Initialization sequence for automatic execution |
 | gsd/auto-worktree-sync.ts | Auto Engine, Worktree | State sync between worktrees and main |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -145,7 +145,8 @@ Model routing (complexity classification, budget pressure, routing history, capa
 | `auto-post-unit.ts` | Post-unit processing — commit, doctor, state rebuild, hooks |
 | `auto-verification.ts` | Post-unit verification gate (lint/test/typecheck with auto-fix retries) |
 | `auto-prompts.ts` | Prompt builders with inline level compression |
-| `auto-worktree.ts` | Worktree lifecycle (create, enter, merge, teardown) |
+| `worktree-lifecycle.ts` | Worktree Lifecycle module — enter, exit, merge guard ordering, teardown, and session root mutation |
+| `auto-worktree.ts` | Lower-level worktree helpers and inner milestone merge primitive wired through Worktree Lifecycle |
 | `auto-recovery.ts` | Expected artifact resolution, completed-key persistence, self-healing |
 | `auto-timeout-recovery.ts` | Timed-out unit recovery and continuation |
 | `auto-timers.ts` | Unit supervision — soft/idle/hard timeouts, continue-here monitor |

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -79,13 +79,14 @@ export async function restorePreflightStashOrStop(
 }
 
 /**
- * Run a milestone merge surrounded by preflight stash + always-on postflight
- * pop. The previous code popped the stash only after a successful merge, which
- * leaked `gsd-preflight-stash:M00x:*` entries whenever `mergeAndExit` threw —
- * leaving the user's pre-merge working tree silently stashed away after a
- * merge-conflict or other merge error. This helper restores the stash on
- * every exit path, then surfaces the merge or stash failure (in priority
- * order) as the loop's stop reason.
+ * Run a milestone merge through Worktree Lifecycle's guarded merge option,
+ * which surrounds the inner merge with preflight stash + always-on postflight
+ * pop. The previous closeout code popped the stash only after a successful
+ * merge, which leaked `gsd-preflight-stash:M00x:*` entries whenever
+ * `mergeAndExit` threw — leaving the user's pre-merge working tree silently
+ * stashed away after a merge-conflict or other merge error. Lifecycle now
+ * restores the stash on every attempted merge path, then this adapter surfaces
+ * the merge or stash failure (in priority order) as the loop's stop reason.
  *
  * Returns a `break` action when auto-mode must stop, or `null` when the merge
  * succeeded and the stash (if any) was restored cleanly.

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -11,7 +11,6 @@ import type { GSDState } from "../types.js";
 import type { IterationContext } from "./types.js";
 import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
 import { MergeConflictError } from "../git-service.js";
-import { runGuardedMilestoneMerge } from "../worktree-lifecycle.js";
 import { findUnmergedCompletedMilestones } from "../unmerged-milestone-guard.js";
 import { getIsolationMode } from "../preferences.js";
 import { isDbAvailable, getMilestone } from "../gsd-db.js";
@@ -99,16 +98,18 @@ export async function _runMilestoneMergeWithStashRestore(
   const { ctx, pi, s, deps } = ic;
 
   const projectRoot = s.originalBasePath || s.basePath;
-  const mergeResult = runGuardedMilestoneMerge({
-    lifecycle: deps.lifecycle,
-    deps: {
-      preflightCleanRoot: deps.preflightCleanRoot,
-      postflightPopStash: deps.postflightPopStash,
-    },
-    projectRoot,
+  const mergeResult = deps.lifecycle.exitMilestone(
     milestoneId,
-    notify: ctx.ui.notify.bind(ctx.ui),
-  });
+    {
+      merge: true,
+      guardedMerge: {
+        projectRoot,
+        preflightCleanRoot: deps.preflightCleanRoot,
+        postflightPopStash: deps.postflightPopStash,
+      },
+    },
+    ctx.ui,
+  );
 
   if (mergeResult.ok) {
     await markMilestoneMergedAndRebuild(s);

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -67,6 +67,76 @@ async function drainMicrotasks(turns = 20): Promise<void> {
   }
 }
 
+function guardedExitMilestoneForTest(
+  merge: (milestoneId: string, opts: { merge: boolean }) => {
+    ok: boolean;
+    merged?: boolean;
+    codeFilesChanged?: boolean;
+    reason?: string;
+    cause?: unknown;
+  },
+) {
+  return (
+    milestoneId: string,
+    opts: {
+      merge: boolean;
+      guardedMerge?: {
+        projectRoot: string;
+        preflightCleanRoot: (
+          basePath: string,
+          milestoneId: string,
+          notify: (message: string, level: "info" | "warning" | "error") => void,
+        ) => { blocked?: boolean; blockedReason?: string; stashPushed: boolean; stashMarker?: string };
+        postflightPopStash: (
+          basePath: string,
+          milestoneId: string,
+          stashMarker: string | undefined,
+          notify: (message: string, level: "info" | "warning" | "error") => void,
+        ) => { needsManualRecovery?: boolean };
+      };
+    },
+    ctx?: { notify: (message: string, level: "info" | "warning" | "error") => void },
+  ) => {
+    const notify = ctx?.notify ?? (() => {});
+    const guard = opts.guardedMerge;
+    if (opts.merge && guard) {
+      const preflight = guard.preflightCleanRoot(guard.projectRoot, milestoneId, notify);
+      if (preflight.blocked) {
+        return {
+          ok: false,
+          reason: preflight.blockedReason?.startsWith("unmerged-conflicts")
+            ? "preflight-unmerged-conflicts"
+            : "preflight-dirty-overlap",
+        };
+      }
+
+      const mergeResult = merge(milestoneId, { merge: true });
+      const postflight = preflight.stashPushed
+        ? guard.postflightPopStash(
+            guard.projectRoot,
+            milestoneId,
+            preflight.stashMarker,
+            notify,
+          )
+        : undefined;
+
+      if (!mergeResult.ok) {
+        return {
+          ok: false,
+          reason: mergeResult.reason === "merge-conflict" ? "merge-conflict" : "merge-failed",
+          cause: mergeResult.cause,
+          postflight,
+        };
+      }
+      if (postflight?.needsManualRecovery) {
+        return { ok: false, reason: "postflight-stash-restore-failed", postflight };
+      }
+      return mergeResult;
+    }
+    return merge(milestoneId, opts);
+  };
+}
+
 async function waitForMicrotasks(
   condition: () => boolean,
   label: string,
@@ -1335,11 +1405,11 @@ function makeMockDeps(
     GitServiceImpl: class {} as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
-      exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
+      exitMilestone: guardedExitMilestoneForTest((_mid, opts) => ({
         ok: true,
         merged: opts.merge,
         codeFilesChanged: false,
-      }),
+      })),
     } as any,
     worktreeProjection: new WorktreeStateProjection(),
     postUnitPreVerification: async () => {
@@ -1762,10 +1832,10 @@ test("autoLoop marks transition merge complete before postflight recovery stop",
       enterMilestone: () => {
         assert.fail("must not enter the next milestone after postflight recovery fails");
       },
-      exitMilestone: (_mid: string, opts: { merge: boolean }) => {
+      exitMilestone: guardedExitMilestoneForTest((_mid, opts) => {
         if (opts.merge) mergeCalls += 1;
         return { ok: true, merged: opts.merge, codeFilesChanged: false };
-      },
+      }),
     } as any,
     stopAuto: async (_ctx, _pi, reason) => {
       deps.callLog.push("stopAuto");

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -61,6 +61,30 @@ function buildIc(opts: {
     },
   };
 
+  const plainExitMilestone = (exitOpts: { merge: boolean }) => {
+    log.mergeCalls += 1;
+    if (opts.mergeBehavior === "succeed") {
+      return { ok: true, merged: exitOpts.merge, codeFilesChanged: false } as const;
+    }
+    try {
+      opts.mergeBehavior();
+      return { ok: true, merged: exitOpts.merge, codeFilesChanged: false } as const;
+    } catch (err) {
+      // Mirror Lifecycle's typed-result wrapping of MergeConflictError
+      // and other thrown values per worktree-lifecycle.exitMilestone.
+      const isMergeConflict =
+        err !== null &&
+        typeof err === "object" &&
+        err !== undefined &&
+        (err as { name?: string }).name === "MergeConflictError";
+      return {
+        ok: false,
+        reason: isMergeConflict ? "merge-conflict" : "teardown-failed",
+        cause: err,
+      } as const;
+    }
+  };
+
   const deps = {
     preflightCleanRoot: () => {
       log.preflightCalls += 1;
@@ -79,28 +103,72 @@ function buildIc(opts: {
       },
     },
     lifecycle: {
-      exitMilestone: (_mid: string, exitOpts: { merge: boolean }) => {
-        log.mergeCalls += 1;
-        if (opts.mergeBehavior === "succeed") {
-          return { ok: true, merged: exitOpts.merge, codeFilesChanged: false };
+      exitMilestone: (
+        _mid: string,
+        exitOpts: {
+          merge: boolean;
+          guardedMerge?: {
+            projectRoot: string;
+            preflightCleanRoot: (
+              basePath: string,
+              milestoneId: string,
+              notify: (message: string, level: "info" | "warning" | "error") => void,
+            ) => PreflightResult;
+            postflightPopStash: (
+              basePath: string,
+              milestoneId: string,
+              stashMarker: string | undefined,
+              notify: (message: string, level: "info" | "warning" | "error") => void,
+            ) => PostflightResult;
+          };
+        },
+        exitCtx?: { notify: (message: string, level: "info" | "warning" | "error") => void },
+      ) => {
+        const notify = exitCtx?.notify ?? (() => {});
+        const guarded = exitOpts.guardedMerge;
+        if (exitOpts.merge && guarded) {
+          const preflight = guarded.preflightCleanRoot(guarded.projectRoot, _mid, notify);
+          if (preflight.blocked) {
+            return {
+              ok: false,
+              reason: preflight.blockedReason?.startsWith("unmerged-conflicts")
+                ? "preflight-unmerged-conflicts"
+                : "preflight-dirty-overlap",
+            } as const;
+          }
+
+          const mergeResult = plainExitMilestone({ merge: true });
+          const postflight = preflight.stashPushed
+            ? guarded.postflightPopStash(
+                guarded.projectRoot,
+                _mid,
+                preflight.stashMarker,
+                notify,
+              )
+            : undefined;
+
+          if (!mergeResult.ok) {
+            if (mergeResult.reason === "merge-conflict") {
+              return { ...mergeResult, postflight } as const;
+            }
+            return {
+              ok: false,
+              reason: "merge-failed",
+              cause: mergeResult.cause,
+              postflight,
+            } as const;
+          }
+          if (postflight?.needsManualRecovery) {
+            return {
+              ok: false,
+              reason: "postflight-stash-restore-failed",
+              postflight,
+            } as const;
+          }
+          return mergeResult;
         }
-        try {
-          opts.mergeBehavior();
-          return { ok: true, merged: exitOpts.merge, codeFilesChanged: false };
-        } catch (err) {
-          // Mirror Lifecycle's typed-result wrapping of MergeConflictError
-          // and other thrown values per worktree-lifecycle.exitMilestone.
-          const isMergeConflict =
-            err !== null &&
-            typeof err === "object" &&
-            err !== undefined &&
-            (err as { name?: string }).name === "MergeConflictError";
-          return {
-            ok: false,
-            reason: isMergeConflict ? "merge-conflict" : "teardown-failed",
-            cause: err,
-          } as const;
-        }
+
+        return plainExitMilestone(exitOpts);
       },
     },
     stopAuto: async (

--- a/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
@@ -82,13 +82,70 @@ const ic = {
       return { ok: true, needsManualRecovery: false };
     },
     lifecycle: {
-      exitMilestone() {
-        calls.push("merge");
-        return {
-          ok: false,
-          reason: "teardown-failed",
-          cause: new Error("remote rejected push"),
+      // Mirror WorktreeLifecycle.exitMilestone's guarded-merge branch
+      // (preflight -> inner merge -> postflight). Since #1169 the closeout
+      // routes the guard through the lifecycle verb, so a non-conflict inner
+      // failure ("teardown-failed") is mapped to "merge-failed" here rather
+      // than by the caller.
+      exitMilestone(
+        milestoneId: string,
+        exitOpts: {
+          merge: boolean;
+          guardedMerge?: {
+            projectRoot: string;
+            preflightCleanRoot: (
+              basePath: string,
+              milestoneId: string,
+              notify: (message: string, level: "info" | "warning" | "error") => void,
+            ) => { blocked?: boolean; blockedReason?: string; stashPushed: boolean; stashMarker?: string };
+            postflightPopStash: (
+              basePath: string,
+              milestoneId: string,
+              stashMarker: string | undefined,
+              notify: (message: string, level: "info" | "warning" | "error") => void,
+            ) => { needsManualRecovery?: boolean };
+          };
+        },
+        exitCtx?: { notify: (message: string, level: "info" | "warning" | "error") => void },
+      ) {
+        const notify = exitCtx?.notify ?? (() => {});
+        const plainExitMilestone = () => {
+          calls.push("merge");
+          return {
+            ok: false as const,
+            reason: "teardown-failed" as const,
+            cause: new Error("remote rejected push"),
+          };
         };
+        const guarded = exitOpts.guardedMerge;
+        if (exitOpts.merge && guarded) {
+          const preflight = guarded.preflightCleanRoot(guarded.projectRoot, milestoneId, notify);
+          if (preflight.blocked) {
+            return {
+              ok: false,
+              reason: preflight.blockedReason?.startsWith("unmerged-conflicts")
+                ? "preflight-unmerged-conflicts"
+                : "preflight-dirty-overlap",
+            };
+          }
+          const mergeResult = plainExitMilestone();
+          const postflight = preflight.stashPushed
+            ? guarded.postflightPopStash(guarded.projectRoot, milestoneId, preflight.stashMarker, notify)
+            : undefined;
+          if (!mergeResult.ok) {
+            return {
+              ok: false,
+              reason: mergeResult.reason === "merge-conflict" ? "merge-conflict" : "merge-failed",
+              cause: mergeResult.cause,
+              postflight,
+            };
+          }
+          if (postflight?.needsManualRecovery) {
+            return { ok: false, reason: "postflight-stash-restore-failed", postflight };
+          }
+          return mergeResult;
+        }
+        return plainExitMilestone();
       },
     },
     async stopAuto(_ctx: unknown, _pi: unknown, reason?: string) {

--- a/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
@@ -109,14 +109,6 @@ const ic = {
         exitCtx?: { notify: (message: string, level: "info" | "warning" | "error") => void },
       ) {
         const notify = exitCtx?.notify ?? (() => {});
-        const plainExitMilestone = () => {
-          calls.push("merge");
-          return {
-            ok: false as const,
-            reason: "teardown-failed" as const,
-            cause: new Error("remote rejected push"),
-          };
-        };
         const guarded = exitOpts.guardedMerge;
         if (exitOpts.merge && guarded) {
           const preflight = guarded.preflightCleanRoot(guarded.projectRoot, milestoneId, notify);
@@ -128,24 +120,19 @@ const ic = {
                 : "preflight-dirty-overlap",
             };
           }
-          const mergeResult = plainExitMilestone();
-          const postflight = preflight.stashPushed
-            ? guarded.postflightPopStash(guarded.projectRoot, milestoneId, preflight.stashMarker, notify)
-            : undefined;
-          if (!mergeResult.ok) {
-            return {
-              ok: false,
-              reason: mergeResult.reason === "merge-conflict" ? "merge-conflict" : "merge-failed",
-              cause: mergeResult.cause,
-              postflight,
-            };
+          // Inner merge fails with a non-conflict error. The lifecycle still
+          // runs postflight stash restore on the failed-merge path, then maps
+          // the non-conflict failure to "merge-failed" (a MergeConflictError
+          // would instead map to "merge-conflict").
+          calls.push("merge");
+          const cause = new Error("remote rejected push");
+          if (preflight.stashPushed) {
+            guarded.postflightPopStash(guarded.projectRoot, milestoneId, preflight.stashMarker, notify);
           }
-          if (postflight?.needsManualRecovery) {
-            return { ok: false, reason: "postflight-stash-restore-failed", postflight };
-          }
-          return mergeResult;
+          return { ok: false, reason: "merge-failed", cause };
         }
-        return plainExitMilestone();
+        calls.push("merge");
+        return { ok: false, reason: "teardown-failed", cause: new Error("remote rejected push") };
       },
     },
     async stopAuto(_ctx: unknown, _pi: unknown, reason?: string) {

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -268,7 +268,7 @@ export interface GuardedMilestoneMergeDeps {
 }
 
 /**
- * Optional `exitMilestone({ merge: true, guardedMerge })` contract for callers
+ * Optional `exitMilestone(..., { merge: true, guardedMerge })` contract for callers
  * that need root-clean preflight and postflight stash restoration around the
  * lifecycle-owned merge attempt. `projectRoot` is the workspace root whose
  * user changes are protected by the supplied guard functions.

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -286,10 +286,11 @@ function preflightBlockedMergeReason(
  * Run a milestone merge behind the Worktree Lifecycle seam with the root-clean
  * stash guard that protects user changes around merge.
  *
- * The helper owns the invariant ordering (preflight -> lifecycle exit ->
- * postflight on every attempted merge path) and returns a typed result. Auto
- * closeout remains responsible for translating that result into loop policy
- * (pause vs. stop, visible transcript preservation, projection rebuild).
+ * The helper owns the invariant ordering (preflight -> merge callback ->
+ * postflight on every attempted merge path) and returns the same typed result
+ * shape as `exitMilestone`. Auto closeout remains responsible for translating
+ * that result into loop policy (pause vs. stop, visible transcript
+ * preservation, projection rebuild).
  */
 function runGuardedMilestoneMerge(request: {
   merge: () => ExitResult;
@@ -1538,11 +1539,20 @@ export class WorktreeLifecycle {
    * With `opts.merge === false`, runs auto-commit and teardown without
    * merging to main.
    *
+   * When `opts.guardedMerge` is present with `opts.merge === true`, the
+   * lifecycle verb also owns the root-clean guard around the merge: preflight
+   * runs before the inner merge, postflight stash restore runs after every
+   * attempted merge path, and guard failures are returned as typed
+   * `ExitResult` reasons.
+   *
    * Returns a typed `ExitResult`. `MergeConflictError` is surfaced as
    * `{ ok: false, reason: "merge-conflict", cause }` instead of thrown,
-   * giving callers a typed branch for the expected failure path.
-   * Unexpected failures (filesystem, git permissions, etc.) are wrapped
-   * as `{ ok: false, reason: "teardown-failed", cause }` so callers always
+   * giving callers a typed branch for the expected failure path. Guarded merge
+   * failures surface as `preflight-dirty-overlap`,
+   * `preflight-unmerged-conflicts`, `merge-failed`, or
+   * `postflight-stash-restore-failed`. Unexpected failures (filesystem, git
+   * permissions, etc.) are wrapped as
+   * `{ ok: false, reason: "teardown-failed", cause }` so callers always
    * receive a discriminated union — no exceptions for any expected outcome.
    */
   exitMilestone(

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -267,6 +267,12 @@ export interface GuardedMilestoneMergeDeps {
   ) => PostflightResult;
 }
 
+/**
+ * Optional `exitMilestone({ merge: true, guardedMerge })` contract for callers
+ * that need root-clean preflight and postflight stash restoration around the
+ * lifecycle-owned merge attempt. `projectRoot` is the workspace root whose
+ * user changes are protected by the supplied guard functions.
+ */
 export interface GuardedMilestoneMergeOptions extends GuardedMilestoneMergeDeps {
   projectRoot: string;
 }

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -240,7 +240,18 @@ export interface StrandedMilestoneAdoptionOptions {
 
 export type ExitResult =
   | { ok: true; merged: boolean; codeFilesChanged: boolean }
-  | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
+  | {
+      ok: false;
+      reason:
+        | "merge-conflict"
+        | "teardown-failed"
+        | "preflight-dirty-overlap"
+        | "preflight-unmerged-conflicts"
+        | "merge-failed"
+        | "postflight-stash-restore-failed";
+      cause?: unknown;
+      postflight?: PostflightResult;
+    };
 
 export interface GuardedMilestoneMergeDeps {
   preflightCleanRoot: (
@@ -256,23 +267,15 @@ export interface GuardedMilestoneMergeDeps {
   ) => PostflightResult;
 }
 
-export type GuardedMilestoneMergeResult =
-  | { ok: true }
-  | {
-      ok: false;
-      reason:
-        | "preflight-dirty-overlap"
-        | "preflight-unmerged-conflicts"
-        | "merge-conflict"
-        | "merge-failed"
-        | "postflight-stash-restore-failed";
-      cause?: unknown;
-      postflight?: PostflightResult;
-    };
+export interface GuardedMilestoneMergeOptions extends GuardedMilestoneMergeDeps {
+  projectRoot: string;
+}
+
+type GuardedMilestoneMergeResult = ExitResult;
 
 function preflightBlockedMergeReason(
   blockedReason: PreflightResult["blockedReason"],
-): Extract<GuardedMilestoneMergeResult, { ok: false }>["reason"] {
+): Extract<ExitResult, { ok: false }>["reason"] {
   if (blockedReason?.startsWith("unmerged-conflicts")) {
     return "preflight-unmerged-conflicts";
   }
@@ -288,17 +291,14 @@ function preflightBlockedMergeReason(
  * closeout remains responsible for translating that result into loop policy
  * (pause vs. stop, visible transcript preservation, projection rebuild).
  */
-export function runGuardedMilestoneMerge(request: {
-  lifecycle: {
-    exitMilestone: (milestoneId: string, opts: { merge: true }, ctx: NotifyCtx) => ExitResult;
-  };
-  deps: GuardedMilestoneMergeDeps;
-  projectRoot: string;
+function runGuardedMilestoneMerge(request: {
+  merge: () => ExitResult;
+  guard: GuardedMilestoneMergeOptions;
   milestoneId: string;
   notify: NotifyCtx["notify"];
 }): GuardedMilestoneMergeResult {
-  const { lifecycle, deps, projectRoot, milestoneId, notify } = request;
-  const preflight = deps.preflightCleanRoot(projectRoot, milestoneId, notify);
+  const { merge, guard, milestoneId, notify } = request;
+  const preflight = guard.preflightCleanRoot(guard.projectRoot, milestoneId, notify);
   if (preflight.blocked) {
     return {
       ok: false,
@@ -307,15 +307,15 @@ export function runGuardedMilestoneMerge(request: {
   }
 
   let mergeError: unknown = null;
-  const exitResult = lifecycle.exitMilestone(milestoneId, { merge: true }, { notify });
+  const exitResult = merge();
   if (!exitResult.ok) {
     mergeError = exitResult.cause ?? new Error(`exit ${exitResult.reason}`);
   }
 
   let postflight: PostflightResult | undefined;
   if (preflight.stashPushed) {
-    postflight = deps.postflightPopStash(
-      projectRoot,
+    postflight = guard.postflightPopStash(
+      guard.projectRoot,
       milestoneId,
       preflight.stashMarker,
       notify,
@@ -331,7 +331,7 @@ export function runGuardedMilestoneMerge(request: {
   if (postflight?.needsManualRecovery) {
     return { ok: false, reason: "postflight-stash-restore-failed", postflight };
   }
-  return { ok: true };
+  return exitResult;
 }
 
 /**
@@ -1547,9 +1547,23 @@ export class WorktreeLifecycle {
    */
   exitMilestone(
     milestoneId: string,
-    opts: { merge: boolean; preserveBranch?: boolean; preserveWorktree?: boolean },
+    opts: {
+      merge: boolean;
+      preserveBranch?: boolean;
+      preserveWorktree?: boolean;
+      guardedMerge?: GuardedMilestoneMergeOptions;
+    },
     ctx: NotifyCtx,
   ): ExitResult {
+    if (opts.merge && opts.guardedMerge) {
+      return runGuardedMilestoneMerge({
+        merge: () => this.exitMilestone(milestoneId, { merge: true }, ctx),
+        guard: opts.guardedMerge,
+        milestoneId,
+        notify: ctx.notify,
+      });
+    }
+
     if (opts.merge) {
       try {
         const merged = this._mergeAndExit(milestoneId, ctx);


### PR DESCRIPTION
## What Changed

- Moved guarded milestone merge handling into `WorktreeLifecycle.exitMilestone`, so lifecycle-owned merges can run preflight clean-root checks and always attempt postflight stash restoration around merge exits.
- Updated auto closeout to use the lifecycle guarded-merge path while preserving existing pause/stop behavior for preflight blocks, merge conflicts, merge failures, and postflight recovery failures.
- Expanded GSD regression coverage and synced lifecycle/guarded-merge architecture docs to reflect the new closeout seam.

## Risk Assessment

⚠️ Medium: The change is focused and covered by targeted regression tests, but it moves guarded merge behavior into the core worktree lifecycle exit path, so merge/closeout regressions would have high user impact if missed.

## Testing

After confirming the worktree state and reviewing CONTRIBUTING plus the lifecycle/closeout diff, I restored local dependencies and built the contracts package needed by the targeted tests, then ran the focused GSD closeout/auto-loop tests successfully; I also produced a reviewer-visible JSON transcript showing the end-to-end guarded exit sequence restoring the stash after a simulated merge failure and cleaned generated dependency/build artifacts from the worktree.

<details>
<summary>Evidence: Guarded milestone merge evidence</summary>

<code>{&#10;&#34;scenario&#34;: &#34;guarded lifecycle milestone exit restores preflight stash after merge failure&#34;,&#10;&#34;events&#34;: [&#10;&#34;preflight stashed user changes at /tmp/gsd-project-root for M001&#34;,&#10;&#34;inner merge attempted and failed&#34;,&#10;&#34;postflight restored gsd-preflight-stash:M001:evidence at /tmp/gsd-project-root for M001&#34;&#10;],&#10;&#34;result&#34;: {&#10;&#34;ok&#34;: false,&#10;&#34;reason&#34;: &#34;merge-failed&#34;,&#10;&#34;cause&#34;: &#34;simulated merge failure&#34;,&#10;&#34;postflightNeedsManualRecovery&#34;: false&#10;},&#10;&#34;demonstrated&#34;: true&#10;}</code>

```text
{
  "scenario": "guarded lifecycle milestone exit restores preflight stash after merge failure",
  "events": [
    "preflight stashed user changes at /tmp/gsd-project-root for M001",
    "inner merge attempted and failed",
    "postflight restored gsd-preflight-stash:M001:evidence at /tmp/gsd-project-root for M001"
  ],
  "notifications": [
    {
      "level": "info",
      "message": "preflight: stashed user changes"
    },
    {
      "level": "info",
      "message": "postflight: restored user changes"
    }
  ],
  "result": {
    "ok": false,
    "reason": "merge-failed",
    "cause": "simulated merge failure",
    "postflightNeedsManualRecovery": false
  },
  "demonstrated": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - medium risk</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pwd && git status --short --branch && git rev-parse --abbrev-ref HEAD && git branch --contains HEAD --merged | sed -n '1,20p' && ls`
- `sed -n '1,220p' CONTRIBUTING.md && git diff --stat d2169a019076765303376ca4192bcaf2d3211eff..d62816f33789b9514f1e92e1f0361ecc3d5bd5e3 && git diff --name-status d2169a019076765303376ca4192bcaf2d3211eff..d62816f33789b9514f1e92e1f0361ecc3d5bd5e3`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts` (initial attempt exposed missing local dependencies)</code>
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:contracts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts src/resources/extensions/gsd/tests/auto-loop.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KWJ487RSP67Q646X5FM7NNJM/guarded-merge-evidence.mjs | tee /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KWJ487RSP67Q646X5FM7NNJM/guarded-merge-evidence.json`
- `rm -rf node_modules extensions/google-search/node_modules packages/*/node_modules packages/contracts/dist web/node_modules && find . -name '*.tsbuildinfo' -type f -delete`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
