### PR TITLE
fix(issue): [Bug]: post-unit gate block message names the hook's trigger unit, not the just-completed unit, making the block confusing to triage

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2398,7 +2398,8 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
       const verdict = gateBlock.verdict ? ` verdict=${gateBlock.verdict};` : "";
       const artifact = gateBlock.artifact ? ` artifact=${gateBlock.artifact};` : "";
       const message =
-        `Post-unit gate "${gateBlock.hookName}" blocked ${gateBlock.triggerUnitType} ${gateBlock.triggerUnitId}:` +
+        `Post-unit gate "${gateBlock.hookName}" blocked ${gateBlock.triggerUnitType} ${gateBlock.triggerUnitId} ` +
+        `(detected on completion of ${s.currentUnit.type} ${s.currentUnit.id}):` +
         `${verdict}${artifact} ${gateBlock.reason}. Run /gsd status to inspect, then /gsd auto after recovery.`;
       ctx.ui.notify(message, "warning");
       await pauseAuto(ctx, pi);

--- a/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
@@ -260,7 +260,14 @@ test("post-unit blocking gate pauses auto-mode on needs-attention verdict", asyn
     const result = await postUnitPostVerification(pctx);
     assert.equal(result, "stopped");
     assert.equal(pauseAuto.mock.callCount(), 1);
-    assert.match(notifications.join("\n"), /Post-unit gate "review-arbiter" blocked execute-task M001\/S01\/T01/);
+    // Regression (#1245): the block message must name BOTH the hook's trigger
+    // unit (execute-task M001/S01/T01) and the just-completed unit that surfaced
+    // the block (s.currentUnit = hook/review-arbiter M001/S01/T01), so the pause
+    // is unambiguous to triage. The pre-fix message stopped at the trigger unit.
+    assert.match(
+      notifications.join("\n"),
+      /Post-unit gate "review-arbiter" blocked execute-task M001\/S01\/T01 \(detected on completion of hook\/review-arbiter M001\/S01\/T01\)/,
+    );
     assert.match(notifications.join("\n"), /\/gsd status/);
   } finally {
     process.chdir(originalCwd);


### PR DESCRIPTION
## Summary
- Appended the just-completed unit (`s.currentUnit`) to the post-unit gate block notification in auto-post-unit.ts; verified variable scope and that the existing substring-based notification test still matches.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1245
- [#1245 [Bug]: post-unit gate block message names the hook's trigger unit, not the just-completed unit, making the block confusing to triage](https://github.com/open-gsd/gsd-pi/issues/1245)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1245-bug-post-unit-gate-block-message-names-t-1783227948`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing notification text only; no changes to gate logic, pause flow, or persistence.
> 
> **Overview**
> When auto-mode pauses because a **post-unit gate** blocked, the warning now names **both** the hook’s trigger unit (`gateBlock.triggerUnitType` / `triggerUnitId`) and the unit that **just finished** (`s.currentUnit`), via `(detected on completion of …)`.
> 
> This is a **copy-only** change in `auto-post-unit.ts`; pause behavior and gate handling are unchanged. Existing tests still match the original substring for the blocked trigger unit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144ea4ec04bf37361a35666e1efdbc3f49bb5991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->