### PR TITLE
fix(issue): complete-slice's full-suite gate reopens a task without surfacing why, causing an infinite execute-task ↔ complete-slice loop

### DIFF
--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -1196,17 +1196,23 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         return skipped;
       }
 
-      // Stuck-loop detection: when the window is saturated with copies of
-      // `nextKey` (count >= STUCK_WINDOW_SIZE), consult the Dispatch History
-      // module's full detect-stuck rule set for the verdict instead of the old
-      // bare saturation count. This keeps the saturation threshold (the window
-      // deliberately records benign idempotent repeats, so earlier-firing
-      // rules would false-positive on pause/resume re-advances) while gaining
-      // retry-budget suppression and diagnosable rule reasons. A saturated
-      // window with no verdict means the dispatch ledger says we are inside
-      // the unit's retry-backoff budget — let the retry proceed.
-      const stuckVerdict =
-        matchingCount >= STUCK_WINDOW_SIZE ? this.dispatchHistory.detectStuck() : null;
+      // Stuck-loop detection: consult the Dispatch History module's full
+      // detect-stuck rule set once the window is *full* — not only when a
+      // single key saturates it. Gating on a single key's saturation count
+      // (matchingCount >= STUCK_WINDOW_SIZE) let two-unit oscillations slip
+      // through forever: an execute-task ↔ complete-slice loop (a slice gate
+      // that keeps reopening the same task, #1225) fills the window with two
+      // alternating keys, so neither key ever reaches the saturation count and
+      // detect-stuck's oscillation/repeat rules were never even invoked. Firing
+      // on window saturation instead covers both shapes. Consecutive same-key
+      // re-advances (the benign pause/resume churn the old count gate guarded
+      // against) are already short-circuited above by the idempotency skip, and
+      // legitimate retry backoff is still suppressed inside detect-stuck via the
+      // dispatch ledger — a saturated window with no verdict means we are inside
+      // the unit's retry-backoff budget, so let the retry proceed.
+      const windowSaturated =
+        this.dispatchHistory.getRecentWindow().length >= STUCK_WINDOW_SIZE;
+      const stuckVerdict = windowSaturated ? this.dispatchHistory.detectStuck() : null;
       if (stuckVerdict) {
         // #442: before declaring a stuck loop, verify the unit didn't actually
         // complete on disk (stale DB) and recover if so — legacy graduated

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -797,9 +797,11 @@ test("stuck-loop: empty ring on a freshly constructed orchestrator advances norm
   assert.equal(result.kind, "advanced");
 });
 
-test("stuck-loop: partial fill of mixed units does not block", async (t) => {
+test("stuck-loop: distinct units making forward progress do not block", async (t) => {
+  // Healthy forward progress visits new units every advance — no key repeats,
+  // so no oscillation/repeat rule fires even once the window is full.
   let i = 0;
-  const sequence = ["M001/S01/A", "M001/S01/B", "M001/S01/A", "M001/S01/B", "M001/S01/A", "M001/S01/B"];
+  const sequence = ["M001/S01/A", "M001/S01/B", "M001/S01/C", "M001/S01/D", "M001/S01/E", "M001/S01/F"];
   const f = makeFixture({
     dispatch: () => ({ action: "dispatch", unitType: "execute-task", unitId: sequence[i++ % sequence.length], prompt: "p" }),
   });
@@ -809,6 +811,43 @@ test("stuck-loop: partial fill of mixed units does not block", async (t) => {
     const result = await f.orchestrator.advance();
     assert.equal(result.kind, "advanced", `round ${round} should advance, got ${result.kind}`);
   }
+});
+
+test("stuck-loop #1225: two-unit oscillation blocks once the window saturates", async (t) => {
+  // Reproduces the execute-task ↔ complete-slice loop: a slice gate keeps
+  // reopening the same task, so two keys alternate forever. Neither key ever
+  // saturates the window on its own, so the old matchingCount>=SIZE gate never
+  // consulted detect-stuck and the loop ran until an external kill. The window
+  // still fills, so detect-stuck's oscillation/repeat rules must now fire.
+  let i = 0;
+  const sequence: Array<{ unitType: string; unitId: string }> = [
+    { unitType: "execute-task", unitId: "M001/S01/T01" },
+    { unitType: "complete-slice", unitId: "M001/S01" },
+  ];
+  const f = makeFixture({
+    dispatch: () => {
+      const next = sequence[i++ % sequence.length];
+      return { action: "dispatch", unitType: next.unitType, unitId: next.unitId, prompt: "p" };
+    },
+  });
+  t.after(() => f.cleanup());
+
+  let blocked: Awaited<ReturnType<typeof f.orchestrator.advance>> | undefined;
+  for (let round = 0; round < STUCK_WINDOW_SIZE; round++) {
+    const result = await f.orchestrator.advance();
+    if (result.kind === "blocked") {
+      blocked = result;
+      break;
+    }
+  }
+
+  assert.ok(blocked, "oscillation must be detected once the window saturates");
+  if (!blocked || blocked.kind !== "blocked") return;
+  assert.equal(blocked.action, "stop");
+  assert.ok(
+    blocked.reason.startsWith("stuck-loop:"),
+    `expected stuck-loop verdict, got: ${blocked.reason}`,
+  );
 });
 
 test("stuck-loop: ring saturated with same unit blocks with action 'stop' and stuck-loop reason", async (t) => {


### PR DESCRIPTION
## Summary
- Fixed the auto-orchestrator stuck-loop gate to run detect-stuck on full window saturation (not just single-key saturation) so execute-task↔complete-slice oscillations halt with a blocker; verified via auto-orchestrator and stuck-detection test suites (200 tests passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1225
- [#1225 complete-slice's full-suite gate reopens a task without surfacing why, causing an infinite execute-task ↔ complete-slice loop](https://github.com/open-gsd/gsd-pi/issues/1225)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1225-complete-slice-s-full-suite-gate-reopens-1783226216`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-orchestration advance/stop logic; behavior change could affect when loops halt vs continue, though idempotency and ledger backoff are preserved.
> 
> **Overview**
> Fixes **#1225** by changing when the auto-orchestrator runs `detectStuck()`: it now runs once the dispatch history **window is full**, instead of only when one dispatch key has repeated `STUCK_WINDOW_SIZE` times.
> 
> That closes a gap where **execute-task ↔ complete-slice** oscillation could run forever—two alternating keys never hit the old per-key threshold, so oscillation rules never ran. Same-key saturation still blocks via the existing path; benign same-unit repeats stay on the idempotency skip, and retry backoff inside `detect-stuck` is unchanged.
> 
> Tests add a regression for the two-unit oscillation and adjust the “forward progress” case to use distinct units so a full window does not false-positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62fc6161bb7cc1fbb9312378eba1217e2a2a524c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->