### PR TITLE
fix(issue): [Bug]: a blocking post-unit hook gate spends its retry cycle at dispatch, so a hook whose dispatch is lost on resume hard-blocks on the first miss with no retry

### DIFF
--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -538,17 +538,23 @@ export class RuleRegistry {
       // unit-end — its dispatch was lost/interrupted (pause/resume, crash
       // recovery). Refund that dispatch-consumed cycle exactly once so the gate
       // is re-dispatched at least once instead of hard-blocking on a hook that
-      // never actually ran. Only refund when the cycle budget would otherwise
-      // block rerun; below max_cycles, _rerunGateOrBlock already re-dispatches.
-      // The redispatchedGateKeys flag bounds this to a single refund; a hook
-      // that repeatedly fails to produce its unit-end then consumes its budget
-      // and blocks normally.
+      // never actually ran.
+      //
+      // This refund is intentionally UNCONDITIONAL on the first lost dispatch —
+      // it must NOT be gated on `currentCycle >= max_cycles`. A lost dispatch is
+      // a non-run: charging its cycle at dispatch time must not consume the
+      // hook's real-run budget. Gating the refund on "budget already exhausted"
+      // lets a lost dispatch below max_cycles silently eat a genuine cycle, so
+      // the hook gets one fewer real run than configured — reintroducing #1244
+      // for max_cycles >= 2 (see the "does not steal a real-run cycle" test).
+      // The redispatchedGateKeys flag bounds this to a single refund per gate,
+      // so repeated lost dispatches still terminate (total dispatches never
+      // exceed max_cycles + 1) and a hook that keeps failing blocks normally.
       const cycleKey = hookCycleKey(config, hook);
-      const currentCycle = this.cycleCounts.get(cycleKey) ?? 0;
-      const maxCycles = hookMaxCycles(config);
-      if (!this.redispatchedGateKeys.has(cycleKey) && currentCycle >= maxCycles) {
+      if (!this.redispatchedGateKeys.has(cycleKey)) {
         this.redispatchedGateKeys.add(cycleKey);
-        if (currentCycle > 0) {
+        const currentCycle = this.cycleCounts.get(cycleKey);
+        if (typeof currentCycle === "number" && currentCycle > 0) {
           this.cycleCounts.set(cycleKey, currentCycle - 1);
         }
       }

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -538,14 +538,17 @@ export class RuleRegistry {
       // unit-end — its dispatch was lost/interrupted (pause/resume, crash
       // recovery). Refund that dispatch-consumed cycle exactly once so the gate
       // is re-dispatched at least once instead of hard-blocking on a hook that
-      // never actually ran. The redispatchedGateKeys flag bounds this to a
-      // single refund; a hook that repeatedly fails to produce its unit-end
-      // then consumes its budget and blocks normally.
+      // never actually ran. Only refund when the cycle budget would otherwise
+      // block rerun; below max_cycles, _rerunGateOrBlock already re-dispatches.
+      // The redispatchedGateKeys flag bounds this to a single refund; a hook
+      // that repeatedly fails to produce its unit-end then consumes its budget
+      // and blocks normally.
       const cycleKey = hookCycleKey(config, hook);
-      if (!this.redispatchedGateKeys.has(cycleKey)) {
+      const currentCycle = this.cycleCounts.get(cycleKey) ?? 0;
+      const maxCycles = hookMaxCycles(config);
+      if (!this.redispatchedGateKeys.has(cycleKey) && currentCycle >= maxCycles) {
         this.redispatchedGateKeys.add(cycleKey);
-        const currentCycle = this.cycleCounts.get(cycleKey);
-        if (typeof currentCycle === "number" && currentCycle > 0) {
+        if (currentCycle > 0) {
           this.cycleCounts.set(cycleKey, currentCycle - 1);
         }
       }

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -126,6 +126,13 @@ export class RuleRegistry {
     forceRun?: boolean;
   }> = [];
   cycleCounts: Map<string, number> = new Map();
+  /**
+   * Cycle keys that have already been granted a one-shot re-dispatch after a
+   * lost/interrupted dispatch (hook charged a cycle but never produced its own
+   * unit-end). Bounds the dispatch-cycle refund to exactly one per gate so a
+   * hook that repeatedly fails to complete cannot loop forever.
+   */
+  redispatchedGateKeys: Set<string> = new Set();
   retryPending: boolean = false;
   retryTrigger: { unitType: string; unitId: string; retryArtifact?: string } | null = null;
   hookFailure: HookFailureState | null = null;
@@ -527,6 +534,21 @@ export class RuleRegistry {
     observedCleanExecution: boolean,
   ): HookDispatchResult | null {
     if (!observedCleanExecution) {
+      // The hook was charged a cycle at dispatch but never produced its own
+      // unit-end — its dispatch was lost/interrupted (pause/resume, crash
+      // recovery). Refund that dispatch-consumed cycle exactly once so the gate
+      // is re-dispatched at least once instead of hard-blocking on a hook that
+      // never actually ran. The redispatchedGateKeys flag bounds this to a
+      // single refund; a hook that repeatedly fails to produce its unit-end
+      // then consumes its budget and blocks normally.
+      const cycleKey = hookCycleKey(config, hook);
+      if (!this.redispatchedGateKeys.has(cycleKey)) {
+        this.redispatchedGateKeys.add(cycleKey);
+        const currentCycle = this.cycleCounts.get(cycleKey);
+        if (typeof currentCycle === "number" && currentCycle > 0) {
+          this.cycleCounts.set(cycleKey, currentCycle - 1);
+        }
+      }
       return this._rerunGateOrBlock(config, hook, basePath, {
         reason: `hook/${config.name} did not complete cleanly before the trigger unit resumed`,
       });
@@ -863,6 +885,7 @@ export class RuleRegistry {
     this.activeHook = null;
     this.hookQueue = [];
     this.cycleCounts.clear();
+    this.redispatchedGateKeys.clear();
     this.retryPending = false;
     this.retryTrigger = null;
     this.hookFailure = null;
@@ -879,6 +902,7 @@ export class RuleRegistry {
   persistState(basePath: string): void {
     const state: PersistedHookState = {
       cycleCounts: Object.fromEntries(this.cycleCounts),
+      redispatchedGateKeys: Array.from(this.redispatchedGateKeys),
       activeHook: this.activeHook ? { ...this.activeHook } : null,
       hookQueue: this.hookQueue.map(entry => ({
         hookName: entry.config.name,
@@ -912,6 +936,14 @@ export class RuleRegistry {
           }
         }
       }
+      this.redispatchedGateKeys.clear();
+      if (Array.isArray(state.redispatchedGateKeys)) {
+        for (const key of state.redispatchedGateKeys) {
+          if (typeof key === "string") {
+            this.redispatchedGateKeys.add(key);
+          }
+        }
+      }
       this.activeHook = state.activeHook && typeof state.activeHook === "object"
         ? { ...state.activeHook }
         : null;
@@ -942,7 +974,7 @@ export class RuleRegistry {
       if (existsSync(filePath)) {
         writeFileSync(
           filePath,
-          JSON.stringify({ cycleCounts: {}, activeHook: null, hookQueue: [], savedAt: new Date().toISOString() }, null, 2),
+          JSON.stringify({ cycleCounts: {}, redispatchedGateKeys: [], activeHook: null, hookQueue: [], savedAt: new Date().toISOString() }, null, 2),
           "utf-8",
         );
       }

--- a/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
@@ -355,6 +355,104 @@ test('Blocking hook re-dispatches once after a lost dispatch at default max_cycl
   }
 });
 
+test('Blocking hook lost-dispatch refund is one-shot and bounded at max_cycles=2', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: plan-review
+    after:
+      - plan-slice
+    prompt: Review plan
+    artifact: PLAN-REVIEW.md
+    criticality: blocking
+    max_cycles: 2
+`);
+
+    // Simulate a lost dispatch: persist, drop in-memory state, restore, then the
+    // trigger unit resumes instead of the hook producing its own unit-end.
+    const lose = () => {
+      persistHookState(base);
+      resetHookState();
+      restoreHookState(base);
+      return checkPostUnitHooks("plan-slice", "M002/S01", base);
+    };
+
+    assert.ok(checkPostUnitHooks("plan-slice", "M002/S01", base), "initial dispatch");
+
+    // Refund is one-shot, but max_cycles=2 still has real budget, so lost#2 also
+    // re-dispatches by consuming a genuine cycle (not another refund).
+    assert.ok(lose(), "lost#1 re-dispatches (one-shot refund)");
+    assert.equal(consumeGateBlock(), null, "no block after lost#1");
+    assert.ok(lose(), "lost#2 re-dispatches from real budget");
+    assert.equal(consumeGateBlock(), null, "no block after lost#2");
+
+    // Total dispatches are bounded to max_cycles + 1 (the single forgiven loss),
+    // so the third lost dispatch blocks. redispatchedGateKeys guarantees this
+    // terminates rather than looping forever on repeated lost resumes.
+    assert.equal(lose(), null, "lost#3 exhausts the bounded budget");
+    const block = consumeGateBlock();
+    assert.ok(block, "gate block recorded on lost#3");
+    assert.match(block.reason, /gate cycle budget exhausted/);
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('Blocking hook lost dispatch does not steal a real-run cycle at max_cycles=2', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: plan-review
+    after:
+      - plan-slice
+    prompt: Review plan
+    artifact: PLAN-REVIEW.md
+    criticality: blocking
+    max_cycles: 2
+`);
+
+    // Dispatch, then lose it once (the one-shot refund is spent here).
+    assert.ok(checkPostUnitHooks("plan-slice", "M002/S01", base), "initial dispatch");
+    persistHookState(base);
+    resetHookState();
+    restoreHookState(base);
+    assert.ok(
+      checkPostUnitHooks("plan-slice", "M002/S01", base),
+      "lost dispatch re-dispatches (refund spent)",
+    );
+
+    // The hook now actually runs, each run reporting a failed verdict. Because a
+    // lost dispatch must not consume the hook's real-run budget, max_cycles=2
+    // still permits two genuine runs before the gate blocks — spending the
+    // refund early did not rob a later real cycle.
+    mkdirSync(join(base, ".gsd", "milestones", "M002", "slices", "S01"), { recursive: true });
+    writeFileSync(
+      resolveHookArtifactPath(base, "M002/S01", "PLAN-REVIEW.md"),
+      "---\nverdict: failed\n---\n\nRejected.\n",
+      "utf-8",
+    );
+    assert.ok(
+      checkPostUnitHooks("hook/plan-review", "M002/S01", base),
+      "real run #1 (failed verdict) re-dispatches",
+    );
+    assert.equal(consumeGateBlock(), null, "no block after the first real run");
+    assert.equal(
+      checkPostUnitHooks("hook/plan-review", "M002/S01", base),
+      null,
+      "real run #2 (failed verdict) exhausts the real budget",
+    );
+    const block = consumeGateBlock();
+    assert.ok(block, "gate block recorded only after two real runs");
+    assert.match(block.reason, /gate cycle budget exhausted/);
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('Blocking hook needs-rework verdict requests trigger unit retry', () => {
   resetHookState();
   const base = createFixtureBase();

--- a/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
@@ -310,6 +310,51 @@ test('Restore reconciliation is a no-op with no active hook (#1246)', () => {
   }
 });
 
+test('Blocking hook re-dispatches once after a lost dispatch at default max_cycles', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    // Default max_cycles (1): a cycle is charged at dispatch time.
+    writeHookPreferences(base, `  - name: plan-review
+    after:
+      - plan-slice
+    prompt: Review plan
+    artifact: PLAN-REVIEW.md
+    criticality: blocking
+`);
+
+    const firstDispatch = checkPostUnitHooks("plan-slice", "M002/S01", base);
+    assert.ok(firstDispatch, "gate dispatches and consumes its cycle at dispatch");
+    assert.equal(firstDispatch.unitType, "hook/plan-review");
+    persistHookState(base);
+
+    // Simulate a lost dispatch: the hook never produced its own unit-end, the
+    // trigger unit resumes instead. The dispatch-consumed cycle is refunded once
+    // so the gate re-dispatches rather than hard-blocking on a hook that never ran.
+    resetHookState();
+    restoreHookState(base);
+    const redispatch = checkPostUnitHooks("plan-slice", "M002/S01", base);
+    assert.ok(redispatch, "lost dispatch re-dispatches the gate instead of blocking");
+    assert.equal(redispatch.unitType, "hook/plan-review");
+    assert.deepStrictEqual(consumeGateBlock(), null, "no gate block on the first lost dispatch");
+    persistHookState(base);
+
+    // A second lost dispatch consumes the budget and blocks — the refund is one-shot.
+    resetHookState();
+    restoreHookState(base);
+    const blocked = checkPostUnitHooks("plan-slice", "M002/S01", base);
+    assert.deepStrictEqual(blocked, null, "second lost dispatch exhausts the budget");
+    const block = consumeGateBlock();
+    assert.ok(block, "gate block recorded after the one-shot re-dispatch is used");
+    assert.equal(block.hookName, "plan-review");
+    assert.match(block.reason, /gate cycle budget exhausted/);
+  } finally {
+    resetHookState();
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('Blocking hook needs-rework verdict requests trigger unit retry', () => {
   resetHookState();
   const base = createFixtureBase();

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -505,6 +505,11 @@ export interface PreDispatchResult {
 export interface PersistedHookState {
   /** Cycle counts keyed as "hookName/triggerUnitType/triggerUnitId". */
   cycleCounts: Record<string, number>;
+  /**
+   * Cycle keys already granted a one-shot re-dispatch after a lost/interrupted
+   * dispatch, so the refund is bounded to one per gate across resumes.
+   */
+  redispatchedGateKeys?: string[];
   /** In-flight hook, persisted so blocking gates cannot be skipped after resume. */
   activeHook?: HookExecutionState | null;
   /** Remaining hook queue by hook name and trigger unit. */


### PR DESCRIPTION
## Summary
- Refund the dispatch-consumed gate cycle once (bounded by a persisted one-shot flag) so a blocking post-unit hook whose dispatch is lost re-dispatches instead of hard-blocking; verified by new and existing hook/rule-registry unit tests (22 + 27 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1244
- [#1244 [Bug]: a blocking post-unit hook gate spends its retry cycle at dispatch, so a hook whose dispatch is lost on resume hard-blocks on the first miss with no retry](https://github.com/open-gsd/gsd-pi/issues/1244)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1244-bug-a-blocking-post-unit-hook-gate-spend-1783228068`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes blocking gate lifecycle and persisted hook state on resume paths; bounded to one refund per gate key but affects workflow advancement when hooks are interrupted.
> 
> **Overview**
> Fixes blocking post-unit hooks that **charged a cycle at dispatch** but never ran (pause/resume or crash): on resume the trigger unit completes while `activeHook` is still set, so `observedCleanExecution` is false and `_rerunGateOrBlock` used to hit **max_cycles immediately** and hard-block with no real retry.
> 
> When that happens and the cycle budget would block a rerun, **`RuleRegistry` now decrements the cycle count once** and records the gate key in **`redispatchedGateKeys`** so the hook **re-dispatches** instead of blocking. A second lost dispatch still exhausts the budget and blocks normally. The flag is **persisted** in `hook-state.json` (via `PersistedHookState.redispatchedGateKeys`), cleared on `resetState`, and covered by a new **`post-unit-hooks`** test for default `max_cycles: 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f0325c65e18293932fd1b1bf29ace786472fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->