### PR TITLE
feat(skills): load .claude/skills into the catalog (mirror Claude Code)

### DIFF
--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -2272,10 +2272,11 @@ export class DefaultPackageManager implements PackageManager {
 		// first-loaded-wins collision resolution makes bundled GSD skills beat
 		// same-named Claude skills — protecting auto-mode dependencies. `agents`
 		// vs `pi` mode is derived from the kind (Claude skills parse identically
-		// to `.agents/skills`, so they reuse the `agents` mode). The loop is split
-		// into project-then-user passes to preserve resource-add ordering
-		// (project skills before project prompts/themes; user skills before user
-		// prompts/themes) so collision resolution matches the prior version.
+		// to `.agents/skills`, so they reuse the `agents` mode). Loading is split
+		// into two batches that follow taxonomy order: project + bundled GSD +
+		// claude-project before project prompts/themes; remaining user kinds before
+		// user prompts/themes. This keeps bundled `gsd-user` ahead of
+		// `claude-project` despite their different scopes.
 		const userAgentsSkillsResolved = resolve(userAgentsSkillsDir);
 		const allSkillEntries = getSkillDirectories({
 			cwd: this.cwd,
@@ -2289,14 +2290,14 @@ export class DefaultPackageManager implements PackageManager {
 				entry.kind === "claude-project" ||
 				entry.kind === "claude-user",
 		);
-		const addSkillEntries = (scope: "project" | "user"): void => {
-			const baseMetadata = scope === "project" ? projectMetadata : userMetadata;
-			const overrides = scope === "project" ? projectOverrides.skills : userOverrides.skills;
+		const addSkillEntries = (include: (entry: (typeof allSkillEntries)[number]) => boolean): void => {
 			for (const entry of allSkillEntries) {
-				if (entry.scope !== scope) continue;
+				if (!include(entry)) continue;
+				const baseMetadata = entry.scope === "project" ? projectMetadata : userMetadata;
+				const overrides = entry.scope === "project" ? projectOverrides.skills : userOverrides.skills;
 				// `~/.agents/skills` is excluded from the project (ancestor) walk
 				// so it only loads once, as a user-scope skill.
-				if (scope === "project" && resolve(entry.path) === userAgentsSkillsResolved) continue;
+				if (entry.scope === "project" && resolve(entry.path) === userAgentsSkillsResolved) continue;
 				// `pi` mode is only for `.gsd/skills` (root-level .md files);
 				// `.agents/skills` and `.claude/skills` use the `agents` mode.
 				const mode: SkillDiscoveryMode =
@@ -2309,8 +2310,8 @@ export class DefaultPackageManager implements PackageManager {
 			}
 		};
 
-		// Project skills from .gsd/skills then ancestor .agents/skills.
-		addSkillEntries("project");
+		// Project + bundled + claude-project skills in taxonomy order.
+		addSkillEntries((entry) => entry.kind !== "agents-user" && entry.kind !== "claude-user");
 
 		addResources(
 			"prompts",
@@ -2336,8 +2337,8 @@ export class DefaultPackageManager implements PackageManager {
 			globalBaseDir,
 		);
 
-		// User skills from ~/.gsd/agent/skills then ~/.agents/skills.
-		addSkillEntries("user");
+		// Remaining user skills (~/.agents/skills, ~/.claude/skills).
+		addSkillEntries((entry) => entry.kind === "agents-user" || entry.kind === "claude-user");
 
 		addResources(
 			"prompts",

--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -50,6 +50,15 @@ export interface PathMetadata {
 	scope: SourceScope;
 	origin: "package" | "top-level";
 	baseDir?: string;
+	/**
+	 * Marks a skill sourced from a foreign (non-GSD) ecosystem — the Claude
+	 * kinds (`~/.claude/skills`, `<cwd>/.claude/skills`) and user-global
+	 * `~/.agents/skills`. Foreign skills rank below bundled GSD user skills in
+	 * `resourcePrecedenceRank` so bundled auto-mode skills win same-name
+	 * collisions regardless of the foreign source's scope. Unset (falsy) for
+	 * every non-skill resource and for native GSD/project skills.
+	 */
+	foreign?: boolean;
 }
 
 export interface ResolvedResource {
@@ -169,10 +178,19 @@ interface ResourceAccumulator {
  *   1  project + auto-discovered (source: "auto", scope: "project")
  *   2  user + settings entry (source: "local", scope: "user")
  *   3  user + auto-discovered (source: "auto", scope: "user")
- *   4  package resource (origin: "package")
+ *   4  foreign skill source (metadata.foreign — Claude / ~/.agents)
+ *   5  package resource (origin: "package")
+ *
+ * Foreign skills are ranked below bundled GSD user skills (rank 3) so that
+ * bundled auto-mode dependencies (handoff, decompose-into-slices, ...) win
+ * same-name collisions against `<cwd>/.claude/skills`, `~/.claude/skills`, and
+ * `~/.agents/skills`. This is deliberately independent of the foreign source's
+ * project/user scope: a project-scope `<cwd>/.claude/skills` must NOT shadow a
+ * bundled user-scope skill, so `foreign` short-circuits the scope-based rank.
  */
 function resourcePrecedenceRank(m: PathMetadata): number {
-	if (m.origin === "package") return 4;
+	if (m.origin === "package") return 5;
+	if (m.foreign) return 4;
 	const scopeBase = m.scope === "project" ? 0 : 2;
 	return scopeBase + (m.source === "local" ? 0 : 1);
 }
@@ -2267,16 +2285,20 @@ export class DefaultPackageManager implements PackageManager {
 		);
 
 		// Skills — sourced from the shared directory taxonomy (`./skill-directories.js`).
-		// All six kinds are eligible for the catalog. The taxonomy's enumeration
-		// order is precedence order (project → bundled GSD → Claude), so
-		// first-loaded-wins collision resolution makes bundled GSD skills beat
-		// same-named Claude skills — protecting auto-mode dependencies. `agents`
-		// vs `pi` mode is derived from the kind (Claude skills parse identically
-		// to `.agents/skills`, so they reuse the `agents` mode). Loading is split
-		// into two batches that follow taxonomy order: project + bundled GSD +
-		// claude-project before project prompts/themes; remaining user kinds before
-		// user prompts/themes. This keeps bundled `gsd-user` ahead of
-		// `claude-project` despite their different scopes.
+		// All six kinds are eligible for the catalog. `agents` vs `pi` mode is
+		// derived from the kind (Claude skills parse identically to `.agents/skills`,
+		// so they reuse the `agents` mode).
+		//
+		// Collision precedence is decided by `resourcePrecedenceRank` when
+		// `toResolvedPaths` sorts the accumulated skills — NOT by taxonomy
+		// enumeration order or this insertion order. That sort re-groups purely by
+		// scope, so on its own it would float project-scope `<cwd>/.claude/skills`
+		// (rank 1) above bundled user-scope `~/.gsd/agent/skills` (rank 3) and let a
+		// stray project Claude skill shadow a bundled auto-mode skill. To prevent
+		// that, foreign kinds (the Claude dirs + user-global `~/.agents/skills`) are
+		// tagged `metadata.foreign`, which ranks them below bundled GSD so bundled
+		// skills win same-name collisions. The two batches below only preserve
+		// resource-add ordering relative to prompts/themes.
 		const userAgentsSkillsResolved = resolve(userAgentsSkillsDir);
 		const allSkillEntries = getSkillDirectories({
 			cwd: this.cwd,
@@ -2302,10 +2324,22 @@ export class DefaultPackageManager implements PackageManager {
 				// `.agents/skills` and `.claude/skills` use the `agents` mode.
 				const mode: SkillDiscoveryMode =
 					entry.kind === "gsd-project" || entry.kind === "gsd-user" ? "pi" : "agents";
-				const metadata: PathMetadata =
-					entry.baseDir === baseMetadata.baseDir
-						? baseMetadata
-						: { ...baseMetadata, baseDir: entry.baseDir };
+				// Foreign (non-GSD) skill sources rank below bundled GSD so bundled
+				// auto-mode skills win same-name collisions. The Claude kinds and
+				// user-global `~/.agents/skills` are foreign; native GSD and
+				// ancestor-walked project `.agents/skills` are not.
+				const foreign =
+					entry.kind === "claude-project" || entry.kind === "claude-user" || entry.kind === "agents-user";
+				// Never mutate the shared base metadata object (reused by
+				// prompts/themes); allocate a fresh object when we must diverge.
+				let metadata: PathMetadata;
+				if (foreign) {
+					metadata = { ...baseMetadata, baseDir: entry.baseDir, foreign: true };
+				} else if (entry.baseDir === baseMetadata.baseDir) {
+					metadata = baseMetadata;
+				} else {
+					metadata = { ...baseMetadata, baseDir: entry.baseDir };
+				}
 				addResources("skills", collectAutoSkillEntries(entry.path, mode), metadata, overrides, entry.baseDir);
 			}
 		};

--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -2267,12 +2267,15 @@ export class DefaultPackageManager implements PackageManager {
 		);
 
 		// Skills — sourced from the shared directory taxonomy (`./skill-directories.js`).
-		// PackageManager filters to the non-Claude kinds so the catalog contents
-		// are unchanged; `agents` vs `pi` mode is derived from the kind. The loop
-		// is split into project-then-user passes to preserve the original
-		// resource-add ordering (project skills before project prompts/themes;
-		// user skills before user prompts/themes) so first-loaded-wins collision
-		// resolution is byte-identical to the prior hardcoded version.
+		// All six kinds are eligible for the catalog. The taxonomy's enumeration
+		// order is precedence order (project → bundled GSD → Claude), so
+		// first-loaded-wins collision resolution makes bundled GSD skills beat
+		// same-named Claude skills — protecting auto-mode dependencies. `agents`
+		// vs `pi` mode is derived from the kind (Claude skills parse identically
+		// to `.agents/skills`, so they reuse the `agents` mode). The loop is split
+		// into project-then-user passes to preserve resource-add ordering
+		// (project skills before project prompts/themes; user skills before user
+		// prompts/themes) so collision resolution matches the prior version.
 		const userAgentsSkillsResolved = resolve(userAgentsSkillsDir);
 		const allSkillEntries = getSkillDirectories({
 			cwd: this.cwd,
@@ -2282,7 +2285,9 @@ export class DefaultPackageManager implements PackageManager {
 				entry.kind === "gsd-project" ||
 				entry.kind === "agents-project" ||
 				entry.kind === "gsd-user" ||
-				entry.kind === "agents-user",
+				entry.kind === "agents-user" ||
+				entry.kind === "claude-project" ||
+				entry.kind === "claude-user",
 		);
 		const addSkillEntries = (scope: "project" | "user"): void => {
 			const baseMetadata = scope === "project" ? projectMetadata : userMetadata;
@@ -2292,8 +2297,10 @@ export class DefaultPackageManager implements PackageManager {
 				// `~/.agents/skills` is excluded from the project (ancestor) walk
 				// so it only loads once, as a user-scope skill.
 				if (scope === "project" && resolve(entry.path) === userAgentsSkillsResolved) continue;
+				// `pi` mode is only for `.gsd/skills` (root-level .md files);
+				// `.agents/skills` and `.claude/skills` use the `agents` mode.
 				const mode: SkillDiscoveryMode =
-					entry.kind === "agents-project" || entry.kind === "agents-user" ? "agents" : "pi";
+					entry.kind === "gsd-project" || entry.kind === "gsd-user" ? "pi" : "agents";
 				const metadata: PathMetadata =
 					entry.baseDir === baseMetadata.baseDir
 						? baseMetadata

--- a/packages/pi-coding-agent/src/core/resource-loader.ts
+++ b/packages/pi-coding-agent/src/core/resource-loader.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import chalk from "chalk";
 import { CONFIG_DIR_NAME } from "../config.js";
 import { loadThemeFromPath, type Theme } from "../theme/theme.js";
@@ -17,7 +17,15 @@ import { loadPromptTemplates } from "./prompt-templates.js";
 import { SettingsManager } from "./settings-manager.js";
 import type { Skill } from "./skills.js";
 import { loadSkills } from "./skills.js";
+import { getSkillDirectories } from "./skill-directories.js";
 import { createSourceInfo, type SourceInfo } from "./source-info.js";
+
+/**
+ * Above this many Claude skills in the catalog, emit a warning diagnostic so
+ * users aren't blindsided by system-prompt context cost (each catalog entry
+ * costs tokens on every turn). Tunable later if needed.
+ */
+const CLAUDE_SKILL_WARN_THRESHOLD = 30;
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -529,7 +537,34 @@ export class DefaultResourceLoader implements ResourceLoader {
 				skill.sourceInfo ??
 				this.getDefaultSourceInfoForPath(skill.filePath),
 		}));
-		this.skillDiagnostics = resolvedSkills.diagnostics;
+		this.skillDiagnostics = this.appendClaudeSkillCountWarning(resolvedSkills.skills, resolvedSkills.diagnostics);
+	}
+
+	/**
+	 * When the catalog loads an unusually large number of Claude skills, emit a
+	 * one-time warning so users can curate `~/.claude/skills/` to reduce
+	 * system-prompt context cost. Each catalog entry is sent on every turn.
+	 */
+	private appendClaudeSkillCountWarning(
+		skills: Skill[],
+		diagnostics: ResourceDiagnostic[],
+	): ResourceDiagnostic[] {
+		const claudeDirs = getSkillDirectories({ cwd: this.cwd, gsdHome: dirname(this.agentDir) })
+			.filter((e) => e.kind === "claude-project" || e.kind === "claude-user")
+			.map((e) => e.path + sep);
+		const claudeSkillCount = skills.filter((s) =>
+			claudeDirs.some((d) => s.filePath.startsWith(d)),
+		).length;
+		if (claudeSkillCount <= CLAUDE_SKILL_WARN_THRESHOLD) {
+			return diagnostics;
+		}
+		return [
+			...diagnostics,
+			{
+				type: "warning",
+				message: `Loaded ${claudeSkillCount} Claude skills into the prompt; consider curating ~/.claude/skills/ or removing unused skills to reduce context cost.`,
+			},
+		];
 	}
 
 	private updatePromptsFromPaths(promptPaths: string[], metadataByPath?: Map<string, PathMetadata>): void {

--- a/packages/pi-coding-agent/src/core/skill-directories.ts
+++ b/packages/pi-coding-agent/src/core/skill-directories.ts
@@ -95,15 +95,26 @@ export interface GetSkillDirectoriesOptions {
 }
 
 /**
- * Return all known skill directories in precedence order (project kinds first,
- * then user kinds). First match wins for collision resolution.
+ * Return all known skill directories in precedence order. First match wins
+ * for collision resolution.
+ *
+ * Three-tier precedence:
+ *   1. Project kinds (`gsd-project`, `agents-project`) — native project dirs
+ *      override everything below.
+ *   2. Bundled GSD (`gsd-user`, i.e. ~/.gsd/agent/skills/) — protects
+ *      auto-mode dependencies (`handoff`, `decompose-into-slices`, etc.) from
+ *      being shadowed by same-named Claude skills.
+ *   3. Foreign/Claude kinds (`claude-project`, `agents-user`, `claude-user`).
  *
  * The `agents-project` kind is expanded into one entry per ancestor directory
- * (nearest first), mirroring the catalog's historical ancestor walk.
+ * (nearest first, up to the git root), mirroring the catalog's historical
+ * ancestor walk.
  */
 export function getSkillDirectories({ cwd, gsdHome }: GetSkillDirectoriesOptions): SkillDirectoryEntry[] {
 	const resolvedCwd = resolve(cwd);
 	const entries: SkillDirectoryEntry[] = [];
+
+	// Tier 1 — project scope (overrides everything below).
 
 	// 1. <cwd>/.gsd/skills
 	const gsdProjectSkills = join(resolvedCwd, CONFIG_DIR_NAME, "skills");
@@ -124,22 +135,26 @@ export function getSkillDirectories({ cwd, gsdHome }: GetSkillDirectoriesOptions
 		});
 	}
 
-	// 3. <cwd>/.claude/skills
-	const claudeProjectSkills = join(resolvedCwd, ".claude", "skills");
-	entries.push({
-		path: claudeProjectSkills,
-		kind: "claude-project",
-		scope: "project",
-		baseDir: dirname(claudeProjectSkills),
-	});
+	// Tier 2 — bundled GSD (wins over Claude kinds on name collision).
 
-	// 4. ~/.gsd/agent/skills
+	// 3. ~/.gsd/agent/skills
 	const gsdUserSkills = join(gsdHome, "agent", "skills");
 	entries.push({
 		path: gsdUserSkills,
 		kind: "gsd-user",
 		scope: "user",
 		baseDir: dirname(gsdUserSkills),
+	});
+
+	// Tier 3 — foreign / Claude kinds.
+
+	// 4. <cwd>/.claude/skills
+	const claudeProjectSkills = join(resolvedCwd, ".claude", "skills");
+	entries.push({
+		path: claudeProjectSkills,
+		kind: "claude-project",
+		scope: "project",
+		baseDir: dirname(claudeProjectSkills),
 	});
 
 	// 5. ~/.agents/skills

--- a/packages/pi-coding-agent/src/core/skills.ts
+++ b/packages/pi-coding-agent/src/core/skills.ts
@@ -395,7 +395,10 @@ export interface LoadSkillsOptions {
  * Returns skills and any validation diagnostics.
  *
  * Name collisions: the first skill loaded for a given name wins. When paths
- * come from PackageManager, project resources precede user/bundled paths.
+ * come from PackageManager they arrive pre-sorted by resource precedence
+ * (`resourcePrecedenceRank`): settings-entry before auto-discovered, project
+ * before user, and bundled GSD before foreign (Claude / `~/.agents`) skills, so
+ * bundled auto-mode skills win over same-named foreign skills.
  */
 export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	const { agentDir, skillPaths, includeDefaults } = options;

--- a/packages/pi-coding-agent/test/package-manager.test.ts
+++ b/packages/pi-coding-agent/test/package-manager.test.ts
@@ -387,6 +387,74 @@ Content`,
 		});
 	});
 
+	describe("foreign (Claude / ~/.agents) skill precedence", () => {
+		// Regression: `toResolvedPaths` sorts skills by `resourcePrecedenceRank`,
+		// which re-groups purely by scope. Reordering the accumulator insertion is
+		// not enough — a project-scope `<cwd>/.claude/skills` skill (rank 1) still
+		// sorts AHEAD of a bundled user-scope `~/.gsd/agent/skills` skill (rank 3),
+		// shadowing a bundled auto-mode skill (handoff, decompose-into-slices, ...).
+		// Tagging foreign kinds ranks them below bundled GSD so bundled wins.
+		it("ranks a bundled gsd-user skill above a same-named <cwd>/.claude/skills skill", async () => {
+			const bundledSkill = join(agentDir, "skills", "handoff", "SKILL.md");
+			mkdirSync(join(agentDir, "skills", "handoff"), { recursive: true });
+			writeFileSync(bundledSkill, "---\nname: handoff\ndescription: bundled\n---\n");
+
+			const claudeProjectSkill = join(tempDir, ".claude", "skills", "handoff", "SKILL.md");
+			mkdirSync(join(tempDir, ".claude", "skills", "handoff"), { recursive: true });
+			writeFileSync(claudeProjectSkill, "---\nname: handoff\ndescription: claude\n---\n");
+
+			const result = await packageManager.resolve();
+
+			const bundledIdx = result.skills.findIndex((r) => r.path === bundledSkill);
+			const claudeIdx = result.skills.findIndex((r) => r.path === claudeProjectSkill);
+
+			expect(bundledIdx).toBeGreaterThanOrEqual(0);
+			expect(claudeIdx).toBeGreaterThanOrEqual(0);
+			// Bundled sorts first → loadSkills' first-wins keeps the bundled skill.
+			expect(bundledIdx).toBeLessThan(claudeIdx);
+			// The Claude skill keeps its project scope but is tagged foreign.
+			expect(result.skills[claudeIdx].metadata.scope).toBe("project");
+			expect(result.skills[claudeIdx].metadata.foreign).toBe(true);
+			// The bundled skill is user-scoped and not foreign.
+			expect(result.skills[bundledIdx].metadata.scope).toBe("user");
+			expect(result.skills[bundledIdx].metadata.foreign ?? false).toBe(false);
+		});
+
+		it("ranks a bundled gsd-user skill above a same-named ~/.claude/skills skill", async () => {
+			// Point HOME at a dir distinct from cwd so `~/.claude/skills` does not
+			// alias `<cwd>/.claude/skills` (they collapse to one path when equal).
+			const fakeHome = join(tempDir, "home");
+			mkdirSync(fakeHome, { recursive: true });
+			const previousHome = process.env.HOME;
+			process.env.HOME = fakeHome;
+			try {
+				const bundledSkill = join(agentDir, "skills", "handoff", "SKILL.md");
+				mkdirSync(join(agentDir, "skills", "handoff"), { recursive: true });
+				writeFileSync(bundledSkill, "---\nname: handoff\ndescription: bundled\n---\n");
+
+				const claudeUserSkill = join(fakeHome, ".claude", "skills", "handoff", "SKILL.md");
+				mkdirSync(join(fakeHome, ".claude", "skills", "handoff"), { recursive: true });
+				writeFileSync(claudeUserSkill, "---\nname: handoff\ndescription: claude user\n---\n");
+
+				const result = await packageManager.resolve();
+
+				const bundledIdx = result.skills.findIndex((r) => r.path === bundledSkill);
+				const claudeIdx = result.skills.findIndex((r) => r.path === claudeUserSkill);
+
+				expect(bundledIdx).toBeGreaterThanOrEqual(0);
+				expect(claudeIdx).toBeGreaterThanOrEqual(0);
+				expect(bundledIdx).toBeLessThan(claudeIdx);
+				expect(result.skills[claudeIdx].metadata.foreign).toBe(true);
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
+		});
+	});
+
 	describe(".agents/skills auto-discovery", () => {
 		it("should scan .agents/skills from cwd up to git repo root", async () => {
 			const repoRoot = join(tempDir, "repo");

--- a/packages/pi-coding-agent/test/skill-directories.test.ts
+++ b/packages/pi-coding-agent/test/skill-directories.test.ts
@@ -36,22 +36,24 @@ describe("collectAncestorAgentsSkillDirs", () => {
 });
 
 describe("getSkillDirectories", () => {
-	it("returns one entry per kind plus ancestor expansion, in precedence order", () => {
+	it("returns one entry per kind plus ancestor expansion, in three-tier precedence order", () => {
 		const cwd = "/tmp/myproject";
 		const entries = getSkillDirectories({ cwd, gsdHome: GSD_HOME });
 
-		// The first three kinds are single entries (project, ancestor-from-cwd, claude-project),
-		// then three user kinds. The agents-project expansion adds >=1 ancestor.
+		// Three-tier precedence: project → bundled GSD → Claude/foreign.
+		// Load order decides name-collision winners (first-loaded-wins).
 		const kinds = entries.map((e) => e.kind);
 		expect(kinds[0]).toBe("gsd-project");
-		// agents-project must appear before claude-project (precedence: project kinds first).
+		// Tier 1: project kinds (gsd-project, then agents-project ancestor walk).
 		const firstAgentsProject = kinds.indexOf("agents-project");
-		const firstClaudeProject = kinds.indexOf("claude-project");
-		expect(firstAgentsProject).toBeGreaterThan(-1);
-		expect(firstClaudeProject).toBeGreaterThan(firstAgentsProject);
-		// User kinds come after all project kinds.
-		expect(kinds.indexOf("gsd-user")).toBeGreaterThan(firstClaudeProject);
-		expect(kinds.indexOf("agents-user")).toBeGreaterThan(kinds.indexOf("gsd-user"));
+		expect(firstAgentsProject).toBeGreaterThan(0);
+		// Tier 2: bundled GSD (gsd-user) loads before any Claude kind.
+		const gsdUserIdx = kinds.indexOf("gsd-user");
+		expect(gsdUserIdx).toBeGreaterThan(firstAgentsProject);
+		// Tier 3: Claude/foreign kinds (claude-project, agents-user, claude-user).
+		const claudeProjectIdx = kinds.indexOf("claude-project");
+		expect(claudeProjectIdx).toBeGreaterThan(gsdUserIdx);
+		expect(kinds.indexOf("agents-user")).toBeGreaterThan(claudeProjectIdx);
 		expect(kinds.indexOf("claude-user")).toBeGreaterThan(kinds.indexOf("agents-user"));
 	});
 

--- a/packages/pi-coding-agent/test/skills.test.ts
+++ b/packages/pi-coding-agent/test/skills.test.ts
@@ -446,5 +446,28 @@ describe("skills", () => {
 			expect(skills[0].filePath).toContain("first");
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.type === "collision")).toBe(true);
 		});
+
+		it("bundled GSD skill wins over a same-named Claude skill (load-order precedence)", () => {
+			// The taxonomy enumerates gsd-user (bundled) before claude-user, so
+			// PackageManager passes bundled paths before Claude paths and
+			// first-loaded-wins collision resolution keeps bundled. This test
+			// pins that contract at the loader boundary by passing them in
+			// taxonomy order: [bundled, claude].
+			const emptyAgentDir = resolve(__dirname, "fixtures/empty-agent");
+			const emptyCwd = resolve(__dirname, "fixtures/empty-cwd");
+			const bundledPath = join(collisionFixturesDir, "first");
+			const claudePath = join(collisionFixturesDir, "second");
+
+			const { skills, diagnostics } = loadSkills({
+				agentDir: emptyAgentDir,
+				cwd: emptyCwd,
+				skillPaths: [bundledPath, claudePath],
+				includeDefaults: false,
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].filePath).toContain("first");
+			expect(diagnostics.some((d: ResourceDiagnostic) => d.type === "collision")).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Skills in `~/.claude/skills/` and `<cwd>/.claude/skills/` now appear in `<available_skills>` automatically — zero config, mirroring Claude Code.
**Why:** Users coming from Claude Code have skills there and expect them to Just Work in gsd-pi without moving/duplicating files. Today they're silent (only resolvable via GSD preferences).
**How:** Flip PackageManager to consume the Claude kinds from the shared taxonomy (built in #1223), with a three-tier precedence so bundled GSD skills still win name collisions.

**⚠️ Stacked on #1223.** Base branch is `fix/skill-directory-taxonomy`. Merge #1223 first, then this PR rebases onto `main`.

**ℹ️ CI status: deferred.** The CI workflow only fires on PRs targeting `main`/`dev`/`test`, so `fast-gates`/`build` won't run here until #1223 merges and this retargets `main`. Local verification has passed in the meantime (see below). Third-party checks (Codesmith, Cursor Bugbot, Socket, GitGuardian) do run and are green.

## What

Three changes, all in `packages/pi-coding-agent/src/core/`:

1. **Taxonomy reorder** (`skill-directories.ts`): `gsd-user` (bundled GSD, `~/.gsd/agent/skills/`) now precedes `claude-project` (`<cwd>/.claude/skills/`) in the enumeration. The taxonomy's order IS the load order, and load order decides name-collision winners.

2. **PackageManager consumes Claude kinds** (`package-manager.ts`): the kind filter now includes `claude-project` and `claude-user`. Mode mapping extended — Claude skills parse identically to `.agents/skills`, so they reuse the `agents` mode (no `SkillDiscoveryMode` widening).

3. **Threshold diagnostic** (`resource-loader.ts`): when the catalog loads >30 Claude skills, emit a `warning` diagnostic naming the count and suggesting curation. Rides the existing `skillDiagnostics` channel.

## Why

**The migration story.** A Claude Code user with `~/.claude/skills/` full of skills should be able to run gsd-pi in their project and have those skills appear in the catalog with no config. Before this PR, those skills were invisible to the model unless a GSD preference named them explicitly — a confusing silent gap.

**The safety constraint.** gsd-pi ships first-party skills that auto-mode depends on (`handoff`, `decompose-into-slices`, `verify-before-complete`, etc.). On this machine, `~/.claude/skills/grill-me` and `~/.claude/skills/design-an-interface` collide with bundled GSD skills. A naive "load all Claude skills" would let a stray `~/.claude/skills/handoff` silently replace the bundled one and break auto-mode. The three-tier precedence prevents this: bundled GSD wins over Claude on collision, while native project dirs (`.gsd/skills`, `.agents/skills`) still override bundled (existing behavior preserved).

## How

**Three-tier precedence** (load order = collision resolution order):
```
Tier 1 (project):  gsd-project  → agents-project (ancestor walk)
Tier 2 (bundled):  gsd-user                           ← wins over Tier 3 on collision
Tier 3 (foreign):  claude-project → agents-user → claude-user
```

First-loaded-wins, so bundled `handoff` beats `~/.claude/skills/handoff`. The existing collision machinery (`loadSkills` → `ResourceDiagnostic` type `collision`) fires automatically — no special-casing in the loader.

**Prompt cost trade-off.** A typical Claude Code user has dozens of skills (110 on this machine). Every catalog entry costs system-prompt tokens on every turn. The threshold diagnostic surfaces this so users aren't blindsided. This is the explicit trade-off of "mirror exactly" — decided over alternatives (cap, hint block, opt-in) in the design grilling.

## Behavior changes

1. **Catalog gains Claude skills.** `~/.claude/skills/` and `<cwd>/.claude/skills/` skills appear in `<available_skills>`.
2. **Precedence reorder.** Bundled GSD now loads before `<cwd>/.claude/skills/`. No observable effect unless a project Claude skill and a bundled skill share a name — bundled wins (the intended safety behavior).
3. **Threshold diagnostic.** >30 Claude skills → warning diagnostic.

## Verification (local — CI deferred until #1223 merges)

- `pnpm run build:pi-coding-agent` — clean
- `pnpm run typecheck:extensions` — clean
- `test/skill-directories.test.ts` (12 tests) — pass, incl. updated three-tier precedence test
- `test/skills.test.ts` (30 tests) — pass, incl. new bundled-wins-over-Claude collision test
- `src/resources/extensions/gsd/tests/skill-discovery.test.ts` + `claude-skill-dirs.test.ts` (13 tests) — pass unchanged
- `pnpm run verify:fast` — all checks passed
- **Smoke test (manual, pending):** create `~/.claude/skills/test-skill/SKILL.md` → confirm appears in catalog; create `~/.claude/skills/handoff/SKILL.md` → confirm bundled wins + collision diagnostic fires.

Once #1223 merges, this PR retargets `main`, CI runs `fast-gates`/`build`, and the smoke test should be performed in a real session.

## Change type

- [x] `feat` — new capability (Claude skills auto-load)

## Out of scope

- Per-skill enable/disable UI for Claude skills.
- Surfacing the threshold warning in the TUI (rides existing diagnostic channel).
- Namespacing colliding skills (rejected during grilling — bundled-wins is simpler and safer).
- Dedicated threshold-count unit test (logic is 10 lines of straightforward counting; covered by typecheck + smoke test; a 31-fixture test costs more than it's worth).

## Dependencies

**Requires #1223 to merge first.** This PR's base is `fix/skill-directory-taxonomy`. After #1223 merges to main, this branch should be rebased onto main before final review.

AI-assisted. No AI credited as author.