### PR TITLE
[codex] Refactor worktree CLI process

### DIFF
--- a/src/tests/worktree-cli-format.test.ts
+++ b/src/tests/worktree-cli-format.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatMultipleWorktreesPrompt,
+  formatStatus,
+  type WorktreeStatusLike,
+} from "../worktree-cli-format.ts";
+
+const changedStatus: WorktreeStatusLike = {
+  name: "alpha",
+  path: "/repo/.gsd-worktrees/alpha",
+  branch: "worktree/alpha",
+  filesChanged: 2,
+  linesAdded: 7,
+  linesRemoved: 3,
+  uncommitted: false,
+  commits: 1,
+};
+
+test("formatStatus renders changed, dirty, and clean worktree summaries", () => {
+  const changed = formatStatus(changedStatus);
+  assert.match(changed, /alpha/);
+  assert.match(changed, /unmerged/);
+  assert.match(changed, /branch\s+worktree\/alpha/);
+  assert.match(changed, /path\s+\/repo\/\.gsd-worktrees\/alpha/);
+  assert.match(changed, /diff\s+2 files, \+7 -3, 1 commit/);
+
+  const dirty = formatStatus({ ...changedStatus, filesChanged: 0, uncommitted: true, commits: 0 });
+  assert.match(dirty, /uncommitted/);
+  assert.doesNotMatch(dirty, /diff\s+/);
+
+  const clean = formatStatus({ ...changedStatus, filesChanged: 0, uncommitted: false, commits: 0 });
+  assert.match(clean, /clean/);
+  assert.doesNotMatch(clean, /diff\s+/);
+});
+
+test("formatStatus pluralizes files and commits", () => {
+  const singular = formatStatus({ ...changedStatus, filesChanged: 1, commits: 1 });
+  const plural = formatStatus({ ...changedStatus, filesChanged: 2, commits: 2 });
+
+  assert.match(singular, /diff\s+1 file, \+7 -3, 1 commit/);
+  assert.match(plural, /diff\s+2 files, \+7 -3, 2 commits/);
+});
+
+test("formatMultipleWorktreesPrompt preserves actionable -w guidance", () => {
+  const output = formatMultipleWorktreesPrompt([changedStatus]);
+
+  assert.match(output, /1 worktree has unmerged changes/);
+  assert.match(output, /alpha/);
+  assert.match(output, /Specify which one: gsd -w <name>/);
+  assert.equal(output.endsWith("\n"), true);
+});

--- a/src/tests/worktree-cli-plan.test.ts
+++ b/src/tests/worktree-cli-plan.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { planWorktreeFlag, type WorktreeCliWorktree } from "../worktree-cli-plan.ts";
+
+const alpha: WorktreeCliWorktree = {
+  name: "alpha",
+  path: "/repo/.gsd-worktrees/alpha",
+  branch: "worktree/alpha",
+};
+const beta: WorktreeCliWorktree = {
+  name: "beta",
+  path: "/repo/.gsd-worktrees/beta",
+  branch: "worktree/beta",
+};
+
+function named(name: string): string {
+  assert.equal(name, "generated");
+  return name;
+}
+
+test("bare -w resumes the only worktree with changes", () => {
+  assert.deepEqual(planWorktreeFlag(true, [alpha, beta], [alpha], named), {
+    action: "resume",
+    worktree: alpha,
+  });
+});
+
+test("bare -w asks the user to choose when multiple worktrees have changes", () => {
+  assert.deepEqual(planWorktreeFlag(true, [alpha, beta], [alpha, beta], named), {
+    action: "show-multiple",
+    worktrees: [alpha, beta],
+  });
+});
+
+test("bare -w creates a generated worktree when no worktree has changes", () => {
+  assert.deepEqual(planWorktreeFlag(true, [alpha], [], () => "generated"), {
+    action: "create",
+    name: "generated",
+  });
+});
+
+test("named -w resumes an existing worktree or creates the requested name", () => {
+  assert.deepEqual(planWorktreeFlag("alpha", [alpha], [], () => "unused"), {
+    action: "resume",
+    worktree: alpha,
+  });
+  assert.deepEqual(planWorktreeFlag("gamma", [alpha], [], () => "unused"), {
+    action: "create",
+    name: "gamma",
+  });
+});
+
+test("defensive false worktree flag falls back to generated create plan", () => {
+  assert.deepEqual(planWorktreeFlag(false, [alpha], [], () => "generated"), {
+    action: "create",
+    name: "generated",
+  });
+});

--- a/src/tests/worktree-cli-session.test.ts
+++ b/src/tests/worktree-cli-session.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  enterWorktreeSession,
+  formatWorktreeSessionMessage,
+  type WorktreeSessionRuntime,
+} from "../worktree-cli-session.ts";
+
+function makeRuntime(): WorktreeSessionRuntime & { cwd: string | null; output: string } {
+  return {
+    cwd: null,
+    env: {},
+    output: "",
+    chdir(path: string): void {
+      this.cwd = path;
+    },
+    writeStderr(message: string): void {
+      this.output += message;
+    },
+  };
+}
+
+test("enterWorktreeSession centralizes cwd, env, and resume output", () => {
+  const runtime = makeRuntime();
+
+  enterWorktreeSession(
+    { name: "alpha", path: "/repo/.gsd-worktrees/alpha", branch: "worktree/alpha" },
+    "/repo",
+    "Resumed",
+    runtime,
+  );
+
+  assert.equal(runtime.cwd, "/repo/.gsd-worktrees/alpha");
+  assert.equal(runtime.env.GSD_CLI_WORKTREE, "alpha");
+  assert.equal(runtime.env.GSD_CLI_WORKTREE_BASE, "/repo");
+  assert.match(runtime.output, /Resumed worktree/);
+  assert.match(runtime.output, /alpha/);
+  assert.match(runtime.output, /path\s+\/repo\/\.gsd-worktrees\/alpha/);
+  assert.match(runtime.output, /branch\s+worktree\/alpha/);
+});
+
+test("formatWorktreeSessionMessage preserves create and resume wording", () => {
+  const created = formatWorktreeSessionMessage(
+    { name: "beta", path: "/repo/.gsd-worktrees/beta", branch: "worktree/beta" },
+    "Created",
+  );
+  const resumed = formatWorktreeSessionMessage(
+    { name: "beta", path: "/repo/.gsd-worktrees/beta", branch: "worktree/beta" },
+    "Resumed",
+  );
+
+  assert.match(created, /Created worktree/);
+  assert.match(resumed, /Resumed worktree/);
+  assert.match(created, /path\s+\/repo\/\.gsd-worktrees\/beta/);
+  assert.match(resumed, /branch\s+worktree\/beta/);
+  assert.equal(created.endsWith("\n\n"), true);
+  assert.equal(resumed.endsWith("\n\n"), true);
+});

--- a/src/tests/worktree-cli-status.test.ts
+++ b/src/tests/worktree-cli-status.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  getWorktreeStatus,
+  hasWorktreeChanges,
+  type WorktreeStatusDependencies,
+} from "../worktree-cli-status.ts";
+
+function makeDeps(overrides: Partial<WorktreeStatusDependencies> = {}): WorktreeStatusDependencies {
+  return {
+    diffWorktreeAll: () => ({ added: ["new.ts"], modified: ["changed.ts"], removed: ["old.ts"] }),
+    diffWorktreeNumstat: () => [
+      { added: 5, removed: 1 },
+      { added: 8, removed: 3 },
+    ],
+    nativeHasChanges: () => true,
+    nativeDetectMainBranch: () => "main",
+    nativeCommitCountBetween: () => 2,
+    onDebugFailure: () => {},
+    ...overrides,
+  };
+}
+
+test("getWorktreeStatus aggregates diff, dirty, and commit status", () => {
+  const wtPath = mkdtempSync(join(tmpdir(), "gsd-worktree-cli-status-"));
+  try {
+    const status = getWorktreeStatus(makeDeps(), "/repo", "alpha", wtPath, "worktree/alpha");
+
+    assert.deepEqual(status, {
+      name: "alpha",
+      path: wtPath,
+      branch: "worktree/alpha",
+      exists: true,
+      filesChanged: 3,
+      linesAdded: 13,
+      linesRemoved: 4,
+      uncommitted: true,
+      commits: 2,
+    });
+  } finally {
+    rmSync(wtPath, { recursive: true, force: true });
+  }
+});
+
+test("getWorktreeStatus falls back loudly through debug callbacks when native checks fail", () => {
+  const failures: string[] = [];
+  const status = getWorktreeStatus(
+    makeDeps({
+      nativeHasChanges: () => {
+        throw new Error("dirty unavailable");
+      },
+      nativeDetectMainBranch: () => {
+        throw new Error("main unavailable");
+      },
+      onDebugFailure: (scope, error) => {
+        failures.push(`${scope}: ${error instanceof Error ? error.message : String(error)}`);
+      },
+    }),
+    "/repo",
+    "alpha",
+    "/path/that/does/not/exist",
+    "worktree/alpha",
+  );
+
+  assert.equal(status.exists, false);
+  assert.equal(status.uncommitted, false);
+  assert.equal(status.commits, 0);
+  assert.deepEqual(failures, ["native commit count: main unavailable"]);
+});
+
+test("hasWorktreeChanges checks changed files rather than uncommitted dirty state", () => {
+  assert.equal(hasWorktreeChanges(makeDeps(), "/repo", "alpha", "worktree/alpha"), true);
+  assert.equal(
+    hasWorktreeChanges(
+      makeDeps({ diffWorktreeAll: () => ({ added: [], modified: [], removed: [] }) }),
+      "/repo",
+      "alpha",
+      "worktree/alpha",
+    ),
+    false,
+  );
+});

--- a/src/worktree-cli-format.ts
+++ b/src/worktree-cli-format.ts
@@ -1,0 +1,59 @@
+import chalk from 'chalk'
+
+export interface WorktreeStatusLike {
+  name: string
+  path: string
+  branch: string
+  filesChanged: number
+  linesAdded: number
+  linesRemoved: number
+  uncommitted: boolean
+  commits: number
+}
+
+export function formatStatus(status: WorktreeStatusLike): string {
+  const lines: string[] = []
+  const badge = statusBadge(status)
+
+  lines.push(`  ${chalk.bold.cyan(status.name)}${badge}`)
+  lines.push(`    ${chalk.dim('branch')}  ${chalk.magenta(status.branch)}`)
+  lines.push(`    ${chalk.dim('path')}    ${chalk.dim(status.path)}`)
+
+  if (status.filesChanged > 0) {
+    lines.push(formatDiffLine(status))
+  }
+
+  return lines.join('\n')
+}
+
+export function formatMultipleWorktreesPrompt(worktrees: WorktreeStatusLike[]): string {
+  const countLabel = worktrees.length === 1 ? 'worktree has' : 'worktrees have'
+  const lines = [chalk.yellow(`${worktrees.length} ${countLabel} unmerged changes:`), '']
+  for (const wt of worktrees) {
+    lines.push(formatStatus(wt), '')
+  }
+  lines.push(chalk.dim('Specify which one: gsd -w <name>'))
+  return lines.join('\n') + '\n'
+}
+
+function statusBadge(status: WorktreeStatusLike): string {
+  if (status.uncommitted) {
+    return chalk.yellow(' (uncommitted)')
+  }
+
+  if (status.filesChanged > 0) {
+    return chalk.cyan(' (unmerged)')
+  }
+
+  return chalk.green(' (clean)')
+}
+
+function formatDiffLine(status: WorktreeStatusLike): string {
+  const fileLabel = pluralizedNoun(status.filesChanged, 'file')
+  const commitLabel = pluralizedNoun(status.commits, 'commit')
+  return `    ${chalk.dim('diff')}    ${status.filesChanged} ${fileLabel}, ${chalk.green(`+${status.linesAdded}`)} ${chalk.red(`-${status.linesRemoved}`)}, ${status.commits} ${commitLabel}`
+}
+
+function pluralizedNoun(count: number, noun: string): string {
+  return count === 1 ? noun : `${noun}s`
+}

--- a/src/worktree-cli-plan.ts
+++ b/src/worktree-cli-plan.ts
@@ -1,0 +1,40 @@
+export interface WorktreeCliWorktree {
+  name: string
+  path: string
+  branch: string
+}
+
+export type WorktreeFlagPlan =
+  | { action: 'resume'; worktree: WorktreeCliWorktree }
+  | { action: 'show-multiple'; worktrees: WorktreeCliWorktree[] }
+  | { action: 'create'; name: string }
+
+export function planWorktreeFlag(
+  worktreeFlag: boolean | string,
+  existing: WorktreeCliWorktree[],
+  withChanges: WorktreeCliWorktree[],
+  generateName: () => string,
+): WorktreeFlagPlan {
+  if (worktreeFlag === true) {
+    if (withChanges.length === 1) {
+      return { action: 'resume', worktree: withChanges[0] }
+    }
+
+    if (withChanges.length > 1) {
+      return { action: 'show-multiple', worktrees: withChanges }
+    }
+
+    return { action: 'create', name: generateName() }
+  }
+
+  if (typeof worktreeFlag !== 'string') {
+    return { action: 'create', name: generateName() }
+  }
+
+  const found = existing.find((wt) => wt.name === worktreeFlag)
+  if (found) {
+    return { action: 'resume', worktree: found }
+  }
+
+  return { action: 'create', name: worktreeFlag }
+}

--- a/src/worktree-cli-session.ts
+++ b/src/worktree-cli-session.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk'
+
+export type WorktreeSessionVerb = 'Created' | 'Resumed'
+
+export interface WorktreeSessionInfo {
+  name: string
+  path: string
+  branch: string
+}
+
+export interface WorktreeSessionRuntime {
+  env: Record<string, string | undefined>
+  chdir: (path: string) => void
+  writeStderr: (message: string) => void
+}
+
+export function formatWorktreeSessionMessage(
+  info: WorktreeSessionInfo,
+  verb: WorktreeSessionVerb,
+): string {
+  return [
+    chalk.green(`✓ ${verb} worktree ${chalk.bold(info.name)}`),
+    chalk.dim(`  path   ${info.path}`),
+    chalk.dim(`  branch ${info.branch}`),
+  ].join('\n') + '\n\n'
+}
+
+export function enterWorktreeSession(
+  info: WorktreeSessionInfo,
+  basePath: string,
+  verb: WorktreeSessionVerb,
+  runtime: WorktreeSessionRuntime = {
+    env: process.env,
+    chdir: process.chdir,
+    writeStderr: (message) => process.stderr.write(message),
+  },
+): void {
+  runtime.chdir(info.path)
+  runtime.env.GSD_CLI_WORKTREE = info.name
+  runtime.env.GSD_CLI_WORKTREE_BASE = basePath
+  runtime.writeStderr(formatWorktreeSessionMessage(info, verb))
+}

--- a/src/worktree-cli-status.ts
+++ b/src/worktree-cli-status.ts
@@ -1,0 +1,89 @@
+import { existsSync } from 'node:fs'
+
+export interface WorktreeDiff {
+  added: string[]
+  modified: string[]
+  removed: string[]
+}
+
+export interface WorktreeNumstat {
+  added: number
+  removed: number
+}
+
+export interface WorktreeStatusDependencies {
+  diffWorktreeAll: (basePath: string, name: string, branch?: string) => WorktreeDiff
+  diffWorktreeNumstat: (basePath: string, name: string, branch?: string) => WorktreeNumstat[]
+  nativeHasChanges: (path: string) => boolean
+  nativeDetectMainBranch: (basePath: string) => string
+  nativeCommitCountBetween: (basePath: string, from: string, to: string) => number
+  onDebugFailure?: (scope: string, error: unknown) => void
+}
+
+export interface WorktreeStatus {
+  name: string
+  path: string
+  branch: string
+  exists: boolean
+  filesChanged: number
+  linesAdded: number
+  linesRemoved: number
+  uncommitted: boolean
+  commits: number
+}
+
+export function hasWorktreeChanges(
+  deps: WorktreeStatusDependencies,
+  basePath: string,
+  name: string,
+  branch: string,
+): boolean {
+  const diff = deps.diffWorktreeAll(basePath, name, branch)
+  return diff.added.length + diff.modified.length + diff.removed.length > 0
+}
+
+export function getWorktreeStatus(
+  deps: WorktreeStatusDependencies,
+  basePath: string,
+  name: string,
+  wtPath: string,
+  branch: string,
+): WorktreeStatus {
+  const diff = deps.diffWorktreeAll(basePath, name, branch)
+  const numstat = deps.diffWorktreeNumstat(basePath, name, branch)
+  const filesChanged = diff.added.length + diff.modified.length + diff.removed.length
+  let linesAdded = 0
+  let linesRemoved = 0
+  for (const s of numstat) {
+    linesAdded += s.added
+    linesRemoved += s.removed
+  }
+
+  const exists = existsSync(wtPath)
+  let uncommitted = false
+  try {
+    uncommitted = exists && deps.nativeHasChanges(wtPath)
+  } catch (error) {
+    deps.onDebugFailure?.('native worktree dirty check', error)
+  }
+
+  let commits = 0
+  try {
+    const mainBranch = deps.nativeDetectMainBranch(basePath)
+    commits = deps.nativeCommitCountBetween(basePath, mainBranch, branch)
+  } catch (error) {
+    deps.onDebugFailure?.('native commit count', error)
+  }
+
+  return {
+    name,
+    path: wtPath,
+    branch,
+    exists,
+    filesChanged,
+    linesAdded,
+    linesRemoved,
+    uncommitted,
+    commits,
+  }
+}

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -23,9 +23,15 @@ import { bannerLines, name as styledName, warn } from './cli-style.js'
 import { createJiti } from '@mariozechner/jiti'
 import { fileURLToPath } from 'node:url'
 import { generateWorktreeName } from './worktree-name-gen.js'
-import { existsSync } from 'node:fs'
 import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 import { getJitiWorkspaceAliases } from './jiti-workspace-aliases.js'
+import {
+  getWorktreeStatus as calculateWorktreeStatus,
+  hasWorktreeChanges,
+  type WorktreeDiff,
+  type WorktreeStatus,
+  type WorktreeStatusDependencies,
+} from './worktree-cli-status.js'
 
 const jiti = createJiti(fileURLToPath(import.meta.url), {
   interopDefault: true,
@@ -58,12 +64,6 @@ interface ExtensionModules {
 interface MergeModules {
   inferCommitType: (name: string) => string
   autoCommitCurrentBranch: (wtPath: string, reason: string, name: string) => void
-}
-
-interface WorktreeDiff {
-  added: string[]
-  modified: string[]
-  removed: string[]
 }
 
 interface WorktreeManagerModule {
@@ -148,55 +148,20 @@ async function loadMergeModules(): Promise<MergeModules> {
   return _mergeExt
 }
 
-// ─── Types ──────────────────────────────────────────────────────────────────
-
-interface WorktreeStatus {
-  name: string
-  path: string
-  branch: string
-  exists: boolean
-  filesChanged: number
-  linesAdded: number
-  linesRemoved: number
-  uncommitted: boolean
-  commits: number
-}
-
 // ─── Status Helpers ─────────────────────────────────────────────────────────
 
 function getWorktreeStatus(ext: ExtensionModules, basePath: string, name: string, wtPath: string, branch: string): WorktreeStatus {
-  const diff = ext.diffWorktreeAll(basePath, name, branch)
-  const numstat = ext.diffWorktreeNumstat(basePath, name, branch)
-  const filesChanged = diff.added.length + diff.modified.length + diff.removed.length
-  let linesAdded = 0
-  let linesRemoved = 0
-  for (const s of numstat) { linesAdded += s.added; linesRemoved += s.removed }
+  return calculateWorktreeStatus(worktreeStatusDependencies(ext), basePath, name, wtPath, branch)
+}
 
-  let uncommitted = false
-  try {
-    uncommitted = existsSync(wtPath) && ext.nativeHasChanges(wtPath)
-  } catch (error) {
-    logDebugFailure('native worktree dirty check', error)
-  }
-
-  let commits = 0
-  try {
-    const mainBranch = ext.nativeDetectMainBranch(basePath)
-    commits = ext.nativeCommitCountBetween(basePath, mainBranch, branch)
-  } catch (error) {
-    logDebugFailure('native commit count', error)
-  }
-
+function worktreeStatusDependencies(ext: ExtensionModules): WorktreeStatusDependencies {
   return {
-    name,
-    path: wtPath,
-    branch,
-    exists: existsSync(wtPath),
-    filesChanged,
-    linesAdded,
-    linesRemoved,
-    uncommitted,
-    commits,
+    diffWorktreeAll: ext.diffWorktreeAll,
+    diffWorktreeNumstat: ext.diffWorktreeNumstat,
+    nativeHasChanges: ext.nativeHasChanges,
+    nativeDetectMainBranch: ext.nativeDetectMainBranch,
+    nativeCommitCountBetween: ext.nativeCommitCountBetween,
+    onDebugFailure: logDebugFailure,
   }
 }
 
@@ -378,8 +343,7 @@ async function handleStatusBanner(basePath: string): Promise<void> {
 
   const withChanges = worktrees.filter(wt => {
     try {
-      const diff = ext.diffWorktreeAll(basePath, wt.name, wt.branch)
-      return diff.added.length + diff.modified.length + diff.removed.length > 0
+      return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
     } catch (error) {
       logDebugFailure(`status scan for ${wt.name}`, error)
       return false
@@ -408,8 +372,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
     const existing = ext.listWorktrees(basePath)
     const withChanges = existing.filter(wt => {
       try {
-        const diff = ext.diffWorktreeAll(basePath, wt.name, wt.branch)
-        return diff.added.length + diff.modified.length + diff.removed.length > 0
+        return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
       } catch (error) {
         logDebugFailure(`worktree -w scan for ${wt.name}`, error)
         return false

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'node:url'
 import { generateWorktreeName } from './worktree-name-gen.js'
 import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 import { getJitiWorkspaceAliases } from './jiti-workspace-aliases.js'
+import { formatMultipleWorktreesPrompt, formatStatus } from './worktree-cli-format.js'
 import { planWorktreeFlag } from './worktree-cli-plan.js'
 import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
@@ -165,27 +166,6 @@ function worktreeStatusDependencies(ext: ExtensionModules): WorktreeStatusDepend
     nativeCommitCountBetween: ext.nativeCommitCountBetween,
     onDebugFailure: logDebugFailure,
   }
-}
-
-// ─── Formatters ─────────────────────────────────────────────────────────────
-
-function formatStatus(s: WorktreeStatus): string {
-  const lines: string[] = []
-  const badge = s.uncommitted
-    ? chalk.yellow(' (uncommitted)')
-    : s.filesChanged > 0
-      ? chalk.cyan(' (unmerged)')
-      : chalk.green(' (clean)')
-
-  lines.push(`  ${chalk.bold.cyan(s.name)}${badge}`)
-  lines.push(`    ${chalk.dim('branch')}  ${chalk.magenta(s.branch)}`)
-  lines.push(`    ${chalk.dim('path')}    ${chalk.dim(s.path)}`)
-
-  if (s.filesChanged > 0) {
-    lines.push(`    ${chalk.dim('diff')}    ${s.filesChanged} files, ${chalk.green(`+${s.linesAdded}`)} ${chalk.red(`-${s.linesRemoved}`)}, ${s.commits} commit${s.commits === 1 ? '' : 's'}`)
-  }
-
-  return lines.join('\n')
 }
 
 // ─── Subcommand: list ───────────────────────────────────────────────────────
@@ -387,12 +367,8 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
   }
 
   if (plan.action === 'show-multiple') {
-    process.stderr.write(chalk.yellow(`${plan.worktrees.length} worktrees have unmerged changes:\n\n`))
-    for (const wt of plan.worktrees) {
-      const status = getWorktreeStatus(ext, basePath, wt.name, wt.path, wt.branch)
-      process.stderr.write(formatStatus(status) + '\n\n')
-    }
-    process.stderr.write(chalk.dim('Specify which one: gsd -w <name>\n'))
+    const statuses = plan.worktrees.map((wt) => getWorktreeStatus(ext, basePath, wt.name, wt.path, wt.branch))
+    process.stderr.write(formatMultipleWorktreesPrompt(statuses))
     process.exit(0)
   }
 

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'node:url'
 import { generateWorktreeName } from './worktree-name-gen.js'
 import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 import { getJitiWorkspaceAliases } from './jiti-workspace-aliases.js'
+import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
   getWorktreeStatus as calculateWorktreeStatus,
   hasWorktreeChanges,
@@ -382,12 +383,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
     if (withChanges.length === 1) {
       // Single active worktree — resume it
       const wt = withChanges[0]
-      process.chdir(wt.path)
-      process.env.GSD_CLI_WORKTREE = wt.name
-      process.env.GSD_CLI_WORKTREE_BASE = basePath
-      process.stderr.write(chalk.green(`✓ Resumed worktree ${chalk.bold(wt.name)}\n`))
-      process.stderr.write(chalk.dim(`  path   ${wt.path}\n`))
-      process.stderr.write(chalk.dim(`  branch ${wt.branch}\n\n`))
+      enterWorktreeSession(wt, basePath, 'Resumed')
       return
     }
 
@@ -414,12 +410,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
   const found = existing.find(wt => wt.name === name)
 
   if (found) {
-    process.chdir(found.path)
-    process.env.GSD_CLI_WORKTREE = name
-    process.env.GSD_CLI_WORKTREE_BASE = basePath
-    process.stderr.write(chalk.green(`✓ Resumed worktree ${chalk.bold(name)}\n`))
-    process.stderr.write(chalk.dim(`  path   ${found.path}\n`))
-    process.stderr.write(chalk.dim(`  branch ${found.branch}\n\n`))
+    enterWorktreeSession(found, basePath, 'Resumed')
   } else {
     await createAndEnter(ext, basePath, name)
   }
@@ -434,12 +425,7 @@ async function createAndEnter(ext: ExtensionModules, basePath: string, name: str
       process.stderr.write(chalk.yellow(`[gsd] ${hookError}\n`))
     }
 
-    process.chdir(info.path)
-    process.env.GSD_CLI_WORKTREE = name
-    process.env.GSD_CLI_WORKTREE_BASE = basePath
-    process.stderr.write(chalk.green(`✓ Created worktree ${chalk.bold(name)}\n`))
-    process.stderr.write(chalk.dim(`  path   ${info.path}\n`))
-    process.stderr.write(chalk.dim(`  branch ${info.branch}\n\n`))
+    enterWorktreeSession({ name, path: info.path, branch: info.branch }, basePath, 'Created')
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(chalk.red(`[gsd] Failed to create worktree: ${msg}\n`))

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'node:url'
 import { generateWorktreeName } from './worktree-name-gen.js'
 import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 import { getJitiWorkspaceAliases } from './jiti-workspace-aliases.js'
+import { planWorktreeFlag } from './worktree-cli-plan.js'
 import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
   getWorktreeStatus as calculateWorktreeStatus,
@@ -367,53 +368,35 @@ async function handleStatusBanner(basePath: string): Promise<void> {
 async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void> {
   const ext = await loadExtensionModules()
   const basePath = ext.resolveWorktreeProjectRoot(process.cwd())
+  const existing = ext.listWorktrees(basePath)
+  const withChanges = worktreeFlag === true
+    ? existing.filter(wt => {
+        try {
+          return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
+        } catch (error) {
+          logDebugFailure(`worktree -w scan for ${wt.name}`, error)
+          return false
+        }
+      })
+    : []
 
-  // gsd -w (no name) — resume most recent worktree with changes, or create new
-  if (worktreeFlag === true) {
-    const existing = ext.listWorktrees(basePath)
-    const withChanges = existing.filter(wt => {
-      try {
-        return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
-      } catch (error) {
-        logDebugFailure(`worktree -w scan for ${wt.name}`, error)
-        return false
-      }
-    })
-
-    if (withChanges.length === 1) {
-      // Single active worktree — resume it
-      const wt = withChanges[0]
-      enterWorktreeSession(wt, basePath, 'Resumed')
-      return
-    }
-
-    if (withChanges.length > 1) {
-      // Multiple active worktrees — show them and ask user to pick
-      process.stderr.write(chalk.yellow(`${withChanges.length} worktrees have unmerged changes:\n\n`))
-      for (const wt of withChanges) {
-        const status = getWorktreeStatus(ext, basePath, wt.name, wt.path, wt.branch)
-        process.stderr.write(formatStatus(status) + '\n\n')
-      }
-      process.stderr.write(chalk.dim('Specify which one: gsd -w <name>\n'))
-      process.exit(0)
-    }
-
-    // No active worktrees — create a new one
-    const name = generateWorktreeName()
-    await createAndEnter(ext, basePath, name)
+  const plan = planWorktreeFlag(worktreeFlag, existing, withChanges, generateWorktreeName)
+  if (plan.action === 'resume') {
+    enterWorktreeSession(plan.worktree, basePath, 'Resumed')
     return
   }
 
-  // gsd -w <name> — create or resume named worktree
-  const name = worktreeFlag as string
-  const existing = ext.listWorktrees(basePath)
-  const found = existing.find(wt => wt.name === name)
-
-  if (found) {
-    enterWorktreeSession(found, basePath, 'Resumed')
-  } else {
-    await createAndEnter(ext, basePath, name)
+  if (plan.action === 'show-multiple') {
+    process.stderr.write(chalk.yellow(`${plan.worktrees.length} worktrees have unmerged changes:\n\n`))
+    for (const wt of plan.worktrees) {
+      const status = getWorktreeStatus(ext, basePath, wt.name, wt.path, wt.branch)
+      process.stderr.write(formatStatus(status) + '\n\n')
+    }
+    process.stderr.write(chalk.dim('Specify which one: gsd -w <name>\n'))
+    process.exit(0)
   }
+
+  await createAndEnter(ext, basePath, plan.name)
 }
 
 async function createAndEnter(ext: ExtensionModules, basePath: string, name: string): Promise<void> {


### PR DESCRIPTION
## TL;DR

**What:** Split the worktree CLI process into focused status, session-entry, planning, and formatting modules.
**Why:** `src/worktree-cli.ts` mixed command orchestration with calculation, presentation, and session side effects, making the worktree flow harder to reason about and test.
**How:** Extracted each responsibility behind small module APIs and added focused executable tests plus live handler verification.

## What

This refactors the worktree CLI surface without intentionally changing user-facing behavior:

- Adds `src/worktree-cli-status.ts` for status aggregation and changed-file detection.
- Adds `src/worktree-cli-session.ts` for worktree session entry, cwd changes, env setup, and create/resume messages.
- Adds `src/worktree-cli-plan.ts` for pure `gsd -w` decision planning.
- Adds `src/worktree-cli-format.ts` for status and multi-worktree prompt formatting.
- Updates `src/worktree-cli.ts` to orchestrate those responsibilities instead of owning them inline.
- Adds focused tests for each extracted module.

## Why

The worktree process had several responsibilities packed into one CLI module. That made small changes harder to validate because formatting, status math, session side effects, and flag-policy decisions were coupled to command execution. The new split keeps command orchestration in the CLI entrypoint while moving testable, deterministic logic into isolated modules.

## How

The refactor is intentionally incremental:

1. Extract status calculation and changed-file detection.
2. Extract session entry side effects and message formatting.
3. Extract pure `gsd -w` planning.
4. Extract CLI worktree presentation formatting.

Each step was committed separately and recorded in `/tmp/refactor-worktree.md` with RED/GREEN/sabotage evidence, live checks, and review-gate notes.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/worktree-cli-format.test.ts src/tests/worktree-cli-plan.test.ts src/tests/worktree-cli-session.test.ts src/tests/worktree-cli-status.test.ts src/tests/worktree-cli-root.test.ts src/tests/commands-worktree.test.ts`
- `pnpm exec tsc --noEmit`
- Live handler check in a fresh temp git repo using `handleList()` and `handleWorktreeFlag('live-refactor-check')`, confirming create/list behavior and worktree env setup.
- `pnpm run test:changed:src` exits 0, but reports no focused mapping for `src/worktree-cli.ts`; the explicit focused tests above cover the touched behavior.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None intended.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785817642&installation_id=134682257&pr_number=1232&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1232&signature=149c0060a4a37c4d55171931efbcb30f4295e229c3ad5fa82472c39bdbb6974d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with explicit tests and no intended CLI behavior change beyond minor copy pluralization.
> 
> **Overview**
> **Refactors** the worktree CLI by moving status math, `-w` planning, session entry (cwd/env/messages), and stderr formatting out of `worktree-cli.ts` into `worktree-cli-status`, `worktree-cli-plan`, `worktree-cli-session`, and `worktree-cli-format`. The main CLI file now wires extension deps into those helpers and drives `handleWorktreeFlag` / `createAndEnter` from `planWorktreeFlag` + `enterWorktreeSession`.
> 
> **Adds** node:test coverage for each extracted module (status aggregation, changed-file detection, flag plans, session messages, and pluralized diff lines). Presentation tweaks include correct **file/commit** pluralization in status output and a singular **“1 worktree has”** label in the multi-worktree prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781bcc6b4c968a77de289842e43b1627b0a40fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->