### PR TITLE
fix(issue): [Bug]: CODEBASE.md timestamp rewritten continuously when file count > maxFiles

### DIFF
--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -675,10 +675,16 @@ export function ensureCodebaseMapFresh(
 
   const metadata = parseCodebaseMapMetadata(existing);
   const existingDescriptions = parseCodebaseMap(existing);
+  // Compare against the truncated count: when the repository has more tracked
+  // files than maxFiles, the map only lists the first maxFiles entries, so a
+  // stored fileCount above the cap (e.g. from an older map that recorded the
+  // full count) still matches the current truncated listing. Comparing raw
+  // values would flag "file-count-changed" on every turn, rewriting the
+  // timestamp and invalidating the provider KV cache prefix.
   const staleReason =
     !metadata ? "missing-metadata"
     : metadata.fingerprint !== fingerprint ? "files-changed"
-    : metadata.fileCount !== listed.files.length ? "file-count-changed"
+    : Math.min(metadata.fileCount, resolved.maxFiles) !== listed.files.length ? "file-count-changed"
     : metadata.truncated !== listed.truncated ? "truncation-changed"
     : undefined;
 

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -697,6 +697,28 @@ test("ensureCodebaseMapFresh: does not rewrite expired metadata when fingerprint
   }
 });
 
+test("ensureCodebaseMapFresh: stays fresh when stored fileCount exceeds maxFiles", () => {
+  const base = makeTmpRepo();
+  try {
+    for (let i = 0; i < 10; i++) addFile(base, `file${i}.ts`);
+    ensureCodebaseMapFresh(base, { maxFiles: 5 }, { ttlMs: 0, force: true });
+
+    // Simulate a map written by an older version that recorded the full
+    // (untruncated) file count in its metadata rather than the capped count.
+    const original = readCodebaseMap(base);
+    assert.ok(original);
+    const fullCountContent = original.replace(/"fileCount":5\b/, '"fileCount":10');
+    writeCodebaseMap(base, fullCountContent);
+
+    const refreshed = ensureCodebaseMapFresh(base, { maxFiles: 5 }, { ttlMs: 0, force: true });
+    assert.equal(refreshed.status, "fresh");
+    // Timestamp must be preserved so the injected prompt stays byte-identical.
+    assert.equal(readCodebaseMap(base), fullCountContent);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("ensureCodebaseMapFresh: uses TTL cache before enumerating files", () => {
   const base = makeTmpRepo();
   try {


### PR DESCRIPTION
## Summary
- Fixed the CODEBASE.md freshness check to compare `Math.min(metadata.fileCount, maxFiles)` against the truncated listing so maps aren't rewritten every turn when file count exceeds maxFiles; verified with a new regression test and the full 55-test suite passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1219
- [#1219 [Bug]: CODEBASE.md timestamp rewritten continuously when file count > maxFiles](https://github.com/open-gsd/gsd-pi/issues/1219)

## User
- @gianlorenzomungiovino

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1219-bug-codebase-md-timestamp-rewritten-cont-1783188182`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to CODEBASE.md freshness heuristics with a dedicated regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a bug where **CODEBASE.md** was treated as stale on every agent turn when the repo had more tracked files than `maxFiles`, especially if metadata still stored the full (uncapped) `fileCount` from an older generator.
> 
> **`ensureCodebaseMapFresh`** now compares `Math.min(metadata.fileCount, maxFiles)` to the truncated listing length instead of the raw stored count, so fingerprint-unchanged maps stay **fresh** and the file (including `generatedAt`) is not rewritten—keeping injected prompt bytes stable for provider KV cache prefixes.
> 
> Adds a regression test that simulates `fileCount: 10` with `maxFiles: 5` and asserts status **fresh** and unchanged map content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fb91f57635fe6752330a6ad407f4b3e5145070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->