### PR TITLE
fix(issue): open-gsd-hermes plugin /gsd auto times out — GSD_CLI_PATH=gsd resolves to non-existent project-relative path

### DIFF
--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import threading
 import time
@@ -62,7 +63,12 @@ class GsdMcpClient:
 
     def _env(self) -> dict[str, str]:
         env = os.environ.copy()
-        env["GSD_CLI_PATH"] = self._config.cli_path
+        # Resolve cli_path to an absolute path so the MCP server's
+        # resolveCLIPath() does not resolve a bare command name (e.g. "gsd")
+        # against the project directory, producing a non-existent
+        # project-relative path that hangs gsd_execute until timeout.
+        resolved = shutil.which(self._config.cli_path) or self._config.cli_path
+        env["GSD_CLI_PATH"] = resolved
         return env
 
     def ensure_version(self) -> None:


### PR DESCRIPTION
## Summary
- Resolved `cli_path` to an absolute path via `shutil.which` in the Hermes plugin's `_env()` so `GSD_CLI_PATH` no longer becomes a non-existent project-relative path; verified with the full plugin test suite (92 passed).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1191
- [#1191 open-gsd-hermes plugin /gsd auto times out — GSD_CLI_PATH=gsd resolves to non-existent project-relative path](https://github.com/open-gsd/gsd-pi/issues/1191)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1191-open-gsd-hermes-plugin-gsd-auto-times-ou-1783081857`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized env wiring change with no auth or data-model impact; worst case is a wrong CLI path if `which` and config disagree.
> 
> **Overview**
> Fixes **`/gsd auto` timeouts** in the open-gsd-hermes plugin when `cli_path` is a bare command name like `gsd`.
> 
> In `GsdMcpClient._env()`, **`GSD_CLI_PATH` is now set to `shutil.which(cli_path)`** (falling back to the configured value if lookup fails) instead of passing the raw string. That stops the MCP server’s `resolveCLIPath()` from treating `gsd` as a path under the project directory, which pointed at a non-existent binary and left **`gsd_execute` hanging until timeout**.
> 
> Only **`integrations/hermes/open_gsd_hermes/gsd_client.py`** changes: adds `shutil` and updates `_env()`; every subprocess that uses `_env()` (MCP sidecar, progress CLI, milestone headless) gets the same fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f6cbb81b10ed054f9859438d6ce9a6ad1f19c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->