### PR TITLE
fix(issue): [Bug]: On WSL/`/mnt/c`, external-state migration hard-fails because the `.gsd` rename's copy-fallback matches only EPERM/EBUSY, not the EACCES that DrvFs reports for the same file lock

### DIFF
--- a/src/resources/extensions/gsd/migrate-external.ts
+++ b/src/resources/extensions/gsd/migrate-external.ts
@@ -94,12 +94,12 @@ export function migrateToExternalState(basePath: string): MigrationResult {
 
     // Rename .gsd -> .gsd.migrating (atomic lock).
     // On Windows, NTFS may reject rename with EPERM if file descriptors are
-    // open (VS Code watchers, antivirus on-access scan). Fall back to
-    // copy+delete (#1292).
+    // open (VS Code watchers, antivirus on-access scan). WSL/DrvFs can report
+    // the same transient lock as EACCES. Fall back to copy+delete (#1292).
     try {
       renameSync(localGsd, migratingPath);
     } catch (renameErr: any) {
-      if (renameErr?.code === "EPERM" || renameErr?.code === "EBUSY") {
+      if (renameErr?.code === "EPERM" || renameErr?.code === "EBUSY" || renameErr?.code === "EACCES") {
         try {
           cpSync(localGsd, migratingPath, { recursive: true, force: true });
           rmSync(localGsd, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/migrate-external-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-external-worktree.test.ts
@@ -119,6 +119,63 @@ describe("migrate-external worktree guard (#2970)", () => {
   });
 });
 
+describe("migrateToExternalState rename fallback (#1179)", () => {
+  test("falls back to copy/delete when rename fails with EACCES", () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-migrate-eacces-")));
+    const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-state-eacces-")));
+    const previousStateDir = process.env.GSD_STATE_DIR;
+    const previousProjectId = process.env.GSD_PROJECT_ID;
+    const originalRenameSync = fs.renameSync;
+    const localGsd = join(base, ".gsd");
+    const migratingPath = join(base, ".gsd.migrating");
+    let renameAttempts = 0;
+
+    process.env.GSD_STATE_DIR = stateDir;
+    process.env.GSD_PROJECT_ID = "rename-eacces";
+
+    try {
+      run("git init -b main", base);
+      mkdirSync(localGsd, { recursive: true });
+      writeFileSync(join(localGsd, "PREFERENCES.md"), "# prefs\n", "utf-8");
+
+      fs.renameSync = ((src, dst) => {
+        if (String(src) === localGsd && String(dst) === migratingPath) {
+          renameAttempts += 1;
+          const error = new Error("simulated WSL/DrvFs rename lock") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        return originalRenameSync(src, dst);
+      }) as typeof fs.renameSync;
+      syncBuiltinESMExports();
+
+      const result = migrateToExternalState(base);
+
+      assert.equal(result.migrated, true, "EACCES rename failure should use copy/delete fallback");
+      assert.equal(result.error, undefined);
+      assert.equal(renameAttempts, 1, "should exercise the EACCES rename fallback once");
+      assert.equal(readFileSync(join(stateDir, "projects", "rename-eacces", "PREFERENCES.md"), "utf-8"), "# prefs\n");
+      assert.equal(readFileSync(join(base, ".gsd", "PREFERENCES.md"), "utf-8"), "# prefs\n");
+      assert.ok(!existsSync(migratingPath), "backup staging dir must be removed after successful migration");
+    } finally {
+      fs.renameSync = originalRenameSync;
+      syncBuiltinESMExports();
+      if (previousStateDir === undefined) {
+        delete process.env.GSD_STATE_DIR;
+      } else {
+        process.env.GSD_STATE_DIR = previousStateDir;
+      }
+      if (previousProjectId === undefined) {
+        delete process.env.GSD_PROJECT_ID;
+      } else {
+        process.env.GSD_PROJECT_ID = previousProjectId;
+      }
+      rmSync(base, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("migrateToExternalState copy failure rollback (#1047)", () => {
   test("restores .gsd when a source entry fails to copy", () => {
     const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-migrate-copy-fail-")));


### PR DESCRIPTION
## Summary
- Handled WSL/DrvFs EACCES rename failures with the existing copy/delete migration fallback and verified the diff, while runtime tests were blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1179
- [#1179 [Bug]: On WSL/`/mnt/c`, external-state migration hard-fails because the `.gsd` rename's copy-fallback matches only EPERM/EBUSY, not the EACCES that DrvFs reports for the same file lock](https://github.com/open-gsd/gsd-pi/issues/1179)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1179-bug-on-wsl-mnt-c-external-state-migratio-1783027224`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows a one-line condition in the migration rename fallback and adds a test; behavior for other error codes is unchanged.
> 
> **Overview**
> On WSL when `.gsd` lives under `/mnt/c`, DrvFs can surface the same transient directory lock as **`EACCES`** instead of **`EPERM`/`EBUSY`**. External-state migration used to hard-fail on that code because only **`EPERM`/`EBUSY`** triggered the existing copy+delete fallback.
> 
> **`migrateToExternalState`** now treats **`EACCES`** like the other lock errors for the `.gsd` → `.gsd.migrating` rename step, with a short comment noting WSL/DrvFs. A regression test stubs **`renameSync`** to throw **`EACCES`** and asserts migration still completes and leaves no **`.gsd.migrating`** staging dir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a041cea0b79454c86b6fed4553b8f9df2c3a4fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->