### PR TITLE
fix(issue): bug: renderAssessmentFromDb writes to slices/SID/ for flat-phase milestones, causing reassess-roadmap verification to fail

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -1299,9 +1299,21 @@ export async function renderAssessmentFromDb(
   sliceId: string,
   assessmentData: AssessmentData,
 ): Promise<{ assessmentPath: string; content: string }> {
-  // Flat-phase: assessment file lives in the phase dir
-  const slicePath = resolveSlicePath(basePath, milestoneId, sliceId)
-    ?? join(milestonesDir(basePath), canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title));
+  // Flat-phase: the assessment file lives in the phase dir, NOT in a slices/SID/
+  // subdir. resolveSlicePath() detects a slices/SID/ dir unconditionally, so a
+  // stray slices/SID/ created by an earlier planning step would send this write
+  // to a hybrid path (wrong dir, flat filename) that verification cannot find.
+  // Guard with the same legacy-base check relSlicePath() uses so flat-phase
+  // milestones always target the phase dir.
+  const mDir = resolveMilestonePath(basePath, milestoneId);
+  const legacyBase = legacyMilestonesDir(basePath);
+  const isLegacyLayout = mDir
+    ? mDir.startsWith(legacyBase + "/") || mDir.startsWith(legacyBase + "\\")
+    : false;
+  const fallbackDir = join(milestonesDir(basePath), canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title));
+  const slicePath = isLegacyLayout
+    ? (resolveSlicePath(basePath, milestoneId, sliceId) ?? fallbackDir)
+    : (mDir ?? fallbackDir);
   const phaseNum = milestoneIdToPhaseNum(milestoneId);
   const planNum = sliceIdToPlanNum(sliceId);
   const absPath = join(slicePath, planFileName(phaseNum, planNum, "ASSESSMENT"));

--- a/src/resources/extensions/gsd/tests/flat-phase-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-renderer.test.ts
@@ -7,7 +7,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { renderPlanFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
+import { renderPlanFromDb, renderRoadmapFromDb, renderAssessmentFromDb } from "../markdown-renderer.ts";
+import { clearPathCache } from "../paths.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
 
 const tmpDirs: string[] = [];
@@ -80,4 +81,27 @@ test("renderPlanFromDb does NOT write per-task plan files", async () => {
   const result = await renderPlanFromDb(base, "M001", "S01");
   // taskPlanPaths should be empty — no per-task files written
   assert.equal(result.taskPlanPaths.length, 0);
+});
+
+// Regression for #1190: a stray slices/SID/ subdir inside a flat-phase milestone
+// must not divert the ASSESSMENT write into slices/SID/ (a hybrid path that
+// auto-mode verification cannot find). It must land at the phase root.
+test("renderAssessmentFromDb writes to the phase root even when a stray slices/SID/ dir exists", async () => {
+  const base = makeTmp();
+  const plan = await renderPlanFromDb(base, "M001", "S01");
+  const phaseDir = plan.planPath.slice(0, plan.planPath.lastIndexOf("01-01-PLAN.md"));
+
+  // Simulate the anomaly: an earlier planning step created slices/S01/ inside
+  // the flat-phase dir.
+  mkdirSync(join(phaseDir, "slices", "S01"), { recursive: true });
+  clearPathCache();
+
+  const result = await renderAssessmentFromDb(base, "M001", "S01", {
+    verdict: "on-track",
+    assessment: "Roadmap is on track.",
+  });
+
+  assert.match(result.assessmentPath, /phases[/\\]01-[^/\\]+[/\\]01-01-ASSESSMENT\.md$/);
+  assert.ok(!result.assessmentPath.includes(join("slices", "S01")), "must not write under slices/S01/");
+  assert.ok(existsSync(result.assessmentPath), "assessment file should exist at the phase root");
 });


### PR DESCRIPTION
## Summary
- Guarded `renderAssessmentFromDb` with the flat-phase/legacy check so ASSESSMENT files write to the phase root instead of a stray `slices/SID/` subdir; verified with a new regression test that fails without the fix.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1190
- [#1190 bug: renderAssessmentFromDb writes to slices/SID/ for flat-phase milestones, causing reassess-roadmap verification to fail](https://github.com/open-gsd/gsd-pi/issues/1190)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1190-bug-renderassessmentfromdb-writes-to-sli-1783081849`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted path-resolution fix in markdown projection plus a test; no auth or data-model changes.
> 
> **Overview**
> **`renderAssessmentFromDb`** no longer picks the output directory only via **`resolveSlicePath`**, which treated any existing **`slices/SID/`** folder as legacy layout. For **flat-phase** milestones, ASSESSMENT markdown now goes to the **phase directory** (same legacy-base guard as **`relSlicePath`**); legacy milestones still use **`slices/SID/`** when present.
> 
> Adds a **regression test** (#1190) that creates a stray **`slices/S01/`** under a flat-phase phase dir and asserts **`01-01-ASSESSMENT.md`** is written at the phase root so **reassess-roadmap** verification can find it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0949c2b3b82eca26c373d3995215acdb98b5e2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->