### PR TITLE
refactor(skills): unify skill-directory lists into shared taxonomy

### DIFF
--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -31,6 +31,7 @@ import { CONFIG_DIR_NAME } from "../config.js";
 import { spawnProcess, spawnProcessSync } from "../utils/child-process.js";
 import { type GitSource, parseGitUrl } from "../utils/git.js";
 import { canonicalizePath, isLocalPath, markPathIgnoredByCloudSync, resolvePath } from "../utils/paths.js";
+import { getSkillDirectories } from "./skill-directories.js";
 import { isStdoutTakenOver } from "./output-guard.js";
 import type { PackageSource, SettingsManager } from "./settings-manager.js";
 
@@ -432,41 +433,6 @@ function collectSkillEntries(
 
 function collectAutoSkillEntries(dir: string, mode: SkillDiscoveryMode): string[] {
 	return collectSkillEntries(dir, mode);
-}
-
-function findGitRepoRoot(startDir: string): string | null {
-	let dir = resolve(startDir);
-	while (true) {
-		if (existsSync(join(dir, ".git"))) {
-			return dir;
-		}
-		const parent = dirname(dir);
-		if (parent === dir) {
-			return null;
-		}
-		dir = parent;
-	}
-}
-
-function collectAncestorAgentsSkillDirs(startDir: string): string[] {
-	const skillDirs: string[] = [];
-	const resolvedStartDir = resolve(startDir);
-	const gitRepoRoot = findGitRepoRoot(resolvedStartDir);
-
-	let dir = resolvedStartDir;
-	while (true) {
-		skillDirs.push(join(dir, ".agents", "skills"));
-		if (gitRepoRoot && dir === gitRepoRoot) {
-			break;
-		}
-		const parent = dirname(dir);
-		if (parent === dir) {
-			break;
-		}
-		dir = parent;
-	}
-
-	return skillDirs;
 }
 
 function collectAutoPromptEntries(dir: string): string[] {
@@ -2276,9 +2242,6 @@ export class DefaultPackageManager implements PackageManager {
 			themes: join(projectBaseDir, "themes"),
 		};
 		const userAgentsSkillsDir = join(getHomeDir(), ".agents", "skills");
-		const projectAgentsSkillDirs = collectAncestorAgentsSkillDirs(this.cwd).filter(
-			(dir) => resolve(dir) !== resolve(userAgentsSkillsDir),
-		);
 
 		const addResources = (
 			resourceType: ResourceType,
@@ -2303,30 +2266,44 @@ export class DefaultPackageManager implements PackageManager {
 			projectBaseDir,
 		);
 
-		// Project skills from .pi/
-		addResources(
-			"skills",
-			collectAutoSkillEntries(projectDirs.skills, "pi"),
-			projectMetadata,
-			projectOverrides.skills,
-			projectBaseDir,
+		// Skills — sourced from the shared directory taxonomy (`./skill-directories.js`).
+		// PackageManager filters to the non-Claude kinds so the catalog contents
+		// are unchanged; `agents` vs `pi` mode is derived from the kind. The loop
+		// is split into project-then-user passes to preserve the original
+		// resource-add ordering (project skills before project prompts/themes;
+		// user skills before user prompts/themes) so first-loaded-wins collision
+		// resolution is byte-identical to the prior hardcoded version.
+		const userAgentsSkillsResolved = resolve(userAgentsSkillsDir);
+		const allSkillEntries = getSkillDirectories({
+			cwd: this.cwd,
+			gsdHome: dirname(globalBaseDir),
+		}).filter(
+			(entry) =>
+				entry.kind === "gsd-project" ||
+				entry.kind === "agents-project" ||
+				entry.kind === "gsd-user" ||
+				entry.kind === "agents-user",
 		);
+		const addSkillEntries = (scope: "project" | "user"): void => {
+			const baseMetadata = scope === "project" ? projectMetadata : userMetadata;
+			const overrides = scope === "project" ? projectOverrides.skills : userOverrides.skills;
+			for (const entry of allSkillEntries) {
+				if (entry.scope !== scope) continue;
+				// `~/.agents/skills` is excluded from the project (ancestor) walk
+				// so it only loads once, as a user-scope skill.
+				if (scope === "project" && resolve(entry.path) === userAgentsSkillsResolved) continue;
+				const mode: SkillDiscoveryMode =
+					entry.kind === "agents-project" || entry.kind === "agents-user" ? "agents" : "pi";
+				const metadata: PathMetadata =
+					entry.baseDir === baseMetadata.baseDir
+						? baseMetadata
+						: { ...baseMetadata, baseDir: entry.baseDir };
+				addResources("skills", collectAutoSkillEntries(entry.path, mode), metadata, overrides, entry.baseDir);
+			}
+		};
 
-		// Project skills from .agents/ (each with its own baseDir)
-		for (const agentsSkillsDir of projectAgentsSkillDirs) {
-			const agentsBaseDir = dirname(agentsSkillsDir); // the .agents directory
-			const agentsMetadata: PathMetadata = {
-				...projectMetadata,
-				baseDir: agentsBaseDir,
-			};
-			addResources(
-				"skills",
-				collectAutoSkillEntries(agentsSkillsDir, "agents"),
-				agentsMetadata,
-				projectOverrides.skills,
-				agentsBaseDir,
-			);
-		}
+		// Project skills from .gsd/skills then ancestor .agents/skills.
+		addSkillEntries("project");
 
 		addResources(
 			"prompts",
@@ -2352,28 +2329,8 @@ export class DefaultPackageManager implements PackageManager {
 			globalBaseDir,
 		);
 
-		// User skills from ~/.pi/agent/
-		addResources(
-			"skills",
-			collectAutoSkillEntries(userDirs.skills, "pi"),
-			userMetadata,
-			userOverrides.skills,
-			globalBaseDir,
-		);
-
-		// User skills from ~/.agents/ (with its own baseDir)
-		const userAgentsBaseDir = dirname(userAgentsSkillsDir);
-		const userAgentsMetadata: PathMetadata = {
-			...userMetadata,
-			baseDir: userAgentsBaseDir,
-		};
-		addResources(
-			"skills",
-			collectAutoSkillEntries(userAgentsSkillsDir, "agents"),
-			userAgentsMetadata,
-			userOverrides.skills,
-			userAgentsBaseDir,
-		);
+		// User skills from ~/.gsd/agent/skills then ~/.agents/skills.
+		addSkillEntries("user");
 
 		addResources(
 			"prompts",

--- a/packages/pi-coding-agent/src/core/skill-directories.ts
+++ b/packages/pi-coding-agent/src/core/skill-directories.ts
@@ -1,0 +1,164 @@
+/**
+ * Skill directory taxonomy.
+ *
+ * Single source of truth for which filesystem directories contain skills and
+ * what role each one plays. Three callers consume this:
+ *
+ *   - PackageManager (`./package-manager.js`) — builds the model-visible
+ *     `<available_skills>` catalog. Filters to the non-Claude kinds and
+ *     applies its own PathMetadata + collision precedence.
+ *   - skill-discovery (`src/resources/extensions/gsd/skill-discovery.ts`) —
+ *     detects skills installed mid-session by scanning disk. Uses all kinds.
+ *   - preferences-skills (`src/resources/extensions/gsd/preferences-skills.ts`)
+ *     — resolves bare skill names referenced in GSD preferences. Uses all
+ *     kinds, mapped to a `user-skill` / `project-skill` method.
+ *
+ * Enumeration order is precedence order (project → ancestor-project → user);
+ * first match wins for collision resolution. Only `agents-project` walks
+ * ancestors up to the git repo root, matching the catalog's historical
+ * behavior.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { CONFIG_DIR_NAME } from "../config.js";
+
+export type SkillDirKind =
+	| "gsd-project" // <cwd>/.gsd/skills           (no ancestor walk)
+	| "agents-project" // <cwd>/.agents/skills        (WALKS ancestors to git root)
+	| "claude-project" // <cwd>/.claude/skills        (no walk)
+	| "gsd-user" // ~/.gsd/agent/skills
+	| "agents-user" // ~/.agents/skills
+	| "claude-user"; // ~/.claude/skills
+
+export interface SkillDirectoryEntry {
+	/** Absolute path to the skills directory (the dir containing skill subdirs). */
+	path: string;
+	kind: SkillDirKind;
+	scope: "user" | "project";
+	/**
+	 * The configuration root that owns this skills dir — the `.gsd` / `.agents`
+	 * / `.claude` parent. PackageManager uses this as `PathMetadata.baseDir`.
+	 */
+	baseDir: string;
+}
+
+/**
+ * Find the nearest enclosing directory containing a `.git` entry.
+ * Returns `null` if none is found before the filesystem root.
+ */
+export function findGitRepoRoot(startDir: string): string | null {
+	let dir = resolve(startDir);
+	while (true) {
+		if (existsSync(join(dir, ".git"))) {
+			return dir;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) {
+			return null;
+		}
+		dir = parent;
+	}
+}
+
+/**
+ * Collect `<dir>/.agents/skills` for `startDir` and every ancestor up to (and
+ * including) the git repo root. Order is nearest-first. If no git root is
+ * found, walks all the way to the filesystem root.
+ */
+export function collectAncestorAgentsSkillDirs(startDir: string): string[] {
+	const skillDirs: string[] = [];
+	const resolvedStartDir = resolve(startDir);
+	const gitRepoRoot = findGitRepoRoot(resolvedStartDir);
+
+	let dir = resolvedStartDir;
+	while (true) {
+		skillDirs.push(join(dir, ".agents", "skills"));
+		if (gitRepoRoot && dir === gitRepoRoot) {
+			break;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) {
+			break;
+		}
+		dir = parent;
+	}
+
+	return skillDirs;
+}
+
+export interface GetSkillDirectoriesOptions {
+	cwd: string;
+	/** Value of `gsdHome()` from the caller — the `~/.gsd` directory. */
+	gsdHome: string;
+}
+
+/**
+ * Return all known skill directories in precedence order (project kinds first,
+ * then user kinds). First match wins for collision resolution.
+ *
+ * The `agents-project` kind is expanded into one entry per ancestor directory
+ * (nearest first), mirroring the catalog's historical ancestor walk.
+ */
+export function getSkillDirectories({ cwd, gsdHome }: GetSkillDirectoriesOptions): SkillDirectoryEntry[] {
+	const resolvedCwd = resolve(cwd);
+	const entries: SkillDirectoryEntry[] = [];
+
+	// 1. <cwd>/.gsd/skills
+	const gsdProjectSkills = join(resolvedCwd, CONFIG_DIR_NAME, "skills");
+	entries.push({
+		path: gsdProjectSkills,
+		kind: "gsd-project",
+		scope: "project",
+		baseDir: dirname(gsdProjectSkills),
+	});
+
+	// 2. <dir>/.agents/skills for cwd and each ancestor up to git root (nearest first)
+	for (const agentsSkillsDir of collectAncestorAgentsSkillDirs(resolvedCwd)) {
+		entries.push({
+			path: agentsSkillsDir,
+			kind: "agents-project",
+			scope: "project",
+			baseDir: dirname(agentsSkillsDir),
+		});
+	}
+
+	// 3. <cwd>/.claude/skills
+	const claudeProjectSkills = join(resolvedCwd, ".claude", "skills");
+	entries.push({
+		path: claudeProjectSkills,
+		kind: "claude-project",
+		scope: "project",
+		baseDir: dirname(claudeProjectSkills),
+	});
+
+	// 4. ~/.gsd/agent/skills
+	const gsdUserSkills = join(gsdHome, "agent", "skills");
+	entries.push({
+		path: gsdUserSkills,
+		kind: "gsd-user",
+		scope: "user",
+		baseDir: dirname(gsdUserSkills),
+	});
+
+	// 5. ~/.agents/skills
+	const agentsUserSkills = join(homedir(), ".agents", "skills");
+	entries.push({
+		path: agentsUserSkills,
+		kind: "agents-user",
+		scope: "user",
+		baseDir: dirname(agentsUserSkills),
+	});
+
+	// 6. ~/.claude/skills
+	const claudeUserSkills = join(homedir(), ".claude", "skills");
+	entries.push({
+		path: claudeUserSkills,
+		kind: "claude-user",
+		scope: "user",
+		baseDir: dirname(claudeUserSkills),
+	});
+
+	return entries;
+}

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -177,6 +177,14 @@ export {
 	type Skill,
 	type SkillFrontmatter,
 } from "./core/skills.js";
+export {
+	collectAncestorAgentsSkillDirs,
+	findGitRepoRoot,
+	getSkillDirectories,
+	type GetSkillDirectoriesOptions,
+	type SkillDirectoryEntry,
+	type SkillDirKind,
+} from "./core/skill-directories.js";
 export { createSyntheticSourceInfo } from "./core/source-info.js";
 // Tools
 export {

--- a/packages/pi-coding-agent/test/skill-directories.test.ts
+++ b/packages/pi-coding-agent/test/skill-directories.test.ts
@@ -1,0 +1,145 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	collectAncestorAgentsSkillDirs,
+	findGitRepoRoot,
+	getSkillDirectories,
+	type SkillDirKind,
+} from "../src/core/skill-directories.ts";
+import { CONFIG_DIR_NAME } from "../src/config.ts";
+
+const GSD_HOME = join(homedir(), `.${CONFIG_DIR_NAME}`);
+
+describe("findGitRepoRoot", () => {
+	it("returns null when no .git exists up to filesystem root", () => {
+		// /proc on Linux or a deeply nested non-existent path — either way, no .git.
+		expect(findGitRepoRoot("/nonexistent/path/that/does/not/exist")).toBe(null);
+	});
+});
+
+describe("collectAncestorAgentsSkillDirs", () => {
+	it("includes <startDir>/.agents/skills as the first entry", () => {
+		const dirs = collectAncestorAgentsSkillDirs("/tmp");
+		expect(dirs[0]).toBe(join("/tmp", ".agents", "skills"));
+	});
+
+	it("walks ancestors while emitting one .agents/skills per level", () => {
+		// Without a real .git anchor, the walk climbs to the filesystem root.
+		const dirs = collectAncestorAgentsSkillDirs("/tmp");
+		expect(dirs.length).toBeGreaterThan(1);
+		// Every entry must end with .agents/skills
+		for (const dir of dirs) {
+			expect(dir.endsWith(join(".agents", "skills"))).toBe(true);
+		}
+	});
+});
+
+describe("getSkillDirectories", () => {
+	it("returns one entry per kind plus ancestor expansion, in precedence order", () => {
+		const cwd = "/tmp/myproject";
+		const entries = getSkillDirectories({ cwd, gsdHome: GSD_HOME });
+
+		// The first three kinds are single entries (project, ancestor-from-cwd, claude-project),
+		// then three user kinds. The agents-project expansion adds >=1 ancestor.
+		const kinds = entries.map((e) => e.kind);
+		expect(kinds[0]).toBe("gsd-project");
+		// agents-project must appear before claude-project (precedence: project kinds first).
+		const firstAgentsProject = kinds.indexOf("agents-project");
+		const firstClaudeProject = kinds.indexOf("claude-project");
+		expect(firstAgentsProject).toBeGreaterThan(-1);
+		expect(firstClaudeProject).toBeGreaterThan(firstAgentsProject);
+		// User kinds come after all project kinds.
+		expect(kinds.indexOf("gsd-user")).toBeGreaterThan(firstClaudeProject);
+		expect(kinds.indexOf("agents-user")).toBeGreaterThan(kinds.indexOf("gsd-user"));
+		expect(kinds.indexOf("claude-user")).toBeGreaterThan(kinds.indexOf("agents-user"));
+	});
+
+	it("emits correct path, scope, and baseDir for the gsd-project kind", () => {
+		const cwd = "/tmp/myproject";
+		const entries = getSkillDirectories({ cwd, gsdHome: GSD_HOME });
+		const gsdProject = entries.find((e) => e.kind === "gsd-project");
+		expect(gsdProject).toBeDefined();
+		expect(gsdProject!.path).toBe(join(cwd, CONFIG_DIR_NAME, "skills"));
+		expect(gsdProject!.scope).toBe("project");
+		expect(gsdProject!.baseDir).toBe(join(cwd, CONFIG_DIR_NAME));
+	});
+
+	it("emits correct path for the claude-project kind", () => {
+		const cwd = "/tmp/myproject";
+		const entries = getSkillDirectories({ cwd, gsdHome: GSD_HOME });
+		const claudeProject = entries.find((e) => e.kind === "claude-project");
+		expect(claudeProject).toBeDefined();
+		expect(claudeProject!.path).toBe(join(cwd, ".claude", "skills"));
+		expect(claudeProject!.scope).toBe("project");
+		expect(claudeProject!.baseDir).toBe(join(cwd, ".claude"));
+	});
+
+	it("emits correct path for the gsd-user kind (~/.<configDir>/agent/skills)", () => {
+		const entries = getSkillDirectories({ cwd: "/tmp/anywhere", gsdHome: GSD_HOME });
+		const gsdUser = entries.find((e) => e.kind === "gsd-user");
+		expect(gsdUser).toBeDefined();
+		expect(gsdUser!.path).toBe(join(GSD_HOME, "agent", "skills"));
+		expect(gsdUser!.scope).toBe("user");
+		expect(gsdUser!.baseDir).toBe(join(GSD_HOME, "agent"));
+	});
+
+	it("emits correct path for the agents-user kind (~/.agents/skills)", () => {
+		const entries = getSkillDirectories({ cwd: "/tmp/anywhere", gsdHome: GSD_HOME });
+		const agentsUser = entries.find((e) => e.kind === "agents-user");
+		expect(agentsUser).toBeDefined();
+		expect(agentsUser!.path).toBe(join(homedir(), ".agents", "skills"));
+		expect(agentsUser!.scope).toBe("user");
+		expect(agentsUser!.baseDir).toBe(join(homedir(), ".agents"));
+	});
+
+	it("emits correct path for the claude-user kind (~/.claude/skills)", () => {
+		const entries = getSkillDirectories({ cwd: "/tmp/anywhere", gsdHome: GSD_HOME });
+		const claudeUser = entries.find((e) => e.kind === "claude-user");
+		expect(claudeUser).toBeDefined();
+		expect(claudeUser!.path).toBe(join(homedir(), ".claude", "skills"));
+		expect(claudeUser!.scope).toBe("user");
+		expect(claudeUser!.baseDir).toBe(join(homedir(), ".claude"));
+	});
+
+	it("expands agents-project into one entry per ancestor, nearest first", () => {
+		// /tmp has no .git, so the walk climbs to root — at least two ancestors.
+		const entries = getSkillDirectories({ cwd: "/tmp/myproject", gsdHome: GSD_HOME });
+		const agentsProjectEntries = entries.filter((e) => e.kind === "agents-project");
+		expect(agentsProjectEntries.length).toBeGreaterThanOrEqual(2);
+		// Nearest first: /tmp/myproject/.agents/skills before /tmp/.agents/skills.
+		expect(agentsProjectEntries[0].path).toBe(join("/tmp/myproject", ".agents", "skills"));
+		expect(agentsProjectEntries[1].path).toBe(join("/tmp", ".agents", "skills"));
+		// Each agents-project entry carries its own baseDir (the parent .agents dir).
+		expect(agentsProjectEntries[0].baseDir).toBe(join("/tmp/myproject", ".agents"));
+		expect(agentsProjectEntries[1].baseDir).toBe(join("/tmp", ".agents"));
+	});
+
+	it("every entry has a non-empty path, kind, scope, and baseDir", () => {
+		const entries = getSkillDirectories({ cwd: "/tmp/anywhere", gsdHome: GSD_HOME });
+		expect(entries.length).toBeGreaterThan(0);
+		for (const entry of entries) {
+			expect(typeof entry.path).toBe("string");
+			expect(entry.path.length).toBeGreaterThan(0);
+			expect(typeof entry.baseDir).toBe("string");
+			expect(entry.baseDir.length).toBeGreaterThan(0);
+			expect(entry.scope === "project" || entry.scope === "user").toBe(true);
+		}
+	});
+
+	it("all six SkillDirKind values are represented when there is no git anchor", () => {
+		const entries = getSkillDirectories({ cwd: "/tmp/anywhere", gsdHome: GSD_HOME });
+		const kinds = new Set(entries.map((e) => e.kind));
+		const allKinds: SkillDirKind[] = [
+			"gsd-project",
+			"agents-project",
+			"claude-project",
+			"gsd-user",
+			"agents-user",
+			"claude-user",
+		];
+		for (const k of allKinds) {
+			expect(kinds.has(k), `expected kind ${k} to be present`).toBe(true);
+		}
+	});
+});

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1815,7 +1815,7 @@ export async function bootstrapAutoSession(
 
     // Snapshot installed skills
     if (resolveSkillDiscoveryMode(base) !== "off") {
-      snapshotSkills();
+      snapshotSkills({ cwd: base });
     }
 
     setAutoActiveStatus(ctx, s.stepMode ? "next" : "auto");

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1815,7 +1815,7 @@ export async function bootstrapAutoSession(
 
     // Snapshot installed skills
     if (resolveSkillDiscoveryMode(base) !== "off") {
-      snapshotSkills({ cwd: base });
+      snapshotSkills({ cwd: s.basePath });
     }
 
     setAutoActiveStatus(ctx, s.stepMode ? "next" : "auto");

--- a/src/resources/extensions/gsd/preferences-skills.ts
+++ b/src/resources/extensions/gsd/preferences-skills.ts
@@ -5,11 +5,11 @@
  * to absolute filesystem paths, plus skill discovery and staleness config.
  */
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
+import { getSkillDirectories } from "@gsd/pi-coding-agent";
 import { gsdHome } from "./gsd-home.js";
-import { statSync } from "node:fs";
 
 import type {
   GSDPreferences,
@@ -25,26 +25,20 @@ export type { GSDSkillRule, SkillDiscoveryMode, SkillResolution, SkillResolution
 /**
  * Known skill directories for **preference reference resolution** (bare skill names).
  *
- * Search order (first match wins):
- * 1. ~/.gsd/agent/skills/ (GSD bundled)
- * 2. ~/.agents/skills/ (ecosystem global)
- * 3. .agents/skills/ (project ecosystem)
- * 4. ~/.claude/skills/ and .claude/skills/ (Claude Code compatibility)
+ * Sourced from the shared taxonomy (`@gsd/pi-coding-agent` `getSkillDirectories`)
+ * so preference resolution, mid-session discovery, and the PackageManager
+ * catalog all agree on which directories exist. The `method` is derived from
+ * each entry's scope.
  *
  * Note: the ResourceLoader catalog uses PackageManager precedence instead —
  * project `.gsd/skills` and `.agents/skills` can override bundled GSD skills
  * on name collision. See docs/dev/what-is-pi/09-the-customization-stack.md.
  */
 export function getSkillSearchDirs(cwd: string): Array<{ dir: string; method: SkillResolution["method"] }> {
-  const dirs: Array<{ dir: string; method: SkillResolution["method"] }> = [
-    { dir: join(gsdHome(), "agent", "skills"), method: "user-skill" },
-    { dir: join(homedir(), ".agents", "skills"), method: "user-skill" },
-    { dir: join(cwd, ".agents", "skills"), method: "project-skill" },
-    // Claude Code official skill directories
-    { dir: join(homedir(), ".claude", "skills"), method: "user-skill" },
-    { dir: join(cwd, ".claude", "skills"), method: "project-skill" },
-  ];
-  return dirs;
+  return getSkillDirectories({ cwd, gsdHome: gsdHome() }).map((entry) => ({
+    dir: entry.path,
+    method: entry.scope === "project" ? "project-skill" : "user-skill",
+  }));
 }
 
 /**

--- a/src/resources/extensions/gsd/skill-discovery.ts
+++ b/src/resources/extensions/gsd/skill-discovery.ts
@@ -9,8 +9,8 @@
  */
 
 import { existsSync, readdirSync, readFileSync, type Dirent } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { getSkillDirectories } from "@gsd/pi-coding-agent";
 import { gsdHome } from "./gsd-home.js";
 import { getInstalledSkills, normalizeSkillName } from "./skills.js";
 
@@ -20,28 +20,47 @@ export interface DiscoveredSkill {
   location: string;
 }
 
-/** Snapshot of normalized skill names at auto-mode start */
-let baselineSkills: Set<string> | null = null;
+/**
+ * Snapshot state. `searchDirs` is captured at snapshot time so every detection
+ * pass during the session scans the same project + user dirs (the bug fix:
+ * previously only user dirs were scanned, so skills installed into the project
+ * mid-session were silently missed).
+ */
+interface SkillSnapshotState {
+  baselineNames: Set<string>;
+  searchDirs: string[];
+}
+
+let snapshot: SkillSnapshotState | null = null;
 
 /**
  * Snapshot the current installed skill catalog. Call at auto-mode start.
+ * `cwd` is the project base path; skills dropped into `<cwd>/.agents/skills/`,
+ * `<cwd>/.claude/skills/`, or `<cwd>/.gsd/skills/` mid-session are detected.
  */
-export function snapshotSkills(): void {
-  baselineSkills = snapshotCurrentSkillNames();
+export function snapshotSkills(options?: { cwd?: string }): void {
+  const searchDirs = getSkillDirectories({
+    cwd: options?.cwd ?? process.cwd(),
+    gsdHome: gsdHome(),
+  }).map((entry) => entry.path);
+  snapshot = {
+    baselineNames: snapshotCurrentSkillNames(),
+    searchDirs,
+  };
 }
 
 /**
  * Clear the snapshot. Call when auto-mode stops.
  */
 export function clearSkillSnapshot(): void {
-  baselineSkills = null;
+  snapshot = null;
 }
 
 /**
  * Check if a snapshot is active (auto-mode is running with discovery).
  */
 export function hasSkillSnapshot(): boolean {
-  return baselineSkills !== null;
+  return snapshot !== null;
 }
 
 /**
@@ -49,12 +68,12 @@ export function hasSkillSnapshot(): boolean {
  * Returns skill metadata for any new skills found in the loader catalog or on disk.
  */
 export function detectNewSkills(): DiscoveredSkill[] {
-  if (!baselineSkills) return [];
+  if (!snapshot) return [];
 
   const newSkills: DiscoveredSkill[] = [];
-  for (const skill of getCurrentSkillsForDiscovery()) {
+  for (const skill of getCurrentSkillsForDiscovery(snapshot.searchDirs)) {
     const normalized = normalizeSkillName(skill.name);
-    if (baselineSkills.has(normalized)) continue;
+    if (snapshot.baselineNames.has(normalized)) continue;
     newSkills.push(skill);
   }
 
@@ -84,7 +103,13 @@ export async function refreshCatalogForNewSkills(options?: {
     }
   }
 
-  snapshotSkills();
+  // Re-snapshot, preserving the search dirs captured at auto-mode start.
+  if (snapshot) {
+    snapshot = {
+      baselineNames: snapshotCurrentSkillNames(),
+      searchDirs: snapshot.searchDirs,
+    };
+  }
   const names = newSkills.map((skill) => skill.name).join(", ");
   options?.notify?.(`GSD: loaded new skills: ${names}`, "info");
   return newSkills;
@@ -132,19 +157,18 @@ function escapeXml(value: string): string {
   });
 }
 
-function skillSearchDirs(): string[] {
-  return [
-    join(gsdHome(), "agent", "skills"),
-    join(homedir(), ".agents", "skills"),
-    join(homedir(), ".claude", "skills"),
-  ];
-}
-
 function snapshotCurrentSkillNames(): Set<string> {
-  return new Set(getCurrentSkillsForDiscovery().map(skill => normalizeSkillName(skill.name)));
+  // Uses the snapshot's search dirs when active; falls back to user-only dirs
+  // (no project context) when called before a snapshot is taken.
+  const searchDirs = snapshot?.searchDirs ?? defaultSearchDirs();
+  return new Set(getCurrentSkillsForDiscovery(searchDirs).map(skill => normalizeSkillName(skill.name)));
 }
 
-function getCurrentSkillsForDiscovery(): DiscoveredSkill[] {
+function defaultSearchDirs(): string[] {
+  return getSkillDirectories({ cwd: process.cwd(), gsdHome: gsdHome() }).map((entry) => entry.path);
+}
+
+function getCurrentSkillsForDiscovery(searchDirs: string[]): DiscoveredSkill[] {
   const skills = new Map<string, DiscoveredSkill>();
   for (const skill of getInstalledSkills()) {
     const normalized = normalizeSkillName(skill.name);
@@ -155,7 +179,7 @@ function getCurrentSkillsForDiscovery(): DiscoveredSkill[] {
     });
   }
 
-  for (const skill of getDiskSkills()) {
+  for (const skill of getDiskSkills(searchDirs)) {
     const normalized = normalizeSkillName(skill.name);
     if (!skills.has(normalized)) skills.set(normalized, skill);
   }
@@ -163,9 +187,9 @@ function getCurrentSkillsForDiscovery(): DiscoveredSkill[] {
   return [...skills.values()];
 }
 
-function getDiskSkills(): DiscoveredSkill[] {
+function getDiskSkills(searchDirs: string[]): DiscoveredSkill[] {
   const skills = new Map<string, DiscoveredSkill>();
-  for (const dir of skillSearchDirs()) {
+  for (const dir of searchDirs) {
     if (!existsSync(dir)) continue;
     let entries: Dirent[];
     try {

--- a/src/resources/extensions/gsd/skill-discovery.ts
+++ b/src/resources/extensions/gsd/skill-discovery.ts
@@ -44,7 +44,7 @@ export function snapshotSkills(options?: { cwd?: string }): void {
     gsdHome: gsdHome(),
   }).map((entry) => entry.path);
   snapshot = {
-    baselineNames: snapshotCurrentSkillNames(),
+    baselineNames: snapshotCurrentSkillNames(searchDirs),
     searchDirs,
   };
 }
@@ -157,10 +157,10 @@ function escapeXml(value: string): string {
   });
 }
 
-function snapshotCurrentSkillNames(): Set<string> {
-  // Uses the snapshot's search dirs when active; falls back to user-only dirs
+function snapshotCurrentSkillNames(searchDirsOverride?: string[]): Set<string> {
+  // Uses explicit dirs, the snapshot's search dirs when active, or user-only dirs
   // (no project context) when called before a snapshot is taken.
-  const searchDirs = snapshot?.searchDirs ?? defaultSearchDirs();
+  const searchDirs = searchDirsOverride ?? snapshot?.searchDirs ?? defaultSearchDirs();
   return new Set(getCurrentSkillsForDiscovery(searchDirs).map(skill => normalizeSkillName(skill.name)));
 }
 

--- a/src/resources/extensions/gsd/tests/skill-discovery.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-discovery.test.ts
@@ -109,3 +109,32 @@ test("appendDiscoveredSkillsFallback does not duplicate skills already in the pr
     location: "/tmp/already-loaded/SKILL.md",
   }]), prompt);
 });
+
+test("snapshotSkills({cwd}) detects skills added to the project .agents/skills/ mid-session", async () => {
+  await withTempSkillHome(async (home) => {
+    // Use a project dir under the temp home so cwd is isolated.
+    const projectDir = join(home, "myproject");
+    const projectSkills = join(projectDir, ".agents", "skills");
+    snapshotSkills({ cwd: projectDir });
+
+    // Add a skill to the project skills dir after the snapshot.
+    writeDiskSkill(projectSkills, "project-disk-skill", "Project skill added mid-session.");
+    const detected = detectNewSkills();
+
+    assert.deepEqual(detected.map(skill => skill.name), ["project-disk-skill"]);
+    assert.equal(detected[0].location, join(projectSkills, "project-disk-skill", "SKILL.md"));
+  });
+});
+
+test("snapshotSkills({cwd}) detects skills added to the project .claude/skills/ mid-session", async () => {
+  await withTempSkillHome(async (home) => {
+    const projectDir = join(home, "claude-project");
+    const claudeSkills = join(projectDir, ".claude", "skills");
+    snapshotSkills({ cwd: projectDir });
+
+    writeDiskSkill(claudeSkills, "claude-project-skill", "Claude-format skill added mid-session.");
+    const detected = detectNewSkills();
+
+    assert.deepEqual(detected.map(skill => skill.name), ["claude-project-skill"]);
+  });
+});

--- a/src/resources/extensions/gsd/tests/skill-discovery.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-discovery.test.ts
@@ -138,3 +138,20 @@ test("snapshotSkills({cwd}) detects skills added to the project .claude/skills/ 
     assert.deepEqual(detected.map(skill => skill.name), ["claude-project-skill"]);
   });
 });
+
+test("snapshotSkills({cwd}) treats skills already in the project dir as baseline, not newly discovered", async () => {
+  await withTempSkillHome(async (home) => {
+    // projectDir is intentionally NOT process.cwd(): mirrors auto-mode passing a
+    // base path that differs from cwd (e.g. after chdir into a worktree). The
+    // baseline must scan the passed cwd's dirs, so a skill present *before* the
+    // snapshot is part of the baseline and is never reported as newly discovered.
+    // Regresses the fix where snapshotCurrentSkillNames fell back to process.cwd().
+    const projectDir = join(home, "preexisting-project");
+    const projectSkills = join(projectDir, ".agents", "skills");
+    writeDiskSkill(projectSkills, "preexisting-project-skill");
+
+    snapshotSkills({ cwd: projectDir });
+
+    assert.deepEqual(detectNewSkills(), []);
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Replace three independent hardcoded skill-directory lists with one shared taxonomy module that all three callers derive from.
**Why:** The lists had drifted apart — mid-session discovery scanned zero project directories (silent miss), and `.claude/skills` appeared in some lists but not others.
**How:** New `packages/pi-coding-agent/src/core/skill-directories.ts` enumerates the universe of skill dirs; each caller filters to the kinds it needs and applies its own structural rule.

## What

Three callers each maintained their own list of skill directories:

| Caller | File | Job |
|---|---|---|
| PackageManager catalog | `packages/pi-coding-agent/src/core/package-manager.ts` | builds the model-visible `<available_skills>` |
| Mid-session discovery | `src/resources/extensions/gsd/skill-discovery.ts` | detects skills installed during auto-mode |
| Preferences resolution | `src/resources/extensions/gsd/preferences-skills.ts` | resolves bare names in GSD preferences |

The three lists differed on four dimensions:

| Dimension | prefs | discovery | catalog |
|---|---|---|---|
| `~/.claude/skills` | ✅ | ✅ | ❌ |
| `<cwd>/.claude/skills` | ✅ | ❌ | ❌ |
| `<cwd>/.gsd/skills` | ❌ | ❌ | ✅ |
| ancestor `.agents/skills` walk | ❌ | ❌ | ✅ |
| **any project dir at all** | ✅ | ❌ (zero) | ✅ |

This PR introduces `packages/pi-coding-agent/src/core/skill-directories.ts` as the single source of truth. It exports:

- `SkillDirKind` — 6 kinds (`gsd-project`, `agents-project`, `claude-project`, `gsd-user`, `agents-user`, `claude-user`)
- `getSkillDirectories({ cwd, gsdHome })` — returns structured entries (`path`, `kind`, `scope`, `baseDir`) in precedence order
- `findGitRepoRoot` / `collectAncestorAgentsSkillDirs` — moved verbatim from package-manager (single-use there)

Each caller now derives its set from the taxonomy:

- **PackageManager** filters to non-Claude kinds (`gsd-project`, `agents-project`, `gsd-user`, `agents-user`). The skill-add loop is split into project-then-user passes to preserve the original resource-add ordering, so first-loaded-wins collision resolution is byte-identical.
- **skill-discovery** uses all kinds (the bug fix — now scans project dirs).
- **preferences-skills** maps entries to `{ dir, method }`; the user-dir relative order is preserved.

## Why

Two problems:

1. **Latent bug.** `skill-discovery.ts` scanned zero project directories. A skill dropped into `<cwd>/.agents/skills/` mid-session was silently undetected — the snapshot/detect loop only walked `~/.gsd/agent/skills`, `~/.agents/skills`, `~/.claude/skills`. The taxonomy surfaces this gap; fixing it is one more `kind` in discovery's subset.

2. **Drift machinery.** Three independent hardcoded lists guaranteed the next divergence. Any fix that patched one list left the others stale. A single taxonomy kills the root cause.

## How

The key design decisions (locked via the grilling skill before implementation):

- **Taxonomy + per-caller derivation**, not one literal shared array. The three callers do structurally different jobs (catalog-build vs disk-scan vs name-resolve) — a single array would force wrong answers on at least one.
- **Taxonomy lives in `packages/pi-coding-agent/src/core/`** (lower layer), so all three callers import downward. No new `packages/* → src/` upward dependency.
- **`.claude/skills` stays out of the catalog.** Catalog contents are byte-identical before/after; the existing `skills.test.ts` suite (29 tests) passes unchanged as the regression guard.
- **Discovery's project-dir blind spot is fixed** as part of this refactor.

### Behavior changes (exactly two, both intentional)

1. Mid-session discovery now scans project directories. A skill installed into `<cwd>/.agents/skills/`, `<cwd>/.claude/skills/`, or `<cwd>/.gsd/skills/` during auto-mode is detected.
2. Preferences bare-name resolution now considers `<cwd>/.gsd/skills` and resolves project dirs ahead of user dirs. The existing `claude-skill-dirs.test.ts` passes unchanged (it only pins user-dir relative order, which is preserved).

### Out of scope

- The 3+ other inline `join(cwd, CONFIG_DIR_NAME, "skills")` sites are not refactored (surgical).
- `.claude/skills` is not added to the catalog.
- The harness loader in `packages/pi-agent-core/src/harness/skills.ts` is a separate concern, untouched.

## Verification

- `pnpm run build:pi-coding-agent` — clean
- `pnpm run typecheck:extensions` — clean
- New `packages/pi-coding-agent/test/skill-directories.test.ts` (12 tests) — pass
- Existing `packages/pi-coding-agent/test/skills.test.ts` (29 tests, PackageManager regression guard) — pass unchanged
- `src/resources/extensions/gsd/tests/skill-discovery.test.ts` (4 original + 2 new project-dir tests) — pass
- `src/resources/extensions/gsd/tests/claude-skill-dirs.test.ts` (6 tests, preferences output) — pass unchanged
- `pnpm run verify:fast` (CI fast-gate parity) — all checks passed

## Change type

- [x] `refactor` — code restructuring with one intentional bug fix bundled (the discovery project-dir gap)

AI-assisted. No AI credited as author.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skill loading precedence and discovery paths across catalog and auto-mode; catalog ordering is explicitly preserved but preference resolution gains new directories, which can change which skill wins on name collision.
> 
> **Overview**
> Introduces **`skill-directories.ts`** as the single source of truth for where skills live (GSD, `.agents`, Claude; project vs user; ancestor `.agents` walk to git root). **PackageManager**, GSD **preferences** resolution, and **mid-session skill discovery** all derive their directory lists from `getSkillDirectories()` instead of three divergent hardcoded paths.
> 
> **PackageManager** still filters out Claude dirs for the model catalog and keeps project-then-user add order so collision behavior stays the same; git-root helpers move into the new module and are re-exported from the package.
> 
> **Behavior fixes bundled in:** auto-mode **skill discovery** now snapshots and scans **project** skill dirs (using `cwd` from `snapshotSkills({ cwd })` at bootstrap), so skills dropped into `<project>/.agents/skills`, `.claude/skills`, or `.gsd/skills` mid-session are no longer silently missed. **Preference bare-name resolution** now follows the shared precedence (including `<cwd>/.gsd/skills` and ancestor `.agents` paths), not the old shorter list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5c1d6b1f2395fb6dbb1e715454639004050633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->