### PR TITLE
fix(issue): [Bug]: an exception during auto-start bypasses `cleanupAfterLoopExit`, leaking `s.active` and the auto lock so every later `/gsd auto` silently no-ops until restart

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2895,15 +2895,18 @@ export async function startAuto(
       debugLog("resume-orchestration-resume", { error: err instanceof Error ? err.message : String(err) });
     }
     startAutoCommandPolling(s.basePath);
-    await runAutoLoopWithUok({
-      ctx,
-      pi,
-      s,
-      deps: loopDeps,
-      runKernelLoop: runUokKernelLoop,
-      runLegacyLoop: runLegacyAutoLoop,
-    });
-    await cleanupAfterLoopExit(ctx);
+    try {
+      await runAutoLoopWithUok({
+        ctx,
+        pi,
+        s,
+        deps: loopDeps,
+        runKernelLoop: runUokKernelLoop,
+        runLegacyLoop: runLegacyAutoLoop,
+      });
+    } finally {
+      await cleanupAfterLoopExit(ctx);
+    }
     return;
   }
 
@@ -2957,15 +2960,18 @@ export async function startAuto(
   startAutoCommandPolling(s.basePath);
 
   // Dispatch the first unit
-  await runAutoLoopWithUok({
-    ctx,
-    pi,
-    s,
-    deps: loopDeps,
-    runKernelLoop: runUokKernelLoop,
-    runLegacyLoop: runLegacyAutoLoop,
-  });
-  await cleanupAfterLoopExit(ctx);
+  try {
+    await runAutoLoopWithUok({
+      ctx,
+      pi,
+      s,
+      deps: loopDeps,
+      runKernelLoop: runUokKernelLoop,
+      runLegacyLoop: runLegacyAutoLoop,
+    });
+  } finally {
+    await cleanupAfterLoopExit(ctx);
+  }
 }
 
 // describeNextUnit is imported from auto-dashboard.ts and re-exported

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -615,11 +615,27 @@ export function startAutoDetached(
     milestoneLock?: string | null;
   },
 ): void {
-  void withDetachedAutoKeepalive(startAuto(ctx, pi, base, verboseMode, options)).catch((err) => {
+  void withDetachedAutoKeepalive(startAuto(ctx, pi, base, verboseMode, options)).catch(async (err) => {
     const message = getErrorMessage(err);
     ctx.ui.notify(`Auto-start failed: ${message}`, "error");
     logWarning("engine", `auto start error: ${message}`, { file: "auto.ts" });
     debugLog("auto-start-failed", { error: message });
+    // Backstop cleanup (#1235): if startAuto threw after auto-mode was activated
+    // (e.g. an exception during bootstrap, before the loop's try/finally could
+    // run cleanupAfterLoopExit), s.active and the on-disk auto lock leak, so the
+    // re-entry guard silently no-ops every later /gsd auto until restart. Clear
+    // the leaked activation here so a failed start is always recoverable.
+    if (s.active) {
+      try {
+        await cleanupAfterLoopExit(ctx);
+      } catch (cleanupErr) {
+        logWarning(
+          "engine",
+          `auto start cleanup failed: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+          { file: "auto.ts" },
+        );
+      }
+    }
   });
 }
 
@@ -2934,7 +2950,15 @@ export async function startAuto(
     bootstrapDeps,
     freshStartAssessment,
   );
-  if (!ready) return;
+  if (!ready) {
+    // bootstrapAutoSession sets s.active = true (auto-start.ts) before several
+    // post-activation bail-outs return false without a loop ever running (e.g.
+    // the SQLite-unavailable gate). Without this, s.active and the auto lock
+    // leak and every later /gsd auto silently no-ops via the re-entry guard
+    // (#1235). Run the canonical cleanup so a failed bootstrap stays recoverable.
+    if (s.active) await cleanupAfterLoopExit(ctx);
+    return;
+  }
 
   // Build scope after bootstrap has populated s.basePath / s.originalBasePath /
   // s.currentMilestoneId (including worktree setup inside bootstrapAutoSession).

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -208,6 +208,38 @@ test("startAutoDetached reports failures asynchronously (#3733)", () => {
   );
 });
 
+test("failed auto-start always clears leaked s.active so later /gsd auto is not bricked (#1235)", () => {
+  const autoSrc = readGsdFile("auto.ts");
+
+  // 1. startAutoDetached is the single funnel for any exception thrown out of
+  //    startAuto — including a bootstrap throw that escapes before the loop's
+  //    try/finally could run cleanupAfterLoopExit. The failure handler must
+  //    clear leaked activation, or s.active + the on-disk auto lock persist and
+  //    the re-entry guard silently no-ops every later /gsd auto until restart.
+  const detachedIdx = autoSrc.indexOf("export function startAutoDetached");
+  assert.ok(detachedIdx > -1, "startAutoDetached should exist");
+  const detachedBody = autoSrc.slice(detachedIdx, autoSrc.indexOf("\n}", detachedIdx));
+  assert.ok(
+    detachedBody.includes("if (s.active)") &&
+      detachedBody.includes("cleanupAfterLoopExit(ctx)"),
+    "startAutoDetached failure handler must run cleanupAfterLoopExit when auto-mode is still active",
+  );
+
+  // 2. bootstrapAutoSession sets s.active = true before some bail-outs return
+  //    false (e.g. the SQLite-unavailable gate), so the fresh-start !ready path
+  //    must clear the leaked activation before returning.
+  const startAutoIdx = autoSrc.indexOf("export async function startAuto(");
+  assert.ok(startAutoIdx > -1, "startAuto should exist");
+  const startAutoBody = autoSrc.slice(startAutoIdx);
+  const notReadyIdx = startAutoBody.indexOf("if (!ready) {");
+  assert.ok(notReadyIdx > -1, "fresh start should guard on bootstrap readiness with a block body");
+  const notReadyBlock = startAutoBody.slice(notReadyIdx, notReadyIdx + 600);
+  assert.ok(
+    notReadyBlock.includes("if (s.active) await cleanupAfterLoopExit(ctx)"),
+    "fresh-start !ready bail-out must clear leaked auto activation before returning",
+  );
+});
+
 test("detached auto-start keeps a ref'ed handle until the run settles", async () => {
   const originalSetInterval = globalThis.setInterval;
   const originalClearInterval = globalThis.clearInterval;


### PR DESCRIPTION
## Summary
- Wrapped both auto-loop entry paths in try/finally so cleanupAfterLoopExit always clears s.active and the auto lock on failure; verified with tsc (no auto.ts errors).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1235
- [#1235 [Bug]: an exception during auto-start bypasses `cleanupAfterLoopExit`, leaking `s.active` and the auto lock so every later `/gsd auto` silently no-ops until restart](https://github.com/open-gsd/gsd-pi/issues/1235)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1235-bug-an-exception-during-auto-start-bypas-1783226992`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change around existing cleanup; no new behavior on the success path beyond guaranteed finally execution.
> 
> **Overview**
> **Fixes leaked auto session state** when `runAutoLoopWithUok` throws during resume or fresh `/gsd auto` startup. Both entry paths now wrap the auto loop in `try/finally` so `cleanupAfterLoopExit` runs on success and on failure.
> 
> That cleanup clears `s.active`, releases the crash/session lock, and restores env/UI state—preventing later `/gsd auto` from no-op’ing until process restart (#1235).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5812f45727de3e75ea7009ee3d434bbf2004f765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->