### PR TITLE
fix(issue): [Bug]: tool-loop-guard triggers false positives during productive iterative debugging (local models)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1725,7 +1725,7 @@ export function registerHooks(
       }
     }
     if (!event.isError) {
-      recordToolCallLoopMutation(toolName);
+      recordToolCallLoopMutation(toolName, event.details);
       refreshSourceObservationAfterMutation(toolName, event.input, ctx);
       clearSourceObservationsAfterShell(toolName);
     }

--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -59,17 +59,40 @@ const STATE_MUTATING_TOOL_SET = new Set(["edit", "write", "multi_edit", "noteboo
  * Only successful calls reach {@link recordToolCallLoopMutation}: the
  * tool_result hook skips `isError` results, and the bash tool throws on
  * non-zero exit, so a genuinely stuck improvisation loop of failing commands
- * (#783) never decays and still trips the cap.
+ * (#783) never decays and still trips the cap. `async_bash` is excluded
+ * because it only registers a background job; command success is reported
+ * later via `await_job`. `bg_shell` may return `isError: false` for failed
+ * `run`/`start` outcomes, so the hook passes `details` for validation.
  */
 const STATE_PROGRESSING_EXEC_TOOL_SET = new Set([
   "bash",
   "bg_shell",
-  "async_bash",
   "shell",
   "powershell",
   "gsd_exec",
   "gsd_uat_exec",
 ]);
+
+function isSuccessfulBgShellLoopProgress(details: unknown): boolean {
+  if (!details || typeof details !== "object") return false;
+  const record = details as Record<string, unknown>;
+  switch (record.action) {
+    case "run":
+      return record.exitCode === 0 && record.timedOut !== true;
+    case "start":
+    case "restart": {
+      const process = record.process;
+      if (!process || typeof process !== "object") return false;
+      return (process as Record<string, unknown>).alive === true;
+    }
+    case "wait_for_ready":
+      return record.ready === true;
+    case "send_and_wait":
+      return record.matched === true;
+    default:
+      return true;
+  }
+}
 
 /**
  * User-tunable configuration shape for the loop guard (#1198).
@@ -328,9 +351,14 @@ export function checkToolCallLoop(
  * only invokes this for non-error results, so failing improvisation loops
  * (#783) never decay and still trip the per-tool cap.
  */
-export function recordToolCallLoopMutation(toolName: string): void {
+export function recordToolCallLoopMutation(toolName: string, details?: unknown): void {
   if (!enabled) return;
-  if (!STATE_MUTATING_TOOL_SET.has(toolName) && !STATE_PROGRESSING_EXEC_TOOL_SET.has(toolName)) return;
+  if (STATE_MUTATING_TOOL_SET.has(toolName)) {
+    mutationEpoch++;
+    return;
+  }
+  if (!STATE_PROGRESSING_EXEC_TOOL_SET.has(toolName)) return;
+  if (toolName === "bg_shell" && details !== undefined && !isSuccessfulBgShellLoopProgress(details)) return;
   mutationEpoch++;
 }
 

--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -14,13 +14,16 @@
  * to stop tooling for the rest of that turn and answer in text.
  *
  * The per-tool-name check (#783 Brief C) tracks call counts within a
- * turn regardless of args, decaying after successful state-mutating tools.
+ * turn regardless of args, decaying after successful state-progressing tools.
  * This catches improvisation
  * loops where the model attempts the same missing workflow tool through
  * varied surfaces (bash → `node -e` → CLI), each with a different
  * signature, so the identical-args streak never trips, while allowing
- * tool-heavy turns that are making file-mutation progress. Whichever guard
- * trips first blocks.
+ * tool-heavy turns that are making progress. Progress means a successful file
+ * mutation (edit/write) or a successful shell/exec call (bg_shell,
+ * gsd_uat_exec, …) — so a local model running a legitimate iterative
+ * debugging loop (restart server, npm install, curl an endpoint) is not
+ * blocked as a false loop (#1206). Whichever guard trips first blocks.
  *
  * Thresholds, exempt tools, and enable flags are user-tunable (#1198) via the
  * `tool_call_loop_guard` key in `.gsd/PREFERENCES.md` and `GSD_TOOL_LOOP_*`
@@ -44,6 +47,29 @@ const STRICT_LOOP_TOOLS = new Set(["ask_user_questions"]);
 const MAX_CONSECUTIVE_STRICT = 1;
 
 const STATE_MUTATING_TOOL_SET = new Set(["edit", "write", "multi_edit", "notebook_edit"]);
+
+/**
+ * Successful shell/exec calls are state progression too (#1206), not just file
+ * mutations. A local model debugging a UAT scenario legitimately restarts
+ * servers, runs `npm install`, and curls endpoints via bg_shell / gsd_uat_exec
+ * with varied args — productive work that never touches a file, so Guard 2's
+ * per-tool cap would otherwise misfire as a false loop. Decaying on these
+ * successful calls keeps the guard from aborting a progressing turn.
+ *
+ * Only successful calls reach {@link recordToolCallLoopMutation}: the
+ * tool_result hook skips `isError` results, and the bash tool throws on
+ * non-zero exit, so a genuinely stuck improvisation loop of failing commands
+ * (#783) never decays and still trips the cap.
+ */
+const STATE_PROGRESSING_EXEC_TOOL_SET = new Set([
+  "bash",
+  "bg_shell",
+  "async_bash",
+  "shell",
+  "powershell",
+  "gsd_exec",
+  "gsd_uat_exec",
+]);
 
 /**
  * User-tunable configuration shape for the loop guard (#1198).
@@ -295,10 +321,16 @@ export function checkToolCallLoop(
   return { block: false, count: consecutiveCount };
 }
 
-/** Record successful mutation progress so Guard 2 can decay on the next count. */
+/**
+ * Record successful state progress so Guard 2 can decay on the next count.
+ * File mutations (edit/write/…) and successful shell/exec calls (bash,
+ * bg_shell, gsd_uat_exec, …) both count as progress (#1092, #1206). The caller
+ * only invokes this for non-error results, so failing improvisation loops
+ * (#783) never decay and still trip the per-tool cap.
+ */
 export function recordToolCallLoopMutation(toolName: string): void {
   if (!enabled) return;
-  if (!STATE_MUTATING_TOOL_SET.has(toolName)) return;
+  if (!STATE_MUTATING_TOOL_SET.has(toolName) && !STATE_PROGRESSING_EXEC_TOOL_SET.has(toolName)) return;
   mutationEpoch++;
 }
 

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -300,6 +300,52 @@ console.log('\n── Loop guard: failing exec loop (no progress recorded) still
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// bg_shell/async_bash false-success must not decay the per-tool cap (#783)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: bg_shell failed run/start does not decay the cap (#783) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  for (let i = 1; i <= 15; i++) {
+    const result = checkToolCallLoop('bg_shell', { action: 'run', command: `try-missing-tool ${i}` });
+    assert.ok(result.block === false, `failing bg_shell run ${i} should be allowed up to the cap`);
+    recordToolCallLoopMutation('bg_shell', { action: 'run', exitCode: 1, timedOut: false });
+  }
+  const blocked = checkToolCallLoop('bg_shell', { action: 'run', command: 'try-missing-tool 16' });
+  assert.ok(blocked.block === true, '16th failing bg_shell run should be blocked by the per-tool cap');
+}
+
+{
+  resetToolCallLoopGuard();
+
+  for (let i = 1; i <= 15; i++) {
+    checkToolCallLoop('bg_shell', { action: 'start', command: `bad-server ${i}` });
+    recordToolCallLoopMutation('bg_shell', {
+      action: 'start',
+      process: { alive: false, exitCode: 1 },
+    });
+  }
+  const blocked = checkToolCallLoop('bg_shell', { action: 'start', command: 'bad-server 16' });
+  assert.ok(blocked.block === true, '16th dead bg_shell start should be blocked by the per-tool cap');
+}
+
+console.log('\n── Loop guard: async_bash job registration does not decay the cap (#783) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  for (let i = 1; i <= 6; i++) {
+    const result = checkToolCallLoop('async_bash', { command: `try-missing-tool ${i}` });
+    assert.ok(result.block === false, `async_bash call ${i} should be allowed up to the cap`);
+    recordToolCallLoopMutation('async_bash');
+  }
+  const blocked = checkToolCallLoop('async_bash', { command: 'try-missing-tool 7' });
+  assert.ok(blocked.block === true, '7th async_bash call should be blocked by the per-tool cap');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Distinct read-only navigation calls are context gathering, not repeated-tool loops.
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -253,6 +253,53 @@ console.log('\n── Loop guard: mutation progress decays per-tool counts (#109
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Successful shell/exec progress decays per-tool counts (#1206)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: successful shell/exec progress decays per-tool counts (#1206) ──');
+
+{
+  // A local model debugging a UAT scenario runs many varied bg_shell /
+  // gsd_uat_exec calls (restart server, npm install, curl an endpoint). Each
+  // successful call is state progression, so Guard 2 must decay and never
+  // block the productive turn — even past the repeatable cap.
+  for (const execTool of ['bg_shell', 'gsd_uat_exec', 'bash', 'gsd_exec']) {
+    resetToolCallLoopGuard();
+
+    for (let i = 1; i <= 20; i++) {
+      const result = checkToolCallLoop(execTool, { command: `step ${i}` });
+      assert.ok(result.block === false, `${execTool} call ${i} after exec progress should be allowed`);
+      assert.deepStrictEqual(getToolCallCountForTool(execTool), 1, `${execTool} count should decay before call ${i}`);
+
+      // A successful (non-error) exec call records progress, like a file mutation.
+      recordToolCallLoopMutation(execTool);
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Failing exec loops still trip the per-tool cap (#783 vs #1206)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: failing exec loop (no progress recorded) still trips the cap (#783) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  // The improvisation loop from #783: the model retries a missing tool through
+  // varied bash commands. Those fail (non-zero exit → isError), so the caller
+  // never records progress and the per-tool cap must still trip.
+  for (let i = 1; i <= 15; i++) {
+    const result = checkToolCallLoop('bash', { command: `try-missing-tool ${i}` });
+    assert.ok(result.block === false, `failing bash call ${i} should be allowed up to the cap`);
+    // No recordToolCallLoopMutation — the command errored.
+  }
+  const blocked = checkToolCallLoop('bash', { command: 'try-missing-tool 16' });
+  assert.ok(blocked.block === true, '16th failing bash call should be blocked by the per-tool cap');
+  assert.ok(blocked.reason?.includes('repeated tool'), 'reason should identify the per-tool guard');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Distinct read-only navigation calls are context gathering, not repeated-tool loops.
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- Made the tool-loop-guard treat successful shell/exec calls (bg_shell, gsd_uat_exec, bash, gsd_exec) as state progress that decays the per-tool cap, fixing false-positive loop blocks during productive debugging while keeping failing improvisation loops blocked; verified with unit tests and typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1206
- [#1206 [Bug]: tool-loop-guard triggers false positives during productive iterative debugging (local models)](https://github.com/open-gsd/gsd-pi/issues/1206)

## User
- @palmique

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1206-bug-tool-loop-guard-triggers-false-posit-1783143225`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the tool-loop guard’s decay rules and hook wiring in the GSD bootstrap path; scope is narrow with extensive tests, though misclassified bg_shell details could theoretically decay too often or too little.
> 
> **Overview**
> Fixes **false-positive** blocks from Guard 2 (per-tool-name cap) during productive debugging turns—especially local models running many varied **bash** / **bg_shell** / **gsd_uat_exec** steps without file edits.
> 
> **Guard 2 “progress”** now decays the per-tool counter on successful **file mutations** (unchanged) **and** on successful **shell/exec** tools (`bash`, `bg_shell`, `shell`, `powershell`, `gsd_exec`, `gsd_uat_exec`). The `tool_result` hook passes **`event.details`** into `recordToolCallLoopMutation` so **`bg_shell`** only counts when outcomes are actually successful (e.g. `run` with `exitCode === 0`, `start`/`restart` with `process.alive`, etc.), not when the tool returns non-error for a failed run.
> 
> **#783 behavior is preserved:** failed commands never record progress (hook skips errors); failing **bash** loops still hit the cap; failed **bg_shell** runs/starts and **`async_bash`** registration do not decay. New unit tests cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8699d2316925446339d2d061c06e072cbd91d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->