### PR TITLE
fix(issue): ScheduleWakeup advertised in every session but only fires inside an active auto-mode unit; interactive wakeups never fire

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -103,11 +103,12 @@ Writes outside those allowed paths, unsafe bash commands, and subagent dispatch 
 
 ### ScheduleWakeup Continuations
 
-`ScheduleWakeup` is an auto-mode tool for long external waits inside `execute-task` units. It keeps the same unit session alive by scheduling a delayed follow-up prompt instead of ending the unit as incomplete.
+`ScheduleWakeup` schedules a delayed follow-up prompt. In auto mode, it is used for long external waits inside `execute-task` units and keeps the same unit session alive instead of ending the unit as incomplete. Outside auto mode, it waits for the requested delay and then starts a new triggered turn with the supplied wakeup prompt.
 
 - Use it when a task kicked off external work (for example CI, deploy, or async jobs) and needs a later poll.
 - Include a concrete follow-up prompt that says what to check and what artifact to write when done.
 - Re-arm it on each poll turn while the external process is still running.
+- Outside auto mode, use it when you ask GSD to check back or poll later; the wakeup dispatches after the delay, not synchronously.
 
 Auto mode consumes the scheduled wakeup only for the same `basePath + unitType + unitId`, waits the requested delay, and then dispatches the follow-up prompt in the same session. For safety, wakeups are bounded per unit; hitting the cap stops the unit with a timeout-style cancellation.
 

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -26,7 +26,7 @@ import { debugLog } from "../debug-logger.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import { resolveAutoSupervisorConfig } from "../preferences.js";
 import { readUnitRuntimeRecord, type AutoUnitRuntimeRecord } from "../unit-runtime.js";
-import { consumeAutoWakeup } from "./schedule-wakeup.js";
+import { clearAutoWakeup, consumeAutoWakeup } from "./schedule-wakeup.js";
 import { applyUnitSkillVisibility } from "../skill-scope.js";
 
 const UNIT_FAILSAFE_BUFFER_MS = 30_000;
@@ -248,7 +248,7 @@ export async function runUnit(
     ((supervisor.idle_timeout_minutes ?? 10) * 60 * 1000) + UNIT_FAILSAFE_BUFFER_MS,
   );
   let unitTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  let result: UnitResult;
+  let result: UnitResult = { status: "cancelled" };
   try {
     const awaitAgentEndWithTimeout = (agentEndPromise: Promise<UnitResult>): Promise<UnitResult> => {
       const timeoutResult = new Promise<UnitResult>((resolve) => {
@@ -360,6 +360,9 @@ export async function runUnit(
     }
   } finally {
     if (unitTimeoutHandle) clearTimeout(unitTimeoutHandle);
+    if (result.status !== "completed") {
+      clearAutoWakeup(s.basePath, unitType, unitId);
+    }
     ctx.ui.setWorkingMessage?.(undefined);
     setVisibleSkills?.(undefined);
   }

--- a/src/resources/extensions/gsd/auto/schedule-wakeup.ts
+++ b/src/resources/extensions/gsd/auto/schedule-wakeup.ts
@@ -35,6 +35,14 @@ export function consumeAutoWakeup(
   return wakeup;
 }
 
+export function clearAutoWakeup(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+): void {
+  pendingWakeups.delete(wakeupKey(basePath, unitType, unitId));
+}
+
 export function _resetAutoWakeupsForTest(): void {
   pendingWakeups.clear();
 }

--- a/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
+++ b/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
@@ -12,21 +12,26 @@ import { resolveCtxCwd } from "./dynamic-tools.js";
 const MAX_WAKEUP_DELAY_SECONDS = 24 * 60 * 60;
 const INTERACTIVE_WAKEUP_CUSTOM_TYPE = "gsd-schedule-wakeup";
 
-let pendingInteractiveWakeupHandle: ReturnType<typeof setTimeout> | null = null;
+// One pending interactive wakeup per session, keyed by base path — the same
+// scoping auto-mode uses for its wakeup map (see `wakeupKey`). Re-arming cancels
+// only that session's prior timer, so repeated polling never stacks overlapping
+// wakeups, and concurrent projects in one host process don't cancel each other.
+const pendingInteractiveWakeups = new Map<string, ReturnType<typeof setTimeout>>();
 
 function scheduleInteractiveWakeup(
   pi: ExtensionAPI,
+  key: string,
   delaySeconds: number,
   prompt: string,
   reason: string,
 ): void {
-  if (pendingInteractiveWakeupHandle !== null) {
-    clearTimeout(pendingInteractiveWakeupHandle);
-    pendingInteractiveWakeupHandle = null;
-  }
+  const existing = pendingInteractiveWakeups.get(key);
+  if (existing) clearTimeout(existing);
 
   const handle = setTimeout(() => {
-    pendingInteractiveWakeupHandle = null;
+    if (pendingInteractiveWakeups.get(key) === handle) {
+      pendingInteractiveWakeups.delete(key);
+    }
     try {
       void Promise.resolve(pi.sendMessage(
         {
@@ -49,7 +54,7 @@ function scheduleInteractiveWakeup(
       );
     }
   }, delaySeconds * 1000);
-  pendingInteractiveWakeupHandle = handle;
+  pendingInteractiveWakeups.set(key, handle);
   if (
     typeof handle === "object" &&
     handle !== null &&
@@ -58,6 +63,13 @@ function scheduleInteractiveWakeup(
   ) {
     handle.unref();
   }
+}
+
+export function _resetInteractiveWakeupsForTest(): void {
+  for (const handle of pendingInteractiveWakeups.values()) {
+    clearTimeout(handle);
+  }
+  pendingInteractiveWakeups.clear();
 }
 
 export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
@@ -98,7 +110,8 @@ export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
       const reason = params.reason ?? "";
 
       if (!dash.active || !currentUnit) {
-        scheduleInteractiveWakeup(pi, delaySeconds, params.prompt, reason);
+        const interactiveKey = dash.basePath || resolveCtxCwd(ctx);
+        scheduleInteractiveWakeup(pi, interactiveKey, delaySeconds, params.prompt, reason);
         return {
           content: [{
             type: "text",

--- a/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
+++ b/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
@@ -6,22 +6,64 @@ import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
 import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
 import { scheduleAutoWakeup } from "../auto/schedule-wakeup.js";
+import { logWarning } from "../workflow-logger.js";
 import { resolveCtxCwd } from "./dynamic-tools.js";
 
 const MAX_WAKEUP_DELAY_SECONDS = 24 * 60 * 60;
+const INTERACTIVE_WAKEUP_CUSTOM_TYPE = "gsd-schedule-wakeup";
+
+function scheduleInteractiveWakeup(
+  pi: ExtensionAPI,
+  delaySeconds: number,
+  prompt: string,
+  reason: string,
+): void {
+  const handle = setTimeout(() => {
+    try {
+      void Promise.resolve(pi.sendMessage(
+        {
+          customType: INTERACTIVE_WAKEUP_CUSTOM_TYPE,
+          content: prompt,
+          display: true,
+          details: { delaySeconds, reason },
+        },
+        { triggerTurn: true },
+      )).catch((error) => {
+        logWarning(
+          "bootstrap",
+          `ScheduleWakeup interactive dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    } catch (error) {
+      logWarning(
+        "bootstrap",
+        `ScheduleWakeup interactive dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }, delaySeconds * 1000);
+  if (
+    typeof handle === "object" &&
+    handle !== null &&
+    "unref" in handle &&
+    typeof handle.unref === "function"
+  ) {
+    handle.unref();
+  }
+}
 
 export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "ScheduleWakeup",
     label: "Schedule Wakeup",
     description:
-      "In GSD auto-mode, pause the current unit and continue the same session after a delay. " +
-      "Use this for long external processes that need polling without ending the unit as no-artifact.",
-    promptSnippet: "Schedule a same-session auto-mode wakeup after a delay.",
+      "Schedule a delayed continuation turn. In GSD auto-mode, continue the current unit in the same session; " +
+      "outside auto-mode, start a new triggered turn with the supplied wakeup prompt.",
+    promptSnippet: "Schedule a wakeup prompt after a delay.",
     promptGuidelines: [
       "Use ScheduleWakeup at the end of an execute-task turn when waiting for a long external process.",
       "Include a prompt that says exactly what external state to check next and what artifact to write when done.",
       "Re-arm ScheduleWakeup on each polling turn if the external process is still running.",
+      "Outside auto-mode, use ScheduleWakeup when the user asks you to check back or poll later.",
     ],
     parameters: Type.Object({
       delaySeconds: Type.Number({
@@ -40,27 +82,31 @@ export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const dash = getAutoRuntimeSnapshot();
       const currentUnit = dash.currentUnit;
-      const basePath = dash.basePath || resolveCtxCwd(ctx);
-
-      if (!dash.active || !currentUnit) {
-        return {
-          content: [{ type: "text", text: "ScheduleWakeup is only available during an active GSD auto-mode unit." }],
-          details: { operation: "schedule_wakeup", error: "auto_mode_inactive" },
-          isError: true,
-        };
-      }
-
       const delaySeconds = Math.max(
         1,
         Math.min(MAX_WAKEUP_DELAY_SECONDS, Math.floor(params.delaySeconds)),
       );
+      const reason = params.reason ?? "";
+
+      if (!dash.active || !currentUnit) {
+        scheduleInteractiveWakeup(pi, delaySeconds, params.prompt, reason);
+        return {
+          content: [{
+            type: "text",
+            text: `Wakeup scheduled for ${delaySeconds}s. GSD will start a new turn with the wakeup prompt.`,
+          }],
+          details: { operation: "schedule_wakeup", delaySeconds, mode: "interactive" },
+        };
+      }
+
+      const basePath = dash.basePath || resolveCtxCwd(ctx);
       scheduleAutoWakeup({
         basePath,
         unitType: currentUnit.type,
         unitId: currentUnit.id,
         delayMs: delaySeconds * 1000,
         prompt: params.prompt,
-        reason: params.reason ?? "",
+        reason,
         createdAt: Date.now(),
       });
 

--- a/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
+++ b/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
@@ -12,13 +12,21 @@ import { resolveCtxCwd } from "./dynamic-tools.js";
 const MAX_WAKEUP_DELAY_SECONDS = 24 * 60 * 60;
 const INTERACTIVE_WAKEUP_CUSTOM_TYPE = "gsd-schedule-wakeup";
 
+let pendingInteractiveWakeupHandle: ReturnType<typeof setTimeout> | null = null;
+
 function scheduleInteractiveWakeup(
   pi: ExtensionAPI,
   delaySeconds: number,
   prompt: string,
   reason: string,
 ): void {
+  if (pendingInteractiveWakeupHandle !== null) {
+    clearTimeout(pendingInteractiveWakeupHandle);
+    pendingInteractiveWakeupHandle = null;
+  }
+
   const handle = setTimeout(() => {
+    pendingInteractiveWakeupHandle = null;
     try {
       void Promise.resolve(pi.sendMessage(
         {
@@ -41,6 +49,7 @@ function scheduleInteractiveWakeup(
       );
     }
   }, delaySeconds * 1000);
+  pendingInteractiveWakeupHandle = handle;
   if (
     typeof handle === "object" &&
     handle !== null &&

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -22,7 +22,7 @@ import {
   isSessionSwitchAbortGraceActive,
 } from "../auto/resolve.js";
 import { runUnit, shouldDeferUnitFailsafeTimeout } from "../auto/run-unit.js";
-import { scheduleAutoWakeup, _resetAutoWakeupsForTest } from "../auto/schedule-wakeup.js";
+import { consumeAutoWakeup, scheduleAutoWakeup, _resetAutoWakeupsForTest } from "../auto/schedule-wakeup.js";
 import { writeUnitRuntimeRecord, readUnitRuntimeRecord } from "../unit-runtime.js";
 import { autoLoop as rawAutoLoop } from "../auto/loop.js";
 import { runPreDispatch } from "../auto/pre-dispatch.js";
@@ -550,6 +550,62 @@ test("runUnit honors ScheduleWakeup by continuing the same unit session", async 
   assert.equal(result.status, "completed");
   assert.deepEqual(result.event, secondEvent);
   assert.equal(pi.calls.length, 2);
+});
+
+test("runUnit clears scheduled wakeups when the unit is cancelled", async () => {
+  _resetPendingResolve();
+  _resetAutoWakeupsForTest();
+
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession();
+
+  const resultPromise = runUnit(
+    ctx,
+    pi,
+    s,
+    "execute-task",
+    "M001/S01/T02",
+    "submit external job",
+  );
+
+  await waitForMicrotasks(() => pi.calls.length === 1, "initial unit dispatch");
+  scheduleAutoWakeup({
+    basePath: s.basePath,
+    unitType: "execute-task",
+    unitId: "M001/S01/T02",
+    delayMs: 0,
+    prompt: "stale prompt from cancelled unit",
+    reason: "poll external job",
+    createdAt: Date.now(),
+  });
+  resolveAgentEndCancelled({
+    message: "Auto-mode paused",
+    category: "aborted",
+    isTransient: true,
+  });
+
+  const result = await resultPromise;
+  assert.equal(result.status, "cancelled");
+  assert.equal(
+    consumeAutoWakeup(s.basePath, "execute-task", "M001/S01/T02"),
+    null,
+    "cancelled units must not leave stale ScheduleWakeup prompts for later retries",
+  );
 });
 
 test("runUnit suppresses the global working-message loader for auto dashboard runs", async () => {

--- a/src/resources/extensions/gsd/tests/schedule-wakeup-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/schedule-wakeup-tool.test.ts
@@ -5,10 +5,14 @@ import test, { mock } from "node:test";
 import assert from "node:assert/strict";
 
 import { autoSession } from "../auto-runtime-state.ts";
-import { registerScheduleWakeupTool } from "../bootstrap/schedule-wakeup-tool.ts";
+import {
+  registerScheduleWakeupTool,
+  _resetInteractiveWakeupsForTest,
+} from "../bootstrap/schedule-wakeup-tool.ts";
 
 test("ScheduleWakeup arms an interactive wakeup when auto-mode is inactive", async () => {
   autoSession.reset();
+  _resetInteractiveWakeupsForTest();
   mock.timers.enable({ apis: ["setTimeout"] });
 
   const sent: Array<{ message: unknown; options: unknown }> = [];
@@ -59,6 +63,105 @@ test("ScheduleWakeup arms an interactive wakeup when auto-mode is inactive", asy
     });
   } finally {
     mock.timers.reset();
+    _resetInteractiveWakeupsForTest();
+    autoSession.reset();
+  }
+});
+
+test("ScheduleWakeup re-arm cancels the prior interactive timer instead of stacking", async () => {
+  autoSession.reset();
+  _resetInteractiveWakeupsForTest();
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  const sent: Array<{ message: any; options: unknown }> = [];
+  let tool: any;
+  const pi = {
+    registerTool(registered: any) {
+      tool = registered;
+    },
+    sendMessage(message: unknown, options: unknown) {
+      sent.push({ message, options } as { message: any; options: unknown });
+    },
+  };
+
+  try {
+    registerScheduleWakeupTool(pi as any);
+    assert.ok(tool, "ScheduleWakeup tool should be registered");
+
+    const ctx = { cwd: process.cwd() };
+    await tool.execute(
+      "call-1",
+      { delaySeconds: 5, prompt: "stale prompt", reason: "first arm" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await tool.execute(
+      "call-2",
+      { delaySeconds: 5, prompt: "fresh prompt", reason: "re-arm" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    mock.timers.tick(5000);
+
+    assert.equal(sent.length, 1, "re-arming must not stack overlapping wakeups");
+    assert.equal(sent[0].message.content, "fresh prompt");
+  } finally {
+    mock.timers.reset();
+    _resetInteractiveWakeupsForTest();
+    autoSession.reset();
+  }
+});
+
+test("ScheduleWakeup keeps interactive wakeups isolated per session base path", async () => {
+  autoSession.reset();
+  _resetInteractiveWakeupsForTest();
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  const sent: Array<{ message: any; options: unknown }> = [];
+  let tool: any;
+  const pi = {
+    registerTool(registered: any) {
+      tool = registered;
+    },
+    sendMessage(message: unknown, options: unknown) {
+      sent.push({ message, options } as { message: any; options: unknown });
+    },
+  };
+
+  try {
+    registerScheduleWakeupTool(pi as any);
+    assert.ok(tool, "ScheduleWakeup tool should be registered");
+
+    // Two concurrent interactive sessions (different cwds) arm wakeups. One
+    // session re-arming must not cancel the other session's pending wakeup.
+    await tool.execute(
+      "call-a",
+      { delaySeconds: 5, prompt: "session A", reason: "poll A" },
+      undefined,
+      undefined,
+      { cwd: "/tmp" },
+    );
+    await tool.execute(
+      "call-b",
+      { delaySeconds: 5, prompt: "session B", reason: "poll B" },
+      undefined,
+      undefined,
+      { cwd: process.cwd() },
+    );
+
+    mock.timers.tick(5000);
+
+    assert.equal(sent.length, 2, "distinct sessions must each keep their wakeup");
+    assert.deepEqual(
+      sent.map((s) => s.message.content).sort(),
+      ["session A", "session B"],
+    );
+  } finally {
+    mock.timers.reset();
+    _resetInteractiveWakeupsForTest();
     autoSession.reset();
   }
 });

--- a/src/resources/extensions/gsd/tests/schedule-wakeup-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/schedule-wakeup-tool.test.ts
@@ -1,0 +1,64 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for ScheduleWakeup tool behavior.
+
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+import { autoSession } from "../auto-runtime-state.ts";
+import { registerScheduleWakeupTool } from "../bootstrap/schedule-wakeup-tool.ts";
+
+test("ScheduleWakeup arms an interactive wakeup when auto-mode is inactive", async () => {
+  autoSession.reset();
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  const sent: Array<{ message: unknown; options: unknown }> = [];
+  let tool: any;
+  const pi = {
+    registerTool(registered: any) {
+      tool = registered;
+    },
+    sendMessage(message: unknown, options: unknown) {
+      sent.push({ message, options });
+    },
+  };
+
+  try {
+    registerScheduleWakeupTool(pi as any);
+    assert.ok(tool, "ScheduleWakeup tool should be registered");
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        delaySeconds: 1,
+        prompt: "Check the external job and report back.",
+        reason: "poll external job",
+      },
+      undefined,
+      undefined,
+      { cwd: process.cwd() },
+    );
+
+    assert.equal(result.isError, undefined);
+    assert.match(result.content[0].text, /Wakeup scheduled for 1s/);
+    assert.equal(sent.length, 0, "wakeup should not dispatch synchronously");
+
+    mock.timers.tick(999);
+    assert.equal(sent.length, 0, "wakeup should wait for the configured delay");
+
+    mock.timers.tick(1);
+    assert.equal(sent.length, 1);
+    assert.deepEqual(sent[0].options, { triggerTurn: true });
+    assert.deepEqual(sent[0].message, {
+      customType: "gsd-schedule-wakeup",
+      content: "Check the external job and report back.",
+      display: true,
+      details: {
+        delaySeconds: 1,
+        reason: "poll external job",
+      },
+    });
+  } finally {
+    mock.timers.reset();
+    autoSession.reset();
+  }
+});


### PR DESCRIPTION
## Summary
- Fixed interactive ScheduleWakeup dispatch and cancelled-unit wakeup cleanup, with syntax and diff checks passing while dependency-backed tests were blocked by registry DNS.

## Bugs Addressed
- [x] **tool advertised globally, functional only inside a live auto-mode unit (feature gap)**
- [x] **wakeups orphaned when the unit result is not "completed"**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1148
- [#1148 ScheduleWakeup advertised in every session but only fires inside an active auto-mode unit; interactive wakeups never fire](https://github.com/open-gsd/gsd-pi/issues/1148)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1148-schedulewakeup-advertised-in-every-sessi-1783022537`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto unit lifecycle and global tool dispatch timing; behavior is localized to ScheduleWakeup with new tests, but incorrect cleanup or interactive timers could affect follow-up turns.
> 
> **Overview**
> **ScheduleWakeup** now works outside an active auto-mode unit instead of returning a hard error. When auto mode is inactive, the tool arms a delayed `setTimeout` and dispatches the wakeup prompt via `pi.sendMessage` with `triggerTurn: true` (custom type `gsd-schedule-wakeup`), replacing a new interactive turn after the delay.
> 
> Auto-mode behavior is unchanged: wakeups still queue on the current unit and continue in the same session via `runUnit`. **Stale wakeup cleanup** is added—`clearAutoWakeup` runs in `runUnit`'s `finally` when the unit does not end `completed`, so cancelled or interrupted units do not leave prompts for later retries.
> 
> Tool copy and **auto-mode docs** describe both paths (same-session continuations vs interactive delayed turns). Regression tests cover interactive scheduling and cancelled-unit cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32376cfc7da343e3f64379b1bd2caa6596130f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->