### PR TITLE
refactor(gsd): centralize db state derivation construction

### DIFF
--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: DB-backed GSD state derivation pipeline stage.
 
-import type { ActiveRef, GSDState, MilestoneRegistryEntry } from '../../types.js';
+import type { ActiveRef, GSDState, MilestoneRegistryEntry, Phase } from '../../types.js';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import { isClosedStatus, isDeferredStatus } from '../../status-guards.js';
@@ -40,6 +40,57 @@ import {
 } from './db-open.js';
 
 const isStatusDone = isClosedStatus;
+
+type MilestoneProgress = { done: number; total: number };
+type SliceProgress = { done: number; total: number };
+type TaskProgress = { done: number; total: number };
+
+interface DerivedStateContext {
+  activeMilestone: ActiveRef | null;
+  activeSlice?: ActiveRef | null;
+  activeTask?: ActiveRef | null;
+  registry: MilestoneRegistryEntry[];
+  requirements: GSDState["requirements"];
+  milestoneProgress: MilestoneProgress;
+  sliceProgress?: SliceProgress;
+  taskProgress?: TaskProgress;
+}
+
+interface DerivedStateOptions {
+  blockers?: string[];
+  lastCompletedMilestone?: ActiveRef | null;
+}
+
+function buildProgress(context: DerivedStateContext): NonNullable<GSDState["progress"]> {
+  return {
+    milestones: context.milestoneProgress,
+    ...(context.sliceProgress ? { slices: context.sliceProgress } : {}),
+    ...(context.taskProgress ? { tasks: context.taskProgress } : {}),
+  };
+}
+
+function buildDerivedState(
+  context: DerivedStateContext,
+  phase: Phase,
+  nextAction: string,
+  options: DerivedStateOptions = {},
+): GSDState {
+  return {
+    activeMilestone: context.activeMilestone,
+    activeSlice: context.activeSlice ?? null,
+    activeTask: context.activeTask ?? null,
+    phase,
+    recentDecisions: [],
+    blockers: options.blockers ?? [],
+    nextAction,
+    ...(options.lastCompletedMilestone !== undefined
+      ? { lastCompletedMilestone: options.lastCompletedMilestone }
+      : {}),
+    registry: context.registry,
+    requirements: context.requirements,
+    progress: buildProgress(context),
+  };
+}
 
 function stripMilestonePrefix(title: string): string {
   return title.replace(/^M\d+(?:-[a-z0-9]{6})?[^:]*:\s*/, '') || title;
@@ -182,58 +233,47 @@ function handleNoActiveMilestone(
   const pendingEntries = registry.filter(e => e.status === 'pending');
   const parkedEntries = registry.filter(e => e.status === 'parked');
 
+  const context: DerivedStateContext = {
+    activeMilestone: null,
+    registry,
+    requirements,
+    milestoneProgress,
+  };
+
   if (pendingEntries.length > 0) {
     const blockerDetails = pendingEntries
       .filter(e => e.dependsOn && e.dependsOn.length > 0)
       .map(e => `${e.id} is waiting on unmet deps: ${e.dependsOn!.join(', ')}`);
-    return {
-      activeMilestone: null, activeSlice: null, activeTask: null,
-      phase: 'blocked',
-      recentDecisions: [], blockers: blockerDetails.length > 0
+    return buildDerivedState(context, 'blocked', 'Resolve milestone dependencies before proceeding.', {
+      blockers: blockerDetails.length > 0
         ? blockerDetails
         : ['All remaining milestones are dep-blocked but no deps listed — check CONTEXT.md files'],
-      nextAction: 'Resolve milestone dependencies before proceeding.',
-      registry, requirements,
-      progress: { milestones: milestoneProgress },
-    };
+    });
   }
 
   if (parkedEntries.length > 0) {
     const parkedIds = parkedEntries.map(e => e.id).join(', ');
-    return {
-      activeMilestone: null, activeSlice: null, activeTask: null,
-      phase: 'pre-planning',
-      recentDecisions: [], blockers: [],
-      nextAction: `All remaining milestones are parked (${parkedIds}). Run /gsd unpark <id> or create a new milestone.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress },
-    };
+    return buildDerivedState(
+      context,
+      'pre-planning',
+      `All remaining milestones are parked (${parkedIds}). Run /gsd unpark <id> or create a new milestone.`,
+    );
   }
 
   if (registry.length === 0) {
-    return {
-      activeMilestone: null, activeSlice: null, activeTask: null,
-      phase: 'pre-planning',
-      recentDecisions: [], blockers: [],
-      nextAction: 'No milestones found. Run /gsd to create one.',
-      registry: [], requirements,
-      progress: { milestones: { done: 0, total: 0 } },
-    };
+    return buildDerivedState(
+      { ...context, registry: [], milestoneProgress: { done: 0, total: 0 } },
+      'pre-planning',
+      'No milestones found. Run /gsd to create one.',
+    );
   }
 
   const lastEntry = registry[registry.length - 1];
   const unmappedActive = countUnmappedActiveRequirements();
   const completionNote = formatCompletePhaseNextAction(unmappedActive);
-  return {
-    activeMilestone: null,
+  return buildDerivedState(context, 'complete', completionNote, {
     lastCompletedMilestone: lastEntry ? { id: lastEntry.id, title: lastEntry.title } : null,
-    activeSlice: null, activeTask: null,
-    phase: 'complete',
-    recentDecisions: [], blockers: [],
-    nextAction: completionNote,
-    registry, requirements,
-    progress: { milestones: milestoneProgress },
-  };
+  });
 }
 
 async function handleAllSlicesDone(
@@ -248,52 +288,48 @@ async function handleAllSlicesDone(
   const verdict = typeof validation?.status === "string" ? validation.status : undefined;
   const validationTerminal = verdict != null && verdict !== "";
 
+  const context: DerivedStateContext = {
+    activeMilestone,
+    registry,
+    requirements,
+    milestoneProgress,
+    sliceProgress,
+  };
+
   if (!validationTerminal) {
-    return {
-      activeMilestone, activeSlice: null, activeTask: null,
-      phase: 'validating-milestone',
-      recentDecisions: [], blockers: [],
-      nextAction: `Validate milestone ${activeMilestone.id} before completion.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress },
-    };
+    return buildDerivedState(
+      context,
+      'validating-milestone',
+      `Validate milestone ${activeMilestone.id} before completion.`,
+    );
   }
 
   // All roadmap slices are done (enforced by caller) and verdict is
   // needs-remediation — remediation cannot progress without new slices.
   // Return blocked instead of re-dispatching validate-milestone (#4506).
   if (verdict === 'needs-attention') {
-    return {
-      activeMilestone, activeSlice: null, activeTask: null,
-      phase: 'blocked',
-      recentDecisions: [],
-      blockers: [formatNeedsAttentionBlocker(activeMilestone.id)],
-      nextAction: `Resolve ${activeMilestone.id} validation attention before proceeding.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress },
-    };
+    return buildDerivedState(
+      context,
+      'blocked',
+      `Resolve ${activeMilestone.id} validation attention before proceeding.`,
+      { blockers: [formatNeedsAttentionBlocker(activeMilestone.id)] },
+    );
   }
 
   if (verdict === 'needs-remediation') {
-    return {
-      activeMilestone, activeSlice: null, activeTask: null,
-      phase: 'blocked',
-      recentDecisions: [],
-      blockers: [formatNeedsRemediationBlocker(activeMilestone.id)],
-      nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress },
-    };
+    return buildDerivedState(
+      context,
+      'blocked',
+      `Resolve ${activeMilestone.id} remediation before proceeding.`,
+      { blockers: [formatNeedsRemediationBlocker(activeMilestone.id)] },
+    );
   }
 
-  return {
-    activeMilestone, activeSlice: null, activeTask: null,
-    phase: 'completing-milestone',
-    recentDecisions: [], blockers: [],
-    nextAction: `All slices complete in ${activeMilestone.id}. Write milestone summary.`,
-    registry, requirements,
-    progress: { milestones: milestoneProgress, slices: sliceProgress },
-  };
+  return buildDerivedState(
+    context,
+    'completing-milestone',
+    `All slices complete in ${activeMilestone.id}. Write milestone summary.`,
+  );
 }
 
 function resolveSliceDependencies(activeMilestoneSlices: SliceRow[]): { activeSlice: ActiveRef | null, activeSliceRow: SliceRow | null } {

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -59,6 +59,7 @@ interface DerivedStateContext {
 interface DerivedStateOptions {
   blockers?: string[];
   lastCompletedMilestone?: ActiveRef | null;
+  includeActiveWorkspace?: boolean;
 }
 
 function buildProgress(context: DerivedStateContext): NonNullable<GSDState["progress"]> {
@@ -86,6 +87,7 @@ function buildDerivedState(
     ...(options.lastCompletedMilestone !== undefined
       ? { lastCompletedMilestone: options.lastCompletedMilestone }
       : {}),
+    ...(options.includeActiveWorkspace ? { activeWorkspace: undefined } : {}),
     registry: context.registry,
     requirements: context.requirements,
     progress: buildProgress(context),
@@ -392,13 +394,16 @@ export async function deriveStateFromDb(
     : allMilestones;
 
   if (milestones.length === 0) {
-    return {
-      activeMilestone: null, activeSlice: null, activeTask: null,
-      phase: 'pre-planning', recentDecisions: [], blockers: [],
-      nextAction: 'No milestones found. Run /gsd to create one.',
-      registry: [], requirements,
-      progress: { milestones: { done: 0, total: 0 } },
-    };
+    return buildDerivedState(
+      {
+        activeMilestone: null,
+        registry: [],
+        requirements,
+        milestoneProgress: { done: 0, total: 0 },
+      },
+      'pre-planning',
+      'No milestones found. Run /gsd to create one.',
+    );
   }
 
   const { completeMilestoneIds, parkedMilestoneIds } = buildCompletenessSet(basePath, milestones);
@@ -420,18 +425,24 @@ export async function deriveStateFromDb(
     const nextAction = activeMilestoneHasDraft
       ? `Discuss draft context for milestone ${activeMilestone.id}.`
       : `Plan milestone ${activeMilestone.id}.`;
-    return {
-      activeMilestone, activeSlice: null, activeTask: null,
-      phase, recentDecisions: [], blockers: [],
-      nextAction, registry, requirements,
-      progress: { milestones: milestoneProgress },
-    };
+    return buildDerivedState(
+      { activeMilestone, registry, requirements, milestoneProgress },
+      phase,
+      nextAction,
+    );
   }
 
   const allSlicesDone = activeMilestoneSlices.every(s => isStatusDone(s.status));
   const sliceProgress = {
     done: activeMilestoneSlices.filter(s => isStatusDone(s.status)).length,
     total: activeMilestoneSlices.length,
+  };
+  const sliceStateContext: DerivedStateContext = {
+    activeMilestone,
+    registry,
+    requirements,
+    milestoneProgress,
+    sliceProgress,
   };
 
   if (allSlicesDone) {
@@ -443,21 +454,19 @@ export async function deriveStateFromDb(
     // If locked slice wasn't found, it returns null but logs warning, we need to return 'blocked'
     const sliceLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_SLICE_LOCK : undefined;
     if (sliceLock) {
-      return {
-        activeMilestone, activeSlice: null, activeTask: null,
-        phase: 'blocked', recentDecisions: [], blockers: [`GSD_SLICE_LOCK=${sliceLock} not found in active milestone slices`],
-        nextAction: 'Slice lock references a non-existent slice — check orchestrator dispatch.',
-        registry, requirements,
-        progress: { milestones: milestoneProgress, slices: sliceProgress },
-      };
+      return buildDerivedState(
+        sliceStateContext,
+        'blocked',
+        'Slice lock references a non-existent slice — check orchestrator dispatch.',
+        { blockers: [`GSD_SLICE_LOCK=${sliceLock} not found in active milestone slices`] },
+      );
     }
-    return {
-      activeMilestone, activeSlice: null, activeTask: null,
-      phase: 'blocked', recentDecisions: [], blockers: ['No slice eligible — check dependency ordering'],
-      nextAction: 'Resolve dependency blockers or plan next slice.',
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress },
-    };
+    return buildDerivedState(
+      sliceStateContext,
+      'blocked',
+      'Resolve dependency blockers or plan next slice.',
+      { blockers: ['No slice eligible — check dependency ordering'] },
+    );
   }
   const { activeSlice } = activeSliceContext;
   const activeSliceRow = activeSliceContext.activeSliceRow;
@@ -468,13 +477,11 @@ export async function deriveStateFromDb(
   // PLAN.md and preference flags are projections/configuration and are
   // deliberately not used to infer whether the slice itself is a sketch.
   if (activeSliceRow?.is_sketch === 1) {
-    return {
-      activeMilestone, activeSlice, activeTask: null,
-      phase: 'refining', recentDecisions: [], blockers: [],
-      nextAction: `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress },
-    };
+    return buildDerivedState(
+      { ...sliceStateContext, activeSlice },
+      'refining',
+      `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
+    );
   }
 
   const tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
@@ -483,30 +490,35 @@ export async function deriveStateFromDb(
     done: tasks.filter(t => isStatusDone(t.status)).length,
     total: tasks.length,
   };
+  const taskStateContext: DerivedStateContext = {
+    ...sliceStateContext,
+    activeSlice,
+    taskProgress,
+  };
 
   const activeTaskRow = tasks.find(t => !isStatusDone(t.status));
 
   if (!activeTaskRow && tasks.length > 0) {
-    return {
-      activeMilestone, activeSlice, activeTask: null,
-      phase: 'summarizing', recentDecisions: [], blockers: [],
-      nextAction: `All tasks done in ${activeSlice.id}. Write slice summary and complete slice.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-    };
+    return buildDerivedState(
+      taskStateContext,
+      'summarizing',
+      `All tasks done in ${activeSlice.id}. Write slice summary and complete slice.`,
+    );
   }
 
   if (!activeTaskRow) {
-    return {
-      activeMilestone, activeSlice, activeTask: null,
-      phase: 'planning', recentDecisions: [], blockers: [],
-      nextAction: `Slice ${activeSlice.id} has no DB tasks. Plan slice tasks before execution.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-    };
+    return buildDerivedState(
+      taskStateContext,
+      'planning',
+      `Slice ${activeSlice.id} has no DB tasks. Plan slice tasks before execution.`,
+    );
   }
 
   const activeTask: ActiveRef = { id: activeTaskRow.id, title: activeTaskRow.title };
+  const activeTaskStateContext: DerivedStateContext = {
+    ...taskStateContext,
+    activeTask,
+  };
 
   // ── Quality gate evaluation check ──────────────────────────────────
   // Pause before execution only when gates owned by the `gate-evaluate`
@@ -521,28 +533,26 @@ export async function deriveStateFromDb(
     "gate-evaluate",
   );
   if (pendingGateCount > 0) {
-    return {
-      activeMilestone, activeSlice, activeTask: null,
-      phase: 'evaluating-gates', recentDecisions: [], blockers: [],
-      nextAction: `Evaluate ${pendingGateCount} quality gate(s) for ${activeSlice.id} before execution.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-    };
+    return buildDerivedState(
+      taskStateContext,
+      'evaluating-gates',
+      `Evaluate ${pendingGateCount} quality gate(s) for ${activeSlice.id} before execution.`,
+    );
   }
 
   const blockerTaskId = await detectBlockers(basePath, activeMilestone.id, activeSlice.id, tasks);
   if (blockerTaskId) {
     const replanHistory = getReplanHistory(activeMilestone.id, activeSlice.id);
     if (replanHistory.length === 0) {
-      return {
-        activeMilestone, activeSlice, activeTask,
-        phase: 'replanning-slice', recentDecisions: [],
-        blockers: [`Task ${blockerTaskId} discovered a blocker requiring slice replan`],
-        nextAction: `Task ${blockerTaskId} reported blocker_discovered. Replan slice ${activeSlice.id} before continuing.`,
-        activeWorkspace: undefined,
-        registry, requirements,
-        progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-      };
+      return buildDerivedState(
+        activeTaskStateContext,
+        'replanning-slice',
+        `Task ${blockerTaskId} reported blocker_discovered. Replan slice ${activeSlice.id} before continuing.`,
+        {
+          blockers: [`Task ${blockerTaskId} discovered a blocker requiring slice replan`],
+          includeActiveWorkspace: true,
+        },
+      );
     }
   }
 
@@ -558,15 +568,15 @@ export async function deriveStateFromDb(
   // and the user's prior resolution never lands.
   const escalatingTaskId = detectPendingEscalation(tasks, basePath);
   if (escalatingTaskId) {
-    return {
-      activeMilestone, activeSlice, activeTask,
-      phase: 'escalating-task', recentDecisions: [],
-      blockers: [`Task ${escalatingTaskId} requires a user decision before the loop can proceed`],
-      nextAction: `Run /gsd escalate show ${escalatingTaskId} to review, then /gsd escalate resolve ${escalatingTaskId} <choice> to proceed.`,
-      activeWorkspace: undefined,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-    };
+    return buildDerivedState(
+      activeTaskStateContext,
+      'escalating-task',
+      `Run /gsd escalate show ${escalatingTaskId} to review, then /gsd escalate resolve ${escalatingTaskId} <choice> to proceed.`,
+      {
+        blockers: [`Task ${escalatingTaskId} requires a user decision before the loop can proceed`],
+        includeActiveWorkspace: true,
+      },
+    );
   }
 
   if (!blockerTaskId) {
@@ -574,24 +584,22 @@ export async function deriveStateFromDb(
     if (isTriggered) {
       const replanHistory = getReplanHistory(activeMilestone.id, activeSlice.id);
       if (replanHistory.length === 0) {
-        return {
-          activeMilestone, activeSlice, activeTask,
-          phase: 'replanning-slice', recentDecisions: [],
-          blockers: ['Triage replan trigger detected — slice replan required'],
-          nextAction: `Triage replan triggered for slice ${activeSlice.id}. Replan before continuing.`,
-          activeWorkspace: undefined,
-          registry, requirements,
-          progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-        };
+        return buildDerivedState(
+          activeTaskStateContext,
+          'replanning-slice',
+          `Triage replan triggered for slice ${activeSlice.id}. Replan before continuing.`,
+          {
+            blockers: ['Triage replan trigger detected — slice replan required'],
+            includeActiveWorkspace: true,
+          },
+        );
       }
     }
   }
 
-  return {
-    activeMilestone, activeSlice, activeTask,
-    phase: 'executing', recentDecisions: [], blockers: [],
-    nextAction: `Execute ${activeTask.id}: ${activeTask.title} in slice ${activeSlice.id}.`,
-    registry, requirements,
-    progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-  };
+  return buildDerivedState(
+    activeTaskStateContext,
+    'executing',
+    `Execute ${activeTask.id}: ${activeTask.title} in slice ${activeSlice.id}.`,
+  );
 }

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -1034,6 +1034,10 @@ describe('derive-state-db', async () => {
 
       assert.deepStrictEqual(dbState.phase, 'replanning-slice', 'replan-db: phase is replanning-slice');
       assert.deepStrictEqual(dbState.phase, fileState.phase, 'replan-db: phase matches filesystem');
+      assert.ok(
+        Object.hasOwn(dbState, 'activeWorkspace'),
+        'replan-db: state preserves explicit activeWorkspace field for auto-loop consumers',
+      );
 
       closeDatabase();
     } finally {


### PR DESCRIPTION
## TL;DR

**What:** Refactors DB-backed GSD state derivation to use a single local helper for constructing `GSDState` envelopes.
**Why:** The phase-selection logic was mixed with repeated return-object boilerplate, making future state-machine changes easier to get subtly inconsistent.
**How:** Adds local typed builder/context helpers inside `from-db.ts` and routes DB derivation branches through them while preserving existing phase behavior and output fields.

## What

This updates `src/resources/extensions/gsd/state/derive/from-db.ts` only.

The change centralizes repeated `GSDState` envelope construction for DB-backed state derivation:

- Adds local `DerivedStateContext` / `DerivedStateOptions` types.
- Adds local `buildProgress` and `buildDerivedState` helpers.
- Converts no-active, all-slices-done, slice, task, replan, escalation, and executing branches to use the shared local builder.
- Preserves the prior `activeWorkspace: undefined` shape for branches that already emitted it.

## Why

The DB-backed state derivation function has many phase branches. Before this change, each branch manually assembled the same envelope fields (`activeMilestone`, `activeSlice`, `activeTask`, `phase`, `recentDecisions`, `blockers`, `nextAction`, `registry`, `requirements`, `progress`). That repetition makes it easier for future state-machine work to accidentally omit or drift one of those shared fields.

This is a behavior-preserving architecture cleanup: phase-selection logic stays local and readable, but state-object construction now has one typed path.

## How

The helper remains local to `from-db.ts` because it has one owner today. Avoiding a new exported helper or cross-file abstraction keeps the refactor focused and easy to review.

## Verification

- `pnpm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/derive-state-helpers.test.ts src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts`
- Sabotage check: changed `completing-milestone` branch to return `validating-milestone`; targeted test failed, then passed after restore.
- Sabotage check: changed `summarizing` branch to return `planning`; targeted test failed, then passed after restore.
- `codex review --uncommitted` reported no actionable findings.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in one derivation module; phase logic is unchanged and tests lock in parity including `activeWorkspace`.
> 
> **Overview**
> **`deriveStateFromDb`** in `from-db.ts` no longer builds `GSDState` inline in every branch. It now funnels returns through local **`buildDerivedState`** / **`buildProgress`** helpers with **`DerivedStateContext`** and **`DerivedStateOptions`** (blockers, `lastCompletedMilestone`, **`includeActiveWorkspace`**).
> 
> Phase selection and messages are unchanged; only envelope assembly is centralized so replanning, escalation, and other paths keep the same fields—including **`activeWorkspace: undefined`** where auto-loop consumers expect it. **`derive-state-db.test.ts`** adds an assertion that replanning-slice DB state still owns an explicit **`activeWorkspace`** key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6834e6a19a284fa87aac046b76b5a7a58d687e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->