### PR TITLE
fix(issue): PREFERENCES.md language setting not injected into agent system prompt

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -27,7 +27,7 @@ import {
   buildRunUatPrompt,
   buildReplanSlicePrompt,
 } from "./auto-prompts.js";
-import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { loadEffectiveGSDPreferences, renderLanguageDirectiveForPrompt } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { pauseAuto } from "./auto.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
@@ -286,8 +286,15 @@ export async function dispatchDirectPhase(
     ctx.ui.notify("Session creation cancelled.", "warning");
     return;
   }
+  // Inject the configured response language into the dispatched prompt content
+  // — the new session's system prompt does not carry the preferences block, so
+  // the language setting would otherwise never reach the unit (#1210).
+  const languageDirective = renderLanguageDirectiveForPrompt(
+    loadEffectiveGSDPreferences(dispatchBase)?.preferences,
+  );
+  const dispatchContent = languageDirective ? `${languageDirective}\n\n${prompt}` : prompt;
   pi.sendMessage(
-    { customType: "gsd-dispatch", content: prompt, display: false },
+    { customType: "gsd-dispatch", content: dispatchContent, display: false },
     { triggerTurn: true },
   );
 }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,6 +14,7 @@
 
 import type { GSDState, TaskIO } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
+import { renderLanguageDirectiveForPrompt } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
 import { getUatBrowserToolSupportError, type UatType } from "./uat-policy.js";
@@ -1834,6 +1835,21 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
 import { getRegistry } from "./rule-registry.js";
 
+/**
+ * Prepend the configured response-language directive to a dispatched unit
+ * prompt so auto-execution units respond in the language set in PREFERENCES.md
+ * (#1210). No-op for non-dispatch actions or when no language is configured.
+ */
+function applyLanguageDirectiveToDispatch(
+  action: DispatchAction,
+  prefs: GSDPreferences | undefined,
+): DispatchAction {
+  if (action.action !== "dispatch" || !action.prompt) return action;
+  const directive = renderLanguageDirectiveForPrompt(prefs);
+  if (!directive) return action;
+  return { ...action, prompt: `${directive}\n\n${action.prompt}` };
+}
+
 // ─── Resolver ─────────────────────────────────────────────────────────────
 
 /**
@@ -1896,7 +1912,7 @@ export async function resolveDispatch(
         level: "error",
       };
     }
-    return action;
+    return applyLanguageDirectiveToDispatch(action, ctx.prefs);
   } catch (err) {
     // Registry not initialized — fall back to inline loop
     logWarning("dispatch", `registry dispatch failed, falling back to inline rules: ${err instanceof Error ? err.message : String(err)}`);
@@ -1918,7 +1934,7 @@ export async function resolveDispatch(
           matchedRule: rule.name,
         };
       }
-      return action;
+      return applyLanguageDirectiveToDispatch(action, ctx.prefs);
     }
   }
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -50,7 +50,7 @@ import { readSessionLockData, isSessionLockProcessAlive } from "./session-lock.j
 import { nativeAddAll, nativeCommit, nativeHasCommittedHead, nativeIsRepo, nativeInit } from "./native-git-bridge.js";
 import { isInheritedRepo } from "./repo-identity.js";
 import { ensureGitignore, ensurePreferences, untrackRuntimeFiles } from "./gitignore.js";
-import { getIsolationMode, loadEffectiveGSDPreferences } from "./preferences.js";
+import { getIsolationMode, loadEffectiveGSDPreferences, renderLanguageDirectiveForPrompt } from "./preferences.js";
 import { getAutoWorktreePath } from "./auto-worktree-path-resolution.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { ensurePlanV2Graph, isMissingFinalizedContextResult } from "./uok/plan-v2.js";
@@ -921,7 +921,7 @@ function resolveAvailableModel<T extends { id: string; provider: string }>(
  * Build the discuss-and-plan prompt for a new milestone.
  * Used by all three "new milestone" paths (first ever, no active, all complete).
  */
-function buildDiscussPrompt(nextId: string, preamble: string, _basePath: string, pi: ExtensionAPI, ctx: ExtensionCommandContext, preparationContext?: string): string {
+function buildDiscussPrompt(nextId: string, preamble: string, basePath: string, pi: ExtensionAPI, ctx: ExtensionCommandContext, preparationContext?: string): string {
   const milestoneRel = `.gsd/milestones/${nextId}`;
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
   const inlinedTemplates = [
@@ -931,7 +931,7 @@ function buildDiscussPrompt(nextId: string, preamble: string, _basePath: string,
     inlineTemplate("roadmap", "Roadmap"),
     inlineTemplate("decisions", "Decisions"),
   ].join("\n\n---\n\n");
-  return loadPrompt("discuss", {
+  return prependLanguageDirective(basePath, loadPrompt("discuss", {
     milestoneId: nextId,
     preamble,
     preparationContext: preparationContext ?? "",
@@ -941,14 +941,26 @@ function buildDiscussPrompt(nextId: string, preamble: string, _basePath: string,
     inlinedTemplates,
     commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): context, requirements, and roadmap`),
     multiMilestoneCommitInstruction: buildDocsCommitInstruction("docs: project plan — N milestones"),
-  });
+  }));
+}
+
+/**
+ * Prepend the configured response-language directive to a dispatched discuss
+ * prompt so the discuss/QA conversation is held in the language set in
+ * PREFERENCES.md (#1210). No-op when no language is configured.
+ */
+function prependLanguageDirective(basePath: string, prompt: string): string {
+  const directive = renderLanguageDirectiveForPrompt(
+    loadEffectiveGSDPreferences(basePath)?.preferences,
+  );
+  return directive ? `${directive}\n\n${prompt}` : prompt;
 }
 
 /**
  * Build the discuss prompt for headless milestone creation.
  * Uses the discuss-headless prompt template with seed context injected.
  */
-function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, _basePath: string): string {
+function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, basePath: string): string {
   const milestoneRel = `.gsd/milestones/${nextId}`;
   const inlinedTemplates = [
     inlineTemplate("project", "Project"),
@@ -957,7 +969,7 @@ function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, _basePa
     inlineTemplate("roadmap", "Roadmap"),
     inlineTemplate("decisions", "Decisions"),
   ].join("\n\n---\n\n");
-  return loadPrompt("discuss-headless", {
+  return prependLanguageDirective(basePath, loadPrompt("discuss-headless", {
     milestoneId: nextId,
     seedContext,
     contextPath: `${milestoneRel}/${nextId}-CONTEXT.md`,
@@ -965,7 +977,7 @@ function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, _basePa
     inlinedTemplates,
     commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): context, requirements, and roadmap`),
     multiMilestoneCommitInstruction: buildDocsCommitInstruction("docs: project plan — N milestones"),
-  });
+  }));
 }
 
 /**

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -1033,6 +1033,26 @@ export function renderPreferencesForSystemPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Render a compact response-language directive for injection into dispatched
+ * prompt *content* (discuss/QA and auto-execution unit prompts).
+ *
+ * The main session's system prompt already carries the full GSD Skill
+ * Preferences block (including language) via `before_agent_start`, but
+ * discuss/QA turns and auto-execution units are dispatched as separate
+ * turns/sessions whose prompts are assembled here — without that block — so the
+ * configured language never reaches them (#1210). Injecting this directive into
+ * the dispatched prompt content makes the `language` preference effective across
+ * both guided and auto workflows.
+ *
+ * Returns "" when no language is configured.
+ */
+export function renderLanguageDirectiveForPrompt(preferences: GSDPreferences | undefined): string {
+  if (!preferences?.language) return "";
+  const safeLang = preferences.language.replace(/[\r\n]/g, " ").slice(0, 50);
+  return `## Response Language\n\nAlways respond in ${safeLang} — questions, explanations, and summaries.`;
+}
+
 // ─── Hook Resolution ──────────────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -24,6 +24,7 @@ import {
   loadProjectGSDPreferences,
   parsePreferencesMarkdown,
   renderPreferencesForSystemPrompt,
+  renderLanguageDirectiveForPrompt,
   clearGSDPreferencesCache,
   _resetParseWarningFlag,
 } from "../preferences.ts";
@@ -1672,6 +1673,24 @@ test("language: renderPreferencesForSystemPrompt includes language instruction w
 test("language: renderPreferencesForSystemPrompt omits language line when not set", () => {
   const output = renderPreferencesForSystemPrompt({});
   assert.ok(!output.includes("Always respond in"), `expected no language line in output, got:\n${output}`);
+});
+
+test("language: renderLanguageDirectiveForPrompt emits directive when language set", () => {
+  const output = renderLanguageDirectiveForPrompt({ language: "Chinese" });
+  assert.ok(output.includes("## Response Language"), `expected language heading, got:\n${output}`);
+  assert.ok(output.includes("Always respond in Chinese"), `expected language instruction, got:\n${output}`);
+});
+
+test("language: renderLanguageDirectiveForPrompt returns empty when language unset", () => {
+  assert.equal(renderLanguageDirectiveForPrompt({}), "");
+  assert.equal(renderLanguageDirectiveForPrompt(undefined), "");
+});
+
+test("language: renderLanguageDirectiveForPrompt sanitizes newlines and caps length", () => {
+  const output = renderLanguageDirectiveForPrompt({ language: `Chinese\ninjected${"x".repeat(80)}` });
+  assert.ok(!output.includes("\ninjected"), `expected newlines stripped, got:\n${output}`);
+  // "Chinese injected" + padding, capped to 50 chars after newline replacement.
+  assert.ok(output.includes("Always respond in Chinese injected"), `got:\n${output}`);
 });
 
 test("language: parses from markdown frontmatter", () => {


### PR DESCRIPTION
## Summary
- Added `renderLanguageDirectiveForPrompt` and injected the configured language into discuss/QA and auto-execution dispatch prompts; verified with 110 passing preferences tests (3 new) and 89 dispatch tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1210
- [#1210 PREFERENCES.md language setting not injected into agent system prompt](https://github.com/open-gsd/gsd-pi/issues/1210)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1210-preferences-md-language-setting-not-inje-1783168548`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized prompt-prefix behavior with input sanitization; no changes to auth, persistence, or dispatch orchestration beyond prepending optional text.
> 
> **Overview**
> Fixes **#1210** by making the `language` preference apply outside the main session system prompt. The main chat already gets language via `renderPreferencesForSystemPrompt` on `before_agent_start`, but **discuss/QA** and **auto-execution** units build prompts in separate turns/sessions that never included that block.
> 
> Adds **`renderLanguageDirectiveForPrompt`** in `preferences.ts` — a short `## Response Language` block with the same newline stripping and 50-character cap as the system-prompt renderer. When `language` is unset, callers get a no-op.
> 
> **Auto-mode:** `applyLanguageDirectiveToDispatch` prepends the directive to every `dispatch` action returned from `resolveDispatch` (registry and inline rule paths).
> 
> **Manual `/gsd dispatch`:** `auto-direct-dispatch.ts` prepends the directive to `gsd-dispatch` message content after `newSession`, using effective preferences from the dispatch worktree.
> 
> **Guided new-milestone discuss:** `prependLanguageDirective` wraps `buildDiscussPrompt` and `buildHeadlessDiscussPrompt` in `guided-flow.ts`.
> 
> Unit tests cover emit, empty when unset, and sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 088fabc6ad1d7bf7437355a821a480cf2e4a9c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->