### PR TITLE
fix(issue): migrateToFlatPhase() orphans legacy milestones/ artifact rows; doctor's stale-artifact repair direction is inverted — permanent unfixable artifact_file_missing errors

### DIFF
--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -678,6 +678,7 @@ export async function checkEngineHealth(
         for (const row of artifactRows) {
           const unitId = artifactUnitId(row);
           const issuePath = artifactPathRelativeToGsd(row.path);
+          if (artifactExistsOnDisk(basePath, row.path)) continue;
           if (options?.repair && staleArtifactRowFixable(basePath, row, artifactRows)) {
             // Route the write through the Single Writer owner (gsd-db.ts) instead
             // of issuing raw DELETE SQL here — doctor is a read-only consumer and

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -14,7 +14,15 @@ import {
 } from "./gsd-db.js";
 import { MEMORIES_FTS_REBUILT_KEY } from "./db-memory-fts-schema.js";
 import { isAfter, latestExplicitReopenAt } from "./milestone-reopen-events.js";
-import { gsdProjectionRoot, gsdRoot, resolveGsdPathContract, resolveMilestoneFile, resolveSliceFile } from "./paths.js";
+import {
+  buildTaskFileName,
+  gsdProjectionRoot,
+  gsdRoot,
+  resolveGsdPathContract,
+  resolveMilestoneFile,
+  resolveMilestonePath,
+  resolveSliceFile,
+} from "./paths.js";
 import { deriveState } from "./state.js";
 import { isClosedStatus } from "./status-guards.js";
 import { workflowEventLogPath } from "./workflow-event-ledger.js";
@@ -23,6 +31,7 @@ import { flushWorkflowProjections } from "./projection-flush.js";
 import { parseRoadmapSlices } from "./roadmap-slices.js";
 import { parsePlan } from "./parsers-legacy.js";
 import { parseSummary } from "./files.js";
+import { LAYOUT_SEGMENTS } from "./layout-policy.js";
 
 const USER_AUTHORED_ARTIFACT_TYPES = new Set(["CONTEXT", "RESEARCH"]);
 
@@ -160,11 +169,11 @@ function isClearedByMilestoneShellProjectionFlush(
   return issue.file === relativeFile(basePath, roadmapPath);
 }
 
-function artifactExistsOnDisk(basePath: string, artifactPath: string): boolean {
-  return resolveArtifactDiskPath(basePath, artifactPath) !== null;
+function artifactExistsOnDisk(basePath: string, artifactPath: string, row?: ArtifactRow): boolean {
+  return resolveArtifactDiskPath(basePath, artifactPath, row) !== null;
 }
 
-function resolveArtifactDiskPath(basePath: string, artifactPath: string): string | null {
+function resolveLiteralArtifactDiskPath(basePath: string, artifactPath: string): string | null {
   const relativeArtifactPath = artifactPathRelativeToGsd(artifactPath);
   if (isAbsolute(relativeArtifactPath)) {
     return existsSync(relativeArtifactPath) ? relativeArtifactPath : null;
@@ -174,6 +183,50 @@ function resolveArtifactDiskPath(basePath: string, artifactPath: string): string
     if (isPathInside(root, candidate) && existsSync(candidate)) return candidate;
   }
   return null;
+}
+
+function relativeToGsdRoot(basePath: string, diskPath: string): string | null {
+  for (const root of [gsdProjectionRoot(basePath), gsdRoot(basePath)]) {
+    if (!isPathInside(root, diskPath)) continue;
+    return relative(root, diskPath).split("\\").join("/");
+  }
+  return null;
+}
+
+function isFlatPhaseDiskPath(basePath: string, diskPath: string): boolean {
+  return relativeToGsdRoot(basePath, diskPath)?.startsWith(`${LAYOUT_SEGMENTS.level1}/`) ?? false;
+}
+
+function hasFlatPhaseLayout(basePath: string): boolean {
+  return existsSync(join(gsdProjectionRoot(basePath), LAYOUT_SEGMENTS.level1));
+}
+
+function resolveFlatPhaseArtifactDiskPath(basePath: string, row: ArtifactRow): string | null {
+  if (!hasFlatPhaseLayout(basePath)) return null;
+  if (!row.milestone_id) return null;
+  const artifactType = normalizedArtifactType(row.artifact_type);
+  if (!artifactType) return null;
+
+  if (row.slice_id && row.task_id) {
+    const phaseDir = resolveMilestonePath(basePath, row.milestone_id);
+    if (!phaseDir || !isFlatPhaseDiskPath(basePath, phaseDir)) return null;
+    const candidate = join(phaseDir, buildTaskFileName(row.task_id, artifactType));
+    return existsSync(candidate) ? candidate : null;
+  }
+
+  const candidate = row.slice_id
+    ? resolveSliceFile(basePath, row.milestone_id, row.slice_id, artifactType)
+    : resolveMilestoneFile(basePath, row.milestone_id, artifactType);
+
+  return candidate && isFlatPhaseDiskPath(basePath, candidate) ? candidate : null;
+}
+
+function resolveArtifactDiskPath(basePath: string, artifactPath: string, row?: ArtifactRow): string | null {
+  if (row && isMilestonesArtifactPath(row.path)) {
+    const flatPath = resolveFlatPhaseArtifactDiskPath(basePath, row);
+    if (flatPath) return flatPath;
+  }
+  return resolveLiteralArtifactDiskPath(basePath, artifactPath);
 }
 
 function taskExistsInPlan(basePath: string, milestoneId: string, sliceId: string, taskId: string): boolean {
@@ -228,7 +281,7 @@ function readTaskCompletionEvidenceFromSummary(
   if (!row.task_status && Number(row.task_count) > 0 && !taskExistsInPlan(basePath, row.milestone_id, row.slice_id, row.task_id)) {
     return null;
   }
-  const diskPath = resolveArtifactDiskPath(basePath, row.path);
+  const diskPath = resolveArtifactDiskPath(basePath, row.path, { ...row, artifact_type: "SUMMARY" });
   if (!diskPath) return null;
   try {
     const fullSummaryMd = readFileSync(diskPath, "utf-8");
@@ -262,6 +315,7 @@ function repairTaskArtifactDbStatusDivergence(
   basePath: string,
   row: {
     path: string;
+    artifact_type?: string;
     milestone_id: string;
     slice_id: string | null;
     task_id: string | null;
@@ -351,6 +405,49 @@ function hasPresentMilestonesReplacement(basePath: string, row: ArtifactRow, art
       sameArtifactIdentity(row, other) &&
       artifactExistsOnDisk(basePath, other.path),
   );
+}
+
+function hasPresentFlatPhaseReplacement(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {
+  if (resolveFlatPhaseArtifactDiskPath(basePath, row)) return true;
+
+  return artifactRows.some(
+    (other) =>
+      other.path !== row.path &&
+      !isMilestonesArtifactPath(other.path) &&
+      sameArtifactIdentity(row, other) &&
+      artifactExistsOnDisk(basePath, other.path, other),
+  );
+}
+
+function hasNoFlatPhaseFileEquivalent(row: ArtifactRow): boolean {
+  const artifactType = normalizedArtifactType(row.artifact_type);
+  if (row.slice_id && row.task_id) {
+    return artifactType === "PLAN" || artifactType === "SUMMARY";
+  }
+  return Boolean(row.slice_id && !row.task_id && artifactType === "SUMMARY");
+}
+
+function staleMilestonesArtifactRowFixable(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {
+  if (!isMilestonesArtifactPath(row.path)) return false;
+  if (!hasFlatPhaseLayout(basePath)) return false;
+  if (hasPresentFlatPhaseReplacement(basePath, row, artifactRows)) return true;
+  return hasNoFlatPhaseFileEquivalent(row) && !resolveLiteralArtifactDiskPath(basePath, row.path);
+}
+
+function stalePhasesArtifactRowFixable(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {
+  const issuePath = artifactPathRelativeToGsd(row.path);
+  return issuePath.startsWith(`${LAYOUT_SEGMENTS.level1}/`) && hasPresentMilestonesReplacement(basePath, row, artifactRows);
+}
+
+function staleArtifactRowFixable(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {
+  return staleMilestonesArtifactRowFixable(basePath, row, artifactRows) ||
+    stalePhasesArtifactRowFixable(basePath, row, artifactRows);
+}
+
+function staleArtifactPruneMessage(row: ArtifactRow): string {
+  return isMilestonesArtifactPath(row.path)
+    ? `pruned stale legacy artifact row ${row.path}`
+    : `pruned stale flat-phase artifact row ${row.path}`;
 }
 
 export async function checkEngineHealth(
@@ -579,17 +676,17 @@ export async function checkEngineHealth(
           .all() as ArtifactRow[];
 
         for (const row of artifactRows) {
-          if (artifactExistsOnDisk(basePath, row.path)) continue;
           const unitId = artifactUnitId(row);
           const issuePath = artifactPathRelativeToGsd(row.path);
-          if (options?.repair && issuePath.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows)) {
+          if (options?.repair && staleArtifactRowFixable(basePath, row, artifactRows)) {
             // Route the write through the Single Writer owner (gsd-db.ts) instead
             // of issuing raw DELETE SQL here — doctor is a read-only consumer and
             // the single-writer invariant forbids write SQL outside the allowlist.
             deleteArtifactByPath(row.path);
-            fixesApplied.push(`pruned stale flat-phase artifact row ${row.path}`);
+            fixesApplied.push(staleArtifactPruneMessage(row));
             continue;
           }
+          if (artifactExistsOnDisk(basePath, row.path, row)) continue;
           if (isUserAuthoredArtifactType(row.artifact_type)) {
             const artifactType = normalizedArtifactType(row.artifact_type);
             missingUserContentArtifacts.push({ path: issuePath, artifactType });
@@ -611,7 +708,7 @@ export async function checkEngineHealth(
             unitId,
             message: `Artifact ${issuePath} is recorded in the database as ${row.artifact_type || "UNKNOWN"} but no matching file exists on disk`,
             file: issuePath,
-            fixable: issuePath.startsWith("phases/") && hasPresentMilestonesReplacement(basePath, row, artifactRows),
+            fixable: staleArtifactRowFixable(basePath, row, artifactRows),
           });
         }
       } catch {
@@ -643,6 +740,7 @@ export async function checkEngineHealth(
           )
           .all() as Array<{
             path: string;
+            artifact_type: string;
             milestone_id: string;
             slice_id: string | null;
             task_id: string | null;
@@ -654,7 +752,7 @@ export async function checkEngineHealth(
 
         const seen = new Set<string>();
         for (const row of rows) {
-          if (!artifactExistsOnDisk(basePath, row.path)) continue;
+          if (!artifactExistsOnDisk(basePath, row.path, row)) continue;
           const reopenAt = latestExplicitReopenAt(basePath, row.milestone_id);
           if (!isAfter(row.imported_at, reopenAt)) continue;
           const isSliceSummary = row.slice_id && !row.task_id && row.slice_status && !["complete", "done", "skipped", "closed"].includes(row.slice_status);

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -6,7 +6,7 @@ import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSyn
 import { join } from "node:path";
 
 import { renderAllFromDb, renderRoadmapFromDb } from "./markdown-renderer.js";
-import { getAllMilestones, getMilestoneSlices } from "./gsd-db.js";
+import { deleteArtifactsByPathPrefix, getAllMilestones, getMilestoneSlices } from "./gsd-db.js";
 import { migrateFromMarkdown } from "./md-importer.js";
 import { countDbHierarchy } from "./migration-auto-check.js";
 import { logWarning } from "./workflow-logger.js";
@@ -195,7 +195,8 @@ export function pruneStaleFlatPhaseBackups(basePath: string): number {
  * 2. Rename .gsd/milestones/ aside so path resolvers target phases/
  * 3. Render flat-phase from the DB (which already has the data)
  * 4. Verify counts match
- * 5. Remove the renamed legacy tree
+ * 5. Prune legacy milestones/ artifact rows
+ * 6. Remove the renamed legacy tree
  *
  * Idempotent: if .gsd/milestones/ doesn't exist, returns immediately.
  */
@@ -313,7 +314,17 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
     throw new Error("flat-phase migration verification failed: no artifacts rendered");
   }
 
-  // 6. Verified — remove the renamed legacy tree (backup already on disk).
+  // 6. Verified — prune legacy artifact rows now that renderAllFromDb has
+  // re-inserted flat-phase rows for artifacts that still have files.
+  try {
+    deleteArtifactsByPathPrefix("milestones/");
+  } catch (err) {
+    logWarning("migration", `flat-phase migration could not prune legacy artifact rows: ${(err as Error).message}`);
+    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    throw err;
+  }
+
+  // 7. Remove the renamed legacy tree (backup already on disk).
   try {
     removePathWithRetries(migratingPath);
   } catch (err) {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1397,6 +1397,19 @@ export function deleteArtifactByPath(path: string): void {
   getDbOrNull()!.prepare("DELETE FROM artifacts WHERE path = :path").run({ ":path": path });
 }
 
+/** Delete artifact rows whose paths share a DB-relative prefix. */
+export function deleteArtifactsByPathPrefix(prefix: string): number {
+  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  return transaction(() => {
+    const likePrefix = `${prefix}%`;
+    const countRow = getDbOrNull()!.prepare(
+      "SELECT COUNT(*) AS count FROM artifacts WHERE path LIKE :prefix",
+    ).get({ ":prefix": likePrefix });
+    getDbOrNull()!.prepare("DELETE FROM artifacts WHERE path LIKE :prefix").run({ ":prefix": likePrefix });
+    return Number(countRow?.["count"] ?? 0);
+  });
+}
+
 /**
  * Drop hierarchy rows in dependency order inside a transaction. Used by
  * `gsd recover --confirm` to rebuild engine state from markdown.

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -540,6 +540,134 @@ test("checkEngineHealth marks escaped phases rows fixable when a milestones repl
   assert.equal(issue.fixable, true, "escaped phases rows with a milestones replacement must be marked fixable");
 });
 
+test("checkEngineHealth resolves legacy milestones rows through flat-phase files", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-flat-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const flatPath = "phases/01-foundation/01-01-PLAN.md";
+  const legacyPath = "milestones/M001/slices/S01/S01-PLAN.md";
+  mkdirSync(join(gsdDir, "phases", "01-foundation"), { recursive: true });
+  writeFileSync(join(gsdDir, flatPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: legacyPath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# legacy plan row\n",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === legacyPath),
+    false,
+    "legacy milestones rows should not be reported missing when the flat-phase file exists",
+  );
+});
+
+test("checkEngineHealth repair prunes stale milestones rows with present flat-phase files", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-stale-legacy-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const flatPath = "phases/01-foundation/01-01-PLAN.md";
+  const stalePath = "milestones/M001/slices/S01/S01-PLAN.md";
+  mkdirSync(join(gsdDir, "phases", "01-foundation"), { recursive: true });
+  writeFileSync(join(gsdDir, flatPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# stale plan row\n",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, { repair: true });
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === stalePath),
+    false,
+    "repair should not report stale legacy rows it pruned",
+  );
+  assert.ok(fixes.includes(`pruned stale legacy artifact row ${stalePath}`));
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), []);
+});
+
+test("checkEngineHealth marks stale milestones task rows without flat files fixable", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-fixable-stale-legacy-task-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const stalePath = "milestones/M001/slices/S01/tasks/T01-PLAN.md";
+  mkdirSync(join(gsdDir, "phases", "01-foundation"), { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    full_content: "# stale task plan row\n",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const issue = issues.find((candidate) => candidate.code === "artifact_file_missing" && candidate.file === stalePath);
+  assert.ok(issue, "missing stale legacy task row should still be reported when repair is off");
+  assert.equal(issue.fixable, true, "stale legacy task rows without flat files should be fixable");
+});
+
+test("checkEngineHealth repair prunes stale milestones task rows without flat files", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-stale-legacy-task-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const stalePath = "milestones/M001/slices/S01/tasks/T01-PLAN.md";
+  mkdirSync(join(gsdDir, "phases", "01-foundation"), { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    full_content: "# stale task plan row\n",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, { repair: true });
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === stalePath),
+    false,
+    "repair should prune stale legacy task rows that have no flat file representation",
+  );
+  assert.ok(fixes.includes(`pruned stale legacy artifact row ${stalePath}`));
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), []);
+});
+
 function taskSummary(id: string, verificationResult = "passed"): string {
   return [
     "---",

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -428,6 +428,52 @@ test("checkEngineHealth repair prunes stale phases artifact rows with present mi
   assert.deepEqual(rows.map((row) => row.path), []);
 });
 
+test("checkEngineHealth repair keeps phases rows whose own file is still present", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-keep-present-phase-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const livePath = "phases/01-m001/01-01-PLAN.md";
+  const replacementPath = "milestones/M001/slices/S01/S01-PLAN.md";
+  // Both the active phases/ file AND a legacy milestones/ copy exist on disk.
+  // The row is "fixable" (a milestones replacement is present), but its own
+  // file is present too — repair must not drop the live row.
+  mkdirSync(join(gsdDir, "phases", "01-m001"), { recursive: true });
+  writeFileSync(join(gsdDir, livePath), "# Plan\n", "utf-8");
+  mkdirSync(join(gsdDir, "milestones", "M001", "slices", "S01"), { recursive: true });
+  writeFileSync(join(gsdDir, replacementPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: livePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# plan\n",
+  });
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, { repair: true });
+
+  assert.equal(
+    fixes.some((fix) => fix.includes(livePath)),
+    false,
+    "repair must not prune a row whose own file is present on disk",
+  );
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === livePath),
+    false,
+    "a present artifact must not be reported missing",
+  );
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), [livePath]);
+});
+
 test("checkEngineHealth repair prunes stale phases task rows against tasks/<T>-<TYPE>.md replacements", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-stale-task-phase-artifact-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -13,7 +13,7 @@ import {
   needsFlatPhaseMigration,
   pruneStaleFlatPhaseBackups,
 } from "../flat-phase-migration.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertArtifact, insertMilestone, insertSlice, insertTask, getAllMilestones, getMilestoneSlices, getSliceTasks, _getAdapter } from "../gsd-db.ts";
 
 const tmpDirs: string[] = [];
 function makeTmp(options: { withTask?: boolean } = {}): string {
@@ -118,6 +118,49 @@ test("migrateToFlatPhase preserves milestone/slice/task counts in DB", async () 
   assert.equal(getAllMilestones().length, msBefore);
   assert.equal(getMilestoneSlices("M001").length, slicesBefore);
   assert.equal(getSliceTasks("M001", "S01").length, tasksBefore);
+});
+
+test("migrateToFlatPhase prunes legacy milestones artifact rows after flat render", async () => {
+  const base = makeTmp();
+  insertArtifact({
+    path: "milestones/M001/M001-ROADMAP.md",
+    artifact_type: "ROADMAP",
+    milestone_id: "M001",
+    slice_id: null,
+    task_id: null,
+    full_content: "# M001: Foundation\n",
+  });
+  insertArtifact({
+    path: "milestones/M001/slices/S01/S01-PLAN.md",
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# Plan\n",
+  });
+  insertArtifact({
+    path: "milestones/M001/slices/S01/tasks/T01-PLAN.md",
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    full_content: "# Task Plan\n",
+  });
+
+  await migrateToFlatPhase(base);
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.equal(
+    rows.some((row) => row.path.startsWith("milestones/")),
+    false,
+    "legacy milestones/ artifact rows should be pruned after successful flat migration",
+  );
+  assert.ok(
+    rows.some((row) => row.path.startsWith("phases/")),
+    "flat-phase render should leave replacement projection rows in the artifacts table",
+  );
 });
 
 test("migrateToFlatPhase is idempotent (second run is a no-op)", async () => {


### PR DESCRIPTION
## Summary
- Fixed flat-phase artifact row cleanup and doctor stale-artifact repair/resolution, with syntax and diff checks passing while full tests were blocked by missing dependencies.

## Bugs Addressed
- [x] **Flat-phase migration leaves legacy artifact rows orphaned**
- [x] **Doctor stale-artifact repair uses the wrong layout direction**
- [x] **Doctor artifact path resolution ignores flat-phase fallbacks**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1185
- [#1185 migrateToFlatPhase() orphans legacy milestones/ artifact rows; doctor's stale-artifact repair direction is inverted — permanent unfixable artifact_file_missing errors](https://github.com/open-gsd/gsd-pi/issues/1185)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1185-migratetoflatphase-orphans-legacy-milest-1783049123`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact table deletes during migration and doctor repair, which affects DB/disk consistency for projects mid-layout migration; behavior is heavily test-covered but mistakes could drop or mis-report artifact rows.
> 
> **Overview**
> Fixes **flat-phase migration** leaving `milestones/` rows in `artifacts` after disk moves to `phases/`, and **doctor** treating layout mismatches only one way (pruning `phases/` when a legacy file existed) while still flagging legacy paths as missing even when the flat file is present.
> 
> **Migration:** After a verified `renderAllFromDb`, `migrateToFlatPhase` calls new `deleteArtifactsByPathPrefix("milestones/")` (transactional delete in `gsd-db`). Failure rolls back the migration like other post-verify steps.
> 
> **Doctor:** Artifact existence resolution is **row-aware**. Legacy `milestones/` DB paths can satisfy checks via computed flat-phase paths (`resolveFlatPhaseArtifactDiskPath`); SUMMARY-based repair uses the same logic. Stale-row repair is **bidirectional** via `staleArtifactRowFixable` (prune legacy rows when flat replacements exist—or no flat equivalent—and prune stale `phases/` rows when legacy replacements exist). Repair still skips rows whose literal path is on disk, so live `phases/` rows are not dropped when both layouts exist.
> 
> Tests cover migration pruning, flat fallback for legacy rows, legacy pruning, fixable legacy task rows without flat files, and keeping present phase artifact rows during repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2fdeaa7d6a3dbc9e3a001b2f14cf3bdca49028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->