### PR TITLE
fix(issue): [Bug]: Session JSONL header cwd never updated after worktree chdir, all auto-mode sessions show project root

### DIFF
--- a/packages/gsd-agent-core/src/agent-session.test.ts
+++ b/packages/gsd-agent-core/src/agent-session.test.ts
@@ -1,7 +1,9 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { SessionManager } from "@gsd/pi-coding-agent/core/session-manager.js";
 import { parseSkillBlock } from "./agent-session.ts";
 import { AgentSessionExtensionsModule } from "./session/agent-session-extensions.ts";
+import { AgentSessionNavigationModule } from "./session/agent-session-navigation.ts";
 import { AgentSessionPromptModule } from "./session/agent-session-prompt.ts";
 
 describe("parseSkillBlock", () => {
@@ -79,6 +81,52 @@ describe("AgentSessionExtensionsModule", () => {
 
     assert.match(prompt, /<name>Review-Skill<\/name>/);
     assert.doesNotMatch(prompt, /<name>other-skill<\/name>/);
+  });
+});
+
+describe("AgentSessionNavigationModule", () => {
+  test("records workspaceRoot as the new session header cwd", async () => {
+    const projectRoot = "/tmp/project-root";
+    const worktreeRoot = "/tmp/project-root/.gsd-worktrees/M001";
+    const sessionManager = SessionManager.inMemory(projectRoot);
+    let rebuiltRuntime = false;
+
+    const host = {
+      sessionFile: undefined,
+      _extensionRunner: undefined,
+      _cwd: projectRoot,
+      _steeringMessages: ["old"],
+      _followUpMessages: ["old"],
+      _pendingNextTurnMessages: ["old"],
+      thinkingLevel: "off",
+      agent: {
+        state: { isStreaming: false },
+        sessionId: sessionManager.getSessionId(),
+        waitForIdle: async () => {},
+        reset: () => {},
+      },
+      sessionManager,
+      abortRetry: () => {},
+      abort: async () => {},
+      disconnectFromAgent: () => {},
+      reconnectToAgent: () => {},
+      getActiveToolNames: () => [],
+      buildRuntime: () => {
+        rebuiltRuntime = true;
+      },
+      refreshToolRegistry: () => {},
+      emitSessionStartWithLegacySwitch: async () => {},
+    };
+
+    const result = await new AgentSessionNavigationModule(host as any).newSession({
+      workspaceRoot: worktreeRoot,
+    });
+
+    assert.equal(result, true);
+    assert.equal(host._cwd, worktreeRoot);
+    assert.equal(sessionManager.getHeader()?.cwd, worktreeRoot);
+    assert.equal(sessionManager.getCwd(), worktreeRoot);
+    assert.equal(rebuiltRuntime, true);
   });
 });
 

--- a/packages/gsd-agent-core/src/session/agent-session-navigation.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-navigation.ts
@@ -73,7 +73,10 @@ export class AgentSessionNavigationModule {
 		const previousCwd = this.host._cwd;
 		this.host._cwd = options?.workspaceRoot ?? process.cwd();
 
-		this.host.sessionManager.newSession({ parentSession: options?.parentSession });
+		this.host.sessionManager.newSession({
+			cwd: this.host._cwd,
+			parentSession: options?.parentSession,
+		});
 		this.host.agent.sessionId = this.host.sessionManager.getSessionId();
 		this.host._steeringMessages = [];
 		this.host._followUpMessages = [];

--- a/packages/pi-coding-agent/src/core/session-manager-types.ts
+++ b/packages/pi-coding-agent/src/core/session-manager-types.ts
@@ -14,6 +14,7 @@ export interface SessionHeader {
 
 export interface NewSessionOptions {
 	id?: string;
+	cwd?: string;
 	parentSession?: string;
 }
 

--- a/packages/pi-coding-agent/src/core/session-manager.ts
+++ b/packages/pi-coding-agent/src/core/session-manager.ts
@@ -194,6 +194,9 @@ export class SessionManager {
 
 	newSession(options?: NewSessionOptions): string | undefined {
 		this.sessionId = options?.id ?? createSessionId();
+		if (options?.cwd) {
+			this.cwd = resolvePath(options.cwd);
+		}
 		const timestamp = new Date().toISOString();
 		const header: SessionHeader = {
 			type: "session",


### PR DESCRIPTION
## Summary
- Updated session creation to record workspaceRoot cwd in JSONL headers and verified diff whitespace; focused test was blocked by missing TypeScript dependency.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1161
- [#1161 [Bug]: Session JSONL header cwd never updated after worktree chdir, all auto-mode sessions show project root](https://github.com/open-gsd/gsd-pi/issues/1161)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1161-bug-session-jsonl-header-cwd-never-updat-1783022504`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible API extension with targeted navigation wiring and a focused test; no auth or persistence format migration.
> 
> **Overview**
> Fixes session JSONL headers still recording the **project root** after the agent starts a new session from a **worktree** (`workspaceRoot`), which made auto-mode sessions look like they always ran at the repo root.
> 
> `SessionManager.newSession()` now accepts an optional **`cwd`** and updates internal cwd before writing the header. **`AgentSessionNavigationModule.newSession()`** passes the resolved workspace directory (including `workspaceRoot`) into that call so `getHeader().cwd` and `getCwd()` match the active worktree.
> 
> Adds a unit test that starting a session with `workspaceRoot` updates host cwd, session header cwd, session manager cwd, and triggers a runtime rebuild when cwd changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c0ded3f783150839d1467363d879661a95b3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->