### PR TITLE
fix(issue): fix(auto): stuck-artifact recovery declares checkbox↔DB task divergence fatal instead of promoting — execute-task hard-stops "state did not advance" forever

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -234,12 +234,47 @@ export function refreshRecoveryDbForArtifact(
   }
 
   if (!isClosedStatus(task.status)) {
-    return {
-      ok: false,
-      fatal: true,
-      reason: "execute-task-artifact-db-mismatch",
-      message: `Stuck recovery found execute-task ${unitId} artifacts, but the DB task status is still '${task.status}' after refresh.`,
-    };
+    // The artifact was already confirmed on disk by verifyExpectedArtifact
+    // upstream (Gate 1 accepts a checked disk checkbox as proof of completion),
+    // but the DB task row is still open. A bare refreshWorkflowDatabaseFromDisk
+    // never promotes the disk checkbox into task status (the checkbox is
+    // rendered *from* the DB, never *into* it), so this divergence can never
+    // self-heal. Promote the task to align the DB with disk instead of failing
+    // shut — otherwise the lowest-pending derivation re-picks the same task
+    // forever and execute-task hard-stops with "state did not advance" (#1204).
+    // Mirrors the promotion pattern used by the context-exhaustion and
+    // reactive-execute-blocker recovery paths.
+    const ts = new Date().toISOString();
+    try {
+      updateTaskStatus(mid, sid, tid, "complete", ts);
+      const artifactBase = resolveArtifactVerificationBase(unitId, basePath);
+      const planPath = resolveExpectedArtifactPath("plan-slice", `${mid}/${sid}`, artifactBase);
+      if (planPath && existsSync(planPath)) {
+        const planContent = readFileSync(planPath, "utf-8");
+        const updatedPlan = planContent.replace(
+          new RegExp(`^(\\s*-\\s+)\\[ \\]\\s+\\*\\*${tid}:`, "m"),
+          `$1[x] **${tid}:`,
+        );
+        if (updatedPlan !== planContent) {
+          atomicWriteSync(planPath, updatedPlan);
+        }
+      }
+      clearPathCache();
+      clearParseCache();
+    } catch (e) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "execute-task-artifact-db-promote-failed",
+        message: `Stuck recovery found execute-task ${unitId} artifacts, but promoting the DB task status from '${task.status}' failed: ${getErrorMessage(e)}`,
+      };
+    }
+    // Append event so worktree reconciliation can replay this recovery completion.
+    try {
+      appendEvent(basePath, { cmd: "complete-task", params: { milestoneId: mid, sliceId: sid, taskId: tid }, ts, actor: "system", trigger_reason: "stuck-artifact-recovery" });
+    } catch (e) {
+      logWarning("recovery", `appendEvent failed for stuck-artifact task promotion: ${getErrorMessage(e)}`);
+    }
   }
 
   return { ok: true };

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -245,8 +245,22 @@ export function refreshRecoveryDbForArtifact(
     // Mirrors the promotion pattern used by the context-exhaustion and
     // reactive-execute-blocker recovery paths.
     const ts = new Date().toISOString();
+    // Only the DB promotion is load-bearing: if it throws, nothing advanced
+    // and failing shut is correct. The plan checkbox rewrite and cache clears
+    // are best-effort follow-ups — a throw there must NOT abort recovery, or
+    // the DB is left complete without ever emitting the stuck-artifact-recovery
+    // event (#1221), stranding worktree reconciliation.
     try {
       updateTaskStatus(mid, sid, tid, "complete", ts);
+    } catch (e) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "execute-task-artifact-db-promote-failed",
+        message: `Stuck recovery found execute-task ${unitId} artifacts, but promoting the DB task status from '${task.status}' failed: ${getErrorMessage(e)}`,
+      };
+    }
+    try {
       const artifactBase = resolveArtifactVerificationBase(unitId, basePath);
       const planPath = resolveExpectedArtifactPath("plan-slice", `${mid}/${sid}`, artifactBase);
       if (planPath && existsSync(planPath)) {
@@ -262,12 +276,7 @@ export function refreshRecoveryDbForArtifact(
       clearPathCache();
       clearParseCache();
     } catch (e) {
-      return {
-        ok: false,
-        fatal: true,
-        reason: "execute-task-artifact-db-promote-failed",
-        message: `Stuck recovery found execute-task ${unitId} artifacts, but promoting the DB task status from '${task.status}' failed: ${getErrorMessage(e)}`,
-      };
+      logWarning("recovery", `stuck-artifact plan checkbox sync failed after DB promotion of ${unitId}: ${getErrorMessage(e)}`);
     }
     // Append event so worktree reconciliation can replay this recovery completion.
     try {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -299,6 +299,37 @@ test("refreshRecoveryDbForArtifact treats missing execute-task DB rows as fatal 
   });
 });
 
+test("refreshRecoveryDbForArtifact promotes an open execute-task DB row when artifacts are verified on disk (#1204)", () => {
+  const dir = makeTmpProject();
+  insertTask({
+    milestoneId: "M001",
+    sliceId: "S01",
+    id: "T01",
+    title: "Stuck Task",
+    status: "pending",
+  });
+  const sliceDir = join(dir, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+    "# S01 Plan",
+    "",
+    "- [ ] **T01: Implement feature** `est:1h`",
+    "",
+  ].join("\n"));
+
+  const result = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", dir);
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(getTask("M001", "S01", "T01")?.status, "complete");
+  const planContent = readFileSync(join(sliceDir, "S01-PLAN.md"), "utf-8");
+  assert.ok(planContent.includes("[x] **T01:"), "plan checkbox should be re-rendered to [x]");
+  const events = readEvents(join(dir, ".gsd", "event-log.jsonl"));
+  assert.ok(
+    events.some((e) => e.cmd === "complete-task" && e.trigger_reason === "stuck-artifact-recovery"),
+    "a complete-task recovery event should be appended",
+  );
+});
+
 test("refreshRecoveryDbForArtifact closes complete-milestone DB row when artifacts exist but DB is stale (#5568)", async () => {
   const base = mkdtempSync(join(tmpdir(), "auto-recovery-complete-ms-"));
   mkdirSync(join(base, ".gsd"), { recursive: true });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -330,6 +330,32 @@ test("refreshRecoveryDbForArtifact promotes an open execute-task DB row when art
   );
 });
 
+test("refreshRecoveryDbForArtifact still appends the recovery event when the plan checkbox sync throws after DB promotion (#1221)", () => {
+  const dir = makeTmpProject();
+  insertTask({
+    milestoneId: "M001",
+    sliceId: "S01",
+    id: "T01",
+    title: "Stuck Task",
+    status: "pending",
+  });
+  const sliceDir = join(dir, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  // Make the expected plan path a directory so the best-effort checkbox
+  // rewrite (readFileSync) throws EISDIR after the DB row is already promoted.
+  mkdirSync(join(sliceDir, "S01-PLAN.md"), { recursive: true });
+
+  const result = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", dir);
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(getTask("M001", "S01", "T01")?.status, "complete");
+  const events = readEvents(join(dir, ".gsd", "event-log.jsonl"));
+  assert.ok(
+    events.some((e) => e.cmd === "complete-task" && e.trigger_reason === "stuck-artifact-recovery"),
+    "recovery event must still be appended even when the plan checkbox sync fails",
+  );
+});
+
 test("refreshRecoveryDbForArtifact closes complete-milestone DB row when artifacts exist but DB is stale (#5568)", async () => {
   const base = mkdtempSync(join(tmpdir(), "auto-recovery-complete-ms-"));
   mkdirSync(join(base, ".gsd"), { recursive: true });

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -40,6 +40,7 @@ import { readUnitRuntimeRecord } from "../unit-runtime.js";
 import { ModelPolicyDispatchBlockedError } from "../auto-model-selection.js";
 import {
   closeDatabase,
+  getTask,
   insertMilestone,
   insertSlice,
   insertTask,
@@ -445,7 +446,7 @@ test("runDispatch retries when complete-milestone summary exists on disk and stu
   assert.equal(stopCalls, 0, "artifact-based recovery should not hard-stop the loop");
 });
 
-test("runDispatch pauses when execute-task artifacts exist but DB status is still open", async (t) => {
+test("runDispatch promotes execute-task DB status when artifacts exist but DB status is still open (#1204)", async (t) => {
   const capture = createEventCapture();
   let pauseCalls = 0;
   let stopCalls = 0;
@@ -522,16 +523,16 @@ test("runDispatch pauses when execute-task artifacts exist but DB status is stil
 
   const result = await runDispatch(ic, preData, loopState);
 
-  assert.equal(result.action, "break");
-  assert.equal((result as any).reason, "execute-task-artifact-db-mismatch");
-  assert.equal(pauseCalls, 1, "execute-task disk/db mismatch should pause auto-mode");
-  assert.equal(stopCalls, 0, "execute-task disk/db mismatch should not hard-stop the loop");
-  assert.equal(invalidateCalls, 0, "mismatch should not clear caches and continue toward redispatch");
-  assert.equal(loopState.recentUnits.length, 3, "mismatch should keep the stuck window intact");
-  assert.equal(loopState.stuckRecoveryAttempts, 1, "mismatch should not reset the recovery counter");
+  assert.equal(result.action, "continue");
+  assert.equal(pauseCalls, 0, "disk-verified promotion should not pause auto-mode");
+  assert.equal(stopCalls, 0, "disk-verified promotion should not hard-stop the loop");
+  assert.equal(invalidateCalls, 1, "successful promotion should invalidate caches before retrying");
+  assert.equal(loopState.recentUnits.length, 0, "successful promotion should clear the stuck window");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "Level 1 recovery increments the attempt counter");
+  assert.equal(getTask("M001", "S01", "T01")?.status, "complete", "the open DB task should be promoted to complete");
 });
 
-test("runDispatch pauses at Level 2 when execute-task artifacts exist but DB status is still open", async (t) => {
+test("runDispatch promotes execute-task DB status at Level 2 when artifacts exist but DB status is still open (#1204)", async (t) => {
   const capture = createEventCapture();
   let pauseCalls = 0;
   let stopCalls = 0;
@@ -601,13 +602,13 @@ test("runDispatch pauses at Level 2 when execute-task artifacts exist but DB sta
 
   const result = await runDispatch(ic, preData, loopState);
 
-  assert.equal(result.action, "break");
-  assert.equal((result as any).reason, "execute-task-artifact-db-mismatch");
-  assert.equal(pauseCalls, 1, "Level 2 execute-task disk/db mismatch should pause auto-mode");
-  assert.equal(stopCalls, 0, "Level 2 execute-task disk/db mismatch should not hard-stop the loop");
+  assert.equal(result.action, "continue");
+  assert.equal(pauseCalls, 0, "Level 2 disk-verified promotion should not pause auto-mode");
+  assert.equal(stopCalls, 0, "Level 2 disk-verified promotion should not hard-stop the loop");
   assert.equal(invalidateCalls, 1, "Level 2 should invalidate caches before the final artifact recheck");
-  assert.equal(loopState.recentUnits.length, 3, "Level 2 mismatch should keep the stuck window intact");
-  assert.equal(loopState.stuckRecoveryAttempts, 1, "Level 2 mismatch should not reset the recovery counter");
+  assert.equal(loopState.recentUnits.length, 0, "Level 2 successful promotion should clear the stuck window");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "Level 2 does not reset the recovery counter");
+  assert.equal(getTask("M001", "S01", "T01")?.status, "complete", "the open DB task should be promoted to complete");
 });
 
 test("runDispatch clears execute-task stuck state when artifacts and DB status are complete", async (t) => {


### PR DESCRIPTION
## Summary
- Made the stuck-artifact `execute-task` recovery path promote a disk-verified but DB-pending task to complete (re-rendering the plan checkbox and emitting a recovery event) instead of declaring the divergence fatal; verified via the auto-recovery test suite (74 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1204
- [#1204 fix(auto): stuck-artifact recovery declares checkbox↔DB task divergence fatal instead of promoting — execute-task hard-stops "state did not advance" forever](https://github.com/open-gsd/gsd-pi/issues/1204)

## User
- @mitchello77

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1204-fix-auto-stuck-artifact-recovery-declare-1783189078`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode recovery by mutating task DB state and emitting system events; behavior is scoped to a known stuck loop but affects pipeline advancement when disk and DB diverge.
> 
> **Overview**
> **Stuck-artifact recovery** for `execute-task` no longer treats “artifacts verified on disk but DB task still open” as a fatal `execute-task-artifact-db-mismatch`. **`refreshRecoveryDbForArtifact`** now promotes the task to **complete** in the DB (matching disk/checkbox proof), then best-effort syncs the slice plan checkbox to `[x]`, clears path/parse caches, and appends a **`complete-task`** event with **`stuck-artifact-recovery`** so worktree reconciliation can replay the fix (#1204, #1221).
> 
> Only a failed **`updateTaskStatus`** is fatal (`execute-task-artifact-db-promote-failed`); plan rewrite or **`appendEvent`** failures are logged but recovery still returns **`ok: true`**. Tests cover full promotion plus the case where plan sync throws after DB promotion but the event is still written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16a2d5d0c9a681f3336b638aa1cc6312a1ae767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->