### PR TITLE
refactor(gsd): centralize workflow readiness model context

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -31,7 +31,7 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { pauseAuto } from "./auto.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
-import { getUnitWorkflowDispatchReadinessError } from "./tool-contract.js";
+import { getUnitWorkflowDispatchReadinessErrorForModel } from "./tool-contract.js";
 
 export function parseDirectDispatchPhase(raw: string): { phase: string; milestoneId?: string } {
   const tokens = raw.trim().split(/\s+/).filter(Boolean);
@@ -266,13 +266,12 @@ export async function dispatchDirectPhase(
       return;
   }
 
-  const compatibilityError = getUnitWorkflowDispatchReadinessError({
-    provider: ctx.model?.provider,
+  const compatibilityError = getUnitWorkflowDispatchReadinessErrorForModel({
+    model: ctx.model,
+    getProviderAuthMode: (provider) => ctx.modelRegistry.getProviderAuthMode(provider),
     projectRoot,
     surface: "direct phase dispatch",
     unitType,
-    authMode: ctx.model?.provider ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider) : undefined,
-    baseUrl: ctx.model?.baseUrl,
     activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
   });
   if (compatibilityError) {

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -29,7 +29,7 @@ import type { MinimalModelRegistry } from "../context-budget.js";
 import { parseUnitId } from "../unit-id.js";
 import { createCheckpoint, cleanupCheckpoint, rollbackToCheckpoint } from "../safety/git-checkpoint.js";
 import { resolveSafetyHarnessConfig } from "../safety/safety-harness.js";
-import { getUnitWorkflowDispatchReadinessError } from "../tool-contract.js";
+import { getUnitWorkflowDispatchReadinessErrorForModel } from "../tool-contract.js";
 import { prepareWorkflowMcpForProject } from "../workflow-mcp-auto-prep.js";
 import {
   applyThinkingLevelForModel,
@@ -343,17 +343,13 @@ export async function runUnitPhase(
     ? `${(s.currentUnitModel as any).provider ?? ""}/${(s.currentUnitModel as any).id ?? ""}`
     : null;
 
-  const compatibilityError = getUnitWorkflowDispatchReadinessError({
-    provider: s.currentUnitModel?.provider ?? ctx.model?.provider,
+  const compatibilityError = getUnitWorkflowDispatchReadinessErrorForModel({
+    model: s.currentUnitModel as any,
+    fallbackModel: ctx.model,
+    getProviderAuthMode: (provider) => ctx.modelRegistry.getProviderAuthMode(provider),
     projectRoot: s.basePath,
     surface: "auto-mode",
     unitType,
-    authMode: s.currentUnitModel?.provider
-      ? ctx.modelRegistry.getProviderAuthMode(s.currentUnitModel.provider)
-      : ctx.model?.provider
-        ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider)
-        : undefined,
-    baseUrl: (s.currentUnitModel as any)?.baseUrl ?? ctx.model?.baseUrl,
     activeTools: typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [],
   });
   const workflowMcpPrepModel = s.currentUnitModel;

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -94,7 +94,7 @@ import {
 import { probeCoversRequiredWorkflowTools } from "./tool-surface-readiness.js";
 import { getRequiredWorkflowToolsForUnit } from "./unit-tool-contracts.js";
 import { isWorkflowToolSurfaceName } from "./workflow-tool-surface.js";
-import { getUnitWorkflowDispatchReadinessError } from "./tool-contract.js";
+import { getUnitWorkflowDispatchReadinessErrorForModel } from "./tool-contract.js";
 import {
   runPreparation,
   formatCodebaseBrief,
@@ -613,7 +613,7 @@ interface DispatchWorkflowOptions {
   deps?: {
     loadPreferences?: typeof loadEffectiveGSDPreferences;
     selectModel?: typeof selectAndApplyModel;
-    getDispatchReadinessError?: typeof getUnitWorkflowDispatchReadinessError;
+    getDispatchReadinessError?: typeof getUnitWorkflowDispatchReadinessErrorForModel;
   };
 }
 
@@ -730,7 +730,7 @@ async function dispatchWorkflow(
   const loadPreferences = resolvedOptions.deps?.loadPreferences ?? loadEffectiveGSDPreferences;
   const selectModel = resolvedOptions.deps?.selectModel ?? selectAndApplyModel;
   const getDispatchReadinessError = resolvedOptions.deps?.getDispatchReadinessError
-    ?? getUnitWorkflowDispatchReadinessError;
+    ?? getUnitWorkflowDispatchReadinessErrorForModel;
 
   // Route through the dynamic routing pipeline (complexity classification,
   // tier downgrade, fallback chains) — same path as auto-mode dispatches (#2958).
@@ -750,16 +750,12 @@ async function dispatchWorkflow(
     }
 
     const compatibilityError = getDispatchReadinessError({
-      provider: result.appliedModel?.provider ?? ctx.model?.provider,
+      model: result.appliedModel,
+      fallbackModel: ctx.model,
+      getProviderAuthMode: (provider) => ctx.modelRegistry.getProviderAuthMode(provider),
       projectRoot,
       surface: "guided flow",
       unitType,
-      authMode: result.appliedModel?.provider
-        ? ctx.modelRegistry.getProviderAuthMode(result.appliedModel.provider)
-        : ctx.model?.provider
-          ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider)
-          : undefined,
-      baseUrl: result.appliedModel?.baseUrl ?? ctx.model?.baseUrl,
       // Guided flow starts the MCP workflow server as part of dispatch, so the
       // parent session's activeTools doesn't include MCP tools yet. The MCP
       // launch config check (detectWorkflowMcpLaunchConfig) is the right gate

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -10,6 +10,7 @@ import {
   compileUnitContextContract,
   compileUnitToolContract,
   getUnitWorkflowDispatchReadinessError,
+  getUnitWorkflowDispatchReadinessErrorForModel,
 } from "../tool-contract.js";
 import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
 import type { GSDState } from "../types.js";
@@ -109,6 +110,25 @@ test("Tool Contract derives dispatch readiness from Unit workflow tools", () => 
   });
 
   assert.equal(error, null);
+});
+
+test("Tool Contract derives dispatch readiness from selected model context", () => {
+  const authLookups: string[] = [];
+  const error = getUnitWorkflowDispatchReadinessErrorForModel({
+    model: { provider: "claude-code" },
+    fallbackModel: { provider: "openai-codex", baseUrl: "local://claude-code" },
+    getProviderAuthMode(provider) {
+      authLookups.push(provider);
+      return provider === "claude-code" ? "externalCli" : "oauth";
+    },
+    unitType: "plan-slice",
+    projectRoot: "/tmp/project",
+    env: { GSD_WORKFLOW_MCP_COMMAND: "node" },
+    surface: "auto-mode",
+  });
+
+  assert.equal(error, null);
+  assert.deepEqual(authLookups, ["claude-code"]);
 });
 
 test("Unit Context Contract exposes prompt context without workflow tool surface", () => {

--- a/src/resources/extensions/gsd/tool-contract.ts
+++ b/src/resources/extensions/gsd/tool-contract.ts
@@ -85,6 +85,18 @@ export interface UnitWorkflowDispatchReadinessInput {
   activeTools?: string[];
 }
 
+export interface WorkflowDispatchModelContext {
+  provider?: string;
+  baseUrl?: string;
+}
+
+export interface UnitWorkflowDispatchReadinessForModelInput
+  extends Omit<UnitWorkflowDispatchReadinessInput, "provider" | "authMode" | "baseUrl"> {
+  model?: WorkflowDispatchModelContext | null;
+  fallbackModel?: WorkflowDispatchModelContext | null;
+  getProviderAuthMode?: (provider: string) => WorkflowCapabilityOptions["authMode"] | undefined;
+}
+
 export function compileUnitContextContract(unitType: string): UnitContextContractResult {
   const manifest = resolveManifest(unitType);
   if (!manifest) {
@@ -113,6 +125,23 @@ export function getUnitWorkflowDispatchReadinessError(
       activeTools: input.activeTools,
     },
   );
+}
+
+export function getUnitWorkflowDispatchReadinessErrorForModel(
+  input: UnitWorkflowDispatchReadinessForModelInput,
+): string | null {
+  const provider = input.model?.provider ?? input.fallbackModel?.provider;
+  const baseUrl = input.model?.baseUrl ?? input.fallbackModel?.baseUrl;
+  return getUnitWorkflowDispatchReadinessError({
+    provider,
+    unitType: input.unitType,
+    projectRoot: input.projectRoot,
+    env: input.env,
+    surface: input.surface,
+    authMode: provider ? input.getProviderAuthMode?.(provider) : undefined,
+    baseUrl,
+    activeTools: input.activeTools,
+  });
 }
 
 export function compileUnitToolContract(unitType: string): ToolContractResult {


### PR DESCRIPTION
## TL;DR

Centralizes workflow dispatch readiness model-context resolution in the Tool Contract module.

## Details

- Adds `getUnitWorkflowDispatchReadinessErrorForModel` so selected-model/fallback-model provider, baseUrl, and auth lookup precedence lives behind the Tool Contract seam.
- Routes auto unit phase, direct phase dispatch, and guided flow dispatch through the helper.
- Adds characterization coverage for selected-model auth precedence.

## Verification

- `git diff --check`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts src/resources/extensions/gsd/tests/transport-gate-double-complete.test.ts src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts src/resources/extensions/gsd/tests/workflow-phase-contract-matrix.test.ts`
- `pnpm run typecheck:extensions`
- `pnpm run gsd -- --help`
- `pnpm run build:core`
- `codex review --uncommitted --title "Centralize workflow dispatch model readiness"`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785632131&installation_id=134682257&pr_number=1188&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1188&signature=72b58be409f49e671d8431766dc1ad8e72429f00320a8691c25261a71a6019fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with preserved behavior; dispatch gating logic is consolidated but not changed in intent, with new test coverage for model precedence.
> 
> **Overview**
> Introduces **`getUnitWorkflowDispatchReadinessErrorForModel`** in the Tool Contract so workflow dispatch readiness no longer duplicates how **provider**, **baseUrl**, and **auth mode** are chosen from the selected model vs session fallback.
> 
> **Auto unit phase**, **direct phase dispatch**, and **guided flow** now pass `model`, optional `fallbackModel`, and `getProviderAuthMode` instead of hand-assembling those fields at each call site. Guided flow’s injectable readiness dependency is updated to the new helper.
> 
> Adds a characterization test that auth lookup uses the **selected model’s provider** when both model and fallback are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebea76f93b08a823d788ef8e4b7d140661aae039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->