### PR TITLE
refactor(gsd): centralize markdown projection paths

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -38,6 +38,7 @@ import {
   resolveSlicePath,
   resolveTaskFile,
   resolveTasksDir,
+  targetMilestoneFile,
   gsdProjectionRoot,
   gsdRoot,
   buildMilestoneFileName,
@@ -174,23 +175,6 @@ function sanitizeInlineRoadmapText(value: string | null | undefined): string {
     .replace(/[|`]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-}
-
-function resolveRoadmapProjectionPath(basePath: string, milestoneId: string): string {
-  const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const existing = resolveMilestonePath(basePath, milestoneId);
-  const legacyBase = legacyMilestonesDir(basePath);
-  const isLegacyLayout = existing
-    ? existing.startsWith(legacyBase + "/") || existing.startsWith(legacyBase + "\\")
-    : isLegacyMilestonesLayout(basePath);
-  const phaseDir = existing ?? join(
-    isLegacyLayout ? legacyBase : milestonesDir(basePath),
-    isLegacyLayout ? milestoneId : canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title),
-  );
-  const roadmapFileName = isLegacyLayout
-    ? `${milestoneId}-ROADMAP.md`
-    : `${String(phaseNum).padStart(2, "0")}-ROADMAP.md`;
-  return join(phaseDir, roadmapFileName);
 }
 
 function isMilestoneFlatPhaseLayout(basePath: string, milestoneId: string): boolean {
@@ -600,7 +584,7 @@ export async function renderRoadmapFromDb(
       "projection",
       `renderRoadmapFromDb skipped unplanned milestone ${milestoneId} (zero slices, empty vision) — refusing to write a stub ROADMAP`,
     );
-    const absPath = resolveRoadmapProjectionPath(basePath, milestoneId);
+    const absPath = targetMilestoneFile(basePath, milestoneId, "ROADMAP", milestone.title);
     if (existsSync(absPath)) {
       const artifactPath = toArtifactPath(absPath, basePath);
       unlinkSync(absPath);
@@ -614,7 +598,7 @@ export async function renderRoadmapFromDb(
     return { skipped: "unplanned-milestone" };
   }
 
-  const absPath = resolveRoadmapProjectionPath(basePath, milestoneId);
+  const absPath = targetMilestoneFile(basePath, milestoneId, "ROADMAP", milestone.title);
   const artifactPath = toArtifactPath(absPath, basePath);
   const content = renderRoadmapMarkdown(milestone, slices);
 
@@ -1080,7 +1064,7 @@ function detectStaleRendersImpl(basePath: string): StaleEntry[] {
     // TODO(flat-phase): roadmap checkbox parsing may not match flat-phase
     // roadmap format, causing false-positive drift loops. Skip during transition.
     /*
-    const roadmapPath = resolveRoadmapProjectionPath(basePath, milestone.id);
+    const roadmapPath = targetMilestoneFile(basePath, milestone.id, "ROADMAP", milestone.title);
     if (existsSync(roadmapPath)) {
       try {
         const parsed = parseProjectionByIdentity(roadmapPath, parseRoadmap) as ReturnType<typeof parseRoadmap>;

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -41,7 +41,6 @@ import {
   targetMilestoneFile,
   gsdProjectionRoot,
   gsdRoot,
-  buildMilestoneFileName,
   buildTaskFileName,
   buildSliceFileName,
 } from "./paths.js";
@@ -639,25 +638,20 @@ export async function renderMilestoneArtifactsFromDb(
   const artifacts = getMilestoneScopedArtifacts(milestoneId);
   if (artifacts.length === 0) return false;
 
-  const phaseDir = resolveMilestonePath(basePath, milestoneId) ??
-    join(
-      milestonesDir(basePath),
-      canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title),
-    );
-  mkdirSync(phaseDir, { recursive: true });
-
-  const legacyBase = legacyMilestonesDir(basePath);
-  const isLegacy = phaseDir.startsWith(legacyBase + "/") || phaseDir.startsWith(legacyBase + "\\");
+  const milestone = getMilestone(milestoneId);
 
   let wrote = false;
   for (const artifact of artifacts) {
     if (artifact.artifact_type === "ROADMAP") continue;
     if (!artifact.full_content.trim()) continue;
 
-    const fileName = isLegacy
-      ? `${milestoneId}-${artifact.artifact_type}.md`
-      : buildMilestoneFileName(milestoneId, artifact.artifact_type);
-    const absPath = join(phaseDir, fileName);
+    const absPath = targetMilestoneFile(
+      basePath,
+      milestoneId,
+      artifact.artifact_type,
+      milestone?.title,
+    );
+    mkdirSync(dirname(absPath), { recursive: true });
     const artifactPath = toArtifactPath(absPath, basePath);
     await writeAndStore(absPath, artifactPath, artifact.full_content, {
       artifact_type: artifact.artifact_type,

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -39,6 +39,7 @@ import {
   resolveTaskFile,
   resolveTasksDir,
   targetMilestoneFile,
+  targetSliceFile,
   gsdProjectionRoot,
   gsdRoot,
   buildTaskFileName,
@@ -52,9 +53,6 @@ import { readCompatMarker, writeCompatMarker, computeProjectionSha } from "./com
 import type { RiskLevel } from "./types.js";
 import {
   phaseDirName,
-  planFileName,
-  milestoneIdToPhaseNum,
-  sliceIdToPlanNum,
   derivePhaseSlug,
 } from "./layout-policy.js";
 
@@ -802,22 +800,12 @@ export async function renderSliceSummary(
     return false; // No slice data — skip silently
   }
 
-  // Flat-phase: resolve or create the phase dir, since resolveSlicePath only
-  // finds existing dirs. In flat-phase the slice "path" is the phase dir.
-  let slicePath = resolveSlicePath(basePath, milestoneId, sliceId);
-  if (!slicePath) {
-    const mDir = milestonesDir(basePath);
-    const dirName = canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title);
-    slicePath = join(mDir, dirName);
-    mkdirSync(slicePath, { recursive: true });
-  }
-
+  const milestoneTitle = getMilestone(milestoneId)?.title;
   let wrote = false;
 
-  // Write SUMMARY — flat-phase: NN-MM-SUMMARY.md inside phase dir
   if (slice.full_summary_md) {
-    const summaryName = planFileName(milestoneIdToPhaseNum(milestoneId), sliceIdToPlanNum(sliceId), "SUMMARY");
-    const summaryAbs = join(slicePath, summaryName);
+    const summaryAbs = targetSliceFile(basePath, milestoneId, sliceId, "SUMMARY", milestoneTitle);
+    mkdirSync(dirname(summaryAbs), { recursive: true });
     const summaryArtifact = toArtifactPath(summaryAbs, basePath);
 
     await writeAndStore(summaryAbs, summaryArtifact, slice.full_summary_md, {
@@ -828,10 +816,9 @@ export async function renderSliceSummary(
     wrote = true;
   }
 
-  // Write UAT — flat-phase: NN-MM-UAT.md inside phase dir
   if (slice.full_uat_md) {
-    const uatName = planFileName(milestoneIdToPhaseNum(milestoneId), sliceIdToPlanNum(sliceId), "UAT");
-    const uatAbs = join(slicePath, uatName);
+    const uatAbs = targetSliceFile(basePath, milestoneId, sliceId, "UAT", milestoneTitle);
+    mkdirSync(dirname(uatAbs), { recursive: true });
     const uatArtifact = toArtifactPath(uatAbs, basePath);
 
     await writeAndStore(uatAbs, uatArtifact, slice.full_uat_md, {
@@ -1150,36 +1137,28 @@ function detectStaleRendersImpl(basePath: string): StaleEntry[] {
         }
       }
 
-      // Check missing slice summary/UAT files
+      // Check missing slice summary/UAT files. Use the same target helper as
+      // renderSliceSummary so detection and repair agree on flat-phase vs legacy
+      // output locations.
       const sliceRow = getSlice(milestone.id, slice.id);
       if (sliceRow && sliceRow.status === "complete") {
-        // Use the SAME path construction as renderSliceSummary (planFileName format)
-        // so the detector and repair always agree on the file location.
-        const slicePath = resolveSlicePath(basePath, milestone.id, slice.id);
-        if (slicePath) {
-          const phaseNum = milestoneIdToPhaseNum(milestone.id);
-          const planNum = sliceIdToPlanNum(slice.id);
-
-          if (sliceRow.full_summary_md) {
-            const summaryName = planFileName(phaseNum, planNum, "SUMMARY");
-            const summaryAbsPath = join(slicePath, summaryName);
-            if (!existsSync(summaryAbsPath)) {
-              stale.push({
-                path: summaryAbsPath,
-                reason: `${slice.id} is complete with summary in DB but SUMMARY.md missing on disk`,
-              });
-            }
+        if (sliceRow.full_summary_md) {
+          const summaryAbsPath = targetSliceFile(basePath, milestone.id, slice.id, "SUMMARY", milestone.title);
+          if (!existsSync(summaryAbsPath)) {
+            stale.push({
+              path: summaryAbsPath,
+              reason: `${slice.id} is complete with summary in DB but SUMMARY.md missing on disk`,
+            });
           }
+        }
 
-          if (sliceRow.full_uat_md) {
-            const uatName = planFileName(phaseNum, planNum, "UAT");
-            const uatAbsPath = join(slicePath, uatName);
-            if (!existsSync(uatAbsPath)) {
-              stale.push({
-                path: uatAbsPath,
-                reason: `${slice.id} is complete with UAT in DB but UAT.md missing on disk`,
-              });
-            }
+        if (sliceRow.full_uat_md) {
+          const uatAbsPath = targetSliceFile(basePath, milestone.id, slice.id, "UAT", milestone.title);
+          if (!existsSync(uatAbsPath)) {
+            stale.push({
+              path: uatAbsPath,
+              reason: `${slice.id} is complete with UAT in DB but UAT.md missing on disk`,
+            });
           }
         }
       }
@@ -1235,12 +1214,14 @@ export async function renderReplanFromDb(
   sliceId: string,
   replanData: ReplanData,
 ): Promise<{ replanPath: string; content: string }> {
-  // Flat-phase: replan file lives in the phase dir
-  const slicePath = resolveSlicePath(basePath, milestoneId, sliceId)
-    ?? join(milestonesDir(basePath), canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title));
-  const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const planNum = sliceIdToPlanNum(sliceId);
-  const absPath = join(slicePath, planFileName(phaseNum, planNum, "REPLAN"));
+  const absPath = targetSliceFile(
+    basePath,
+    milestoneId,
+    sliceId,
+    "REPLAN",
+    getMilestone(milestoneId)?.title,
+  );
+  mkdirSync(dirname(absPath), { recursive: true });
   const artifactPath = toArtifactPath(absPath, basePath);
 
   const lines: string[] = [];
@@ -1277,24 +1258,14 @@ export async function renderAssessmentFromDb(
   sliceId: string,
   assessmentData: AssessmentData,
 ): Promise<{ assessmentPath: string; content: string }> {
-  // Flat-phase: the assessment file lives in the phase dir, NOT in a slices/SID/
-  // subdir. resolveSlicePath() detects a slices/SID/ dir unconditionally, so a
-  // stray slices/SID/ created by an earlier planning step would send this write
-  // to a hybrid path (wrong dir, flat filename) that verification cannot find.
-  // Guard with the same legacy-base check relSlicePath() uses so flat-phase
-  // milestones always target the phase dir.
-  const mDir = resolveMilestonePath(basePath, milestoneId);
-  const legacyBase = legacyMilestonesDir(basePath);
-  const isLegacyLayout = mDir
-    ? mDir.startsWith(legacyBase + "/") || mDir.startsWith(legacyBase + "\\")
-    : false;
-  const fallbackDir = join(milestonesDir(basePath), canonicalPhaseDirName(milestoneId, getMilestone(milestoneId)?.title));
-  const slicePath = isLegacyLayout
-    ? (resolveSlicePath(basePath, milestoneId, sliceId) ?? fallbackDir)
-    : (mDir ?? fallbackDir);
-  const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const planNum = sliceIdToPlanNum(sliceId);
-  const absPath = join(slicePath, planFileName(phaseNum, planNum, "ASSESSMENT"));
+  const absPath = targetSliceFile(
+    basePath,
+    milestoneId,
+    sliceId,
+    "ASSESSMENT",
+    getMilestone(milestoneId)?.title,
+  );
+  mkdirSync(dirname(absPath), { recursive: true });
   const artifactPath = toArtifactPath(absPath, basePath);
 
   const lines: string[] = [];

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -916,10 +916,21 @@ export function resolveTaskFile(
   basePath: string, milestoneId: string, sliceId: string,
   taskId: string, suffix: string
 ): string | null {
+  const slicePath = resolveSlicePath(basePath, milestoneId, sliceId);
+  const phaseDir = resolveMilestonePath(basePath, milestoneId);
+
+  if (suffix !== "PLAN" && slicePath && phaseDir && slicePath === phaseDir) {
+    const flatPath = join(phaseDir, buildTaskFileName(taskId, suffix));
+    return existsSync(flatPath) ? flatPath : null;
+  }
+
   const tDir = resolveTasksDir(basePath, milestoneId, sliceId);
-  if (!tDir) return null;
-  const file = resolveFile(tDir, taskId, suffix);
-  return file ? join(tDir, file) : null;
+  if (tDir) {
+    const file = resolveFile(tDir, taskId, suffix);
+    if (file) return join(tDir, file);
+  }
+
+  return null;
 }
 
 // ─── Relative Path Builders (for prompts — .gsd/milestones/...) ────────────
@@ -1049,7 +1060,7 @@ export function relSliceFile(
  */
 export function relTaskFile(
   basePath: string, milestoneId: string, sliceId: string,
-  taskId: string, suffix: string
+  taskId: string, suffix: string, milestoneTitle?: string
 ): string {
   const sDir = resolveSlicePath(basePath, milestoneId, sliceId);
   const phaseDir = resolveMilestonePath(basePath, milestoneId);
@@ -1062,6 +1073,6 @@ export function relTaskFile(
   if (suffix === "PLAN") {
     return relSliceFile(basePath, milestoneId, sliceId, "PLAN");
   }
-  const relS = relSlicePath(basePath, milestoneId, sliceId);
+  const relS = relSlicePath(basePath, milestoneId, sliceId, milestoneTitle);
   return `${relS}/${buildTaskFileName(taskId, suffix)}`;
 }

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -916,10 +916,13 @@ export function resolveTaskFile(
   basePath: string, milestoneId: string, sliceId: string,
   taskId: string, suffix: string
 ): string | null {
-  const slicePath = resolveSlicePath(basePath, milestoneId, sliceId);
   const phaseDir = resolveMilestonePath(basePath, milestoneId);
+  if (!phaseDir) return null;
 
-  if (suffix !== "PLAN" && slicePath && phaseDir && slicePath === phaseDir) {
+  const legacyBase = legacyMilestonesDir(basePath);
+  const isLegacy = phaseDir.startsWith(legacyBase + "/") || phaseDir.startsWith(legacyBase + "\\");
+
+  if (suffix !== "PLAN" && !isLegacy) {
     const flatPath = join(phaseDir, buildTaskFileName(taskId, suffix));
     return existsSync(flatPath) ? flatPath : null;
   }

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -11,7 +11,7 @@
  */
 
 import { readdirSync, existsSync, realpathSync, statSync, Dirent } from "node:fs";
-import { join, dirname, normalize, resolve } from "node:path";
+import { join, dirname, normalize, relative, resolve } from "node:path";
 import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
@@ -965,31 +965,41 @@ export function relMilestonePath(basePath: string, milestoneId: string, title?: 
 }
 
 /**
- * Build relative .gsd/ path to a milestone file.
- * Layout-aware: uses resolveMilestoneFile to find NN-SUFFIX.md (flat-phase)
- * or M001-SUFFIX.md (legacy). Falls back to a layout-appropriate canonical
- * name when the file doesn't exist yet.
+ * Build the canonical absolute write target for a milestone file.
+ * Existing compatibility filenames are intentionally ignored; readers that need
+ * to preserve an existing file should call resolveMilestoneFile first.
  */
-export function relMilestoneFile(
-  basePath: string, milestoneId: string, suffix: string
+export function targetMilestoneFile(
+  basePath: string, milestoneId: string, suffix: string, title?: string
 ): string {
-  const mRel = relMilestonePath(basePath, milestoneId);
-  // resolveMilestoneFile checks NN-SUFFIX.md (flat-phase) and MID-SUFFIX.md (legacy).
-  const absFile = resolveMilestoneFile(basePath, milestoneId, suffix);
-  if (absFile) {
-    const fileName = absFile.split(/[/\\]/).pop()!;
-    return `${mRel}/${fileName}`;
-  }
-  // File doesn't exist yet — use layout-aware fallback filename.
   const mDir = resolveMilestonePath(basePath, milestoneId);
   const legacyBase = legacyMilestonesDir(basePath);
   const isLegacy = mDir
     ? mDir.startsWith(legacyBase + "/") || mDir.startsWith(legacyBase + "\\")
-    : false;
+    : isLegacyMilestonesLayout(basePath);
+  const dir = mDir ?? join(
+    isLegacy ? legacyBase : milestonesDir(basePath),
+    isLegacy ? milestoneId : canonicalPhaseDirName(milestoneId, title),
+  );
   const fileName = isLegacy
     ? `${milestoneId}-${suffix}.md`
     : `${String(milestoneIdToPhaseNum(milestoneId)).padStart(2, "0")}-${suffix}.md`;
-  return `${mRel}/${fileName}`;
+  return join(dir, fileName);
+}
+
+/**
+ * Build relative .gsd/ path to a milestone file.
+ * Preserves an existing compatibility filename when present; otherwise falls
+ * back to the canonical write target.
+ */
+export function relMilestoneFile(
+  basePath: string, milestoneId: string, suffix: string, title?: string
+): string {
+  const rel = relative(
+    gsdProjectionRoot(basePath),
+    resolveMilestoneFile(basePath, milestoneId, suffix) ?? targetMilestoneFile(basePath, milestoneId, suffix, title),
+  ).replace(/\\/g, "/");
+  return `.gsd/${rel}`;
 }
 
 /**

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -1031,34 +1031,44 @@ export function relSlicePath(
 }
 
 /**
- * Build relative .gsd/ path to a slice file.
- * Layout-aware: legacy uses S01-SUFFIX.md; flat-phase uses NN-MM-SUFFIX.md.
- *
- * @param milestoneTitle - Optional milestone title forwarded to relSlicePath /
- *   relMilestonePath for title-aware flat-phase fallback dir naming. Only used
- *   when the phase directory does not yet exist on disk.
+ * Build the canonical absolute write target for a slice file.
+ * Existing compatibility filenames are intentionally ignored; readers that need
+ * to preserve an existing file should call resolveSliceFile first.
  */
-export function relSliceFile(
+export function targetSliceFile(
   basePath: string, milestoneId: string, sliceId: string, suffix: string, milestoneTitle?: string
 ): string {
-  const sRel = relSlicePath(basePath, milestoneId, sliceId, milestoneTitle);
-  const absPath = resolveSliceFile(basePath, milestoneId, sliceId, suffix);
-  if (absPath) {
-    const fileName = absPath.split(/[/\\]/).pop()!;
-    return `${sRel}/${fileName}`;
-  }
-  // Fallback when file doesn't exist yet — use layout-aware filename.
   const mDir = resolveMilestonePath(basePath, milestoneId);
   const legacyBase = legacyMilestonesDir(basePath);
   const isLegacy = mDir
     ? mDir.startsWith(legacyBase + "/") || mDir.startsWith(legacyBase + "\\")
-    : false;
-  if (isLegacy) {
-    return `${sRel}/${sliceId}-${suffix}.md`;
-  }
-  const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const planNum = sliceIdToPlanNum(sliceId);
-  return `${sRel}/${planFileName(phaseNum, planNum, suffix)}`;
+    : isLegacyMilestonesLayout(basePath);
+  const milestoneDir = mDir
+    ?? dirname(targetMilestoneFile(basePath, milestoneId, "ROADMAP", milestoneTitle));
+  const slicesDir = join(milestoneDir, "slices");
+  const dir = isLegacy
+    ? join(slicesDir, resolveDir(slicesDir, sliceId) ?? sliceId)
+    : milestoneDir;
+  const fileName = isLegacy
+    ? `${sliceId}-${suffix}.md`
+    : planFileName(milestoneIdToPhaseNum(milestoneId), sliceIdToPlanNum(sliceId), suffix);
+  return join(dir, fileName);
+}
+
+/**
+ * Build relative .gsd/ path to a slice file.
+ * Preserves an existing compatibility filename when present; otherwise falls
+ * back to the canonical write target.
+ */
+export function relSliceFile(
+  basePath: string, milestoneId: string, sliceId: string, suffix: string, milestoneTitle?: string
+): string {
+  const rel = relative(
+    gsdProjectionRoot(basePath),
+    resolveSliceFile(basePath, milestoneId, sliceId, suffix)
+      ?? targetSliceFile(basePath, milestoneId, sliceId, suffix, milestoneTitle),
+  ).replace(/\\/g, "/");
+  return `.gsd/${rel}`;
 }
 
 /**

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -213,21 +213,13 @@ function detectArtifactDbStatusDriftForMilestone(
 
     for (const task of tasks) {
       if (isClosedStatus(task.status)) continue;
-      // Flat-phase: task summaries live in the phase dir as TID-SUMMARY.md
-      let diskTaskSummary = resolveTaskFile(
+      const diskTaskSummary = resolveTaskFile(
         basePath,
         milestoneId,
         slice.id,
         task.id,
         "SUMMARY",
       );
-      if (!diskTaskSummary) {
-        const phaseDir = resolveMilestonePath(basePath, milestoneId);
-        if (phaseDir) {
-          const flatSummary = join(phaseDir, `${task.id}-SUMMARY.md`);
-          if (existsSync(flatSummary)) diskTaskSummary = flatSummary;
-        }
-      }
       if (!diskTaskSummary || !existsSync(diskTaskSummary)) continue;
       addUniqueDrift(drifts, seen, {
         kind: "artifact-db-status-divergence",

--- a/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
@@ -20,11 +20,9 @@ import {
 } from "../../gsd-db.js";
 import {
   resolveMilestoneFile,
-  resolveMilestonePath,
   resolveSliceFile,
   resolveTaskFile,
 } from "../../paths.js";
-import { join } from "node:path";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
@@ -105,23 +103,13 @@ function collectMilestoneCompletionDrift(
     for (const task of getSliceTasks(mid, slice.id)) {
       if (!COMPLETE_STATUSES.has(task.status)) continue;
       if (task.completed_at !== null) continue;
-      // Flat-phase: task summaries live in the phase dir as TID-SUMMARY.md.
-      // Legacy: resolveTaskFile returns the tasks/TID/TID-SUMMARY.md path.
-      let taskSummary = resolveTaskFile(
+      const taskSummary = resolveTaskFile(
         ctx.basePath,
         mid,
         slice.id,
         task.id,
         "SUMMARY",
       );
-      // Flat-phase fallback: check the phase dir directly
-      if (!taskSummary) {
-        const phaseDir = resolveMilestonePath(ctx.basePath, mid);
-        if (phaseDir) {
-          const flatSummary = join(phaseDir, `${task.id}-SUMMARY.md`);
-          if (existsSync(flatSummary)) taskSummary = flatSummary;
-        }
-      }
       if (taskSummary && existsSync(taskSummary)) {
         drifts.push({
           kind: "missing-completion-timestamp",
@@ -182,15 +170,7 @@ export function repairMissingCompletionTimestamp(
       task.completed_at !== null ||
       !COMPLETE_STATUSES.has(task.status)
     ) return;
-    // Flat-phase: task summaries live in the phase dir as TID-SUMMARY.md
-    let summary = resolveTaskFile(ctx.basePath, mid, sid, tid, "SUMMARY");
-    if (!summary) {
-      const phaseDir = resolveMilestonePath(ctx.basePath, mid);
-      if (phaseDir) {
-        const flatSummary = join(phaseDir, `${tid}-SUMMARY.md`);
-        if (existsSync(flatSummary)) summary = flatSummary;
-      }
-    }
+    const summary = resolveTaskFile(ctx.basePath, mid, sid, tid, "SUMMARY");
     const ts = summary ? summaryMtimeIso(summary) : null;
     if (!ts) return;
     updateTaskStatus(mid, sid, tid, task.status, ts);

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -18,6 +18,7 @@ import { randomUUID } from "node:crypto";
 import { handleVerdict, parseValidationFile } from "../commands-verdict.ts";
 import { openDatabase, closeDatabase, _getAdapter, insertAssessment } from "../gsd-db.ts";
 import { invalidateStateCache } from "../state.ts";
+import { resolveMilestoneFile } from "../paths.ts";
 
 interface NotifyCall {
   message: string;
@@ -363,7 +364,8 @@ test("handleVerdict pass override works when validation only exists in DB", asyn
     const { ctx, calls } = makeMockCtx();
     await handleVerdict('pass --milestone M001 --rationale "reviewed and accepted"', ctx, base);
 
-    const validationPath = join(base, ".gsd", "phases", "01-m001", "01-VALIDATION.md");
+    const validationPath = resolveMilestoneFile(base, "M001", "VALIDATION");
+    assert.ok(validationPath, "DB-backed validation should be materialized to disk");
     const rewritten = readFileSync(validationPath, "utf-8");
     assert.match(rewritten, /^verdict: pass$/m, "DB-backed validation should be rewritten as pass");
     assert.match(rewritten, /reviewed and accepted/, "explicit rationale should be persisted");

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -423,5 +423,50 @@ console.log('\n=== complete-milestone: existing SUMMARY.md preserved (#4598) ===
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// complete-milestone: flat-phase compatibility SUMMARY.md is not hidden
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-milestone: flat-phase legacy-named SUMMARY.md preserved (#4598) ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-flat-complete-milestone-'));
+  const phaseDir = path.join(basePath, '.gsd', 'phases', '01-test-milestone');
+  fs.mkdirSync(path.join(phaseDir, 'slices', 'S01', 'tasks'), { recursive: true });
+  seedCompletedMilestone({ basePath, validationVerdict: 'pass' });
+
+  // Flat-phase projects may still contain legacy-named compatibility files.
+  // The no-overwrite guard must preserve those richer summaries instead of
+  // generating a canonical sibling that later readers would prefer.
+  const summaryPath = path.join(phaseDir, 'M001-SUMMARY.md');
+  const canonicalSummaryPath = path.join(phaseDir, '01-SUMMARY.md');
+  const sentinel = '# M001: Pre-existing flat-phase richer summary\n\nDO NOT OVERWRITE ME\n';
+  fs.writeFileSync(summaryPath, sentinel, 'utf-8');
+
+  const result = await handleCompleteMilestone(makeValidParams(), basePath);
+  assertTrue(!('error' in result), 'completion should still succeed when flat-phase compatibility SUMMARY.md exists');
+  if (!('error' in result)) {
+    assertEq(
+      result.summaryPath,
+      fs.realpathSync(summaryPath),
+      'completion should report the preserved existing SUMMARY path',
+    );
+    assertEq(
+      fs.readFileSync(summaryPath, 'utf-8'),
+      sentinel,
+      'flat-phase compatibility SUMMARY.md must be preserved, not hidden by a canonical rewrite',
+    );
+    assertTrue(
+      !fs.existsSync(canonicalSummaryPath),
+      'completion must not create a canonical sibling over an existing compatibility summary',
+    );
+    assertEq(getMilestone('M001')!.status, 'complete', 'milestone should still be marked complete in DB');
+  }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 
 report();

--- a/src/resources/extensions/gsd/tests/flat-phase-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-renderer.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { renderPlanFromDb, renderRoadmapFromDb, renderAssessmentFromDb } from "../markdown-renderer.ts";
+import { renderPlanFromDb, renderRoadmapFromDb, renderAssessmentFromDb, renderReplanFromDb } from "../markdown-renderer.ts";
 import { clearPathCache } from "../paths.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
 
@@ -81,6 +81,27 @@ test("renderPlanFromDb does NOT write per-task plan files", async () => {
   const result = await renderPlanFromDb(base, "M001", "S01");
   // taskPlanPaths should be empty — no per-task files written
   assert.equal(result.taskPlanPaths.length, 0);
+});
+
+
+// Replan uses the same slice-level target rules as assessment: flat-phase
+// writes must stay at the phase root even if an old slices/SID/ dir exists.
+test("renderReplanFromDb writes to the phase root even when a stray slices/SID/ dir exists", async () => {
+  const base = makeTmp();
+  const plan = await renderPlanFromDb(base, "M001", "S01");
+  const phaseDir = plan.planPath.slice(0, plan.planPath.lastIndexOf("01-01-PLAN.md"));
+  mkdirSync(join(phaseDir, "slices", "S01"), { recursive: true });
+  clearPathCache();
+
+  const result = await renderReplanFromDb(base, "M001", "S01", {
+    blockerTaskId: "T01",
+    blockerDescription: "Need a better path target.",
+    whatChanged: "Centralized slice writer path resolution.",
+  });
+
+  assert.match(result.replanPath, /phases[/\\]01-[^/\\]+[/\\]01-01-REPLAN\.md$/);
+  assert.ok(!result.replanPath.includes(join("slices", "S01")), "must not write under slices/S01/");
+  assert.ok(existsSync(result.replanPath), "replan file should exist at the phase root");
 });
 
 // Regression for #1190: a stray slices/SID/ subdir inside a flat-phase milestone

--- a/src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { relMilestoneFile, resolveMilestoneFile } from "../paths.ts";
+import { normalizeRealPath, relMilestoneFile, resolveMilestoneFile, targetMilestoneFile } from "../paths.ts";
 
 function makeFlatPhaseFixture(): { basePath: string; cleanup: () => void } {
   const basePath = mkdtempSync(join(tmpdir(), "flat-phase-validation-"));
@@ -33,42 +33,70 @@ function makeFlatPhaseFixture(): { basePath: string; cleanup: () => void } {
   return { basePath, cleanup: () => rmSync(basePath, { recursive: true, force: true }) };
 }
 
-test("flat-phase: relMilestoneFile resolves to the layout-aware path", () => {
+test("flat-phase: relMilestoneFile resolves to the layout-aware path", (t) => {
   const { basePath, cleanup } = makeFlatPhaseFixture();
-  try {
-    const rel = relMilestoneFile(basePath, "M001", "VALIDATION");
-    assert.equal(rel, ".gsd/phases/01-foo/01-VALIDATION.md");
-    const abs = join(basePath, rel);
-    assert.equal(existsSync(abs), true);
-  } finally {
-    cleanup();
-  }
+  t.after(cleanup);
+
+  const rel = relMilestoneFile(basePath, "M001", "VALIDATION");
+  assert.equal(rel, ".gsd/phases/01-foo/01-VALIDATION.md");
+  const abs = join(basePath, rel);
+  assert.equal(existsSync(abs), true);
 });
 
-test("flat-phase: resolveMilestoneFile finds the on-disk file", () => {
-  const { basePath, cleanup } = makeFlatPhaseFixture();
-  try {
-    const abs = resolveMilestoneFile(basePath, "M001", "VALIDATION");
-    assert.ok(abs, "resolveMilestoneFile must return a path for the flat-phase fixture");
-    assert.equal(abs!.endsWith("/.gsd/phases/01-foo/01-VALIDATION.md"), true);
-    assert.equal(existsSync(abs!), true);
-  } finally {
-    cleanup();
-  }
+test("flat-phase: relMilestoneFile fallback uses the milestone title when no directory exists", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "flat-phase-missing-dir-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+
+  const rel = relMilestoneFile(basePath, "M001", "ROADMAP", "Milestone");
+  assert.equal(rel, ".gsd/phases/01-milestone/01-ROADMAP.md");
 });
 
-test("flat-phase: the legacy hardcoded path does NOT resolve (regression for #876)", () => {
+test("legacy layout: relMilestoneFile fallback stays in milestones when the target dir is missing", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "legacy-missing-dir-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+  const existingLegacyDir = join(basePath, ".gsd", "milestones", "M002");
+  mkdirSync(existingLegacyDir, { recursive: true });
+  writeFileSync(join(existingLegacyDir, "M002-ROADMAP.md"), "# existing legacy roadmap\n");
+
+  const rel = relMilestoneFile(basePath, "M001", "ROADMAP", "Milestone");
+
+  assert.equal(rel, ".gsd/milestones/M001/M001-ROADMAP.md");
+});
+
+test("flat-phase: targetMilestoneFile ignores legacy-named compatibility files when writing", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "flat-phase-legacy-named-file-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+  const phaseDir = join(basePath, ".gsd", "phases", "01-foo");
+  mkdirSync(phaseDir, { recursive: true });
+  writeFileSync(join(phaseDir, "M001-ROADMAP.md"), "# legacy named roadmap\n");
+
+  assert.equal(
+    targetMilestoneFile(basePath, "M001", "ROADMAP", "Foo"),
+    join(normalizeRealPath(phaseDir), "01-ROADMAP.md"),
+  );
+  assert.equal(relMilestoneFile(basePath, "M001", "ROADMAP", "Foo"), ".gsd/phases/01-foo/M001-ROADMAP.md");
+});
+
+test("flat-phase: resolveMilestoneFile finds the on-disk file", (t) => {
   const { basePath, cleanup } = makeFlatPhaseFixture();
-  try {
-    // This is the path that auto-verification.ts:264-270 used to construct.
-    // It must NOT exist on a flat-phase project — that's the whole bug.
-    const legacyHardcoded = join(basePath, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
-    assert.equal(
-      existsSync(legacyHardcoded),
-      false,
-      "legacy hardcoded path must not exist in flat-phase fixture — if it does, the test fixture is wrong",
-    );
-  } finally {
-    cleanup();
-  }
+  t.after(cleanup);
+
+  const abs = resolveMilestoneFile(basePath, "M001", "VALIDATION");
+  assert.ok(abs, "resolveMilestoneFile must return a path for the flat-phase fixture");
+  assert.equal(abs!.endsWith("/.gsd/phases/01-foo/01-VALIDATION.md"), true);
+  assert.equal(existsSync(abs!), true);
+});
+
+test("flat-phase: the legacy hardcoded path does NOT resolve (regression for #876)", (t) => {
+  const { basePath, cleanup } = makeFlatPhaseFixture();
+  t.after(cleanup);
+
+  // This is the path that auto-verification.ts:264-270 used to construct.
+  // It must NOT exist on a flat-phase project — that's the whole bug.
+  const legacyHardcoded = join(basePath, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+  assert.equal(
+    existsSync(legacyHardcoded),
+    false,
+    "legacy hardcoded path must not exist in flat-phase fixture — if it does, the test fixture is wrong",
+  );
 });

--- a/src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { normalizeRealPath, relMilestoneFile, resolveMilestoneFile, targetMilestoneFile } from "../paths.ts";
+import { normalizeRealPath, relMilestoneFile, relSliceFile, resolveMilestoneFile, targetMilestoneFile } from "../paths.ts";
 
 function makeFlatPhaseFixture(): { basePath: string; cleanup: () => void } {
   const basePath = mkdtempSync(join(tmpdir(), "flat-phase-validation-"));
@@ -61,6 +61,18 @@ test("legacy layout: relMilestoneFile fallback stays in milestones when the targ
   const rel = relMilestoneFile(basePath, "M001", "ROADMAP", "Milestone");
 
   assert.equal(rel, ".gsd/milestones/M001/M001-ROADMAP.md");
+});
+
+test("legacy layout: relSliceFile fallback uses slices directory when target milestone is missing", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "legacy-missing-slice-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+  const existingLegacyDir = join(basePath, ".gsd", "milestones", "M002");
+  mkdirSync(existingLegacyDir, { recursive: true });
+  writeFileSync(join(existingLegacyDir, "M002-ROADMAP.md"), "# existing legacy roadmap\n");
+
+  const rel = relSliceFile(basePath, "M001", "S01", "PLAN", "Milestone");
+
+  assert.equal(rel, ".gsd/milestones/M001/slices/S01/S01-PLAN.md");
 });
 
 test("flat-phase: targetMilestoneFile ignores legacy-named compatibility files when writing", (t) => {

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -166,4 +166,26 @@ describe('paths', () => {
       cleanup(root);
     }
   });
+
+  test('Case 9: flat-phase task SUMMARY resolves at phase root despite a stray slices/SID/ dir', () => {
+    const root = tmp();
+    try {
+      // Hybrid flat-phase milestone: phase dir holds flat TID-SUMMARY.md, but a
+      // stray slices/S01/ folder also exists on disk. resolveSlicePath then points
+      // under slices/, so layout (phases/ vs milestones/) — not slicePath===phaseDir
+      // — must decide the flat-phase task summary location.
+      const phaseDir = join(root, ".gsd", "phases", "01-foo");
+      mkdirSync(join(phaseDir, "slices", "S01"), { recursive: true });
+      const flatSummary = join(phaseDir, "T01-SUMMARY.md");
+      writeFileSync(flatSummary, "# task summary\n");
+
+      _clearGsdRootCache();
+
+      assert.deepStrictEqual(
+        resolveTaskFile(root, "M001", "S01", "T01", "SUMMARY"),
+        flatSummary,
+        "flat-phase TID-SUMMARY.md at phase root is found even when slices/S01/ exists",
+      );
+    } finally { cleanup(root); }
+  });
 });

--- a/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-closeout.test.ts
@@ -13,6 +13,7 @@ import {
   isCompletedMilestoneTerminal,
   repairMissingMilestoneSummaryProjection,
 } from "../milestone-closeout.js";
+import { targetMilestoneFile } from "../paths.js";
 import type { DispatchContext } from "../auto-dispatch.js";
 
 /** Build a minimal DispatchContext for the dispatch-policy branches under test. */
@@ -196,7 +197,7 @@ test("repairMissingMilestoneSummaryProjection succeeds when milestone dir does n
   const repair = await repairMissingMilestoneSummaryProjection(base, "M042");
   assert.equal(repair.ok, true, "repair should report success when handler creates the SUMMARY");
   assert.ok(
-    existsSync(join(base, ".gsd", "phases", "42-m042", "42-SUMMARY.md")),
+    existsSync(targetMilestoneFile(base, "M042", "SUMMARY", "Done")),
     "repair should write the SUMMARY artifact to the canonical projection path",
   );
 });

--- a/src/resources/extensions/gsd/tests/reassess-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/reassess-handler.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -392,6 +392,54 @@ test('handleReassessRoadmap invalidates stale milestone-validation when roadmap 
   } finally {
     cleanup(base);
   }
+});
+
+test('handleReassessRoadmap deletes flat-phase compatibility validation files when roadmap changes (#2957)', async (t) => {
+  const base = makeTmpBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone', status: 'active' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice One', status: 'complete', demo: 'Demo' });
+
+  const legacyValidationPath = join(base, '.gsd', 'phases', '01-test', 'M001-VALIDATION.md');
+  const canonicalValidationPath = join(base, '.gsd', 'phases', '01-test', '01-VALIDATION.md');
+  const staleValidation = '---\nverdict: pass\n---\n\n# Stale validation\n';
+  writeFileSync(legacyValidationPath, staleValidation, 'utf-8');
+  writeFileSync(canonicalValidationPath, staleValidation, 'utf-8');
+  insertAssessment({
+    path: legacyValidationPath,
+    milestoneId: 'M001',
+    sliceId: null,
+    taskId: null,
+    status: 'pass',
+    scope: 'milestone-validation',
+    fullContent: staleValidation,
+  });
+
+  const result = await handleReassessRoadmap({
+    milestoneId: 'M001',
+    completedSliceId: 'S01',
+    verdict: 'confirmed',
+    assessment: 'S01 completed. Adding S02 changes roadmap structure.',
+    sliceChanges: {
+      modified: [],
+      added: [
+        {
+          sliceId: 'S02',
+          title: 'New Slice Two',
+          risk: 'low',
+          depends: ['S01'],
+          demo: 'Demo two.',
+        },
+      ],
+      removed: [],
+    },
+  }, base);
+
+  assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+  assert.equal(existsSync(legacyValidationPath), false, 'stale compatibility validation artifact should be deleted');
+  assert.equal(existsSync(canonicalValidationPath), false, 'canonical validation artifact should not remain after reassess');
 });
 
 test('handleReassessRoadmap does NOT invalidate validation when no roadmap structural changes (#2957)', async () => {

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -344,14 +344,12 @@ test('workflow-projections: regenerateIfMissing SUMMARY is idempotent for flat-p
       milestoneId: 'M001',
       title: 'Completed task',
       status: 'complete',
-      summary: {
-        oneLiner: 'Completed the flat task.',
-        narrative: 'The task was completed through the DB-backed projection path.',
-        verificationResult: 'passed',
-        duration: '5m',
-        keyFiles: ['src/example.ts'],
-        keyDecisions: ['Use centralized task summary paths.'],
-      },
+      oneLiner: 'Completed the flat task.',
+      narrative: 'The task was completed through the DB-backed projection path.',
+      verificationResult: 'passed',
+      duration: '5m',
+      keyFiles: ['src/example.ts'],
+      keyDecisions: ['Use centralized task summary paths.'],
     });
 
     const summaryPath = join(phaseDir, 'T01-SUMMARY.md');
@@ -363,7 +361,7 @@ test('workflow-projections: regenerateIfMissing SUMMARY is idempotent for flat-p
     assert.equal(first, true, 'first call regenerates the missing task summary');
     assert.equal(second, false, 'second call sees the flat-phase task summary and does not rewrite it');
     assert.equal(normalizeRealPath(resolveTaskFile(base, 'M001', 'S01', 'T01', 'SUMMARY') ?? ''), normalizeRealPath(summaryPath));
-    assert.match(readFileSync(summaryPath, 'utf-8'), /# T01: Completed task/);
+    assert.match(readFileSync(summaryPath, 'utf-8'), /# T01: Completed the flat task\./);
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -6,10 +6,10 @@ import assert from 'node:assert/strict';
 import { existsSync, mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { regenerateIfMissing, renderPlanContent, renderStateProjection } from '../workflow-projections.ts';
+import { regenerateIfMissing, renderPlanContent, renderStateProjection, renderSummaryProjection } from '../workflow-projections.ts';
 import type { SliceRow, TaskRow } from '../gsd-db.ts';
 import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from '../gsd-db.ts';
-import { clearPathCache, _clearGsdRootCache } from '../paths.ts';
+import { clearPathCache, _clearGsdRootCache, normalizeRealPath, resolveTaskFile } from '../paths.ts';
 import { invalidateStateCache } from '../state.ts';
 import { clearParseCache } from '../files.ts';
 
@@ -237,6 +237,145 @@ test('workflow-projections: regenerateIfMissing PLAN restores slice plan and tas
     assert.equal(regenerated, true, 'regenerateIfMissing reports the PLAN was rebuilt');
     assert.ok(existsSync(slicePlanPath), 'slice PLAN restored on disk');
     // Flat-phase: tasks are checkboxes inside the plan file, not separate task plan files.
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('workflow-projections: regenerateIfMissing SUMMARY is idempotent for flat-phase task summaries', async () => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-projections-flat-summary-'));
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  const phaseDir = join(base, '.gsd', 'phases', '01-milestone');
+  mkdirSync(phaseDir, { recursive: true });
+  openDatabase(dbPath);
+  clearParseCache();
+  clearPathCache();
+  _clearGsdRootCache();
+  invalidateStateCache();
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+    insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Flat slice',
+      status: 'complete',
+      demo: 'Summary regenerates once.',
+      planning: { goal: 'Recover flat-phase summaries from DB.' },
+    });
+    insertTask({
+      id: 'T01',
+      sliceId: 'S01',
+      milestoneId: 'M001',
+      title: 'Completed task',
+      status: 'complete',
+      summary: {
+        oneLiner: 'Completed the flat task.',
+        narrative: 'The task was completed through the DB-backed projection path.',
+        verificationResult: 'passed',
+        duration: '5m',
+        keyFiles: ['src/example.ts'],
+        keyDecisions: ['Use centralized task summary paths.'],
+      },
+    });
+
+    const summaryPath = join(phaseDir, 'T01-SUMMARY.md');
+    assert.ok(!existsSync(summaryPath), 'precondition: flat-phase task summary absent');
+
+    const first = await regenerateIfMissing(base, 'M001', 'S01', 'SUMMARY');
+    const second = await regenerateIfMissing(base, 'M001', 'S01', 'SUMMARY');
+
+    assert.equal(first, true, 'first call regenerates the missing task summary');
+    assert.equal(second, false, 'second call sees the flat-phase task summary and does not rewrite it');
+    assert.equal(normalizeRealPath(resolveTaskFile(base, 'M001', 'S01', 'T01', 'SUMMARY') ?? ''), normalizeRealPath(summaryPath));
+    assert.match(readFileSync(summaryPath, 'utf-8'), /# T01: Completed task/);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('workflow-projections: flat-phase SUMMARY regeneration ignores stale nested task summaries', async () => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-projections-flat-stale-nested-'));
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  const phaseDir = join(base, '.gsd', 'phases', '01-milestone');
+  const nestedTasksDir = join(phaseDir, 'tasks');
+  mkdirSync(nestedTasksDir, { recursive: true });
+  writeFileSync(join(nestedTasksDir, 'T01-SUMMARY.md'), '# stale nested summary\n');
+  openDatabase(dbPath);
+  clearParseCache();
+  clearPathCache();
+  _clearGsdRootCache();
+  invalidateStateCache();
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+    insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Flat slice',
+      status: 'complete',
+      demo: 'Summary regenerates at phase root.',
+      planning: { goal: 'Recover canonical flat-phase summaries from DB.' },
+    });
+    insertTask({
+      id: 'T01',
+      sliceId: 'S01',
+      milestoneId: 'M001',
+      title: 'Completed task',
+      status: 'complete',
+    });
+
+    const rootSummaryPath = join(phaseDir, 'T01-SUMMARY.md');
+    assert.ok(!existsSync(rootSummaryPath), 'precondition: canonical flat-phase task summary absent');
+
+    const regenerated = await regenerateIfMissing(base, 'M001', 'S01', 'SUMMARY');
+
+    assert.equal(regenerated, true, 'missing phase-root summary is regenerated despite stale nested summary');
+    assert.equal(normalizeRealPath(resolveTaskFile(base, 'M001', 'S01', 'T01', 'SUMMARY') ?? ''), normalizeRealPath(rootSummaryPath));
+    assert.match(readFileSync(rootSummaryPath, 'utf-8'), /# T01: Completed task/);
+    assert.equal(readFileSync(join(nestedTasksDir, 'T01-SUMMARY.md'), 'utf-8'), '# stale nested summary\n');
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('workflow-projections: renderSummaryProjection uses milestone title when creating fresh flat-phase dirs', async () => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-projections-fresh-summary-'));
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  mkdirSync(join(base, '.gsd'), { recursive: true });
+  openDatabase(dbPath);
+  clearParseCache();
+  clearPathCache();
+  _clearGsdRootCache();
+  invalidateStateCache();
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+    insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Flat slice',
+      status: 'complete',
+    });
+    insertTask({
+      id: 'T01',
+      sliceId: 'S01',
+      milestoneId: 'M001',
+      title: 'Completed task',
+      status: 'complete',
+    });
+
+    const titleSummaryPath = join(base, '.gsd', 'phases', '01-milestone', 'T01-SUMMARY.md');
+    const idSummaryPath = join(base, '.gsd', 'phases', '01-m001', 'T01-SUMMARY.md');
+
+    renderSummaryProjection(base, 'M001', 'S01', 'T01');
+
+    assert.ok(existsSync(titleSummaryPath), 'fresh summary projection uses the milestone title slug');
+    assert.equal(existsSync(idSummaryPath), false, 'fresh summary projection does not create an id-slug orphan dir');
+    assert.equal(normalizeRealPath(resolveTaskFile(base, 'M001', 'S01', 'T01', 'SUMMARY') ?? ''), normalizeRealPath(titleSummaryPath));
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os';
 import { regenerateIfMissing, renderPlanContent, renderStateProjection, renderSummaryProjection } from '../workflow-projections.ts';
 import type { SliceRow, TaskRow } from '../gsd-db.ts';
 import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from '../gsd-db.ts';
-import { clearPathCache, _clearGsdRootCache, normalizeRealPath, resolveTaskFile } from '../paths.ts';
+import { clearPathCache, _clearGsdRootCache, normalizeRealPath, resolveMilestoneFile, resolveTaskFile } from '../paths.ts';
 import { invalidateStateCache } from '../state.ts';
 import { clearParseCache } from '../files.ts';
 
@@ -237,6 +237,80 @@ test('workflow-projections: regenerateIfMissing PLAN restores slice plan and tas
     assert.equal(regenerated, true, 'regenerateIfMissing reports the PLAN was rebuilt');
     assert.ok(existsSync(slicePlanPath), 'slice PLAN restored on disk');
     // Flat-phase: tasks are checkboxes inside the plan file, not separate task plan files.
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('workflow-projections: regenerateIfMissing ROADMAP is idempotent for flat-phase roadmap projections', async () => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-projections-flat-roadmap-'));
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  const phaseDir = join(base, '.gsd', 'phases', '01-milestone');
+  mkdirSync(phaseDir, { recursive: true });
+  openDatabase(dbPath);
+  clearParseCache();
+  clearPathCache();
+  _clearGsdRootCache();
+  invalidateStateCache();
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active', planning: { vision: 'Ship a layout-aware roadmap.' } });
+    insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Flat slice',
+      status: 'pending',
+      demo: 'Roadmap exists at the flat-phase path.',
+      planning: { goal: 'Keep ROADMAP regeneration idempotent.' },
+    });
+
+    const roadmapPath = join(phaseDir, '01-ROADMAP.md');
+    writeFileSync(roadmapPath, '# existing flat roadmap\n');
+
+    const regenerated = await regenerateIfMissing(base, 'M001', 'S01', 'ROADMAP');
+
+    assert.equal(regenerated, false, 'existing flat-phase ROADMAP is detected without rewriting');
+    assert.equal(readFileSync(roadmapPath, 'utf-8'), '# existing flat roadmap\n');
+    assert.equal(normalizeRealPath(resolveMilestoneFile(base, 'M001', 'ROADMAP') ?? ''), normalizeRealPath(roadmapPath));
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('workflow-projections: regenerateIfMissing ROADMAP regenerates missing flat-phase roadmap projections', async () => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-projections-missing-roadmap-'));
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  const phaseDir = join(base, '.gsd', 'phases', '01-milestone');
+  mkdirSync(phaseDir, { recursive: true });
+  openDatabase(dbPath);
+  clearParseCache();
+  clearPathCache();
+  _clearGsdRootCache();
+  invalidateStateCache();
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active', planning: { vision: 'Ship a layout-aware roadmap.' } });
+    insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Flat slice',
+      status: 'pending',
+      demo: 'Roadmap regenerates at the flat-phase path.',
+      planning: { goal: 'Recover ROADMAP from DB.' },
+    });
+
+    const roadmapPath = join(phaseDir, '01-ROADMAP.md');
+    const legacyRoadmapPath = join(base, '.gsd', 'milestones', 'M001', 'M001-ROADMAP.md');
+    assert.ok(!existsSync(roadmapPath), 'precondition: flat-phase ROADMAP is absent');
+
+    const regenerated = await regenerateIfMissing(base, 'M001', 'S01', 'ROADMAP');
+
+    assert.equal(regenerated, true, 'missing flat-phase ROADMAP is regenerated');
+    assert.match(readFileSync(roadmapPath, 'utf-8'), /Ship a layout-aware roadmap/);
+    assert.equal(existsSync(legacyRoadmapPath), false, 'regeneration does not create a legacy ROADMAP path');
+    assert.equal(normalizeRealPath(resolveMilestoneFile(base, 'M001', 'ROADMAP') ?? ''), normalizeRealPath(roadmapPath));
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -10,7 +10,6 @@
  * for recovery, and invalidates caches.
  */
 
-import { join } from "node:path";
 import { existsSync } from "node:fs";
 
 import {
@@ -21,7 +20,7 @@ import {
   getLatestAssessmentByScope,
   updateMilestoneStatus,
 } from "../gsd-db.js";
-import { gsdProjectionRoot, clearPathCache, relMilestoneFile } from "../paths.js";
+import { clearPathCache, resolveMilestoneFile, targetMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
 import { saveFile, clearParseCache } from "../files.js";
@@ -210,9 +209,14 @@ export async function handleCompleteMilestone(
   // ── Filesystem operations (outside transaction) ─────────────────────────
   const summaryMd = renderMilestoneSummaryMarkdown(params, completedAt);
 
-  // Layout-aware: flat-phase → phases/NN-slug/NN-SUMMARY.md;
-  // legacy → milestones/MID/MID-SUMMARY.md.
-  const summaryPath = join(artifactBasePath, relMilestoneFile(artifactBasePath, params.milestoneId, "SUMMARY"));
+  const summaryPath =
+    resolveMilestoneFile(artifactBasePath, params.milestoneId, "SUMMARY") ??
+    targetMilestoneFile(
+      artifactBasePath,
+      params.milestoneId,
+      "SUMMARY",
+      getMilestone(params.milestoneId)?.title,
+    );
 
   // Guard (#4598): if SUMMARY.md already exists on disk, do not overwrite it.
   // This handles re-dispatch scenarios (DB/disk state divergence) where a prior

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -1,6 +1,6 @@
-import { join } from "node:path";
 import { existsSync, unlinkSync } from "node:fs";
-import { relSliceFile, relMilestoneFile } from "../paths.js";
+import { join } from "node:path";
+import { relSliceFile, resolveMilestoneFile, resolveMilestonePath, targetMilestoneFile } from "../paths.js";
 import { clearParseCache } from "../files.js";
 import { isClosedStatus } from "../status-guards.js";
 import { isNonEmptyString } from "../validation.js";
@@ -290,12 +290,23 @@ export async function handleReassessRoadmap(
       params.sliceChanges.removed.length > 0;
 
     if (hasStructuralChanges) {
-      // Layout-aware: flat-phase → phases/NN-slug/NN-VALIDATION.md; legacy → milestones/MID/MID-VALIDATION.md
-      const validationFile = join(basePath, relMilestoneFile(basePath, params.milestoneId, "VALIDATION"));
-      try {
-        if (existsSync(validationFile)) unlinkSync(validationFile);
-      } catch (e) {
-        logWarning("tool", `validation file cleanup failed: ${(e as Error).message}`);
+      const milestoneDir = resolveMilestonePath(basePath, params.milestoneId);
+      const validationFiles = new Set([
+        resolveMilestoneFile(basePath, params.milestoneId, "VALIDATION"),
+        targetMilestoneFile(
+          basePath,
+          params.milestoneId,
+          "VALIDATION",
+          getMilestone(params.milestoneId)?.title,
+        ),
+        milestoneDir ? join(milestoneDir, `${params.milestoneId}-VALIDATION.md`) : null,
+      ].filter((file): file is string => Boolean(file)));
+      for (const validationFile of validationFiles) {
+        try {
+          if (existsSync(validationFile)) unlinkSync(validationFile);
+        } catch (e) {
+          logWarning("tool", `validation file cleanup failed: ${(e as Error).message}`);
+        }
       }
     }
 

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -12,15 +12,13 @@
  * despite passing validation.
  */
 
-import { join } from "node:path";
-
 import {
   transaction,
   insertAssessment,
   getMilestoneSlices,
   getMilestone,
 } from "../gsd-db.js";
-import { gsdProjectionRoot, clearPathCache, relMilestoneFile } from "../paths.js";
+import { clearPathCache, targetMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { saveFile, clearParseCache } from "../files.js";
@@ -160,11 +158,12 @@ export async function handleValidateMilestone(
   // worktree exists for this milestone, validation reads/writes the
   // worktree's artifacts instead of stale project-root state.
   const validationMd = renderValidationMarkdown(effectiveParams);
-  // Layout-aware: flat-phase → phases/NN-slug/NN-VALIDATION.md;
-  // legacy → milestones/MID/MID-VALIDATION.md.
-  // join(artifactBasePath, relMilestoneFile) gives the absolute path; relMilestoneFile
-  // returns ".gsd/..."-relative so joining with basePath (project/worktree root) is correct.
-  const validationPath = join(artifactBasePath, relMilestoneFile(artifactBasePath, effectiveParams.milestoneId, "VALIDATION"));
+  const validationPath = targetMilestoneFile(
+    artifactBasePath,
+    effectiveParams.milestoneId,
+    "VALIDATION",
+    getMilestone(effectiveParams.milestoneId)?.title,
+  );
 
   // ── DB write first — matches complete-task/complete-slice pattern ───
   // Write DB before disk so a crash between the two leaves a recoverable
@@ -204,7 +203,12 @@ export async function handleValidateMilestone(
     const projectRoot = resolveWorktreeProjectRoot(basePath);
     if (projectRoot !== artifactBasePath) {
       // Mirror to project root using the project root's layout (same logic as above).
-      const projectValidationPath = join(projectRoot, relMilestoneFile(projectRoot, effectiveParams.milestoneId, "VALIDATION"));
+      const projectValidationPath = targetMilestoneFile(
+        projectRoot,
+        effectiveParams.milestoneId,
+        "VALIDATION",
+        getMilestone(effectiveParams.milestoneId)?.title,
+      );
       try {
         await saveFile(projectValidationPath, validationMd);
       } catch (mirrorErr) {

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -17,7 +17,7 @@ import type { MilestoneRow } from "./db-milestone-artifact-rows.js";
 import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { VerificationEvidenceRow } from "./db-verification-evidence-rows.js";
 import { atomicWriteSync } from "./atomic-write.js";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { mkdirSync, existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { logWarning } from "./workflow-logger.js";
@@ -26,7 +26,7 @@ import { deriveState } from "./state.js";
 import type { GSDState } from "./types.js";
 import { renderPlanFromDb, renderRoadmapFromDb } from "./markdown-renderer.js";
 import { readManifest } from "./workflow-manifest.js";
-import { gsdRoot, resolveSliceFile, resolveMilestonePath, resolveSlicePath, gsdProjectionRoot } from "./paths.js";
+import { gsdRoot, resolveSliceFile, resolveTaskFile, relTaskFile } from "./paths.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -329,24 +329,10 @@ export function renderSummaryProjection(basePath: string, milestoneId: string, s
   const evidenceRows = getVerificationEvidence(milestoneId, sliceId, taskId);
   const content = renderSummaryContent(taskRow, sliceId, milestoneId, evidenceRows);
 
-  // Layout-aware: avoid creating a milestones/ directory as a side effect for
-  // flat-phase projects. If milestonesDir() sees a freshly-created milestones/
-  // dir it treats the project as legacy, breaking all subsequent path resolution.
-  const slicePath = resolveSlicePath(basePath, milestoneId, sliceId);
-  const phaseDir = resolveMilestonePath(basePath, milestoneId);
-  let dir: string;
-  if (slicePath && phaseDir && slicePath !== phaseDir) {
-    // Legacy layout: slice has its own slices/SID/ subdir → tasks/ subdir
-    dir = join(slicePath, "tasks");
-  } else if (phaseDir) {
-    // Flat-phase: task summaries go in the phase dir (no tasks/ subdir needed)
-    dir = phaseDir;
-  } else {
-    // Fallback: legacy hardcoded path (milestone dir not on disk yet)
-    dir = join(gsdProjectionRoot(basePath), "milestones", milestoneId, "slices", sliceId, "tasks");
-  }
-  mkdirSync(dir, { recursive: true });
-  atomicWriteSync(join(dir, `${taskId}-SUMMARY.md`), content);
+  const summaryPath = resolveTaskFile(basePath, milestoneId, sliceId, taskId, "SUMMARY")
+    ?? join(basePath, relTaskFile(basePath, milestoneId, sliceId, taskId, "SUMMARY", getMilestone(milestoneId)?.title));
+  mkdirSync(dirname(summaryPath), { recursive: true });
+  atomicWriteSync(summaryPath, content);
 }
 
 // ─── STATE.md Projection ────────────────────────────────────────────────
@@ -553,8 +539,7 @@ export async function regenerateIfMissing(
     const doneTasks = taskRows.filter(t => t.status === "done" || t.status === "complete");
     let regenerated = 0;
     for (const task of doneTasks) {
-      const summaryPath = join(basePath, ".gsd", "milestones", milestoneId, "slices", sliceId, "tasks", `${task.id}-SUMMARY.md`);
-      if (!existsSync(summaryPath)) {
+      if (!resolveTaskFile(basePath, milestoneId, sliceId, task.id, "SUMMARY")) {
         try {
           renderSummaryProjection(basePath, milestoneId, sliceId, task.id);
           regenerated++;

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -26,7 +26,7 @@ import { deriveState } from "./state.js";
 import type { GSDState } from "./types.js";
 import { renderPlanFromDb, renderRoadmapFromDb } from "./markdown-renderer.js";
 import { readManifest } from "./workflow-manifest.js";
-import { gsdRoot, resolveSliceFile, resolveTaskFile, relTaskFile } from "./paths.js";
+import { gsdRoot, resolveMilestoneFile, resolveSliceFile, resolveTaskFile, relTaskFile } from "./paths.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -522,7 +522,7 @@ export async function regenerateIfMissing(
       filePath = resolveSliceFile(basePath, milestoneId, sliceId, "PLAN") ?? "";
       break;
     case "ROADMAP":
-      filePath = join(basePath, ".gsd", "milestones", milestoneId, `${milestoneId}-ROADMAP.md`);
+      filePath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP") ?? "";
       break;
     case "SUMMARY":
       // For SUMMARY, we regenerate all task summaries in the slice
@@ -576,7 +576,7 @@ export async function regenerateIfMissing(
         return !!(resolveSliceFile(basePath, milestoneId, sliceId, "PLAN"));
       case "ROADMAP":
         await renderRoadmapFromDb(basePath, milestoneId);
-        return existsSync(filePath);
+        return !!resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
       case "STATE":
         await renderStateProjection(basePath);
         return existsSync(filePath);

--- a/src/resources/extensions/gsd/workspace.ts
+++ b/src/resources/extensions/gsd/workspace.ts
@@ -2,14 +2,11 @@
 
 import { dirname, join, resolve } from "node:path";
 import {
-  buildMilestoneFileName,
-  canonicalPhaseDirName,
-  isLegacyMilestonesLayout,
-  milestonesDir,
   type GsdPathContract,
   resolveGsdPathContract,
   resolveMilestoneFile,
   resolveMilestonePath,
+  targetMilestoneFile,
   normalizeRealPath,
 } from "./paths.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
@@ -41,27 +38,14 @@ function tryRealpath(p: string): string {
   return normalizeRealPath(p);
 }
 
-function isLegacyMilestoneDirectory(dir: string): boolean {
-  const parent = dirname(dir);
-  return parent.endsWith("/milestones") || parent.endsWith("\\milestones");
-}
-
 function scopeMilestoneDir(basePath: string, milestoneId: string): string {
-  return resolveMilestonePath(basePath, milestoneId) ?? join(
-    milestonesDir(basePath),
-    isLegacyMilestonesLayout(basePath) ? milestoneId : canonicalPhaseDirName(milestoneId),
-  );
+  return resolveMilestonePath(basePath, milestoneId)
+    ?? dirname(targetMilestoneFile(basePath, milestoneId, "ROADMAP"));
 }
 
 function scopeMilestoneFile(basePath: string, milestoneId: string, suffix: string): string {
-  const existing = resolveMilestoneFile(basePath, milestoneId, suffix);
-  if (existing) return existing;
-
-  const dir = scopeMilestoneDir(basePath, milestoneId);
-  const filename = isLegacyMilestoneDirectory(dir)
-    ? `${milestoneId}-${suffix}.md`
-    : buildMilestoneFileName(milestoneId, suffix);
-  return join(dir, filename);
+  return resolveMilestoneFile(basePath, milestoneId, suffix)
+    ?? targetMilestoneFile(basePath, milestoneId, suffix);
 }
 
 /**


### PR DESCRIPTION
## TL;DR

**What:** Centralizes GSD markdown/projection path targeting for task, milestone, and slice artifacts.
**Why:** Multiple callers were rebuilding flat-phase vs legacy paths independently, which made renderer, validation, regeneration, and stale-repair behavior drift.
**How:** Adds explicit compatibility-preserving reader vs canonical writer helpers and routes projection writers through them.

## What

This refactors the GSD markdown/projection path architecture across the GSD extension:

- centralizes task summary projection resolution for workflow regeneration and drift repair
- adds milestone-level canonical write targets while preserving existing compatibility filenames for readers/guards
- adds slice-level canonical write targets and routes slice renderers through them
- updates validation, complete-milestone, reassess-roadmap, workspace scope fallback, renderer, and stale-render paths to share the path helpers
- adds regression coverage for flat-phase/legacy edge cases, including hybrid `slices/S01` directories that must not divert flat-phase REPLAN/ASSESSMENT writes

## Why

The old architecture had several call sites independently assembling markdown projection paths. That duplicated the same flat-phase vs legacy decisions and made it easy for one path to preserve a compatibility file while another writer repaired or regenerated a different location.

This PR makes the path module the source of truth for projection placement so renderers and repair paths agree on where files belong.

## How

Key design split:

- `resolve*File` / `rel*File`: compatibility-preserving reader and prompt paths, used when existing files should be honored
- `targetMilestoneFile` / `targetSliceFile`: canonical write targets, used when renderers or repair tools create or replace projections

Call sites now choose explicitly between preserving an existing artifact and writing the canonical layout target instead of rebuilding layout rules locally.

## Validation

Per-slice validation was run throughout the refactor. Final local checks:

- `pnpm run verify:fast` — passed
- `pnpm run test:changed:src` — passed `31/41` with `10` intentional skips
- Focused renderer/path/projection tests — passed `67/77` with `10` intentional skips
- `git diff --check` — passed
- `codex review --uncommitted` after each significant slice — final review found no correctness issues
- `GSD_LIVE_TESTS=1 node --experimental-strip-types tests/live-workflow/test-tiny-milestone.ts` — skipped with exit `77` because provider credentials are not configured locally

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None expected. This preserves compatibility readers while centralizing canonical writer targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core artifact I/O and layout detection across many call sites; wrong targeting could misplace or duplicate markdown, though broad regression tests mitigate this.
> 
> **Overview**
> Introduces **`targetMilestoneFile`** / **`targetSliceFile`** as canonical write targets (layout-aware flat-phase vs legacy) while **`resolve*File`** / updated **`rel*File`** keep existing compatibility filenames for reads and prompts.
> 
> **Renderers and tools** (roadmap, milestone/slice artifacts, REPLAN/ASSESSMENT/SUMMARY/UAT, validate/complete/reassess, workspace fallbacks, `workflow-projections` regeneration) drop duplicated path assembly and route writes through the targets; **complete-milestone** prefers `resolveMilestoneFile` before writing so legacy-named summaries are not shadowed.
> 
> **`resolveTaskFile`** now finds flat-phase `TID-SUMMARY.md` at the phase root even when a stray `slices/SID/` exists, so drift/completion detection no longer needs ad-hoc fallbacks. **Reassess** deletes both resolved and canonical validation paths when the roadmap changes structurally.
> 
> Regression tests cover hybrid flat-phase dirs, compatibility filenames, and idempotent ROADMAP/SUMMARY regeneration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e4302ae94072690f4563674c4e00fe88485a99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->