### PR TITLE
fix(issue): open-gsd-hermes plugin uses Content-Length MCP protocol but gsd-mcp-server expects NDJSON — gsd_execute hangs indefinitely

### DIFF
--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -140,9 +140,11 @@ class GsdMcpClient:
     def _send(self, payload: dict[str, Any], *, project_dir: str | None = None) -> None:
         proc = self._ensure_process(project_dir)
         assert proc.stdin is not None
-        body = json.dumps(payload).encode("utf-8")
-        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
-        proc.stdin.write(header + body)
+        # gsd-mcp-server uses the @modelcontextprotocol/sdk stdio transport,
+        # which is newline-delimited JSON (NDJSON), not the Content-Length
+        # framing from the LSP-style MCP spec. Emit one JSON object per line.
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8") + b"\n"
+        proc.stdin.write(data)
         proc.stdin.flush()
 
     def _read_stdout_chunk(self, deadline: float) -> None:
@@ -185,42 +187,23 @@ class GsdMcpClient:
             f"{self._config.mcp_read_timeout_seconds:g}s"
         )
 
-    def _read_header(self, deadline: float) -> bytes:
+    def _read_line(self, deadline: float) -> bytes:
         while True:
-            crlf_idx = self._stdout_buffer.find(b"\r\n\r\n")
-            lf_idx = self._stdout_buffer.find(b"\n\n")
-            candidates = [
-                (idx, sep_len)
-                for idx, sep_len in ((crlf_idx, 4), (lf_idx, 2))
-                if idx >= 0
-            ]
-            if candidates:
-                idx, sep_len = min(candidates)
-                header = self._stdout_buffer[:idx]
-                self._stdout_buffer = self._stdout_buffer[idx + sep_len :]
-                return header
+            idx = self._stdout_buffer.find(b"\n")
+            if idx >= 0:
+                raw = self._stdout_buffer[:idx]
+                self._stdout_buffer = self._stdout_buffer[idx + 1 :]
+                return raw.rstrip(b"\r")
             self._read_stdout_chunk(deadline)
-
-    def _read_exact(self, length: int, deadline: float) -> bytes:
-        while len(self._stdout_buffer) < length:
-            self._read_stdout_chunk(deadline)
-        body = self._stdout_buffer[:length]
-        self._stdout_buffer = self._stdout_buffer[length:]
-        return body
 
     def _read_message(self) -> dict[str, Any]:
         deadline = time.monotonic() + self._config.mcp_read_timeout_seconds
-        header = self._read_header(deadline)
-        headers: dict[str, str] = {}
-        for raw_line in header.splitlines():
-            decoded = raw_line.decode("utf-8").strip()
-            if not decoded:
-                continue
-            key, _, val = decoded.partition(":")
-            headers[key.strip().lower()] = val.strip()
-        length = int(headers.get("content-length", "0"))
-        body = self._read_exact(length, deadline)
-        return json.loads(body.decode("utf-8"))
+        # gsd-mcp-server emits newline-delimited JSON (NDJSON); each line is a
+        # complete JSON-RPC message. Skip blank keep-alive lines.
+        while True:
+            line = self._read_line(deadline)
+            if line.strip():
+                return json.loads(line.decode("utf-8"))
 
     def _initialize(self) -> None:
         self._request_id += 1

--- a/integrations/hermes/tests/test_gsd_client_timeout.py
+++ b/integrations/hermes/tests/test_gsd_client_timeout.py
@@ -31,7 +31,7 @@ def test_read_message_times_out_waiting_for_headers() -> None:
         proc.kill()
 
 
-def test_read_message_times_out_waiting_for_body() -> None:
+def test_read_message_times_out_waiting_for_newline() -> None:
     client = GsdMcpClient(GsdConfig(mcp_read_timeout_seconds=0.05))
     proc = subprocess.Popen(
         [
@@ -39,7 +39,7 @@ def test_read_message_times_out_waiting_for_body() -> None:
             "-c",
             (
                 "import sys, time; "
-                "sys.stdout.buffer.write(b'Content-Length: 2\\r\\n\\r\\n{'); "
+                "sys.stdout.buffer.write(b'{\"jsonrpc\":\"2.0\"'); "
                 "sys.stdout.flush(); "
                 "time.sleep(10)"
             ),
@@ -59,7 +59,7 @@ def test_read_message_times_out_waiting_for_body() -> None:
         proc.kill()
 
 
-def test_read_message_fails_without_respawning_when_stdout_closes_mid_body(
+def test_read_message_fails_without_respawning_when_stdout_closes_mid_line(
     tmp_path,
 ) -> None:
     client = GsdMcpClient(GsdConfig(mcp_read_timeout_seconds=1))
@@ -69,7 +69,7 @@ def test_read_message_fails_without_respawning_when_stdout_closes_mid_body(
             "-c",
             (
                 "import sys; "
-                "sys.stdout.buffer.write(b'Content-Length: 20\\r\\n\\r\\n{'); "
+                "sys.stdout.buffer.write(b'{\"jsonrpc\":\"2.0\"'); "
                 "sys.stdout.flush()"
             ),
         ],


### PR DESCRIPTION
## Summary
- Switched the hermes plugin's MCP stdio client from Content-Length framing to NDJSON to match gsd-mcp-server, and updated timeout tests; verified with the hermes pytest suite (92 passed).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1197
- [#1197 open-gsd-hermes plugin uses Content-Length MCP protocol but gsd-mcp-server expects NDJSON — gsd_execute hangs indefinitely](https://github.com/open-gsd/gsd-pi/issues/1197)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1197-open-gsd-hermes-plugin-uses-content-leng-1783117766`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core MCP JSON-RPC transport for all Hermes GSD tool calls; mis-framing would break execute/status/cancel, but scope is limited to `gsd_client.py` with targeted timeout tests.
> 
> **Overview**
> Fixes **open-gsd-hermes** talking past **gsd-mcp-server** on stdio: the client used LSP-style `Content-Length` framing while the server uses **@modelcontextprotocol/sdk** newline-delimited JSON, which caused **`gsd_execute`** (and other MCP tool calls) to hang waiting for responses that never arrived.
> 
> **`GsdMcpClient`** now writes each JSON-RPC payload as a single UTF-8 line and reads messages by scanning for newlines, parsing one JSON object per non-blank line. Content-Length header parsing and fixed-length body reads are removed. Timeout tests were updated to simulate partial NDJSON lines instead of truncated `Content-Length` bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d9bb797611eebeab3aee442a1366f0d0bf56b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->