### PR TITLE
fix(issue): [Bug]: the pending post-unit hook dispatch is not persisted, so on pause/resume a restored active hook is charged against the next unrelated unit and blocks it

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -73,7 +73,7 @@ import { emitWorktreeOrphaned } from "./worktree-telemetry.js";
 import { queryJournal } from "./journal.js";
 import { initMetrics } from "./metrics.js";
 import { initRoutingHistory } from "./routing-history.js";
-import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
+import { restoreHookState, resetHookState, reconcileRestoredHookDispatch } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
 import { isDbAvailable, getMilestone, getAllMilestones, insertMilestone, updateMilestoneStatus } from "./gsd-db.js";
@@ -1624,6 +1624,10 @@ export async function bootstrapAutoSession(
     s.unitLifetimeDispatches.clear();
     resetHookState();
     restoreHookState(base);
+    // A restored activeHook has no live dispatch (the sidecar queue is not
+    // persisted); re-enqueue it so the hook runs instead of blocking the next
+    // unrelated unit's close-out (#1246).
+    reconcileRestoredHookDispatch(base, s.sidecarQueue);
     resetProactiveHealing();
     // Notify user on health level transitions (green→yellow→red and back)
     setLevelChangeCallback((_from, to, summary) => {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -127,6 +127,7 @@ import {
   runPreDispatchHooks,
   persistHookState,
   restoreHookState,
+  reconcileRestoredHookDispatch,
   clearPersistedHookState,
 } from "./post-unit-hooks.js";
 import { runGSDDoctor, rebuildState } from "./doctor.js";
@@ -2827,6 +2828,10 @@ export async function startAuto(
       "info",
     );
     restoreHookState(s.basePath);
+    // A restored activeHook has no live dispatch (the sidecar queue is not
+    // persisted); re-enqueue it so the hook runs instead of blocking the next
+    // unrelated unit's close-out (#1246).
+    reconcileRestoredHookDispatch(s.basePath, s.sidecarQueue);
     // Re-sync managed resources on resume so long-lived auto sessions pick up
     // bundled extension updates before resume-time verification/state logic runs.
     // GSD_PKG_ROOT is set by loader.ts and points to the gsd-pi package root.

--- a/src/resources/extensions/gsd/post-unit-hooks.ts
+++ b/src/resources/extensions/gsd/post-unit-hooks.ts
@@ -11,6 +11,7 @@ import type {
   HookStatusEntry,
   PostUnitGateBlock,
 } from "./types.js";
+import type { SidecarItem } from "./auto/session.js";
 import { getOrCreateRegistry, resolveHookArtifactPath } from "./rule-registry.js";
 
 // Re-export resolveHookArtifactPath so existing importers still work.
@@ -73,6 +74,37 @@ export function persistHookState(basePath: string): void {
 
 export function restoreHookState(basePath: string): void {
   getOrCreateRegistry().restoreState(basePath);
+}
+
+/**
+ * Reconcile a restored `activeHook` against the session's sidecar queue.
+ *
+ * The registry persists `activeHook` to disk but the pending hook *dispatch*
+ * lives only on the non-persisted `s.sidecarQueue`. After a pause/resume or
+ * crash-recovery, `restoreHookState` re-hydrates `activeHook` while the dispatch
+ * is gone, so the registry believes a hook is in-flight but nothing will ever
+ * complete it — and the next unrelated unit's close-out is falsely charged
+ * against the stale hook and blocked. Re-enqueue the missing dispatch so the
+ * hook actually runs, restoring the invariant that a persisted `activeHook`
+ * always has a live dispatch (#1246).
+ */
+export function reconcileRestoredHookDispatch(
+  basePath: string,
+  sidecarQueue: SidecarItem[],
+): void {
+  const dispatch = getOrCreateRegistry().getPendingHookDispatch(basePath);
+  if (!dispatch) return;
+  const alreadyQueued = sidecarQueue.some(
+    item => item.kind === "hook" && item.unitType === dispatch.unitType,
+  );
+  if (alreadyQueued) return;
+  sidecarQueue.push({
+    kind: "hook",
+    unitType: dispatch.unitType,
+    unitId: dispatch.unitId,
+    prompt: dispatch.prompt,
+    model: dispatch.model,
+  });
 }
 
 export function clearPersistedHookState(basePath: string): void {

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -364,6 +364,14 @@ export class RuleRegistry {
       pendingRetry: false,
     };
 
+    return this._buildHookDispatch(config, triggerUnitId);
+  }
+
+  /** Construct the sidecar dispatch for a hook without mutating registry state. */
+  private _buildHookDispatch(
+    config: PostUnitHookConfig,
+    triggerUnitId: string,
+  ): HookDispatchResult {
     const { milestone: mid, slice: sid, task: tid } = parseUnitId(triggerUnitId);
     let prompt = config.prompt
       .replace(/\{milestoneId\}/g, mid ?? "")
@@ -379,6 +387,22 @@ export class RuleRegistry {
       unitType: `hook/${config.name}`,
       unitId: triggerUnitId,
     };
+  }
+
+  /**
+   * Reconstruct the in-flight hook's dispatch from the restored `activeHook`
+   * state, without mutating the registry. Used to reconcile a persisted
+   * `activeHook` whose session-local dispatch was lost across a pause/resume
+   * or crash-recovery, so the hook actually runs instead of being charged
+   * against the next unrelated unit's close-out (#1246).
+   */
+  getPendingHookDispatch(basePath: string): HookDispatchResult | null {
+    if (!this.activeHook) return null;
+    const config = resolvePostUnitHooks(basePath).find(
+      h => h.name === this.activeHook!.hookName,
+    );
+    if (!config) return null;
+    return this._buildHookDispatch(config, this.activeHook.triggerUnitId);
   }
 
   private _assessHookCompletion(

--- a/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
@@ -16,6 +16,7 @@ import {
   runPreDispatchHooks,
   persistHookState,
   restoreHookState,
+  reconcileRestoredHookDispatch,
   clearPersistedHookState,
   getHookStatus,
   formatHookStatus,
@@ -218,6 +219,90 @@ test('Blocking hook restored from disk does not trust artifact without clean hoo
     const resumed = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
     assert.ok(resumed, "persisted active gate reruns when clean hook completion was not observed");
     assert.equal(resumed.unitType, "hook/security-review");
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Restore reconciliation re-enqueues the lost hook dispatch (#1246)', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: plan-review
+    after:
+      - plan-slice
+    prompt: Review the plan for {milestoneId}/{sliceId}
+    artifact: PLAN-REVIEW.md
+    criticality: blocking
+    max_cycles: 2
+`);
+    // Trigger unit completes: activeHook set + persisted, dispatch enqueued.
+    const dispatch = checkPostUnitHooks("plan-slice", "M002/S01", base);
+    assert.ok(dispatch, "gate dispatches on trigger unit completion");
+    assert.equal(dispatch.unitType, "hook/plan-review");
+    persistHookState(base);
+
+    // Pause/resume: activeHook restored, but the session-local sidecar queue is
+    // gone (never persisted).
+    resetHookState();
+    restoreHookState(base);
+    assert.ok(getActiveHook(), "activeHook restored from disk");
+
+    // Reconciliation re-enqueues the missing dispatch so the hook actually runs.
+    const sidecarQueue: any[] = [];
+    reconcileRestoredHookDispatch(base, sidecarQueue);
+    assert.equal(sidecarQueue.length, 1, "lost hook dispatch is re-enqueued");
+    assert.equal(sidecarQueue[0].kind, "hook");
+    assert.equal(sidecarQueue[0].unitType, "hook/plan-review");
+    assert.equal(sidecarQueue[0].unitId, "M002/S01");
+    assert.match(sidecarQueue[0].prompt, /Review the plan for M002\/S01/);
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Restore reconciliation is a no-op when the dispatch is already queued (#1246)', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: plan-review
+    after:
+      - plan-slice
+    prompt: Review the plan
+    artifact: PLAN-REVIEW.md
+    criticality: blocking
+    max_cycles: 2
+`);
+    const dispatch = checkPostUnitHooks("plan-slice", "M002/S01", base);
+    assert.ok(dispatch, "gate dispatches on trigger unit completion");
+    persistHookState(base);
+    resetHookState();
+    restoreHookState(base);
+
+    const sidecarQueue: any[] = [
+      { kind: "hook", unitType: "hook/plan-review", unitId: "M002/S01", prompt: "already here" },
+    ];
+    reconcileRestoredHookDispatch(base, sidecarQueue);
+    assert.equal(sidecarQueue.length, 1, "does not duplicate an existing hook dispatch");
+    assert.equal(sidecarQueue[0].prompt, "already here");
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Restore reconciliation is a no-op with no active hook (#1246)', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    const sidecarQueue: any[] = [];
+    reconcileRestoredHookDispatch(base, sidecarQueue);
+    assert.equal(sidecarQueue.length, 0, "nothing enqueued when no active hook");
   } finally {
     resetHookState();
     invalidateAllCaches();


### PR DESCRIPTION
## Summary
- Reconcile a restored in-flight post-unit hook's lost sidecar dispatch on pause/resume so it re-runs instead of falsely blocking the next unrelated unit; verified via 24 passing post-unit-hooks tests including 3 new ones.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1246
- [#1246 [Bug]: the pending post-unit hook dispatch is not persisted, so on pause/resume a restored active hook is charged against the next unrelated unit and blocks it](https://github.com/open-gsd/gsd-pi/issues/1246)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1246-bug-the-pending-post-unit-hook-dispatch--1783227469`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-mode bootstrap/resume and post-unit hook gating; wrong reconciliation could duplicate hook runs or leave stale blocks, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes a pause/resume bug where **`activeHook`** was restored from disk but the in-memory **sidecar hook dispatch** was not, so auto-mode thought a blocking hook was still in flight and could **block unrelated units** at close-out.
> 
> Adds **`reconcileRestoredHookDispatch`**, called right after **`restoreHookState`** on fresh bootstrap and on resume, which rebuilds the pending dispatch via **`RuleRegistry.getPendingHookDispatch`** (refactored **`_buildHookDispatch`**) and pushes a `hook` item onto **`s.sidecarQueue`** when it is not already queued.
> 
> Three tests cover re-enqueue, no duplicate when already queued, and no-op when there is no active hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fdf2674fe31ef6c705d53bd84ebcb6bd19ff19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->