### PR TITLE
[codex] Refactor worktree CLI process

### DIFF
--- a/src/tests/worktree-cli-create.test.ts
+++ b/src/tests/worktree-cli-create.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createAndEnterWorktree,
+  type WorktreeCreateDependencies,
+  type WorktreeCreateRuntime,
+} from "../worktree-cli-create.ts";
+
+function makeRuntime(): WorktreeCreateRuntime & { cwd: string | null; output: string; env: Record<string, string | undefined> } {
+  const runtime = {
+    cwd: null as string | null,
+    output: "",
+    env: {} as Record<string, string | undefined>,
+    chdir(path: string): void {
+      runtime.cwd = path;
+    },
+    writeStderr(message: string): void {
+      runtime.output += message;
+    },
+  };
+  return runtime;
+}
+
+function makeDeps(hookError: string | null = null): WorktreeCreateDependencies {
+  return {
+    createWorktree: (basePath, name) => {
+      assert.equal(basePath, "/repo");
+      assert.equal(name, "alpha");
+      return { path: "/repo/.gsd-worktrees/alpha", branch: "worktree/alpha" };
+    },
+    runWorktreePostCreateHook: (basePath, wtPath) => {
+      assert.equal(basePath, "/repo");
+      assert.equal(wtPath, "/repo/.gsd-worktrees/alpha");
+      return hookError;
+    },
+  };
+}
+
+test("createAndEnterWorktree creates, runs the hook, and enters the session", () => {
+  const runtime = makeRuntime();
+
+  createAndEnterWorktree(makeDeps(), "/repo", "alpha", runtime);
+
+  assert.equal(runtime.cwd, "/repo/.gsd-worktrees/alpha");
+  assert.equal(runtime.env.GSD_CLI_WORKTREE, "alpha");
+  assert.equal(runtime.env.GSD_CLI_WORKTREE_BASE, "/repo");
+  assert.match(runtime.output, /Created worktree/);
+  assert.match(runtime.output, /alpha/);
+});
+
+test("createAndEnterWorktree surfaces post-create hook warnings before entering", () => {
+  const runtime = makeRuntime();
+
+  createAndEnterWorktree(makeDeps("hook skipped"), "/repo", "alpha", runtime);
+
+  assert.match(runtime.output, /\[gsd\] hook skipped/);
+  assert.match(runtime.output, /Created worktree/);
+  assert.ok(runtime.output.indexOf("hook skipped") < runtime.output.indexOf("Created worktree"));
+});

--- a/src/tests/worktree-cli-status.test.ts
+++ b/src/tests/worktree-cli-status.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import {
   getWorktreeStatus,
   hasWorktreeChanges,
+  findWorktreesWithChanges,
   type WorktreeStatusDependencies,
 } from "../worktree-cli-status.ts";
 
@@ -83,4 +84,26 @@ test("hasWorktreeChanges checks changed files rather than uncommitted dirty stat
     ),
     false,
   );
+});
+
+test("findWorktreesWithChanges skips scan failures and reports debug scope", () => {
+  const failures: string[] = [];
+  const worktrees = [
+    { name: "alpha", path: "/repo/a", branch: "worktree/alpha" },
+    { name: "beta", path: "/repo/b", branch: "worktree/beta" },
+    { name: "gamma", path: "/repo/g", branch: "worktree/gamma" },
+  ];
+  const deps = makeDeps({
+    diffWorktreeAll: (_basePath, name) => {
+      if (name === "beta") throw new Error("diff failed");
+      if (name === "gamma") return { added: [], modified: [], removed: [] };
+      return { added: ["new.ts"], modified: [], removed: [] };
+    },
+    onDebugFailure: (scope, error) => {
+      failures.push(`${scope}: ${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  assert.deepEqual(findWorktreesWithChanges(deps, "/repo", worktrees, "test scan"), [worktrees[0]]);
+  assert.deepEqual(failures, ["test scan for beta: diff failed"]);
 });

--- a/src/worktree-cli-create.ts
+++ b/src/worktree-cli-create.ts
@@ -1,0 +1,25 @@
+import chalk from 'chalk'
+import { enterWorktreeSession, type WorktreeSessionRuntime } from './worktree-cli-session.js'
+
+export interface WorktreeCreateDependencies {
+  createWorktree: (basePath: string, name: string) => { path: string; branch: string }
+  runWorktreePostCreateHook: (basePath: string, wtPath: string) => string | null
+}
+
+export type WorktreeCreateRuntime = WorktreeSessionRuntime
+
+export function createAndEnterWorktree(
+  deps: WorktreeCreateDependencies,
+  basePath: string,
+  name: string,
+  runtime?: WorktreeCreateRuntime,
+): void {
+  const info = deps.createWorktree(basePath, name)
+  const hookError = deps.runWorktreePostCreateHook(basePath, info.path)
+  if (hookError) {
+    const writeStderr = runtime?.writeStderr ?? ((message: string) => process.stderr.write(message))
+    writeStderr(chalk.yellow(`[gsd] ${hookError}\n`))
+  }
+
+  enterWorktreeSession({ name, path: info.path, branch: info.branch }, basePath, 'Created', runtime)
+}

--- a/src/worktree-cli-status.ts
+++ b/src/worktree-cli-status.ts
@@ -11,6 +11,11 @@ export interface WorktreeNumstat {
   removed: number
 }
 
+export interface WorktreeScanItem {
+  name: string
+  branch: string
+}
+
 export interface WorktreeStatusDependencies {
   diffWorktreeAll: (basePath: string, name: string, branch?: string) => WorktreeDiff
   diffWorktreeNumstat: (basePath: string, name: string, branch?: string) => WorktreeNumstat[]
@@ -40,6 +45,22 @@ export function hasWorktreeChanges(
 ): boolean {
   const diff = deps.diffWorktreeAll(basePath, name, branch)
   return diff.added.length + diff.modified.length + diff.removed.length > 0
+}
+
+export function findWorktreesWithChanges<T extends WorktreeScanItem>(
+  deps: WorktreeStatusDependencies,
+  basePath: string,
+  worktrees: T[],
+  debugScope: string,
+): T[] {
+  return worktrees.filter((wt) => {
+    try {
+      return hasWorktreeChanges(deps, basePath, wt.name, wt.branch)
+    } catch (error) {
+      deps.onDebugFailure?.(`${debugScope} for ${wt.name}`, error)
+      return false
+    }
+  })
 }
 
 export function getWorktreeStatus(

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -27,6 +27,7 @@ import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 import { getJitiWorkspaceAliases } from './jiti-workspace-aliases.js'
 import { formatMultipleWorktreesPrompt, formatStatus } from './worktree-cli-format.js'
 import { planWorktreeFlag } from './worktree-cli-plan.js'
+import { createAndEnterWorktree } from './worktree-cli-create.js'
 import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
   getWorktreeStatus as calculateWorktreeStatus,
@@ -377,14 +378,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
 
 async function createAndEnter(ext: ExtensionModules, basePath: string, name: string): Promise<void> {
   try {
-    const info = ext.createWorktree(basePath, name)
-
-    const hookError = ext.runWorktreePostCreateHook(basePath, info.path)
-    if (hookError) {
-      process.stderr.write(chalk.yellow(`[gsd] ${hookError}\n`))
-    }
-
-    enterWorktreeSession({ name, path: info.path, branch: info.branch }, basePath, 'Created')
+    createAndEnterWorktree(ext, basePath, name)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(chalk.red(`[gsd] Failed to create worktree: ${msg}\n`))

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -31,7 +31,7 @@ import { createAndEnterWorktree } from './worktree-cli-create.js'
 import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
   getWorktreeStatus as calculateWorktreeStatus,
-  hasWorktreeChanges,
+  findWorktreesWithChanges,
   type WorktreeDiff,
   type WorktreeStatus,
   type WorktreeStatusDependencies,
@@ -324,14 +324,7 @@ async function handleStatusBanner(basePath: string): Promise<void> {
   const worktrees = ext.listWorktrees(basePath)
   if (worktrees.length === 0) return
 
-  const withChanges = worktrees.filter(wt => {
-    try {
-      return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
-    } catch (error) {
-      logDebugFailure(`status scan for ${wt.name}`, error)
-      return false
-    }
-  })
+  const withChanges = findWorktreesWithChanges(worktreeStatusDependencies(ext), basePath, worktrees, 'status scan')
 
   if (withChanges.length === 0) return
 
@@ -351,14 +344,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
   const basePath = ext.resolveWorktreeProjectRoot(process.cwd())
   const existing = ext.listWorktrees(basePath)
   const withChanges = worktreeFlag === true
-    ? existing.filter(wt => {
-        try {
-          return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
-        } catch (error) {
-          logDebugFailure(`worktree -w scan for ${wt.name}`, error)
-          return false
-        }
-      })
+    ? findWorktreesWithChanges(worktreeStatusDependencies(ext), basePath, existing, 'worktree -w scan')
     : []
 
   const plan = planWorktreeFlag(worktreeFlag, existing, withChanges, generateWorktreeName)


### PR DESCRIPTION
## TL;DR

**What:** Split the worktree CLI process into focused status, session-entry, create-entry, planning, scan, and formatting modules.
**Why:** `src/worktree-cli.ts` mixed command orchestration with calculation, presentation, scan policy, creation side effects, and session side effects, making the worktree flow harder to reason about and test.
**How:** Extracted each responsibility behind small module APIs and added focused executable tests plus live handler verification.

## What

This refactors the worktree CLI surface without intentionally changing user-facing behavior:

- Adds `src/worktree-cli-status.ts` for status aggregation, changed-file detection, and changed-worktree scanning.
- Adds `src/worktree-cli-session.ts` for worktree session entry, cwd changes, env setup, and create/resume messages.
- Adds `src/worktree-cli-create.ts` for worktree creation plus post-create hook handling before entering the session.
- Adds `src/worktree-cli-plan.ts` for pure `gsd -w` decision planning.
- Adds `src/worktree-cli-format.ts` for status and multi-worktree prompt formatting.
- Updates `src/worktree-cli.ts` to orchestrate those responsibilities instead of owning them inline.
- Adds focused tests for each extracted module.

## Why

The worktree process had several responsibilities packed into one CLI module. That made small changes harder to validate because formatting, status math, scan behavior, session side effects, create-entry behavior, and flag-policy decisions were coupled to command execution. The new split keeps command orchestration in the CLI entrypoint while moving testable logic into isolated modules.

## How

The refactor is intentionally incremental:

1. Extract status calculation and changed-file detection.
2. Extract session entry side effects and message formatting.
3. Extract pure `gsd -w` planning.
4. Extract CLI worktree presentation formatting.
5. Extract create-and-enter behavior.
6. Centralize changed-worktree scan behavior.

Each step was committed separately. The original progress log is in `/tmp/refactor-worktree.md`; the final two extractions were also validated before publishing this replacement PR.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/worktree-cli-create.test.ts src/tests/worktree-cli-format.test.ts src/tests/worktree-cli-plan.test.ts src/tests/worktree-cli-session.test.ts src/tests/worktree-cli-status.test.ts src/tests/worktree-cli-root.test.ts src/tests/commands-worktree.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run test:changed:src`
- Live handler check in a fresh temp git repo using `handleList()` and `handleWorktreeFlag('live-refactor-check')`, confirming create/list behavior and worktree env setup.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with dependency injection and duplicated logic collapsed; intended CLI behavior is unchanged aside from shared error-handling for scans.
> 
> **Overview**
> Continues splitting the worktree CLI by moving **create → hook → enter session** into `createAndEnterWorktree` in `worktree-cli-create.ts`, with injectable dependencies and an optional runtime so tests can assert cwd, env, and stderr without hitting the real process.
> 
> **Changed-worktree scanning** is centralized in `findWorktreesWithChanges` in `worktree-cli-status.ts`, replacing duplicate try/catch filters in the status banner and `gsd -w` paths; per-worktree diff failures are skipped and reported via `onDebugFailure` with a caller-provided scope (e.g. `status scan for beta`).
> 
> `worktree-cli.ts` now delegates to those helpers; new/updated unit tests cover happy-path create, hook warnings before the “Created worktree” message, and resilient scanning when one worktree’s diff throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1528bf30694cfb5d822dbde63e4bd982f93190bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->