### PR TITLE
[codex] Land missing worktree CLI refactor seams

### DIFF
--- a/src/tests/worktree-cli-create.test.ts
+++ b/src/tests/worktree-cli-create.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createAndEnterWorktree,
+  type WorktreeCreateDependencies,
+  type WorktreeCreateRuntime,
+} from "../worktree-cli-create.ts";
+
+function makeRuntime(): WorktreeCreateRuntime & { cwd: string | null; output: string; env: Record<string, string | undefined> } {
+  const runtime = {
+    cwd: null as string | null,
+    output: "",
+    env: {} as Record<string, string | undefined>,
+    chdir(path: string): void {
+      runtime.cwd = path;
+    },
+    writeStderr(message: string): void {
+      runtime.output += message;
+    },
+  };
+  return runtime;
+}
+
+function makeDeps(hookError: string | null = null): WorktreeCreateDependencies {
+  return {
+    createWorktree: (basePath, name) => {
+      assert.equal(basePath, "/repo");
+      assert.equal(name, "alpha");
+      return { path: "/repo/.gsd-worktrees/alpha", branch: "worktree/alpha" };
+    },
+    runWorktreePostCreateHook: (basePath, wtPath) => {
+      assert.equal(basePath, "/repo");
+      assert.equal(wtPath, "/repo/.gsd-worktrees/alpha");
+      return hookError;
+    },
+  };
+}
+
+test("createAndEnterWorktree creates, runs the hook, and enters the session", () => {
+  const runtime = makeRuntime();
+
+  createAndEnterWorktree(makeDeps(), "/repo", "alpha", runtime);
+
+  assert.equal(runtime.cwd, "/repo/.gsd-worktrees/alpha");
+  assert.equal(runtime.env.GSD_CLI_WORKTREE, "alpha");
+  assert.equal(runtime.env.GSD_CLI_WORKTREE_BASE, "/repo");
+  assert.match(runtime.output, /Created worktree/);
+  assert.match(runtime.output, /alpha/);
+});
+
+test("createAndEnterWorktree surfaces post-create hook warnings before entering", () => {
+  const runtime = makeRuntime();
+
+  createAndEnterWorktree(makeDeps("hook skipped"), "/repo", "alpha", runtime);
+
+  assert.match(runtime.output, /\[gsd\] hook skipped/);
+  assert.match(runtime.output, /Created worktree/);
+  assert.ok(runtime.output.indexOf("hook skipped") < runtime.output.indexOf("Created worktree"));
+});

--- a/src/tests/worktree-cli-status.test.ts
+++ b/src/tests/worktree-cli-status.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import {
   getWorktreeStatus,
   hasWorktreeChanges,
+  findWorktreesWithChanges,
   type WorktreeStatusDependencies,
 } from "../worktree-cli-status.ts";
 
@@ -83,4 +84,26 @@ test("hasWorktreeChanges checks changed files rather than uncommitted dirty stat
     ),
     false,
   );
+});
+
+test("findWorktreesWithChanges skips scan failures and reports debug scope", () => {
+  const failures: string[] = [];
+  const worktrees = [
+    { name: "alpha", path: "/repo/a", branch: "worktree/alpha" },
+    { name: "beta", path: "/repo/b", branch: "worktree/beta" },
+    { name: "gamma", path: "/repo/g", branch: "worktree/gamma" },
+  ];
+  const deps = makeDeps({
+    diffWorktreeAll: (_basePath, name) => {
+      if (name === "beta") throw new Error("diff failed");
+      if (name === "gamma") return { added: [], modified: [], removed: [] };
+      return { added: ["new.ts"], modified: [], removed: [] };
+    },
+    onDebugFailure: (scope, error) => {
+      failures.push(`${scope}: ${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  assert.deepEqual(findWorktreesWithChanges(deps, "/repo", worktrees, "test scan"), [worktrees[0]]);
+  assert.deepEqual(failures, ["test scan for beta: diff failed"]);
 });

--- a/src/worktree-cli-create.ts
+++ b/src/worktree-cli-create.ts
@@ -1,0 +1,25 @@
+import chalk from 'chalk'
+import { enterWorktreeSession, type WorktreeSessionRuntime } from './worktree-cli-session.js'
+
+export interface WorktreeCreateDependencies {
+  createWorktree: (basePath: string, name: string) => { path: string; branch: string }
+  runWorktreePostCreateHook: (basePath: string, wtPath: string) => string | null
+}
+
+export type WorktreeCreateRuntime = WorktreeSessionRuntime
+
+export function createAndEnterWorktree(
+  deps: WorktreeCreateDependencies,
+  basePath: string,
+  name: string,
+  runtime?: WorktreeCreateRuntime,
+): void {
+  const info = deps.createWorktree(basePath, name)
+  const hookError = deps.runWorktreePostCreateHook(basePath, info.path)
+  if (hookError) {
+    const writeStderr = runtime?.writeStderr ?? ((message: string) => process.stderr.write(message))
+    writeStderr(chalk.yellow(`[gsd] ${hookError}\n`))
+  }
+
+  enterWorktreeSession({ name, path: info.path, branch: info.branch }, basePath, 'Created', runtime)
+}

--- a/src/worktree-cli-status.ts
+++ b/src/worktree-cli-status.ts
@@ -11,6 +11,11 @@ export interface WorktreeNumstat {
   removed: number
 }
 
+export interface WorktreeScanItem {
+  name: string
+  branch: string
+}
+
 export interface WorktreeStatusDependencies {
   diffWorktreeAll: (basePath: string, name: string, branch?: string) => WorktreeDiff
   diffWorktreeNumstat: (basePath: string, name: string, branch?: string) => WorktreeNumstat[]
@@ -40,6 +45,22 @@ export function hasWorktreeChanges(
 ): boolean {
   const diff = deps.diffWorktreeAll(basePath, name, branch)
   return diff.added.length + diff.modified.length + diff.removed.length > 0
+}
+
+export function findWorktreesWithChanges<T extends WorktreeScanItem>(
+  deps: WorktreeStatusDependencies,
+  basePath: string,
+  worktrees: T[],
+  debugScope: string,
+): T[] {
+  return worktrees.filter((wt) => {
+    try {
+      return hasWorktreeChanges(deps, basePath, wt.name, wt.branch)
+    } catch (error) {
+      deps.onDebugFailure?.(`${debugScope} for ${wt.name}`, error)
+      return false
+    }
+  })
 }
 
 export function getWorktreeStatus(

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -27,6 +27,7 @@ import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 import { getJitiWorkspaceAliases } from './jiti-workspace-aliases.js'
 import { formatMultipleWorktreesPrompt, formatStatus } from './worktree-cli-format.js'
 import { planWorktreeFlag } from './worktree-cli-plan.js'
+import { createAndEnterWorktree } from './worktree-cli-create.js'
 import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
   getWorktreeStatus as calculateWorktreeStatus,
@@ -377,14 +378,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
 
 async function createAndEnter(ext: ExtensionModules, basePath: string, name: string): Promise<void> {
   try {
-    const info = ext.createWorktree(basePath, name)
-
-    const hookError = ext.runWorktreePostCreateHook(basePath, info.path)
-    if (hookError) {
-      process.stderr.write(chalk.yellow(`[gsd] ${hookError}\n`))
-    }
-
-    enterWorktreeSession({ name, path: info.path, branch: info.branch }, basePath, 'Created')
+    createAndEnterWorktree(ext, basePath, name)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(chalk.red(`[gsd] Failed to create worktree: ${msg}\n`))

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -31,7 +31,7 @@ import { createAndEnterWorktree } from './worktree-cli-create.js'
 import { enterWorktreeSession } from './worktree-cli-session.js'
 import {
   getWorktreeStatus as calculateWorktreeStatus,
-  hasWorktreeChanges,
+  findWorktreesWithChanges,
   type WorktreeDiff,
   type WorktreeStatus,
   type WorktreeStatusDependencies,
@@ -324,14 +324,7 @@ async function handleStatusBanner(basePath: string): Promise<void> {
   const worktrees = ext.listWorktrees(basePath)
   if (worktrees.length === 0) return
 
-  const withChanges = worktrees.filter(wt => {
-    try {
-      return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
-    } catch (error) {
-      logDebugFailure(`status scan for ${wt.name}`, error)
-      return false
-    }
-  })
+  const withChanges = findWorktreesWithChanges(worktreeStatusDependencies(ext), basePath, worktrees, 'status scan')
 
   if (withChanges.length === 0) return
 
@@ -351,14 +344,7 @@ async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void>
   const basePath = ext.resolveWorktreeProjectRoot(process.cwd())
   const existing = ext.listWorktrees(basePath)
   const withChanges = worktreeFlag === true
-    ? existing.filter(wt => {
-        try {
-          return hasWorktreeChanges(worktreeStatusDependencies(ext), basePath, wt.name, wt.branch)
-        } catch (error) {
-          logDebugFailure(`worktree -w scan for ${wt.name}`, error)
-          return false
-        }
-      })
+    ? findWorktreesWithChanges(worktreeStatusDependencies(ext), basePath, existing, 'worktree -w scan')
     : []
 
   const plan = planWorktreeFlag(worktreeFlag, existing, withChanges, generateWorktreeName)


### PR DESCRIPTION
## TL;DR

**What:** Lands the two worktree CLI refactor commits that were accidentally left on the already-merged source branch.
**Why:** PR #1232 merged the earlier refactor seams, but the create-entry and changed-scan extractions were pushed after the merge and were not included in `main`.
**How:** Cherry-picks those two commits onto a fresh branch from current `origin/main` and keeps the changes focused on tested helper extraction.

## What

This follow-up completes the worktree CLI architecture cleanup by adding:

- `src/worktree-cli-create.ts` for the create → post-create hook → session-entry flow.
- A shared `findWorktreesWithChanges()` helper in `src/worktree-cli-status.ts` for fail-soft changed-worktree scans.
- Focused tests for both extracted seams.

## Why

The original refactor PR (#1232) was merged before these final two commits made it into `main`. This PR moves only the missing commits onto a clean branch from current `main` so the intended architecture is complete without reopening or mutating the merged branch.

## How

The implementation keeps behavior unchanged and extracts repeated logic behind injectable, testable helpers:

- `createAndEnterWorktree()` owns successful worktree creation, post-create hook warning output, and session entry.
- `findWorktreesWithChanges()` owns the shared scan policy used by the status banner and bare `-w` handling: report debug failures and skip failed scans.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/worktree-cli-create.test.ts src/tests/worktree-cli-session.test.ts src/tests/worktree-cli-format.test.ts src/tests/worktree-cli-plan.test.ts src/tests/worktree-cli-status.test.ts`
- `pnpm run test:compile`
- Re-ran the same targeted test command after compile.
- `node dist/loader.js worktree list`

## Change type checklist

- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785818814&installation_id=134682257&pr_number=1240&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1240&signature=bd77c6b6e630e80759da3091345363a704b251fce2e92c2afd8fd82b42678d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with behavior preserved; CLI paths are covered by new unit tests and existing compile/test validation.
> 
> **Overview**
> Completes the worktree CLI refactor by moving two seams that were left out of an earlier merge: **create/enter** and **shared “worktrees with changes” scanning**.
> 
> **`createAndEnterWorktree()`** in `worktree-cli-create.ts` now owns create → post-create hook warning on stderr → `enterWorktreeSession('Created')`, with injectable dependencies and an optional runtime for tests. `worktree-cli.ts` delegates to it and keeps only try/catch and error exit around failures.
> 
> **`findWorktreesWithChanges()`** in `worktree-cli-status.ts` replaces duplicated filter/try/catch loops in the status banner and bare `gsd -w` path: per-worktree diff via `hasWorktreeChanges`, skip on error, and `onDebugFailure` with a scoped label. New unit tests cover the create helper (including hook-before-enter ordering) and fail-soft scan behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5224ec1804fd6be122e1b08b503aed373999865b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->