### PR TITLE
fix(issue): Flat-phase migration leaks a .gsd-backups/migrate-<ts>/ on every session_start when verification fails (rollback does not clean the backup; gate re-fires unconditionally)

### DIFF
--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -108,11 +108,30 @@ function rollbackPartialMigration(
       `rollback: could not remove partial ${LAYOUT_SEGMENTS.level1}/: ${(removeErr as Error).message}`,
     );
   }
+  // Only the standalone .gsd-backups/migrate-<ts>/ copy is disposable once the
+  // restore succeeds. When resuming an interrupted migration, backupDir IS the
+  // preserved migrating tree (the sole surviving data source) and must never be
+  // removed here. Deleting the backup after a successful rollback keeps the gate
+  // from leaking one .gsd-backups/migrate-<ts>/ per session_start.
+  const isDisposableBackup = Boolean(backupDir) && backupDir !== migratingPath;
+  const cleanupBackup = (): void => {
+    if (!isDisposableBackup || !existsSync(backupDir)) return;
+    try {
+      removePathWithRetries(backupDir);
+    } catch (cleanupErr) {
+      logWarning(
+        "migration",
+        `rollback: could not clean backup ${backupDir}: ${(cleanupErr as Error).message}`,
+      );
+    }
+  };
+
   // Restore milestones/ — prefer renaming the preserved migrating copy back.
   const milestonesPath = join(basePath, ".gsd", "milestones");
   try {
     if (migratingPath && existsSync(migratingPath) && !existsSync(milestonesPath)) {
       movePathWithCopyDeleteFallback(migratingPath, milestonesPath);
+      cleanupBackup();
       return;
     }
     if (existsSync(backupDir)) {
@@ -121,6 +140,7 @@ function rollbackPartialMigration(
     if (migratingPath && existsSync(migratingPath)) {
       removePathWithRetries(migratingPath);
     }
+    cleanupBackup();
   } catch (restoreErr) {
     logWarning(
       "migration",

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -136,11 +136,11 @@ function rollbackPartialMigration(
     }
     if (existsSync(backupDir)) {
       cpSync(backupDir, milestonesPath, { recursive: true });
+      cleanupBackup();
     }
     if (migratingPath && existsSync(migratingPath)) {
       removePathWithRetries(migratingPath);
     }
-    cleanupBackup();
   } catch (restoreErr) {
     logWarning(
       "migration",

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -109,6 +109,33 @@ test("migrateToFlatPhase creates a backup", async () => {
   assert.ok(backups.length >= 1, "at least one migrate-* backup dir should exist");
 });
 
+test("failed migration rolls back without leaking a .gsd-backups/migrate-* dir", async (t) => {
+  const base = makeTmp();
+  const milestonesPath = join(base, ".gsd", "milestones");
+  const phasesPath = join(base, ".gsd", "phases");
+
+  // Fail the pre-render clear of phases/ to drive the rollback path, which by
+  // this point has already created the .gsd-backups/migrate-<ts>/ backup.
+  const restoreFsOps = _setFlatPhaseMigrationFsOpsForTest({
+    rmSync(target, opts) {
+      if (target === phasesPath) {
+        throw Object.assign(new Error("simulated locked phases/"), { code: "EPERM" });
+      }
+      return rmSync(target, opts as never);
+    },
+  });
+  t.after(restoreFsOps);
+
+  await assert.rejects(migrateToFlatPhase(base), /simulated locked/);
+
+  assert.ok(existsSync(milestonesPath), "legacy milestones/ should be restored on rollback");
+  const backupRoot = join(base, ".gsd-backups");
+  const leaked = existsSync(backupRoot)
+    ? readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"))
+    : [];
+  assert.equal(leaked.length, 0, "rollback must delete the migrate-* backup it created");
+});
+
 test("migrateToFlatPhase preserves milestone/slice/task counts in DB", async () => {
   const base = makeTmp();
   const msBefore = getAllMilestones().length;


### PR DESCRIPTION
## Summary
- Made `rollbackPartialMigration` delete the migrate-<ts> backup it created after a successful restore (guarding the resume case), stopping the per-session `.gsd-backups/` leak; added a regression test and verified 13/13 tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1209
- [#1209 Flat-phase migration leaks a .gsd-backups/migrate-<ts>/ on every session_start when verification fails (rollback does not clean the backup; gate re-fires unconditionally)](https://github.com/open-gsd/gsd-pi/issues/1209)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1209-flat-phase-migration-leaks-a-gsd-backups-1783168555`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches migration rollback and on-disk backup cleanup; incorrect deletion of `backupDir` during resume could lose the only copy of legacy data, though the `backupDir !== migratingPath` guard targets that case.
> 
> **Overview**
> **Fixes accumulation of `.gsd-backups/migrate-<ts>/` directories** when flat-phase migration fails and rolls back (e.g. on each `session_start` while verification keeps failing).
> 
> `rollbackPartialMigration` now removes the standalone backup copy **after milestones are restored successfully**, via `cleanupBackup()` and an `isDisposableBackup` check so interrupted migrations are not harmed when `backupDir` is the preserved `milestones.migrating` tree.
> 
> Adds a regression test that forces rollback after backup creation and asserts legacy `milestones/` is back with **no** leftover `migrate-*` dirs under `.gsd-backups`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a87ab5bb212889d20a82ac8059c69e25721d5fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->