### PR TITLE
fix(issue): Make tool-call loop guard thresholds configurable

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -285,6 +285,11 @@ With this configuration, a Haiku-4-5 subagent sees only `gsd-workflow` and `goog
 | `PI_DISABLE_SYNC_OUTPUT` | (unset) | Set to literal `1` to disable synchronized terminal output mode in the TUI on non-Windows platforms. By default synchronized output is enabled on macOS/Linux and always disabled on Windows. |
 | `PI_TUI_MOUSE` | (unset) | Set to literal `1` to enable terminal mouse reporting for TUI clicks and wheel events. Native drag selection is preserved by default; when mouse reporting is enabled, most terminals require Shift+drag to select text. |
 | `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |
+| `GSD_TOOL_LOOP_GUARD_ENABLED` | (from preferences) | Master switch for the tool-call loop guard. `true`/`false`. Overrides `tool_call_loop_guard.enabled`. |
+| `GSD_TOOL_LOOP_IDENTICAL_MAX` | (from preferences) | Max consecutive identical-args calls before the guard trips. Overrides `tool_call_loop_guard.identical_args.max_consecutive_calls`. |
+| `GSD_TOOL_LOOP_REPEATED_DEFAULT_CAP` | (from preferences) | Per-turn per-tool cap for ordinary tools. Overrides `tool_call_loop_guard.repeated_tool.default_cap`. |
+| `GSD_TOOL_LOOP_REPEATED_REPEATABLE_CAP` | (from preferences) | Per-turn per-tool cap for inherently repeatable tools. Overrides `tool_call_loop_guard.repeated_tool.repeatable_cap`. |
+| `GSD_TOOL_LOOP_EXEMPT_TOOLS` | (from preferences) | Comma-separated tool names exempted from the per-tool cap. Added to the built-in exempt defaults and any `tool_call_loop_guard.repeated_tool.exempt_tools`. |
 
 ### Developer and test environment variables
 
@@ -589,6 +594,31 @@ context_pause_threshold: 80   # pause at 80% context usage
 ```
 
 Default: `0` (disabled)
+
+### `tool_call_loop_guard`
+
+Tunes the tool-call loop guard, which stops a model from repeating tool calls within a single turn. The two guards are configured independently:
+
+- **Identical-args guard** — blocks a streak of calls to the same tool with identical arguments. Catches real infinite loops; usually keep enabled.
+- **Repeated-tool-name cap** — caps how many times a tool name may be called per turn regardless of arguments. Catches improvisation loops, but is more likely to false-positive during legitimate automation (e.g. GSD-heavy or context-mode workflows). Tunable and disableable on its own.
+
+```yaml
+tool_call_loop_guard:
+  enabled: true                    # master switch for both guards (default: true)
+  identical_args:
+    enabled: true                  # default: true
+    max_consecutive_calls: 4       # default: 4
+  repeated_tool:
+    enabled: true                  # default: true
+    default_cap: 6                 # default: 6
+    repeatable_cap: 15             # default: 15 (for inherently repeatable tools like bash/edit/gsd_exec)
+    exempt_tools:                  # additive to built-in exempt defaults
+      - ctx_execute
+      - ctx_batch_execute
+      - ctx_search
+```
+
+Omitted fields fall back to built-in defaults, so existing installs keep their current behavior. `exempt_tools` is merged with the built-in exempt set (`find`, `glob`, `grep`, `ls`, `read`, `search_and_read`) rather than replacing it. Every field can also be overridden with `GSD_TOOL_LOOP_*` environment variables (see [Environment Variables](#environment-variables)), which win over the preferences file. When a call is blocked, the message names the active cap and the relevant config key. Applies to both interactive sessions and `/gsd auto`.
 
 ### `uat_dispatch`
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -40,7 +40,7 @@ import {
 } from "../auto-tool-tracking.js";
 import { applyProviderPayloadPolicy } from "../provider-payload-policy.js";
 
-import { checkToolCallLoop, recordToolCallLoopMutation, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
+import { checkToolCallLoop, configureToolCallLoopGuard, recordToolCallLoopMutation, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { MINIMAL_AUTO_BASE_TOOL_NAMES } from "./core-session-tools.js";
 import { maybePauseAutoForApprovalGate, resetPendingGatePauseGuard } from "./pending-gate-pause.js";
 import { saveActivityLog } from "../activity-log.js";
@@ -594,6 +594,22 @@ async function applyCompactionThresholdOverride(ctx: ExtensionContext): Promise<
   }
 }
 
+/**
+ * Apply user-tunable tool-call loop guard thresholds (#1198) from GSD
+ * preferences plus GSD_TOOL_LOOP_* env overrides. Runs at session boundaries
+ * so both interactive sessions and `/gsd auto` pick up the configuration.
+ * Non-fatal: falls back to built-in defaults when preferences cannot be loaded.
+ */
+async function applyToolCallLoopGuardConfig(basePath: string): Promise<void> {
+  try {
+    const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+    const prefs = loadEffectiveGSDPreferences(basePath);
+    configureToolCallLoopGuard(prefs?.preferences.tool_call_loop_guard);
+  } catch {
+    configureToolCallLoopGuard(null);
+  }
+}
+
 function clearDeferredApprovalGate(basePath?: string): void {
   if (!basePath) {
     deferredApprovalGates.clear();
@@ -996,6 +1012,7 @@ export function registerHooks(
     }
     resetWriteGateState(basePath);
     resetToolCallLoopGuard();
+    await applyToolCallLoopGuardConfig(basePath);
     approvalQuestionAbortInFlight = false;
     clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
@@ -1087,6 +1104,7 @@ export function registerHooks(
     initSessionNotifications(ctx);
     resetWriteGateState(basePath);
     resetToolCallLoopGuard();
+    await applyToolCallLoopGuardConfig(basePath);
     clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState(basePath);

--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -21,6 +21,11 @@
  * signature, so the identical-args streak never trips, while allowing
  * tool-heavy turns that are making file-mutation progress. Whichever guard
  * trips first blocks.
+ *
+ * Thresholds, exempt tools, and enable flags are user-tunable (#1198) via the
+ * `tool_call_loop_guard` key in `.gsd/PREFERENCES.md` and `GSD_TOOL_LOOP_*`
+ * environment variables, applied through {@link configureToolCallLoopGuard}.
+ * Defaults preserve the original hardcoded behavior.
  */
 
 import { createHash } from "node:crypto";
@@ -28,26 +33,143 @@ import { INHERENTLY_REPEATABLE_TOOL_SET } from "./core-session-tools.js";
 import { hasBrowserContractPrefix } from "../../shared/browser-contract.js";
 import { canonicalToolName } from "../engine-hook-contract.js";
 
-const MAX_CONSECUTIVE_IDENTICAL_CALLS = 4;
+/** Built-in defaults. Preserved when preferences/env do not override them. */
+const DEFAULT_MAX_CONSECUTIVE_IDENTICAL_CALLS = 4;
+const DEFAULT_PER_TOOL_DEFAULT_CAP = 6;
+const DEFAULT_PER_TOOL_REPEATABLE_CAP = 15;
+const DEFAULT_PER_TOOL_CAP_EXEMPT_TOOLS = ["find", "glob", "grep", "ls", "read", "search_and_read"] as const;
 
 /** Interactive/user-facing tools where even 1 duplicate is confusing. */
 const STRICT_LOOP_TOOLS = new Set(["ask_user_questions"]);
 const MAX_CONSECUTIVE_STRICT = 1;
 
-/**
- * Per-turn cap on calls to the SAME tool name, regardless of args (#783).
- *
- * General-purpose execution tools are routinely called many times per turn
- * (touching multiple files, running several commands), so they get a higher
- * ceiling. Everything else — workflow one-shot tools (e.g. gsd_complete_milestone)
- * and any non-allowlisted tool — gets the default cap. The default is generous
- * enough to absorb legitimate retries but catches the reported improvisation
- * loop (~51 calls) well before a cost spike.
- */
-const PER_TOOL_DEFAULT_CAP = 6;
-const PER_TOOL_REPEATABLE_CAP = 15;
-const PER_TOOL_CAP_EXEMPT_TOOLS = new Set(["find", "glob", "grep", "ls", "read", "search_and_read"]);
 const STATE_MUTATING_TOOL_SET = new Set(["edit", "write", "multi_edit", "notebook_edit"]);
+
+/**
+ * User-tunable configuration shape for the loop guard (#1198).
+ *
+ * Mirrors the `tool_call_loop_guard` key in `.gsd/PREFERENCES.md`. All fields
+ * are optional; anything omitted falls back to the built-in defaults so that
+ * existing installs keep their current behavior.
+ */
+export interface ToolCallLoopGuardConfig {
+  enabled?: boolean;
+  identical_args?: {
+    enabled?: boolean;
+    max_consecutive_calls?: number;
+  };
+  repeated_tool?: {
+    enabled?: boolean;
+    default_cap?: number;
+    repeatable_cap?: number;
+    exempt_tools?: string[];
+  };
+}
+
+/**
+ * Active, resolved configuration. Set by {@link configureToolCallLoopGuard}
+ * from preferences + environment overrides, and deliberately NOT touched by
+ * {@link resetToolCallLoopGuard} so a session's tuning survives turn
+ * boundaries.
+ */
+interface ResolvedGuardConfig {
+  /** Master switch for both guards. */
+  guardEnabled: boolean;
+  identicalEnabled: boolean;
+  maxConsecutiveIdentical: number;
+  repeatedEnabled: boolean;
+  perToolDefaultCap: number;
+  perToolRepeatableCap: number;
+  /** Tool names exempt from Guard 2 (per-tool-name cap). */
+  perToolExempt: Set<string>;
+}
+
+function defaultGuardConfig(): ResolvedGuardConfig {
+  return {
+    guardEnabled: true,
+    identicalEnabled: true,
+    maxConsecutiveIdentical: DEFAULT_MAX_CONSECUTIVE_IDENTICAL_CALLS,
+    repeatedEnabled: true,
+    perToolDefaultCap: DEFAULT_PER_TOOL_DEFAULT_CAP,
+    perToolRepeatableCap: DEFAULT_PER_TOOL_REPEATABLE_CAP,
+    perToolExempt: new Set<string>(DEFAULT_PER_TOOL_CAP_EXEMPT_TOOLS),
+  };
+}
+
+let config: ResolvedGuardConfig = defaultGuardConfig();
+
+/** Parse a positive-integer env var, returning undefined when unset/invalid. */
+function envPositiveInt(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : undefined;
+}
+
+/** Parse a boolean env var (`true`/`1` vs `false`/`0`), undefined when unset. */
+function envBool(name: string): boolean | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const v = raw.trim().toLowerCase();
+  if (v === "true" || v === "1" || v === "yes" || v === "on") return true;
+  if (v === "false" || v === "0" || v === "no" || v === "off") return false;
+  return undefined;
+}
+
+/** Parse a comma-separated tool-name list env var. */
+function envToolList(name: string): string[] {
+  const raw = process.env[name];
+  if (!raw) return [];
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Resolve preferences + environment overrides into the active configuration.
+ * Environment variables win over preferences; preferences win over built-in
+ * defaults. User-supplied exempt tools are additive to the built-in exempt
+ * set so defaults are always preserved.
+ *
+ * Applied to both interactive sessions and `/gsd auto` (called from the
+ * session_start / session_switch hooks).
+ */
+export function configureToolCallLoopGuard(prefs?: ToolCallLoopGuardConfig | null): void {
+  const next = defaultGuardConfig();
+
+  if (prefs) {
+    if (typeof prefs.enabled === "boolean") next.guardEnabled = prefs.enabled;
+    if (prefs.identical_args) {
+      if (typeof prefs.identical_args.enabled === "boolean") next.identicalEnabled = prefs.identical_args.enabled;
+      if (typeof prefs.identical_args.max_consecutive_calls === "number" && prefs.identical_args.max_consecutive_calls >= 1) {
+        next.maxConsecutiveIdentical = Math.floor(prefs.identical_args.max_consecutive_calls);
+      }
+    }
+    if (prefs.repeated_tool) {
+      if (typeof prefs.repeated_tool.enabled === "boolean") next.repeatedEnabled = prefs.repeated_tool.enabled;
+      if (typeof prefs.repeated_tool.default_cap === "number" && prefs.repeated_tool.default_cap >= 1) {
+        next.perToolDefaultCap = Math.floor(prefs.repeated_tool.default_cap);
+      }
+      if (typeof prefs.repeated_tool.repeatable_cap === "number" && prefs.repeated_tool.repeatable_cap >= 1) {
+        next.perToolRepeatableCap = Math.floor(prefs.repeated_tool.repeatable_cap);
+      }
+      for (const tool of prefs.repeated_tool.exempt_tools ?? []) {
+        if (typeof tool === "string" && tool.trim()) next.perToolExempt.add(tool.trim());
+      }
+    }
+  }
+
+  // Environment overrides (win over preferences).
+  const envEnabled = envBool("GSD_TOOL_LOOP_GUARD_ENABLED");
+  if (envEnabled !== undefined) next.guardEnabled = envEnabled;
+  const envIdenticalMax = envPositiveInt("GSD_TOOL_LOOP_IDENTICAL_MAX");
+  if (envIdenticalMax !== undefined) next.maxConsecutiveIdentical = envIdenticalMax;
+  const envDefaultCap = envPositiveInt("GSD_TOOL_LOOP_REPEATED_DEFAULT_CAP");
+  if (envDefaultCap !== undefined) next.perToolDefaultCap = envDefaultCap;
+  const envRepeatableCap = envPositiveInt("GSD_TOOL_LOOP_REPEATED_REPEATABLE_CAP");
+  if (envRepeatableCap !== undefined) next.perToolRepeatableCap = envRepeatableCap;
+  for (const tool of envToolList("GSD_TOOL_LOOP_EXEMPT_TOOLS")) next.perToolExempt.add(tool);
+
+  config = next;
+}
 
 let consecutiveCount = 0;
 let lastSignature = "";
@@ -82,17 +204,20 @@ function hashToolCall(toolName: string, args: Record<string, unknown>): string {
  * Returns `{ block: true, reason }` when the loop threshold is exceeded.
  *
  * Two independent guards run; whichever trips first blocks:
- *  1. Identical-signature streak (MAX_CONSECUTIVE_IDENTICAL_CALLS, strict for
+ *  1. Identical-signature streak (config.maxConsecutiveIdentical, strict for
  *     ask_user_questions).
- *  2. Per-tool-name cap (PER_TOOL_DEFAULT_CAP / PER_TOOL_REPEATABLE_CAP),
+ *  2. Per-tool-name cap (config.perToolDefaultCap / config.perToolRepeatableCap),
  *     independent of args, reset after file-mutation progress — catches
  *     improvisation loops (#783).
+ *
+ * Both guards, their thresholds, and the per-tool exempt set are user-tunable
+ * via {@link configureToolCallLoopGuard} (#1198).
  */
 export function checkToolCallLoop(
   toolName: string,
   args: Record<string, unknown>,
 ): { block: boolean; reason?: string; count?: number } {
-  if (!enabled) return { block: false, count: 0 };
+  if (!enabled || !config.guardEnabled) return { block: false, count: 0 };
 
   const sig = hashToolCall(toolName, args);
 
@@ -107,14 +232,16 @@ export function checkToolCallLoop(
   // ── Guard 1: identical-signature streak ──
   const threshold = STRICT_LOOP_TOOLS.has(toolName)
     ? MAX_CONSECUTIVE_STRICT
-    : MAX_CONSECUTIVE_IDENTICAL_CALLS;
+    : config.maxConsecutiveIdentical;
 
-  if (consecutiveCount > threshold) {
+  if (config.identicalEnabled && consecutiveCount > threshold) {
     return {
       block: true,
       reason:
         `Tool loop detected (identical args): ${toolName} called ${consecutiveCount} times ` +
-        `with identical arguments. Blocking to prevent infinite loop. ` +
+        `with identical arguments (max ${threshold}). Blocking to prevent infinite loop. ` +
+        `Raise tool_call_loop_guard.identical_args.max_consecutive_calls in .gsd/PREFERENCES.md ` +
+        `(or GSD_TOOL_LOOP_IDENTICAL_MAX) if this is expected. ` +
         `Do not retry this tool or call other tools this turn — stop and respond to the user in text.`,
       count: consecutiveCount,
     };
@@ -139,15 +266,16 @@ export function checkToolCallLoop(
   // Guard 1's identical-signature streak still catches a genuinely stuck
   // browser loop.
   if (
-    PER_TOOL_CAP_EXEMPT_TOOLS.has(toolName) ||
+    !config.repeatedEnabled ||
+    config.perToolExempt.has(toolName) ||
     hasBrowserContractPrefix(canonicalToolName(toolName))
   ) {
     return { block: false, count: consecutiveCount };
   }
 
   const perToolCap = INHERENTLY_REPEATABLE_TOOL_SET.has(toolName)
-    ? PER_TOOL_REPEATABLE_CAP
-    : PER_TOOL_DEFAULT_CAP;
+    ? config.perToolRepeatableCap
+    : config.perToolDefaultCap;
 
   if (perToolCount > perToolCap) {
     return {
@@ -156,6 +284,9 @@ export function checkToolCallLoop(
         `Tool loop detected (repeated tool): ${toolName} called ${perToolCount} times ` +
         `this turn (cap ${perToolCap}). Blocking to prevent infinite loop. ` +
         `The tool may be unavailable or failing repeatedly. ` +
+        `Raise tool_call_loop_guard.repeated_tool.default_cap/repeatable_cap or add "${toolName}" ` +
+        `to tool_call_loop_guard.repeated_tool.exempt_tools in .gsd/PREFERENCES.md ` +
+        `(or GSD_TOOL_LOOP_REPEATED_* / GSD_TOOL_LOOP_EXEMPT_TOOLS) if this is expected. ` +
         `Do not retry this tool or pivot to other tools this turn — stop and respond to the user in text.`,
       count: perToolCount,
     };

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -30,6 +30,33 @@ export interface ContextManagementConfig {
 }
 
 /**
+ * User-tunable thresholds for the tool-call loop guard (#1198). Keeps the two
+ * guards separately configurable: the identical-args guard (catches real
+ * infinite loops) and the repeated-tool-name cap (catches improvisation loops,
+ * more likely to false-positive on legitimate automation). All fields are
+ * optional; omitted fields fall back to the built-in defaults so existing
+ * installs keep their current behavior. Also overridable via GSD_TOOL_LOOP_*
+ * environment variables.
+ */
+export interface ToolCallLoopGuardConfig {
+  /** Master switch for both guards. Default: true. */
+  enabled?: boolean;
+  /** Identical-args sliding-window guard. */
+  identical_args?: {
+    enabled?: boolean;                    // default: true
+    max_consecutive_calls?: number;       // default: 4, min: 1
+  };
+  /** Per-tool-name cap, independent of args. */
+  repeated_tool?: {
+    enabled?: boolean;                    // default: true
+    default_cap?: number;                 // default: 6, min: 1
+    repeatable_cap?: number;              // default: 15, min: 1
+    /** Additional tool names exempt from the per-tool cap (merged with built-in defaults). */
+    exempt_tools?: string[];
+  };
+}
+
+/**
  * Opt-in tool-output sandboxing for sub-sessions. When enabled, the gsd_exec
  * MCP tool runs scripts in an isolated subprocess and returns only a short
  * digest to the calling agent's context window; capped stdout/stderr persist
@@ -139,6 +166,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "min_request_interval_ms",
   "stale_commit_threshold_minutes",
   "context_management",
+  "tool_call_loop_guard",
   "experimental",
   "codebase",
   "slice_parallel",
@@ -440,6 +468,8 @@ export interface GSDPreferences {
    */
   context_window_override?: number;
   context_management?: ContextManagementConfig;
+  /** User-tunable tool-call loop guard thresholds (#1198). */
+  tool_call_loop_guard?: ToolCallLoopGuardConfig;
   /**
    * Tool-output sandboxing via gsd_exec. Keeps sub-session context windows
    * clean by running scripts in a subprocess and only surfacing a short

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -794,6 +794,75 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Tool-call loop guard (#1198) ────────────────────────────────────────
+  if (preferences.tool_call_loop_guard !== undefined) {
+    if (typeof preferences.tool_call_loop_guard === "object" && preferences.tool_call_loop_guard !== null) {
+      const g = preferences.tool_call_loop_guard as unknown as Record<string, unknown>;
+      const validGuard: Record<string, unknown> = {};
+
+      if (g.enabled !== undefined) {
+        if (typeof g.enabled === "boolean") validGuard.enabled = g.enabled;
+        else errors.push("tool_call_loop_guard.enabled must be a boolean");
+      }
+
+      if (g.identical_args !== undefined) {
+        if (typeof g.identical_args === "object" && g.identical_args !== null) {
+          const ia = g.identical_args as Record<string, unknown>;
+          const validIa: Record<string, unknown> = {};
+          if (ia.enabled !== undefined) {
+            if (typeof ia.enabled === "boolean") validIa.enabled = ia.enabled;
+            else errors.push("tool_call_loop_guard.identical_args.enabled must be a boolean");
+          }
+          if (ia.max_consecutive_calls !== undefined) {
+            const n = ia.max_consecutive_calls;
+            if (typeof n === "number" && Number.isInteger(n) && n >= 1) validIa.max_consecutive_calls = n;
+            else errors.push("tool_call_loop_guard.identical_args.max_consecutive_calls must be an integer >= 1");
+          }
+          if (Object.keys(validIa).length > 0) validGuard.identical_args = validIa;
+        } else {
+          errors.push("tool_call_loop_guard.identical_args must be an object");
+        }
+      }
+
+      if (g.repeated_tool !== undefined) {
+        if (typeof g.repeated_tool === "object" && g.repeated_tool !== null) {
+          const rt = g.repeated_tool as Record<string, unknown>;
+          const validRt: Record<string, unknown> = {};
+          if (rt.enabled !== undefined) {
+            if (typeof rt.enabled === "boolean") validRt.enabled = rt.enabled;
+            else errors.push("tool_call_loop_guard.repeated_tool.enabled must be a boolean");
+          }
+          if (rt.default_cap !== undefined) {
+            const n = rt.default_cap;
+            if (typeof n === "number" && Number.isInteger(n) && n >= 1) validRt.default_cap = n;
+            else errors.push("tool_call_loop_guard.repeated_tool.default_cap must be an integer >= 1");
+          }
+          if (rt.repeatable_cap !== undefined) {
+            const n = rt.repeatable_cap;
+            if (typeof n === "number" && Number.isInteger(n) && n >= 1) validRt.repeatable_cap = n;
+            else errors.push("tool_call_loop_guard.repeated_tool.repeatable_cap must be an integer >= 1");
+          }
+          if (rt.exempt_tools !== undefined) {
+            if (Array.isArray(rt.exempt_tools) && rt.exempt_tools.every((t) => typeof t === "string")) {
+              validRt.exempt_tools = rt.exempt_tools;
+            } else {
+              errors.push("tool_call_loop_guard.repeated_tool.exempt_tools must be an array of strings");
+            }
+          }
+          if (Object.keys(validRt).length > 0) validGuard.repeated_tool = validRt;
+        } else {
+          errors.push("tool_call_loop_guard.repeated_tool must be an object");
+        }
+      }
+
+      if (Object.keys(validGuard).length > 0) {
+        validated.tool_call_loop_guard = validGuard as any;
+      }
+    } else {
+      errors.push("tool_call_loop_guard must be an object");
+    }
+  }
+
   // ─── Context Mode (gsd_exec sandbox) ────────────────────────────────────
   if (preferences.context_mode !== undefined) {
     if (typeof preferences.context_mode === "object" && preferences.context_mode !== null) {

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -79,6 +79,11 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   min_request_interval_ms: 250,
   stale_commit_threshold_minutes: 15,
   context_management: { enabled: true },
+  tool_call_loop_guard: {
+    enabled: true,
+    identical_args: { enabled: true, max_consecutive_calls: 4 },
+    repeated_tool: { enabled: true, default_cap: 6, repeatable_cap: 15, exempt_tools: ["ctx_execute"] },
+  },
   experimental: { rtk: true },
   codebase: { indexing: "auto" },
   slice_parallel: { enabled: true, max_workers: 2 },

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   checkToolCallLoop,
+  configureToolCallLoopGuard,
   recordToolCallLoopMutation,
   resetToolCallLoopGuard,
   disableToolCallLoopGuard,
@@ -448,3 +449,105 @@ console.log('\n── Loop guard: browser exemption does not widen to other tool
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Configurable thresholds (#1198)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: master switch disables both guards (#1198) ──');
+
+{
+  configureToolCallLoopGuard({ enabled: false });
+  resetToolCallLoopGuard();
+  // Neither identical-args nor per-tool cap should ever trip while disabled.
+  for (let i = 1; i <= 30; i++) {
+    const result = checkToolCallLoop('gsd_complete_milestone', { same: 'args' });
+    assert.ok(result.block === false, `disabled guard should allow call ${i}`);
+  }
+  // Restore defaults for subsequent tests.
+  configureToolCallLoopGuard(null);
+}
+
+console.log('\n── Loop guard: repeated_tool disabled keeps identical-args protection (#1198) ──');
+
+{
+  configureToolCallLoopGuard({ repeated_tool: { enabled: false } });
+  resetToolCallLoopGuard();
+  // Per-tool cap is off: many varied-arg calls are allowed.
+  for (let i = 1; i <= 20; i++) {
+    const result = checkToolCallLoop('gsd_exec', { cmd: `run-${i}` });
+    assert.ok(result.block === false, `repeated_tool disabled should allow varied call ${i}`);
+  }
+  // Identical-args guard is still active.
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 4; i++) {
+    assert.ok(checkToolCallLoop('gsd_exec', { cmd: 'same' }).block === false);
+  }
+  const blocked = checkToolCallLoop('gsd_exec', { cmd: 'same' });
+  assert.ok(blocked.block === true, 'identical-args guard should still trip when repeated_tool is off');
+  assert.ok(blocked.reason?.includes('identical args'));
+  configureToolCallLoopGuard(null);
+}
+
+console.log('\n── Loop guard: raised caps allow more repeated calls (#1198) ──');
+
+{
+  configureToolCallLoopGuard({ repeated_tool: { default_cap: 10 } });
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 10; i++) {
+    const result = checkToolCallLoop('gsd_complete_milestone', { arg: `v${i}` });
+    assert.ok(result.block === false, `raised-cap call ${i} should be allowed`);
+  }
+  const blocked = checkToolCallLoop('gsd_complete_milestone', { arg: 'v11' });
+  assert.ok(blocked.block === true, '11th call should trip the raised cap of 10');
+  assert.ok(blocked.reason?.includes('cap 10'), 'block message should mention the active cap');
+  assert.ok(blocked.reason?.includes('tool_call_loop_guard'), 'block message should mention the config key');
+  configureToolCallLoopGuard(null);
+}
+
+console.log('\n── Loop guard: user-added exempt tools bypass the per-tool cap (#1198) ──');
+
+{
+  configureToolCallLoopGuard({ repeated_tool: { exempt_tools: ['ctx_execute'] } });
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 30; i++) {
+    const result = checkToolCallLoop('ctx_execute', { arg: `v${i}` });
+    assert.ok(result.block === false, `exempt tool call ${i} should be allowed`);
+  }
+  // Built-in exempt defaults are preserved alongside the user-added tool.
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 30; i++) {
+    assert.ok(checkToolCallLoop('read', { path: `f${i}` }).block === false, 'built-in exempt read should remain exempt');
+  }
+  configureToolCallLoopGuard(null);
+}
+
+console.log('\n── Loop guard: identical-args max is configurable (#1198) ──');
+
+{
+  configureToolCallLoopGuard({ identical_args: { max_consecutive_calls: 2 } });
+  resetToolCallLoopGuard();
+  assert.ok(checkToolCallLoop('web_search', { q: 'x' }).block === false, 'call 1 allowed');
+  assert.ok(checkToolCallLoop('web_search', { q: 'x' }).block === false, 'call 2 allowed');
+  const blocked = checkToolCallLoop('web_search', { q: 'x' });
+  assert.ok(blocked.block === true, '3rd identical call should trip lowered max of 2');
+  assert.ok(blocked.reason?.includes('max 2'), 'block message should mention active max');
+  configureToolCallLoopGuard(null);
+}
+
+console.log('\n── Loop guard: env overrides win over preferences (#1198) ──');
+
+{
+  process.env.GSD_TOOL_LOOP_REPEATED_DEFAULT_CAP = '2';
+  configureToolCallLoopGuard({ repeated_tool: { default_cap: 6 } });
+  resetToolCallLoopGuard();
+  assert.ok(checkToolCallLoop('gsd_complete_milestone', { a: '1' }).block === false, 'call 1 allowed');
+  assert.ok(checkToolCallLoop('gsd_complete_milestone', { a: '2' }).block === false, 'call 2 allowed');
+  const blocked = checkToolCallLoop('gsd_complete_milestone', { a: '3' });
+  assert.ok(blocked.block === true, 'env override cap of 2 should win over preference cap of 6');
+  delete process.env.GSD_TOOL_LOOP_REPEATED_DEFAULT_CAP;
+  configureToolCallLoopGuard(null);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Reset restores default guard state after configuration tests
+// ═══════════════════════════════════════════════════════════════════════════
+resetToolCallLoopGuard();


### PR DESCRIPTION
## Summary
- Made the tool-call loop guard thresholds/exempt-tools configurable via `.gsd/PREFERENCES.md` (`tool_call_loop_guard`) and `GSD_TOOL_LOOP_*` env vars with defaults preserving current behavior, applied at session start for interactive and auto mode; verified with typecheck, targeted tests (118 passing), and verify:fast.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1198
- [#1198 Make tool-call loop guard thresholds configurable](https://github.com/open-gsd/gsd-pi/issues/1198)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1198-make-tool-call-loop-guard-thresholds-con-1783117764`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving defaults with opt-in tuning; changes only loop-guard limits and messaging on the native `tool_call` hook path.
> 
> **Overview**
> Makes the **tool-call loop guard** user-tunable instead of fixed constants, while keeping the same defaults so existing behavior is unchanged unless configured.
> 
> **Configuration:** New `tool_call_loop_guard` in `.gsd/PREFERENCES.md` with a master switch, separate **identical-args** and **repeated-tool** guards (each can be disabled), caps, and additive `exempt_tools`. Matching `GSD_TOOL_LOOP_*` env vars override preferences. Docs cover YAML shape and env table entries.
> 
> **Runtime:** `configureToolCallLoopGuard` resolves prefs + env; `checkToolCallLoop` uses resolved thresholds and can skip each guard independently. Block messages cite the active cap and how to raise it. `register-hooks` loads config on `session_start` / `session_switch` (interactive and `/gsd auto`); turn state still resets via `resetToolCallLoopGuard` without wiping resolved config.
> 
> **Types/validation:** `ToolCallLoopGuardConfig` on preferences plus validation for the new block. Tests cover master switch, per-guard disable, raised caps, exempt tools, env precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22218b091355842a9837dbeb553f9b329c39765b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->