### PR TITLE
fix(issue): [Bug]: plan-slice stuck-loop retries 3+ times with artifact-verification-retry when task plans use flat-phase layout

### DIFF
--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -356,6 +356,15 @@ export function verifyExpectedArtifact(
       try {
         let taskIds: string[] | null = null;
         let dbPrimary = false;
+        const planContent = readFileSync(absPath, "utf-8");
+        let parsedTaskIds: string[] | null = null;
+        const getParsedTaskIds = (): string[] => {
+          if (parsedTaskIds) return parsedTaskIds;
+          parsedTaskIds = parseLegacyPlan(planContent).tasks.map((t: { id: string }) => t.id);
+          return parsedTaskIds;
+        };
+        const hasEmbeddedTaskEntries =
+          /<tasks>[\s\S]*?<\/tasks>/i.test(planContent) && getParsedTaskIds().length > 0;
         if (isDbAvailable()) {
           const refreshed = refreshWorkflowDatabaseFromDisk();
           if (refreshed) {
@@ -368,18 +377,17 @@ export function verifyExpectedArtifact(
         }
 
         if (!taskIds) {
-          const planContent = readFileSync(absPath, "utf-8");
           const hasCheckboxTask = /^\s*- \[[xX ]\] \*\*T\d+/m.test(planContent);
           const hasHeadingTask = /^\s*#{2,4}\s+T\d+\s*(?:--|—|:)/m.test(planContent);
           if (!hasCheckboxTask && !hasHeadingTask) {
             logWarning("recovery", `verify-fail ${unitType} ${unitId}: plan has no task checkbox/heading (len=${planContent.length}) at ${absPath}`);
             return false;
           }
-          const plan = parseLegacyPlan(planContent);
-          if (plan.tasks.length > 0) taskIds = plan.tasks.map((t: { id: string }) => t.id);
+          const parsedIds = getParsedTaskIds();
+          if (parsedIds.length > 0) taskIds = parsedIds;
         }
 
-        if (taskIds && taskIds.length > 0) {
+        if (taskIds && taskIds.length > 0 && !hasEmbeddedTaskEntries) {
           const tasksDir = join(dirname(absPath), "tasks");
           if (existsSync(tasksDir)) {
             for (const tid of taskIds) {

--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -363,8 +363,12 @@ export function verifyExpectedArtifact(
           parsedTaskIds = parseLegacyPlan(planContent).tasks.map((t: { id: string }) => t.id);
           return parsedTaskIds;
         };
+        const tasksBlockMatch = planContent.match(/<tasks>([\s\S]*?)<\/tasks>/i);
+        const tasksBlock = tasksBlockMatch?.[1] ?? "";
         const hasEmbeddedTaskEntries =
-          /<tasks>[\s\S]*?<\/tasks>/i.test(planContent) && getParsedTaskIds().length > 0;
+          tasksBlock.length > 0 &&
+          (/^\s*- \[[xX ]\] \*\*T\d+/m.test(tasksBlock) ||
+            /^\s*#{2,4}\s+T\d+\s*(?:--|—|:)/m.test(tasksBlock));
         if (isDbAvailable()) {
           const refreshed = refreshWorkflowDatabaseFromDisk();
           if (refreshed) {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -838,6 +838,29 @@ test("verifyExpectedArtifact plan-slice fails when a task plan file is missing (
   }
 });
 
+test("verifyExpectedArtifact accepts flat-phase plan-slice with embedded tasks and no task plan files", () => {
+  const base = join(tmpdir(), `gsd-test-${randomUUID()}`);
+  try {
+    const phaseDir = join(base, ".gsd", "phases", "01-test");
+    mkdirSync(join(phaseDir, "tasks"), { recursive: true });
+    writeFileSync(join(phaseDir, "01-01-PLAN.md"), [
+      "# S01: Test Slice",
+      "",
+      "<tasks>",
+      "- [ ] **T01**: Implement feature _(1h)_",
+      "  - Files: `src/index.ts`",
+      "  - Verify: pnpm test",
+      "- [ ] **T02**: Write tests _(1h)_",
+      "</tasks>",
+    ].join("\n"));
+
+    const result = verifyExpectedArtifact("plan-slice", "M001/S01", base);
+    assert.equal(result, true, "flat-phase embedded tasks should not require tasks/T##-PLAN.md files");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("verifyExpectedArtifact plan-slice fails for plan with no tasks (#699)", () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -861,6 +861,37 @@ test("verifyExpectedArtifact accepts flat-phase plan-slice with embedded tasks a
   }
 });
 
+test("verifyExpectedArtifact plan-slice still verifies per-task files for legacy ## Tasks plan with a stray empty <tasks> block", () => {
+  const base = makeTmpBase();
+  try {
+    const tasksDir = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+    const planPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md");
+    // Legacy layout: real tasks live in a "## Tasks" section with separate
+    // per-task PLAN files, but the plan also carries an empty <tasks></tasks>
+    // block. The empty block must NOT flip the plan into flat-phase mode and
+    // skip the per-task artifact checks.
+    const planContent = [
+      "# S01: Test Slice",
+      "",
+      "<tasks>",
+      "</tasks>",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: First task** `est:1h`",
+      "- [ ] **T02: Second task** `est:2h`",
+    ].join("\n");
+    writeFileSync(planPath, planContent);
+    // Only T01-PLAN.md exists; T02's artifact is missing.
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n\nDo the thing.");
+
+    const result = verifyExpectedArtifact("plan-slice", "M001/S01", base);
+    assert.equal(result, false, "a stray <tasks> block must not skip per-task file verification for a legacy ## Tasks plan");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("verifyExpectedArtifact plan-slice fails for plan with no tasks (#699)", () => {
   const base = makeTmpBase();
   try {


### PR DESCRIPTION
## Summary
- Fixed plan-slice artifact verification for flat-phase embedded tasks and verified changed files with strip-types syntax checks; dependency-based tests were blocked by missing node_modules and no registry access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1163
- [#1163 [Bug]: plan-slice stuck-loop retries 3+ times with artifact-verification-retry when task plans use flat-phase layout](https://github.com/open-gsd/gsd-pi/issues/1163)

## User
- @simon-kuzin

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1163-bug-plan-slice-stuck-loop-retries-3-time-1783022503`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to recovery verification for plan-slice only, with a targeted test; milestone layouts that expect separate task files are unchanged.
> 
> **Overview**
> Fixes **plan-slice** auto-recovery verification so flat-phase slice plans that list tasks inside a `<tasks>` block are accepted without `tasks/T##-PLAN.md` (or summary) files on disk.
> 
> `verifyExpectedArtifact` now reads the slice plan once, detects checkbox/heading tasks **inside** `<tasks>`, and **skips** the per-task file loop when that embedded layout is present. Milestone-style plans that only reference tasks in headings (outside `<tasks>`) still require the separate task artifacts.
> 
> Adds a regression test under `.gsd/phases/` with embedded tasks and no task plan files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fda538121e8e90575f75844a851bccb2acd81db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->