### PR TITLE
fix(gsd): align suffixed flat-phase projections

### DIFF
--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -124,6 +124,7 @@ function alignBareMarkdownIdsWithSuffixedDb(markdownScan: HierarchyScan, dbScan:
     replaceSetPrefix(markdownScan.milestones, bareId, dbId);
     replaceSetPrefix(markdownScan.slices, bareId, dbId);
     replaceSetPrefix(markdownScan.tasks, bareId, dbId);
+    replaceSetPrefix(markdownScan.milestonesWithoutRoadmap, bareId, dbId);
   }
 }
 

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -112,6 +112,21 @@ function alignNumericMarkdownIdsWithDb(markdownScan: HierarchyScan, dbScan: Hier
   }
 }
 
+function bareMilestoneId(id: string): string | null {
+  const match = id.match(/^(M\d{3})-[a-z0-9]{6}$/);
+  return match?.[1] ?? null;
+}
+
+function alignBareMarkdownIdsWithSuffixedDb(markdownScan: HierarchyScan, dbScan: HierarchyScan): void {
+  for (const dbId of dbScan.milestones) {
+    const bareId = bareMilestoneId(dbId);
+    if (!bareId || dbScan.milestones.has(bareId) || !markdownScan.milestones.has(bareId)) continue;
+    replaceSetPrefix(markdownScan.milestones, bareId, dbId);
+    replaceSetPrefix(markdownScan.slices, bareId, dbId);
+    replaceSetPrefix(markdownScan.tasks, bareId, dbId);
+  }
+}
+
 /**
  * True when the DB holds any milestone/slice/task identity the markdown lacks —
  * i.e. a `/gsd recover --confirm` (markdown → DB) would DELETE authoritative DB
@@ -208,6 +223,7 @@ export async function checkMarkdownHierarchyAgainstDb(
   const dbScan = scanDbHierarchy();
   const beforeDb = dbScan.counts;
   alignNumericMarkdownIdsWithDb(markdownScan, dbScan);
+  alignBareMarkdownIdsWithSuffixedDb(markdownScan, dbScan);
 
   // Discussion-phase scratch: a milestone dir with no ROADMAP and no DB row is
   // a pre-registration discussion artifact (CONTEXT/CONTEXT-DRAFT only — the

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -102,13 +102,28 @@ function replaceSetPrefix(values: Set<string>, from: string, to: string): void {
   }
 }
 
+/**
+ * Rewrite one milestone identity across EVERY markdown identity set. The
+ * roadmapless subset is a view of `milestones`, so it must speak the same
+ * aligned vocabulary; otherwise the discussion-phase exclusion below keys off
+ * the stale bare id, fails its `dbScan.milestones.has(...)` membership check,
+ * and decrements the milestone count even though the aligned identity remains
+ * in the set, reporting false drift for a milestone that is actually in sync.
+ * Centralising the set list here keeps every alignment path from silently
+ * missing a set (the defect that regressed the suffixed roadmapless case).
+ */
+function realignMilestonePrefix(markdownScan: HierarchyScan, from: string, to: string): void {
+  replaceSetPrefix(markdownScan.milestones, from, to);
+  replaceSetPrefix(markdownScan.slices, from, to);
+  replaceSetPrefix(markdownScan.tasks, from, to);
+  replaceSetPrefix(markdownScan.milestonesWithoutRoadmap, from, to);
+}
+
 function alignNumericMarkdownIdsWithDb(markdownScan: HierarchyScan, dbScan: HierarchyScan): void {
   for (const dbId of dbScan.milestones) {
     const paddedId = paddedMilestoneId(dbId);
     if (!paddedId || dbScan.milestones.has(paddedId) || !markdownScan.milestones.has(paddedId)) continue;
-    replaceSetPrefix(markdownScan.milestones, paddedId, dbId);
-    replaceSetPrefix(markdownScan.slices, paddedId, dbId);
-    replaceSetPrefix(markdownScan.tasks, paddedId, dbId);
+    realignMilestonePrefix(markdownScan, paddedId, dbId);
   }
 }
 
@@ -121,10 +136,7 @@ function alignBareMarkdownIdsWithSuffixedDb(markdownScan: HierarchyScan, dbScan:
   for (const dbId of dbScan.milestones) {
     const bareId = bareMilestoneId(dbId);
     if (!bareId || dbScan.milestones.has(bareId) || !markdownScan.milestones.has(bareId)) continue;
-    replaceSetPrefix(markdownScan.milestones, bareId, dbId);
-    replaceSetPrefix(markdownScan.slices, bareId, dbId);
-    replaceSetPrefix(markdownScan.tasks, bareId, dbId);
-    replaceSetPrefix(markdownScan.milestonesWithoutRoadmap, bareId, dbId);
+    realignMilestonePrefix(markdownScan, bareId, dbId);
   }
 }
 

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -696,7 +696,16 @@ function pickPreferredPhaseDir(phasesDir: string, matches: string[]): string {
   return best;
 }
 
-function phaseDirMatchesMilestoneId(dirName: string, milestoneId: string, phaseNum: number): boolean {
+function slugLooksLikeTeamSuffixProjection(slugPart: string): boolean {
+  return /^[a-z0-9]{6}(-|$)/.test(slugPart);
+}
+
+function phaseDirMatchesMilestoneId(
+  dirName: string,
+  milestoneId: string,
+  phaseNum: number,
+  allowTeamSuffixSlugs = false,
+): boolean {
   const numMatch = dirName.match(/^(\d+)-(.*)$/);
   if (!numMatch || parseInt(numMatch[1]!, 10) !== phaseNum) return false;
   const slugPart = numMatch[2]!;
@@ -704,8 +713,7 @@ function phaseDirMatchesMilestoneId(dirName: string, milestoneId: string, phaseN
   if (suffix) {
     return slugPart === suffix || slugPart.startsWith(`${suffix}-`);
   }
-  // Plain sequential IDs may need to resolve a suffixed team-mode phase dir
-  // during markdown-vs-DB drift checks before the DB identity has been aligned.
+  if (slugLooksLikeTeamSuffixProjection(slugPart) && !allowTeamSuffixSlugs) return false;
   return true;
 }
 
@@ -725,6 +733,15 @@ function resolvePhaseDir(basePath: string, milestoneId: string): string | null {
         if (!entry.isDirectory()) continue;
         if (phaseDirMatchesMilestoneId(entry.name, milestoneId, phaseNum)) {
           matches.push(entry.name);
+        }
+      }
+      // Bare milestone ids may only have a suffixed team-mode projection on disk.
+      if (matches.length === 0 && !milestoneIdUniqueSuffix(milestoneId)) {
+        for (const entry of readdirSync(phasesDir, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue;
+          if (phaseDirMatchesMilestoneId(entry.name, milestoneId, phaseNum, true)) {
+            matches.push(entry.name);
+          }
         }
       }
     } catch {

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -704,8 +704,9 @@ function phaseDirMatchesMilestoneId(dirName: string, milestoneId: string, phaseN
   if (suffix) {
     return slugPart === suffix || slugPart.startsWith(`${suffix}-`);
   }
-  // Plain sequential IDs must not resolve to unique-suffix phase dirs.
-  return !/^[a-z0-9]{6}(-|$)/.test(slugPart);
+  // Plain sequential IDs may need to resolve a suffixed team-mode phase dir
+  // during markdown-vs-DB drift checks before the DB identity has been aligned.
+  return true;
 }
 
 function resolvePhaseDir(basePath: string, milestoneId: string): string | null {

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -352,6 +352,85 @@ test("canonical worktree + project-root legacy dir produces legacy filename (#bu
       resolved,
       join(projectLegacyDir, "01-ROADMAP.md"),
       "must NOT produce flat-phase filename 01-ROADMAP.md for a legacy milestones/ dir",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── cursor[bot] 3523932401: bare milestone id must not match a team-suffix ────
+//
+// A bare milestone id (M001, no team-mode suffix) resolves its phase dir by
+// scanning phases/NN-*. Before the guard (commit 8f45bf3),
+// phaseDirMatchesMilestoneId returned true for ANY same-number dir, so a
+// leftover team-mode projection (phases/01-<6char>-.../, from a prior
+// team-suffixed run) matched the bare id too. When that stale dir carried a
+// newer mtime, pickPreferredPhaseDir selected it over the real title dir and
+// resolved the ROADMAP into a directory that has no ROADMAP — the file-not-found
+// retry loop. The guard (slugLooksLikeTeamSuffixProjection) rejects
+// team-suffix-looking slugs for bare ids in the primary pass; the suffixed
+// projection stays available only as a fallback when the primary pass finds
+// nothing (#1195, guarded by the second test below).
+
+test("bare milestone id prefers the real title dir over a newer team-suffix projection (cursor 3523932401)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-bare-teamsuffix-")));
+  try {
+    const phasesDir = join(root, ".gsd", "phases");
+    // Intended flat-phase dir for the bare id: 01-<title-slug>/ with the ROADMAP.
+    const intendedDir = join(phasesDir, "01-clean-continuation");
+    mkdirSync(intendedDir, { recursive: true });
+    writeFileSync(join(intendedDir, "01-ROADMAP.md"), "# roadmap\n");
+
+    // Leftover team-mode projection: 01-<6char>-.../ with NO ROADMAP, made
+    // NEWER so an mtime tiebreak would wrongly prefer it without the guard.
+    const staleDir = join(phasesDir, "01-re4q3k-old-team-projection");
+    mkdirSync(staleDir, { recursive: true });
+    const newer = new Date(Date.now() + 60_000);
+    const older = new Date(Date.now() - 60_000);
+    utimesSync(staleDir, newer, newer);
+    utimesSync(intendedDir, older, older);
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("plan-milestone", "M001", root);
+    assert.equal(
+      resolved,
+      join(intendedDir, "01-ROADMAP.md"),
+      "bare id must resolve to the real title dir, not the newer team-suffix projection",
+    );
+    assert.notEqual(
+      resolved,
+      join(staleDir, "01-ROADMAP.md"),
+      "must NOT resolve into the team-suffix projection dir that has no ROADMAP",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bare milestone id still falls back to a lone team-suffix projection (#1195)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-bare-teamsuffix-only-")));
+  try {
+    const phasesDir = join(root, ".gsd", "phases");
+    // The only on-disk dir for the bare id is a team-mode projection. With no
+    // non-suffixed candidate, the fallback pass must still resolve to it.
+    const onlyDir = join(phasesDir, "01-re4q3k-clean-continuation");
+    mkdirSync(onlyDir, { recursive: true });
+    writeFileSync(join(onlyDir, "01-ROADMAP.md"), "# roadmap\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const resolved = resolveExpectedArtifactPath("plan-milestone", "M001", root);
+    assert.equal(
+      resolved,
+      join(onlyDir, "01-ROADMAP.md"),
+      "with no non-suffixed dir, the team-suffix projection is the correct fallback",
     );
   } finally {
     _clearGsdRootCache();

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -439,6 +439,30 @@ test("migration auto-check still compares a roadmapless milestone that HAS a DB 
   }
 });
 
+test("migration auto-check aligns a roadmapless milestone dir to its suffixed DB row (no false drift)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    // Team-mode suffixed milestone whose markdown dir has no ROADMAP yet (e.g. a
+    // freshly handed-off / zero-slice milestone). Markdown discovers the bare
+    // "M001"; the DB stores the authoritative suffixed "M001-re4q3k". The
+    // bare-to-suffixed alignment must rewrite EVERY markdown set, including the
+    // roadmapless subset, so the discussion-phase exclusion sees the DB row and
+    // does not decrement the milestone count into false drift.
+    insertMilestone({ id: "M001-re4q3k", title: "Suffixed milestone", status: "queued" });
+    writeScratchMilestoneDir(base, "M001", "M001-CONTEXT.md");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 0, tasks: 0 });
+    assert.deepEqual(result.beforeDb, { milestones: 1, slices: 0, tasks: 0 });
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("rebuildMarkdownProjectionsFromDb realigns markdown when DB holds extra rows", async () => {
   const base = makeBase();
   try {

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -250,6 +250,73 @@ test("migration auto-check canonicalizes a legacy descriptor milestone dir (no f
   }
 });
 
+test("migration auto-check recognizes suffixed flat-phase projection directories", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+
+    insertMilestone({
+      id: "M001-re4q3k",
+      title: "Clean GSD Continuation Readiness",
+      status: "complete",
+      planning: { vision: "Keep continuation state readable." },
+    });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001-re4q3k",
+      title: "Readiness slice",
+      status: "complete",
+      risk: "low",
+      depends: [],
+      demo: "Readable continuation state.",
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001-re4q3k",
+      title: "Readiness task",
+      status: "complete",
+    });
+    insertMilestone({
+      id: "M002-a1rwmq",
+      title: "Support Command Policy Hardening",
+      status: "complete",
+      planning: { vision: "Harden support command policy." },
+    });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M002-a1rwmq",
+      title: "Policy slice",
+      status: "complete",
+      risk: "low",
+      depends: [],
+      demo: "Policy is hardened.",
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M002-a1rwmq",
+      title: "Policy task",
+      status: "complete",
+    });
+
+    const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.ts");
+    const rebuild = await rebuildMarkdownProjectionsFromDb(base);
+    assert.ok(rebuild.rendered > 0, "expected flat-phase markdown projections to render");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 2, slices: 2, tasks: 2 });
+    assert.deepEqual(result.beforeDb, { milestones: 2, slices: 2, tasks: 2 });
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("migration auto-check refreshes a stale open DB handle before comparing", async () => {
   const base = makeBase();
   try {


### PR DESCRIPTION
## TL;DR

**What:** Align markdown-vs-DB hierarchy checks when flat-phase directories encode team-mode milestone suffixes.
**Why:** Rebuilt `.gsd/phases/NN-suffix-title` projections could be treated as stale/missing against authoritative `M###-suffix` DB rows.
**How:** Let bare phase-number resolution read flat-phase directories, then align bare markdown identities to matching suffixed DB milestone identities during hierarchy comparison.

## What

- Updates flat-phase path matching so a discovered bare phase number can resolve existing suffixed phase directories during drift checks.
- Adds DB-backed identity alignment from bare markdown IDs such as `M001` to authoritative suffixed DB IDs such as `M001-re4q3k`.
- Adds regression coverage that renders two completed suffixed milestones to `.gsd/phases` and verifies markdown and DB counts/identities are in sync after rebuild.

## Why

Closes #1195.

After `/gsd rebuild markdown`, flat-phase projections could exist on disk under directories like `.gsd/phases/01-re4q3k-clean-gsd-continuation-readiness`, while the authoritative DB stored `M001-re4q3k`. The hierarchy check could compare bare markdown identities against suffixed DB identities and incorrectly report stale markdown drift.

## How

The fix keeps the DB authoritative and avoids destructive repair. Markdown scanning may initially discover a bare `M###` from the phase number; after the DB is opened/refreshed, the checker rewrites that bare identity to the matching suffixed DB identity when the DB has `M###-xxxxxx` and does not also have the bare `M###`. That keeps title slugs that happen to start with six letters from being misclassified as suffixes.

## Verification

- [x] RED: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migration-auto-check.test.ts --test-name-pattern "suffixed flat-phase"` failed before the fix with `actual: recovery-required`, `expected: none`.
- [x] GREEN: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migration-auto-check.test.ts` passed (16/16).
- [x] Sabotage: temporarily disabled `alignBareMarkdownIdsWithSuffixedDb(...)`; the suffixed flat-phase regression failed with `actual: recovery-required`, then passed after restore.
- [x] Nearby tests: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts src/resources/extensions/gsd/tests/layout-policy.test.ts src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts` passed after building workspace packages.
- [x] `pnpm run build:core` passed.
- [x] `pnpm run typecheck:extensions` passed after `build:core`.

## Impact analysis

- Blast radius: moderate. This touches markdown/DB drift checks and path resolution for flat-phase milestone directories.
- Affected workflows: `/gsd rebuild markdown`, `/gsd new-milestone` startup drift checks, `/gsd recover` data-loss guard comparisons, and doctor/dispatch code that resolves existing flat-phase paths.
- Risks or compatibility notes: Plain `M###` discovery can now read an existing same-number flat-phase directory before DB identity alignment. The identity rewrite only happens when the authoritative DB has the matching suffixed milestone and no bare DB milestone for that sequence.

## Notes

- Draft because issue #1195 is labeled `large-scope` / `needs-maintainer-review`, and `no-mistakes axi run` could not be started for this branch due its daemon resolving an unrelated parked run and returning `no run started ... no previous run for branch`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785794936&installation_id=134682257&pr_number=1227&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1227&signature=f9d065f4a649fa156950b2231eceed4f5d3268b08c06ceec830745ab4d059a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup drift checks, flat-phase path resolution, and recover/rebuild routing; behavior change is gated (suffixed DB + bare markdown alignment, optional second phase-dir scan) but affects multiple GSD workflows.
> 
> **Overview**
> **Fixes false “recovery required” drift** after `/gsd rebuild markdown` when the authoritative DB uses team-mode milestone IDs like `M001-re4q3k` but flat-phase directories live under names such as `01-re4q3k-…`.
> 
> **Path resolution** (`paths.ts`): for milestones without an embedded unique suffix, `resolvePhaseDir` can take a second pass that treats six-character slug prefixes as team suffix projections, so bare `M###` lookups still find existing suffixed phase dirs without treating arbitrary title slugs as suffixes in the default path.
> 
> **Hierarchy comparison** (`migration-auto-check.ts`): after the existing numeric ID alignment, **`alignBareMarkdownIdsWithSuffixedDb`** rewrites markdown scan identities from bare `M###` to the matching suffixed DB milestone (and related slice/task/`milestonesWithoutRoadmap` keys) when the DB has `M###-xxxxxx` and no bare `M###` row.
> 
> **Regression test** rebuilds two suffixed milestones to flat-phase markdown and asserts `checkMarkdownHierarchyAgainstDb` reports **in-sync**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6418f227b4ae795854e56ebfe605f07e5e79581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->