### PR TITLE
fix(issue): [Bug]: ask_user_questions elicitation expires at the MCP SDK's hidden 60s default instead of the declared 10-minute ELICIT_TIMEOUT_MS, cutting off users mid-answer

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -24,6 +24,7 @@ import {
   buildAskUserQuestionsElicitRequest,
   createMcpServer,
   formatAskUserQuestionsElicitResult,
+  isLocalElicitClientAbortError,
   isLocalElicitTimeoutError,
   withElicitTimeout,
 } from './server.js';
@@ -1614,6 +1615,44 @@ describe('createMcpServer tool registration', () => {
     assert.match(result.content[0]?.text ?? '', /Local elicitation failed/);
     assert.match(result.content[0]?.text ?? '', /remote transport failed/);
   });
+
+  it('ask_user_questions returns cancelled structuredContent (not isError) and does NOT fall through to remote when the client aborts', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+    let remoteCalls = 0;
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        // withElicitTimeout rejects with this message when the tool-call
+        // AbortSignal fires (client tore down the request).
+        throw new Error('ask_user_questions cancelled by client');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        remoteCalls++;
+        throw new Error('remote must not be called on client abort');
+      },
+    });
+
+    assert.equal(remoteCalls, 0, 'client abort must NOT fall through to remote');
+    assert.equal('isError' in result && result.isError, false, 'client abort is not an error result');
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true },
+    );
+    assert.match(result.content[0]?.text ?? '', /cancelled by the client/i);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1649,6 +1688,31 @@ describe('isLocalElicitTimeoutError', () => {
     assert.equal(isLocalElicitTimeoutError('timed out'), false);
     assert.equal(isLocalElicitTimeoutError(undefined), false);
     assert.equal(isLocalElicitTimeoutError(null), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLocalElicitClientAbortError
+// ---------------------------------------------------------------------------
+
+describe('isLocalElicitClientAbortError', () => {
+  it('recognizes the withElicitTimeout client-abort rejection', () => {
+    assert.equal(
+      isLocalElicitClientAbortError(new Error('ask_user_questions cancelled by client')),
+      true,
+    );
+  });
+
+  it('does not misclassify timeouts or other elicitation errors', () => {
+    assert.equal(isLocalElicitClientAbortError(new Error('ask_user_questions timed out after 10 minutes')), false);
+    assert.equal(isLocalElicitClientAbortError(new Error('MCP host does not support elicitation')), false);
+    assert.equal(isLocalElicitClientAbortError(new Error('MCP error -32001: Request timed out')), false);
+  });
+
+  it('does not misclassify non-Error values', () => {
+    assert.equal(isLocalElicitClientAbortError('cancelled by client'), false);
+    assert.equal(isLocalElicitClientAbortError(undefined), false);
+    assert.equal(isLocalElicitClientAbortError(null), false);
   });
 });
 

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -772,6 +772,44 @@ describe('createMcpServer tool registration', () => {
     assert.ok(typeof server.close === 'function');
   });
 
+  it('ask_user_questions passes the declared elicitation timeout and signal to the MCP SDK request', async () => {
+    const { server } = await createMcpServer(sm);
+    const askTool = (server as any)._registeredTools?.ask_user_questions;
+    assert.ok(askTool, 'ask_user_questions should be registered');
+
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    const signal = new AbortController().signal;
+    let receivedParams: unknown;
+    let receivedOptions: unknown;
+
+    server.server.elicitInput = async (params, options) => {
+      receivedParams = params;
+      receivedOptions = options;
+      return {
+        action: 'accept',
+        content: {
+          depth_verification_M001: 'Yes, you got it (Recommended)',
+        },
+      };
+    };
+
+    const result = await askTool.handler({ questions }, { signal });
+
+    assert.equal('isError' in result && result.isError, false);
+    assert.deepEqual(receivedParams, buildAskUserQuestionsElicitRequest(questions));
+    assert.deepEqual(receivedOptions, { timeout: 600000, signal });
+  });
+
   it('advertises workflow aliases by default for external MCP clients', async () => {
     const previous = process.env.GSD_MCP_HIDE_ALIASES;
     delete process.env.GSD_MCP_HIDE_ALIASES;
@@ -1194,7 +1232,7 @@ describe('createMcpServer tool registration', () => {
       },
     ];
     let remoteCalls = 0;
-    const signal = AbortSignal.abort();
+    const signal = new AbortController().signal;
 
     const result = await askUserQuestionsHandler(questions, { signal }, {
       async elicitInput() {
@@ -1493,7 +1531,7 @@ describe('createMcpServer tool registration', () => {
 
     const result = await askUserQuestionsHandler(questions, undefined, {
       async elicitInput() {
-        // The Claude Agent SDK's internal ~60s timeout surfaces as this error.
+        // MCP SDK request deadline expiry surfaces as this error.
         throw new Error('MCP error -32001: Request timed out');
       },
       isRemoteConfigured() {
@@ -1583,7 +1621,7 @@ describe('createMcpServer tool registration', () => {
 // ---------------------------------------------------------------------------
 
 describe('isLocalElicitTimeoutError', () => {
-  it('recognizes the Claude Agent SDK -32001 timeout', () => {
+  it('recognizes the MCP SDK -32001 timeout', () => {
     assert.equal(
       isLocalElicitTimeoutError(new Error('MCP error -32001: Request timed out')),
       true,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -730,8 +730,22 @@ export function isLocalElicitTimeoutError(err: unknown): boolean {
   );
 }
 
+/**
+ * Detect a client-side cancellation of the tools/call. `withElicitTimeout`
+ * rejects with `<label> cancelled by client` when the tool-call AbortSignal
+ * fires. This is the caller tearing down the request, not a channel failure,
+ * so the handler must return a clean cancelled result rather than re-throwing
+ * into a raw `isError` response that skips `recordAskUserQuestionsGateResult`
+ * and leaves the depth-verification gate pending with no cancellation signal.
+ */
+export function isLocalElicitClientAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.toLowerCase().includes('cancelled by client');
+}
+
 function isLocalElicitFallbackError(err: unknown): boolean {
   if (isLocalElicitTimeoutError(err)) return true;
+  if (isLocalElicitClientAbortError(err)) return true;
   if (!(err instanceof Error)) return false;
   const message = err.message.toLowerCase();
   return (
@@ -776,6 +790,7 @@ export async function askUserQuestionsHandler(
     // depth-verification gate when the user is sitting in front of the host.
     let localElicitError: unknown;
     let localElicitTimedOut = false;
+    let localElicitCancelledByClient = false;
     try {
       const elicitation = await withElicitTimeout(
         deps.elicitInput(buildAskUserQuestionsElicitRequest(questions), {
@@ -807,6 +822,11 @@ export async function askUserQuestionsHandler(
       // the user instead of looping on the blocked call (#852).
       if (isLocalElicitTimeoutError(err)) {
         localElicitTimedOut = true;
+      } else if (isLocalElicitClientAbortError(err)) {
+        // The caller aborted the tools/call. Handled below (do not fall
+        // through to remote; the signal is already aborted and no one is
+        // there to answer it either).
+        localElicitCancelledByClient = true;
       } else {
         console.warn(`[gsd:mcp] ask_user_questions local elicitation unavailable; trying remote fallback: ${formatErrorMessage(err)}`);
       }
@@ -826,6 +846,23 @@ export async function askUserQuestionsHandler(
       return {
         content: [{ type: 'text' as const, text: formatAskUserQuestionsTimeoutMessage(localElicitError) }],
         structuredContent: timedOutStructured as unknown as Record<string, unknown>,
+      };
+    }
+
+    // Client aborted the tools/call. Do not fall through to remote (the signal
+    // is already aborted and no one is there to answer). Return a clean
+    // `cancelled` result so the gate hook sees a cancellation (gate stays
+    // pending, model re-asks) instead of a raw `isError` that skips the gate
+    // result recording entirely.
+    if (localElicitCancelledByClient) {
+      const cancelledStructured: AskUserQuestionsStructuredContent = {
+        questions,
+        response: null,
+        cancelled: true,
+      };
+      return {
+        content: [{ type: 'text' as const, text: 'ask_user_questions was cancelled by the client' }],
+        structuredContent: cancelledStructured as unknown as Record<string, unknown>,
       };
     }
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -342,6 +342,11 @@ export interface McpToolExtra {
   sendNotification?: (notification: unknown) => void | Promise<void>;
 }
 
+interface ElicitRequestOptions {
+  timeout?: number;
+  signal?: AbortSignal;
+}
+
 interface McpServerInstance {
   tool(
     name: string,
@@ -352,7 +357,7 @@ interface McpServerInstance {
   server: {
     elicitInput(
       params: AskUserQuestionsElicitRequest | ElicitRequestFormParams,
-      options?: unknown,
+      options?: ElicitRequestOptions,
     ): Promise<AskUserQuestionsElicitResult>;
   };
   connect(transport: unknown): Promise<void>;
@@ -602,7 +607,10 @@ export function buildAskUserQuestionsRoundResult(
 }
 
 interface AskUserQuestionsHandlerDeps {
-  elicitInput(params: AskUserQuestionsElicitRequest): Promise<AskUserQuestionsElicitResult>;
+  elicitInput(
+    params: AskUserQuestionsElicitRequest,
+    options?: ElicitRequestOptions,
+  ): Promise<AskUserQuestionsElicitResult>;
   isRemoteConfigured(): boolean;
   tryRemoteQuestions(questions: AskUserQuestion[], signal?: AbortSignal): Promise<RemoteToolResult | null>;
   writeGate?: AskUserQuestionsWriteGateModule | null;
@@ -704,9 +712,9 @@ async function recordAskUserQuestionsGateResult(
  * Detect an elicitation-side timeout error so the handler returns a clean
  * "timed_out" result rather than a raw error the model will retry.
  *
- * The Claude Agent SDK enforces its own ~60s elicitation timeout
- * (`MCP error -32001: Request timed out`); `withElicitTimeout` enforces a
- * longer 10-minute timeout (`… timed out after … minutes`). Both surface as
+ * The MCP SDK surfaces request deadline expiry as
+ * (`MCP error -32001: Request timed out`); `withElicitTimeout` also enforces
+ * the 10-minute user window (`… timed out after … minutes`). Both surface as
  * elicitation fallback errors that should never become a raw `errorContent`
  * response — without recognition they re-throw, skip
  * `recordAskUserQuestionsGateResult`, leave the depth-verification gate
@@ -770,8 +778,13 @@ export async function askUserQuestionsHandler(
     let localElicitTimedOut = false;
     try {
       const elicitation = await withElicitTimeout(
-        deps.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
+        deps.elicitInput(buildAskUserQuestionsElicitRequest(questions), {
+          timeout: ELICIT_TIMEOUT_MS,
+          ...(extra?.signal ? { signal: extra.signal } : {}),
+        }),
         'ask_user_questions',
+        undefined,
+        extra?.signal,
       );
       if (elicitation.action === 'accept' && elicitation.content) {
         const structured: AskUserQuestionsStructuredContent = {
@@ -1255,7 +1268,7 @@ export async function createMcpServer(
     async (args: Record<string, unknown>, extra?: McpToolExtra) => {
       const { questions } = args as unknown as AskUserQuestionsParams;
       return askUserQuestionsHandler(questions, extra, {
-        elicitInput: (params) => server.server.elicitInput(params),
+        elicitInput: (params, options) => server.server.elicitInput(params, options),
         isRemoteConfigured,
         tryRemoteQuestions,
       });


### PR DESCRIPTION
## Summary
- Fixed ask_user_questions to pass the declared 10-minute elicitation timeout and request signal, with a regression test added; verification was limited to git diff checks because dependency install was network-blocked.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1150
- [#1150 [Bug]: ask_user_questions elicitation expires at the MCP SDK's hidden 60s default instead of the declared 10-minute ELICIT_TIMEOUT_MS, cutting off users mid-answer](https://github.com/open-gsd/gsd-pi/issues/1150)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1150-bug-ask-user-questions-elicitation-expir-1783022529`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to MCP `ask_user_questions` elicitation wiring and tests; behavior change is extending the user answer window and honoring client cancellation, with no auth or data-path changes.
> 
> **Overview**
> **`ask_user_questions` local elicitation now forwards the intended 10-minute window and the tool-call abort signal into the MCP SDK** instead of relying on the SDK’s shorter default deadline (~60s), which was cutting users off mid-answer.
> 
> The handler wires `ELICIT_TIMEOUT_MS` and optional `extra.signal` through a typed `ElicitRequestOptions` on `elicitInput`, and the registered tool passes both arguments to `server.server.elicitInput`. Comments and tests were updated to describe MCP SDK `-32001` timeout behavior rather than a Claude Agent SDK–specific limit.
> 
> A regression test asserts the `ask_user_questions` tool handler calls elicitation with `{ timeout: 600000, signal }` and the built form request payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d557a739ecbf91bd17ccbe4b99a1e1e88499dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->