### PR TITLE
fix(issue): ask_user_questions: overflow text shows +N lines hidden with no way to scroll/expand

### DIFF
--- a/src/resources/extensions/ask-user-questions.ts
+++ b/src/resources/extensions/ask-user-questions.ts
@@ -289,7 +289,7 @@ export default function AskUserQuestions(pi: ExtensionAPI) {
 			"For single-select: each question must have 2-3 options. Put the recommended option first with '(Recommended)' suffix. Do not include an 'Other' or 'None of the above' option - the client adds one automatically.",
 			"For multi-select: set allowMultiple: true. The user can pick any number of options. No 'None of the above' is added.",
 			"When options involve code patterns, config choices, or architecture decisions, add a 'preview' field with markdown content (code blocks, lists, headers, etc.). The preview renders in a side-by-side panel when the option is highlighted.",
-			"Preview content is rendered in a fixed-height panel (max ~20 lines visible). Keep previews concise — show the most relevant snippet, not exhaustive examples. Longer content is truncated with a '+N lines hidden' indicator.",
+			"Preview content is rendered in a fixed-height panel (max ~20 lines visible). Keep previews concise — show the most relevant snippet, not exhaustive examples. Longer content stays fully accessible: the user scrolls it with PgUp/PgDn, with '▲/▼ N more' indicators marking hidden rows.",
 		],
 		parameters: AskUserQuestionsParams,
 

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -244,6 +244,14 @@ export async function showInterviewRound(
 		let completed = false;
 		let removeAbortListener: (() => void) | undefined;
 
+		// Preview-panel scrolling. previewScroll is the first visible line of the
+		// side-by-side preview column; the viewport/total are captured on each
+		// render so PgUp/PgDn input can clamp against real bounds.
+		let previewScroll = 0;
+		let previewViewport = 0;
+		let previewTotal = 0;
+		function resetPreviewScroll() { previewScroll = 0; }
+
 		function finish(result: RoundResult) {
 			if (completed) return;
 			completed = true;
@@ -309,6 +317,7 @@ export async function showInterviewRound(
 			if (newIdx === currentIdx) return;
 			saveEditorToState();
 			currentIdx = newIdx;
+			resetPreviewScroll();
 			loadStateToEditor();
 			focusNotes = states[currentIdx].notesVisible && states[currentIdx].notes.length > 0;
 			refresh();
@@ -455,9 +464,20 @@ export async function showInterviewRound(
 				if (matchesKey(data, Key.right)) { switchQuestion((currentIdx + 1) % questions.length); return; }
 			}
 
+			// ── Preview scrolling ────────────────────────────────────────
+			if (matchesKey(data, Key.pageUp)) {
+				if (previewScroll > 0) { previewScroll = Math.max(0, previewScroll - previewViewport); refresh(); }
+				return;
+			}
+			if (matchesKey(data, Key.pageDown)) {
+				const maxScroll = Math.max(0, previewTotal - previewViewport);
+				if (previewScroll < maxScroll) { previewScroll = Math.min(maxScroll, previewScroll + previewViewport); refresh(); }
+				return;
+			}
+
 			// ── Cursor navigation ────────────────────────────────────────
-			if (matchesKey(data, Key.up)) { st.cursorIndex = (st.cursorIndex - 1 + optCount) % optCount; refresh(); return; }
-			if (matchesKey(data, Key.down)) { st.cursorIndex = (st.cursorIndex + 1) % optCount; refresh(); return; }
+			if (matchesKey(data, Key.up)) { st.cursorIndex = (st.cursorIndex - 1 + optCount) % optCount; resetPreviewScroll(); refresh(); return; }
+			if (matchesKey(data, Key.down)) { st.cursorIndex = (st.cursorIndex + 1) % optCount; resetPreviewScroll(); refresh(); return; }
 
 			if (multiSel) {
 				const doneI = noneOrDoneIdx(currentIdx);
@@ -561,6 +581,12 @@ export async function showInterviewRound(
 		}
 
 		// ── Preview helpers ──────────────────────────────────────────────
+
+		// Centered dim label between horizontal rules, used to mark hidden/scrollable rows.
+		function scrollIndicator(lbl: string, colWidth: number): string {
+			const d = "─".repeat(Math.max(0, Math.floor((colWidth - lbl.length - 2) / 2)));
+			return truncateToWidth(theme.fg("dim", ` ${d} ${lbl} ${d}`), colWidth);
+		}
 
 		let mdThemeCache: ReturnType<typeof getMarkdownTheme> | null = null;
 		let previewCache: { markdown: string; width: number; lines: string[] } | null = null;
@@ -666,6 +692,10 @@ export async function showInterviewRound(
 			const useSideBySide = questionHasAnyPreview()
 				&& contentWidth >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
 
+			// No scrollable preview unless the side-by-side path sets these below.
+			previewTotal = 0;
+			previewViewport = 0;
+
 			if (useSideBySide) {
 				// ── Preview path ──────────────────────────────────────
 				const ui = makeUI(theme, contentWidth);
@@ -707,19 +737,35 @@ export async function showInterviewRound(
 				const leftLines = fullLeft.slice(0, maxBody);
 				if (fullLeft.length > maxBody) {
 					const n = fullLeft.length - maxBody + 1;
-					const lbl = `+${n} lines hidden`;
-					const d = "─".repeat(Math.max(0, Math.floor((leftWidth - lbl.length - 2) / 2)));
-					leftLines[maxBody - 1] = truncateToWidth(theme.fg("dim", ` ${d} ${lbl} ${d}`), leftWidth);
+					leftLines[maxBody - 1] = scrollIndicator(`+${n} lines hidden`, leftWidth);
 				}
 
 				const preview = getCurrentPreview();
 				const fullRight = preview ? renderPreviewColumn(preview, previewWidth) : [];
-				const rightLines = fullRight.slice(0, maxBody);
-				if (fullRight.length > maxBody) {
-					const n = fullRight.length - maxBody + 1;
-					const lbl = `+${n} lines hidden`;
-					const d = "─".repeat(Math.max(0, Math.floor((previewWidth - lbl.length - 2) / 2)));
-					rightLines[maxBody - 1] = truncateToWidth(theme.fg("dim", ` ${d} ${lbl} ${d}`), previewWidth);
+				// The first two lines are the pinned "Preview" header; the body
+				// below them scrolls via PgUp/PgDn so no content is unreachable.
+				const headerRows = fullRight.length > 0 ? 2 : 0;
+				const previewBody = fullRight.slice(headerRows);
+				const bodyViewport = Math.max(1, maxBody - headerRows);
+				previewTotal = previewBody.length;
+				previewViewport = bodyViewport;
+				const maxScroll = Math.max(0, previewBody.length - bodyViewport);
+				if (previewScroll > maxScroll) previewScroll = maxScroll;
+
+				const rightLines = fullRight.slice(0, headerRows);
+				if (previewBody.length <= bodyViewport) {
+					rightLines.push(...previewBody);
+				} else {
+					rightLines.push(...previewBody.slice(previewScroll, previewScroll + bodyViewport));
+					const hiddenAbove = previewScroll;
+					const hiddenBelow = previewBody.length - (previewScroll + bodyViewport);
+					// Overwrite the top/bottom visible rows with scroll indicators.
+					if (hiddenAbove > 0) {
+						rightLines[headerRows] = scrollIndicator(`▲ ${hiddenAbove} more`, previewWidth);
+					}
+					if (hiddenBelow > 0) {
+						rightLines[rightLines.length - 1] = scrollIndicator(`▼ ${hiddenBelow} more · PgUp/PgDn`, previewWidth);
+					}
 				}
 
 				while (leftLines.length < maxBody) leftLines.push("");
@@ -744,6 +790,7 @@ export async function showInterviewRound(
 					if (isMultiQuestion) hints.push("←/→ navigate");
 					hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
 				}
+				if (previewTotal > previewViewport) hints.push("pgup/pgdn scroll preview");
 				hints.push("esc to exit");
 				const footer = ui.hints(hints)[0] ?? "";
 

--- a/src/resources/extensions/shared/tests/interview-ui-border.test.ts
+++ b/src/resources/extensions/shared/tests/interview-ui-border.test.ts
@@ -16,6 +16,8 @@ import {
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 const ENTER = "\r";
 const ESC = "\x1b";
+const PAGE_DOWN = "\x1b[6~";
+const PAGE_UP = "\x1b[5~";
 
 before(() => { initTheme(); });
 
@@ -159,5 +161,35 @@ describe("interview-ui dialog borders", () => {
 	it("renders the wrap-up screen with a full border", async () => {
 		const widget = await captureWrapUpWidget();
 		assertFullOuterBorder(widget.render(80), 80);
+	});
+
+	it("makes an overflowing preview scrollable with PgUp/PgDn", async () => {
+		const longPreview = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join("\n");
+		const widget = await captureInterviewWidget([{
+			...questions[0],
+			options: [
+				{ label: "Web App", description: "Frontend or full-stack", preview: longPreview },
+			],
+		}]);
+
+		// Initial render: content overflows, so a bottom "more" indicator and the
+		// scroll hint are shown, and the border stays intact.
+		const initial = stripAnsi(widget.render(100).join("\n"));
+		assertFullOuterBorder(widget.render(100), 100);
+		assert.match(initial, /▼ \d+ more/, "bottom scroll indicator should appear when preview overflows");
+		assert.match(initial, /pgup\/pgdn scroll preview/, "footer should hint at preview scrolling");
+		assert.doesNotMatch(initial, /▲ \d+ more/, "top indicator should be absent before scrolling");
+
+		// Scroll down: content below is now revealed and a top indicator appears.
+		widget.handleInput(PAGE_DOWN);
+		const scrolled = stripAnsi(widget.render(100).join("\n"));
+		assertFullOuterBorder(widget.render(100), 100);
+		assert.match(scrolled, /▲ \d+ more/, "top scroll indicator should appear after scrolling down");
+		assert.ok(scrolled !== initial, "scrolling should change the rendered preview");
+
+		// Scroll back up returns to the original view.
+		widget.handleInput(PAGE_UP);
+		const back = stripAnsi(widget.render(100).join("\n"));
+		assert.doesNotMatch(back, /▲ \d+ more/, "top indicator should disappear after scrolling back to top");
 	});
 });


### PR DESCRIPTION
## Summary
- Made the ask_user_questions preview panel scrollable with PgUp/PgDn and live ▲/▼ hidden-row indicators instead of a dead-end "+N lines hidden", verified by the interview-ui border/scroll test suite (5/5 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1216
- [#1216 ask_user_questions: overflow text shows +N lines hidden with no way to scroll/expand](https://github.com/open-gsd/gsd-pi/issues/1216)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1216-ask-user-questions-overflow-text-shows-n-1783178145`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input/render changes in shared interview UI plus doc and test updates; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **#1216**: long option previews in the side-by-side `ask_user_questions` / interview UI are no longer a dead end at `+N lines hidden`.
> 
> The preview column keeps its pinned header and scrolls the markdown body with **PgUp/PgDn**, showing **▲/▼ N more** indicators and a footer hint when content overflows. Scroll position resets when switching questions or moving the option cursor. The options column still truncates with `+N lines hidden` when it overflows.
> 
> `ask_user_questions` **prompt guidelines** now tell the model that longer previews remain reachable via scrolling. A border test covers overflow indicators, scrolling, and layout integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a315a855913e10c9ac1026804089d5942c7f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->