### PR TITLE
fix(issue): Flat-phase task artifact verification incorrectly expects summaries under tasks/

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -22,7 +22,7 @@ import {
 } from "./paths.js";
 import { milestoneIdToPhaseNum } from "./layout-policy.js";
 import { parseUnitId } from "./unit-id.js";
-import { dirname, join, relative } from "node:path";
+import { basename, dirname, join, relative } from "node:path";
 import { existsSync } from "node:fs";
 
 function resolveMilestoneArtifactPath(
@@ -221,8 +221,17 @@ export function resolveExpectedArtifactPath(
         ?? resolveProjectSlicePath(base, mid, sid!)
         ?? resolveSlicePath(base, mid, sid!);
       if (!slicePath || !tid) return null;
-      const tasksDir = resolveTasksDir(base, mid, sid!) ?? slicePath;
-      return join(tasksDir, buildTaskFileName(tid, "SUMMARY"));
+      // Legacy layout: slice dirs live under slices/<SID>/ and task summaries
+      // live in a tasks/ subdir. Flat-phase layout: slicePath IS the phase dir
+      // and task summaries live beside the plan files at the phase root. A
+      // tasks/ subdir may still exist in flat-phase for auxiliary task-scoped
+      // artifacts (e.g. T01-VERIFY.json gate outputs) — its mere existence must
+      // NOT redirect summary resolution into tasks/ (#1208).
+      const isLegacySlice = basename(dirname(slicePath)) === "slices";
+      const summaryDir = isLegacySlice
+        ? (resolveTasksDir(base, mid, sid!) ?? slicePath)
+        : slicePath;
+      return join(summaryDir, buildTaskFileName(tid, "SUMMARY"));
     }
     case "complete-slice": {
       return resolveSliceArtifactPath(base, mid, sid!, "SUMMARY");

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -360,6 +360,95 @@ test("canonical worktree + project-root legacy dir produces legacy filename (#bu
   }
 });
 
+// ── #1208: flat-phase execute-task summaries resolve at the phase root ────────
+//
+// In flat-phase layout task summaries are written beside the plan files
+// (phases/<phase>/T##-SUMMARY.md), NOT under a tasks/ subdir. A tasks/ dir may
+// still exist to hold auxiliary task-scoped gate artifacts (e.g. T01-VERIFY.json).
+// Before the fix, the mere existence of that tasks/ dir redirected summary
+// verification into tasks/T##-SUMMARY.md — which never exists — trapping auto-mode
+// in a false verification retry that eventually paused after a successful task.
+
+test("flat-phase execute-task summary resolves at phase root when no tasks/ dir exists (#1208)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-flat-task-summary-")));
+  try {
+    const gsd = join(root, ".gsd");
+    const phaseDir = join(gsd, "phases", "49-end-to-end-mandates");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "49-03-PLAN.md"), "# plan\n- [x] T02\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    assert.equal(
+      resolveExpectedArtifactPath("execute-task", "M049/S03/T02", root),
+      join(phaseDir, "T02-SUMMARY.md"),
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("flat-phase execute-task summary resolves at phase root even when tasks/ dir holds gate artifacts (#1208)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-flat-task-tasksdir-")));
+  try {
+    const gsd = join(root, ".gsd");
+    const phaseDir = join(gsd, "phases", "49-end-to-end-mandates");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "49-03-PLAN.md"), "# plan\n- [x] T02\n");
+    // Auxiliary task-scoped gate artifact — creates the tasks/ dir but must not
+    // redirect the T02 summary into tasks/.
+    const tasksDir = join(phaseDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "T01-VERIFY.json"), '{"ok":true}');
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("execute-task", "M049/S03/T02", root);
+    assert.equal(
+      resolved,
+      join(phaseDir, "T02-SUMMARY.md"),
+      "flat-phase task summary must resolve at the phase root, not tasks/",
+    );
+    assert.notEqual(
+      resolved,
+      join(tasksDir, "T02-SUMMARY.md"),
+      "a tasks/ dir with gate artifacts must NOT redirect summary resolution into tasks/",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("legacy execute-task summary still resolves under slices/<SID>/tasks/ (#1208 regression guard)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-legacy-task-summary-")));
+  try {
+    const milestoneDir = join(root, ".gsd", "milestones", "M001");
+    const sliceDir = join(milestoneDir, "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(milestoneDir, "M001-CONTEXT.md"), "# context\n");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), "# plan\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    assert.equal(
+      resolveExpectedArtifactPath("execute-task", "M001/S01/T02", root),
+      join(tasksDir, "T02-SUMMARY.md"),
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 // ── resolveSliceResearchLocation / resolveExistingSliceResearchPath ───────────
 //
 // Added in the code-quality consolidation PR as the shared dual-path resolver


### PR DESCRIPTION
## Summary
- Fixed flat-phase execute-task summary resolution to use the phase root instead of a stray tasks/ dir, and added regression tests (auto-artifact-paths.test.ts passes 17/17).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1208
- [#1208 Flat-phase task artifact verification incorrectly expects summaries under tasks/](https://github.com/open-gsd/gsd-pi/issues/1208)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1208-flat-phase-task-artifact-verification-in-1783168558`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to execute-task summary path resolution in auto-mode verification, with explicit flat-phase vs legacy branching and new regression tests.
> 
> **Overview**
> Fixes **execute-task** artifact verification for flat-phase layouts so `T##-SUMMARY.md` is expected at the **phase directory root** (alongside plan files), not under `tasks/`.
> 
> Previously, if a phase had a `tasks/` folder for auxiliary gate files (e.g. `T01-VERIFY.json`), resolution always preferred that directory and looked for `tasks/T##-SUMMARY.md`, which flat-phase never writes—causing false verification failures and auto-mode retries/pauses after successful tasks.
> 
> **`resolveExpectedArtifactPath`** now treats slices under `.../slices/<SID>/` as legacy (summaries still under `tasks/`) and all other slice paths as flat-phase (summaries at the resolved slice/phase root). Regression tests cover flat-phase with and without a `tasks/` dir, plus legacy layout unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9118bacdc3c561fa3ad8b9c2fa09d8885c88aed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->