### PR TITLE
fix(gsd): preserve restored projection edits after merge

### DIFF
--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -4,8 +4,9 @@
 import { importExtensionModule, type ExtensionAPI, type ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { join, basename } from "node:path";
-import { existsSync, cpSync } from "node:fs";
+import { existsSync, cpSync, readFileSync } from "node:fs";
 import type { AutoSession } from "./session.js";
 import type { LoopDeps } from "./loop-deps.js";
 import type { GSDState } from "../types.js";
@@ -100,6 +101,7 @@ export async function _runMilestoneMergeWithStashRestore(
   const { ctx, pi, s, deps } = ic;
 
   const projectRoot = s.originalBasePath || s.basePath;
+  const ignoredProjectionSnapshot = snapshotIgnoredGsdMarkdownProjections(projectRoot);
   const mergeResult = deps.lifecycle.exitMilestone(
     milestoneId,
     {
@@ -114,12 +116,12 @@ export async function _runMilestoneMergeWithStashRestore(
   );
 
   if (mergeResult.ok) {
-    await markMilestoneMergedAndRebuild(s);
+    await markMilestoneMergedAndRebuild(s, ignoredProjectionSnapshot);
     return null;
   }
 
   if (mergeResult.reason === "postflight-stash-restore-failed") {
-    await markMilestoneMergedAndRebuild(s);
+    await markMilestoneMergedAndRebuild(s, ignoredProjectionSnapshot);
   }
 
   if (mergeResult.reason === "preflight-dirty-overlap" || mergeResult.reason === "preflight-unmerged-conflicts") {
@@ -181,10 +183,15 @@ export async function _runMilestoneMergeWithStashRestore(
   return null;
 }
 
-async function markMilestoneMergedAndRebuild(s: AutoSession): Promise<void> {
+type GsdMarkdownSnapshot = Map<string, string>;
+
+async function markMilestoneMergedAndRebuild(
+  s: AutoSession,
+  ignoredProjectionSnapshot: GsdMarkdownSnapshot | null,
+): Promise<void> {
   s.milestoneMergedInPhases = true;
   const rebuildBasePath = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
-  if (hasDirtyGsdMarkdownProjections(rebuildBasePath)) {
+  if (hasDirtyGsdMarkdownProjections(rebuildBasePath, ignoredProjectionSnapshot)) {
     logWarning(
       "engine",
       "skipping markdown projection rebuild after milestone merge because restored .gsd edits are dirty",
@@ -203,19 +210,60 @@ async function markMilestoneMergedAndRebuild(s: AutoSession): Promise<void> {
   }
 }
 
-function hasDirtyGsdMarkdownProjections(basePath: string): boolean {
+function hasDirtyGsdMarkdownProjections(
+  basePath: string,
+  ignoredProjectionSnapshot: GsdMarkdownSnapshot | null,
+): boolean {
   try {
     const output = execFileSync(
       "git",
-      ["status", "--porcelain", "--", ".gsd"],
+      ["status", "--porcelain", "--untracked-files=all", "--", ".gsd"],
       { cwd: basePath, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
-    return output
+    if (output
       .split(/\r?\n/)
-      .some((line) => /\.md$/.test(line.trim()));
+      .some((line) => /\.md$/.test(line.trim()))) {
+      return true;
+    }
   } catch {
-    return false;
+    // Fall through to ignored-file snapshot comparison below.
   }
+  return ignoredGsdMarkdownProjectionSnapshotChanged(basePath, ignoredProjectionSnapshot);
+}
+
+function snapshotIgnoredGsdMarkdownProjections(basePath: string): GsdMarkdownSnapshot | null {
+  try {
+    const output = execFileSync(
+      "git",
+      ["ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", ".gsd"],
+      { cwd: basePath, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const snapshot: GsdMarkdownSnapshot = new Map();
+    for (const path of output.split("\0")) {
+      if (!path.endsWith(".md")) continue;
+      snapshot.set(path, hashFile(join(basePath, path)));
+    }
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+function hashFile(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function ignoredGsdMarkdownProjectionSnapshotChanged(
+  basePath: string,
+  before: GsdMarkdownSnapshot | null,
+): boolean {
+  if (!before) return false;
+  const after = snapshotIgnoredGsdMarkdownProjections(basePath);
+  if (!after || after.size !== before.size) return true;
+  for (const [path, hash] of before) {
+    if (after.get(path) !== hash) return true;
+  }
+  return false;
 }
 
 export async function _runMilestoneMergeOnceWithStashRestore(

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -233,7 +233,8 @@ function hasDirtyGsdMarkdownProjections(
         if (dest.endsWith(".md")) return true;
       }
     }
-  } catch {
+  } catch (err) {
+    void err;
     // Fall through to ignored-file snapshot comparison below.
   }
   return ignoredGsdMarkdownProjectionSnapshotChanged(basePath, ignoredProjectionSnapshot);

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -101,7 +101,8 @@ export async function _runMilestoneMergeWithStashRestore(
   const { ctx, pi, s, deps } = ic;
 
   const projectRoot = s.originalBasePath || s.basePath;
-  const ignoredProjectionSnapshot = snapshotIgnoredGsdMarkdownProjections(projectRoot);
+  const projectionGuardPath = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
+  const ignoredProjectionSnapshot = snapshotIgnoredGsdMarkdownProjections(projectionGuardPath);
   const mergeResult = deps.lifecycle.exitMilestone(
     milestoneId,
     {
@@ -217,13 +218,20 @@ function hasDirtyGsdMarkdownProjections(
   try {
     const output = execFileSync(
       "git",
-      ["status", "--porcelain", "--untracked-files=all", "--", ".gsd"],
+      ["status", "--porcelain", "-z", "--untracked-files=all", "--", ".gsd"],
       { cwd: basePath, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
-    if (output
-      .split(/\r?\n/)
-      .some((line) => /\.md$/.test(line.trim()))) {
-      return true;
+    const entries = output.split("\0").filter(Boolean);
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (entry.length <= 3) continue;
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      if (path.endsWith(".md")) return true;
+      if ((status === "R " || status === "C ") && i + 1 < entries.length) {
+        const dest = entries[++i];
+        if (dest.endsWith(".md")) return true;
+      }
     }
   } catch {
     // Fall through to ignored-file snapshot comparison below.
@@ -257,7 +265,7 @@ function ignoredGsdMarkdownProjectionSnapshotChanged(
   basePath: string,
   before: GsdMarkdownSnapshot | null,
 ): boolean {
-  if (!before) return false;
+  if (!before) return true;
   const after = snapshotIgnoredGsdMarkdownProjections(basePath);
   if (!after || after.size !== before.size) return true;
   for (const [path, hash] of before) {

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -100,9 +100,15 @@ export async function _runMilestoneMergeWithStashRestore(
 ): Promise<{ action: "break"; reason: string } | null> {
   const { ctx, pi, s, deps } = ic;
 
-  const projectRoot = s.originalBasePath || s.basePath;
-  const projectionGuardPath = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
-  const ignoredProjectionSnapshot = snapshotIgnoredGsdMarkdownProjections(projectionGuardPath);
+  // Resolve the project root once, before the merge can flip session path
+  // pointers (worktree teardown mutates s.basePath / s.scope). The guarded
+  // merge's preflight/postflight stash restore, the pre-merge ignored-markdown
+  // snapshot, the dirty-projection check, and the rebuild must all target this
+  // same tree; otherwise `.gsd` markdown restored on one tree can be silently
+  // overwritten by a rebuild on another. canonicalProjectRoot is the
+  // authoritative `.gsd`/DB writer path (see AutoSession.canonicalProjectRoot).
+  const projectRoot = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
+  const ignoredProjectionSnapshot = snapshotIgnoredGsdMarkdownProjections(projectRoot);
   const mergeResult = deps.lifecycle.exitMilestone(
     milestoneId,
     {
@@ -117,12 +123,12 @@ export async function _runMilestoneMergeWithStashRestore(
   );
 
   if (mergeResult.ok) {
-    await markMilestoneMergedAndRebuild(s, ignoredProjectionSnapshot);
+    await markMilestoneMergedAndRebuild(s, projectRoot, ignoredProjectionSnapshot);
     return null;
   }
 
   if (mergeResult.reason === "postflight-stash-restore-failed") {
-    await markMilestoneMergedAndRebuild(s, ignoredProjectionSnapshot);
+    await markMilestoneMergedAndRebuild(s, projectRoot, ignoredProjectionSnapshot);
   }
 
   if (mergeResult.reason === "preflight-dirty-overlap" || mergeResult.reason === "preflight-unmerged-conflicts") {
@@ -188,10 +194,10 @@ type GsdMarkdownSnapshot = Map<string, string>;
 
 async function markMilestoneMergedAndRebuild(
   s: AutoSession,
+  rebuildBasePath: string,
   ignoredProjectionSnapshot: GsdMarkdownSnapshot | null,
 ): Promise<void> {
   s.milestoneMergedInPhases = true;
-  const rebuildBasePath = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
   if (hasDirtyGsdMarkdownProjections(rebuildBasePath, ignoredProjectionSnapshot)) {
     logWarning(
       "engine",

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -3,6 +3,7 @@
 
 import { importExtensionModule, type ExtensionAPI, type ExtensionContext } from "@gsd/pi-coding-agent";
 
+import { execFileSync } from "node:child_process";
 import { join, basename } from "node:path";
 import { existsSync, cpSync } from "node:fs";
 import type { AutoSession } from "./session.js";
@@ -182,8 +183,16 @@ export async function _runMilestoneMergeWithStashRestore(
 
 async function markMilestoneMergedAndRebuild(s: AutoSession): Promise<void> {
   s.milestoneMergedInPhases = true;
+  const rebuildBasePath = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
+  if (hasDirtyGsdMarkdownProjections(rebuildBasePath)) {
+    logWarning(
+      "engine",
+      "skipping markdown projection rebuild after milestone merge because restored .gsd edits are dirty",
+    );
+    return;
+  }
+
   try {
-    const rebuildBasePath = s.originalBasePath || s.canonicalProjectRoot || s.basePath;
     const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.js");
     await rebuildMarkdownProjectionsFromDb(rebuildBasePath);
   } catch (err) {
@@ -191,6 +200,21 @@ async function markMilestoneMergedAndRebuild(s: AutoSession): Promise<void> {
       "engine",
       `markdown projection rebuild after milestone merge failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+}
+
+function hasDirtyGsdMarkdownProjections(basePath: string): boolean {
+  try {
+    const output = execFileSync(
+      "git",
+      ["status", "--porcelain", "--", ".gsd"],
+      { cwd: basePath, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return output
+      .split(/\r?\n/)
+      .some((line) => /\.md$/.test(line.trim()));
+  } catch {
+    return false;
   }
 }
 

--- a/src/resources/extensions/gsd/auto/closeout.ts
+++ b/src/resources/extensions/gsd/auto/closeout.ts
@@ -18,7 +18,7 @@ import { getIsolationMode } from "../preferences.js";
 import { isDbAvailable, getMilestone } from "../gsd-db.js";
 import { refreshWorkflowDatabaseFromDisk } from "../db-workspace.js";
 import { isClosedStatus } from "../status-guards.js";
-import { gsdRoot } from "../paths.js";
+import { gsdRoot, PLANNING_ARTIFACT_SUFFIXES } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import { debugLog } from "../debug-logger.js";
@@ -233,10 +233,10 @@ function hasDirtyGsdMarkdownProjections(
       if (entry.length <= 3) continue;
       const status = entry.slice(0, 2);
       const path = entry.slice(3);
-      if (path.endsWith(".md")) return true;
+      if (isGeneratedGsdMarkdownProjection(path)) return true;
       if ((status === "R " || status === "C ") && i + 1 < entries.length) {
         const dest = entries[++i];
-        if (dest.endsWith(".md")) return true;
+        if (isGeneratedGsdMarkdownProjection(dest)) return true;
       }
     }
   } catch (err) {
@@ -244,6 +244,26 @@ function hasDirtyGsdMarkdownProjections(
     // Fall through to ignored-file snapshot comparison below.
   }
   return ignoredGsdMarkdownProjectionSnapshotChanged(basePath, ignoredProjectionSnapshot);
+}
+
+function isGeneratedGsdMarkdownProjection(path: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized === ".gsd/DECISIONS.md") return true;
+  if (!normalized.startsWith(".gsd/milestones/") && !normalized.startsWith(".gsd/phases/")) {
+    return false;
+  }
+  return isGeneratedPlanningArtifactFileName(basename(normalized));
+}
+
+function isGeneratedPlanningArtifactFileName(fileName: string): boolean {
+  if (!fileName.endsWith(".md")) return false;
+  const stem = fileName.slice(0, -".md".length).toUpperCase();
+  for (const suffix of PLANNING_ARTIFACT_SUFFIXES) {
+    if (!stem.endsWith(`-${suffix}`)) continue;
+    const idPrefix = stem.slice(0, -suffix.length - 1);
+    return /^(?:[MST]\d+|\d{2,})(?:-[A-Z0-9]+)*$/.test(idPrefix);
+  }
+  return false;
 }
 
 function snapshotIgnoredGsdMarkdownProjections(basePath: string): GsdMarkdownSnapshot | null {
@@ -255,7 +275,7 @@ function snapshotIgnoredGsdMarkdownProjections(basePath: string): GsdMarkdownSna
     );
     const snapshot: GsdMarkdownSnapshot = new Map();
     for (const path of output.split("\0")) {
-      if (!path.endsWith(".md")) continue;
+      if (!isGeneratedGsdMarkdownProjection(path)) continue;
       snapshot.set(path, hashFile(join(basePath, path)));
     }
     return snapshot;

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -287,6 +287,19 @@ async function withProjectionBackedProject<T>(fn: (basePath: string, roadmapPath
   }
 }
 
+function insertFreshDbSlice(): void {
+  insertSlice({
+    id: "S02",
+    milestoneId: "M002",
+    title: "Fresh DB Slice",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+    demo: "demo",
+    sequence: 2,
+  });
+}
+
 const POP_OK: PostflightResult = {
   restored: true,
   needsManualRecovery: false,
@@ -548,19 +561,102 @@ test("postflight-restored projection edits survive successful merge rebuild", as
   });
 });
 
+test("untracked markdown under a new .gsd directory suppresses successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      const restoredDir = join(basePath, ".gsd", "restored-projections");
+      mkdirSync(restoredDir, { recursive: true });
+      writeFileSync(join(restoredDir, "local.md"), "# restored local markdown\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.doesNotMatch(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "untracked markdown projections inside new .gsd directories must suppress rebuild",
+    );
+  });
+});
+
+test("ignored untracked markdown under .gsd suppresses successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    writeFileSync(join(basePath, ".gitignore"), ".gsd\n", "utf8");
+    git(basePath, ["add", ".gitignore"]);
+    git(basePath, ["commit", "-m", "ignore gsd projections"], "ignore");
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      const restoredDir = join(basePath, ".gsd", "ignored-restored-projections");
+      mkdirSync(restoredDir, { recursive: true });
+      writeFileSync(join(restoredDir, "local.md"), "# ignored restored local markdown\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.doesNotMatch(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "ignored .gsd markdown projections restored by postflight must suppress rebuild",
+    );
+  });
+});
+
+test("preexisting ignored markdown under .gsd does not suppress successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    writeFileSync(join(basePath, ".gitignore"), ".gsd\n", "utf8");
+    git(basePath, ["add", ".gitignore"]);
+    git(basePath, ["commit", "-m", "ignore gsd projections"], "ignore");
+    mkdirSync(join(basePath, ".gsd", "ignored-existing-projections"), { recursive: true });
+    writeFileSync(
+      join(basePath, ".gsd", "ignored-existing-projections", "local.md"),
+      "# already ignored local markdown\n",
+      "utf8",
+    );
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.match(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "stable preexisting ignored .gsd markdown must not block the required projection rebuild",
+    );
+  });
+});
 
 test("non-projection .gsd dirt does not suppress successful merge rebuild", async () => {
   await withProjectionBackedProject(async (basePath, roadmapPath) => {
-    insertSlice({
-      id: "S02",
-      milestoneId: "M002",
-      title: "Fresh DB Slice",
-      status: "pending",
-      risk: "medium",
-      depends: [],
-      demo: "demo",
-      sequence: 2,
-    });
+    insertFreshDbSlice();
     mkdirSync(join(basePath, ".gsd", "runtime"), { recursive: true });
 
     const { ic } = buildIc({

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -3,6 +3,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   _runMilestoneMergeOnceWithStashRestore,
@@ -10,6 +14,9 @@ import {
 } from "../auto/closeout.js";
 import type { IterationContext } from "../auto/types.js";
 import { MergeConflictError } from "../git-service.js";
+import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.js";
+import { renderAllFromDb } from "../markdown-renderer.js";
+import { resolveMilestoneFile } from "../paths.js";
 import type {
   PostflightResult,
   PreflightResult,
@@ -233,6 +240,52 @@ const PREFLIGHT_UNMERGED_EVAL_FAILED: PreflightResult = {
   conflictedPaths: ["todo.js"],
   summary: "Unable to fully evaluate unresolved Git conflicts before milestone M002 merge.",
 };
+
+function git(basePath: string, args: string[], stdio: "ignore" | "pipe" = "pipe"): void {
+  execFileSync("git", args, { cwd: basePath, stdio });
+}
+
+async function withProjectionBackedProject<T>(fn: (basePath: string, roadmapPath: string) => Promise<T>): Promise<T> {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-postflight-projection-"));
+  try {
+    mkdirSync(join(basePath, ".gsd"), { recursive: true });
+    openDatabase(join(basePath, ".gsd", "gsd.db"));
+    insertMilestone({
+      id: "M002",
+      title: "Postflight Guard",
+      status: "active",
+    });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M002",
+      title: "Slice",
+      status: "pending",
+      risk: "medium",
+      depends: [],
+      demo: "demo",
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M002",
+      title: "Task",
+      status: "pending",
+    });
+    await renderAllFromDb(basePath);
+    git(basePath, ["init"], "ignore");
+    git(basePath, ["config", "user.email", "test@example.invalid"]);
+    git(basePath, ["config", "user.name", "Test"]);
+    git(basePath, ["add", ".gsd"]);
+    git(basePath, ["commit", "-m", "initial projections"], "ignore");
+    const roadmapPath = resolveMilestoneFile(basePath, "M002", "ROADMAP");
+    assert.ok(roadmapPath, "expected rendered M002 roadmap path");
+    return await fn(basePath, roadmapPath);
+  } finally {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+}
 
 const POP_OK: PostflightResult = {
   restored: true,
@@ -467,6 +520,70 @@ test("already-merged milestone skips guarded merge to terminate duplicate closeo
     0,
     "already-merged guard must not re-trigger stash restore",
   );
+});
+
+
+test("postflight-restored projection edits survive successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      writeFileSync(roadmapPath, "# local projection edit restored from stash\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.equal(
+      readFileSync(roadmapPath, "utf8"),
+      "# local projection edit restored from stash\n",
+      "projection rebuild must not overwrite user edits restored by postflight stash pop",
+    );
+  });
+});
+
+
+test("non-projection .gsd dirt does not suppress successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertSlice({
+      id: "S02",
+      milestoneId: "M002",
+      title: "Fresh DB Slice",
+      status: "pending",
+      risk: "medium",
+      depends: [],
+      demo: "demo",
+      sequence: 2,
+    });
+    mkdirSync(join(basePath, ".gsd", "runtime"), { recursive: true });
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      writeFileSync(join(basePath, ".gsd", "runtime", "restored.json"), "{}\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.match(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "non-projection .gsd dirt must not block the required projection rebuild",
+    );
+  });
 });
 
 test("merge succeeds but stash pop needs manual recovery -> postflight-stash-restore-failed break", async () => {

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -725,6 +725,84 @@ test("non-projection .gsd dirt does not suppress successful merge rebuild", asyn
   });
 });
 
+test("guarded merge stash restore and rebuild target the same canonical project root", async () => {
+  await withProjectionBackedProject(async (realRoot, roadmapPath) => {
+    insertFreshDbSlice();
+    let postflightProjectRoot: string | undefined;
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    // originalBasePath empty + basePath diverging from canonicalProjectRoot is
+    // the exact condition where the guard (snapshot / dirty check / rebuild)
+    // could run against a different tree than the postflight stash restore.
+    // The postflight restore must land on the same canonical root the guard
+    // inspects and the rebuild writes, otherwise restored edits are missed.
+    (ic.s as unknown as {
+      basePath: string;
+      originalBasePath: string;
+      canonicalProjectRoot: string;
+    }).basePath = "/tmp/gsd-decoy-basepath-not-the-project-root";
+    (ic.s as unknown as { originalBasePath: string }).originalBasePath = "";
+    (ic.s as unknown as { canonicalProjectRoot: string }).canonicalProjectRoot = realRoot;
+    (ic.deps as unknown as { postflightPopStash: (projectRoot: string) => PostflightResult }).postflightPopStash =
+      (projectRoot: string) => {
+        postflightProjectRoot = projectRoot;
+        writeFileSync(roadmapPath, "# projection edit restored from stash\n", "utf8");
+        return POP_OK;
+      };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.equal(
+      postflightProjectRoot,
+      realRoot,
+      "postflight stash restore must run at the canonical project root the guard and rebuild use",
+    );
+    assert.equal(
+      readFileSync(roadmapPath, "utf8"),
+      "# projection edit restored from stash\n",
+      "restored projection edits on the canonical root must suppress the rebuild",
+    );
+  });
+});
+
+test("git-quoted special-character .gsd markdown paths still suppress rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      const restoredDir = join(basePath, ".gsd", "restored");
+      mkdirSync(restoredDir, { recursive: true });
+      // A non-ASCII filename that `git status --porcelain` C-quotes as
+      // "...caf\303\251.md" without -z; a naive line.endsWith(".md") check
+      // would miss the quoted path. NUL-delimited (-z) parsing sees the raw
+      // path and still detects it as a dirty markdown projection.
+      writeFileSync(join(restoredDir, "café.md"), "# restored local markdown\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.doesNotMatch(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "special-character .gsd markdown restored by postflight must suppress the rebuild",
+    );
+  });
+});
+
 test("merge succeeds but stash pop needs manual recovery -> postflight-stash-restore-failed break", async () => {
   const { ic, log } = buildIc({
     preflightResult: STASH_PUSHED,

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../auto/closeout.js";
 import type { IterationContext } from "../auto/types.js";
 import { MergeConflictError } from "../git-service.js";
-import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.js";
+import { closeDatabase, insertDecision, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.js";
 import { renderAllFromDb } from "../markdown-renderer.js";
 import { resolveMilestoneFile } from "../paths.js";
 import type {
@@ -566,7 +566,7 @@ test("postflight-restored projection edits survive successful merge rebuild", as
   });
 });
 
-test("untracked markdown under a new .gsd directory suppresses successful merge rebuild", async () => {
+test("untracked markdown under a new generated .gsd projection directory suppresses successful merge rebuild", async () => {
   await withProjectionBackedProject(async (basePath, roadmapPath) => {
     insertFreshDbSlice();
 
@@ -578,9 +578,9 @@ test("untracked markdown under a new .gsd directory suppresses successful merge 
     (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
     (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
     (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
-      const restoredDir = join(basePath, ".gsd", "restored-projections");
+      const restoredDir = join(basePath, ".gsd", "milestones", "M002", "slices", "S99");
       mkdirSync(restoredDir, { recursive: true });
-      writeFileSync(join(restoredDir, "local.md"), "# restored local markdown\n", "utf8");
+      writeFileSync(join(restoredDir, "S99-SUMMARY.md"), "# restored local markdown\n", "utf8");
       return POP_OK;
     };
 
@@ -590,7 +590,7 @@ test("untracked markdown under a new .gsd directory suppresses successful merge 
     assert.doesNotMatch(
       readFileSync(roadmapPath, "utf8"),
       /Fresh DB Slice/,
-      "untracked markdown projections inside new .gsd directories must suppress rebuild",
+      "untracked markdown projections inside generated .gsd directories must suppress rebuild",
     );
   });
 });
@@ -610,9 +610,9 @@ test("ignored untracked markdown under .gsd suppresses successful merge rebuild"
     (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
     (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
     (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
-      const restoredDir = join(basePath, ".gsd", "ignored-restored-projections");
+      const restoredDir = join(basePath, ".gsd", "milestones", "M002", "ignored-restored-projections");
       mkdirSync(restoredDir, { recursive: true });
-      writeFileSync(join(restoredDir, "local.md"), "# ignored restored local markdown\n", "utf8");
+      writeFileSync(join(restoredDir, "S99-SUMMARY.md"), "# ignored restored local markdown\n", "utf8");
       return POP_OK;
     };
 
@@ -632,9 +632,9 @@ test("preexisting ignored markdown under .gsd does not suppress successful merge
     writeFileSync(join(basePath, ".gitignore"), ".gsd\n", "utf8");
     git(basePath, ["add", ".gitignore"]);
     git(basePath, ["commit", "-m", "ignore gsd projections"], "ignore");
-    mkdirSync(join(basePath, ".gsd", "ignored-existing-projections"), { recursive: true });
+    mkdirSync(join(basePath, ".gsd", "milestones", "M002", "ignored-existing-projections"), { recursive: true });
     writeFileSync(
-      join(basePath, ".gsd", "ignored-existing-projections", "local.md"),
+      join(basePath, ".gsd", "milestones", "M002", "ignored-existing-projections", "S99-SUMMARY.md"),
       "# already ignored local markdown\n",
       "utf8",
     );
@@ -695,6 +695,111 @@ test("failed pre-merge ignored snapshot still suppresses rebuild over restored i
       "a null pre-merge ignored snapshot must fail closed and preserve restored ignored .gsd markdown",
     );
   }, { gitInit: false });
+});
+
+test("non-projection .gsd markdown does not suppress successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      writeFileSync(join(basePath, ".gsd", "PREFERENCES.md"), "# local preferences note\n", "utf8");
+      mkdirSync(join(basePath, ".gsd", "milestones", "M002"), { recursive: true });
+      writeFileSync(join(basePath, ".gsd", "milestones", "M002", "NOTES.md"), "# local milestone note\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.match(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "non-generated .gsd markdown must not block the required projection rebuild",
+    );
+  });
+});
+
+test("three-digit flat-phase projection restored by postflight suppresses successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      const restoredDir = join(basePath, ".gsd", "phases", "999-db-backed-planning");
+      mkdirSync(restoredDir, { recursive: true });
+      writeFileSync(join(restoredDir, "999-ROADMAP.md"), "# restored 3-digit projection\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.doesNotMatch(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "three-digit flat-phase projections restored by postflight must suppress rebuild",
+    );
+  });
+});
+
+test("root DECISIONS projection restored by postflight suppresses successful merge rebuild", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertFreshDbSlice();
+    insertDecision({
+      id: "D001",
+      when_context: "closeout",
+      scope: "global",
+      decision: "Regenerate decisions from DB",
+      choice: "Use database projection",
+      rationale: "Exercise root decision projection rebuild",
+      revisable: "Yes",
+      made_by: "agent",
+      superseded_by: null,
+    });
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      writeFileSync(
+        join(basePath, ".gsd", "DECISIONS.md"),
+        "# local decisions edit restored from stash\n",
+        "utf8",
+      );
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.doesNotMatch(
+      readFileSync(roadmapPath, "utf8"),
+      /Fresh DB Slice/,
+      "root generated DECISIONS.md restored by postflight must suppress rebuild",
+    );
+    assert.equal(
+      readFileSync(join(basePath, ".gsd", "DECISIONS.md"), "utf8"),
+      "# local decisions edit restored from stash\n",
+      "rebuild must not overwrite restored root DECISIONS.md edits",
+    );
+  });
 });
 
 test("non-projection .gsd dirt does not suppress successful merge rebuild", async () => {
@@ -782,13 +887,13 @@ test("git-quoted special-character .gsd markdown paths still suppress rebuild", 
     (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
     (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
     (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
-      const restoredDir = join(basePath, ".gsd", "restored");
+      const restoredDir = join(basePath, ".gsd", "milestones", "M002", "restoréd");
       mkdirSync(restoredDir, { recursive: true });
-      // A non-ASCII filename that `git status --porcelain` C-quotes as
-      // "...caf\303\251.md" without -z; a naive line.endsWith(".md") check
-      // would miss the quoted path. NUL-delimited (-z) parsing sees the raw
-      // path and still detects it as a dirty markdown projection.
-      writeFileSync(join(restoredDir, "café.md"), "# restored local markdown\n", "utf8");
+      // A non-ASCII generated projection path that `git status --porcelain`
+      // C-quotes without -z; a naive line.endsWith(".md") check would miss the
+      // quoted path. NUL-delimited (-z) parsing sees the raw path and still
+      // detects it as generated projection dirt.
+      writeFileSync(join(restoredDir, "S99-SUMMARY.md"), "# restored local markdown\n", "utf8");
       return POP_OK;
     };
 
@@ -798,7 +903,7 @@ test("git-quoted special-character .gsd markdown paths still suppress rebuild", 
     assert.doesNotMatch(
       readFileSync(roadmapPath, "utf8"),
       /Fresh DB Slice/,
-      "special-character .gsd markdown restored by postflight must suppress the rebuild",
+      "special-character generated .gsd markdown restored by postflight must suppress the rebuild",
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -245,7 +245,10 @@ function git(basePath: string, args: string[], stdio: "ignore" | "pipe" = "pipe"
   execFileSync("git", args, { cwd: basePath, stdio });
 }
 
-async function withProjectionBackedProject<T>(fn: (basePath: string, roadmapPath: string) => Promise<T>): Promise<T> {
+async function withProjectionBackedProject<T>(
+  fn: (basePath: string, roadmapPath: string) => Promise<T>,
+  options: { gitInit?: boolean } = {},
+): Promise<T> {
   const basePath = mkdtempSync(join(tmpdir(), "gsd-postflight-projection-"));
   try {
     mkdirSync(join(basePath, ".gsd"), { recursive: true });
@@ -273,11 +276,13 @@ async function withProjectionBackedProject<T>(fn: (basePath: string, roadmapPath
       status: "pending",
     });
     await renderAllFromDb(basePath);
-    git(basePath, ["init"], "ignore");
-    git(basePath, ["config", "user.email", "test@example.invalid"]);
-    git(basePath, ["config", "user.name", "Test"]);
-    git(basePath, ["add", ".gsd"]);
-    git(basePath, ["commit", "-m", "initial projections"], "ignore");
+    if (options.gitInit !== false) {
+      git(basePath, ["init"], "ignore");
+      git(basePath, ["config", "user.email", "test@example.invalid"]);
+      git(basePath, ["config", "user.name", "Test"]);
+      git(basePath, ["add", ".gsd"]);
+      git(basePath, ["commit", "-m", "initial projections"], "ignore");
+    }
     const roadmapPath = resolveMilestoneFile(basePath, "M002", "ROADMAP");
     assert.ok(roadmapPath, "expected rendered M002 roadmap path");
     return await fn(basePath, roadmapPath);
@@ -652,6 +657,44 @@ test("preexisting ignored markdown under .gsd does not suppress successful merge
       "stable preexisting ignored .gsd markdown must not block the required projection rebuild",
     );
   });
+});
+
+test("failed pre-merge ignored snapshot still suppresses rebuild over restored ignored markdown", async () => {
+  await withProjectionBackedProject(async (basePath, roadmapPath) => {
+    insertFreshDbSlice();
+
+    const { ic } = buildIc({
+      preflightResult: STASH_PUSHED,
+      mergeBehavior: "succeed",
+      postflightResult: POP_OK,
+    });
+    (ic.s as { basePath: string; originalBasePath: string }).basePath = basePath;
+    (ic.s as { basePath: string; originalBasePath: string }).originalBasePath = basePath;
+    (ic.deps as unknown as { postflightPopStash: () => PostflightResult }).postflightPopStash = () => {
+      // Git only becomes available AFTER the pre-merge ignored-markdown
+      // snapshot was attempted, so `before` is null. Postflight then restores
+      // ignored `.gsd` markdown that plain `git status` cannot see. With no
+      // baseline to diff against, the guard must fail closed and refuse to
+      // rebuild over the restored edit.
+      git(basePath, ["init"], "ignore");
+      git(basePath, ["config", "user.email", "test@example.invalid"]);
+      git(basePath, ["config", "user.name", "Test"]);
+      writeFileSync(join(basePath, ".gitignore"), ".gsd\n", "utf8");
+      git(basePath, ["add", ".gitignore"]);
+      git(basePath, ["commit", "-m", "ignore gsd projections"], "ignore");
+      writeFileSync(roadmapPath, "# ignored projection edit restored from stash\n", "utf8");
+      return POP_OK;
+    };
+
+    const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+    assert.equal(result, null);
+    assert.equal(
+      readFileSync(roadmapPath, "utf8"),
+      "# ignored projection edit restored from stash\n",
+      "a null pre-merge ignored snapshot must fail closed and preserve restored ignored .gsd markdown",
+    );
+  }, { gitInit: false });
 });
 
 test("non-projection .gsd dirt does not suppress successful merge rebuild", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Preserves postflight-restored `.gsd` markdown projection edits after guarded milestone merges.
**Why:** PR #1165 fixed the merge flag/postflight recovery path, but verification found projection rebuild could overwrite restored local projection edits.
**How:** Skip the best-effort projection rebuild only when dirty `.gsd/**/*.md` projection files are present after postflight restore; non-projection `.gsd` dirt still allows rebuild.

## What

This updates the auto closeout merge path so `markMilestoneMergedAndRebuild` still marks `milestoneMergedInPhases`, but avoids rebuilding markdown projections over user `.gsd` markdown edits restored by postflight stash pop.

It also adds regression coverage for both sides of the policy:

- restored `.gsd` markdown projection edits survive successful merge closeout
- non-projection `.gsd` dirt, such as runtime files, does not suppress the required projection rebuild

## Why

The guarded merge/stash closeout path protects user recovery state. A successful merge followed by postflight stash restore can reintroduce local `.gsd` markdown edits; rebuilding projections after that restore can overwrite those edits silently.

## How

The rebuild guard now checks Git status for dirty `.gsd` markdown files only. If dirty markdown projections are present, GSD logs a warning and skips the best-effort rebuild. Runtime/DB dirt under `.gsd` does not block rebuild, preserving normal closeout projection updates.

## Testing

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts src/resources/extensions/gsd/tests/closeout-recovery.test.ts src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts src/resources/extensions/gsd/tests/double-merge-guard.test.ts src/resources/extensions/gsd/tests/merge-conflict-stops-loop.test.ts src/resources/extensions/gsd/tests/stop-auto-merge-back.test.ts src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts src/resources/extensions/gsd/tests/orphan-stash-audit.test.ts src/resources/extensions/gsd/tests/stash-pop-gsd-conflict.test.ts`
- `pnpm run build:core`
- `pnpm run typecheck:extensions`
- `pnpm run verify:fast`
- `pnpm run gsd -- --help`
- `git diff --check`
- `codex review --uncommitted --title "Preserve postflight-restored projection edits"`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785630647&installation_id=134682257&pr_number=1187&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1187&signature=c9e1f751173467a8f1c1fd133b37965d7340409c5a2060399dd5bf2b171a5a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches milestone auto-closeout merge/rebuild behavior where incorrect guards could leave stale projections or skip needed rebuilds; changes are localized with extensive regression coverage.
> 
> **Overview**
> Guarded milestone merge closeout now **pins one canonical `projectRoot`** (`originalBasePath` → `canonicalProjectRoot` → `basePath`) for stash restore, the pre-merge ignored-projection snapshot, dirty checks, and DB markdown rebuild so worktree path churn cannot rebuild over edits restored on a different tree.
> 
> After a successful merge (including some postflight-stash-restore-failed paths), **`markMilestoneMergedAndRebuild` still sets `milestoneMergedInPhases` but skips** `rebuildMarkdownProjectionsFromDb` when generated `.gsd` markdown projections look dirty: `git status --porcelain -z` under `.gsd` (including renames and NUL-safe paths), plus a **SHA256 snapshot** of ignored generated projection files before merge; a failed/null pre-merge snapshot **fails closed** (no rebuild). Non-projection `.gsd` markdown/runtime dirt does not block rebuild.
> 
> Adds broad regression tests in `milestone-merge-stash-restore.test.ts` for restored/ignored/untracked projections, canonical-root alignment, and special-character paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a2d934a12478f86339b586899be604973f9e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->