### PR TITLE
chore(pkg): sync vendored export-html template.js with its #1107 source change

### DIFF
--- a/pkg/dist/core/export-html/template.js
+++ b/pkg/dist/core/export-html/template.js
@@ -894,15 +894,64 @@
         const isError = result?.isError || false;
         const statusClass = result ? (isError ? 'error' : 'success') : 'pending';
 
+        // This template runs as a standalone browser script in exported HTML,
+        // so it cannot import normalizeToolResultContent from @gsd/pi-ai.
+        // Keep these fallback semantics aligned with that helper.
+        const stringifyResultContent = (content) => {
+          try {
+            const value = JSON.stringify(content);
+            if (typeof value === 'string') return value;
+          } catch {
+            // Fall through to String(content). JSON.stringify can throw for cycles.
+          }
+
+          try {
+            return String(content);
+          } catch {
+            return '[unstringifiable tool result content]';
+          }
+        };
+
+        const serializableCacheControl = (block) => {
+          if (!block || typeof block !== 'object' || !('cache_control' in block)) return {};
+          try {
+            JSON.stringify(block.cache_control);
+            return { cache_control: block.cache_control };
+          } catch {
+            return {};
+          }
+        };
+
+        const normalizeResultContentBlock = (block) => {
+          if (typeof block === 'string') return { type: 'text', text: block };
+          if (block && typeof block === 'object') {
+            const cacheControl = serializableCacheControl(block);
+            if (block.type === 'text' && typeof block.text === 'string') return { type: 'text', text: block.text, ...cacheControl };
+            if (block.type === 'image' && typeof block.data === 'string' && typeof block.mimeType === 'string') {
+              return { type: 'image', data: block.data, mimeType: block.mimeType, ...cacheControl };
+            }
+          }
+          return { type: 'text', text: stringifyResultContent(block) };
+        };
+
+        const getResultContent = () => {
+          if (!result) return [];
+          if (Array.isArray(result.content)) {
+            const blocks = result.content.map(normalizeResultContentBlock);
+            return blocks.length > 0 ? blocks : [{ type: 'text', text: '' }];
+          }
+          if (typeof result.content === 'string') return [{ type: 'text', text: result.content }];
+          if (result.content == null) return [{ type: 'text', text: '' }];
+          return [{ type: 'text', text: stringifyResultContent(result.content) }];
+        };
+
         const getResultText = () => {
-          if (!result) return '';
-          const textBlocks = result.content.filter(c => c.type === 'text');
+          const textBlocks = getResultContent().filter(c => c.type === 'text');
           return textBlocks.map(c => c.text).join('\n');
         };
 
         const getResultImages = () => {
-          if (!result) return [];
-          return result.content.filter(c => c.type === 'image');
+          return getResultContent().filter(c => c.type === 'image');
         };
 
         const renderResultImages = () => {

--- a/src/tests/vendored-export-html-parity.test.ts
+++ b/src/tests/vendored-export-html-parity.test.ts
@@ -1,0 +1,52 @@
+// Project/App: gsd-pi
+// File Purpose: Guard the vendored pkg/dist export-html assets against drifting from their source.
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+function findRepoRoot(start: string): string {
+	let dir = start;
+	for (let i = 0; i < 10; i++) {
+		try {
+			const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+			if (pkg.name === "@opengsd/gsd-pi" && existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+		} catch {
+			// Keep walking.
+		}
+		const parent = resolve(dir, "..");
+		if (parent === dir) break;
+		dir = parent;
+	}
+	throw new Error(`Could not locate repo root from ${start}`);
+}
+
+const projectRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
+
+// These assets are plain files copied verbatim by the build: gsd-agent-core's build
+// stages them into packages/gsd-agent-core/dist/export-html, and
+// scripts/copy-export-html.cjs copies that directory over pkg/dist/core/export-html.
+// The pkg/dist copies are force-added to git, so a source edit that skips the
+// regen step leaves the shipped template stale (#1107 → PR #1218).
+// pkg/dist/core/export-html/vendor/* is third-party (not built from src), so it
+// has no source counterpart to compare against.
+const VERBATIM_ASSETS = ["template.js", "template.css", "template.html"];
+
+for (const asset of VERBATIM_ASSETS) {
+	test(`vendored pkg/dist export-html ${asset} matches its packages/gsd-agent-core source`, () => {
+		const sourcePath = join(projectRoot, "packages/gsd-agent-core/src/export-html", asset);
+		const vendoredPath = join(projectRoot, "pkg/dist/core/export-html", asset);
+		// allow-source-grep: parity guardrail intentionally reads source and vendored assets to compare them.
+		const source = readFileSync(sourcePath, "utf8");
+		const vendored = readFileSync(vendoredPath, "utf8");
+		assert.equal(
+			vendored,
+			source,
+			`pkg/dist/core/export-html/${asset} is stale: it no longer matches ` +
+				`packages/gsd-agent-core/src/export-html/${asset}. ` +
+				`Run \`pnpm run build:core && node scripts/copy-export-html.cjs\` and commit the regenerated copy.`,
+		);
+	});
+}


### PR DESCRIPTION
## Problem

`pkg/dist/core/export-html/template.js` is a tracked vendored artifact (force-added past the `pkg/dist` gitignore), last committed in the original pi-vendoring commit (`af9d27b5`). Commit `910808d8` ("Normalize malformed tool result content", #1107) updated its **source** at `packages/gsd-agent-core/src/export-html/template.js` without regenerating the vendored copy.

Since the build's `scripts/copy-export-html.cjs` step copies the freshly compiled `packages/gsd-agent-core/dist/export-html/` over `pkg/dist/core/export-html/`, **every `pnpm run build:core` now leaves the working tree dirty on a tracked file** (+53/−4 on `template.js`) — a footgun for any contributor, and a merge hazard for downstream forks carrying local state.

The other tracked files in that dir (`template.css`, `template.html`, `vendor/*`) are unaffected — `template.js` is the only stale one.

## Fix

Recommit the regenerated artifact. Produced with the build's own pipeline (`pnpm run build:core` → `copy-export-html.cjs`); the committed file is byte-identical to `packages/gsd-agent-core/dist/export-html/template.js`. The diff is exactly #1107's `normalizeToolResultContent` fallback logic compiled into the standalone template — no other changes.

## Verification

- `pnpm run build:core` on this branch → `git status` clean (no tracked-file drift)
- `diff pkg/dist/core/export-html/template.js packages/gsd-agent-core/dist/export-html/template.js` → identical

## Note

The structural alternative — not tracking generated artifacts at all — is the direction of #617; this PR just restores consistency for the tracked-artifact status quo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785775931&installation_id=134682257&pr_number=1218&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1218&signature=1fb257f392d69ab0666815c2788004771305fc73862220fadf496087223a8b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->