### PR TITLE
fix(issue): gsd-browser daemon has no way to pass extra Chrome launch flags (e.g. --no-sandbox), so it cannot start in containers without unprivileged user namespaces

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -160,6 +160,8 @@ If you prefer to maintain the MCP entry manually, add:
 
 `--identity-key` and `--identity-project` are stable project identifiers (not filesystem paths) — they may not contain path separators.
 
+Set `GSD_BROWSER_MCP_EXTRA_ARGS` to forward extra flags to the launched `gsd-browser` daemon without hand-editing `.mcp.json` args. It accepts a plain command-line string (`--stealth --browser-path /usr/bin/chromium`) or a JSON array (`["--stealth"]`), and the flags are appended after the managed session/identity flags for both the MCP server entry and the daemon-start warm-up. Use this in environments where Chrome needs extra launch flags — for example, containers with unprivileged user namespaces disabled (Ubuntu 23.10+, many CI runners), where Chrome's sandbox refuses to start; there, `GSD_BROWSER_MCP_EXTRA_ARGS=--stealth` supplies Chrome's `--no-sandbox`.
+
 Keep this in `.gsd/mcp.json` when browser paths, vault settings, or session state are machine-local. Use `.mcp.json` only when the team should share the same server entry. Set `GSD_BROWSER_MCP_ENABLED=0` only to skip writing the external MCP entry; it does not disable Pi browser tools. Browser-facing projects automatically prefer the managed `gsd-browser` engine when it is available and starts cleanly, falling back to Playwright otherwise. Use `GSD_BROWSER_ENGINE=gsd-browser` to force the managed engine, `GSD_BROWSER_ENGINE=playwright` (or `legacy`) to force the Playwright engine, or `GSD_BROWSER_ENGINE=off` to disable Pi browser tools.
 
 ### Example: HTTP server

--- a/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
@@ -55,6 +55,31 @@ describe("resolveGsdBrowserMcpLaunchConfig identity flags", () => {
     assert.equal(args[1], "mcp");
   });
 
+  it("appends GSD_BROWSER_MCP_EXTRA_ARGS after the identity flags (string form)", () => {
+    const { args } = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {
+      GSD_BROWSER_MCP_EXTRA_ARGS: "--stealth --browser-path /usr/bin/chromium",
+    });
+
+    // Managed flags stay intact and the extra flags trail them.
+    assert.ok(args.indexOf("--identity-project") >= 0);
+    assert.deepEqual(args.slice(-3), ["--stealth", "--browser-path", "/usr/bin/chromium"]);
+    assert.ok(args.indexOf("--stealth") > args.indexOf("--identity-project"));
+  });
+
+  it("accepts GSD_BROWSER_MCP_EXTRA_ARGS as a JSON array", () => {
+    const { args } = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {
+      GSD_BROWSER_MCP_EXTRA_ARGS: '["--stealth"]',
+    });
+    assert.equal(args[args.length - 1], "--stealth");
+  });
+
+  it("forwards GSD_BROWSER_MCP_EXTRA_ARGS to the daemon-start invocation", () => {
+    const env = { GSD_BROWSER_MCP_EXTRA_ARGS: "--stealth" };
+    const daemon = resolveGsdBrowserDaemonStartInvocation("/tmp/example-project", env);
+    assert.equal(daemon.args[daemon.args.length - 1], "--stealth");
+    assert.ok(daemon.args.indexOf("daemon") >= 0 && daemon.args.indexOf("start") >= 0);
+  });
+
   it("uses a path-safe identity-project identifier", () => {
     const { args } = resolveGsdBrowserMcpLaunchConfig("/tmp/example/project", {});
     const projectId = args[args.indexOf("--identity-project") + 1];

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -66,6 +66,30 @@ function splitCommandLine(commandLine: string): string[] {
   });
 }
 
+/**
+ * Extra gsd-browser CLI flags to forward verbatim to the launched daemon, from
+ * GSD_BROWSER_MCP_EXTRA_ARGS. Unlike GSD_BROWSER_MCP_ARGS (a full args override),
+ * these are *appended* to the default `mcp`/`daemon start` invocation so callers
+ * keep the managed session/identity flags. Accepts a JSON array (e.g.
+ * `["--stealth"]`) or a plain, optionally-quoted command-line string
+ * (e.g. `--stealth --browser-path /usr/bin/chromium`). This is the config-level
+ * knob for environments where Chrome needs extra launch flags — e.g. containers
+ * without unprivileged user namespaces, where `--stealth` supplies Chrome's
+ * `--no-sandbox`.
+ */
+function resolveExtraGsdBrowserArgs(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.GSD_BROWSER_MCP_EXTRA_ARGS?.trim();
+  if (!raw) return [];
+  if (raw.startsWith("[")) {
+    const parsed = parseJsonEnv<unknown>(env, "GSD_BROWSER_MCP_EXTRA_ARGS");
+    if (!Array.isArray(parsed)) {
+      throw new Error("GSD_BROWSER_MCP_EXTRA_ARGS JSON must be an array of strings");
+    }
+    return parsed.map(String);
+  }
+  return splitCommandLine(raw);
+}
+
 function buildPathGsdBrowserVersionInvocation(platform: NodeJS.Platform): { command: string; args: string[] } {
   if (platform === "win32") {
     return { command: "cmd", args: ["/d", "/s", "/c", "gsd-browser", "--version"] };
@@ -297,6 +321,10 @@ export function resolveGsdBrowserMcpLaunchConfig(
     || (preferPathCli ? "gsd-browser" : undefined)
     || (bundledCliPath ? process.execPath : undefined)
     || "gsd-browser";
+  // Appended after the managed session/identity flags so they survive the
+  // daemon-start transformation (which forwards everything after `mcp`), letting
+  // callers add extra Chrome/gsd-browser launch flags via one config knob.
+  const extraArgs = resolveExtraGsdBrowserArgs(env);
   const args = Array.isArray(explicitArgs) && explicitArgs.length > 0
     ? explicitArgs.map(String)
     : [
@@ -311,6 +339,7 @@ export function resolveGsdBrowserMcpLaunchConfig(
         identityKey,
         "--identity-project",
         identityProject,
+        ...extraArgs,
       ];
   const cwd = env.GSD_BROWSER_MCP_CWD?.trim() || resolvedProjectRoot;
 


### PR DESCRIPTION
## Summary
- Added a `GSD_BROWSER_MCP_EXTRA_ARGS` passthrough that appends extra gsd-browser launch flags into both the `.mcp.json` entry and daemon-start warm-up, verified by new and existing launch-config tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1224
- [#1224 gsd-browser daemon has no way to pass extra Chrome launch flags (e.g. --no-sandbox), so it cannot start in containers without unprivileged user namespaces](https://github.com/open-gsd/gsd-pi/issues/1224)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1224-gsd-browser-daemon-has-no-way-to-pass-ex-1783226221`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to gsd-browser launch argument resolution and documentation; no auth or data-path changes, with behavior covered by new unit tests.
> 
> **Overview**
> Adds **`GSD_BROWSER_MCP_EXTRA_ARGS`** so operators can pass extra `gsd-browser` / Chrome launch flags without editing `.mcp.json`. Values can be a plain CLI string or a JSON string array; flags are **appended after** the managed session and identity arguments on both the MCP launch config and **`daemon start`** warm-up (unlike a full `GSD_BROWSER_MCP_ARGS` override).
> 
> User docs describe the knob for container/CI setups where Chrome needs flags such as **`--stealth`** (maps to **`--no-sandbox`** when user namespaces are unavailable). New launch-config tests cover string and JSON forms and daemon forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377b6844b02ffa6fa3d66e9562f5c457f970e93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->