### PR TITLE
fix(issue): [Bug]: Orchestrator state desync: Forced re-planning after UAT abort fails because previous tasks remain marked as "complete" in DB

### DIFF
--- a/src/resources/extensions/gsd/db/writers/cascades.ts
+++ b/src/resources/extensions/gsd/db/writers/cascades.ts
@@ -41,12 +41,14 @@ export type ReopenSliceOutcome =
  *
  * A closed slice is always reopenable. An open slice is only reopenable when it
  * carries a completed-task state desync (#1205): a UAT→planning fallback can
- * leave the slice "pending" while its tasks stay "complete", which deadlocks
- * every recovery path (plan-slice/replan-slice/complete-task all reject the
- * still-closed tasks, and slice_reopen historically rejected the still-open
- * slice). Resetting those tasks to pending gives the planner the clean slate it
- * needs. An open slice with nothing completed has nothing to reset and is still
- * rejected as "slice-not-complete".
+ * leave the slice "pending" while *all* its tasks stay "complete", which
+ * deadlocks every recovery path (plan-slice/replan-slice/complete-task all
+ * reject the still-closed tasks, and slice_reopen historically rejected the
+ * still-open slice). Resetting those tasks to pending gives the planner the
+ * clean slate it needs. An open slice that still has any unfinished
+ * (pending/in-progress) task is a normal in-flight slice, not the desync, and
+ * stays rejected as "slice-not-complete" so a full reset can't wipe its
+ * legitimate progress.
  */
 export function reopenSliceCascade(milestoneId: string, sliceId: string): ReopenSliceOutcome {
   requireDb();
@@ -59,7 +61,14 @@ export function reopenSliceCascade(milestoneId: string, sliceId: string): Reopen
     if (!slice) { outcome = { ok: false, reason: "slice-not-found" }; return; }
 
     const tasks = getSliceTasks(milestoneId, sliceId);
-    if (!isClosedStatus(slice.status) && !tasks.some((t) => isClosedStatus(t.status))) {
+    // A closed slice is always reopenable. An open slice is only the #1205
+    // desync when EVERY task is already closed (a UAT→planning fallback left the
+    // slice open with all tasks still "complete"). Requiring *all* tasks closed
+    // (not merely one) means a normal in-flight slice — which keeps at least one
+    // pending/in-progress task — is rejected, so a full reset can't wipe its
+    // legitimate progress.
+    const allTasksClosed = tasks.length > 0 && tasks.every((t) => isClosedStatus(t.status));
+    if (!isClosedStatus(slice.status) && !allTasksClosed) {
       outcome = { ok: false, reason: "slice-not-complete", status: slice.status };
       return;
     }

--- a/src/resources/extensions/gsd/db/writers/cascades.ts
+++ b/src/resources/extensions/gsd/db/writers/cascades.ts
@@ -38,6 +38,15 @@ export type ReopenSliceOutcome =
  * completion timestamps cleared, in one commit. Folds the hand-rolled
  * transaction-plus-cascade previously in tools/reopen-slice.ts. Guards run
  * inside the transaction (TOCTOU-safe).
+ *
+ * A closed slice is always reopenable. An open slice is only reopenable when it
+ * carries a completed-task state desync (#1205): a UAT→planning fallback can
+ * leave the slice "pending" while its tasks stay "complete", which deadlocks
+ * every recovery path (plan-slice/replan-slice/complete-task all reject the
+ * still-closed tasks, and slice_reopen historically rejected the still-open
+ * slice). Resetting those tasks to pending gives the planner the clean slate it
+ * needs. An open slice with nothing completed has nothing to reset and is still
+ * rejected as "slice-not-complete".
  */
 export function reopenSliceCascade(milestoneId: string, sliceId: string): ReopenSliceOutcome {
   requireDb();
@@ -48,9 +57,13 @@ export function reopenSliceCascade(milestoneId: string, sliceId: string): Reopen
     if (isClosedStatus(milestone.status)) { outcome = { ok: false, reason: "milestone-closed", status: milestone.status }; return; }
     const slice = getSlice(milestoneId, sliceId);
     if (!slice) { outcome = { ok: false, reason: "slice-not-found" }; return; }
-    if (!isClosedStatus(slice.status)) { outcome = { ok: false, reason: "slice-not-complete", status: slice.status }; return; }
 
     const tasks = getSliceTasks(milestoneId, sliceId);
+    if (!isClosedStatus(slice.status) && !tasks.some((t) => isClosedStatus(t.status))) {
+      outcome = { ok: false, reason: "slice-not-complete", status: slice.status };
+      return;
+    }
+
     getDbOrNull()!.prepare(
       `UPDATE slices SET status = 'in_progress', completed_at = NULL WHERE milestone_id = :mid AND id = :sid`,
     ).run({ ":mid": milestoneId, ":sid": sliceId });

--- a/src/resources/extensions/gsd/tests/reopen-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/reopen-slice.test.ts
@@ -150,6 +150,33 @@ test('handleReopenSlice: recovers a desynced slice (open status, completed tasks
   }
 });
 
+test('handleReopenSlice: rejects an in-flight slice with mixed task progress and preserves it — #1205', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+  try {
+    // Normal in-flight slice, NOT the #1205 desync: one task finished while
+    // another is still in progress. The desync guard must not treat a single
+    // completed task as reopenable, or a full reset would wipe live progress.
+    insertMilestone({ id: 'M001', title: 'Active', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', status: 'in_progress' });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete' });
+    insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', status: 'in_progress' });
+
+    const result = await handleReopenSlice({ milestoneId: 'M001', sliceId: 'S01' }, base);
+
+    assert.ok('error' in result, 'in-flight slice with unfinished tasks must be rejected');
+    assert.match(result.error, /not complete/);
+
+    // Progress must be untouched — nothing reset to pending.
+    const byId = Object.fromEntries(getSliceTasks('M001', 'S01').map(t => [t.id, t.status]));
+    assert.equal(byId['T01'], 'complete', 'completed task must stay complete');
+    assert.equal(byId['T02'], 'in_progress', 'in-progress task must stay in_progress');
+    assert.equal(getSlice('M001', 'S01')!.status, 'in_progress', 'slice status must be untouched');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handleReopenSlice: rejects reopening a slice that is not complete', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tests/reopen-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/reopen-slice.test.ts
@@ -125,6 +125,31 @@ test('handleReopenSlice: rejects slice in a closed milestone', async () => {
   }
 });
 
+test('handleReopenSlice: recovers a desynced slice (open status, completed tasks) — #1205', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+  try {
+    // Desync signature: slice left "pending" by a UAT→planning fallback while
+    // its tasks stayed "complete" from the first execution pass.
+    insertMilestone({ id: 'M001', title: 'Active', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', status: 'pending' });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete' });
+    insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', status: 'complete' });
+
+    const result = await handleReopenSlice({ milestoneId: 'M001', sliceId: 'S01' }, base);
+
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+    assert.equal(result.tasksReset, 2, 'both completed tasks should be reset');
+
+    const slice = getSlice('M001', 'S01');
+    assert.equal(slice!.status, 'in_progress', 'slice should be reopened to in_progress');
+    const tasks = getSliceTasks('M001', 'S01');
+    assert.ok(tasks.every(t => t.status === 'pending'), 'all tasks should be reset to pending');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handleReopenSlice: rejects reopening a slice that is not complete', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/reopen-slice.ts
+++ b/src/resources/extensions/gsd/tools/reopen-slice.ts
@@ -5,6 +5,11 @@
  * tasks back to "pending". This is intentional — if you're reopening a
  * slice, you're re-doing the work. Partial resets create ambiguous state.
  *
+ * Also recovers a desynced slice (#1205): when a UAT→planning fallback leaves
+ * the slice open (e.g. "pending") but its tasks still "complete", this clears
+ * that state so the planner can re-plan without hitting "already complete"
+ * rejections.
+ *
  * The parent milestone must still be open (not complete).
  */
 


### PR DESCRIPTION
## Summary
- Made `reopenSliceCascade` recover the UAT→planning desync (open slice with completed tasks) so `gsd_slice_reopen` resets tasks to pending instead of deadlocking; verified with a new #1205 regression test and the single-writer tool-surface suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1205
- [#1205 [Bug]: Orchestrator state desync: Forced re-planning after UAT abort fails because previous tasks remain marked as "complete" in DB](https://github.com/open-gsd/gsd-pi/issues/1205)

## User
- @palmique

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1205-bug-orchestrator-state-desync-forced-re--1783168540`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow reopen guards in the single-writer cascade path; behavior is transactional and covered by a new regression test, but it affects orchestrator recovery after UAT/planning fallbacks.
> 
> **Overview**
> Fixes orchestrator deadlock after UAT abort when a **UAT→planning fallback** leaves the slice open (e.g. `pending`) while tasks remain **`complete`**, blocking replan and other recovery tools.
> 
> **`reopenSliceCascade`** no longer requires a closed slice only: reopen is allowed when the slice is closed **or** any task is in a closed status; open slices with no completed tasks still return `slice-not-complete`. The same transaction still sets the slice to `in_progress` and resets all tasks to `pending`.
> 
> Adds a **#1205 regression test** for the desync case and documents the behavior on the cascade and `gsd_slice_reopen` handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e1292d9ce71700c568916f3efe9f8a5f3b365a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->