### PR TITLE
fix(issue): [Bug]: A telemetry-only `uok-kernel-enter` audit write aborts `/gsd auto` entirely when the DB handle is not writable

### DIFF
--- a/src/resources/extensions/gsd/tests/uok-kernel-path.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-kernel-path.test.ts
@@ -1,8 +1,9 @@
 // Project/App: gsd-pi
-// File Purpose: Verifies UOK kernel path selection and legacy fallback telemetry.
+// File Purpose: Verifies UOK kernel path selection, legacy fallback telemetry,
+// and that a failing telemetry-only audit emit never aborts orchestration.
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -14,6 +15,8 @@ import type { LoopDeps } from "../auto/loop-deps.ts";
 import { gsdRoot } from "../paths.ts";
 import type { GSDPreferences } from "../preferences.ts";
 import { getLegacyTelemetry, resetLegacyTelemetry } from "../legacy-telemetry.ts";
+import { closeDatabase, openDatabase, _getAdapter } from "../gsd-db.ts";
+import { peekLogs, _resetLogs } from "../workflow-logger.ts";
 
 function makeBasePath(): string {
   return mkdtempSync(join(tmpdir(), "gsd-uok-kernel-"));
@@ -173,6 +176,59 @@ test("runAutoLoopWithUok respects GSD_UOK_FORCE_LEGACY emergency switch", async 
     resetLegacyTelemetry();
     if (previous === undefined) delete process.env.GSD_UOK_FORCE_LEGACY;
     else process.env.GSD_UOK_FORCE_LEGACY = previous;
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("runAutoLoopWithUok does not abort when the uok-kernel-enter audit emit fails (regression #1233)", async () => {
+  const basePath = makeBasePath();
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  const previousAuditEnv = process.env.GSD_UOK_AUDIT_UNIFIED;
+  // Open a real DB so emitUokAuditEvent takes the authoritative write branch,
+  // then drop audit_events so that write throws — the on-disk analogue of a DB
+  // handle that is open but not writable, exactly the #1233 failure mode.
+  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true, "DB must open for this scenario");
+  _getAdapter()!.exec("DROP TABLE audit_events");
+  try {
+    resetLegacyTelemetry();
+    _resetLogs();
+    const args = makeArgs(basePath, {
+      uok: {
+        enabled: true,
+        audit_unified: { enabled: true },
+        gitops: { enabled: false },
+      },
+    });
+
+    // Before the fix, the telemetry-only kernel-enter emit propagated the DB
+    // write error and aborted /gsd auto before the loop ever ran. It must now
+    // resolve and let orchestration proceed.
+    await runAutoLoopWithUok(args);
+
+    assert.equal(args.calls.kernel, 1, "kernel loop must still run after a failed audit emit");
+    assert.equal(args.calls.legacy, 0);
+
+    // A clean enter + exit parity pair proves the loop ran to completion.
+    const events = readParityEvents(basePath);
+    assert.equal(events.length, 2);
+    assert.equal(events[0]?.phase, "enter");
+    assert.equal(events[1]?.phase, "exit");
+    assert.equal(events[1]?.status, "ok");
+
+    // The failure must be recorded as a non-fatal warning, not silently lost.
+    const warned = peekLogs().some(
+      (e) =>
+        e.severity === "warn" &&
+        e.component === "db" &&
+        /uok-kernel-enter audit emit failed/u.test(e.message),
+    );
+    assert.ok(warned, "a non-fatal db warning must be recorded for the failed audit emit");
+  } finally {
+    closeDatabase();
+    _resetLogs();
+    resetLegacyTelemetry();
+    if (previousAuditEnv === undefined) delete process.env.GSD_UOK_AUDIT_UNIFIED;
+    else process.env.GSD_UOK_AUDIT_UNIFIED = previousAuditEnv;
     rmSync(basePath, { recursive: true, force: true });
   }
 });

--- a/src/resources/extensions/gsd/uok/kernel.ts
+++ b/src/resources/extensions/gsd/uok/kernel.ts
@@ -12,6 +12,7 @@ import { setUnifiedAuditEnabled } from "./audit-toggle.js";
 import { resolveUokFlags } from "./flags.js";
 import { createTurnObserver } from "./loop-adapter.js";
 import { incrementLegacyTelemetry } from "../legacy-telemetry.js";
+import { logWarning } from "../workflow-logger.js";
 
 interface RunAutoLoopWithUokArgs {
   ctx: ExtensionContext;
@@ -70,18 +71,28 @@ export async function runAutoLoopWithUok(args: RunAutoLoopWithUokArgs): Promise<
   });
 
   if (flags.auditUnified) {
-    emitUokAuditEvent(
-      s.basePath,
-      buildAuditEnvelope({
-        traceId: `session:${String(s.autoStartTime || Date.now())}`,
-        category: "orchestration",
-        type: "uok-kernel-enter",
-        payload: {
-          flags,
-          sessionId: ctx.sessionManager?.getSessionId?.(),
-        },
-      }),
-    );
+    try {
+      emitUokAuditEvent(
+        s.basePath,
+        buildAuditEnvelope({
+          traceId: `session:${String(s.autoStartTime || Date.now())}`,
+          category: "orchestration",
+          type: "uok-kernel-enter",
+          payload: {
+            flags,
+            sessionId: ctx.sessionManager?.getSessionId?.(),
+          },
+        }),
+      );
+    } catch (err) {
+      // Telemetry/observability must never abort orchestration. Matches the
+      // best-effort semantics of the parity event above and the JSONL sink
+      // inside emitUokAuditEvent.
+      logWarning(
+        "db",
+        `uok-kernel-enter audit emit failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   const decoratedDeps: LoopDeps = flags.enabled


### PR DESCRIPTION
## Summary
- Wrapped the telemetry-only `uok-kernel-enter` audit emit in a non-fatal try/catch so a non-writable DB no longer aborts `/gsd auto`; verified via the uok kernel-path and audit test suites (11 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1233
- [#1233 [Bug]: A telemetry-only `uok-kernel-enter` audit write aborts `/gsd auto` entirely when the DB handle is not writable](https://github.com/open-gsd/gsd-pi/issues/1233)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1233-bug-a-telemetry-only-uok-kernel-enter-au-1783227114`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows failure handling for telemetry-only audit on kernel enter; core loop behavior is unchanged except that audit errors no longer propagate.
> 
> **Overview**
> Fixes **`/gsd auto`** aborting when unified audit is on but the DB (or audit sink) is not writable: the **`uok-kernel-enter`** `emitUokAuditEvent` call is now wrapped in **try/catch** so orchestration continues.
> 
> On failure, a **`logWarning("db", …)`** records a non-fatal message, aligned with **`writeParityEvent`** and the JSONL audit path’s best-effort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc37863f13d48211f0b21a94761074b9ac4d075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->