### PR TITLE
fix(issue): [Bug]: execute-task completion lost-update — gsd_task_complete succeeds but the tasks row reverts to pending; auto-mode hard-stops "state did not advance" after the first execute-task

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -454,6 +454,14 @@ export function insertTask(t: {
   fullSummaryMd?: string;
   sequence?: number;
   planning?: Partial<TaskPlanningRecord>;
+  // #1222 (metadata half): when re-importing from markdown, the caller only
+  // knows the plan/status — not the execution prose that gsd_task_complete
+  // wrote to the DB. Setting this preserves the existing row's execution
+  // columns (and completed_at) whenever the incoming value is empty/default,
+  // so a re-import cannot silently blank a completed task's summary metadata
+  // or refresh its completion timestamp. Off by default: callers that own the
+  // execution metadata (gsd_task_complete, planning) keep overwrite semantics.
+  preserveCompletionMetadata?: boolean;
 }): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   getDbOrNull()!.prepare(
@@ -473,17 +481,17 @@ export function insertTask(t: {
     ON CONFLICT(milestone_id, slice_id, id) DO UPDATE SET
       title = CASE WHEN NULLIF(:title, '') IS NOT NULL THEN :title ELSE tasks.title END,
       status = :status,
-      one_liner = :one_liner,
-      narrative = :narrative,
-      verification_result = :verification_result,
-      duration = :duration,
-      completed_at = :completed_at,
-      blocker_discovered = :blocker_discovered,
-      deviations = :deviations,
-      known_issues = :known_issues,
-      key_files = :key_files,
-      key_decisions = :key_decisions,
-      full_summary_md = :full_summary_md,
+      one_liner = CASE WHEN :preserve_completion = 1 AND NULLIF(:one_liner, '') IS NULL THEN tasks.one_liner ELSE :one_liner END,
+      narrative = CASE WHEN :preserve_completion = 1 AND NULLIF(:narrative, '') IS NULL THEN tasks.narrative ELSE :narrative END,
+      verification_result = CASE WHEN :preserve_completion = 1 AND NULLIF(:verification_result, '') IS NULL THEN tasks.verification_result ELSE :verification_result END,
+      duration = CASE WHEN :preserve_completion = 1 AND NULLIF(:duration, '') IS NULL THEN tasks.duration ELSE :duration END,
+      completed_at = CASE WHEN :preserve_completion = 1 AND tasks.completed_at IS NOT NULL THEN tasks.completed_at ELSE :completed_at END,
+      blocker_discovered = CASE WHEN :preserve_completion = 1 AND :blocker_discovered = 0 THEN tasks.blocker_discovered ELSE :blocker_discovered END,
+      deviations = CASE WHEN :preserve_completion = 1 AND NULLIF(:deviations, '') IS NULL THEN tasks.deviations ELSE :deviations END,
+      known_issues = CASE WHEN :preserve_completion = 1 AND NULLIF(:known_issues, '') IS NULL THEN tasks.known_issues ELSE :known_issues END,
+      key_files = CASE WHEN :preserve_completion = 1 AND NULLIF(:key_files, '[]') IS NULL THEN tasks.key_files ELSE :key_files END,
+      key_decisions = CASE WHEN :preserve_completion = 1 AND NULLIF(:key_decisions, '[]') IS NULL THEN tasks.key_decisions ELSE :key_decisions END,
+      full_summary_md = CASE WHEN :preserve_completion = 1 AND NULLIF(:full_summary_md, '') IS NULL THEN tasks.full_summary_md ELSE :full_summary_md END,
       description = CASE WHEN NULLIF(:description, '') IS NOT NULL THEN :description ELSE tasks.description END,
       estimate = CASE WHEN NULLIF(:estimate, '') IS NOT NULL THEN :estimate ELSE tasks.estimate END,
       files = CASE WHEN NULLIF(:files, '[]') IS NOT NULL THEN :files ELSE tasks.files END,
@@ -523,6 +531,7 @@ export function insertTask(t: {
     ":observability_impact": t.planning?.observabilityImpact ?? "",
     ":full_plan_md": t.planning?.fullPlanMd ?? "",
     ":sequence": t.sequence ?? 0,
+    ":preserve_completion": t.preserveCompletionMetadata ? 1 : 0,
     ":target_repositories": JSON.stringify(t.planning?.targetRepositories ?? []),
     ":raw_target_repositories":
       t.planning && "targetRepositories" in t.planning

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -531,7 +531,7 @@ export function insertTask(t: {
     ":observability_impact": t.planning?.observabilityImpact ?? "",
     ":full_plan_md": t.planning?.fullPlanMd ?? "",
     ":sequence": t.sequence ?? 0,
-    ":preserve_completion": t.preserveCompletionMetadata ? 1 : 0,
+    ":preserve_completion": t.preserveCompletionMetadata && (t.status === "complete" || t.status === "done") ? 1 : 0,
     ":target_repositories": JSON.stringify(t.planning?.targetRepositories ?? []),
     ":raw_target_repositories":
       t.planning && "targetRepositories" in t.planning

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -881,6 +881,12 @@ export function migrateHierarchyToDb(basePath: string): {
             files: taskEntry.files ?? [],
             verify: taskEntry.verify ?? '',
           },
+          // #1222 (metadata half): re-import derives status from the plan/summary
+          // but has none of the execution prose gsd_task_complete wrote to the DB.
+          // Preserve the existing row's execution columns and completed_at so a
+          // re-import cannot blank a completed task's summary metadata or refresh
+          // its completion timestamp — the DB row is strictly richer than the plan.
+          preserveCompletionMetadata: true,
         });
         counts.tasks++;
       }

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -825,19 +825,28 @@ export function migrateHierarchyToDb(basePath: string): {
         const slicePath = resolveSlicePath(basePath, milestoneId, sliceEntry.id);
         let taskSummaryFile: string | null = null;
         let isLegacySlice = false;
+        // Legacy layout keeps per-task summaries under a tasks/ subdir. Its
+        // presence — not merely "is this a legacy slice" — is what makes a
+        // missing summary a downgrade signal. resolveTasksDir returns null when
+        // no such dir exists, so a legacy slice whose checkbox is the only
+        // completion signal (no tasks/ dir at all) is left complete on import.
+        let legacyTasksDir: string | null = null;
         if (slicePath) {
           isLegacySlice = basename(dirname(slicePath)) === 'slices';
-          const summaryDir = isLegacySlice
-            ? (resolveTasksDir(basePath, milestoneId, sliceEntry.id) ?? slicePath)
-            : slicePath;
+          legacyTasksDir = isLegacySlice
+            ? resolveTasksDir(basePath, milestoneId, sliceEntry.id)
+            : null;
+          const summaryDir = legacyTasksDir ?? slicePath;
           taskSummaryFile = join(summaryDir, `${taskEntry.id}-SUMMARY.md`);
         }
         const hasTaskSummary = taskSummaryFile !== null && existsSync(taskSummaryFile);
 
-        // Pre-migration consistency (legacy layout only): if a task is marked
-        // done but has no per-task SUMMARY.md, import it as pending so it gets
-        // re-executed rather than silently entering the DB as complete.
-        if (taskStatus === 'complete' && isLegacySlice && !hasTaskSummary) {
+        // Pre-migration consistency (legacy tasks/ layout only): if a task is
+        // marked done but its tasks/ dir has no per-task SUMMARY.md, import it
+        // as pending so it gets re-executed rather than silently entering the DB
+        // as complete. A legacy slice with no tasks/ dir (checkbox-only
+        // completion) and flat-phase layout are both left as-is here.
+        if (taskStatus === 'complete' && legacyTasksDir !== null && !hasTaskSummary) {
           taskStatus = 'pending';
           process.stderr.write(
             `gsd-migrate: ${milestoneId}/${sliceEntry.id}/${taskEntry.id} marked done but missing summary — importing as pending\n`,

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -903,11 +903,22 @@ export function migrateHierarchyToDb(basePath: string): {
               : slicePathForTasks)
           : null;
         const allTasksDone = plan.tasks.length > 0 && plan.tasks.every(t => {
-          const hasTaskSummary = taskSummaryDir !== null
-            && existsSync(join(taskSummaryDir, `${t.id}-SUMMARY.md`));
+          const taskSummaryFile = taskSummaryDir !== null
+            ? join(taskSummaryDir, `${t.id}-SUMMARY.md`)
+            : null;
+          const hasTaskSummary = taskSummaryFile !== null && existsSync(taskSummaryFile);
+          let summaryAttestsCompletion = hasTaskSummary;
+          if (summaryAttestsCompletion && !isLegacySliceLayout && roadmap.slices.length > 1 && taskSummaryFile) {
+            try {
+              const summaryContent = readFileSync(taskSummaryFile, 'utf-8');
+              summaryAttestsCompletion = parseSummary(summaryContent).frontmatter.parent === sliceEntry.id;
+            } catch {
+              summaryAttestsCompletion = false;
+            }
+          }
           // Match per-task import rules above: SUMMARY attestation wins over a stale
           // checkbox (#1222); flat-phase checkboxes are authoritative without summary.
-          return hasTaskSummary || (t.done && !isLegacySliceLayout);
+          return summaryAttestsCompletion || (t.done && !isLegacySliceLayout);
         });
         if (allTasksDone && hasSliceSummary) {
           if (_getAdapter()) {

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -5,7 +5,7 @@
 // Exports: parseDecisionsTable, parseRequirementsSections, migrateFromMarkdown
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
-import { join, relative, basename } from 'node:path';
+import { join, relative, basename, dirname } from 'node:path';
 import type { Decision, Requirement } from './types.js';
 import {
   upsertDecision,
@@ -24,6 +24,7 @@ import {
   resolveGsdRootFile,
   resolveMilestoneFile,
   resolveSliceFile,
+  resolveSlicePath,
   resolveTasksDir,
   legacyMilestonesDir,
   gsdRoot,
@@ -818,21 +819,25 @@ export function migrateHierarchyToDb(basePath: string): {
 
         // Resolve the per-task SUMMARY.md. Legacy layout keeps summaries under
         // a tasks/ subdir; flat-phase writes TID-SUMMARY.md directly in the
-        // phase dir (execute-task's gsd_task_complete writes it there).
-        const tDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
+        // phase dir (execute-task's gsd_task_complete writes it there). A tasks/
+        // subdir may still exist in flat-phase for auxiliary artifacts — its
+        // mere existence must NOT redirect summary resolution into tasks/ (#1208).
+        const slicePath = resolveSlicePath(basePath, milestoneId, sliceEntry.id);
         let taskSummaryFile: string | null = null;
-        if (tDir) {
-          taskSummaryFile = join(tDir, `${taskEntry.id}-SUMMARY.md`);
-        } else {
-          const phaseDir = resolveMilestonePath(basePath, milestoneId);
-          if (phaseDir) taskSummaryFile = join(phaseDir, `${taskEntry.id}-SUMMARY.md`);
+        let isLegacySlice = false;
+        if (slicePath) {
+          isLegacySlice = basename(dirname(slicePath)) === 'slices';
+          const summaryDir = isLegacySlice
+            ? (resolveTasksDir(basePath, milestoneId, sliceEntry.id) ?? slicePath)
+            : slicePath;
+          taskSummaryFile = join(summaryDir, `${taskEntry.id}-SUMMARY.md`);
         }
         const hasTaskSummary = taskSummaryFile !== null && existsSync(taskSummaryFile);
 
         // Pre-migration consistency (legacy layout only): if a task is marked
         // done but has no per-task SUMMARY.md, import it as pending so it gets
         // re-executed rather than silently entering the DB as complete.
-        if (taskStatus === 'complete' && tDir && !hasTaskSummary) {
+        if (taskStatus === 'complete' && isLegacySlice && !hasTaskSummary) {
           taskStatus = 'pending';
           process.stderr.write(
             `gsd-migrate: ${milestoneId}/${sliceEntry.id}/${taskEntry.id} marked done but missing summary — importing as pending\n`,

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -34,7 +34,7 @@ import {
 import { findMilestoneIds } from './guided-flow.js';
 import { milestoneIdToPhaseNum } from './layout-policy.js';
 import { parseRoadmap, parsePlan } from './parsers-legacy.js';
-import { parseContextDependsOn } from './files.js';
+import { parseContextDependsOn, parseSummary } from './files.js';
 import { logWarning } from './workflow-logger.js';
 
 // ─── DECISIONS.md Parser ───────────────────────────────────────────────────
@@ -852,7 +852,19 @@ export function migrateHierarchyToDb(basePath: string): {
         // first execute-task. The surviving SUMMARY wins over a stale checkbox.
         // reopen-task removes the SUMMARY, so this never re-completes an
         // intentionally reopened task.
-        if (taskStatus === 'pending' && hasTaskSummary) {
+        // Flat-phase summaries are phase-scoped (T01-SUMMARY.md); when a milestone
+        // has multiple slices, require the summary parent frontmatter to match so
+        // one slice's completion does not attest a sibling's same-named task.
+        let summaryAttestsCompletion = hasTaskSummary;
+        if (summaryAttestsCompletion && !isLegacySlice && roadmap.slices.length > 1 && taskSummaryFile) {
+          try {
+            const summaryContent = readFileSync(taskSummaryFile, 'utf-8');
+            summaryAttestsCompletion = parseSummary(summaryContent).frontmatter.parent === sliceEntry.id;
+          } catch {
+            summaryAttestsCompletion = false;
+          }
+        }
+        if (taskStatus === 'pending' && summaryAttestsCompletion) {
           taskStatus = 'complete';
           process.stderr.write(
             `gsd-migrate: ${milestoneId}/${sliceEntry.id}/${taskEntry.id} unchecked in plan but SUMMARY.md present — importing as complete (#1222)\n`,

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -882,12 +882,20 @@ export function migrateHierarchyToDb(basePath: string): {
       if (!sliceEntry.done) {
         const sliceSummaryPath = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'SUMMARY');
         const hasSliceSummary = sliceSummaryPath !== null && existsSync(sliceSummaryPath);
+        const slicePathForTasks = resolveSlicePath(basePath, milestoneId, sliceEntry.id);
+        const isLegacySliceLayout = slicePathForTasks !== null
+          && basename(dirname(slicePathForTasks)) === 'slices';
+        const taskSummaryDir = slicePathForTasks
+          ? (isLegacySliceLayout
+              ? (resolveTasksDir(basePath, milestoneId, sliceEntry.id) ?? slicePathForTasks)
+              : slicePathForTasks)
+          : null;
         const allTasksDone = plan.tasks.length > 0 && plan.tasks.every(t => {
-          if (!t.done) return false;
-          const tDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
-          // Flat-phase has no per-task summary files — checkbox state is authoritative.
-          if (!tDir) return true;
-          return existsSync(join(tDir, `${t.id}-SUMMARY.md`));
+          const hasTaskSummary = taskSummaryDir !== null
+            && existsSync(join(taskSummaryDir, `${t.id}-SUMMARY.md`));
+          // Match per-task import rules above: SUMMARY attestation wins over a stale
+          // checkbox (#1222); flat-phase checkboxes are authoritative without summary.
+          return hasTaskSummary || (t.done && !isLegacySliceLayout);
         });
         if (allTasksDone && hasSliceSummary) {
           if (_getAdapter()) {

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -816,22 +816,42 @@ export function migrateHierarchyToDb(basePath: string): {
         // Per K002: use 'complete' not 'done'
         let taskStatus: string = taskEntry.done ? 'complete' : 'pending';
 
+        // Resolve the per-task SUMMARY.md. Legacy layout keeps summaries under
+        // a tasks/ subdir; flat-phase writes TID-SUMMARY.md directly in the
+        // phase dir (execute-task's gsd_task_complete writes it there).
+        const tDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
+        let taskSummaryFile: string | null = null;
+        if (tDir) {
+          taskSummaryFile = join(tDir, `${taskEntry.id}-SUMMARY.md`);
+        } else {
+          const phaseDir = resolveMilestonePath(basePath, milestoneId);
+          if (phaseDir) taskSummaryFile = join(phaseDir, `${taskEntry.id}-SUMMARY.md`);
+        }
+        const hasTaskSummary = taskSummaryFile !== null && existsSync(taskSummaryFile);
+
         // Pre-migration consistency (legacy layout only): if a task is marked
         // done but has no per-task SUMMARY.md, import it as pending so it gets
         // re-executed rather than silently entering the DB as complete.
-        // Flat-phase has no per-task summary files by design — the checkbox
-        // state is the authoritative completion signal and is imported as-is.
-        if (taskStatus === 'complete') {
-          const tDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
-          if (tDir) {
-            const summaryFile = join(tDir, `${taskEntry.id}-SUMMARY.md`);
-            if (!existsSync(summaryFile)) {
-              taskStatus = 'pending';
-              process.stderr.write(
-                `gsd-migrate: ${milestoneId}/${sliceEntry.id}/${taskEntry.id} marked done but missing summary — importing as pending\n`,
-              );
-            }
-          }
+        if (taskStatus === 'complete' && tDir && !hasTaskSummary) {
+          taskStatus = 'pending';
+          process.stderr.write(
+            `gsd-migrate: ${milestoneId}/${sliceEntry.id}/${taskEntry.id} marked done but missing summary — importing as pending\n`,
+          );
+        }
+
+        // Lost-update guard (#1222): a per-task SUMMARY.md is the durable
+        // completion attestation written by gsd_task_complete. When the plan
+        // checkbox is stale-unchecked but the SUMMARY exists on disk, a
+        // re-import must NOT downgrade the completed task back to pending — that
+        // silent revert is the lost-update that hard-stopped auto-mode after the
+        // first execute-task. The surviving SUMMARY wins over a stale checkbox.
+        // reopen-task removes the SUMMARY, so this never re-completes an
+        // intentionally reopened task.
+        if (taskStatus === 'pending' && hasTaskSummary) {
+          taskStatus = 'complete';
+          process.stderr.write(
+            `gsd-migrate: ${milestoneId}/${sliceEntry.id}/${taskEntry.id} unchecked in plan but SUMMARY.md present — importing as complete (#1222)\n`,
+          );
         }
 
         insertTask({

--- a/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
+++ b/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
-import { openDatabase, closeDatabase, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, getAllMilestones, getMilestoneSlices, getSliceTasks, repairTaskCompletionFromSummary } from "../gsd-db.ts";
 import { migrateHierarchyToDb } from "../md-importer.ts";
 import { invalidateStateCache } from "../state.ts";
 
@@ -38,12 +38,22 @@ function copyFixture(): string {
 }
 
 function taskStatus(base: string): string | undefined {
+  return t01Row()?.status;
+}
+
+function t01Row() {
   const ms = getAllMilestones();
   if (ms.length === 0) return undefined;
   const slices = getMilestoneSlices(ms[0]!.id);
   if (slices.length === 0) return undefined;
   const tasks = getSliceTasks(ms[0]!.id, slices[0]!.id);
-  return tasks.find((t) => t.id === "T01")?.status;
+  return tasks.find((t) => t.id === "T01");
+}
+
+function t01Ids() {
+  const ms = getAllMilestones();
+  const slices = getMilestoneSlices(ms[0]!.id);
+  return { milestoneId: ms[0]!.id, sliceId: slices[0]!.id };
 }
 
 test("re-import keeps a flat-phase task complete when its SUMMARY.md is present (#1222)", () => {
@@ -96,6 +106,50 @@ test("re-import keeps a flat-phase task complete even when an auxiliary tasks/ s
     "complete",
     "a phase-root SUMMARY.md must win even when a tasks/ subdir exists (no shadowing)",
   );
+});
+
+test("re-import preserves execution metadata and completed_at of an attested-complete task (#1222)", () => {
+  const base = copyFixture();
+  // T01 is completed on disk (SUMMARY present) but its plan checkbox is stale-unchecked.
+  writeFileSync(join(base, SUMMARY_REL), "# T01 SUMMARY\n\nDone.\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+
+  // Simulate the row gsd_task_complete leaves behind: real execution prose plus
+  // a completion timestamp from when the task actually finished.
+  const OLD_COMPLETED_AT = "2026-07-01T00:00:00.000Z";
+  const REAL_ONE_LINER = "Implemented the widget frobnicator end-to-end";
+  const REAL_SUMMARY = "# T01 full summary\n\nEverything about how T01 was done.";
+  const REAL_VERIFICATION = "all 12 checks passed";
+  const { milestoneId, sliceId } = t01Ids();
+  repairTaskCompletionFromSummary({
+    milestoneId,
+    sliceId,
+    taskId: "T01",
+    oneLiner: REAL_ONE_LINER,
+    verificationResult: REAL_VERIFICATION,
+    completedAt: OLD_COMPLETED_AT,
+    fullSummaryMd: REAL_SUMMARY,
+  });
+  invalidateStateCache();
+
+  const before = t01Row()!;
+  assert.equal(before.status, "complete", "precondition: T01 is complete");
+  assert.equal(before.one_liner, REAL_ONE_LINER, "precondition: one_liner set");
+  assert.equal(before.completed_at, OLD_COMPLETED_AT, "precondition: completed_at set");
+
+  // The pre-dispatch reconcile re-imports the whole tree (plan checkbox still [ ]).
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+
+  const after = t01Row()!;
+  assert.equal(after.status, "complete", "status must survive re-import");
+  assert.equal(after.one_liner, REAL_ONE_LINER, "one_liner must survive re-import");
+  assert.equal(after.full_summary_md, REAL_SUMMARY, "full_summary_md must survive re-import");
+  assert.equal(after.verification_result, REAL_VERIFICATION, "verification_result must survive re-import");
+  assert.equal(after.completed_at, OLD_COMPLETED_AT, "completed_at must not be refreshed by re-import");
 });
 
 test("removing the SUMMARY.md (reopen) lets a re-import return the task to pending (#1222)", () => {

--- a/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
+++ b/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
@@ -7,7 +7,7 @@
 
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { cpSync, mkdtempSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
+import { cpSync, mkdtempSync, rmSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -75,6 +75,26 @@ test("re-import leaves an unchecked flat-phase task pending when no SUMMARY.md e
     taskStatus(base),
     "pending",
     "unchecked task without a SUMMARY.md must stay pending",
+  );
+});
+
+test("re-import keeps a flat-phase task complete even when an auxiliary tasks/ subdir exists (#1222)", () => {
+  const base = copyFixture();
+  // Flat-phase may keep a tasks/ subdir for gate artifacts (e.g. T01-VERIFY.json)
+  // while gsd_task_complete still writes TID-SUMMARY.md at the phase root. The
+  // tasks/ subdir must NOT shadow that real summary and downgrade the task.
+  mkdirSync(join(base, PHASE_DIR, "tasks"), { recursive: true });
+  writeFileSync(join(base, PHASE_DIR, "tasks", "T01-VERIFY.json"), "{}\n");
+  writeFileSync(join(base, SUMMARY_REL), "# T01 SUMMARY\n\nDone.\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+
+  assert.equal(
+    taskStatus(base),
+    "complete",
+    "a phase-root SUMMARY.md must win even when a tasks/ subdir exists (no shadowing)",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
+++ b/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
@@ -152,7 +152,7 @@ test("re-import preserves execution metadata and completed_at of an attested-com
   assert.equal(after.completed_at, OLD_COMPLETED_AT, "completed_at must not be refreshed by re-import");
 });
 
-test("removing the SUMMARY.md (reopen) lets a re-import return the task to pending (#1222)", () => {
+test("removing the SUMMARY.md (reopen) lets a re-import return the task to pending and clears completion metadata (#1222)", () => {
   const base = copyFixture();
   writeFileSync(join(base, SUMMARY_REL), "# T01 SUMMARY\n\nDone.\n");
 
@@ -161,13 +161,36 @@ test("removing the SUMMARY.md (reopen) lets a re-import return the task to pendi
   invalidateStateCache();
   assert.equal(taskStatus(base), "complete", "precondition: task imports complete with SUMMARY present");
 
+  // Simulate the durable completion row gsd_task_complete leaves behind.
+  const { milestoneId, sliceId } = t01Ids();
+  repairTaskCompletionFromSummary({
+    milestoneId,
+    sliceId,
+    taskId: "T01",
+    oneLiner: "Implemented the widget frobnicator end-to-end",
+    verificationResult: "all 12 checks passed",
+    completedAt: "2026-07-01T00:00:00.000Z",
+    fullSummaryMd: "# T01 full summary\n\nEverything about how T01 was done.",
+  });
+  invalidateStateCache();
+  const before = t01Row()!;
+  assert.equal(before.status, "complete", "precondition: T01 is complete");
+  assert.equal(before.completed_at, "2026-07-01T00:00:00.000Z", "precondition: completed_at set");
+
   // reopen-task deletes the flat-phase SUMMARY; the next re-import must respect it.
   unlinkSync(join(base, SUMMARY_REL));
   migrateHierarchyToDb(base);
   invalidateStateCache();
+  const after = t01Row()!;
   assert.equal(
-    taskStatus(base),
+    after.status,
     "pending",
     "after the SUMMARY is removed, a re-import must return the unchecked task to pending",
   );
+  // A pending re-import must not preserve stale completion metadata (#1228 thread):
+  // preserveCompletionMetadata only applies to complete/done imports.
+  assert.ok(!after.completed_at, "completed_at must be cleared when the task reverts to pending");
+  assert.ok(!after.one_liner, "one_liner must be cleared when the task reverts to pending");
+  assert.ok(!after.full_summary_md, "full_summary_md must be cleared when the task reverts to pending");
+  assert.ok(!after.verification_result, "verification_result must be cleared when the task reverts to pending");
 });

--- a/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
+++ b/src/resources/extensions/gsd/tests/import-completion-lost-update.test.ts
@@ -1,0 +1,99 @@
+// Project/App: gsd-pi
+// File Purpose: Regression for #1222 — a re-import must not silently downgrade
+// a completed flat-phase task back to pending when its SUMMARY.md attests the
+// completion. gsd_task_complete succeeds and writes TID-SUMMARY.md, but a stale
+// plan checkbox re-imported into the DB would revert the task to pending,
+// hard-stopping auto-mode on its "state did not advance" guard.
+
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import { openDatabase, closeDatabase, getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.ts";
+import { migrateHierarchyToDb } from "../md-importer.ts";
+import { invalidateStateCache } from "../state.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, "__fixtures__", "flat-phase");
+// The flat-phase fixture parses to M001/S01/T01 (phase 01, plan 01, task T01).
+const PHASE_DIR = join(".gsd", "phases", "01-foundation");
+const SUMMARY_REL = join(PHASE_DIR, "T01-SUMMARY.md");
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+function copyFixture(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-lostupdate-${randomUUID()}`));
+  cpSync(FIXTURE_ROOT, base, { recursive: true });
+  tmpDirs.push(base);
+  return base;
+}
+
+function taskStatus(base: string): string | undefined {
+  const ms = getAllMilestones();
+  if (ms.length === 0) return undefined;
+  const slices = getMilestoneSlices(ms[0]!.id);
+  if (slices.length === 0) return undefined;
+  const tasks = getSliceTasks(ms[0]!.id, slices[0]!.id);
+  return tasks.find((t) => t.id === "T01")?.status;
+}
+
+test("re-import keeps a flat-phase task complete when its SUMMARY.md is present (#1222)", () => {
+  const base = copyFixture();
+  // The fixture plan leaves T01 unchecked ([ ]). Simulate a completed task: the
+  // durable SUMMARY.md exists even though the plan checkbox is stale-unchecked.
+  writeFileSync(join(base, SUMMARY_REL), "# T01 SUMMARY\n\nDone.\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+
+  assert.equal(
+    taskStatus(base),
+    "complete",
+    "task with SUMMARY.md on disk must import as complete, not revert to pending",
+  );
+});
+
+test("re-import leaves an unchecked flat-phase task pending when no SUMMARY.md exists (#1222)", () => {
+  const base = copyFixture();
+  // No SUMMARY.md — the unchecked checkbox is the authoritative signal.
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+
+  assert.equal(
+    taskStatus(base),
+    "pending",
+    "unchecked task without a SUMMARY.md must stay pending",
+  );
+});
+
+test("removing the SUMMARY.md (reopen) lets a re-import return the task to pending (#1222)", () => {
+  const base = copyFixture();
+  writeFileSync(join(base, SUMMARY_REL), "# T01 SUMMARY\n\nDone.\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+  assert.equal(taskStatus(base), "complete", "precondition: task imports complete with SUMMARY present");
+
+  // reopen-task deletes the flat-phase SUMMARY; the next re-import must respect it.
+  unlinkSync(join(base, SUMMARY_REL));
+  migrateHierarchyToDb(base);
+  invalidateStateCache();
+  assert.equal(
+    taskStatus(base),
+    "pending",
+    "after the SUMMARY is removed, a re-import must return the unchecked task to pending",
+  );
+});

--- a/src/resources/extensions/gsd/tools/reopen-task.ts
+++ b/src/resources/extensions/gsd/tools/reopen-task.ts
@@ -25,7 +25,7 @@ import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
 import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { resolveTasksDir, clearPathCache } from "../paths.js";
+import { resolveTasksDir, resolveMilestonePath, clearPathCache } from "../paths.js";
 
 export interface ReopenTaskParams {
   milestoneId: string;
@@ -106,10 +106,14 @@ export async function handleReopenTask(
   // ── Clean up stale filesystem artifacts (M12 fix) ────────────────────────
   // Without this, the DB-filesystem reconciler sees the SUMMARY.md and
   // auto-corrects the task back to "complete", making reopen a no-op (#3161).
+  // Legacy layout keeps the summary under a tasks/ subdir; flat-phase writes
+  // TID-SUMMARY.md directly in the phase dir. Remove whichever exists so the
+  // re-import lost-update guard (#1222) doesn't re-complete a reopened task.
   try {
     const tasksDir = resolveTasksDir(basePath, params.milestoneId, params.sliceId);
-    if (tasksDir) {
-      const summaryPath = join(tasksDir, `${params.taskId}-SUMMARY.md`);
+    const summaryDir = tasksDir ?? resolveMilestonePath(basePath, params.milestoneId);
+    if (summaryDir) {
+      const summaryPath = join(summaryDir, `${params.taskId}-SUMMARY.md`);
       if (existsSync(summaryPath)) unlinkSync(summaryPath);
     }
   } catch (cleanupErr) {

--- a/src/resources/extensions/gsd/tools/reopen-task.ts
+++ b/src/resources/extensions/gsd/tools/reopen-task.ts
@@ -24,8 +24,8 @@ import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
 import { existsSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
-import { resolveTasksDir, resolveMilestonePath, clearPathCache } from "../paths.js";
+import { join, basename, dirname } from "node:path";
+import { resolveTasksDir, resolveSlicePath, clearPathCache } from "../paths.js";
 
 export interface ReopenTaskParams {
   milestoneId: string;
@@ -107,12 +107,16 @@ export async function handleReopenTask(
   // Without this, the DB-filesystem reconciler sees the SUMMARY.md and
   // auto-corrects the task back to "complete", making reopen a no-op (#3161).
   // Legacy layout keeps the summary under a tasks/ subdir; flat-phase writes
-  // TID-SUMMARY.md directly in the phase dir. Remove whichever exists so the
-  // re-import lost-update guard (#1222) doesn't re-complete a reopened task.
+  // TID-SUMMARY.md directly in the phase dir. A tasks/ subdir may still exist
+  // in flat-phase for auxiliary artifacts — its mere existence must NOT redirect
+  // summary cleanup into tasks/ (#1208).
   try {
-    const tasksDir = resolveTasksDir(basePath, params.milestoneId, params.sliceId);
-    const summaryDir = tasksDir ?? resolveMilestonePath(basePath, params.milestoneId);
-    if (summaryDir) {
+    const slicePath = resolveSlicePath(basePath, params.milestoneId, params.sliceId);
+    if (slicePath) {
+      const isLegacySlice = basename(dirname(slicePath)) === "slices";
+      const summaryDir = isLegacySlice
+        ? (resolveTasksDir(basePath, params.milestoneId, params.sliceId) ?? slicePath)
+        : slicePath;
       const summaryPath = join(summaryDir, `${params.taskId}-SUMMARY.md`);
       if (existsSync(summaryPath)) unlinkSync(summaryPath);
     }


### PR DESCRIPTION
## Summary
- Prevented flat-phase re-import from downgrading a completed task to pending when its SUMMARY.md attests completion (and made reopen delete the flat-phase SUMMARY), fixing the execute-task completion lost-update; verified with a new regression test and related import/reopen suites (27 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1222
- [#1222 [Bug]: execute-task completion lost-update — gsd_task_complete succeeds but the tasks row reverts to pending; auto-mode hard-stops "state did not advance" after the first execute-task](https://github.com/open-gsd/gsd-pi/issues/1222)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1222-bug-execute-task-completion-lost-update--1783202260`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task status and upsert semantics during hierarchy re-import and reopen cleanup; behavior is scoped to import/reopen paths with regression tests, but incorrect summary attestation logic could mis-classify task completion.
> 
> **Overview**
> Fixes **execute-task completion lost-update**: after `gsd_task_complete` writes a flat-phase `TID-SUMMARY.md`, a pre-dispatch markdown re-import was downgrading the task to **pending** when the plan checkbox was still unchecked, which hard-stopped auto-mode.
> 
> **Markdown import** now treats an on-disk per-task `SUMMARY.md` as completion attestation over a stale plan checkbox, resolves summaries at the **phase root** for flat-phase (legacy stays under `tasks/`; an auxiliary `tasks/` dir must not shadow the real summary), and in multi-slice flat-phase requires summary frontmatter `parent` to match the slice. Re-import calls `insertTask` with **`preserveCompletionMetadata`** so existing execution fields and `completed_at` are not wiped or refreshed.
> 
> **`insertTask`** adds optional `preserveCompletionMetadata`: on upsert, when importing complete/done tasks, empty incoming execution columns keep the existing DB values.
> 
> **`reopen-task`** uses the same summary path rules when deleting `SUMMARY.md`, so reopen stays effective.
> 
> Regression coverage is in **`import-completion-lost-update.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0cde12430d9f6b628c6f7c828b41c2288d05ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->