### PR TITLE
fix(issue): [Bug]: GSD system prompt still injects legacy `.gsd/milestones/.../tasks/T##-PLAN.md` layout after flat-phase migration

### DIFF
--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -38,7 +38,7 @@ If a `GSD Skill Preferences` block appears below, treat it as durable guidance f
 
 ### Naming Convention
 
-Directories use bare IDs. Files use ID-SUFFIX format. Milestones: `M001/` or `M{seq}-{rand6}/` when `unique_milestone_ids: true`; files like `M001-CONTEXT.md`, `M001-ROADMAP.md`, `M001-RESEARCH.md`. Slices: `S01/` with `S01-PLAN.md`, `S01-RESEARCH.md`, `S01-SUMMARY.md`, `S01-UAT.md`. Tasks: `T01-PLAN.md`, `T01-SUMMARY.md`. Titles live inside content, not names.
+GSD projects use a flat-phase layout. Phase directories are `{MM}-{slug}` where `{MM}` is the zero-padded phase number and `{slug}` is derived from the phase title (e.g. `47-real-time-runtime-hardening`). Phase-level files are `{MM}-SUFFIX.md` (e.g. `47-CONTEXT.md`, `47-RESEARCH.md`, `47-ROADMAP.md`, `47-VALIDATION.md`, `47-SUMMARY.md`). Slice/plan files live directly in the phase directory as `{MM}-{SS}-SUFFIX.md` (e.g. `47-01-PLAN.md`, `47-01-SUMMARY.md`, `47-01-UAT.md`). Task plan content lives inside the slice plan file (`{MM}-{SS}-PLAN.md`) as checkboxes; there is no `tasks/` subdirectory and no `tasks/T##-PLAN.md`. Titles live inside content, not names. Prefer GSD-provided layout-aware paths/resolvers over hardcoding artifact paths, since phase slugs are title-derived.
 
 ### Directory Structure
 
@@ -46,12 +46,12 @@ Directories use bare IDs. Files use ID-SUFFIX format. Milestones: `M001/` or `M{
 .gsd/
   PROJECT.md, REQUIREMENTS.md, DECISIONS.md, KNOWLEDGE.md, CODEBASE.md, OVERRIDES.md, QUEUE.md, STATE.md
   runtime/, activity/, worktrees/
-  milestones/M001/
-    M001-CONTEXT.md, M001-RESEARCH.md, M001-ROADMAP.md, M001-SUMMARY.md
-    slices/S01/
-      S01-CONTEXT.md, S01-RESEARCH.md, S01-PLAN.md, S01-SUMMARY.md, S01-UAT.md
-      tasks/T01-PLAN.md, tasks/T01-SUMMARY.md
+  phases/{MM}-{slug}/
+    {MM}-CONTEXT.md, {MM}-RESEARCH.md, {MM}-ROADMAP.md, {MM}-VALIDATION.md, {MM}-SUMMARY.md
+    {MM}-{SS}-PLAN.md, {MM}-{SS}-SUMMARY.md, {MM}-{SS}-UAT.md
 ```
+
+Task plan content is embedded in `{MM}-{SS}-PLAN.md`; do not expect `tasks/T##-PLAN.md`.
 
 `runtime/`, `activity/`, `worktrees/`, and `STATE.md` are system-managed. `PROJECT.md` is current state; `REQUIREMENTS.md` is the active capability contract; `DECISIONS.md` and `KNOWLEDGE.md` are append-only; `CODEBASE.md` is an auto-refreshed codebase map.
 

--- a/src/resources/extensions/gsd/tests/system-flat-phase-layout.test.ts
+++ b/src/resources/extensions/gsd/tests/system-flat-phase-layout.test.ts
@@ -1,0 +1,33 @@
+// gsd-pi — Regression tests: system.md documents the flat-phase layout, not legacy milestone/slice/task paths
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const promptsDir = join(process.cwd(), "src/resources/extensions/gsd/prompts");
+
+function readPrompt(name: string): string {
+  return readFileSync(join(promptsDir, `${name}.md`), "utf-8");
+}
+
+test("system.md does not advertise legacy milestone/slice/task artifact paths", () => {
+  const prompt = readPrompt("system");
+  for (const legacy of [".gsd/milestones", "milestones/M001", "slices/S01", "tasks/T01-PLAN.md"]) {
+    assert.ok(
+      !prompt.includes(legacy),
+      `system.md must not reference the legacy path fragment "${legacy}" after flat-phase migration`,
+    );
+  }
+});
+
+test("system.md documents the flat-phase directory structure", () => {
+  const prompt = readPrompt("system");
+  assert.match(prompt, /phases\/\{MM\}-\{slug\}/, "system.md must document phases/{MM}-{slug}/ directories");
+  assert.match(prompt, /\{MM\}-\{SS\}-PLAN\.md/, "system.md must document {MM}-{SS}-PLAN.md slice plans");
+  assert.match(
+    prompt,
+    /do not expect `tasks\/T##-PLAN\.md`/,
+    "system.md must state task plan content lives inside the slice plan, not tasks/T##-PLAN.md",
+  );
+});


### PR DESCRIPTION
## Summary
- Rewrote system.md's Naming Convention and Directory Structure to the flat-phase layout (removing legacy milestone/slice/task paths) and added a passing regression test asserting the legacy fragments are gone.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1194
- [#1194 [Bug]: GSD system prompt still injects legacy `.gsd/milestones/.../tasks/T##-PLAN.md` layout after flat-phase migration](https://github.com/open-gsd/gsd-pi/issues/1194)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1194-bug-gsd-system-prompt-still-injects-lega-1783091748`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and prompt regression tests only; no runtime or artifact resolver behavior changes.
> 
> **Overview**
> Updates **`system.md`** so GSD agents are told the **flat-phase** layout instead of the old **`.gsd/milestones/.../slices/.../tasks/T##-PLAN.md`** tree.
> 
> **Naming Convention** and **Directory Structure** now describe `phases/{MM}-{slug}/`, phase files like `{MM}-CONTEXT.md`, and slice artifacts as `{MM}-{SS}-PLAN.md` (with task checkboxes inside the slice plan). Legacy milestone/slice/task path examples are removed, with an explicit note that **`tasks/T##-PLAN.md`** should not be expected.
> 
> Adds **`system-flat-phase-layout.test.ts`** to block reintroduction of legacy path fragments and to assert the new flat-phase documentation is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33962c7d9b86d4e7e3b4284018ca00c3aed5f6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->