### PR TITLE
fix(issue): [Bug]: External-state migration re-fires on an already-migrated project when its `.gsd` symlink is replaced by a real directory, and can overwrite newer external state

### DIFF
--- a/src/resources/extensions/gsd/migrate-external.ts
+++ b/src/resources/extensions/gsd/migrate-external.ts
@@ -9,7 +9,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, renameSync, cpSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
-import { externalGsdRoot, isInsideWorktree } from "./repo-identity.js";
+import { externalGsdRoot, externalStateAlreadyExistsForProject, isInsideWorktree } from "./repo-identity.js";
 import { getErrorMessage } from "./error-utils.js";
 import { hasGitTrackedGsdFiles } from "./gitignore.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
@@ -83,6 +83,16 @@ export function migrateToExternalState(basePath: string): MigrationResult {
       // Can't read worktrees dir — skip migration to be safe
       return { migrated: false };
     }
+  }
+
+  // If external state already contains project data, this is not a legacy
+  // migration source. It is likely an already-migrated project whose symlink
+  // was replaced by a real directory, so copying would risk data loss.
+  if (externalStateAlreadyExistsForProject(basePath)) {
+    return {
+      migrated: false,
+      error: "External state already exists for this project; leaving local .gsd directory untouched to avoid overwriting authoritative state",
+    };
   }
 
   const externalPath = externalGsdRoot(basePath);

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -355,6 +355,23 @@ export function externalProjectsRoot(): string {
   return join(base, "projects");
 }
 
+/**
+ * Check whether this project already has authoritative external state.
+ *
+ * Used by legacy `.gsd/` migration to avoid re-copying a re-materialized local
+ * directory over newer state when an already-migrated symlink was replaced.
+ */
+export function externalStateAlreadyExistsForProject(basePath: string): boolean {
+  const base = process.env.GSD_STATE_DIR || gsdHome();
+  const computedPath = join(base, "projects", repoIdentity(basePath));
+  if (hasProjectState(computedPath)) return true;
+
+  const markerId = readGsdIdMarker(resolveGitRoot(basePath));
+  if (!markerId) return false;
+
+  return hasProjectState(join(base, "projects", markerId));
+}
+
 // ─── Numbered Variant Cleanup ────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/tests/migrate-external-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-external-worktree.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
 import { migrateToExternalState, recoverFailedMigration } from "../migrate-external.ts";
+import { externalGsdRoot } from "../repo-identity.ts";
 
 function run(command: string, cwd: string): string {
   return execSync(command, {
@@ -160,6 +161,64 @@ describe("migrateToExternalState rename fallback (#1179)", () => {
     } finally {
       fs.renameSync = originalRenameSync;
       syncBuiltinESMExports();
+      if (previousStateDir === undefined) {
+        delete process.env.GSD_STATE_DIR;
+      } else {
+        process.env.GSD_STATE_DIR = previousStateDir;
+      }
+      if (previousProjectId === undefined) {
+        delete process.env.GSD_PROJECT_ID;
+      } else {
+        process.env.GSD_PROJECT_ID = previousProjectId;
+      }
+      rmSync(base, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("migrateToExternalState already-migrated external state guard (#1178)", () => {
+  test("skips migration when external state already exists for a real local .gsd directory", () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-migrate-already-external-")));
+    const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-state-already-external-")));
+    const previousStateDir = process.env.GSD_STATE_DIR;
+    const previousProjectId = process.env.GSD_PROJECT_ID;
+    process.env.GSD_STATE_DIR = stateDir;
+
+    try {
+      run("git init -b main", base);
+      run('git config user.name "Test"', base);
+      run('git config user.email "test@example.com"', base);
+      writeFileSync(join(base, "README.md"), "# Test\n", "utf-8");
+      run("git add README.md", base);
+      run('git commit -m "init"', base);
+
+      const externalPath = externalGsdRoot(base);
+      const identity = externalPath.split(/[\\/]/).pop();
+      assert.ok(identity, "external state path must include an identity segment");
+      mkdirSync(externalPath, { recursive: true });
+      writeFileSync(join(base, ".gsd-id"), `${identity}\n`, "utf-8");
+      writeFileSync(join(externalPath, "gsd.db"), "newer external state\n", "utf-8");
+
+      mkdirSync(join(base, ".gsd"), { recursive: true });
+      writeFileSync(join(base, ".gsd", "gsd.db"), "stale local state\n", "utf-8");
+
+      const result = migrateToExternalState(base);
+
+      assert.equal(result.migrated, false, "already-migrated project must not re-run migration");
+      assert.match(result.error ?? "", /external state already exists/i);
+      assert.equal(
+        readFileSync(join(externalPath, "gsd.db"), "utf-8"),
+        "newer external state\n",
+        "newer external gsd.db must not be overwritten by stale local state",
+      );
+      assert.equal(
+        readFileSync(join(base, ".gsd", "gsd.db"), "utf-8"),
+        "stale local state\n",
+        "local real .gsd directory should be left for explicit recovery",
+      );
+      assert.ok(!existsSync(join(base, ".gsd.migrating")), "migration staging dir must not be created");
+    } finally {
       if (previousStateDir === undefined) {
         delete process.env.GSD_STATE_DIR;
       } else {


### PR DESCRIPTION
## Summary
- Added an external-state migration guard and verified it with the focused migration test plus diff check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1178
- [#1178 [Bug]: External-state migration re-fires on an already-migrated project when its `.gsd` symlink is replaced by a real directory, and can overwrite newer external state](https://github.com/open-gsd/gsd-pi/issues/1178)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1178-bug-external-state-migration-re-fires-on-1783027226`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches migration paths that move or copy GSD state; the change reduces overwrite risk but alters when migration runs for edge cases (symlink replaced by a real directory).
> 
> **Overview**
> Prevents **legacy `.gsd/` → external migration** from running again when the project already has authoritative state under `~/.gsd/projects/<id>/`, even if a real local `.gsd` directory reappeared (e.g. after the post-migration symlink was replaced).
> 
> `migrateToExternalState` now bails out **before** rename/copy with `migrated: false` and an explicit error, leaving both the external store and the local directory untouched. Detection is centralized in new **`externalStateAlreadyExistsForProject`**, which treats either the computed `repoIdentity` path or the **`.gsd-id` marker** path as “already migrated” when `hasProjectState` is true.
> 
> A focused test covers stale local `gsd.db` vs newer external `gsd.db` and asserts no `.gsd.migrating` staging dir is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0eccb85b9b25826f71890606a36b921d4956ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->