### PR TITLE
fix(issue): bug: doctor artifact_file_missing uses wrong base path (../../../ leakage) + stale phases/ rows not pruned

### DIFF
--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join, relative, sep } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
 import {
+  deleteArtifactByPath,
   getAllMilestones,
   getMilestoneSlices,
   getSliceTasks,
@@ -453,7 +454,10 @@ export async function checkEngineHealth(
           const unitId = artifactUnitId(row);
           const issuePath = artifactPathRelativeToGsd(row.path);
           if (options?.repair && issuePath.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows)) {
-            adapter.prepare("DELETE FROM artifacts WHERE path = :path").run({ ":path": row.path });
+            // Route the write through the Single Writer owner (gsd-db.ts) instead
+            // of issuing raw DELETE SQL here — doctor is a read-only consumer and
+            // the single-writer invariant forbids write SQL outside the allowlist.
+            deleteArtifactByPath(row.path);
             fixesApplied.push(`pruned stale flat-phase artifact row ${row.path}`);
             continue;
           }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { isAbsolute, join, relative } from "node:path";
+import { isAbsolute, join, relative, sep } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
 import {
@@ -42,6 +42,18 @@ function userContentRecoveryCommand(artifactType: string): string {
 function userContentMissingMessage(path: string, artifactType: string): string {
   const type = normalizedArtifactType(artifactType) || "UNKNOWN";
   return `Artifact \`${path}\` is a user-authored ${type} file recorded in the database but missing from disk. Re-run \`${userContentRecoveryCommand(type)}\` in this milestone to regenerate it.`;
+}
+
+function artifactPathRelativeToGsd(artifactPath: string): string {
+  const parts = artifactPath.split(/[\\/]+/);
+  const gsdIndex = parts.lastIndexOf(".gsd");
+  if (gsdIndex < 0 || gsdIndex === parts.length - 1) return artifactPath;
+  return parts.slice(gsdIndex + 1).join("/");
+}
+
+function isPathInside(basePath: string, candidatePath: string): boolean {
+  const rel = relative(basePath, candidatePath);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
 }
 
 function reportCheckboxDbStatusDivergence(
@@ -142,11 +154,14 @@ function isClearedByMilestoneShellProjectionFlush(
 }
 
 function artifactExistsOnDisk(basePath: string, artifactPath: string): boolean {
-  if (isAbsolute(artifactPath)) return existsSync(artifactPath);
-  return [
-    join(gsdProjectionRoot(basePath), artifactPath),
-    join(gsdRoot(basePath), artifactPath),
-  ].some((candidate) => existsSync(candidate));
+  const relativeArtifactPath = artifactPathRelativeToGsd(artifactPath);
+  if (isAbsolute(relativeArtifactPath)) return existsSync(relativeArtifactPath);
+
+  const roots = [gsdProjectionRoot(basePath), gsdRoot(basePath)];
+  return roots.some((root) => {
+    const candidate = join(root, relativeArtifactPath);
+    return isPathInside(root, candidate) && existsSync(candidate);
+  });
 }
 
 function artifactUnitId(row: { milestone_id: string | null; slice_id: string | null; task_id: string | null }): string {
@@ -161,6 +176,51 @@ function artifactScope(row: { milestone_id: string | null; slice_id: string | nu
   if (row.slice_id) return "slice";
   if (row.milestone_id) return "milestone";
   return "project";
+}
+
+type ArtifactRow = {
+  path: string;
+  artifact_type: string;
+  milestone_id: string | null;
+  slice_id: string | null;
+  task_id: string | null;
+};
+
+function sameArtifactIdentity(left: ArtifactRow, right: ArtifactRow): boolean {
+  return left.artifact_type === right.artifact_type &&
+    left.milestone_id === right.milestone_id &&
+    left.slice_id === right.slice_id &&
+    left.task_id === right.task_id;
+}
+
+function isMilestonesArtifactPath(artifactPath: string): boolean {
+  return artifactPathRelativeToGsd(artifactPath).startsWith("milestones/");
+}
+
+function expectedMilestonesArtifactPath(row: ArtifactRow): string | null {
+  if (!row.milestone_id) return null;
+  const artifactType = normalizedArtifactType(row.artifact_type);
+  if (!artifactType) return null;
+  if (row.slice_id && row.task_id) {
+    return `milestones/${row.milestone_id}/slices/${row.slice_id}/tasks/${row.task_id}/${row.task_id}-${artifactType}.md`;
+  }
+  if (row.slice_id) {
+    return `milestones/${row.milestone_id}/slices/${row.slice_id}/${row.slice_id}-${artifactType}.md`;
+  }
+  return `milestones/${row.milestone_id}/${row.milestone_id}-${artifactType}.md`;
+}
+
+function hasPresentMilestonesReplacement(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {
+  const expectedPath = expectedMilestonesArtifactPath(row);
+  if (expectedPath && artifactExistsOnDisk(basePath, expectedPath)) return true;
+
+  return artifactRows.some(
+    (other) =>
+      other.path !== row.path &&
+      isMilestonesArtifactPath(other.path) &&
+      sameArtifactIdentity(row, other) &&
+      artifactExistsOnDisk(basePath, other.path),
+  );
 }
 
 export async function checkEngineHealth(
@@ -386,27 +446,27 @@ export async function checkEngineHealth(
              WHERE path != ''
              ORDER BY path`,
           )
-          .all() as Array<{
-            path: string;
-            artifact_type: string;
-            milestone_id: string | null;
-            slice_id: string | null;
-            task_id: string | null;
-          }>;
+          .all() as ArtifactRow[];
 
         for (const row of artifactRows) {
           if (artifactExistsOnDisk(basePath, row.path)) continue;
           const unitId = artifactUnitId(row);
+          const issuePath = artifactPathRelativeToGsd(row.path);
+          if (options?.repair && row.path.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows)) {
+            adapter.prepare("DELETE FROM artifacts WHERE path = :path").run({ ":path": row.path });
+            fixesApplied.push(`pruned stale flat-phase artifact row ${row.path}`);
+            continue;
+          }
           if (isUserAuthoredArtifactType(row.artifact_type)) {
             const artifactType = normalizedArtifactType(row.artifact_type);
-            missingUserContentArtifacts.push({ path: row.path, artifactType });
+            missingUserContentArtifacts.push({ path: issuePath, artifactType });
             issues.push({
               severity: "warning",
               code: "artifact_user_content_missing",
               scope: artifactScope(row),
               unitId,
-              message: userContentMissingMessage(row.path, artifactType),
-              file: row.path,
+              message: userContentMissingMessage(issuePath, artifactType),
+              file: issuePath,
               fixable: false,
             });
             continue;
@@ -416,9 +476,9 @@ export async function checkEngineHealth(
             code: "artifact_file_missing",
             scope: artifactScope(row),
             unitId,
-            message: `Artifact ${row.path} is recorded in the database as ${row.artifact_type || "UNKNOWN"} but no matching file exists on disk`,
-            file: row.path,
-            fixable: false,
+            message: `Artifact ${issuePath} is recorded in the database as ${row.artifact_type || "UNKNOWN"} but no matching file exists on disk`,
+            file: issuePath,
+            fixable: row.path.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows),
           });
         }
       } catch {

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -202,7 +202,7 @@ function expectedMilestonesArtifactPath(row: ArtifactRow): string | null {
   const artifactType = normalizedArtifactType(row.artifact_type);
   if (!artifactType) return null;
   if (row.slice_id && row.task_id) {
-    return `milestones/${row.milestone_id}/slices/${row.slice_id}/tasks/${row.task_id}/${row.task_id}-${artifactType}.md`;
+    return `milestones/${row.milestone_id}/slices/${row.slice_id}/tasks/${row.task_id}-${artifactType}.md`;
   }
   if (row.slice_id) {
     return `milestones/${row.milestone_id}/slices/${row.slice_id}/${row.slice_id}-${artifactType}.md`;
@@ -452,7 +452,7 @@ export async function checkEngineHealth(
           if (artifactExistsOnDisk(basePath, row.path)) continue;
           const unitId = artifactUnitId(row);
           const issuePath = artifactPathRelativeToGsd(row.path);
-          if (options?.repair && row.path.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows)) {
+          if (options?.repair && issuePath.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows)) {
             adapter.prepare("DELETE FROM artifacts WHERE path = :path").run({ ":path": row.path });
             fixesApplied.push(`pruned stale flat-phase artifact row ${row.path}`);
             continue;
@@ -478,7 +478,7 @@ export async function checkEngineHealth(
             unitId,
             message: `Artifact ${issuePath} is recorded in the database as ${row.artifact_type || "UNKNOWN"} but no matching file exists on disk`,
             file: issuePath,
-            fixable: row.path.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows),
+            fixable: issuePath.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows),
           });
         }
       } catch {

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -335,6 +335,98 @@ test("checkEngineHealth reports artifact rows whose files are missing on disk", 
   assert.equal(missing.fixable, false);
 });
 
+test("checkEngineHealth resolves escaped .gsd artifact rows against the project .gsd directory", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-escaped-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const artifactPath = "phases/01-m001/01-01-ASSESSMENT.md";
+  mkdirSync(join(gsdDir, "phases", "01-m001"), { recursive: true });
+  writeFileSync(join(gsdDir, artifactPath), "# Assessment\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: `../../../Documents/Projects/project/.gsd/${artifactPath}`,
+    artifact_type: "ASSESSMENT",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# Assessment\n",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing"),
+    false,
+    "escaped .gsd paths should resolve to the project .gsd artifact",
+  );
+});
+
+test("checkEngineHealth reports escaped missing artifact rows with .gsd-relative paths", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-escaped-missing-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: "../../../Documents/Projects/project/.gsd/phases/01-m001/01-01-PLAN.md",
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# Plan\n",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const issue = issues.find((candidate) => candidate.code === "artifact_file_missing");
+  assert.ok(issue, "missing escaped artifact row should still be reported");
+  assert.equal(issue.file, "phases/01-m001/01-01-PLAN.md");
+  assert.doesNotMatch(issue.message, /\.\.\//);
+});
+
+test("checkEngineHealth repair prunes stale phases artifact rows with present milestones files", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-stale-phase-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const stalePath = "phases/01-m001/01-01-PLAN.md";
+  const replacementPath = "milestones/M001/slices/S01/S01-PLAN.md";
+  mkdirSync(join(gsdDir, "milestones", "M001", "slices", "S01"), { recursive: true });
+  writeFileSync(join(gsdDir, replacementPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# stale plan\n",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, { repair: true });
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === stalePath),
+    false,
+    "repair should not report stale rows it pruned",
+  );
+  assert.ok(fixes.includes(`pruned stale flat-phase artifact row ${stalePath}`));
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), []);
+});
+
 test("checkEngineHealth reports missing CONTEXT and RESEARCH artifacts as user-content warnings", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-user-content-artifact-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -427,6 +427,118 @@ test("checkEngineHealth repair prunes stale phases artifact rows with present mi
   assert.deepEqual(rows.map((row) => row.path), []);
 });
 
+test("checkEngineHealth repair prunes stale phases task rows against tasks/<T>-<TYPE>.md replacements", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-stale-task-phase-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const stalePath = "phases/01-m001/01-01-T01-SUMMARY.md";
+  // Canonical legacy task layout has no per-task subdirectory: the SUMMARY lives
+  // at tasks/<T>-<TYPE>.md, not tasks/<T>/<T>-<TYPE>.md. If the expected-path
+  // builder adds an extra tasks/<T>/ segment, task-scoped stale rows never match
+  // their on-disk replacement and leak unpruned.
+  const replacementPath = "milestones/M001/slices/S01/tasks/T01-SUMMARY.md";
+  mkdirSync(join(gsdDir, "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  writeFileSync(join(gsdDir, replacementPath), "# Summary\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "SUMMARY",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    full_content: "# stale summary\n",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, { repair: true });
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === stalePath),
+    false,
+    "task-scoped stale rows should prune against the tasks/<T>-<TYPE>.md replacement",
+  );
+  assert.ok(fixes.includes(`pruned stale flat-phase artifact row ${stalePath}`));
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), []);
+});
+
+test("checkEngineHealth repair prunes stale phases rows stored as escaped ../ paths", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-escaped-phase-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  // Leaked row: the DB stores an escaped, absolute-ish path rather than a clean
+  // `phases/…` value. The prune must gate on the .gsd-relative path so the row
+  // this repair targets is not skipped just because the raw value starts with `../`.
+  const stalePath = "../../../Documents/Projects/project/.gsd/phases/01-m001/01-01-PLAN.md";
+  const replacementPath = "milestones/M001/slices/S01/S01-PLAN.md";
+  mkdirSync(join(gsdDir, "milestones", "M001", "slices", "S01"), { recursive: true });
+  writeFileSync(join(gsdDir, replacementPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# stale plan\n",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, { repair: true });
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing"),
+    false,
+    "escaped phases rows should prune against the milestones replacement, not be reported missing",
+  );
+  assert.ok(
+    fixes.some((fix) => fix.startsWith("pruned stale flat-phase artifact row") && fix.includes("phases/01-m001/01-01-PLAN.md")),
+    "repair should record a prune for the escaped stale phases row",
+  );
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), [], "escaped stale phases row should be deleted from the DB");
+});
+
+test("checkEngineHealth marks escaped phases rows fixable when a milestones replacement exists", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-escaped-phase-fixable-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const replacementPath = "milestones/M001/slices/S01/S01-PLAN.md";
+  mkdirSync(join(gsdDir, "milestones", "M001", "slices", "S01"), { recursive: true });
+  writeFileSync(join(gsdDir, replacementPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: "../../../Documents/Projects/project/.gsd/phases/01-m001/01-01-PLAN.md",
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# stale plan\n",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const issue = issues.find((candidate) => candidate.code === "artifact_file_missing");
+  assert.ok(issue, "escaped stale row should still be reported when repair is off");
+  assert.equal(issue.file, "phases/01-m001/01-01-PLAN.md");
+  assert.equal(issue.fixable, true, "escaped phases rows with a milestones replacement must be marked fixable");
+});
+
 test("checkEngineHealth reports missing CONTEXT and RESEARCH artifacts as user-content warnings", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-user-content-artifact-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- Fixed doctor artifact path normalization and stale phases-row repair logic, with regression tests added and whitespace verification passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1140
- [#1140 bug: doctor artifact_file_missing uses wrong base path (../../../ leakage) + stale phases/ rows not pruned](https://github.com/open-gsd/gsd-pi/issues/1140)

## User
- @gtkpad

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1140-bug-doctor-artifact-file-missing-uses-wr-1783022539`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact existence logic and repair-mode `DELETE` on `artifacts`; wrong matching could hide real missing files or remove valid rows, but scope is limited to GSD doctor diagnostics.
> 
> **Overview**
> Fixes **doctor** `artifact_file_missing` handling when the `artifacts` table stores escaped or absolute-looking paths (e.g. `../../../.../.gsd/phases/...`). Paths are normalized to **`.gsd`-relative** form via `artifactPathRelativeToGsd`, disk checks join only under projection/project `.gsd` roots with an **`isPathInside`** guard, and reported `file` / messages no longer leak `../` segments.
> 
> For legacy **`phases/`** rows whose files are gone but an equivalent **`milestones/`** artifact exists (same milestone/slice/task/type), doctor now marks those issues **fixable** and, with **`repair: true`**, **deletes** the stale DB row instead of leaving a false error. User-authored missing artifacts still surface as warnings with normalized paths.
> 
> Regression tests cover escaped-path resolution, missing-path reporting, and repair pruning when a milestones replacement file is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7222b10f44b4c8081a0c6cba9a5d2bda147ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->