### PR TITLE
fix(issue): [Bug]: interview form stays interactive after its elicitation expires — answers submitted to the dead form are silently discarded

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -50,6 +50,7 @@ import { markToolStart, markToolEnd } from "../gsd/auto.js";
 import {
 	markInteractiveElicitationStart,
 	markInteractiveElicitationEnd,
+	isInteractiveElicitationInFlight,
 } from "../gsd/auto-tool-tracking.js";
 import {
 	discoverBrowserMcpServerName,
@@ -227,6 +228,36 @@ interface SDKInputUserMessage {
 const OTHER_OPTION_LABEL = "None of the above";
 /** Regex pattern that identifies field names and descriptions that should be treated as sensitive/secure inputs. */
 const SENSITIVE_FIELD_PATTERN = /(password|passphrase|secret|token|api[_\s-]*key|private[_\s-]*key|credential)/i;
+/** Mirrors @opengsd/mcp-server's ask_user_questions host elicitation timeout. */
+const WORKFLOW_ELICIT_TIMEOUT_MS = 10 * 60 * 1000;
+/** Close the local form just before the server drops the MCP elicitation request. */
+const WORKFLOW_ELICIT_TIMEOUT_SKEW_MS = 1_000;
+export const CLAUDE_CODE_INTERVIEW_FORM_TIMEOUT_MS = Math.max(
+	1,
+	WORKFLOW_ELICIT_TIMEOUT_MS - WORKFLOW_ELICIT_TIMEOUT_SKEW_MS,
+);
+const ELICITATION_EXPIRED_NOTICE =
+	"Question expired before you answered - the form was closed and no answers were sent.";
+const activeAskUserQuestionElicitationTimeoutAborters = new Set<() => void>();
+
+function isAskUserQuestionsToolName(toolName: string | undefined): boolean {
+	const name = String(toolName ?? "");
+	return name === "ask_user_questions" || name.endsWith("__ask_user_questions");
+}
+
+function isAskUserQuestionsTimedOutResult(
+	toolCall: Pick<ToolCall, "name">,
+	result: ExternalToolResultPayload,
+): boolean {
+	return isAskUserQuestionsToolName(toolCall.name) && result.details?.timed_out === true;
+}
+
+function abortActiveAskUserQuestionElicitationsForTimeout(): void {
+	if (!isInteractiveElicitationInFlight()) return;
+	for (const abort of [...activeAskUserQuestionElicitationTimeoutAborters]) {
+		abort();
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Stream factory
@@ -1566,12 +1597,32 @@ export function createClaudeCodeElicitationHandler(
 			// it does not tear down the very elicitation that IS the human boundary
 			// (#cc-elicitation-self-cancel). It clears in the finally on every exit.
 			const elicId = "cc-elicit-" + ((request as { id?: string | number }).id ?? `${Date.now()}-${nextElicitationSeq()}`);
+			const formAbortController = new AbortController();
+			let expiryNoticeShown = false;
+			const abortExpiredForm = (): void => {
+				if (formAbortController.signal.aborted) return;
+				formAbortController.abort();
+				if (!expiryNoticeShown) {
+					expiryNoticeShown = true;
+					ui.notify(ELICITATION_EXPIRED_NOTICE, "warning");
+				}
+			};
+			const forwardSdkAbort = (): void => {
+				if (!formAbortController.signal.aborted) formAbortController.abort();
+			};
+			if (signal.aborted) {
+				forwardSdkAbort();
+			} else {
+				signal.addEventListener("abort", forwardSdkAbort, { once: true });
+			}
+			const expiryTimer = setTimeout(abortExpiredForm, CLAUDE_CODE_INTERVIEW_FORM_TIMEOUT_MS);
 			markInteractiveElicitationStart();
 			markToolStart(elicId, "ask_user_questions");
+			activeAskUserQuestionElicitationTimeoutAborters.add(abortExpiredForm);
 			try {
 				const interviewResult = await showInterviewRound(
 					questions,
-					{ signal, overlay: true },
+					{ signal: formAbortController.signal, overlay: true },
 					{ ui } as any,
 				).catch(() => undefined);
 				if (interviewResult === undefined) {
@@ -1580,7 +1631,7 @@ export function createClaudeCodeElicitationHandler(
 					// `finally` runs the moment the promise is created and the fallback
 					// wait runs with zero in-flight tools — reintroducing the
 					// self-cancel on this path (Bugbot #1c00624d).
-					return await promptElicitationWithDialogs(request, questions, ui, signal);
+					return await promptElicitationWithDialogs(request, questions, ui, formAbortController.signal);
 				}
 				if (Object.keys(interviewResult.answers).length === 0) {
 					// A system/host teardown (compaction, session_switch, true
@@ -1596,6 +1647,9 @@ export function createClaudeCodeElicitationHandler(
 					content: roundResultToElicitationContent(questions, interviewResult),
 				};
 			} finally {
+				clearTimeout(expiryTimer);
+				signal.removeEventListener("abort", forwardSdkAbort);
+				activeAskUserQuestionElicitationTimeoutAborters.delete(abortExpiredForm);
 				markToolEnd(elicId);
 				markInteractiveElicitationEnd();
 			}
@@ -2526,6 +2580,9 @@ async function pumpSdkMessages(
 								// Push synthetic completion events with result attached so the
 								// chat-controller can update pending ToolExecutionComponents.
 								if (block.type === "toolCall") {
+									if (isAskUserQuestionsTimedOutResult(block, extResult)) {
+										abortActiveAskUserQuestionElicitationsForTimeout();
+									}
 									if (suppressDuplicateUnavailable) {
 										delete (block as ToolCallWithExternalResult).externalResult;
 										stream.push({
@@ -2554,9 +2611,13 @@ async function pumpSdkMessages(
 									});
 									emittedExternalToolResultIds.add(block.id);
 								} else if (block.type === "serverToolUse") {
+									const toolCall = serverToolUseToToolCallLike(block);
+									if (isAskUserQuestionsTimedOutResult(toolCall, extResult)) {
+										abortActiveAskUserQuestionElicitationsForTimeout();
+									}
 									try {
 										await onExternalToolResult?.({
-											toolCall: serverToolUseToToolCallLike(block),
+											toolCall,
 											result: extResult,
 										});
 									} catch (error) {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,5 +1,5 @@
 // gsd-pi - Claude Code stream adapter regression tests
-import { describe, test } from "node:test";
+import { describe, mock, test } from "node:test";
 import { clearGuidedUnitContext, setGuidedUnitContext } from "../../gsd/guided-unit-context.ts";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -46,6 +46,7 @@ import {
 	buildWorkflowMcpReadinessProgressMessage,
 	pushWorkflowMcpReadinessProgressEvent,
 	resolveWorkflowMcpPreflightServerConfig,
+	CLAUDE_CODE_INTERVIEW_FORM_TIMEOUT_MS,
 } from "../stream-adapter.ts";
 import { CLAUDE_CODE_MODELS } from "../models.ts";
 import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
@@ -818,6 +819,121 @@ describe("stream-adapter — Claude Code external tool results", () => {
 			syntheticCompletions.map((completion) => completion.text),
 			["read result", "grep result"],
 		);
+	});
+
+	test("closes an in-flight interview when ask_user_questions reports timed_out first", async (t) => {
+		const notifications: Array<{ message: string; type?: string }> = [];
+		let elicitationPromise: Promise<unknown> | undefined;
+		let elicitationSignalController: AbortController | undefined;
+		let customOpened = false;
+		const ui = {
+			custom: async (factory: any) => new Promise((resolve) => {
+				customOpened = true;
+				factory({ requestRender() {} } as any, {} as any, {} as any, resolve);
+			}),
+			notify: (message: string, type?: string) => {
+				notifications.push({ message, type });
+			},
+		};
+		t.after(() => {
+			elicitationSignalController?.abort();
+		});
+
+		const stream = streamViaClaudeCode(
+			{ id: "claude-sonnet-4-6" } as any,
+			{ messages: [{ role: "user", content: "Ask me." } as Message] },
+			{
+				extensionUIContext: ui as any,
+				_skipWorkflowMcpPreflightForTest: true,
+				async *_sdkQueryForTest(args: {
+					prompt: string | AsyncIterable<unknown>;
+					options?: Record<string, unknown>;
+				}) {
+					const onElicitation = args.options?.onElicitation as
+						| ((request: unknown, options: { signal: AbortSignal }) => Promise<unknown>)
+						| undefined;
+					assert.equal(typeof onElicitation, "function");
+					elicitationSignalController = new AbortController();
+					elicitationPromise = onElicitation!(askUserQuestionsRequest, {
+						signal: elicitationSignalController.signal,
+					});
+					assert.equal(customOpened, true, "interview overlay should be open before the tool result arrives");
+
+					yield {
+						type: "stream_event",
+						event: {
+							type: "content_block_start",
+							index: 0,
+							content_block: {
+								type: "tool_use",
+								id: "ask-1",
+								name: "mcp__gsd-workflow__ask_user_questions",
+								input: {},
+							},
+						},
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
+					yield {
+						type: "user",
+						uuid: "user-result-1",
+						session_id: "session-1",
+						parent_tool_use_id: "ask-1",
+						message: {
+							role: "user",
+							content: [{
+								type: "mcp_tool_result",
+								tool_use_id: "ask-1",
+								content: [{ type: "text", text: "timed out" }],
+								structuredContent: { timed_out: true },
+								is_error: false,
+							}],
+						},
+					};
+					yield {
+						type: "result",
+						subtype: "success",
+						uuid: "result-1",
+						session_id: "session-1",
+						duration_ms: 1,
+						duration_api_ms: 1,
+						is_error: false,
+						num_turns: 1,
+						result: "done",
+						stop_reason: "end_turn",
+						total_cost_usd: 0,
+						usage: {
+							input_tokens: 0,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					};
+				},
+			} as any,
+		);
+
+		await stream.result();
+		assert.ok(elicitationPromise);
+		let guard: ReturnType<typeof setTimeout> | undefined;
+		const elicitationResult = await Promise.race([
+			elicitationPromise,
+			new Promise<never>((_, reject) => {
+				guard = setTimeout(
+					() => reject(new Error("timed out waiting for in-flight interview to close")),
+					250,
+				);
+			}),
+		]).finally(() => {
+			if (guard) clearTimeout(guard);
+		});
+
+		assert.deepEqual(elicitationResult, { action: "decline" });
+		assert.deepEqual(notifications, [{
+			message: "Question expired before you answered - the form was closed and no answers were sent.",
+			type: "warning",
+		}]);
 	});
 
 	test("serverToolUseToToolCallLike preserves object input for extension tool_result routing", () => {
@@ -3039,6 +3155,43 @@ describe("stream-adapter — MCP elicitation bridge", () => {
 
 		const result = await handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
 		assert.deepEqual(result, { action: "decline" });
+	});
+
+	test("expires the interview overlay before the MCP elicitation response is dropped", async (t) => {
+		mock.timers.enable({ apis: ["setTimeout"] });
+		t.after(() => {
+			mock.timers.reset();
+		});
+
+		const notifications: Array<{ message: string; type?: string }> = [];
+		let customOpened = false;
+		const handler = createClaudeCodeElicitationHandler({
+			custom: async (factory: any) => new Promise((resolve) => {
+				customOpened = true;
+				factory({ requestRender() {} } as any, {} as any, {} as any, resolve);
+			}),
+			notify: (message: string, type?: string) => {
+				notifications.push({ message, type });
+			},
+			select: async () => {
+				throw new Error("expired interview must not re-open dialog fallback");
+			},
+		} as any);
+		assert.ok(handler);
+
+		const resultPromise = handler!(askUserQuestionsRequest, { signal: new AbortController().signal });
+		await Promise.resolve();
+		assert.equal(customOpened, true);
+
+		mock.timers.tick(CLAUDE_CODE_INTERVIEW_FORM_TIMEOUT_MS);
+		const result = await resultPromise;
+
+		assert.deepEqual(result, { action: "decline" });
+		assert.deepEqual(notifications, [{
+			message: "Question expired before you answered - the form was closed and no answers were sent.",
+			type: "warning",
+		}]);
+		assert.equal(isInteractiveElicitationInFlight(), false, "marker must clear after deadline expiry");
 	});
 
 	test("returns cancel (today's semantics) when the user genuinely dismisses", async () => {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -109,6 +109,51 @@ function setWorkflowMcpEnv(
 }
 
 // ---------------------------------------------------------------------------
+// Shared MCP elicitation fixture — a representative ask_user_questions
+// elicitation request. Used both by the external-tool-results interview
+// lifecycle tests and by the MCP elicitation bridge tests, so it lives at
+// module scope.
+// ---------------------------------------------------------------------------
+
+const askUserQuestionsRequest = {
+	serverName: "gsd-workflow",
+	message: "Please answer the following question(s).",
+	mode: "form" as const,
+	requestedSchema: {
+		type: "object" as const,
+		properties: {
+			storage_scope: {
+				type: "string",
+				title: "Storage",
+				description: "Does this app need to sync across devices?",
+				oneOf: [
+					{ const: "Local-only (Recommended)", title: "Local-only (Recommended)" },
+					{ const: "Cloud-synced", title: "Cloud-synced" },
+					{ const: "None of the above", title: "None of the above" },
+				],
+			},
+			storage_scope__note: {
+				type: "string",
+				title: "Storage Note",
+				description: "Optional note for None of the above.",
+			},
+			platform: {
+				type: "array",
+				title: "Platform",
+				description: "Where should it run?",
+				items: {
+					anyOf: [
+						{ const: "Web", title: "Web" },
+						{ const: "Desktop", title: "Desktop" },
+						{ const: "Mobile", title: "Mobile" },
+					],
+				},
+			},
+		},
+	},
+};
+
+// ---------------------------------------------------------------------------
 // Existing tests — exhausted stream fallback (#2575)
 // ---------------------------------------------------------------------------
 
@@ -2711,44 +2756,6 @@ describe("stream-adapter — workflow MCP readiness", () => {
 });
 
 describe("stream-adapter — MCP elicitation bridge", () => {
-	const askUserQuestionsRequest = {
-		serverName: "gsd-workflow",
-		message: "Please answer the following question(s).",
-		mode: "form" as const,
-		requestedSchema: {
-			type: "object" as const,
-			properties: {
-				storage_scope: {
-					type: "string",
-					title: "Storage",
-					description: "Does this app need to sync across devices?",
-					oneOf: [
-						{ const: "Local-only (Recommended)", title: "Local-only (Recommended)" },
-						{ const: "Cloud-synced", title: "Cloud-synced" },
-						{ const: "None of the above", title: "None of the above" },
-					],
-				},
-				storage_scope__note: {
-					type: "string",
-					title: "Storage Note",
-					description: "Optional note for None of the above.",
-				},
-				platform: {
-					type: "array",
-					title: "Platform",
-					description: "Where should it run?",
-					items: {
-						anyOf: [
-							{ const: "Web", title: "Web" },
-							{ const: "Desktop", title: "Desktop" },
-							{ const: "Mobile", title: "Mobile" },
-						],
-					},
-				},
-			},
-		},
-	};
-
 	test("parseAskUserQuestionsElicitation rebuilds interview questions from the MCP schema", () => {
 		const questions = parseAskUserQuestionsElicitation(askUserQuestionsRequest);
 		assert.deepEqual(questions, [

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -904,6 +904,19 @@ describe("stream-adapter — Claude Code external tool results", () => {
 					});
 					assert.equal(customOpened, true, "interview overlay should be open before the tool result arrives");
 
+					// The adapter only assembles tool-call blocks after a
+					// message_start has created the partial-message builder. Real
+					// SDK streams always emit it before a tool_use content block;
+					// without it the timed_out result is never matched to the
+					// in-flight ask_user_questions block, so the interview would
+					// never be closed.
+					yield {
+						type: "stream_event",
+						event: { type: "message_start", message: { model: "claude-sonnet-4-6" } },
+						parent_tool_use_id: null,
+						uuid: "partial-1",
+						session_id: "session-1",
+					};
 					yield {
 						type: "stream_event",
 						event: {


### PR DESCRIPTION
## Summary
- Fixed expired interview overlays by aborting stale ask_user_questions forms and verified syntax/diff checks, with full tests blocked by offline dependency install.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1151
- [#1151 [Bug]: interview form stays interactive after its elicitation expires — answers submitted to the dead form are silently discarded](https://github.com/open-gsd/gsd-pi/issues/1151)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1151-bug-interview-form-stays-interactive-aft-1783022476`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive elicitation timing and abort wiring for ask_user_questions; behavior is scoped but affects foreground UX and MCP answer delivery.
> 
> **Overview**
> Fixes **#1151** by keeping the Claude Code **ask_user_questions** interview UI in sync with the workflow MCP elicitation lifetime instead of leaving a dead form open after the server times out.
> 
> **ask_user_questions** elicitation now uses a **local abort** for the interview overlay, aligned to the MCP host timeout (**~10 minutes**, closed **1s early** via `CLAUDE_CODE_INTERVIEW_FORM_TIMEOUT_MS`). When the deadline hits, the form aborts, the user sees a **warning** that the question expired, and the handler returns **`decline`** (same as an interrupted wait). SDK cancel still propagates through the same abort path.
> 
> If the stream delivers a tool result with **`timed_out: true`** before the local timer fires, **`abortActiveAskUserQuestionElicitationsForTimeout`** closes any still-open interview so answers are not submitted to an expired elicitation.
> 
> Regression tests cover timer-driven expiry and timeout-result-driven closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6560c0dc2fa8f9a1e28f47c2f69b65dfa2aa2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->