### PR TITLE
chore(release): sync Hermes plugin version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -489,7 +489,7 @@ jobs:
             echo "::error::Re-run NPM Publish so the release includes the latest main."
             exit 1
           fi
-          git add package.json pnpm-lock.yaml CHANGELOG.md README.md native/Cargo.toml native/Cargo.lock native/npm/*/package.json pkg/package.json packages/*/package.json extensions/google-search/package.json
+          git add package.json pnpm-lock.yaml CHANGELOG.md README.md native/Cargo.toml native/Cargo.lock native/npm/*/package.json pkg/package.json packages/*/package.json extensions/google-search/package.json integrations/hermes/pyproject.toml integrations/hermes/open_gsd_hermes/gsd_client.py
           git commit -m "release: v${RELEASE_VERSION}"
           git tag "v${RELEASE_VERSION}"
 

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -215,7 +215,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.2.0"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.5.0"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.2.0"
+version = "1.5.0"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -254,3 +254,12 @@ test("main package publish uses explicit prepack and disables npm lifecycle reru
   assert.match(prodPublish.run, /postpack-restore-workspace\.cjs/);
   assert.match(prodPublish.run, /npm publish --ignore-scripts --tag latest/);
 });
+
+test("production release stages bundled open-gsd-hermes version files", () => {
+  const steps = workflow.jobs["prod-release"].steps;
+  const commitRelease = steps.find((step) => step.name === "Commit and tag release");
+
+  assert.ok(commitRelease, "prod-release must create a release commit");
+  assert.match(commitRelease.run, /integrations\/hermes\/pyproject\.toml/);
+  assert.match(commitRelease.run, /integrations\/hermes\/open_gsd_hermes\/gsd_client\.py/);
+});

--- a/scripts/__tests__/version-sync.test.mjs
+++ b/scripts/__tests__/version-sync.test.mjs
@@ -9,7 +9,55 @@ import { createRequire } from "node:module";
 import test from "node:test";
 
 const require = createRequire(import.meta.url);
-const { RELEASE_WORKSPACE_PACKAGE_DIRS, resolveEngineOptionalDependencyVersion, syncVersionSurfaces } = require("../lib/version-sync.cjs");
+const {
+  PLATFORM_PACKAGE_DIRS,
+  RELEASE_WORKSPACE_PACKAGE_DIRS,
+  resolveEngineOptionalDependencyVersion,
+  syncVersionSurfaces,
+  verifyVersionSync,
+} = require("../lib/version-sync.cjs");
+
+function writeJson(filePath, data) {
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function writeHermesVersionFiles(root, version) {
+  const hermesDir = join(root, "integrations", "hermes");
+  mkdirSync(join(hermesDir, "open_gsd_hermes"), { recursive: true });
+  writeFileSync(
+    join(hermesDir, "pyproject.toml"),
+    `[project]\nname = "open-gsd-hermes"\nversion = "${version}"\n`,
+  );
+  writeFileSync(
+    join(hermesDir, "open_gsd_hermes", "gsd_client.py"),
+    `payload = {"clientInfo": {"name": "open-gsd-hermes", "version": "${version}"}}\n`,
+  );
+}
+
+function createVersionSyncFixture(root, version) {
+  const optionalDependencies = Object.fromEntries(
+    PLATFORM_PACKAGE_DIRS.map((dir) => [
+      `@opengsd/engine-${dir.replace("native/npm/", "")}`,
+      version,
+    ]),
+  );
+
+  writeJson(join(root, "package.json"), {
+    name: "@opengsd/gsd-pi",
+    version,
+    optionalDependencies,
+  });
+
+  for (const packageDir of [...RELEASE_WORKSPACE_PACKAGE_DIRS, ...PLATFORM_PACKAGE_DIRS, "pkg"]) {
+    mkdirSync(join(root, packageDir), { recursive: true });
+    writeJson(join(root, packageDir, "package.json"), {
+      name: packageDir.replaceAll("/", "-"),
+      version,
+    });
+  }
+
+  writeFileSync(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+}
 
 test("resolveEngineOptionalDependencyVersion keeps prerelease publishes on stable engine packages", () => {
   // dev and next channels both reuse the stable engine packages — neither
@@ -68,6 +116,67 @@ test("syncVersionSurfaces rewrites internal deps to the stamped prerelease versi
     assert.equal(mcpServer.version, devVersion);
     assert.equal(gateway.version, devVersion);
     assert.equal(gateway.dependencies["@opengsd/mcp-server"], "workspace:*");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("syncVersionSurfaces updates bundled open-gsd-hermes version files for stable releases", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-hermes-version-sync-"));
+  const releaseVersion = "1.6.0";
+
+  try {
+    createVersionSyncFixture(root, "1.5.0");
+    writeHermesVersionFiles(root, "1.2.0");
+
+    syncVersionSurfaces(root, releaseVersion);
+
+    assert.match(
+      readFileSync(join(root, "integrations", "hermes", "pyproject.toml"), "utf8"),
+      /version = "1\.6\.0"/,
+    );
+    assert.match(
+      readFileSync(join(root, "integrations", "hermes", "open_gsd_hermes", "gsd_client.py"), "utf8"),
+      /"version": "1\.6\.0"/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("verifyVersionSync reports stale bundled open-gsd-hermes versions on stable releases", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-hermes-version-verify-"));
+
+  try {
+    createVersionSyncFixture(root, "1.6.0");
+    writeHermesVersionFiles(root, "1.2.0");
+
+    assert.deepEqual(verifyVersionSync(root), [
+      "integrations/hermes/pyproject.toml version is 1.2.0, expected 1.6.0",
+      "integrations/hermes/open_gsd_hermes/gsd_client.py clientInfo version is 1.2.0, expected 1.6.0",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("syncVersionSurfaces leaves open-gsd-hermes on stable Python metadata during prerelease stamps", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-hermes-prerelease-sync-"));
+
+  try {
+    createVersionSyncFixture(root, "1.5.0");
+    writeHermesVersionFiles(root, "1.5.0");
+
+    syncVersionSurfaces(root, "1.6.0-dev.abc1234");
+
+    assert.match(
+      readFileSync(join(root, "integrations", "hermes", "pyproject.toml"), "utf8"),
+      /version = "1\.5\.0"/,
+    );
+    assert.match(
+      readFileSync(join(root, "integrations", "hermes", "open_gsd_hermes", "gsd_client.py"), "utf8"),
+      /"version": "1\.5\.0"/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/lib/version-sync.cjs
+++ b/scripts/lib/version-sync.cjs
@@ -44,6 +44,10 @@ const INTERNAL_PACKAGE_NAMES = new Set([
 
 const NATIVE_CRATE_NAMES = new Set(["gsd-ast", "gsd-engine", "gsd-grep"]);
 
+const HERMES_PYPROJECT_PATH = "integrations/hermes/pyproject.toml";
+const HERMES_CLIENT_PATH = "integrations/hermes/open_gsd_hermes/gsd_client.py";
+const STABLE_SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
 /**
  * Prerelease publishes (dev AND next channels) reuse the stable
  * @opengsd/engine-* packages already on npm — the prerelease workflow does not
@@ -123,6 +127,81 @@ function syncNativeCargoVersion(root, version) {
   }
 }
 
+function isStableReleaseVersion(version) {
+  return STABLE_SEMVER_PATTERN.test(version);
+}
+
+function replaceRequired(content, pattern, replacement, filePath, description) {
+  if (!pattern.test(content)) {
+    throw new Error(`Could not find ${description} in ${filePath}`);
+  }
+  return content.replace(pattern, replacement);
+}
+
+function syncHermesVersion(root, version) {
+  if (!isStableReleaseVersion(version)) return;
+
+  const pyprojectPath = path.join(root, HERMES_PYPROJECT_PATH);
+  if (fs.existsSync(pyprojectPath)) {
+    const pyproject = fs.readFileSync(pyprojectPath, "utf8");
+    const nextPyproject = replaceRequired(
+      pyproject,
+      /(^version = )"[^"]+"/m,
+      `$1"${version}"`,
+      HERMES_PYPROJECT_PATH,
+      "open-gsd-hermes project version",
+    );
+    if (nextPyproject !== pyproject) {
+      fs.writeFileSync(pyprojectPath, nextPyproject);
+    }
+  }
+
+  const clientPath = path.join(root, HERMES_CLIENT_PATH);
+  if (fs.existsSync(clientPath)) {
+    const client = fs.readFileSync(clientPath, "utf8");
+    const nextClient = replaceRequired(
+      client,
+      /("clientInfo": \{"name": "open-gsd-hermes", "version": )"[^"]+"/,
+      `$1"${version}"`,
+      HERMES_CLIENT_PATH,
+      "open-gsd-hermes clientInfo version",
+    );
+    if (nextClient !== client) {
+      fs.writeFileSync(clientPath, nextClient);
+    }
+  }
+}
+
+function readHermesVersion(content, pattern) {
+  return content.match(pattern)?.[1];
+}
+
+function verifyHermesVersion(root, expectedVersion, issues) {
+  if (!isStableReleaseVersion(expectedVersion)) return;
+
+  const pyprojectPath = path.join(root, HERMES_PYPROJECT_PATH);
+  if (fs.existsSync(pyprojectPath)) {
+    const version = readHermesVersion(
+      fs.readFileSync(pyprojectPath, "utf8"),
+      /^version = "([^"]+)"/m,
+    );
+    if (version !== expectedVersion) {
+      issues.push(`${HERMES_PYPROJECT_PATH} version is ${version ?? "missing"}, expected ${expectedVersion}`);
+    }
+  }
+
+  const clientPath = path.join(root, HERMES_CLIENT_PATH);
+  if (fs.existsSync(clientPath)) {
+    const version = readHermesVersion(
+      fs.readFileSync(clientPath, "utf8"),
+      /"clientInfo": \{"name": "open-gsd-hermes", "version": "([^"]+)"/,
+    );
+    if (version !== expectedVersion) {
+      issues.push(`${HERMES_CLIENT_PATH} clientInfo version is ${version ?? "missing"}, expected ${expectedVersion}`);
+    }
+  }
+}
+
 function syncVersionSurfaces(root, version, options = {}) {
   if (options.updateRoot !== false) {
     const rootPkgPath = path.join(root, "package.json");
@@ -141,6 +220,7 @@ function syncVersionSurfaces(root, version, options = {}) {
 
   setPackageVersion(root, "pkg", version);
   syncNativeCargoVersion(root, version);
+  syncHermesVersion(root, version);
 }
 
 function getNativeCargoVersion(root) {
@@ -232,6 +312,7 @@ function verifyVersionSync(root) {
       issues.push(`native/Cargo.lock ${name} version is ${version}, expected ${expectedVersion}`);
     }
   }
+  verifyHermesVersion(root, expectedVersion, issues);
 
   return issues;
 }


### PR DESCRIPTION
## TL;DR

**What:** Add the bundled `open-gsd-hermes` integration to stable release version sync.
**Why:** Hermes metadata and MCP `clientInfo` should not drift from the GSD Pi release that bundles it.
**How:** Sync stable release versions into Hermes metadata/client files, verify stale Hermes versions fail the release sync gate, and stage those files in the production release commit.

## What

- Sync stable release versions into `integrations/hermes/pyproject.toml`.
- Sync stable release versions into the Hermes MCP `clientInfo.version` field.
- Add version-sync regression coverage for stable sync, stale-version verification, and prerelease behavior.
- Update the npm publish workflow so the production release commit stages the Hermes version files.
- Align the current bundled Hermes files with the repo version (`1.5.0`).

## Why

The root package bundles `integrations/hermes`, but its Python metadata and MCP client version were still pinned to `1.2.0`. That made diagnostics and compatibility reporting ambiguous for users installing newer GSD Pi releases.

## How

`syncVersionSurfaces()` now treats Hermes as a stable-release-owned version surface. It intentionally skips prerelease stamps such as `1.6.0-dev.<sha>` so Python package metadata is not rewritten to non-stable prerelease strings during dev/next stamping. `verifyVersionSync()` now reports stale Hermes metadata for stable releases.

## Validation

- `node --test scripts/__tests__/version-sync.test.mjs scripts/__tests__/npm-publish-workflow.test.mjs`
- `npx --yes pnpm@10.12.1 run verify:version-sync`
- `python3 -m pytest integrations/hermes/tests -q`

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/CI tooling and version metadata only; no runtime behavior changes beyond correct version reporting in Hermes MCP initialize.
> 
> **Overview**
> **Stable GSD Pi releases now keep the bundled `open-gsd-hermes` integration aligned** with the main repo version instead of leaving Python package metadata and MCP `clientInfo` stuck on an old pin (e.g. `1.2.0`).
> 
> `syncVersionSurfaces()` and `verifyVersionSync()` in `version-sync.cjs` treat Hermes as a release-owned surface: on **stable** `X.Y.Z` bumps they update `integrations/hermes/pyproject.toml` and the MCP initialize `clientInfo.version` in `gsd_client.py`; on **dev/next** prerelease stamps they intentionally skip Hermes so Python metadata is not rewritten to non-stable strings. The production **Commit and tag release** step stages those Hermes paths in the release commit. Bundled Hermes files are bumped to **1.5.0** to match the current repo, with regression tests for sync, verify failures, prerelease behavior, and workflow staging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56512fba8afd6a41ffa1eb3636685d9605cc18d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->